### PR TITLE
Update go script.

### DIFF
--- a/examples/go
+++ b/examples/go
@@ -2,7 +2,29 @@
 
 set -e
 
+check_disassembly=0
+make_known_good=0
+
+# Argument parsing
+while (( $# )); do
+	case $1 in
+	--)
+		shift
+		break
+	;;
+	-c|--check-disassembly) check_disassembly=1; echo "Checking disassemblies against known good." ;;
+	-m|--make-known-good) make_known_good=1; echo "Making known good." ;;
+	-*)
+		echo >&2 "Invalid option: $1"
+		exit 1
+	;;
+	esac
+	shift
+done
+
+# Make directories if they don't exist
 mkdir -p build
+mkdir -p known_good
 
 check_identical() {
     original_dat="$1"
@@ -11,6 +33,21 @@ check_identical() {
     xxd -g1 "$original_dat" >build/temp1.hex
     xxd -g1 "$new_dat"      >build/temp2.hex
     diff build/temp1.hex build/temp2.hex
+}
+
+check_disassemblies() {
+    candidate_asm=$1
+    known_good_asm=$2
+
+    if [[ $check_disassembly -gt 0 ]]
+    then
+        diff $candidate_asm $known_good_asm
+    fi
+
+    if [[ $make_known_good -gt 0 ]]
+    then
+        cp -f $candidate_asm $known_good_asm
+    fi
 }
 
 test() {
@@ -22,18 +59,21 @@ test() {
     # Beebasm
     echo "Testing $filename for Beebasm"
     python3 "$source_path" > "build/${filename}_beebasm.asm"
+    check_disassemblies "build/${filename}_beebasm.asm" "known_good/${filename}_beebasm.asm"
     beebasm -v -o "build/${filename}_beebasm.dat" -i "build/${filename}_beebasm.asm" > "build/${filename}_beebasm_report.txt"
     check_identical "$original_dat" "build/${filename}_beebasm.dat"
 
     # Acme
     echo "Testing $filename for Acme"
     python3 "$source_path" --acme > "build/${filename}_acme.asm"
+    check_disassemblies "build/${filename}_acme.asm" "known_good/${filename}_acme.asm"
     acme -o "build/${filename}_acme.dat" --report "build/${filename}_acme_report.txt" --symbollist "build/${filename}_acme_symbols.txt" "build/${filename}_acme.asm"
     check_identical "$original_dat" "build/${filename}_acme.dat"
 
     # xa
     echo "Testing $filename for xa"
     python3 "$source_path" --xa > "build/${filename}_xa.asm"
+    check_disassemblies "build/${filename}_xa.asm" "known_good/${filename}_xa.asm"
     xa -o "build/${filename}_xa.dat" -l "build/${filename}_xa_symbols.txt" "build/${filename}_xa.asm"
     check_identical "$original_dat" "build/${filename}_xa.dat"
 }
@@ -47,6 +87,7 @@ test_8080() {
     # z88dk-z80asm
     echo "Testing $filename for z88dk-z80asm"
     python3 "$source_path" --z88dk-8080 > "build/${filename}_8080.asm"
+    check_disassemblies "build/${filename}_8080.asm" "known_good/${filename}_8080.asm"
     z88dk-z80asm -m8080 -b -l -s -o"build/${filename}_8080.bin" "build/${filename}_8080.asm"
     check_identical "$original_dat" "build/${filename}_8080.bin"
 }

--- a/examples/known_good/anfs418_acme.asm
+++ b/examples/known_good/anfs418_acme.asm
@@ -1,0 +1,10974 @@
+; Constants
+osbyte_acknowledge_escape                       = 126
+osbyte_close_spool_exec                         = 119
+osbyte_explode_chars                            = 20
+osbyte_flush_buffer_class                       = 15
+osbyte_insert_input_buffer                      = 153
+osbyte_issue_service_request                    = 143
+osbyte_read_os_version                          = 0
+osbyte_read_write_econet_keyboard_disable       = 201
+osbyte_read_write_econet_os_call_interception   = 206
+osbyte_scan_keyboard                            = 121
+osbyte_scan_keyboard_from_16                    = 122
+osbyte_vsync                                    = 19
+osbyte_write_keys_pressed                       = 120
+osfile_read_catalogue_info                      = 5
+osword_read_palette                             = 11
+service_claim_absolute_workspace                = 1
+service_vectors_changed                         = 15
+
+; Memory locations
+l0000               = $00
+l0001               = $01
+l0012               = $12
+l0013               = $13
+l0014               = $14
+l0015               = $15
+l0016               = $16
+l0032               = $32
+l0053               = $53
+l0054               = $54
+l0055               = $55
+l0056               = $56
+l0063               = $63
+l0078               = $78
+l0098               = $98
+l0099               = $99
+l009a               = $9a
+l009b               = $9b
+l009c               = $9c
+l009d               = $9d
+l009e               = $9e
+l009f               = $9f
+l00a0               = $a0
+l00a1               = $a1
+l00a2               = $a2
+l00a3               = $a3
+l00a4               = $a4
+l00a5               = $a5
+l00a6               = $a6
+l00a7               = $a7
+l00a8               = $a8
+l00a9               = $a9
+l00aa               = $aa
+l00ab               = $ab
+l00ac               = $ac
+l00ad               = $ad
+l00ae               = $ae
+l00af               = $af
+l00b0               = $b0
+l00b1               = $b1
+l00b2               = $b2
+l00b3               = $b3
+l00b4               = $b4
+l00b5               = $b5
+l00b6               = $b6
+l00b7               = $b7
+l00b8               = $b8
+l00b9               = $b9
+l00ba               = $ba
+l00bb               = $bb
+l00bc               = $bc
+l00bd               = $bd
+l00be               = $be
+l00bf               = $bf
+l00c0               = $c0
+l00c1               = $c1
+l00c2               = $c2
+l00c4               = $c4
+l00c7               = $c7
+l00c8               = $c8
+l00cc               = $cc
+l00cd               = $cd
+l00d0               = $d0
+l00ed               = $ed
+l00ef               = $ef
+l00f0               = $f0
+os_text_ptr         = $f2
+l00f3               = $f3
+romsel_copy         = $f4
+osrdsc_ptr          = $f6
+l00f7               = $f7
+l00fd               = $fd
+l00ff               = $ff
+l0100               = $0100
+l0101               = $0101
+l0102               = $0102
+l0103               = $0103
+l0104               = $0104
+brkv                = $0202
+filev               = $0212
+fscv                = $021e
+evntv               = $0220
+netv                = $0224
+l026a               = $026a
+l028d               = $028d
+l02a0               = $02a0
+l0350               = $0350
+l0351               = $0351
+l0355               = $0355
+l04c7               = $04c7
+l04ce               = $04ce
+l0500               = $0500
+l0518               = $0518
+l0600               = $0600
+l0601               = $0601
+l0695               = $0695
+l069e               = $069e
+l0a00               = $0a00
+l0a81               = $0a81
+l0cff               = $0cff
+l0d07               = $0d07
+l0d0c               = $0d0c
+l0d0d               = $0d0d
+l0d0e               = $0d0e
+l0d11               = $0d11
+l0d1a               = $0d1a
+l0d1e               = $0d1e
+l0d20               = $0d20
+l0d21               = $0d21
+l0d22               = $0d22
+l0d23               = $0d23
+l0d24               = $0d24
+l0d25               = $0d25
+l0d26               = $0d26
+l0d3e               = $0d3e
+l0d3f               = $0d3f
+l0d40               = $0d40
+l0d41               = $0d41
+l0d60               = $0d60
+l0d61               = $0d61
+l0d62               = $0d62
+l0d63               = $0d63
+l0d64               = $0d64
+l0d65               = $0d65
+l0d68               = $0d68
+l0d69               = $0d69
+l0d6a               = $0d6a
+l0d6b               = $0d6b
+l0d6c               = $0d6c
+l0d6d               = $0d6d
+l0d6e               = $0d6e
+l0d6f               = $0d6f
+l0d71               = $0d71
+l0df0               = $0df0
+l0dfe               = $0dfe
+l0e00               = $0e00
+l0e01               = $0e01
+l0e02               = $0e02
+l0e03               = $0e03
+l0e04               = $0e04
+l0e05               = $0e05
+l0e06               = $0e06
+l0e07               = $0e07
+l0e08               = $0e08
+l0e09               = $0e09
+l0e0a               = $0e0a
+l0e0b               = $0e0b
+l0e14               = $0e14
+l0e2f               = $0e2f
+l0e30               = $0e30
+l0e31               = $0e31
+l0e32               = $0e32
+l0e38               = $0e38
+l0e81               = $0e81
+l0ef7               = $0ef7
+l0f00               = $0f00
+l0f01               = $0f01
+l0f02               = $0f02
+l0f03               = $0f03
+l0f04               = $0f04
+l0f05               = $0f05
+l0f06               = $0f06
+l0f07               = $0f07
+l0f08               = $0f08
+l0f09               = $0f09
+l0f0a               = $0f0a
+l0f0b               = $0f0b
+l0f0c               = $0f0c
+l0f0d               = $0f0d
+l0f0e               = $0f0e
+l0f10               = $0f10
+l0f11               = $0f11
+l0f12               = $0f12
+l0f13               = $0f13
+l0f14               = $0f14
+l0f2f               = $0f2f
+l0f30               = $0f30
+l0fc8               = $0fc8
+l0fdc               = $0fdc
+l0fdd               = $0fdd
+l0fde               = $0fde
+l0fdf               = $0fdf
+l0fe0               = $0fe0
+l0ff0               = $0ff0
+l0fff               = $0fff
+l1000               = $1000
+l1010               = $1010
+l1020               = $1020
+l1030               = $1030
+l1040               = $1040
+l1050               = $1050
+l1060               = $1060
+l1070               = $1070
+l1071               = $1071
+l1072               = $1072
+l1073               = $1073
+l1074               = $1074
+l1078               = $1078
+l1088               = $1088
+l1098               = $1098
+l10a8               = $10a8
+l10b8               = $10b8
+l10c8               = $10c8
+l10c9               = $10c9
+l10ca               = $10ca
+l10cb               = $10cb
+l10cc               = $10cc
+l10cd               = $10cd
+l10ce               = $10ce
+l10cf               = $10cf
+l10d0               = $10d0
+l10d1               = $10d1
+l10d4               = $10d4
+l10d5               = $10d5
+l10d6               = $10d6
+l10d7               = $10d7
+l10d8               = $10d8
+l10d9               = $10d9
+l10f3               = $10f3
+lfe18               = $fe18
+video_ula_control   = $fe20
+romsel              = $fe30
+system_via_sr       = $fe4a
+system_via_acr      = $fe4b
+system_via_ifr      = $fe4d
+system_via_ier      = $fe4e
+lfe87               = $fe87
+lfea0               = $fea0
+lfea1               = $fea1
+lfea2               = $fea2
+lfea3               = $fea3
+tube_host_r1_status = $fee0
+tube_host_r1_data   = $fee1
+tube_host_r3_data   = $fee5
+tube_host_r4_status = $fee6
+lffb0               = $ffb0
+osrdsc              = $ffb9
+lffbd               = $ffbd
+gsinit              = $ffc2
+gsread              = $ffc5
+osfind              = $ffce
+osbget              = $ffd7
+osargs              = $ffda
+osfile              = $ffdd
+osrdch              = $ffe0
+osasci              = $ffe3
+osnewl              = $ffe7
+oswrch              = $ffee
+osword              = $fff1
+osbyte              = $fff4
+oscli               = $fff7
+
+    * = $8000
+
+; Sideways ROM header
+; $8000 referenced 1 time by $bfe6
+rom_header
+language_entry
+pydis_start
+l8001 = rom_header+1
+l8002 = rom_header+2
+    !byte   0, $42, $43                                               ; 8000: 00 42 43    .BC
+; $8001 referenced 1 time by $bfeb
+; $8002 referenced 1 time by $bff0
+
+; $8003 referenced 1 time by $bff5
+service_entry
+l8004 = service_entry+1
+    jmp service_handler                                               ; 8003: 4c 15 8a    L..
+
+; $8004 referenced 1 time by $bff8
+; $8006 referenced 1 time by $bfda
+rom_type
+    !byte $82                                                         ; 8006: 82          .
+; $8007 referenced 1 time by $bfe2
+copyright_offset
+    !byte copyright - rom_header                                      ; 8007: 19          .
+binary_version
+    !byte 4                                                           ; 8008: 04          .
+title
+    !text "Acorn ANFS 4.18"                                           ; 8009: 41 63 6f... Aco
+version
+    !byte 0                                                           ; 8018: 00          .
+copyright
+    !byte 0                                                           ; 8019: 00          .
+    !text "(C)1985 Acorn", 0                                          ; 801a: 28 43 29... (C)
+
+sub_c8028
+    lda #4                                                            ; 8028: a9 04       ..
+    bit system_via_ifr                                                ; 802a: 2c 4d fe    ,M.
+    bne c8032                                                         ; 802d: d0 03       ..
+    lda #5                                                            ; 802f: a9 05       ..
+    rts                                                               ; 8031: 60          `
+
+; $8032 referenced 1 time by $802d
+c8032
+    txa                                                               ; 8032: 8a          .
+    pha                                                               ; 8033: 48          H
+    tya                                                               ; 8034: 98          .
+    pha                                                               ; 8035: 48          H
+    lda system_via_acr                                                ; 8036: ad 4b fe    .K.
+    and #$e3                                                          ; 8039: 29 e3       ).
+    ora l0d64                                                         ; 803b: 0d 64 0d    .d.
+    sta system_via_acr                                                ; 803e: 8d 4b fe    .K.
+    lda system_via_sr                                                 ; 8041: ad 4a fe    .J.
+    lda #4                                                            ; 8044: a9 04       ..
+    sta system_via_ifr                                                ; 8046: 8d 4d fe    .M.
+    sta system_via_ier                                                ; 8049: 8d 4e fe    .N.
+    ldy l0d65                                                         ; 804c: ac 65 0d    .e.
+    tya                                                               ; 804f: 98          .
+    bmi c805d                                                         ; 8050: 30 0b       0.
+    lda #$fe                                                          ; 8052: a9 fe       ..
+    jsr sub_c805a                                                     ; 8054: 20 5a 80     Z.
+    jmp c8585                                                         ; 8057: 4c 85 85    L..
+
+; $805a referenced 1 time by $8054
+sub_c805a
+    jmp (evntv)                                                       ; 805a: 6c 20 02    l .
+
+; $805d referenced 1 time by $8050
+c805d
+    cpy #$86                                                          ; 805d: c0 86       ..
+    bcs c806c                                                         ; 805f: b0 0b       ..
+    lda l0d68                                                         ; 8061: ad 68 0d    .h.
+    sta l0d69                                                         ; 8064: 8d 69 0d    .i.
+    ora #$1c                                                          ; 8067: 09 1c       ..
+    sta l0d68                                                         ; 8069: 8d 68 0d    .h.
+; $806c referenced 1 time by $805f
+c806c
+    lda #$85                                                          ; 806c: a9 85       ..
+    pha                                                               ; 806e: 48          H
+    lda l84bb,y                                                       ; 806f: b9 bb 84    ...
+    pha                                                               ; 8072: 48          H
+    rts                                                               ; 8073: 60          `
+
+; $8074 referenced 1 time by $8f5d
+sub_c8074
+    bit lfe18                                                         ; 8074: 2c 18 fe    ,..
+    jsr sub_c8969                                                     ; 8077: 20 69 89     i.
+    lda #$ea                                                          ; 807a: a9 ea       ..
+    ldx #0                                                            ; 807c: a2 00       ..
+    stx l0d62                                                         ; 807e: 8e 62 0d    .b.
+    jsr sub_c8e83                                                     ; 8081: 20 83 8e     ..
+    stx l0d63                                                         ; 8084: 8e 63 0d    .c.
+    lda #$8f                                                          ; 8087: a9 8f       ..
+    ldx #$0c                                                          ; 8089: a2 0c       ..
+    jsr sub_c8e85                                                     ; 808b: 20 85 8e     ..
+    ldy #5                                                            ; 808e: a0 05       ..
+sub_c8090
+    cpy #5                                                            ; 8090: c0 05       ..
+    bne c80bd                                                         ; 8092: d0 29       .)
+    ldy #$20 ; ' '                                                    ; 8094: a0 20       .
+; $8096 referenced 1 time by $809d
+loop_c8096
+    lda l89a6,y                                                       ; 8096: b9 a6 89    ...
+    sta l0cff,y                                                       ; 8099: 99 ff 0c    ...
+    dey                                                               ; 809c: 88          .
+    bne loop_c8096                                                    ; 809d: d0 f7       ..
+    lda romsel_copy                                                   ; 809f: a5 f4       ..
+    sta l0d07                                                         ; 80a1: 8d 07 0d    ...
+    sty l0d23                                                         ; 80a4: 8c 23 0d    .#.
+    sty l0099                                                         ; 80a7: 84 99       ..
+    sty l0d65                                                         ; 80a9: 8c 65 0d    .e.
+    ldy lfe18                                                         ; 80ac: ac 18 fe    ...
+    sty l0d22                                                         ; 80af: 8c 22 0d    .".
+    lda #$80                                                          ; 80b2: a9 80       ..
+    sta l0d60                                                         ; 80b4: 8d 60 0d    .`.
+    sta l0d62                                                         ; 80b7: 8d 62 0d    .b.
+    bit video_ula_control                                             ; 80ba: 2c 20 fe    , .
+; $80bd referenced 1 time by $8092
+c80bd
+    rts                                                               ; 80bd: 60          `
+
+; $80be referenced 1 time by $89b2
+c80be
+    lda #1                                                            ; 80be: a9 01       ..
+    bit lfea1                                                         ; 80c0: 2c a1 fe    ,..
+    beq c80fd                                                         ; 80c3: f0 38       .8
+    lda lfea2                                                         ; 80c5: ad a2 fe    ...
+    cmp lfe18                                                         ; 80c8: cd 18 fe    ...
+    beq c80d6                                                         ; 80cb: f0 09       ..
+    cmp #$ff                                                          ; 80cd: c9 ff       ..
+    bne c80e9                                                         ; 80cf: d0 18       ..
+    lda #$40 ; '@'                                                    ; 80d1: a9 40       .@
+    sta l0d3e                                                         ; 80d3: 8d 3e 0d    .>.
+; $80d6 referenced 1 time by $80cb
+c80d6
+    lda #$db                                                          ; 80d6: a9 db       ..
+    jmp l0d11                                                         ; 80d8: 4c 11 0d    L..
+
+    !byte $2c, $a1, $fe, $10, $1d, $ad, $a2, $fe, $f0, $0c, $49, $ff  ; 80db: 2c a1 fe... ,..
+    !byte $f0, $0b                                                    ; 80e7: f0 0b       ..
+
+; $80e9 referenced 1 time by $80cf
+c80e9
+    lda #$a2                                                          ; 80e9: a9 a2       ..
+    sta lfea0                                                         ; 80eb: 8d a0 fe    ...
+    jmp c83fb                                                         ; 80ee: 4c fb 83    L..
+
+    !byte $8d, $3e, $0d, $85, $a2, $a9, $0d, $a0, $81, $4c, $0e, $0d  ; 80f1: 8d 3e 0d... .>.
+
+; $80fd referenced 1 time by $80c3
+c80fd
+    lda lfea1                                                         ; 80fd: ad a1 fe    ...
+    and #$81                                                          ; 8100: 29 81       ).
+    beq c810a                                                         ; 8102: f0 06       ..
+    jsr sub_c8969                                                     ; 8104: 20 69 89     i.
+    jmp c83fb                                                         ; 8107: 4c fb 83    L..
+
+; $810a referenced 1 time by $8102
+c810a
+    jmp c83f8                                                         ; 810a: 4c f8 83    L..
+
+    !byte $a4, $a2, $ad, $a1, $fe, $10, $e9, $ad, $a2, $fe, $99, $2e  ; 810d: a4 a2 ad... ...
+    !byte $0d, $c8, $ad, $a1, $fe, $30,   2, $d0, $15, $ad, $a2, $fe  ; 8119: 0d c8 ad... ...
+    !byte $99, $2e, $0d, $c8, $c0, $0c, $f0, $0a, $84, $a2, $ad, $a1  ; 8125: 99 2e 0d... ...
+    !byte $fe, $d0, $de, $4c, $14, $0d, $a9,   0, $8d, $a0, $fe, $a9  ; 8131: fe d0 de... ...
+    !byte $84, $8d, $a1, $fe, $a9,   2, $2c, $a1, $fe, $f0, $b5, $10  ; 813d: 84 8d a1... ...
+    !byte $b3, $ad, $a2, $fe, $99, $2e, $0d, $a9, $44, $8d, $a0, $fe  ; 8149: b3 ad a2... ...
+    !byte $38, $66, $99, $ad, $31, $0d, $d0,   3, $4c, $55, $84, $2c  ; 8155: 38 66 99... 8f.
+    !byte $3e, $0d, $50,   5, $a9,   7, $8d, $a1, $fe, $2c, $61, $0d  ; 8161: 3e 0d 50... >.P
+    !byte $10, $40, $a9, $c0, $a0,   0, $85, $a6, $84, $a7, $a0,   0  ; 816d: 10 40 a9... .@.
+    !byte $b1, $a6, $f0, $2f, $c9, $7f, $d0, $1e, $c8, $b1, $a6, $f0  ; 8179: b1 a6 f0... ...
+    !byte   5, $cd, $31, $0d, $d0, $14, $c8, $b1, $a6, $f0, $2a, $cd  ; 8185: 05 cd 31... ..1
+    !byte $2e, $0d, $d0, $0a, $c8, $b1, $a6, $f0, $20, $cd, $2f, $0d  ; 8191: 2e 0d d0... ...
+    !byte $f0, $1b, $a5, $a7, $f0, $0c, $a5, $a6, $18, $69, $0c, $85  ; 819d: f0 1b a5... ...
+    !byte $a6, $90, $cb, $4c, $36, $82, $2c, $61, $0d, $50, $f8, $a9  ; 81a9: a6 90 cb... ...
+    !byte   0, $a4, $9f, $d0, $b9, $a9,   3, $8d, $40, $0d, $20, $f2  ; 81b5: 00 a4 9f... ...
+    !byte $88, $90                                                    ; 81c1: 88 90       ..
+    !text "r,>"                                                       ; 81c3: 72 2c 3e    r,>
+    !byte $0d, $50,   3, $4c, $10, $84, $a9, $44, $8d, $a0, $fe, $a9  ; 81c6: 0d 50 03... .P.
+    !byte $a7, $8d, $a1, $fe, $a9, $dd, $a0, $81, $4c,   8, $83, $a9  ; 81d2: a7 8d a1... ...
+    !byte $82, $8d, $a0, $fe, $a9, $e7, $4c, $11, $0d, $a9,   1, $2c  ; 81de: 82 8d a0... ...
+    !byte $a1, $fe, $f0, $48, $ad, $a2, $fe, $cd, $18, $fe, $d0, $40  ; 81ea: a1 fe f0... ...
+    !byte $a9, $fb, $4c, $11, $0d, $2c, $a1, $fe, $10, $36, $ad, $a2  ; 81f6: a9 fb 4c... ..L
+    !byte $fe, $d0, $31, $a9, $11, $a0, $82, $2c, $a0, $fe, $30,   3  ; 8202: fe d0 31... ..1
+    !byte $4c, $0e, $0d, $2c, $a1, $fe, $10, $20, $ad, $a2, $fe, $ad  ; 820e: 4c 0e 0d... L..
+    !byte $a2, $fe, $a9,   2, $2c, $3e, $0d, $d0, $0c, $a9, $44, $a0  ; 821a: a2 fe a9... ...
+    !byte $82, $2c, $a0, $fe, $30, $18, $4c, $0e, $0d, $a9, $a1, $a0  ; 8226: 82 2c a0... .,.
+    !byte $82, $4c, $0e, $0d, $ad, $3e, $0d, $10,   3, $4c, $d4, $88  ; 8232: 82 4c 0e... .L.
+    !byte $20, $69, $89, $4c, $f5, $83, $a4, $a2, $ad, $a1, $fe, $10  ; 823e: 20 69 89...  i.
+    !byte $2d, $ad, $a2, $fe, $91, $a4, $c8, $d0,   6, $e6, $a5, $c6  ; 824a: 2d ad a2... -..
+    !byte $a3, $f0, $dd, $ad, $a1, $fe, $30,   2, $d0, $18, $ad, $a2  ; 8256: a3 f0 dd... ...
+    !byte $fe, $91, $a4, $c8, $84, $a2, $d0,   6, $e6, $a5, $c6, $a3  ; 8262: fe 91 a4... ...
+    !byte $f0,   8, $ad, $a1, $fe, $d0, $d4, $4c, $14, $0d, $a9, $84  ; 826e: f0 08 ad... ...
+    !byte $8d, $a1, $fe, $a9,   0, $8d, $a0, $fe, $84, $a2, $a9,   2  ; 827a: 8d a1 fe... ...
+    !byte $2c, $a1, $fe, $f0, $ab, $10, $11, $a5, $a3, $f0, $a5, $ad  ; 8286: 2c a1 fe... ,..
+    !byte $a2, $fe, $a4, $a2, $91, $a4, $e6, $a2, $d0,   2, $e6, $a5  ; 8292: a2 fe a4... ...
+    !byte $4c, $ef, $82, $ad, $a1, $fe, $10, $1e, $ad, $a2, $fe, $20  ; 829e: 4c ef 82... L..
+    !byte $2f, $85, $f0, $e1, $8d, $e5, $fe, $ad, $a2, $fe, $8d, $e5  ; 82aa: 2f 85 f0... /..
+    !byte $fe, $20, $2f, $85, $f0,   8, $ad, $a1, $fe, $d0, $e3, $4c  ; 82b6: fe 20 2f... . /
+    !byte $14, $0d, $a9,   0, $8d, $a0, $fe, $a9, $84, $8d, $a1, $fe  ; 82c2: 14 0d a9... ...
+    !byte $a9,   2, $2c, $a1, $fe, $f0, $ba, $10, $18, $a5, $a2,   5  ; 82ce: a9 02 2c... ..,
+    !byte $a3,   5, $a4,   5, $a5, $f0, $ae, $ad, $a2, $fe, $8d, $42  ; 82da: a3 05 a4... ...
+    !byte $0d, $a9, $20, $0d, $3e, $0d, $8d, $3e, $0d, $ad, $3e, $0d  ; 82e6: 0d a9 20... ..
+    !byte $10,   6, $20, $4f, $83, $4c, $d0, $88, $a9, $44, $8d, $a0  ; 82f2: 10 06 20... ..
+    !byte $fe, $a9, $a7, $8d, $a1, $fe, $a9, $96, $a0, $83, $8d, $43  ; 82fe: fe a9 a7... ...
+    !byte $0d, $8c, $44, $0d, $ad, $2e, $0d, $2c, $a0, $fe, $50, $36  ; 830a: 0d 8c 44... ..D
+    !byte $8d, $a2, $fe, $ad, $2f, $0d, $8d, $a2, $fe, $a9, $26, $a0  ; 8316: 8d a2 fe... ...
+    !byte $83, $4c, $0e, $0d, $ad, $18, $fe, $2c, $a0, $fe, $50, $1e  ; 8322: 83 4c 0e... .L.
+    !byte $8d, $a2, $fe, $a9,   0, $8d, $a2, $fe, $ad, $3e, $0d, $30  ; 832e: 8d a2 fe... ...
+    !byte $0e, $a9, $3f, $8d, $a1, $fe, $ad, $43, $0d, $ac, $44, $0d  ; 833a: 0e a9 3f... ..?
+    !byte $4c, $0e, $0d, $4c, $d1, $87, $4c, $36, $82, $a9,   2, $2c  ; 8346: 4c 0e 0d... L..
+    !byte $3e, $0d, $f0, $3f, $18,   8, $a0,   8, $b1, $a6, $28, $79  ; 8352: 3e 0d f0... >..
+    !byte $9a,   0, $91, $a6, $c8,   8, $c0, $0c, $90, $f2, $28, $a9  ; 835e: 9a 00 91... ...
+    !text " ,>"                                                       ; 836a: 20 2c 3e     ,>
+    !byte $0d, $f0, $23, $8a, $48, $a9,   8, $18, $65, $a6, $aa, $a4  ; 836d: 0d f0 23... ..#
+    !byte $a7, $a9,   1, $20,   6,   4, $ad, $42, $0d, $8d, $e5, $fe  ; 8379: a7 a9 01... ...
+    !byte $38, $a0,   8, $a9,   0, $71, $a6, $91, $a6, $c8, $b0, $f7  ; 8385: 38 a0 08... 8..
+    !byte $68, $aa, $a9, $ff, $60, $ad, $31, $0d, $d0, $0a, $ac, $30  ; 8391: 68 aa a9... h..
+    !byte $0d, $c0, $82, $f0,   3, $4c, $f6, $84, $20, $4f, $83, $d0  ; 839d: 0d c0 82... ...
+    !byte $12, $a5, $a2, $18, $65, $a4, $90,   2, $e6, $a5, $a0,   8  ; 83a9: 12 a5 a2... ...
+    !byte $91, $a6, $c8, $a5, $a5, $91, $a6, $ad, $31, $0d, $f0, $34  ; 83b5: 91 a6 c8... ...
+    !byte $ad, $2f, $0d, $a0,   3, $91, $a6, $88, $ad, $2e, $0d, $91  ; 83c1: ad 2f 0d... ./.
+    !byte $a6, $88, $ad, $31, $0d, $91, $a6, $88, $ad, $30, $0d,   9  ; 83cd: a6 88 ad... ...
+    !byte $80, $91, $a6, $ad, $6c, $0d, $6a, $90, $13, $a5, $a6, $c8  ; 83d9: 80 91 a6... ...
+    !byte $e9, $0c, $b0, $fb, $88, $c0,   3, $90,   7, $20,   2, $84  ; 83e5: e9 0c b0... ...
+    !byte $98, $4c, $0f, $85, $20,   2, $84                           ; 83f1: 98 4c 0f... .L.
+
+; $83f8 referenced 1 time by $810a
+c83f8
+    jsr c8978                                                         ; 83f8: 20 78 89     x.
+; $83fb referenced 2 times by $80ee, $8107
+c83fb
+    lda #$be                                                          ; 83fb: a9 be       ..
+    ldy #$80                                                          ; 83fd: a0 80       ..
+    jmp l0d0e                                                         ; 83ff: 4c 0e 0d    L..
+
+    !byte $a9,   2, $2d, $63, $0d, $2c, $3e, $0d, $f0,   3, $20, $49  ; 8402: a9 02 2d... ..-
+    !byte $84, $60, $8a, $48, $a2,   4, $a9,   2, $2c, $3e, $0d, $d0  ; 840e: 84 60 8a... .`.
+    !byte $1c, $a4, $a2, $bd, $2e, $0d, $91, $a4, $c8, $d0,   6, $e6  ; 841a: 1c a4 a2... ...
+    !byte $a5, $c6, $a3, $f0, $52, $e8, $84, $a2, $e0, $0c, $d0, $eb  ; 8426: a5 c6 a3... ...
+    !byte $68, $aa, $4c, $a5, $83, $bd, $2e, $0d, $8d, $e5, $fe, $20  ; 8432: 68 aa 4c... h.L
+    !byte $2f, $85, $f0, $3d, $e8, $e0, $0c, $d0, $f0, $f0, $e9       ; 843e: 2f 85 f0... /..
+
+; $8449 referenced 1 time by $893e
+sub_c8449
+    bit l0099                                                         ; 8449: 24 99       $.
+    bmi c8452                                                         ; 844b: 30 05       0.
+    lda #$82                                                          ; 844d: a9 82       ..
+    jsr c0406                                                         ; 844f: 20 06 04     ..
+; $8452 referenced 1 time by $844b
+c8452
+    lsr l0099                                                         ; 8452: 46 99       F.
+    rts                                                               ; 8454: 60          `
+
+    !byte $ac, $30, $0d, $c0, $81, $90, $29, $c0, $89, $b0, $25, $c0  ; 8455: ac 30 0d... .0.
+    !byte $87, $b0, $0e, $98, $38, $e9, $81, $a8, $ad, $68, $0d, $6a  ; 8461: 87 b0 0e... ...
+    !byte $88, $10, $fc, $b0, $86, $ac, $30, $0d, $a9, $84, $48, $b9  ; 846d: 88 10 fc... ...
+    !byte   7, $84, $48, $60, $e6, $a2, $e0, $0b, $f0, $af, $68, $aa  ; 8479: 07 84 48... ..H
+    !byte $4c, $36, $82, $ca, $ad, $8f, $8f, $8f, $e4, $e4, $b8, $a9  ; 8485: 4c 36 82... L6.
+    !byte   0, $85, $a4, $a9, $82, $85, $a2, $a9,   1, $85, $a3, $a5  ; 8491: 00 85 a4... ...
+    !byte $9d, $85, $a5, $a0,   1, $b9, $32, $0d, $99, $66, $0d, $88  ; 849d: 9d 85 a5... ...
+    !byte $10, $f7, $4c, $cc, $81, $a9, $2e, $85, $a6, $a9, $0d, $85  ; 84a9: 10 f7 4c... ..L
+    !byte $a7, $4c, $ba, $81, $a9,   1                                ; 84b5: a7 4c ba... .L.
+; $84bb referenced 1 time by $806f
+l84bb
+    !byte $85, $a3, $a9, $fc, $85, $a2, $a9, $cb, $85, $a4, $a9, $88  ; 84bb: 85 a3 a9... ...
+    !byte $85, $a5, $d0, $12, $a9, $2e, $85, $a6, $a9, $0d, $85, $a7  ; 84c7: 85 a5 d0... ...
+    !byte $a9,   2, $8d, $40, $0d, $20, $f2, $88, $90, $4f, $ad, $3e  ; 84d3: a9 02 8d... ...
+    !byte $0d,   9, $80, $8d, $3e, $0d, $a9, $44, $8d, $a0, $fe, $a9  ; 84df: 0d 09 80... ...
+    !byte $a7, $8d, $a1, $fe, $a9, $0c, $a0, $85, $4c,   8, $83, $a5  ; 84eb: a7 8d a1... ...
+    !byte $a2, $18, $69, $80, $a0, $7f, $91, $9c, $a0, $80, $ad, $2e  ; 84f7: a2 18 69... ..i
+    !byte $0d, $91, $9c, $c8, $ad, $2f, $0d, $91, $9c, $ad, $30, $0d  ; 8503: 0d 91 9c... ...
+    !byte $8d, $65, $0d, $a9, $84, $8d, $4e, $fe, $ad, $4b, $fe, $29  ; 850f: 8d 65 0d... .e.
+    !byte $1c, $8d, $64, $0d, $ad, $4b, $fe, $29, $e3,   9,   8, $8d  ; 851b: 1c 8d 64... ..d
+    !byte $4b, $fe, $2c, $4a, $fe, $4c, $f8, $83, $e6, $a2, $d0, $0a  ; 8527: 4b fe 2c... K.,
+    !byte $e6, $a3, $d0,   6, $e6, $a4, $d0,   2, $e6, $a5            ; 8533: e6 a3 d0... ...
+    !text "`BKYe|"                                                    ; 853d: 60 42 4b... `BK
+    !byte $a9, $85, $48, $a9, $84                                     ; 8543: a9 85 48... ..H
+    !text "Hlf"                                                       ; 8548: 48 6c 66    Hlf
+    !byte $0d, $ae, $66, $0d, $ad, $67, $0d, $a0,   8, $20, $bf, $ff  ; 854b: 0d ae 66... ..f
+    !byte $4c, $85, $85, $ae, $66, $0d, $ac, $67, $0d, $20, $43, $8e  ; 8557: 4c 85 85... L..
+    !byte $4c, $85, $85, $a9,   4, $2c, $61, $0d, $d0, $18, $0d, $61  ; 8563: 4c 85 85... L..
+    !byte $0d, $8d, $61, $0d, $a9,   4                                ; 856f: 0d 8d 61... ..a
+    !text "X,a"                                                       ; 8575: 58 2c 61    X,a
+    !byte $0d, $d0, $fb, $f0,   8, $ad, $61, $0d, $29, $fb, $8d, $61  ; 8578: 0d d0 fb... ...
+    !byte $0d                                                         ; 8584: 0d          .
+
+; $8585 referenced 1 time by $8057
+c8585
+    pla                                                               ; 8585: 68          h
+    tay                                                               ; 8586: a8          .
+    pla                                                               ; 8587: 68          h
+    tax                                                               ; 8588: aa          .
+    lda #0                                                            ; 8589: a9 00       ..
+    rts                                                               ; 858b: 60          `
+
+; $858c referenced 2 times by $98d6, $a89a
+sub_c858c
+    txa                                                               ; 858c: 8a          .
+    pha                                                               ; 858d: 48          H
+    ldy #2                                                            ; 858e: a0 02       ..
+    lda (l00a0),y                                                     ; 8590: b1 a0       ..
+    sta l0d20                                                         ; 8592: 8d 20 0d    . .
+    iny                                                               ; 8595: c8          .
+    lda (l00a0),y                                                     ; 8596: b1 a0       ..
+    sta l0d21                                                         ; 8598: 8d 21 0d    .!.
+    ldy #0                                                            ; 859b: a0 00       ..
+    lda (l00a0),y                                                     ; 859d: b1 a0       ..
+    bmi c85a4                                                         ; 859f: 30 03       0.
+    jmp c862f                                                         ; 85a1: 4c 2f 86    L/.
+
+; $85a4 referenced 1 time by $859f
+c85a4
+    sta l0d24                                                         ; 85a4: 8d 24 0d    .$.
+    tax                                                               ; 85a7: aa          .
+    iny                                                               ; 85a8: c8          .
+    lda (l00a0),y                                                     ; 85a9: b1 a0       ..
+    sta l0d25                                                         ; 85ab: 8d 25 0d    .%.
+    bne c85e3                                                         ; 85ae: d0 33       .3
+    cpx #$83                                                          ; 85b0: e0 83       ..
+    bcs c85cf                                                         ; 85b2: b0 1b       ..
+    sec                                                               ; 85b4: 38          8
+    php                                                               ; 85b5: 08          .
+    ldy #8                                                            ; 85b6: a0 08       ..
+; $85b8 referenced 1 time by $85cc
+loop_c85b8
+    lda (l00a0),y                                                     ; 85b8: b1 a0       ..
+    dey                                                               ; 85ba: 88          .
+    dey                                                               ; 85bb: 88          .
+    dey                                                               ; 85bc: 88          .
+    dey                                                               ; 85bd: 88          .
+    plp                                                               ; 85be: 28          (
+    sbc (l00a0),y                                                     ; 85bf: f1 a0       ..
+    sta l0d26,y                                                       ; 85c1: 99 26 0d    .&.
+    iny                                                               ; 85c4: c8          .
+    iny                                                               ; 85c5: c8          .
+    iny                                                               ; 85c6: c8          .
+    iny                                                               ; 85c7: c8          .
+    iny                                                               ; 85c8: c8          .
+    php                                                               ; 85c9: 08          .
+    cpy #$0c                                                          ; 85ca: c0 0c       ..
+    bcc loop_c85b8                                                    ; 85cc: 90 ea       ..
+    plp                                                               ; 85ce: 28          (
+; $85cf referenced 1 time by $85b2
+c85cf
+    cpx #$81                                                          ; 85cf: e0 81       ..
+    bcc c862f                                                         ; 85d1: 90 5c       .\
+    cpx #$89                                                          ; 85d3: e0 89       ..
+    bcs c862f                                                         ; 85d5: b0 58       .X
+    ldy #$0c                                                          ; 85d7: a0 0c       ..
+; $85d9 referenced 1 time by $85e1
+loop_c85d9
+    lda (l00a0),y                                                     ; 85d9: b1 a0       ..
+    sta l0d1a,y                                                       ; 85db: 99 1a 0d    ...
+    iny                                                               ; 85de: c8          .
+    cpy #$10                                                          ; 85df: c0 10       ..
+    bcc loop_c85d9                                                    ; 85e1: 90 f6       ..
+; $85e3 referenced 1 time by $85ae
+c85e3
+    lda #$20 ; ' '                                                    ; 85e3: a9 20       .
+    bit lfea1                                                         ; 85e5: 2c a1 fe    ,..
+    bne c863f                                                         ; 85e8: d0 55       .U
+    lda #$fd                                                          ; 85ea: a9 fd       ..
+    pha                                                               ; 85ec: 48          H
+    lda #6                                                            ; 85ed: a9 06       ..
+    sta l0d3f                                                         ; 85ef: 8d 3f 0d    .?.
+    lda #0                                                            ; 85f2: a9 00       ..
+    sta l0d41                                                         ; 85f4: 8d 41 0d    .A.
+    pha                                                               ; 85f7: 48          H
+    pha                                                               ; 85f8: 48          H
+    ldy #$e7                                                          ; 85f9: a0 e7       ..
+; $85fb referenced 3 times by $8621, $8626, $862b
+c85fb
+    lda #4                                                            ; 85fb: a9 04       ..
+    php                                                               ; 85fd: 08          .
+    sei                                                               ; 85fe: 78          x
+sub_c85ff
+l8600 = sub_c85ff+1
+    bit lfe18                                                         ; 85ff: 2c 18 fe    ,..
+; $8600 referenced 1 time by $867c
+    bit lfe18                                                         ; 8602: 2c 18 fe    ,..
+    bit lfea1                                                         ; 8605: 2c a1 fe    ,..
+    beq c8619                                                         ; 8608: f0 0f       ..
+    lda lfea0                                                         ; 860a: ad a0 fe    ...
+    lda #$67 ; 'g'                                                    ; 860d: a9 67       .g
+    sta lfea1                                                         ; 860f: 8d a1 fe    ...
+    lda #$10                                                          ; 8612: a9 10       ..
+    bit lfea0                                                         ; 8614: 2c a0 fe    ,..
+    bne c864d                                                         ; 8617: d0 34       .4
+; $8619 referenced 1 time by $8608
+c8619
+    bit video_ula_control                                             ; 8619: 2c 20 fe    , .
+    plp                                                               ; 861c: 28          (
+    tsx                                                               ; 861d: ba          .
+    inc l0101,x                                                       ; 861e: fe 01 01    ...
+    bne c85fb                                                         ; 8621: d0 d8       ..
+    inc l0102,x                                                       ; 8623: fe 02 01    ...
+    bne c85fb                                                         ; 8626: d0 d3       ..
+    inc l0103,x                                                       ; 8628: fe 03 01    ...
+    bne c85fb                                                         ; 862b: d0 ce       ..
+    beq c8633                                                         ; 862d: f0 04       ..
+; $862f referenced 3 times by $85a1, $85d1, $85d5
+c862f
+    lda #$44 ; 'D'                                                    ; 862f: a9 44       .D
+    bne c8641                                                         ; 8631: d0 0e       ..
+; $8633 referenced 1 time by $862d
+c8633
+    lda #7                                                            ; 8633: a9 07       ..
+    sta lfea1                                                         ; 8635: 8d a1 fe    ...
+    pla                                                               ; 8638: 68          h
+    pla                                                               ; 8639: 68          h
+    pla                                                               ; 863a: 68          h
+    lda #$40 ; '@'                                                    ; 863b: a9 40       .@
+    bne c8641                                                         ; 863d: d0 02       ..
+; $863f referenced 1 time by $85e8
+c863f
+    lda #$43 ; 'C'                                                    ; 863f: a9 43       .C
+; $8641 referenced 2 times by $8631, $863d
+c8641
+    ldy #0                                                            ; 8641: a0 00       ..
+    sta (l00a0),y                                                     ; 8643: 91 a0       ..
+    lda #$80                                                          ; 8645: a9 80       ..
+    sta l0d60                                                         ; 8647: 8d 60 0d    .`.
+    pla                                                               ; 864a: 68          h
+    tax                                                               ; 864b: aa          .
+    rts                                                               ; 864c: 60          `
+
+; $864d referenced 1 time by $8617
+c864d
+    sty lfea1                                                         ; 864d: 8c a1 fe    ...
+    ldx #$44 ; 'D'                                                    ; 8650: a2 44       .D
+    stx lfea0                                                         ; 8652: 8e a0 fe    ...
+    ldx #$ea                                                          ; 8655: a2 ea       ..
+    ldy #$86                                                          ; 8657: a0 86       ..
+    stx l0d0c                                                         ; 8659: 8e 0c 0d    ...
+    sty l0d0d                                                         ; 865c: 8c 0d 0d    ...
+    sec                                                               ; 865f: 38          8
+    ror l0099                                                         ; 8660: 66 99       f.
+    bit video_ula_control                                             ; 8662: 2c 20 fe    , .
+    lda l0d25                                                         ; 8665: ad 25 0d    .%.
+    bne c86ac                                                         ; 8668: d0 42       .B
+    ldy l0d24                                                         ; 866a: ac 24 0d    .$.
+    lda l8869,y                                                       ; 866d: b9 69 88    .i.
+    sta l0d3e                                                         ; 8670: 8d 3e 0d    .>.
+    lda l8861,y                                                       ; 8673: b9 61 88    .a.
+    sta l0d3f                                                         ; 8676: 8d 3f 0d    .?.
+    lda #$86                                                          ; 8679: a9 86       ..
+    pha                                                               ; 867b: 48          H
+    lda l8600,y                                                       ; 867c: b9 00 86    ...
+    pha                                                               ; 867f: 48          H
+    rts                                                               ; 8680: 60          `
+
+    !byte <((sub_c868d)-1), <((sub_c8691)-1), <((sub_c86d3)-1)        ; 8681: 8c 90 d2    ...
+    !byte <((sub_c86d3)-1), <((sub_c86d3)-1),     <((c86e3)-1)        ; 8684: d2 d2 e2    ...
+    !byte     <((c86e3)-1), <((sub_c8689)-1)                          ; 8687: e2 88       ..
+
+sub_c8689
+    lda #3                                                            ; 8689: a9 03       ..
+    bne c86d5                                                         ; 868b: d0 48       .H
+sub_c868d
+    lda #3                                                            ; 868d: a9 03       ..
+    bne c8693                                                         ; 868f: d0 02       ..
+sub_c8691
+    lda #2                                                            ; 8691: a9 02       ..
+; $8693 referenced 1 time by $868f
+c8693
+    sta l0d40                                                         ; 8693: 8d 40 0d    .@.
+    clc                                                               ; 8696: 18          .
+    php                                                               ; 8697: 08          .
+    ldy #$0c                                                          ; 8698: a0 0c       ..
+; $869a referenced 1 time by $86a7
+loop_c869a
+    lda l0d1e,y                                                       ; 869a: b9 1e 0d    ...
+    plp                                                               ; 869d: 28          (
+    adc (l00a0),y                                                     ; 869e: 71 a0       q.
+    sta l0d1e,y                                                       ; 86a0: 99 1e 0d    ...
+    iny                                                               ; 86a3: c8          .
+    php                                                               ; 86a4: 08          .
+    cpy #$10                                                          ; 86a5: c0 10       ..
+    bcc loop_c869a                                                    ; 86a7: 90 f1       ..
+    plp                                                               ; 86a9: 28          (
+    bne c86d8                                                         ; 86aa: d0 2c       .,
+; $86ac referenced 1 time by $8668
+c86ac
+    lda l0d20                                                         ; 86ac: ad 20 0d    . .
+    and l0d21                                                         ; 86af: 2d 21 0d    -!.
+    cmp #$ff                                                          ; 86b2: c9 ff       ..
+    bne c86ce                                                         ; 86b4: d0 18       ..
+    lda #$0e                                                          ; 86b6: a9 0e       ..
+    sta l0d3f                                                         ; 86b8: 8d 3f 0d    .?.
+    lda #$40 ; '@'                                                    ; 86bb: a9 40       .@
+    sta l0d3e                                                         ; 86bd: 8d 3e 0d    .>.
+    ldy #4                                                            ; 86c0: a0 04       ..
+; $86c2 referenced 1 time by $86ca
+loop_c86c2
+    lda (l00a0),y                                                     ; 86c2: b1 a0       ..
+    sta l0d22,y                                                       ; 86c4: 99 22 0d    .".
+    iny                                                               ; 86c7: c8          .
+    cpy #$0c                                                          ; 86c8: c0 0c       ..
+    bcc loop_c86c2                                                    ; 86ca: 90 f6       ..
+    bcs c86e3                                                         ; 86cc: b0 15       ..
+; $86ce referenced 1 time by $86b4
+c86ce
+    lda #0                                                            ; 86ce: a9 00       ..
+    sta l0d3e                                                         ; 86d0: 8d 3e 0d    .>.
+sub_c86d3
+    lda #2                                                            ; 86d3: a9 02       ..
+; $86d5 referenced 1 time by $868b
+c86d5
+    sta l0d40                                                         ; 86d5: 8d 40 0d    .@.
+; $86d8 referenced 1 time by $86aa
+c86d8
+    lda l00a0                                                         ; 86d8: a5 a0       ..
+    sta l00a6                                                         ; 86da: 85 a6       ..
+    lda l00a1                                                         ; 86dc: a5 a1       ..
+    sta l00a7                                                         ; 86de: 85 a7       ..
+    jsr sub_c88f2                                                     ; 86e0: 20 f2 88     ..
+; $86e3 referenced 1 time by $86cc
+c86e3
+    plp                                                               ; 86e3: 28          (
+    pla                                                               ; 86e4: 68          h
+    pla                                                               ; 86e5: 68          h
+    pla                                                               ; 86e6: 68          h
+    pla                                                               ; 86e7: 68          h
+    tax                                                               ; 86e8: aa          .
+    rts                                                               ; 86e9: 60          `
+
+    !byte $ac, $41, $0d, $2c, $a0, $fe, $50, $22, $b9, $20, $0d, $8d  ; 86ea: ac 41 0d... .A.
+    !byte $a2, $fe, $c8, $b9, $20, $0d, $c8, $8c, $41, $0d, $8d, $a2  ; 86f6: a2 fe c8... ...
+    !byte $fe, $cc, $3f, $0d, $b0, $1e, $2c, $a0, $fe, $30, $e3, $4c  ; 8702: fe cc 3f... ..?
+    !byte $14, $0d, $a9, $42, $d0,   7, $a9, $67, $8d, $a1, $fe, $a9  ; 870e: 14 0d a9... ...
+    !byte $41, $ac, $18, $fe, $48, $68, $c8, $d0, $fb, $4c, $d6, $88  ; 871a: 41 ac 18... A..
+    !byte $a9, $3f, $8d, $a1, $fe, $a9, $32, $a0, $87, $4c, $0e, $0d  ; 8726: a9 3f 8d... .?.
+    !byte $a9, $82, $8d, $a0, $fe, $2c, $3e, $0d, $50,   3, $4c, $d0  ; 8732: a9 82 8d... ...
+    !byte $88, $a9,   1, $2c, $3e, $0d, $f0,   3, $4c, $78, $88, $a9  ; 873e: 88 a9 01... ...
+    !byte $4e, $4c, $11, $0d, $a9,   1, $2c, $a1, $fe, $f0, $bb, $ad  ; 874a: 4e 4c 11... NL.
+    !byte $a2, $fe, $cd, $18, $fe, $d0, $19, $a9, $62, $4c, $11, $0d  ; 8756: a2 fe cd... ...
+    !byte $2c, $a1, $fe, $10, $0f, $ad, $a2, $fe, $d0, $0a, $a9, $79  ; 8762: 2c a1 fe... ,..
+    !byte $2c, $a0, $fe, $30,   6, $4c, $11, $0d, $4c, $d4, $88, $2c  ; 876e: 2c a0 fe... ,..
+    !byte $a1, $fe, $10, $f8, $ad, $a2, $fe, $cd, $20, $0d, $d0, $f0  ; 877a: a1 fe 10... ...
+    !byte $ad, $a2, $fe, $cd, $21, $0d, $d0, $e8, $a9,   2, $2c, $a1  ; 8786: ad a2 fe... ...
+    !byte $fe, $f0, $e1, $a9, $a7, $8d, $a1, $fe, $a9, $44, $8d, $a0  ; 8792: fe f0 e1... ...
+    !byte $fe, $a9, $78, $a0, $88, $8d, $43, $0d, $8c, $44, $0d, $ad  ; 879e: fe a9 78... ..x
+    !byte $20, $0d, $2c, $a0, $fe, $50, $16, $8d, $a2, $fe, $ad, $21  ; 87aa: 20 0d 2c...  .,
+    !byte $0d, $8d, $a2, $fe, $a9, $c1, $a0, $87, $4c, $0e, $0d, $ad  ; 87b6: 0d 8d a2... ...
+    !byte $18, $fe, $2c, $a0, $fe, $50, $2c, $8d, $a2, $fe, $a9,   0  ; 87c2: 18 fe 2c... ..,
+    !byte $8d, $a2, $fe, $a9,   2, $2c, $3e, $0d, $d0,   7, $a9, $ee  ; 87ce: 8d a2 fe... ...
+    !byte $a0, $87, $4c, $0e, $0d, $a9, $37, $a0, $88, $4c, $0e, $0d  ; 87da: a0 87 4c... ..L
+    !byte $a4, $a3, $f0, $33, $a4, $a2, $f0,   4, $a4, $a2, $f0, $f4  ; 87e6: a4 a3 f0... ...
+    !byte $2c, $a0, $fe, $50, $43, $b1, $a4, $8d, $a2, $fe, $c8, $d0  ; 87f2: 2c a0 fe... ,..
+    !byte   6, $c6, $a3, $f0, $1a, $e6, $a5, $b1, $a4, $8d, $a2, $fe  ; 87fe: 06 c6 a3... ...
+    !byte $c8, $84, $a2, $d0,   6, $c6, $a3, $f0, $0a, $e6, $a5, $2c  ; 880a: c8 84 a2... ...
+    !byte $a0, $fe, $30, $db, $4c, $14, $0d, $a9, $3f, $8d, $a1, $fe  ; 8816: a0 fe 30... ..0
+    !byte $ad, $3e, $0d, $10,   7, $a9, $f5, $a0, $83, $4c, $0e, $0d  ; 8822: ad 3e 0d... .>.
+    !byte $ad, $43, $0d, $ac, $44, $0d, $4c, $0e, $0d, $2c, $a0, $fe  ; 882e: ad 43 0d... .C.
+    !byte $50, $34, $ad, $e5, $fe, $8d, $a2, $fe, $e6, $a2, $d0, $0c  ; 883a: 50 34 ad... P4.
+    !byte $e6, $a3, $d0,   8, $e6, $a4, $d0,   4, $e6, $a5, $f0, $cb  ; 8846: e6 a3 d0... ...
+    !byte $ad, $e5, $fe, $8d, $a2, $fe, $e6, $a2, $d0, $0c, $e6, $a3  ; 8852: ad e5 fe... ...
+    !byte $d0,   8, $e6                                               ; 885e: d0 08 e6    ...
+; $8861 referenced 1 time by $8673
+l8861
+    !byte $a4, $d0,   4, $e6, $a5, $f0, $b5, $2c                      ; 8861: a4 d0 04... ...
+; $8869 referenced 1 time by $866d
+l8869
+    !byte $a0, $fe, $30, $cd, $4c, $14, $0d, $ad, $3e, $0d, $10, $5f  ; 8869: a0 fe 30... ..0
+    !byte $4c, $f5, $83, $a9, $82, $8d, $a0, $fe, $a9, $84, $a0, $88  ; 8875: 4c f5 83... L..
+    !byte $4c, $0e, $0d, $a9,   1, $2c, $a1, $fe, $f0, $49, $ad, $a2  ; 8881: 4c 0e 0d... L..
+    !byte $fe, $cd, $18, $fe, $d0, $41, $a9, $98, $4c, $11, $0d, $2c  ; 888d: fe cd 18... ...
+    !byte $a1, $fe, $10, $37, $ad, $a2, $fe, $d0, $32, $a9, $ac, $2c  ; 8899: a1 fe 10... ...
+    !byte $a0, $fe, $30,   3, $4c, $11, $0d, $2c, $a1, $fe, $10, $23  ; 88a5: a0 fe 30... ..0
+    !byte $ad, $a2, $fe, $cd, $20, $0d, $d0, $1b, $ad, $a2, $fe, $cd  ; 88b1: ad a2 fe... ...
+    !byte $21, $0d, $d0, $13, $ad, $3e, $0d, $10,   3, $4c, $1c, $82  ; 88bd: 21 0d d0... !..
+    !byte $a9,   2, $2c, $a1, $fe, $f0,   4, $a9,   0, $f0,   2, $a9  ; 88c9: a9 02 2c... ..,
+    !byte $41, $a0,   0, $91, $a0, $a9, $80, $8d, $60, $0d, $4c, $f5  ; 88d5: 41 a0 00... A..
+    !byte $83                                                         ; 88e1: 83          .
+    !byte >(l0e81)                                                    ; 88e2: 0e          .
+    !byte >(l0e00)                                                    ; 88e3: 0e          .
+    !byte >(l0a00)                                                    ; 88e4: 0a          .
+    !byte >(l0a00)                                                    ; 88e5: 0a          .
+    !byte >(l0a00)                                                    ; 88e6: 0a          .
+    !byte >(l0601)                                                    ; 88e7: 06          .
+    !byte >(l0601)                                                    ; 88e8: 06          .
+    !byte >(l0a81)                                                    ; 88e9: 0a          .
+    !byte <(l0e81)                                                    ; 88ea: 81          .
+    !byte <(l0e00)                                                    ; 88eb: 00          .
+    !byte <(l0a00)                                                    ; 88ec: 00          .
+    !byte <(l0a00)                                                    ; 88ed: 00          .
+    !byte <(l0a00)                                                    ; 88ee: 00          .
+    !byte <(l0601)                                                    ; 88ef: 01          .
+    !byte <(l0601)                                                    ; 88f0: 01          .
+    !byte <(l0a81)                                                    ; 88f1: 81          .
+
+; $88f2 referenced 1 time by $86e0
+sub_c88f2
+    ldy #7                                                            ; 88f2: a0 07       ..
+    lda (l00a6),y                                                     ; 88f4: b1 a6       ..
+    cmp #$ff                                                          ; 88f6: c9 ff       ..
+    bne c8901                                                         ; 88f8: d0 07       ..
+    dey                                                               ; 88fa: 88          .
+    lda (l00a6),y                                                     ; 88fb: b1 a6       ..
+    cmp #$fe                                                          ; 88fd: c9 fe       ..
+    bcs c8945                                                         ; 88ff: b0 44       .D
+; $8901 referenced 1 time by $88f8
+c8901
+    lda l0d63                                                         ; 8901: ad 63 0d    .c.
+    beq c8945                                                         ; 8904: f0 3f       .?
+    lda l0d3e                                                         ; 8906: ad 3e 0d    .>.
+    ora #2                                                            ; 8909: 09 02       ..
+    sta l0d3e                                                         ; 890b: 8d 3e 0d    .>.
+    sec                                                               ; 890e: 38          8
+    php                                                               ; 890f: 08          .
+    ldy #4                                                            ; 8910: a0 04       ..
+; $8912 referenced 1 time by $8924
+loop_c8912
+    lda (l00a6),y                                                     ; 8912: b1 a6       ..
+    iny                                                               ; 8914: c8          .
+    iny                                                               ; 8915: c8          .
+    iny                                                               ; 8916: c8          .
+    iny                                                               ; 8917: c8          .
+    plp                                                               ; 8918: 28          (
+    sbc (l00a6),y                                                     ; 8919: f1 a6       ..
+    sta l009a,y                                                       ; 891b: 99 9a 00    ...
+    dey                                                               ; 891e: 88          .
+    dey                                                               ; 891f: 88          .
+    dey                                                               ; 8920: 88          .
+    php                                                               ; 8921: 08          .
+    cpy #8                                                            ; 8922: c0 08       ..
+    bcc loop_c8912                                                    ; 8924: 90 ec       ..
+    plp                                                               ; 8926: 28          (
+    txa                                                               ; 8927: 8a          .
+    pha                                                               ; 8928: 48          H
+    lda #4                                                            ; 8929: a9 04       ..
+    clc                                                               ; 892b: 18          .
+    adc l00a6                                                         ; 892c: 65 a6       e.
+    tax                                                               ; 892e: aa          .
+    ldy l00a7                                                         ; 892f: a4 a7       ..
+    lda #$c2                                                          ; 8931: a9 c2       ..
+    jsr c0406                                                         ; 8933: 20 06 04     ..
+    bcc c8942                                                         ; 8936: 90 0a       ..
+    lda l0d40                                                         ; 8938: ad 40 0d    .@.
+    jsr c0406                                                         ; 893b: 20 06 04     ..
+    jsr sub_c8449                                                     ; 893e: 20 49 84     I.
+    sec                                                               ; 8941: 38          8
+; $8942 referenced 1 time by $8936
+c8942
+    pla                                                               ; 8942: 68          h
+    tax                                                               ; 8943: aa          .
+    rts                                                               ; 8944: 60          `
+
+; $8945 referenced 2 times by $88ff, $8904
+c8945
+    ldy #4                                                            ; 8945: a0 04       ..
+    lda (l00a6),y                                                     ; 8947: b1 a6       ..
+    ldy #8                                                            ; 8949: a0 08       ..
+    sec                                                               ; 894b: 38          8
+    sbc (l00a6),y                                                     ; 894c: f1 a6       ..
+    sta l00a2                                                         ; 894e: 85 a2       ..
+    ldy #5                                                            ; 8950: a0 05       ..
+    lda (l00a6),y                                                     ; 8952: b1 a6       ..
+    sbc #0                                                            ; 8954: e9 00       ..
+    sta l00a5                                                         ; 8956: 85 a5       ..
+    ldy #8                                                            ; 8958: a0 08       ..
+    lda (l00a6),y                                                     ; 895a: b1 a6       ..
+    sta l00a4                                                         ; 895c: 85 a4       ..
+    ldy #9                                                            ; 895e: a0 09       ..
+    lda (l00a6),y                                                     ; 8960: b1 a6       ..
+    sec                                                               ; 8962: 38          8
+    sbc l00a5                                                         ; 8963: e5 a5       ..
+    sta l00a3                                                         ; 8965: 85 a3       ..
+    sec                                                               ; 8967: 38          8
+    rts                                                               ; 8968: 60          `
+
+; $8969 referenced 2 times by $8077, $8104
+sub_c8969
+    lda #$c1                                                          ; 8969: a9 c1       ..
+    sta lfea0                                                         ; 896b: 8d a0 fe    ...
+    lda #$1e                                                          ; 896e: a9 1e       ..
+    sta lfea3                                                         ; 8970: 8d a3 fe    ...
+    lda #0                                                            ; 8973: a9 00       ..
+    sta lfea1                                                         ; 8975: 8d a1 fe    ...
+; $8978 referenced 2 times by $83f8, $89a4
+c8978
+    lda #$82                                                          ; 8978: a9 82       ..
+    sta lfea0                                                         ; 897a: 8d a0 fe    ...
+    lda #$67 ; 'g'                                                    ; 897d: a9 67       .g
+    sta lfea1                                                         ; 897f: 8d a1 fe    ...
+    rts                                                               ; 8982: 60          `
+
+sub_c8983
+    bit l0d62                                                         ; 8983: 2c 62 0d    ,b.
+    bpl c89a4                                                         ; 8986: 10 1c       ..
+; $8988 referenced 2 times by $898d, $8994
+c8988
+    lda l0d0c                                                         ; 8988: ad 0c 0d    ...
+    cmp #$be                                                          ; 898b: c9 be       ..
+    bne c8988                                                         ; 898d: d0 f9       ..
+    lda l0d0d                                                         ; 898f: ad 0d 0d    ...
+    eor #$80                                                          ; 8992: 49 80       I.
+    bne c8988                                                         ; 8994: d0 f2       ..
+    bit lfe18                                                         ; 8996: 2c 18 fe    ,..
+    bit lfe18                                                         ; 8999: 2c 18 fe    ,..
+    sta l0d60                                                         ; 899c: 8d 60 0d    .`.
+    sta l0d62                                                         ; 899f: 8d 62 0d    .b.
+    ldy #5                                                            ; 89a2: a0 05       ..
+; $89a4 referenced 1 time by $8986
+c89a4
+l89a6 = c89a4+2
+    jmp c8978                                                         ; 89a4: 4c 78 89    Lx.
+
+; $89a6 referenced 1 time by $8096
+    bit lfe18                                                         ; 89a7: 2c 18 fe    ,..
+    pha                                                               ; 89aa: 48          H
+    tya                                                               ; 89ab: 98          .
+    pha                                                               ; 89ac: 48          H
+    lda #0                                                            ; 89ad: a9 00       ..
+    sta romsel                                                        ; 89af: 8d 30 fe    .0.
+    jmp c80be                                                         ; 89b2: 4c be 80    L..
+
+    sty l0d0d                                                         ; 89b5: 8c 0d 0d    ...
+    sta l0d0c                                                         ; 89b8: 8d 0c 0d    ...
+    lda romsel_copy                                                   ; 89bb: a5 f4       ..
+    sta romsel                                                        ; 89bd: 8d 30 fe    .0.
+    pla                                                               ; 89c0: 68          h
+    tay                                                               ; 89c1: a8          .
+    pla                                                               ; 89c2: 68          h
+    bit video_ula_control                                             ; 89c3: 2c 20 fe    , .
+    rti                                                               ; 89c6: 40          @
+
+    !byte   1,   0, $18                                               ; 89c7: 01 00 18    ...
+; $89ca referenced 1 time by $8e52
+jump_table_low
+    !byte 4                                                           ; 89ca: 04          .
+    !byte <(just_rts-1)                                               ; 89cb: 57          W
+    !byte <(service_handler_claim_absolute_workspace-1)               ; 89cc: a4          .
+    !byte <(service_handler_claim_private_workspace-1)                ; 89cd: b7          .
+    !byte <(sub_c8cca-1)                                              ; 89ce: c9          .
+    !byte <(sub_c8c4e-1)                                              ; 89cf: 4d          M
+    !byte <(sub_c8028-1)                                              ; 89d0: 27          '
+    !byte <(just_rts-1)                                               ; 89d1: 57          W
+    !byte <(sub_c8e92-1)                                              ; 89d2: 91          .
+    !byte <(sub_ca4ee-1)                                              ; 89d3: ed          .
+    !byte <(sub_c8c5d-1)                                              ; 89d4: 5c          \
+    !byte <(just_rts-1)                                               ; 89d5: 57          W
+    !byte <(sub_c8090-1)                                              ; 89d6: 8f          .
+    !byte <(sub_c8983-1)                                              ; 89d7: 82          .
+    !byte <(sub_c8b0d-1)                                              ; 89d8: 0c          .
+    !byte <(sub_c95ce-1)                                              ; 89d9: cd          .
+    !byte <(sub_c9580-1)                                              ; 89da: 7f          .
+    !byte <(sub_cac98-1)                                              ; 89db: 97          .
+    !byte <(sub_c95ae-1)                                              ; 89dc: ad          .
+    !byte <(sub_c95be-1)                                              ; 89dd: bd          .
+    !byte <(sub_c9dc8-1)                                              ; 89de: c7          .
+    !byte <(sub_c9dee-1)                                              ; 89df: ed          .
+    !byte <(ca1c1-1)                                                  ; 89e0: c0          .
+    !byte <(ca114-1)                                                  ; 89e1: 13          .
+    !byte <(ca1c1-1)                                                  ; 89e2: c0          .
+    !byte <(sub_cad80-1)                                              ; 89e3: 7f          .
+    !byte <(sub_c8f99-1)                                              ; 89e4: 98          .
+    !byte <(sub_c92b0-1)                                              ; 89e5: af          .
+    !byte <(sub_caf3e-1)                                              ; 89e6: 3d          =
+    !byte <(sub_ca391-1)                                              ; 89e7: 90          .
+    !byte <(sub_ca39b-1)                                              ; 89e8: 9a          .
+    !byte <(ca2f4-1)                                                  ; 89e9: f3          .
+    !byte <(ca1c1-1)                                                  ; 89ea: c0          .
+    !byte <(sub_ca2fa-1)                                              ; 89eb: f9          .
+    !byte <(sub_ca0e4-1)                                              ; 89ec: e3          .
+    !byte <(sub_ca0ea-1)                                              ; 89ed: e9          .
+    !byte <(sub_ca0fa-1)                                              ; 89ee: f9          .
+; $89ef referenced 1 time by $8e4e
+jump_table_high
+    !byte $d3                                                         ; 89ef: d3          .
+    !byte >(just_rts-1)                                               ; 89f0: 8e          .
+    !byte >(service_handler_claim_absolute_workspace-1)               ; 89f1: 8e          .
+    !byte >(service_handler_claim_private_workspace-1)                ; 89f2: 8e          .
+    !byte >(sub_c8cca-1)                                              ; 89f3: 8c          .
+    !byte >(sub_c8c4e-1)                                              ; 89f4: 8c          .
+    !byte >(sub_c8028-1)                                              ; 89f5: 80          .
+    !byte >(just_rts-1)                                               ; 89f6: 8e          .
+    !byte >(sub_c8e92-1)                                              ; 89f7: 8e          .
+    !byte >(sub_ca4ee-1)                                              ; 89f8: a4          .
+    !byte >(sub_c8c5d-1)                                              ; 89f9: 8c          .
+    !byte >(just_rts-1)                                               ; 89fa: 8e          .
+    !byte >(sub_c8090-1)                                              ; 89fb: 80          .
+    !byte >(sub_c8983-1)                                              ; 89fc: 89          .
+    !byte >(sub_c8b0d-1)                                              ; 89fd: 8b          .
+    !byte >(sub_c95ce-1)                                              ; 89fe: 95          .
+    !byte >(sub_c9580-1)                                              ; 89ff: 95          .
+    !byte >(sub_cac98-1)                                              ; 8a00: ac          .
+    !byte >(sub_c95ae-1)                                              ; 8a01: 95          .
+    !byte >(sub_c95be-1)                                              ; 8a02: 95          .
+    !byte >(sub_c9dc8-1)                                              ; 8a03: 9d          .
+    !byte >(sub_c9dee-1)                                              ; 8a04: 9d          .
+    !byte >(ca1c1-1)                                                  ; 8a05: a1          .
+    !byte >(ca114-1)                                                  ; 8a06: a1          .
+    !byte >(ca1c1-1)                                                  ; 8a07: a1          .
+    !byte >(sub_cad80-1)                                              ; 8a08: ad          .
+    !byte >(sub_c8f99-1)                                              ; 8a09: 8f          .
+    !byte >(sub_c92b0-1)                                              ; 8a0a: 92          .
+    !byte >(sub_caf3e-1)                                              ; 8a0b: af          .
+    !byte >(sub_ca391-1)                                              ; 8a0c: a3          .
+    !byte >(sub_ca39b-1)                                              ; 8a0d: a3          .
+    !byte >(ca2f4-1)                                                  ; 8a0e: a2          .
+    !byte >(ca1c1-1)                                                  ; 8a0f: a1          .
+    !byte >(sub_ca2fa-1)                                              ; 8a10: a2          .
+    !byte >(sub_ca0e4-1)                                              ; 8a11: a0          .
+    !byte >(sub_ca0ea-1)                                              ; 8a12: a0          .
+    !byte >(sub_ca0fa-1)                                              ; 8a13: a0          .
+    !byte $8a                                                         ; 8a14: 8a          .
+
+; $8a15 referenced 1 time by $8003
+service_handler
+    pha                                                               ; 8a15: 48          H
+    cmp #service_vectors_changed                                      ; 8a16: c9 0f       ..
+    bne service_handler_common1                                       ; 8a18: d0 22       ."
+; Extra processing for vectors changed service call
+    tya                                                               ; 8a1a: 98          .
+    pha                                                               ; 8a1b: 48          H
+    lda #osbyte_read_os_version                                       ; 8a1c: a9 00       ..
+    ldx #1                                                            ; 8a1e: a2 01       ..
+    jsr osbyte                                                        ; 8a20: 20 f4 ff     ..
+    cpx #1                                                            ; 8a23: e0 01       ..
+    beq c8a38                                                         ; 8a25: f0 11       ..
+    cpx #2                                                            ; 8a27: e0 02       ..
+    beq c8a38                                                         ; 8a29: f0 0d       ..
+    txa                                                               ; 8a2b: 8a          .
+    php                                                               ; 8a2c: 08          .
+    ldx romsel_copy                                                   ; 8a2d: a6 f4       ..
+    plp                                                               ; 8a2f: 28          (
+    beq c8a33                                                         ; 8a30: f0 01       ..
+    inx                                                               ; 8a32: e8          .
+; $8a33 referenced 1 time by $8a30
+c8a33
+    lda #0                                                            ; 8a33: a9 00       ..
+    sta l02a0,x                                                       ; 8a35: 9d a0 02    ...
+; $8a38 referenced 2 times by $8a25, $8a29
+c8a38
+    ldx romsel_copy                                                   ; 8a38: a6 f4       ..
+    pla                                                               ; 8a3a: 68          h
+    tay                                                               ; 8a3b: a8          .
+; $8a3c referenced 1 time by $8a18
+service_handler_common1
+    pla                                                               ; 8a3c: 68          h
+    jsr service_handler_tube_service_calls                            ; 8a3d: 20 62 be     b.
+    pha                                                               ; 8a40: 48          H
+    cmp #service_claim_absolute_workspace                             ; 8a41: c9 01       ..
+    bne service_handler_common2                                       ; 8a43: d0 15       ..
+; Extra processing for absolute workspace claim service call
+    lda lfea0                                                         ; 8a45: ad a0 fe    ...
+    and #$ed                                                          ; 8a48: 29 ed       ).
+    bne c8a53                                                         ; 8a4a: d0 07       ..
+    lda lfea1                                                         ; 8a4c: ad a1 fe    ...
+    and #$db                                                          ; 8a4f: 29 db       ).
+    beq service_handler_common2                                       ; 8a51: f0 07       ..
+; $8a53 referenced 1 time by $8a4a
+c8a53
+    rol l0df0,x                                                       ; 8a53: 3e f0 0d    >..
+    sec                                                               ; 8a56: 38          8
+    ror l0df0,x                                                       ; 8a57: 7e f0 0d    ~..
+; $8a5a referenced 2 times by $8a43, $8a51
+service_handler_common2
+    lda l0df0,x                                                       ; 8a5a: bd f0 0d    ...
+    asl                                                               ; 8a5d: 0a          .
+    pla                                                               ; 8a5e: 68          h
+    bcc c8a62                                                         ; 8a5f: 90 01       ..
+    rts                                                               ; 8a61: 60          `
+
+; $8a62 referenced 1 time by $8a5f
+c8a62
+    cmp #service_vectors_changed                                      ; 8a62: c9 0f       ..
+    bne service_handler_not_vectors_changed                           ; 8a64: d0 41       .A
+    ldx l0d6a                                                         ; 8a66: ae 6a 0d    .j.
+    bne c8a6f                                                         ; 8a69: d0 04       ..
+    inx                                                               ; 8a6b: e8          .
+    stx l028d                                                         ; 8a6c: 8e 8d 02    ...
+; $8a6f referenced 1 time by $8a69
+c8a6f
+    sta l00ac                                                         ; 8a6f: 85 ac       ..
+; $8a71 referenced 1 time by $8a9a
+c8a71
+    lda #$80                                                          ; 8a71: a9 80       ..
+    sta l00f7                                                         ; 8a73: 85 f7       ..
+    lda #$0c                                                          ; 8a75: a9 0c       ..
+    sta osrdsc_ptr                                                    ; 8a77: 85 f6       ..
+    jsr sub_c8aa0                                                     ; 8a79: 20 a0 8a     ..
+    cmp #$4e ; 'N'                                                    ; 8a7c: c9 4e       .N
+    bne c8a98                                                         ; 8a7e: d0 18       ..
+    jsr sub_c8aa0                                                     ; 8a80: 20 a0 8a     ..
+    cmp #$45 ; 'E'                                                    ; 8a83: c9 45       .E
+    bne c8a98                                                         ; 8a85: d0 11       ..
+    jsr sub_c8aa0                                                     ; 8a87: 20 a0 8a     ..
+    cmp #$54 ; 'T'                                                    ; 8a8a: c9 54       .T
+    bne c8a98                                                         ; 8a8c: d0 0a       ..
+    ldx l00ac                                                         ; 8a8e: a6 ac       ..
+    lda l0df0,x                                                       ; 8a90: bd f0 0d    ...
+    ora #$80                                                          ; 8a93: 09 80       ..
+    sta l0df0,x                                                       ; 8a95: 9d f0 0d    ...
+; $8a98 referenced 3 times by $8a7e, $8a85, $8a8c
+c8a98
+    dec l00ac                                                         ; 8a98: c6 ac       ..
+    bpl c8a71                                                         ; 8a9a: 10 d5       ..
+    lda #$0f                                                          ; 8a9c: a9 0f       ..
+    bne c8ad1                                                         ; 8a9e: d0 31       .1
+; $8aa0 referenced 3 times by $8a79, $8a80, $8a87
+sub_c8aa0
+    inc osrdsc_ptr                                                    ; 8aa0: e6 f6       ..
+    ldy l00ac                                                         ; 8aa2: a4 ac       ..
+    jmp osrdsc                                                        ; 8aa4: 4c b9 ff    L..
+
+; $8aa7 referenced 1 time by $8a64
+service_handler_not_vectors_changed
+    tax                                                               ; 8aa7: aa          .
+    lda l00a9                                                         ; 8aa8: a5 a9       ..
+    pha                                                               ; 8aaa: 48          H
+    txa                                                               ; 8aab: 8a          .
+    sta l00a9                                                         ; 8aac: 85 a9       ..
+; Call dispatch table entry X+1 for service calls 1<=X<&D.
+; Call dispatch table entry &D+1 for service call &12.
+; Don't handle any other service call.
+; (+1 because jump_table_dispatch_x_plus_y adds 1 if Y=0.)
+    cmp #$0d                                                          ; 8aae: c9 0d       ..
+    bcc c8aba                                                         ; 8ab0: 90 08       ..
+    sbc #5                                                            ; 8ab2: e9 05       ..
+    cmp #$0d                                                          ; 8ab4: c9 0d       ..
+    beq c8aba                                                         ; 8ab6: f0 02       ..
+    lda #0                                                            ; 8ab8: a9 00       ..
+; $8aba referenced 2 times by $8ab0, $8ab6
+c8aba
+    tax                                                               ; 8aba: aa          .
+    beq c8acb                                                         ; 8abb: f0 0e       ..
+    lda l00a8                                                         ; 8abd: a5 a8       ..
+    pha                                                               ; 8abf: 48          H
+    sty l00a8                                                         ; 8ac0: 84 a8       ..
+    tya                                                               ; 8ac2: 98          .
+    ldy #0                                                            ; 8ac3: a0 00       ..
+    jsr jump_table_dispatch_x_plus_y                                  ; 8ac5: 20 49 8e     I.
+    pla                                                               ; 8ac8: 68          h
+    sta l00a8                                                         ; 8ac9: 85 a8       ..
+; $8acb referenced 1 time by $8abb
+c8acb
+    ldx l00a9                                                         ; 8acb: a6 a9       ..
+    pla                                                               ; 8acd: 68          h
+    sta l00a9                                                         ; 8ace: 85 a9       ..
+    txa                                                               ; 8ad0: 8a          .
+; $8ad1 referenced 1 time by $8a9e
+c8ad1
+    ldx romsel_copy                                                   ; 8ad1: a6 f4       ..
+    rts                                                               ; 8ad3: 60          `
+
+sub_c8ad4
+    ldy #0                                                            ; 8ad4: a0 00       ..
+    lda (l009c),y                                                     ; 8ad6: b1 9c       ..
+    beq c8afb                                                         ; 8ad8: f0 21       .!
+    lda #0                                                            ; 8ada: a9 00       ..
+    tax                                                               ; 8adc: aa          .
+    sta (l009c),y                                                     ; 8add: 91 9c       ..
+    tay                                                               ; 8adf: a8          .
+    lda #osbyte_read_write_econet_keyboard_disable                    ; 8ae0: a9 c9       ..
+    jsr osbyte                                                        ; 8ae2: 20 f4 ff     ..
+    lda #$0a                                                          ; 8ae5: a9 0a       ..
+    jsr sub_ca9be                                                     ; 8ae7: 20 be a9     ..
+; $8aea referenced 1 time by $959f
+sub_c8aea
+    stx l009e                                                         ; 8aea: 86 9e       ..
+    lda #osbyte_read_write_econet_os_call_interception                ; 8aec: a9 ce       ..
+; $8aee referenced 1 time by $8af9
+loop_c8aee
+    ldx l009e                                                         ; 8aee: a6 9e       ..
+    ldy #$7f                                                          ; 8af0: a0 7f       ..
+    jsr osbyte                                                        ; 8af2: 20 f4 ff     ..
+    adc #1                                                            ; 8af5: 69 01       i.
+    cmp #$d0                                                          ; 8af7: c9 d0       ..
+    beq loop_c8aee                                                    ; 8af9: f0 f3       ..
+; $8afb referenced 1 time by $8ad8
+c8afb
+    lda #0                                                            ; 8afb: a9 00       ..
+    sta l00a9                                                         ; 8afd: 85 a9       ..
+    sta l009e                                                         ; 8aff: 85 9e       ..
+    rts                                                               ; 8b01: 60          `
+
+; $8b02 referenced 3 times by $8c52, $8c7d, $a2bf
+sub_c8b02
+    pha                                                               ; 8b02: 48          H
+    lda os_text_ptr                                                   ; 8b03: a5 f2       ..
+    sta l00be                                                         ; 8b05: 85 be       ..
+    lda l00f3                                                         ; 8b07: a5 f3       ..
+    sta l00bf                                                         ; 8b09: 85 bf       ..
+    pla                                                               ; 8b0b: 68          h
+; $8b0c referenced 2 times by $8b0f, $8b18
+c8b0c
+    rts                                                               ; 8b0c: 60          `
+
+sub_c8b0d
+    cpy #5                                                            ; 8b0d: c0 05       ..
+    bne c8b0c                                                         ; 8b0f: d0 fb       ..
+    lda #0                                                            ; 8b11: a9 00       ..
+    sta l00a9                                                         ; 8b13: 85 a9       ..
+    bit l0d6c                                                         ; 8b15: 2c 6c 0d    ,l.
+    bmi c8b0c                                                         ; 8b18: 30 f2       0.
+; $8b1a referenced 1 time by $8ce0
+sub_c8b1a
+    jsr sub_c8cb9                                                     ; 8b1a: 20 b9 8c     ..
+    sta l00b1                                                         ; 8b1d: 85 b1       ..
+    lda #0                                                            ; 8b1f: a9 00       ..
+    sta l00b0                                                         ; 8b21: 85 b0       ..
+    clc                                                               ; 8b23: 18          .
+    ldy #$76 ; 'v'                                                    ; 8b24: a0 76       .v
+; $8b26 referenced 1 time by $8b29
+loop_c8b26
+    adc (l00b0),y                                                     ; 8b26: 71 b0       q.
+    dey                                                               ; 8b28: 88          .
+    bpl loop_c8b26                                                    ; 8b29: 10 fb       ..
+    ldy #$77 ; 'w'                                                    ; 8b2b: a0 77       .w
+    eor (l00b0),y                                                     ; 8b2d: 51 b0       Q.
+    beq c8b34                                                         ; 8b2f: f0 03       ..
+    jmp c8fe4                                                         ; 8b31: 4c e4 8f    L..
+
+; $8b34 referenced 1 time by $8b2f
+c8b34
+    jsr sub_c8cfc                                                     ; 8b34: 20 fc 8c     ..
+    ldy #9                                                            ; 8b37: a0 09       ..
+; $8b39 referenced 1 time by $8b41
+loop_c8b39
+    lda (l009c),y                                                     ; 8b39: b1 9c       ..
+    sta l0dfe,y                                                       ; 8b3b: 99 fe 0d    ...
+    dey                                                               ; 8b3e: 88          .
+    cpy #1                                                            ; 8b3f: c0 01       ..
+    bne loop_c8b39                                                    ; 8b41: d0 f6       ..
+    rol l0d6c                                                         ; 8b43: 2e 6c 0d    .l.
+    clc                                                               ; 8b46: 18          .
+    ror l0d6c                                                         ; 8b47: 6e 6c 0d    nl.
+    ldy #$0d                                                          ; 8b4a: a0 0d       ..
+; $8b4c referenced 1 time by $8b53
+loop_c8b4c
+    lda l8e61,y                                                       ; 8b4c: b9 61 8e    .a.
+    sta filev,y                                                       ; 8b4f: 99 12 02    ...
+    dey                                                               ; 8b52: 88          .
+    bpl loop_c8b4c                                                    ; 8b53: 10 f7       ..
+    jsr sub_c8f5d                                                     ; 8b55: 20 5d 8f     ].
+    ldy #$1b                                                          ; 8b58: a0 1b       ..
+    ldx #7                                                            ; 8b5a: a2 07       ..
+    jsr c8f70                                                         ; 8b5c: 20 70 8f     p.
+    lda #0                                                            ; 8b5f: a9 00       ..
+    sta l0e07                                                         ; 8b61: 8d 07 0e    ...
+    sta l10c9                                                         ; 8b64: 8d c9 10    ...
+    sta l1071                                                         ; 8b67: 8d 71 10    .q.
+    sta l00a9                                                         ; 8b6a: 85 a9       ..
+    jsr sub_cb98f                                                     ; 8b6c: 20 8f b9     ..
+    sta l0e08                                                         ; 8b6f: 8d 08 0e    ...
+    jsr sub_c8cc0                                                     ; 8b72: 20 c0 8c     ..
+    jsr sub_cb449                                                     ; 8b75: 20 49 b4     I.
+    ldy #$77 ; 'w'                                                    ; 8b78: a0 77       .w
+; $8b7a referenced 1 time by $8b80
+loop_c8b7a
+    lda (l00cc),y                                                     ; 8b7a: b1 cc       ..
+    sta l1000,y                                                       ; 8b7c: 99 00 10    ...
+    dey                                                               ; 8b7f: 88          .
+    bpl loop_c8b7a                                                    ; 8b80: 10 f8       ..
+    lda #$80                                                          ; 8b82: a9 80       ..
+    ora l0d6c                                                         ; 8b84: 0d 6c 0d    .l.
+    sta l0d6c                                                         ; 8b87: 8d 6c 0d    .l.
+    jmp c8d08                                                         ; 8b8a: 4c 08 8d    L..
+
+; $8b8d referenced 1 time by $8c7a
+c8b8d
+    ldx #$4a ; 'J'                                                    ; 8b8d: a2 4a       .J
+    jsr c8b98                                                         ; 8b8f: 20 98 8b     ..
+sub_c8b92
+    ldx #0                                                            ; 8b92: a2 00       ..
+    beq c8b98                                                         ; 8b94: f0 02       ..
+sub_c8b96
+    ldx #$4a ; 'J'                                                    ; 8b96: a2 4a       .J
+; $8b98 referenced 2 times by $8b8f, $8b94
+c8b98
+    bvc c8ba8                                                         ; 8b98: 50 0e       P.
+    txa                                                               ; 8b9a: 8a          .
+    pha                                                               ; 8b9b: 48          H
+    tya                                                               ; 8b9c: 98          .
+    pha                                                               ; 8b9d: 48          H
+    jsr sub_c8c9f                                                     ; 8b9e: 20 9f 8c     ..
+    pla                                                               ; 8ba1: 68          h
+    tay                                                               ; 8ba2: a8          .
+    pla                                                               ; 8ba3: 68          h
+    tax                                                               ; 8ba4: aa          .
+    clv                                                               ; 8ba5: b8          .
+    bvc c8bab                                                         ; 8ba6: 50 03       P.
+; $8ba8 referenced 1 time by $8b98
+c8ba8
+    jsr osnewl                                                        ; 8ba8: 20 e7 ff     ..
+; $8bab referenced 2 times by $8ba6, $8c6d
+c8bab
+    tya                                                               ; 8bab: 98          .
+    pha                                                               ; 8bac: 48          H
+    php                                                               ; 8bad: 08          .
+; $8bae referenced 1 time by $8c2c
+c8bae
+    lda la3f0,x                                                       ; 8bae: bd f0 a3    ...
+    bpl c8bb6                                                         ; 8bb1: 10 03       ..
+    jmp c8c2f                                                         ; 8bb3: 4c 2f 8c    L/.
+
+; $8bb6 referenced 1 time by $8bb1
+c8bb6
+    jsr print_inline_top_bit_clear                                    ; 8bb6: 20 45 91     E.
+    !text "  "                                                        ; 8bb9: 20 20
+
+    ldy #9                                                            ; 8bbb: a0 09       ..
+    lda la3f0,x                                                       ; 8bbd: bd f0 a3    ...
+; $8bc0 referenced 1 time by $8bc8
+loop_c8bc0
+    jsr osasci                                                        ; 8bc0: 20 e3 ff     ..
+    inx                                                               ; 8bc3: e8          .
+    dey                                                               ; 8bc4: 88          .
+    lda la3f0,x                                                       ; 8bc5: bd f0 a3    ...
+    bpl loop_c8bc0                                                    ; 8bc8: 10 f6       ..
+; $8bca referenced 1 time by $8bd0
+loop_c8bca
+    lda #$20 ; ' '                                                    ; 8bca: a9 20       .
+    jsr osasci                                                        ; 8bcc: 20 e3 ff     ..
+    dey                                                               ; 8bcf: 88          .
+    bpl loop_c8bca                                                    ; 8bd0: 10 f8       ..
+    lda la3f0,x                                                       ; 8bd2: bd f0 a3    ...
+    and #$1f                                                          ; 8bd5: 29 1f       ).
+    cmp #$0e                                                          ; 8bd7: c9 0e       ..
+    beq c8bf6                                                         ; 8bd9: f0 1b       ..
+    tay                                                               ; 8bdb: a8          .
+    lda l9122,y                                                       ; 8bdc: b9 22 91    .".
+    tay                                                               ; 8bdf: a8          .
+; $8be0 referenced 2 times by $8bed, $8bf3
+c8be0
+    iny                                                               ; 8be0: c8          .
+    lda l9022,y                                                       ; 8be1: b9 22 90    .".
+    beq c8c26                                                         ; 8be4: f0 40       .@
+    cmp #$0d                                                          ; 8be6: c9 0d       ..
+    bne c8bf0                                                         ; 8be8: d0 06       ..
+    jsr sub_c8c33                                                     ; 8bea: 20 33 8c     3.
+    jmp c8be0                                                         ; 8bed: 4c e0 8b    L..
+
+; $8bf0 referenced 1 time by $8be8
+c8bf0
+    jsr osasci                                                        ; 8bf0: 20 e3 ff     ..
+    jmp c8be0                                                         ; 8bf3: 4c e0 8b    L..
+
+; $8bf6 referenced 1 time by $8bd9
+c8bf6
+    txa                                                               ; 8bf6: 8a          .
+    pha                                                               ; 8bf7: 48          H
+    jsr print_inline_top_bit_clear                                    ; 8bf8: 20 45 91     E.
+    !text "("                                                         ; 8bfb: 28          (
+
+    ldy #0                                                            ; 8bfc: a0 00       ..
+    ldx #$d3                                                          ; 8bfe: a2 d3       ..
+; $8c00 referenced 1 time by $8c22
+c8c00
+    lda la3f0,x                                                       ; 8c00: bd f0 a3    ...
+    bmi c8c24                                                         ; 8c03: 30 1f       0.
+    dex                                                               ; 8c05: ca          .
+; $8c06 referenced 1 time by $8c0f
+loop_c8c06
+    inx                                                               ; 8c06: e8          .
+    lda la3f0,x                                                       ; 8c07: bd f0 a3    ...
+    bmi c8c12                                                         ; 8c0a: 30 06       0.
+    jsr osasci                                                        ; 8c0c: 20 e3 ff     ..
+    jmp loop_c8c06                                                    ; 8c0f: 4c 06 8c    L..
+
+; $8c12 referenced 1 time by $8c0a
+c8c12
+    and #$7f                                                          ; 8c12: 29 7f       ).
+    jsr osasci                                                        ; 8c14: 20 e3 ff     ..
+    iny                                                               ; 8c17: c8          .
+    cpy #4                                                            ; 8c18: c0 04       ..
+    bne c8c1f                                                         ; 8c1a: d0 03       ..
+    jsr sub_c8c33                                                     ; 8c1c: 20 33 8c     3.
+; $8c1f referenced 1 time by $8c1a
+c8c1f
+    inx                                                               ; 8c1f: e8          .
+    inx                                                               ; 8c20: e8          .
+    inx                                                               ; 8c21: e8          .
+    bne c8c00                                                         ; 8c22: d0 dc       ..
+; $8c24 referenced 1 time by $8c03
+c8c24
+    pla                                                               ; 8c24: 68          h
+    tax                                                               ; 8c25: aa          .
+; $8c26 referenced 1 time by $8be4
+c8c26
+    jsr osnewl                                                        ; 8c26: 20 e7 ff     ..
+    inx                                                               ; 8c29: e8          .
+    inx                                                               ; 8c2a: e8          .
+    inx                                                               ; 8c2b: e8          .
+    jmp c8bae                                                         ; 8c2c: 4c ae 8b    L..
+
+; $8c2f referenced 1 time by $8bb3
+c8c2f
+    plp                                                               ; 8c2f: 28          (
+    pla                                                               ; 8c30: 68          h
+    tay                                                               ; 8c31: a8          .
+    rts                                                               ; 8c32: 60          `
+
+; $8c33 referenced 2 times by $8bea, $8c1c
+sub_c8c33
+    lda l0355                                                         ; 8c33: ad 55 03    .U.
+    beq c8c4d                                                         ; 8c36: f0 15       ..
+    cmp #3                                                            ; 8c38: c9 03       ..
+    beq c8c4d                                                         ; 8c3a: f0 11       ..
+    tya                                                               ; 8c3c: 98          .
+    pha                                                               ; 8c3d: 48          H
+    jsr osnewl                                                        ; 8c3e: 20 e7 ff     ..
+    ldy #$0b                                                          ; 8c41: a0 0b       ..
+    lda #$20 ; ' '                                                    ; 8c43: a9 20       .
+; $8c45 referenced 1 time by $8c49
+loop_c8c45
+    jsr osasci                                                        ; 8c45: 20 e3 ff     ..
+    dey                                                               ; 8c48: 88          .
+    bpl loop_c8c45                                                    ; 8c49: 10 fa       ..
+    pla                                                               ; 8c4b: 68          h
+    tay                                                               ; 8c4c: a8          .
+; $8c4d referenced 2 times by $8c36, $8c3a
+c8c4d
+    rts                                                               ; 8c4d: 60          `
+
+sub_c8c4e
+    ldx #0                                                            ; 8c4e: a2 00       ..
+    ldy l00a8                                                         ; 8c50: a4 a8       ..
+    jsr sub_c8b02                                                     ; 8c52: 20 02 8b     ..
+    jsr sub_ca140                                                     ; 8c55: 20 40 a1     @.
+    bcs c8c70                                                         ; 8c58: b0 16       ..
+    jmp ca125                                                         ; 8c5a: 4c 25 a1    L%.
+
+sub_c8c5d
+    jsr sub_c8d17                                                     ; 8c5d: 20 17 8d     ..
+    ldy l00a8                                                         ; 8c60: a4 a8       ..
+    lda (os_text_ptr),y                                               ; 8c62: b1 f2       ..
+    cmp #$0d                                                          ; 8c64: c9 0d       ..
+    bne c8c73                                                         ; 8c66: d0 0b       ..
+    jsr sub_c8c9f                                                     ; 8c68: 20 9f 8c     ..
+    ldx #$c4                                                          ; 8c6b: a2 c4       ..
+    jsr c8bab                                                         ; 8c6d: 20 ab 8b     ..
+; $8c70 referenced 3 times by $8c58, $8c9d, $8cd8
+c8c70
+    ldy l00a8                                                         ; 8c70: a4 a8       ..
+    rts                                                               ; 8c72: 60          `
+
+; $8c73 referenced 1 time by $8c66
+c8c73
+    bit l9491                                                         ; 8c73: 2c 91 94    ,..
+    cmp #$2e ; '.'                                                    ; 8c76: c9 2e       ..
+    bne c8c7d                                                         ; 8c78: d0 03       ..
+    jmp c8b8d                                                         ; 8c7a: 4c 8d 8b    L..
+
+; $8c7d referenced 1 time by $8c78
+c8c7d
+    jsr sub_c8b02                                                     ; 8c7d: 20 02 8b     ..
+; $8c80 referenced 1 time by $8c9b
+loop_c8c80
+    php                                                               ; 8c80: 08          .
+    ldx #$c4                                                          ; 8c81: a2 c4       ..
+    jsr sub_ca140                                                     ; 8c83: 20 40 a1     @.
+    bcs c8c98                                                         ; 8c86: b0 10       ..
+    plp                                                               ; 8c88: 28          (
+    lda #$8c                                                          ; 8c89: a9 8c       ..
+    pha                                                               ; 8c8b: 48          H
+    lda #$7f                                                          ; 8c8c: a9 7f       ..
+    pha                                                               ; 8c8e: 48          H
+    lda la3f2,x                                                       ; 8c8f: bd f2 a3    ...
+    pha                                                               ; 8c92: 48          H
+    lda la3f1,x                                                       ; 8c93: bd f1 a3    ...
+    pha                                                               ; 8c96: 48          H
+    rts                                                               ; 8c97: 60          `
+
+; $8c98 referenced 1 time by $8c86
+c8c98
+    plp                                                               ; 8c98: 28          (
+    cmp #$0d                                                          ; 8c99: c9 0d       ..
+    bne loop_c8c80                                                    ; 8c9b: d0 e3       ..
+    beq c8c70                                                         ; 8c9d: f0 d1       ..
+; $8c9f referenced 2 times by $8b9e, $8c68
+sub_c8c9f
+    jsr print_inline_top_bit_clear                                    ; 8c9f: 20 45 91     E.
+    !text $0d, "Advanced NFS 4.18", $0d                               ; 8ca2: 0d 41 64... .Ad
+
+    nop                                                               ; 8cb5: ea          .
+    jmp c8ff1                                                         ; 8cb6: 4c f1 8f    L..
+
+; $8cb9 referenced 4 times by $8b1a, $8cc0, $8f87, $afe2
+sub_c8cb9
+    ldy romsel_copy                                                   ; 8cb9: a4 f4       ..
+    lda l0df0,y                                                       ; 8cbb: b9 f0 0d    ...
+    tay                                                               ; 8cbe: a8          .
+    rts                                                               ; 8cbf: 60          `
+
+; $8cc0 referenced 2 times by $8b72, $8ee7
+sub_c8cc0
+    jsr sub_c8cb9                                                     ; 8cc0: 20 b9 8c     ..
+    sty l00cd                                                         ; 8cc3: 84 cd       ..
+    lda #0                                                            ; 8cc5: a9 00       ..
+    sta l00cc                                                         ; 8cc7: 85 cc       ..
+; $8cc9 referenced 1 time by $8ceb
+c8cc9
+    rts                                                               ; 8cc9: 60          `
+
+sub_c8cca
+    lda #osbyte_scan_keyboard_from_16                                 ; 8cca: a9 7a       .z
+    jsr osbyte                                                        ; 8ccc: 20 f4 ff     ..
+    txa                                                               ; 8ccf: 8a          .
+    bmi c8ce0                                                         ; 8cd0: 30 0e       0.
+    cmp #$19                                                          ; 8cd2: c9 19       ..
+    beq c8cda                                                         ; 8cd4: f0 04       ..
+    eor #$55 ; 'U'                                                    ; 8cd6: 49 55       IU
+    bne c8c70                                                         ; 8cd8: d0 96       ..
+; $8cda referenced 1 time by $8cd4
+c8cda
+    tay                                                               ; 8cda: a8          .
+    lda #osbyte_write_keys_pressed                                    ; 8cdb: a9 78       .x
+    jsr osbyte                                                        ; 8cdd: 20 f4 ff     ..
+; $8ce0 referenced 1 time by $8cd0
+c8ce0
+    jsr sub_c8b1a                                                     ; 8ce0: 20 1a 8b     ..
+    jsr c8ff1                                                         ; 8ce3: 20 f1 8f     ..
+    jsr osnewl                                                        ; 8ce6: 20 e7 ff     ..
+    ldx l00a8                                                         ; 8ce9: a6 a8       ..
+    bne c8cc9                                                         ; 8ceb: d0 dc       ..
+    lda l1071                                                         ; 8ced: ad 71 10    .q.
+    ora #4                                                            ; 8cf0: 09 04       ..
+    sta l1071                                                         ; 8cf2: 8d 71 10    .q.
+    ldx #$0f                                                          ; 8cf5: a2 0f       ..
+    ldy #$8d                                                          ; 8cf7: a0 8d       ..
+    jmp ca114                                                         ; 8cf9: 4c 14 a1    L..
+
+; $8cfc referenced 1 time by $8b34
+sub_c8cfc
+    lda #6                                                            ; 8cfc: a9 06       ..
+    jsr sub_c8d05                                                     ; 8cfe: 20 05 8d     ..
+    ldx #$0a                                                          ; 8d01: a2 0a       ..
+    bne c8d0a                                                         ; 8d03: d0 05       ..
+; $8d05 referenced 1 time by $8cfe
+sub_c8d05
+    jmp (fscv)                                                        ; 8d05: 6c 1e 02    l..
+
+; $8d08 referenced 1 time by $8b8a
+c8d08
+    ldx #$0f                                                          ; 8d08: a2 0f       ..
+; $8d0a referenced 1 time by $8d03
+c8d0a
+    lda #osbyte_issue_service_request                                 ; 8d0a: a9 8f       ..
+    jmp osbyte                                                        ; 8d0c: 4c f4 ff    L..
+
+    !text "i .boot"                                                   ; 8d0f: 69 20 2e... i .
+    !byte $0d                                                         ; 8d16: 0d          .
+
+; $8d17 referenced 1 time by $8c5d
+sub_c8d17
+    ldy l00a8                                                         ; 8d17: a4 a8       ..
+    ldx #5                                                            ; 8d19: a2 05       ..
+; $8d1b referenced 1 time by $8d24
+loop_c8d1b
+    lda (os_text_ptr),y                                               ; 8d1b: b1 f2       ..
+    cmp l8d38,x                                                       ; 8d1d: dd 38 8d    .8.
+    bne c8d26                                                         ; 8d20: d0 04       ..
+    iny                                                               ; 8d22: c8          .
+    inx                                                               ; 8d23: e8          .
+    bne loop_c8d1b                                                    ; 8d24: d0 f5       ..
+; $8d26 referenced 1 time by $8d20
+c8d26
+    cpx #$0d                                                          ; 8d26: e0 0d       ..
+    bne c8d37                                                         ; 8d28: d0 0d       ..
+    ldx #0                                                            ; 8d2a: a2 00       ..
+; $8d2c referenced 1 time by $8d35
+loop_c8d2c
+    lda l8d38,x                                                       ; 8d2c: bd 38 8d    .8.
+    beq c8d37                                                         ; 8d2f: f0 06       ..
+    jsr osasci                                                        ; 8d31: 20 e3 ff     ..
+    inx                                                               ; 8d34: e8          .
+    bne loop_c8d2c                                                    ; 8d35: d0 f5       ..
+; $8d37 referenced 2 times by $8d28, $8d2f
+c8d37
+    rts                                                               ; 8d37: 60          `
+
+; $8d38 referenced 2 times by $8d1d, $8d2c
+l8d38
+    !byte $0d                                                         ; 8d38: 0d          .
+    !text "The authors of ANFS are;"                                  ; 8d39: 54 68 65... The
+    !byte $0d                                                         ; 8d51: 0d          .
+    !text "B Cockburn"                                                ; 8d52: 42 20 43... B C
+    !byte $0d                                                         ; 8d5c: 0d          .
+    !text "J Du"                                                      ; 8d5d: 4a 20 44... J D
+; $8d61 referenced 1 time by $b01b
+l8d61
+    !byte $6e, $6e, $0d                                               ; 8d61: 6e 6e 0d    nn.
+    !text "B Robertson"                                               ; 8d64: 42 20 52... B R
+    !byte $0d                                                         ; 8d6f: 0d          .
+    !text "J Wills"                                                   ; 8d70: 4a 20 57... J W
+    !byte $0d,   0                                                    ; 8d77: 0d 00       ..
+
+sub_c8d79
+    tya                                                               ; 8d79: 98          .
+    pha                                                               ; 8d7a: 48          H
+    lda #osbyte_close_spool_exec                                      ; 8d7b: a9 77       .w
+    sta l0e07                                                         ; 8d7d: 8d 07 0e    ...
+    jsr osbyte                                                        ; 8d80: 20 f4 ff     ..
+    ldy #0                                                            ; 8d83: a0 00       ..
+    sty l00b4                                                         ; 8d85: 84 b4       ..
+    jsr sub_cb799                                                     ; 8d87: 20 99 b7     ..
+    lda #0                                                            ; 8d8a: a9 00       ..
+    sta l0e07                                                         ; 8d8c: 8d 07 0e    ...
+    pla                                                               ; 8d8f: 68          h
+    tay                                                               ; 8d90: a8          .
+    lda (l00bb),y                                                     ; 8d91: b1 bb       ..
+    jsr sub_c9258                                                     ; 8d93: 20 58 92     X.
+    bcc c8dbc                                                         ; 8d96: 90 24       .$
+    jsr sub_c916e                                                     ; 8d98: 20 6e 91     n.
+    bcs c8da7                                                         ; 8d9b: b0 0a       ..
+    sta l0e01                                                         ; 8d9d: 8d 01 0e    ...
+    jsr sub_c8e09                                                     ; 8da0: 20 09 8e     ..
+    iny                                                               ; 8da3: c8          .
+    jsr sub_c916e                                                     ; 8da4: 20 6e 91     n.
+; $8da7 referenced 1 time by $8d9b
+c8da7
+    beq c8dbc                                                         ; 8da7: f0 13       ..
+    sta l0e00                                                         ; 8da9: 8d 00 0e    ...
+    ldx #$ff                                                          ; 8dac: a2 ff       ..
+; $8dae referenced 1 time by $8db5
+loop_c8dae
+    inx                                                               ; 8dae: e8          .
+    lda la477,x                                                       ; 8daf: bd 77 a4    .w.
+    sta l0f05,x                                                       ; 8db2: 9d 05 0f    ...
+    bpl loop_c8dae                                                    ; 8db5: 10 f7       ..
+    jsr sub_caf06                                                     ; 8db7: 20 06 af     ..
+    beq c8dbf                                                         ; 8dba: f0 03       ..
+; $8dbc referenced 2 times by $8d96, $8da7
+c8dbc
+    jsr sub_caf02                                                     ; 8dbc: 20 02 af     ..
+; $8dbf referenced 1 time by $8dba
+c8dbf
+    ldy #$ff                                                          ; 8dbf: a0 ff       ..
+; $8dc1 referenced 1 time by $8dcb
+loop_c8dc1
+    iny                                                               ; 8dc1: c8          .
+    lda l0f05,y                                                       ; 8dc2: b9 05 0f    ...
+    cmp #$0d                                                          ; 8dc5: c9 0d       ..
+    beq c8dfa                                                         ; 8dc7: f0 31       .1
+    cmp #$3a ; ':'                                                    ; 8dc9: c9 3a       .:
+    bne loop_c8dc1                                                    ; 8dcb: d0 f4       ..
+    jsr oswrch                                                        ; 8dcd: 20 ee ff     ..
+    sty l00b4                                                         ; 8dd0: 84 b4       ..
+; $8dd2 referenced 4 times by $8de2, $8de6, $8de9, $8df5
+c8dd2
+    lda #$ff                                                          ; 8dd2: a9 ff       ..
+    sta l0098                                                         ; 8dd4: 85 98       ..
+    jsr sub_c9570                                                     ; 8dd6: 20 70 95     p.
+    jsr osrdch                                                        ; 8dd9: 20 e0 ff     ..
+    cmp #$15                                                          ; 8ddc: c9 15       ..
+    bne c8deb                                                         ; 8dde: d0 0b       ..
+    ldy l00b4                                                         ; 8de0: a4 b4       ..
+    bne c8dd2                                                         ; 8de2: d0 ee       ..
+; $8de4 referenced 1 time by $8ded
+loop_c8de4
+    cpy l00b4                                                         ; 8de4: c4 b4       ..
+    beq c8dd2                                                         ; 8de6: f0 ea       ..
+    dey                                                               ; 8de8: 88          .
+    bne c8dd2                                                         ; 8de9: d0 e7       ..
+; $8deb referenced 1 time by $8dde
+c8deb
+    cmp #$7f                                                          ; 8deb: c9 7f       ..
+    beq loop_c8de4                                                    ; 8ded: f0 f5       ..
+    sta l0f05,y                                                       ; 8def: 99 05 0f    ...
+    iny                                                               ; 8df2: c8          .
+    cmp #$0d                                                          ; 8df3: c9 0d       ..
+    bne c8dd2                                                         ; 8df5: d0 db       ..
+    jsr osnewl                                                        ; 8df7: 20 e7 ff     ..
+; $8dfa referenced 1 time by $8dc7
+c8dfa
+    tya                                                               ; 8dfa: 98          .
+    pha                                                               ; 8dfb: 48          H
+    jsr sub_c9473                                                     ; 8dfc: 20 73 94     s.
+    jsr sub_c9894                                                     ; 8dff: 20 94 98     ..
+    pla                                                               ; 8e02: 68          h
+    tax                                                               ; 8e03: aa          .
+    inx                                                               ; 8e04: e8          .
+    ldy #0                                                            ; 8e05: a0 00       ..
+    beq c8e24                                                         ; 8e07: f0 1b       ..
+; $8e09 referenced 1 time by $8da0
+sub_c8e09
+    jsr sub_ca865                                                     ; 8e09: 20 65 a8     e.
+    eor l0e01                                                         ; 8e0c: 4d 01 0e    M..
+    bne c8e14                                                         ; 8e0f: d0 03       ..
+    sta l0e01                                                         ; 8e11: 8d 01 0e    ...
+; $8e14 referenced 1 time by $8e0f
+c8e14
+    rts                                                               ; 8e14: 60          `
+
+; $8e15 referenced 1 time by $9462
+c8e15
+    ldy #0                                                            ; 8e15: a0 00       ..
+    lda (l00be),y                                                     ; 8e17: b1 be       ..
+    cmp #$26 ; '&'                                                    ; 8e19: c9 26       .&
+    bne c8e20                                                         ; 8e1b: d0 03       ..
+    jmp ca1c1                                                         ; 8e1d: 4c c1 a1    L..
+
+; $8e20 referenced 1 time by $8e1b
+c8e20
+    jsr sub_caf02                                                     ; 8e20: 20 02 af     ..
+    tay                                                               ; 8e23: a8          .
+; $8e24 referenced 2 times by $8e07, $9324
+c8e24
+    jsr c94ad                                                         ; 8e24: 20 ad 94     ..
+    ldx l0f03                                                         ; 8e27: ae 03 0f    ...
+    beq just_rts                                                      ; 8e2a: f0 2c       .,
+    lda l0f05                                                         ; 8e2c: ad 05 0f    ...
+    ldy #$17                                                          ; 8e2f: a0 17       ..
+    bne jump_table_dispatch_x_plus_y                                  ; 8e31: d0 16       ..
+    jsr sub_c9295                                                     ; 8e33: 20 95 92     ..
+    cmp #8                                                            ; 8e36: c9 08       ..
+    bcs just_rts                                                      ; 8e38: b0 1e       ..
+    tax                                                               ; 8e3a: aa          .
+    jsr sub_caf32                                                     ; 8e3b: 20 32 af     2.
+    tya                                                               ; 8e3e: 98          .
+    ldy #$13                                                          ; 8e3f: a0 13       ..
+    bne jump_table_dispatch_x_plus_y                                  ; 8e41: d0 06       ..
+    cpx #5                                                            ; 8e43: e0 05       ..
+    bcs just_rts                                                      ; 8e45: b0 11       ..
+    ldy #$0e                                                          ; 8e47: a0 0e       ..
+; Note that if Y=0, this will add 1 instead of 0.
+; $8e49 referenced 5 times by $8ac5, $8e31, $8e41, $8e4b, $8ea2
+jump_table_dispatch_x_plus_y
+    inx                                                               ; 8e49: e8          .
+    dey                                                               ; 8e4a: 88          .
+    bpl jump_table_dispatch_x_plus_y                                  ; 8e4b: 10 fc       ..
+    tay                                                               ; 8e4d: a8          .
+    lda jump_table_high,x                                             ; 8e4e: bd ef 89    ...
+    pha                                                               ; 8e51: 48          H
+sub_c8e52
+l8e54 = sub_c8e52+2
+    lda jump_table_low,x                                              ; 8e52: bd ca 89    ...
+; $8e54 referenced 2 times by $8f70, $8f76
+    pha                                                               ; 8e55: 48          H
+    ldx l00bb                                                         ; 8e56: a6 bb       ..
+; $8e58 referenced 3 times by $8e2a, $8e38, $8e45
+just_rts
+    rts                                                               ; 8e58: 60          `
+
+    !text "PRINT "                                                    ; 8e59: 50 52 49... PRI
+    !byte 1, 0                                                        ; 8e5f: 01 00       ..
+; $8e61 referenced 1 time by $8b4c
+l8e61
+    !byte $1b, $ff, $1e, $ff, $21, $ff, $24, $ff, $27, $ff, $2a, $ff  ; 8e61: 1b ff 1e... ...
+    !byte $2d, $ff, $35, $99, $4a, $be, $9b, $44, $ce, $b7, $57, $4d  ; 8e6d: 2d ff 35... -.5
+    !byte $b8, $42, $2f, $9e, $41, $4e, $9d, $52, $33, $8e            ; 8e79: b8 42 2f... .B/
+
+; $8e83 referenced 3 times by $8081, $8f62, $970e
+sub_c8e83
+    ldx #0                                                            ; 8e83: a2 00       ..
+; $8e85 referenced 1 time by $808b
+sub_c8e85
+    ldy #$ff                                                          ; 8e85: a0 ff       ..
+; $8e87 referenced 1 time by $8e90
+loop_c8e87
+    jmp osbyte                                                        ; 8e87: 4c f4 ff    L..
+
+    !byte $7a, $a9                                                    ; 8e8a: 7a a9       z.
+
+; $8e8c referenced 1 time by $9722
+sub_c8e8c
+    ldx #0                                                            ; 8e8c: a2 00       ..
+    ldy #0                                                            ; 8e8e: a0 00       ..
+    beq loop_c8e87                                                    ; 8e90: f0 f5       ..
+sub_c8e92
+    lda l00ef                                                         ; 8e92: a5 ef       ..
+    sbc #$31 ; '1'                                                    ; 8e94: e9 31       .1
+    cmp #4                                                            ; 8e96: c9 04       ..
+    bcs c8eab                                                         ; 8e98: b0 11       ..
+    tax                                                               ; 8e9a: aa          .
+    lda #0                                                            ; 8e9b: a9 00       ..
+    sta l00a9                                                         ; 8e9d: 85 a9       ..
+    tya                                                               ; 8e9f: 98          .
+    ldy #$21 ; '!'                                                    ; 8ea0: a0 21       .!
+    jmp jump_table_dispatch_x_plus_y                                  ; 8ea2: 4c 49 8e    LI.
+
+service_handler_claim_absolute_workspace
+    cpy #$16                                                          ; 8ea5: c0 16       ..
+    bcs c8eab                                                         ; 8ea7: b0 02       ..
+    ldy #$16                                                          ; 8ea9: a0 16       ..
+; $8eab referenced 2 times by $8e98, $8ea7
+c8eab
+    rts                                                               ; 8eab: 60          `
+
+; $8eac referenced 1 time by $8edf
+clamp_absolute_workspace_and_save
+    tya                                                               ; 8eac: 98          .
+    cmp #$21 ; '!'                                                    ; 8ead: c9 21       .!
+    bcc c8eb3                                                         ; 8eaf: 90 02       ..
+    lda #$21 ; '!'                                                    ; 8eb1: a9 21       .!
+; $8eb3 referenced 1 time by $8eaf
+c8eb3
+    ldy #$0b                                                          ; 8eb3: a0 0b       ..
+    sta (l009c),y                                                     ; 8eb5: 91 9c       ..
+    rts                                                               ; 8eb7: 60          `
+
+service_handler_claim_private_workspace
+    sty l009d                                                         ; 8eb8: 84 9d       ..
+    iny                                                               ; 8eba: c8          .
+    sty l009f                                                         ; 8ebb: 84 9f       ..
+    iny                                                               ; 8ebd: c8          .
+    tya                                                               ; 8ebe: 98          .
+    ldy romsel_copy                                                   ; 8ebf: a4 f4       ..
+    sta l0df0,y                                                       ; 8ec1: 99 f0 0d    ...
+    ldy lfe87                                                         ; 8ec4: ac 87 fe    ...
+    lda #0                                                            ; 8ec7: a9 00       ..
+    sta l009c                                                         ; 8ec9: 85 9c       ..
+    sta l009e                                                         ; 8ecb: 85 9e       ..
+    sta l00a8                                                         ; 8ecd: 85 a8       ..
+    sta l0d60                                                         ; 8ecf: 8d 60 0d    .`.
+    ldy #0                                                            ; 8ed2: a0 00       ..
+    sta (l009c),y                                                     ; 8ed4: 91 9c       ..
+    lda #osbyte_issue_service_request                                 ; 8ed6: a9 8f       ..
+    ldx #service_claim_absolute_workspace                             ; 8ed8: a2 01       ..
+    ldy #$0e                                                          ; 8eda: a0 0e       ..
+    jsr osbyte                                                        ; 8edc: 20 f4 ff     ..
+    jsr clamp_absolute_workspace_and_save                             ; 8edf: 20 ac 8e     ..
+    lda l028d                                                         ; 8ee2: ad 8d 02    ...
+    beq c8f40                                                         ; 8ee5: f0 59       .Y
+    jsr sub_c8cc0                                                     ; 8ee7: 20 c0 8c     ..
+    sta l0d6c                                                         ; 8eea: 8d 6c 0d    .l.
+    tay                                                               ; 8eed: a8          .
+; $8eee referenced 1 time by $8ef3
+loop_c8eee
+    sta (l00cc),y                                                     ; 8eee: 91 cc       ..
+    sta (l009e),y                                                     ; 8ef0: 91 9e       ..
+    iny                                                               ; 8ef2: c8          .
+    bne loop_c8eee                                                    ; 8ef3: d0 f9       ..
+    ldy #8                                                            ; 8ef5: a0 08       ..
+    sta (l009c),y                                                     ; 8ef7: 91 9c       ..
+    jsr sub_cb017                                                     ; 8ef9: 20 17 b0     ..
+    ldy #2                                                            ; 8efc: a0 02       ..
+    lda #$fe                                                          ; 8efe: a9 fe       ..
+    sta l0e00                                                         ; 8f00: 8d 00 0e    ...
+    sta (l009c),y                                                     ; 8f03: 91 9c       ..
+    lda #0                                                            ; 8f05: a9 00       ..
+    sta l0e01                                                         ; 8f07: 8d 01 0e    ...
+    iny                                                               ; 8f0a: c8          .
+    sta (l009c),y                                                     ; 8f0b: 91 9c       ..
+    ldy #3                                                            ; 8f0d: a0 03       ..
+    sta (l009e),y                                                     ; 8f0f: 91 9e       ..
+    dey                                                               ; 8f11: 88          .
+    lda #$eb                                                          ; 8f12: a9 eb       ..
+    sta (l009e),y                                                     ; 8f14: 91 9e       ..
+    ldx #3                                                            ; 8f16: a2 03       ..
+; $8f18 referenced 1 time by $8f1f
+loop_c8f18
+    lda l8f48,x                                                       ; 8f18: bd 48 8f    .H.
+    sta l0d6c,x                                                       ; 8f1b: 9d 6c 0d    .l.
+    dex                                                               ; 8f1e: ca          .
+    bne loop_c8f18                                                    ; 8f1f: d0 f7       ..
+    stx l0d68                                                         ; 8f21: 8e 68 0d    .h.
+    stx l0e05                                                         ; 8f24: 8e 05 0e    ...
+    jsr caae2                                                         ; 8f27: 20 e2 aa     ..
+    dex                                                               ; 8f2a: ca          .
+    stx l0d71                                                         ; 8f2b: 8e 71 0d    .q.
+; $8f2e referenced 1 time by $8f3b
+loop_c8f2e
+    lda l00a8                                                         ; 8f2e: a5 a8       ..
+    jsr sub_ca0ce                                                     ; 8f30: 20 ce a0     ..
+    bcs c8f3d                                                         ; 8f33: b0 08       ..
+    lda #$3f ; '?'                                                    ; 8f35: a9 3f       .?
+    sta (l009e),y                                                     ; 8f37: 91 9e       ..
+    inc l00a8                                                         ; 8f39: e6 a8       ..
+    bne loop_c8f2e                                                    ; 8f3b: d0 f1       ..
+; $8f3d referenced 1 time by $8f33
+c8f3d
+    jsr c8f8c                                                         ; 8f3d: 20 8c 8f     ..
+; $8f40 referenced 1 time by $8ee5
+c8f40
+    ldy lfe18                                                         ; 8f40: ac 18 fe    ...
+    tya                                                               ; 8f43: 98          .
+    bne c8f4c                                                         ; 8f44: d0 06       ..
+; $8f46 referenced 1 time by $8f4d
+loop_c8f46
+l8f48 = loop_c8f46+2
+    jmp c9215                                                         ; 8f46: 4c 15 92    L..
+
+; $8f48 referenced 1 time by $8f18
+    !byte $ff, $28, $0a                                               ; 8f49: ff 28 0a    .(.
+
+; $8f4c referenced 1 time by $8f44
+c8f4c
+    iny                                                               ; 8f4c: c8          .
+    beq loop_c8f46                                                    ; 8f4d: f0 f7       ..
+    ldy #1                                                            ; 8f4f: a0 01       ..
+    sta (l009c),y                                                     ; 8f51: 91 9c       ..
+    ldx #$40 ; '@'                                                    ; 8f53: a2 40       .@
+    stx l0d61                                                         ; 8f55: 8e 61 0d    .a.
+    lda #3                                                            ; 8f58: a9 03       ..
+    jsr sub_cab1b                                                     ; 8f5a: 20 1b ab     ..
+; $8f5d referenced 1 time by $8b55
+sub_c8f5d
+    jsr sub_c8074                                                     ; 8f5d: 20 74 80     t.
+    lda #$a8                                                          ; 8f60: a9 a8       ..
+    jsr sub_c8e83                                                     ; 8f62: 20 83 8e     ..
+    stx l00b8                                                         ; 8f65: 86 b8       ..
+    sty l00b9                                                         ; 8f67: 84 b9       ..
+    ldy #$36 ; '6'                                                    ; 8f69: a0 36       .6
+    sty netv                                                          ; 8f6b: 8c 24 02    .$.
+    ldx #1                                                            ; 8f6e: a2 01       ..
+; $8f70 referenced 2 times by $8b5c, $8f82
+c8f70
+    lda l8e54,y                                                       ; 8f70: b9 54 8e    .T.
+    sta (l00b8),y                                                     ; 8f73: 91 b8       ..
+    iny                                                               ; 8f75: c8          .
+    lda l8e54,y                                                       ; 8f76: b9 54 8e    .T.
+    sta (l00b8),y                                                     ; 8f79: 91 b8       ..
+    iny                                                               ; 8f7b: c8          .
+    lda romsel_copy                                                   ; 8f7c: a5 f4       ..
+    sta (l00b8),y                                                     ; 8f7e: 91 b8       ..
+    iny                                                               ; 8f80: c8          .
+    dex                                                               ; 8f81: ca          .
+    bne c8f70                                                         ; 8f82: d0 ec       ..
+    jsr sub_c8f99                                                     ; 8f84: 20 99 8f     ..
+    jsr sub_c8cb9                                                     ; 8f87: 20 b9 8c     ..
+    iny                                                               ; 8f8a: c8          .
+    rts                                                               ; 8f8b: 60          `
+
+; $8f8c referenced 3 times by $8f3d, $8fa8, $a38e
+c8f8c
+    ldy #9                                                            ; 8f8c: a0 09       ..
+; $8f8e referenced 1 time by $8f96
+loop_c8f8e
+    lda l0dfe,y                                                       ; 8f8e: b9 fe 0d    ...
+    sta (l009c),y                                                     ; 8f91: 91 9c       ..
+    dey                                                               ; 8f93: 88          .
+    cpy #1                                                            ; 8f94: c0 01       ..
+    bne loop_c8f8e                                                    ; 8f96: d0 f6       ..
+    rts                                                               ; 8f98: 60          `
+
+; $8f99 referenced 1 time by $8f84
+sub_c8f99
+    bit l0d6c                                                         ; 8f99: 2c 6c 0d    ,l.
+    bpl c8fca                                                         ; 8f9c: 10 2c       .,
+    ldy #0                                                            ; 8f9e: a0 00       ..
+    jsr sub_cb799                                                     ; 8fa0: 20 99 b7     ..
+    lda #osbyte_close_spool_exec                                      ; 8fa3: a9 77       .w
+    jsr osbyte                                                        ; 8fa5: 20 f4 ff     ..
+    jsr c8f8c                                                         ; 8fa8: 20 8c 8f     ..
+    ldy #$76 ; 'v'                                                    ; 8fab: a0 76       .v
+    lda #0                                                            ; 8fad: a9 00       ..
+    clc                                                               ; 8faf: 18          .
+; $8fb0 referenced 1 time by $8fb4
+loop_c8fb0
+    adc l1000,y                                                       ; 8fb0: 79 00 10    y..
+    dey                                                               ; 8fb3: 88          .
+    bpl loop_c8fb0                                                    ; 8fb4: 10 fa       ..
+    ldy #$77 ; 'w'                                                    ; 8fb6: a0 77       .w
+    bpl c8fbd                                                         ; 8fb8: 10 03       ..
+; $8fba referenced 1 time by $8fc0
+loop_c8fba
+    lda l1000,y                                                       ; 8fba: b9 00 10    ...
+; $8fbd referenced 1 time by $8fb8
+c8fbd
+    sta (l00cc),y                                                     ; 8fbd: 91 cc       ..
+    dey                                                               ; 8fbf: 88          .
+    bpl loop_c8fba                                                    ; 8fc0: 10 f8       ..
+    lda l0d6c                                                         ; 8fc2: ad 6c 0d    .l.
+    and #$7f                                                          ; 8fc5: 29 7f       ).
+    sta l0d6c                                                         ; 8fc7: 8d 6c 0d    .l.
+; $8fca referenced 1 time by $8f9c
+c8fca
+    rts                                                               ; 8fca: 60          `
+
+; $8fcb referenced 2 times by $9dee, $b5fb
+sub_c8fcb
+    php                                                               ; 8fcb: 08          .
+    pha                                                               ; 8fcc: 48          H
+    tya                                                               ; 8fcd: 98          .
+    pha                                                               ; 8fce: 48          H
+    ldy #$76 ; 'v'                                                    ; 8fcf: a0 76       .v
+    lda #0                                                            ; 8fd1: a9 00       ..
+    clc                                                               ; 8fd3: 18          .
+; $8fd4 referenced 1 time by $8fd7
+loop_c8fd4
+    adc (l00cc),y                                                     ; 8fd4: 71 cc       q.
+    dey                                                               ; 8fd6: 88          .
+    bpl loop_c8fd4                                                    ; 8fd7: 10 fb       ..
+    ldy #$77 ; 'w'                                                    ; 8fd9: a0 77       .w
+    cmp (l00cc),y                                                     ; 8fdb: d1 cc       ..
+    bne c8fe4                                                         ; 8fdd: d0 05       ..
+    pla                                                               ; 8fdf: 68          h
+    tay                                                               ; 8fe0: a8          .
+    pla                                                               ; 8fe1: 68          h
+    plp                                                               ; 8fe2: 28          (
+    rts                                                               ; 8fe3: 60          `
+
+; $8fe4 referenced 2 times by $8b31, $8fdd
+c8fe4
+    lda #$aa                                                          ; 8fe4: a9 aa       ..
+    jsr generate_error_inline                                         ; 8fe6: 20 b8 96     ..
+    !text "net sum", 0                                                ; 8fe9: 6e 65 74... net
+
+; $8ff1 referenced 2 times by $8cb6, $8ce3
+c8ff1
+    jsr print_inline_top_bit_clear                                    ; 8ff1: 20 45 91     E.
+    !text "Econet Station "                                           ; 8ff4: 45 63 6f... Eco
+
+    ldy #1                                                            ; 9003: a0 01       ..
+    lda (l009c),y                                                     ; 9005: b1 9c       ..
+    jsr sub_caf85                                                     ; 9007: 20 85 af     ..
+    lda #$20 ; ' '                                                    ; 900a: a9 20       .
+    bit lfea1                                                         ; 900c: 2c a1 fe    ,..
+    beq c901e                                                         ; 900f: f0 0d       ..
+    jsr print_inline_top_bit_clear                                    ; 9011: 20 45 91     E.
+    !text " No Clock"                                                 ; 9014: 20 4e 6f...  No
+
+    nop                                                               ; 901d: ea          .
+; $901e referenced 1 time by $900f
+c901e
+    jsr osnewl                                                        ; 901e: 20 e7 ff     ..
+    rts                                                               ; 9021: 60          `
+
+; $9022 referenced 1 time by $8be1
+l9022
+    !text "(<dir>)"                                                   ; 9022: 28 3c 64... (<d
+    !byte 0                                                           ; 9029: 00          .
+    !text "(<stn. id.>) <user id.> "                                  ; 902a: 28 3c 73... (<s
+    !byte $0d                                                         ; 9042: 0d          .
+    !text "((:<CR>)<password>)"                                       ; 9043: 28 28 3a... ((:
+    !byte 0                                                           ; 9056: 00          .
+    !text "<object>"                                                  ; 9057: 3c 6f 62... <ob
+    !byte 0                                                           ; 905f: 00          .
+    !text "<filename> (<offset> "                                     ; 9060: 3c 66 69... <fi
+    !byte $0d                                                         ; 9075: 0d          .
+    !text "(<address>))"                                              ; 9076: 28 3c 61... (<a
+    !byte 0                                                           ; 9082: 00          .
+    !text "<dir>"                                                     ; 9083: 3c 64 69... <di
+    !byte 0                                                           ; 9088: 00          .
+    !text "<dir> (<number>)"                                          ; 9089: 3c 64 69... <di
+    !byte 0                                                           ; 9099: 00          .
+    !text "(:<CR>) <password> "                                       ; 909a: 28 3a 3c... (:<
+    !byte $0d                                                         ; 90ad: 0d          .
+    !text "<new password>"                                            ; 90ae: 3c 6e 65... <ne
+    !byte 0                                                           ; 90bc: 00          .
+    !text "(<stn. id.>|<ps type>)"                                    ; 90bd: 28 3c 73... (<s
+    !byte 0                                                           ; 90d3: 00          .
+    !text "<object> (L)(W)(R)(/(W)(R))"                               ; 90d4: 3c 6f 62... <ob
+    !byte 0                                                           ; 90ef: 00          .
+    !text "<filename> <new filename>"                                 ; 90f0: 3c 66 69... <fi
+    !byte 0                                                           ; 9109: 00          .
+    !text "(<stn. id.>)"                                              ; 910a: 28 3c 73... (<s
+    !byte 0                                                           ; 9116: 00          .
+    !text "<filename>"                                                ; 9117: 3c 66 69... <fi
+    !byte 0                                                           ; 9121: 00          .
+; $9122 referenced 1 time by $8bdc
+l9122
+    !byte   6, $ff,   7                                               ; 9122: 06 ff 07    ...
+    !text "4=`fw"                                                     ; 9125: 34 3d 60... 4=`
+    !byte $9a, $b1, $cd, $e7, $f4                                     ; 912a: 9a b1 cd... ...
+
+; $912f referenced 4 times by $9a66, $ae11, $ba6a, $bb04
+sub_c912f
+    pha                                                               ; 912f: 48          H
+    lsr                                                               ; 9130: 4a          J
+    lsr                                                               ; 9131: 4a          J
+    lsr                                                               ; 9132: 4a          J
+    lsr                                                               ; 9133: 4a          J
+    jsr sub_c9138                                                     ; 9134: 20 38 91     8.
+    pla                                                               ; 9137: 68          h
+; $9138 referenced 1 time by $9134
+sub_c9138
+    and #$0f                                                          ; 9138: 29 0f       ).
+    cmp #$0a                                                          ; 913a: c9 0a       ..
+    bcc c9140                                                         ; 913c: 90 02       ..
+    adc #6                                                            ; 913e: 69 06       i.
+; $9140 referenced 1 time by $913c
+c9140
+    adc #$30 ; '0'                                                    ; 9140: 69 30       i0
+    jmp osasci                                                        ; 9142: 4c e3 ff    L..
+
+; $9145 referenced 35 times by $8bb6, $8bf8, $8c9f, $8ff1, $9011, $953a, $adc0, $adca, $add8, $ade3, $adff, $ae14, $ae27, $ae36, $af53, $b0a2, $b0ae, $b0c5, $b0cf, $b0da, $b1aa, $b24c, $b261, $b284, $b291, $b2a0, $b2b0, $b2bf, $b3c4, $b3e4, $b431, $ba86, $ba9f, $baac, $bae0
+print_inline_top_bit_clear
+    pla                                                               ; 9145: 68          h
+    sta l00b8                                                         ; 9146: 85 b8       ..
+    pla                                                               ; 9148: 68          h
+    sta l00b9                                                         ; 9149: 85 b9       ..
+    ldy #0                                                            ; 914b: a0 00       ..
+; $914d referenced 1 time by $9168
+loop_c914d
+    inc l00b8                                                         ; 914d: e6 b8       ..
+    bne c9153                                                         ; 914f: d0 02       ..
+    inc l00b9                                                         ; 9151: e6 b9       ..
+; $9153 referenced 1 time by $914f
+c9153
+    lda (l00b8),y                                                     ; 9153: b1 b8       ..
+    bmi c916b                                                         ; 9155: 30 14       0.
+    lda l00b8                                                         ; 9157: a5 b8       ..
+    pha                                                               ; 9159: 48          H
+    lda l00b9                                                         ; 915a: a5 b9       ..
+    pha                                                               ; 915c: 48          H
+    lda (l00b8),y                                                     ; 915d: b1 b8       ..
+    jsr osasci                                                        ; 915f: 20 e3 ff     ..
+    pla                                                               ; 9162: 68          h
+    sta l00b9                                                         ; 9163: 85 b9       ..
+    pla                                                               ; 9165: 68          h
+    sta l00b8                                                         ; 9166: 85 b8       ..
+    jmp loop_c914d                                                    ; 9168: 4c 4d 91    LM.
+
+; $916b referenced 1 time by $9155
+c916b
+    jmp (l00b8)                                                       ; 916b: 6c b8 00    l..
+
+; $916e referenced 5 times by $8d98, $8da4, $a0ad, $a0c2, $ad24
+sub_c916e
+    lda #0                                                            ; 916e: a9 00       ..
+    sta l00b2                                                         ; 9170: 85 b2       ..
+    lda (l00be),y                                                     ; 9172: b1 be       ..
+    cmp #$26 ; '&'                                                    ; 9174: c9 26       .&
+    bne c91ae                                                         ; 9176: d0 36       .6
+    iny                                                               ; 9178: c8          .
+    lda (l00be),y                                                     ; 9179: b1 be       ..
+    bcs c9188                                                         ; 917b: b0 0b       ..
+; $917d referenced 1 time by $91ac
+c917d
+    iny                                                               ; 917d: c8          .
+    lda (l00be),y                                                     ; 917e: b1 be       ..
+    cmp #$2e ; '.'                                                    ; 9180: c9 2e       ..
+    beq c91fb                                                         ; 9182: f0 77       .w
+    cmp #$21 ; '!'                                                    ; 9184: c9 21       .!
+    bcc c91da                                                         ; 9186: 90 52       .R
+; $9188 referenced 1 time by $917b
+c9188
+    cmp #$30 ; '0'                                                    ; 9188: c9 30       .0
+    bcc c9198                                                         ; 918a: 90 0c       ..
+    cmp #$3a ; ':'                                                    ; 918c: c9 3a       .:
+    bcc c919a                                                         ; 918e: 90 0a       ..
+    and #$5f ; '_'                                                    ; 9190: 29 5f       )_
+    adc #$b8                                                          ; 9192: 69 b8       i.
+    bcs c9208                                                         ; 9194: b0 72       .r
+    cmp #$fa                                                          ; 9196: c9 fa       ..
+; $9198 referenced 1 time by $918a
+c9198
+    bcc c9208                                                         ; 9198: 90 6e       .n
+; $919a referenced 1 time by $918e
+c919a
+    and #$0f                                                          ; 919a: 29 0f       ).
+    sta l00b3                                                         ; 919c: 85 b3       ..
+    lda l00b2                                                         ; 919e: a5 b2       ..
+    cmp #$10                                                          ; 91a0: c9 10       ..
+    bcs c9211                                                         ; 91a2: b0 6d       .m
+    asl                                                               ; 91a4: 0a          .
+    asl                                                               ; 91a5: 0a          .
+    asl                                                               ; 91a6: 0a          .
+    asl                                                               ; 91a7: 0a          .
+    adc l00b3                                                         ; 91a8: 65 b3       e.
+    sta l00b2                                                         ; 91aa: 85 b2       ..
+    bcc c917d                                                         ; 91ac: 90 cf       ..
+; $91ae referenced 2 times by $9176, $91d8
+c91ae
+    lda (l00be),y                                                     ; 91ae: b1 be       ..
+    cmp #$2e ; '.'                                                    ; 91b0: c9 2e       ..
+    beq c91fb                                                         ; 91b2: f0 47       .G
+    cmp #$21 ; '!'                                                    ; 91b4: c9 21       .!
+    bcc c91da                                                         ; 91b6: 90 22       ."
+    jsr sub_c9260                                                     ; 91b8: 20 60 92     `.
+    bcc c9229                                                         ; 91bb: 90 6c       .l
+    and #$0f                                                          ; 91bd: 29 0f       ).
+    sta l00b3                                                         ; 91bf: 85 b3       ..
+    asl l00b2                                                         ; 91c1: 06 b2       ..
+    bcs c9211                                                         ; 91c3: b0 4c       .L
+    lda l00b2                                                         ; 91c5: a5 b2       ..
+    asl                                                               ; 91c7: 0a          .
+    bcs c9211                                                         ; 91c8: b0 47       .G
+    asl                                                               ; 91ca: 0a          .
+    bcs c9211                                                         ; 91cb: b0 44       .D
+    adc l00b2                                                         ; 91cd: 65 b2       e.
+    bcs c9211                                                         ; 91cf: b0 40       .@
+    adc l00b3                                                         ; 91d1: 65 b3       e.
+    bcs c9211                                                         ; 91d3: b0 3c       .<
+    sta l00b2                                                         ; 91d5: 85 b2       ..
+    iny                                                               ; 91d7: c8          .
+    bne c91ae                                                         ; 91d8: d0 d4       ..
+; $91da referenced 2 times by $9186, $91b6
+c91da
+    lda l00b4                                                         ; 91da: a5 b4       ..
+    bpl c91e3                                                         ; 91dc: 10 05       ..
+    lda l00b2                                                         ; 91de: a5 b2       ..
+    beq c9235                                                         ; 91e0: f0 53       .S
+    rts                                                               ; 91e2: 60          `
+
+; $91e3 referenced 1 time by $91dc
+c91e3
+    lda l00b2                                                         ; 91e3: a5 b2       ..
+    cmp #$ff                                                          ; 91e5: c9 ff       ..
+    beq c9215                                                         ; 91e7: f0 2c       .,
+    lda l00b2                                                         ; 91e9: a5 b2       ..
+    bne c91f9                                                         ; 91eb: d0 0c       ..
+    lda l00b4                                                         ; 91ed: a5 b4       ..
+    beq c9215                                                         ; 91ef: f0 24       .$
+    dey                                                               ; 91f1: 88          .
+    lda (l00be),y                                                     ; 91f2: b1 be       ..
+    iny                                                               ; 91f4: c8          .
+    eor #$2e ; '.'                                                    ; 91f5: 49 2e       I.
+    bne c9215                                                         ; 91f7: d0 1c       ..
+; $91f9 referenced 1 time by $91eb
+c91f9
+    sec                                                               ; 91f9: 38          8
+    rts                                                               ; 91fa: 60          `
+
+; $91fb referenced 2 times by $9182, $91b2
+c91fb
+    lda l00b4                                                         ; 91fb: a5 b4       ..
+    bne c9229                                                         ; 91fd: d0 2a       .*
+    inc l00b4                                                         ; 91ff: e6 b4       ..
+    lda l00b2                                                         ; 9201: a5 b2       ..
+    cmp #$ff                                                          ; 9203: c9 ff       ..
+    beq c9244                                                         ; 9205: f0 3d       .=
+    rts                                                               ; 9207: 60          `
+
+; $9208 referenced 3 times by $9194, $9198, $bb6b
+c9208
+    lda #$f1                                                          ; 9208: a9 f1       ..
+    jsr generate_error_inline                                         ; 920a: 20 b8 96     ..
+    !text "hex", 0                                                    ; 920d: 68 65 78... hex
+
+; $9211 referenced 6 times by $91a2, $91c3, $91c8, $91cb, $91cf, $91d3
+c9211
+    bit l00b4                                                         ; 9211: 24 b4       $.
+    bmi c9235                                                         ; 9213: 30 20       0
+; $9215 referenced 4 times by $8f46, $91e7, $91ef, $91f7
+c9215
+    lda #$d0                                                          ; 9215: a9 d0       ..
+    jsr generate_error_inline                                         ; 9217: 20 b8 96     ..
+    !text "station number", 0                                         ; 921a: 73 74 61... sta
+
+; $9229 referenced 2 times by $91bb, $91fd
+c9229
+    lda #$f0                                                          ; 9229: a9 f0       ..
+    jsr generate_error_inline                                         ; 922b: 20 b8 96     ..
+    !text "number", 0                                                 ; 922e: 6e 75 6d... num
+
+; $9235 referenced 2 times by $91e0, $9213
+c9235
+    lda #$94                                                          ; 9235: a9 94       ..
+    jsr generate_error_inline                                         ; 9237: 20 b8 96     ..
+    !text "parameter", 0                                              ; 923a: 70 61 72... par
+
+; $9244 referenced 1 time by $9205
+c9244
+    lda #$d1                                                          ; 9244: a9 d1       ..
+    jsr generate_error_inline                                         ; 9246: 20 b8 96     ..
+    !text "network number", 0                                         ; 9249: 6e 65 74... net
+
+; $9258 referenced 3 times by $8d93, $b005, $b1dc
+sub_c9258
+    cmp #$26 ; '&'                                                    ; 9258: c9 26       .&
+    beq c9266                                                         ; 925a: f0 0a       ..
+    cmp #$2e ; '.'                                                    ; 925c: c9 2e       ..
+    beq c9266                                                         ; 925e: f0 06       ..
+; $9260 referenced 1 time by $91b8
+sub_c9260
+    cmp #$3a ; ':'                                                    ; 9260: c9 3a       .:
+    bcs c9267                                                         ; 9262: b0 03       ..
+    cmp #$30 ; '0'                                                    ; 9264: c9 30       .0
+; $9266 referenced 2 times by $925a, $925e
+c9266
+    rts                                                               ; 9266: 60          `
+
+; $9267 referenced 1 time by $9262
+c9267
+    clc                                                               ; 9267: 18          .
+    rts                                                               ; 9268: 60          `
+
+; $9269 referenced 2 times by $9b20, $9b4c
+sub_c9269
+    ldy #$0e                                                          ; 9269: a0 0e       ..
+    lda (l00bb),y                                                     ; 926b: b1 bb       ..
+    and #$3f ; '?'                                                    ; 926d: 29 3f       )?
+    ldx #4                                                            ; 926f: a2 04       ..
+    bne c9277                                                         ; 9271: d0 04       ..
+; $9273 referenced 2 times by $9a2a, $9b69
+sub_c9273
+    and #$1f                                                          ; 9273: 29 1f       ).
+    ldx #$ff                                                          ; 9275: a2 ff       ..
+; $9277 referenced 1 time by $9271
+c9277
+    sta l00b8                                                         ; 9277: 85 b8       ..
+    lda #0                                                            ; 9279: a9 00       ..
+; $927b referenced 1 time by $9283
+loop_c927b
+    inx                                                               ; 927b: e8          .
+    lsr l00b8                                                         ; 927c: 46 b8       F.
+    bcc c9283                                                         ; 927e: 90 03       ..
+    ora l9286,x                                                       ; 9280: 1d 86 92    ...
+; $9283 referenced 1 time by $927e
+c9283
+    bne loop_c927b                                                    ; 9283: d0 f6       ..
+    rts                                                               ; 9285: 60          `
+
+; $9286 referenced 1 time by $9280
+l9286
+    !byte $50, $20,   5,   2, $88,   4,   8, $80, $10,   1,   2       ; 9286: 50 20 05... P .
+
+; $9291 referenced 1 time by $a114
+sub_c9291
+    stx os_text_ptr                                                   ; 9291: 86 f2       ..
+    sty l00f3                                                         ; 9293: 84 f3       ..
+; $9295 referenced 2 times by $8e33, $ad80
+sub_c9295
+    sta l00bd                                                         ; 9295: 85 bd       ..
+    stx l00be                                                         ; 9297: 86 be       ..
+    sty l00bf                                                         ; 9299: 84 bf       ..
+; $929b referenced 1 time by $b984
+sub_c929b
+    stx l00bb                                                         ; 929b: 86 bb       ..
+    sty l00bc                                                         ; 929d: 84 bc       ..
+; $929f referenced 1 time by $9885
+c929f
+    php                                                               ; 929f: 08          .
+    lsr l0098                                                         ; 92a0: 46 98       F.
+    plp                                                               ; 92a2: 28          (
+    rts                                                               ; 92a3: 60          `
+
+; $92a4 referenced 2 times by $9998, $9a9b
+sub_c92a4
+    ldx #4                                                            ; 92a4: a2 04       ..
+; $92a6 referenced 1 time by $92ad
+loop_c92a6
+    lda l00af,x                                                       ; 92a6: b5 af       ..
+    eor l00b3,x                                                       ; 92a8: 55 b3       U.
+    bne c92af                                                         ; 92aa: d0 03       ..
+    dex                                                               ; 92ac: ca          .
+    bne loop_c92a6                                                    ; 92ad: d0 f7       ..
+; $92af referenced 1 time by $92aa
+c92af
+    rts                                                               ; 92af: 60          `
+
+sub_c92b0
+    ldx #$20 ; ' '                                                    ; 92b0: a2 20       .
+    ldy #$2f ; '/'                                                    ; 92b2: a0 2f       ./
+    rts                                                               ; 92b4: 60          `
+
+    !byte   8, $48, $8a, $48, $ba, $bd,   2,   1, $20, $6b, $b4, $30  ; 92b5: 08 48 8a... .H.
+    !byte $1f, $a9, $40, $1d, $60, $10, $9d, $60, $10, $d0, $15,   8  ; 92c1: 1f a9 40... ..@
+    !byte $48, $8a, $48, $ba, $bd,   2,   1, $20, $6b, $b4, $30,   8  ; 92cd: 48 8a 48... H.H
+    !byte $a9, $bf, $3d, $60, $10, $9d, $60, $10, $68, $aa            ; 92d9: a9 bf 3d... ..=
+    !text "h(`"                                                       ; 92e3: 68 28 60    h(`
+
+sub_c92e6
+    jsr sub_c9327                                                     ; 92e6: 20 27 93     '.
+    txa                                                               ; 92e9: 8a          .
+    pha                                                               ; 92ea: 48          H
+    jsr sub_c9349                                                     ; 92eb: 20 49 93     I.
+    jsr sub_cae97                                                     ; 92ee: 20 97 ae     ..
+    pla                                                               ; 92f1: 68          h
+    tax                                                               ; 92f2: aa          .
+    jsr sub_c9309                                                     ; 92f3: 20 09 93     ..
+    cmp #$0d                                                          ; 92f6: c9 0d       ..
+    bne c9311                                                         ; 92f8: d0 17       ..
+; $92fa referenced 3 times by $930e, $9409, $aedf
+c92fa
+    lda #$cc                                                          ; 92fa: a9 cc       ..
+    jsr generate_error_inline                                         ; 92fc: 20 b8 96     ..
+    !text "file name", 0                                              ; 92ff: 66 69 6c... fil
+
+; $9309 referenced 2 times by $92f3, $9311
+sub_c9309
+    lda l0e30                                                         ; 9309: ad 30 0e    .0.
+    cmp #$26 ; '&'                                                    ; 930c: c9 26       .&
+    beq c92fa                                                         ; 930e: f0 ea       ..
+    rts                                                               ; 9310: 60          `
+
+; $9311 referenced 3 times by $92f8, $931f, $93da
+c9311
+    jsr sub_c9309                                                     ; 9311: 20 09 93     ..
+    sta l0f05,x                                                       ; 9314: 9d 05 0f    ...
+    inx                                                               ; 9317: e8          .
+    cmp #$0d                                                          ; 9318: c9 0d       ..
+    beq c9322                                                         ; 931a: f0 06       ..
+    jsr caeb7                                                         ; 931c: 20 b7 ae     ..
+    jmp c9311                                                         ; 931f: 4c 11 93    L..
+
+; $9322 referenced 2 times by $931a, $9402
+c9322
+    ldy #0                                                            ; 9322: a0 00       ..
+    jmp c8e24                                                         ; 9324: 4c 24 8e    L$.
+
+; $9327 referenced 2 times by $92e6, $938b
+sub_c9327
+    tya                                                               ; 9327: 98          .
+    pha                                                               ; 9328: 48          H
+; $9329 referenced 1 time by $932d
+loop_c9329
+    dex                                                               ; 9329: ca          .
+    lda la3f0,x                                                       ; 932a: bd f0 a3    ...
+    bpl loop_c9329                                                    ; 932d: 10 fa       ..
+    inx                                                               ; 932f: e8          .
+    ldy #0                                                            ; 9330: a0 00       ..
+; $9332 referenced 1 time by $933c
+loop_c9332
+    lda la3f0,x                                                       ; 9332: bd f0 a3    ...
+    bmi c933e                                                         ; 9335: 30 07       0.
+    sta l0f05,y                                                       ; 9337: 99 05 0f    ...
+    inx                                                               ; 933a: e8          .
+    iny                                                               ; 933b: c8          .
+    bne loop_c9332                                                    ; 933c: d0 f4       ..
+; $933e referenced 1 time by $9335
+c933e
+    lda #$20 ; ' '                                                    ; 933e: a9 20       .
+    sta l0f05,y                                                       ; 9340: 99 05 0f    ...
+    iny                                                               ; 9343: c8          .
+    tya                                                               ; 9344: 98          .
+    tax                                                               ; 9345: aa          .
+    pla                                                               ; 9346: 68          h
+    tay                                                               ; 9347: a8          .
+; $9348 referenced 1 time by $937d
+c9348
+    rts                                                               ; 9348: 60          `
+
+; $9349 referenced 2 times by $92eb, $9393
+sub_c9349
+    lda #0                                                            ; 9349: a9 00       ..
+    tax                                                               ; 934b: aa          .
+    sta l10d8                                                         ; 934c: 8d d8 10    ...
+; $934f referenced 1 time by $9356
+loop_c934f
+    lda (l00be),y                                                     ; 934f: b1 be       ..
+    cmp #$20 ; ' '                                                    ; 9351: c9 20       .
+    bne c9358                                                         ; 9353: d0 03       ..
+    iny                                                               ; 9355: c8          .
+    bne loop_c934f                                                    ; 9356: d0 f7       ..
+; $9358 referenced 1 time by $9353
+c9358
+    cmp #$22 ; '"'                                                    ; 9358: c9 22       ."
+    bne c9363                                                         ; 935a: d0 07       ..
+    iny                                                               ; 935c: c8          .
+    eor l10d8                                                         ; 935d: 4d d8 10    M..
+    sta l10d8                                                         ; 9360: 8d d8 10    ...
+; $9363 referenced 2 times by $935a, $9378
+c9363
+    lda (l00be),y                                                     ; 9363: b1 be       ..
+    cmp #$22 ; '"'                                                    ; 9365: c9 22       ."
+    bne c9371                                                         ; 9367: d0 08       ..
+    eor l10d8                                                         ; 9369: 4d d8 10    M..
+    sta l10d8                                                         ; 936c: 8d d8 10    ...
+    lda #$20 ; ' '                                                    ; 936f: a9 20       .
+; $9371 referenced 1 time by $9367
+c9371
+    sta l0e30,x                                                       ; 9371: 9d 30 0e    .0.
+    iny                                                               ; 9374: c8          .
+    inx                                                               ; 9375: e8          .
+    cmp #$0d                                                          ; 9376: c9 0d       ..
+    bne c9363                                                         ; 9378: d0 e9       ..
+    lda l10d8                                                         ; 937a: ad d8 10    ...
+    beq c9348                                                         ; 937d: f0 c9       ..
+    lda l00fd                                                         ; 937f: a5 fd       ..
+    jsr generate_error_inline                                         ; 9381: 20 b8 96     ..
+    !text "string", 0                                                 ; 9384: 73 74 72... str
+
+sub_c938b
+    jsr sub_c9327                                                     ; 938b: 20 27 93     '.
+    txa                                                               ; 938e: 8a          .
+    pha                                                               ; 938f: 48          H
+    jsr sub_caf32                                                     ; 9390: 20 32 af     2.
+    jsr sub_c9349                                                     ; 9393: 20 49 93     I.
+    jsr sub_cae97                                                     ; 9396: 20 97 ae     ..
+    pla                                                               ; 9399: 68          h
+    tax                                                               ; 939a: aa          .
+; $939b referenced 1 time by $93b9
+loop_c939b
+    lda l0e30                                                         ; 939b: ad 30 0e    .0.
+    cmp #$0d                                                          ; 939e: c9 0d       ..
+    bne c93ae                                                         ; 93a0: d0 0c       ..
+; $93a2 referenced 1 time by $93d8
+c93a2
+    lda #$b0                                                          ; 93a2: a9 b0       ..
+    jsr generate_error_inline                                         ; 93a4: 20 b8 96     ..
+    !text "rename", 0                                                 ; 93a7: 72 65 6e... ren
+
+; $93ae referenced 1 time by $93a0
+c93ae
+    sta l0f05,x                                                       ; 93ae: 9d 05 0f    ...
+    inx                                                               ; 93b1: e8          .
+    cmp #$20 ; ' '                                                    ; 93b2: c9 20       .
+    beq c93bc                                                         ; 93b4: f0 06       ..
+    jsr caeb7                                                         ; 93b6: 20 b7 ae     ..
+    jmp loop_c939b                                                    ; 93b9: 4c 9b 93    L..
+
+; $93bc referenced 2 times by $93b4, $93c4
+c93bc
+    jsr caeb7                                                         ; 93bc: 20 b7 ae     ..
+    lda l0e30                                                         ; 93bf: ad 30 0e    .0.
+    cmp #$20 ; ' '                                                    ; 93c2: c9 20       .
+    beq c93bc                                                         ; 93c4: f0 f6       ..
+    lda l1071                                                         ; 93c6: ad 71 10    .q.
+    pha                                                               ; 93c9: 48          H
+    jsr sub_caf32                                                     ; 93ca: 20 32 af     2.
+    txa                                                               ; 93cd: 8a          .
+    pha                                                               ; 93ce: 48          H
+    jsr sub_cae97                                                     ; 93cf: 20 97 ae     ..
+    pla                                                               ; 93d2: 68          h
+    tax                                                               ; 93d3: aa          .
+    pla                                                               ; 93d4: 68          h
+    cmp l1071                                                         ; 93d5: cd 71 10    .q.
+    bne c93a2                                                         ; 93d8: d0 c8       ..
+    jmp c9311                                                         ; 93da: 4c 11 93    L..
+
+sub_c93dd
+    lda (l00be),y                                                     ; 93dd: b1 be       ..
+    cmp #$26 ; '&'                                                    ; 93df: c9 26       .&
+    bne c9462                                                         ; 93e1: d0 7f       ..
+    iny                                                               ; 93e3: c8          .
+    lda (l00be),y                                                     ; 93e4: b1 be       ..
+    cmp #$0d                                                          ; 93e6: c9 0d       ..
+    beq c93ee                                                         ; 93e8: f0 04       ..
+    cmp #$20 ; ' '                                                    ; 93ea: c9 20       .
+    bne c9405                                                         ; 93ec: d0 17       ..
+; $93ee referenced 1 time by $93e8
+c93ee
+    ldy #$ff                                                          ; 93ee: a0 ff       ..
+; $93f0 referenced 1 time by $93f8
+loop_c93f0
+    iny                                                               ; 93f0: c8          .
+    lda (l00be),y                                                     ; 93f1: b1 be       ..
+    sta l0f05,y                                                       ; 93f3: 99 05 0f    ...
+    cmp #$26 ; '&'                                                    ; 93f6: c9 26       .&
+    bne loop_c93f0                                                    ; 93f8: d0 f6       ..
+    lda #$0d                                                          ; 93fa: a9 0d       ..
+    sta l0f05,y                                                       ; 93fc: 99 05 0f    ...
+    iny                                                               ; 93ff: c8          .
+    tya                                                               ; 9400: 98          .
+    tax                                                               ; 9401: aa          .
+    jmp c9322                                                         ; 9402: 4c 22 93    L".
+
+; $9405 referenced 1 time by $93ec
+c9405
+    cmp #$2e ; '.'                                                    ; 9405: c9 2e       ..
+    beq c940c                                                         ; 9407: f0 03       ..
+    jmp c92fa                                                         ; 9409: 4c fa 92    L..
+
+; $940c referenced 1 time by $9407
+c940c
+    iny                                                               ; 940c: c8          .
+    sty l00b0                                                         ; 940d: 84 b0       ..
+    lda #4                                                            ; 940f: a9 04       ..
+    sta l0f05                                                         ; 9411: 8d 05 0f    ...
+    lda l1071                                                         ; 9414: ad 71 10    .q.
+    ora #$40 ; '@'                                                    ; 9417: 09 40       .@
+    sta l1071                                                         ; 9419: 8d 71 10    .q.
+    ldx #1                                                            ; 941c: a2 01       ..
+    jsr sub_caf06                                                     ; 941e: 20 06 af     ..
+    ldy #$12                                                          ; 9421: a0 12       ..
+    jsr c94ad                                                         ; 9423: 20 ad 94     ..
+    lda l0f05                                                         ; 9426: ad 05 0f    ...
+    cmp #2                                                            ; 9429: c9 02       ..
+    beq c943c                                                         ; 942b: f0 0f       ..
+    lda #$d6                                                          ; 942d: a9 d6       ..
+    jsr generate_error_inline3                                        ; 942f: 20 d1 96     ..
+    !text "Not found", 0                                              ; 9432: 4e 6f 74... Not
+
+; $943c referenced 1 time by $942b
+c943c
+    lda l0e03                                                         ; 943c: ad 03 0e    ...
+    sta l0f05                                                         ; 943f: 8d 05 0f    ...
+    ldx #1                                                            ; 9442: a2 01       ..
+    ldy #7                                                            ; 9444: a0 07       ..
+    jsr c94ad                                                         ; 9446: 20 ad 94     ..
+    ldx #1                                                            ; 9449: a2 01       ..
+    stx l0f05                                                         ; 944b: 8e 05 0f    ...
+    stx l0f06                                                         ; 944e: 8e 06 0f    ...
+    inx                                                               ; 9451: e8          .
+    ldy l00b0                                                         ; 9452: a4 b0       ..
+    jsr sub_caf06                                                     ; 9454: 20 06 af     ..
+    ldy #6                                                            ; 9457: a0 06       ..
+    jsr c94ad                                                         ; 9459: 20 ad 94     ..
+    ldy l0f05                                                         ; 945c: ac 05 0f    ...
+    jmp ca2f4                                                         ; 945f: 4c f4 a2    L..
+
+; $9462 referenced 1 time by $93e1
+c9462
+    jmp c8e15                                                         ; 9462: 4c 15 8e    L..
+
+; $9465 referenced 1 time by $94f1
+sub_c9465
+    lda #$90                                                          ; 9465: a9 90       ..
+; $9467 referenced 1 time by $9ae0
+sub_c9467
+    jsr sub_c9473                                                     ; 9467: 20 73 94     s.
+    sta l00c1                                                         ; 946a: 85 c1       ..
+    lda #3                                                            ; 946c: a9 03       ..
+    sta l00c4                                                         ; 946e: 85 c4       ..
+    dec l00c0                                                         ; 9470: c6 c0       ..
+    rts                                                               ; 9472: 60          `
+
+; $9473 referenced 4 times by $8dfc, $9467, $94e0, $b93a
+sub_c9473
+    pha                                                               ; 9473: 48          H
+    ldy #$0b                                                          ; 9474: a0 0b       ..
+; $9476 referenced 1 time by $9487
+loop_c9476
+    lda l948b,y                                                       ; 9476: b9 8b 94    ...
+    sta l00c0,y                                                       ; 9479: 99 c0 00    ...
+    cpy #2                                                            ; 947c: c0 02       ..
+    bpl c9486                                                         ; 947e: 10 06       ..
+    lda l0e00,y                                                       ; 9480: b9 00 0e    ...
+    sta l00c2,y                                                       ; 9483: 99 c2 00    ...
+; $9486 referenced 1 time by $947e
+c9486
+    dey                                                               ; 9486: 88          .
+    bpl loop_c9476                                                    ; 9487: 10 ed       ..
+    pla                                                               ; 9489: 68          h
+    rts                                                               ; 948a: 60          `
+
+; $948b referenced 1 time by $9476
+l948b
+    !byte $80, $99,   0,   0,   0, $0f                                ; 948b: 80 99 00... ...
+; $9491 referenced 19 times by $8c73, $964e, $977d, $9b41, $a09e, $a19d, $a316, $a341, $a378, $af7f, $af85, $b025, $b1a5, $b205, $b246, $b2ce, $b55a, $b598, $b99d
+l9491
+    !byte $ff, $ff, $ff, $0f, $ff, $ff                                ; 9491: ff ff ff... ...
+
+; $9497 referenced 1 time by $9f14
+sub_c9497
+    pha                                                               ; 9497: 48          H
+    sec                                                               ; 9498: 38          8
+    bcs c94b5                                                         ; 9499: b0 1a       ..
+; $949b referenced 2 times by $9958, $9a0c
+sub_c949b
+    clv                                                               ; 949b: b8          .
+    bvc c94b4                                                         ; 949c: 50 16       P.
+sub_c949e
+    ldy #0                                                            ; 949e: a0 00       ..
+    jsr sub_cb799                                                     ; 94a0: 20 99 b7     ..
+    lda #osbyte_close_spool_exec                                      ; 94a3: a9 77       .w
+    jsr osbyte                                                        ; 94a5: 20 f4 ff     ..
+    jsr sub_cb559                                                     ; 94a8: 20 59 b5     Y.
+    ldy #$17                                                          ; 94ab: a0 17       ..
+; $94ad referenced 15 times by $8e24, $9423, $9446, $9459, $9b5d, $9de4, $a1d6, $a1fe, $ad41, $adb8, $adf6, $ae65, $b381, $b418, $b917
+c94ad
+    clv                                                               ; 94ad: b8          .
+; $94ae referenced 2 times by $9b44, $af82
+c94ae
+    lda l0e02                                                         ; 94ae: ad 02 0e    ...
+    sta l0f02                                                         ; 94b1: 8d 02 0f    ...
+; $94b4 referenced 1 time by $949c
+c94b4
+    clc                                                               ; 94b4: 18          .
+; $94b5 referenced 1 time by $9499
+c94b5
+    php                                                               ; 94b5: 08          .
+    sty l0f01                                                         ; 94b6: 8c 01 0f    ...
+    ldy #1                                                            ; 94b9: a0 01       ..
+; $94bb referenced 1 time by $94c2
+loop_c94bb
+    lda l0e03,y                                                       ; 94bb: b9 03 0e    ...
+    sta l0f03,y                                                       ; 94be: 99 03 0f    ...
+    dey                                                               ; 94c1: 88          .
+    bpl loop_c94bb                                                    ; 94c2: 10 f7       ..
+    bit l1071                                                         ; 94c4: 2c 71 10    ,q.
+    bvs c94d3                                                         ; 94c7: 70 0a       p.
+    bpl c94d9                                                         ; 94c9: 10 0e       ..
+    lda l0e04                                                         ; 94cb: ad 04 0e    ...
+    sta l0f03                                                         ; 94ce: 8d 03 0f    ...
+    bvc c94d9                                                         ; 94d1: 50 06       P.
+; $94d3 referenced 1 time by $94c7
+c94d3
+    lda l0e02                                                         ; 94d3: ad 02 0e    ...
+    sta l0f03                                                         ; 94d6: 8d 03 0f    ...
+; $94d9 referenced 2 times by $94c9, $94d1
+c94d9
+    plp                                                               ; 94d9: 28          (
+    php                                                               ; 94da: 08          .
+    lda #$90                                                          ; 94db: a9 90       ..
+    sta l0f00                                                         ; 94dd: 8d 00 0f    ...
+    jsr sub_c9473                                                     ; 94e0: 20 73 94     s.
+    txa                                                               ; 94e3: 8a          .
+    adc #5                                                            ; 94e4: 69 05       i.
+    sta l00c8                                                         ; 94e6: 85 c8       ..
+    plp                                                               ; 94e8: 28          (
+    bcs c9505                                                         ; 94e9: b0 1a       ..
+    php                                                               ; 94eb: 08          .
+    jsr sub_c9837                                                     ; 94ec: 20 37 98     7.
+    plp                                                               ; 94ef: 28          (
+; $94f0 referenced 2 times by $9a1f, $9f68
+sub_c94f0
+    php                                                               ; 94f0: 08          .
+    jsr sub_c9465                                                     ; 94f1: 20 65 94     e.
+    jsr sub_c95dd                                                     ; 94f4: 20 dd 95     ..
+    plp                                                               ; 94f7: 28          (
+; $94f8 referenced 1 time by $950c
+loop_c94f8
+    iny                                                               ; 94f8: c8          .
+    lda (l00c4),y                                                     ; 94f9: b1 c4       ..
+    tax                                                               ; 94fb: aa          .
+    beq c9504                                                         ; 94fc: f0 06       ..
+    bvc c9502                                                         ; 94fe: 50 02       P.
+    adc #$2a ; '*'                                                    ; 9500: 69 2a       i*
+; $9502 referenced 1 time by $94fe
+c9502
+    bne c950e                                                         ; 9502: d0 0a       ..
+; $9504 referenced 2 times by $94fc, $9574
+c9504
+    rts                                                               ; 9504: 60          `
+
+; $9505 referenced 1 time by $94e9
+c9505
+    pla                                                               ; 9505: 68          h
+    ldx #$c0                                                          ; 9506: a2 c0       ..
+    iny                                                               ; 9508: c8          .
+    jsr sub_cac24                                                     ; 9509: 20 24 ac     $.
+    bcc loop_c94f8                                                    ; 950c: 90 ea       ..
+; $950e referenced 1 time by $9502
+c950e
+    stx l0e09                                                         ; 950e: 8e 09 0e    ...
+    lda l0e07                                                         ; 9511: ad 07 0e    ...
+    php                                                               ; 9514: 08          .
+    bne c951b                                                         ; 9515: d0 04       ..
+    cpx #$bf                                                          ; 9517: e0 bf       ..
+    bne c9551                                                         ; 9519: d0 36       .6
+; $951b referenced 1 time by $9515
+c951b
+    lda #$40 ; '@'                                                    ; 951b: a9 40       .@
+    pha                                                               ; 951d: 48          H
+    ldx #$f0                                                          ; 951e: a2 f0       ..
+; $9520 referenced 1 time by $952e
+loop_c9520
+    pla                                                               ; 9520: 68          h
+    ora l0fc8,x                                                       ; 9521: 1d c8 0f    ...
+    pha                                                               ; 9524: 48          H
+    lda l0fc8,x                                                       ; 9525: bd c8 0f    ...
+    and #$c0                                                          ; 9528: 29 c0       ).
+    sta l0fc8,x                                                       ; 952a: 9d c8 0f    ...
+    inx                                                               ; 952d: e8          .
+    bmi loop_c9520                                                    ; 952e: 30 f0       0.
+    stx l0e07                                                         ; 9530: 8e 07 0e    ...
+    jsr sub_cb559                                                     ; 9533: 20 59 b5     Y.
+    pla                                                               ; 9536: 68          h
+    ror                                                               ; 9537: 6a          j
+    bcc c9547                                                         ; 9538: 90 0d       ..
+    jsr print_inline_top_bit_clear                                    ; 953a: 20 45 91     E.
+    !text "Data Lost", $0d                                            ; 953d: 44 61 74... Dat
+
+; $9547 referenced 1 time by $9538
+c9547
+    ldx l0e09                                                         ; 9547: ae 09 0e    ...
+    plp                                                               ; 954a: 28          (
+    beq c9551                                                         ; 954b: f0 04       ..
+    pla                                                               ; 954d: 68          h
+    pla                                                               ; 954e: 68          h
+    pla                                                               ; 954f: 68          h
+    rts                                                               ; 9550: 60          `
+
+; $9551 referenced 2 times by $9519, $954b
+c9551
+    ldy #1                                                            ; 9551: a0 01       ..
+    cpx #$a8                                                          ; 9553: e0 a8       ..
+    bcs c955b                                                         ; 9555: b0 04       ..
+    lda #$a8                                                          ; 9557: a9 a8       ..
+    sta (l00c4),y                                                     ; 9559: 91 c4       ..
+; $955b referenced 1 time by $9555
+c955b
+    ldy #$ff                                                          ; 955b: a0 ff       ..
+; $955d referenced 1 time by $9565
+loop_c955d
+    iny                                                               ; 955d: c8          .
+    lda (l00c4),y                                                     ; 955e: b1 c4       ..
+    sta l0100,y                                                       ; 9560: 99 00 01    ...
+    eor #$0d                                                          ; 9563: 49 0d       I.
+    bne loop_c955d                                                    ; 9565: d0 f6       ..
+    sta l0100,y                                                       ; 9567: 99 00 01    ...
+    dey                                                               ; 956a: 88          .
+    tya                                                               ; 956b: 98          .
+    tax                                                               ; 956c: aa          .
+    jmp c96f0                                                         ; 956d: 4c f0 96    L..
+
+; $9570 referenced 2 times by $8dd6, $985b
+sub_c9570
+    lda l00ff                                                         ; 9570: a5 ff       ..
+    and l0098                                                         ; 9572: 25 98       %.
+    bpl c9504                                                         ; 9574: 10 8e       ..
+; $9576 referenced 1 time by $b445
+c9576
+    lda #osbyte_acknowledge_escape                                    ; 9576: a9 7e       .~
+    jsr osbyte                                                        ; 9578: 20 f4 ff     ..
+    lda #6                                                            ; 957b: a9 06       ..
+    jmp c964e                                                         ; 957d: 4c 4e 96    LN.
+
+sub_c9580
+    ldy #0                                                            ; 9580: a0 00       ..
+    lda (l009c),y                                                     ; 9582: b1 9c       ..
+    beq c9589                                                         ; 9584: f0 03       ..
+; $9586 referenced 1 time by $95cc
+c9586
+    jmp cacdd                                                         ; 9586: 4c dd ac    L..
+
+; $9589 referenced 2 times by $9584, $95c2
+c9589
+    ora #9                                                            ; 9589: 09 09       ..
+    sta (l009c),y                                                     ; 958b: 91 9c       ..
+    ldx #$80                                                          ; 958d: a2 80       ..
+    ldy #$80                                                          ; 958f: a0 80       ..
+    lda (l009c),y                                                     ; 9591: b1 9c       ..
+    pha                                                               ; 9593: 48          H
+    iny                                                               ; 9594: c8          .
+    lda (l009c),y                                                     ; 9595: b1 9c       ..
+    ldy #$0f                                                          ; 9597: a0 0f       ..
+    sta (l009e),y                                                     ; 9599: 91 9e       ..
+    dey                                                               ; 959b: 88          .
+    pla                                                               ; 959c: 68          h
+    sta (l009e),y                                                     ; 959d: 91 9e       ..
+    jsr sub_c8aea                                                     ; 959f: 20 ea 8a     ..
+    jsr sub_caa85                                                     ; 95a2: 20 85 aa     ..
+    ldx #1                                                            ; 95a5: a2 01       ..
+    ldy #0                                                            ; 95a7: a0 00       ..
+    lda #osbyte_read_write_econet_keyboard_disable                    ; 95a9: a9 c9       ..
+    jsr osbyte                                                        ; 95ab: 20 f4 ff     ..
+sub_c95ae
+    jsr cacdd                                                         ; 95ae: 20 dd ac     ..
+    lda #0                                                            ; 95b1: a9 00       ..
+    jsr generate_error_inline3                                        ; 95b3: 20 d1 96     ..
+    !text "Remoted", 0                                                ; 95b6: 52 65 6d... Rem
+
+sub_c95be
+    ldy #0                                                            ; 95be: a0 00       ..
+    lda (l009c),y                                                     ; 95c0: b1 9c       ..
+    beq c9589                                                         ; 95c2: f0 c5       ..
+    ldy #$80                                                          ; 95c4: a0 80       ..
+    lda (l009c),y                                                     ; 95c6: b1 9c       ..
+    ldy #$0e                                                          ; 95c8: a0 0e       ..
+    cmp (l009e),y                                                     ; 95ca: d1 9e       ..
+    bne c9586                                                         ; 95cc: d0 b8       ..
+sub_c95ce
+    ldy #$82                                                          ; 95ce: a0 82       ..
+    lda (l009c),y                                                     ; 95d0: b1 9c       ..
+    tay                                                               ; 95d2: a8          .
+    ldx #0                                                            ; 95d3: a2 00       ..
+    jsr cacdd                                                         ; 95d5: 20 dd ac     ..
+    lda #osbyte_insert_input_buffer                                   ; 95d8: a9 99       ..
+    jmp osbyte                                                        ; 95da: 4c f4 ff    L..
+
+; $95dd referenced 5 times by $94f4, $99b2, $9aea, $abd1, $ac73
+sub_c95dd
+    lda l0d6e                                                         ; 95dd: ad 6e 0d    .n.
+    pha                                                               ; 95e0: 48          H
+    lda l0d61                                                         ; 95e1: ad 61 0d    .a.
+    pha                                                               ; 95e4: 48          H
+    lda l009b                                                         ; 95e5: a5 9b       ..
+    bne c95ee                                                         ; 95e7: d0 05       ..
+    ora #$80                                                          ; 95e9: 09 80       ..
+    sta l0d61                                                         ; 95eb: 8d 61 0d    .a.
+; $95ee referenced 1 time by $95e7
+c95ee
+    lda #0                                                            ; 95ee: a9 00       ..
+    pha                                                               ; 95f0: 48          H
+    pha                                                               ; 95f1: 48          H
+    tay                                                               ; 95f2: a8          .
+    tsx                                                               ; 95f3: ba          .
+; $95f4 referenced 3 times by $95fb, $9600, $9605
+c95f4
+    lda (l009a),y                                                     ; 95f4: b1 9a       ..
+    bmi c9607                                                         ; 95f6: 30 0f       0.
+    dec l0101,x                                                       ; 95f8: de 01 01    ...
+    bne c95f4                                                         ; 95fb: d0 f7       ..
+    dec l0102,x                                                       ; 95fd: de 02 01    ...
+    bne c95f4                                                         ; 9600: d0 f2       ..
+    dec l0104,x                                                       ; 9602: de 04 01    ...
+    bne c95f4                                                         ; 9605: d0 ed       ..
+; $9607 referenced 1 time by $95f6
+c9607
+    pla                                                               ; 9607: 68          h
+    pla                                                               ; 9608: 68          h
+    pla                                                               ; 9609: 68          h
+    sta l0d61                                                         ; 960a: 8d 61 0d    .a.
+    pla                                                               ; 960d: 68          h
+    beq c961a                                                         ; 960e: f0 0a       ..
+    rts                                                               ; 9610: 60          `
+
+; $9611 referenced 6 times by $9627, $9660, $967c, $96a6, $96b8, $96d1
+sta_e09_if_d6c_b7_set
+    bit l0d6c                                                         ; 9611: 2c 6c 0d    ,l.
+    bpl c9619                                                         ; 9614: 10 03       ..
+    sta l0e09                                                         ; 9616: 8d 09 0e    ...
+; $9619 referenced 1 time by $9614
+c9619
+    rts                                                               ; 9619: 60          `
+
+; $961a referenced 1 time by $960e
+c961a
+    ldx #8                                                            ; 961a: a2 08       ..
+    ldy l97ad,x                                                       ; 961c: bc ad 97    ...
+    ldx #0                                                            ; 961f: a2 00       ..
+    stx l0100                                                         ; 9621: 8e 00 01    ...
+    lda l97b9,y                                                       ; 9624: b9 b9 97    ...
+    jsr sta_e09_if_d6c_b7_set                                         ; 9627: 20 11 96     ..
+; $962a referenced 1 time by $9634
+loop_c962a
+    lda l97b9,y                                                       ; 962a: b9 b9 97    ...
+    sta l0101,x                                                       ; 962d: 9d 01 01    ...
+    beq c9636                                                         ; 9630: f0 04       ..
+    inx                                                               ; 9632: e8          .
+    iny                                                               ; 9633: c8          .
+    bne loop_c962a                                                    ; 9634: d0 f4       ..
+; $9636 referenced 1 time by $9630
+c9636
+    jsr sub_c974d                                                     ; 9636: 20 4d 97     M.
+    lda #0                                                            ; 9639: a9 00       ..
+    sta l0101,x                                                       ; 963b: 9d 01 01    ...
+    jmp c96f0                                                         ; 963e: 4c f0 96    L..
+
+; $9641 referenced 1 time by $98c6
+c9641
+    lda (l009a,x)                                                     ; 9641: a1 9a       ..
+    cmp #$41 ; 'A'                                                    ; 9643: c9 41       .A
+    bne c9649                                                         ; 9645: d0 02       ..
+    lda #$42 ; 'B'                                                    ; 9647: a9 42       .B
+; $9649 referenced 1 time by $9645
+c9649
+    clv                                                               ; 9649: b8          .
+    bvc c9651                                                         ; 964a: 50 05       P.
+; $964c referenced 1 time by $987f
+c964c
+    lda (l009a,x)                                                     ; 964c: a1 9a       ..
+; $964e referenced 2 times by $957d, $9ddc
+c964e
+    bit l9491                                                         ; 964e: 2c 91 94    ,..
+; $9651 referenced 1 time by $964a
+c9651
+    and #7                                                            ; 9651: 29 07       ).
+    pha                                                               ; 9653: 48          H
+    cmp #2                                                            ; 9654: c9 02       ..
+    bne c969a                                                         ; 9656: d0 42       .B
+    php                                                               ; 9658: 08          .
+    tax                                                               ; 9659: aa          .
+    ldy l97ad,x                                                       ; 965a: bc ad 97    ...
+    lda l97b9,y                                                       ; 965d: b9 b9 97    ...
+    jsr sta_e09_if_d6c_b7_set                                         ; 9660: 20 11 96     ..
+    ldx #0                                                            ; 9663: a2 00       ..
+    stx l0100                                                         ; 9665: 8e 00 01    ...
+; $9668 referenced 1 time by $9672
+loop_c9668
+    lda l97b9,y                                                       ; 9668: b9 b9 97    ...
+    sta l0101,x                                                       ; 966b: 9d 01 01    ...
+    beq c9674                                                         ; 966e: f0 04       ..
+    iny                                                               ; 9670: c8          .
+    inx                                                               ; 9671: e8          .
+    bne loop_c9668                                                    ; 9672: d0 f4       ..
+; $9674 referenced 1 time by $966e
+c9674
+    jsr sub_c974d                                                     ; 9674: 20 4d 97     M.
+    plp                                                               ; 9677: 28          (
+    bvs c9686                                                         ; 9678: 70 0c       p.
+    lda #$a4                                                          ; 967a: a9 a4       ..
+    jsr sta_e09_if_d6c_b7_set                                         ; 967c: 20 11 96     ..
+    sta l0101                                                         ; 967f: 8d 01 01    ...
+    ldy #$0b                                                          ; 9682: a0 0b       ..
+    bne c9688                                                         ; 9684: d0 02       ..
+; $9686 referenced 1 time by $9678
+c9686
+    ldy #9                                                            ; 9686: a0 09       ..
+; $9688 referenced 1 time by $9684
+c9688
+    lda l97ad,y                                                       ; 9688: b9 ad 97    ...
+    tay                                                               ; 968b: a8          .
+; $968c referenced 1 time by $9696
+loop_c968c
+    lda l97b9,y                                                       ; 968c: b9 b9 97    ...
+    sta l0101,x                                                       ; 968f: 9d 01 01    ...
+    beq c9698                                                         ; 9692: f0 04       ..
+    iny                                                               ; 9694: c8          .
+    inx                                                               ; 9695: e8          .
+    bne loop_c968c                                                    ; 9696: d0 f4       ..
+; $9698 referenced 1 time by $9692
+c9698
+    beq c96af                                                         ; 9698: f0 15       ..
+; $969a referenced 1 time by $9656
+c969a
+    tax                                                               ; 969a: aa          .
+    ldy l97ad,x                                                       ; 969b: bc ad 97    ...
+    ldx #0                                                            ; 969e: a2 00       ..
+    stx l0100                                                         ; 96a0: 8e 00 01    ...
+    lda l97b9,y                                                       ; 96a3: b9 b9 97    ...
+    jsr sta_e09_if_d6c_b7_set                                         ; 96a6: 20 11 96     ..
+; $96a9 referenced 1 time by $96b3
+loop_c96a9
+    lda l97b9,y                                                       ; 96a9: b9 b9 97    ...
+    sta l0101,x                                                       ; 96ac: 9d 01 01    ...
+; $96af referenced 1 time by $9698
+c96af
+    beq c96f0                                                         ; 96af: f0 3f       .?
+    iny                                                               ; 96b1: c8          .
+    inx                                                               ; 96b2: e8          .
+sub_c96b3
+error_template_minus_1 = sub_c96b3+1
+    bne loop_c96a9                                                    ; 96b3: d0 f4       ..
+; $96b4 referenced 1 time by $96c5
+    !text "Bad"                                                       ; 96b5: 42 61 64    Bad
+
+; $96b8 referenced 11 times by $8fe6, $920a, $9217, $922b, $9237, $9246, $92fc, $9381, $93a4, $a25f, $bc14
+generate_error_inline
+    jsr sta_e09_if_d6c_b7_set                                         ; 96b8: 20 11 96     ..
+    tay                                                               ; 96bb: a8          .
+    pla                                                               ; 96bc: 68          h
+    sta l00b0                                                         ; 96bd: 85 b0       ..
+    pla                                                               ; 96bf: 68          h
+    sta l00b1                                                         ; 96c0: 85 b1       ..
+    ldx #0                                                            ; 96c2: a2 00       ..
+; $96c4 referenced 1 time by $96cd
+loop_c96c4
+    inx                                                               ; 96c4: e8          .
+    lda error_template_minus_1,x                                      ; 96c5: bd b4 96    ...
+    sta l0101,x                                                       ; 96c8: 9d 01 01    ...
+    cmp #$20 ; ' '                                                    ; 96cb: c9 20       .
+    bne loop_c96c4                                                    ; 96cd: d0 f5       ..
+    beq c96dd                                                         ; 96cf: f0 0c       ..
+; $96d1 referenced 7 times by $942f, $95b3, $a276, $ac00, $ac12, $b485, $b547
+generate_error_inline3
+    jsr sta_e09_if_d6c_b7_set                                         ; 96d1: 20 11 96     ..
+; $96d4 referenced 4 times by $a129, $ba11, $bba7, $bc5d
+generate_error_inline2
+    tay                                                               ; 96d4: a8          .
+    pla                                                               ; 96d5: 68          h
+    sta l00b0                                                         ; 96d6: 85 b0       ..
+    pla                                                               ; 96d8: 68          h
+    sta l00b1                                                         ; 96d9: 85 b1       ..
+    ldx #0                                                            ; 96db: a2 00       ..
+; $96dd referenced 1 time by $96cf
+c96dd
+    sty l0101                                                         ; 96dd: 8c 01 01    ...
+    tya                                                               ; 96e0: 98          .
+    pha                                                               ; 96e1: 48          H
+    ldy #0                                                            ; 96e2: a0 00       ..
+    sty l0100                                                         ; 96e4: 8c 00 01    ...
+; $96e7 referenced 1 time by $96ee
+loop_c96e7
+    inx                                                               ; 96e7: e8          .
+    iny                                                               ; 96e8: c8          .
+    lda (l00b0),y                                                     ; 96e9: b1 b0       ..
+    sta l0101,x                                                       ; 96eb: 9d 01 01    ...
+    bne loop_c96e7                                                    ; 96ee: d0 f7       ..
+; $96f0 referenced 4 times by $956d, $963e, $96af, $b971
+c96f0
+    jsr sub_cb98a                                                     ; 96f0: 20 8a b9     ..
+    bne c96fd                                                         ; 96f3: d0 08       ..
+    pla                                                               ; 96f5: 68          h
+    cmp #$de                                                          ; 96f6: c9 de       ..
+    beq c9740                                                         ; 96f8: f0 46       .F
+; $96fa referenced 1 time by $974b
+c96fa
+    jmp l0100                                                         ; 96fa: 4c 00 01    L..
+
+; $96fd referenced 1 time by $96f3
+c96fd
+    sta l0e08                                                         ; 96fd: 8d 08 0e    ...
+    pha                                                               ; 9700: 48          H
+    txa                                                               ; 9701: 8a          .
+    pha                                                               ; 9702: 48          H
+    jsr sub_cb98a                                                     ; 9703: 20 8a b9     ..
+    sta l00b0                                                         ; 9706: 85 b0       ..
+    lda #0                                                            ; 9708: a9 00       ..
+    sta (l009c),y                                                     ; 970a: 91 9c       ..
+    lda #$c6                                                          ; 970c: a9 c6       ..
+    jsr sub_c8e83                                                     ; 970e: 20 83 8e     ..
+    cpy l00b0                                                         ; 9711: c4 b0       ..
+    beq c971e                                                         ; 9713: f0 09       ..
+    cpx l00b0                                                         ; 9715: e4 b0       ..
+    bne c972c                                                         ; 9717: d0 13       ..
+    pha                                                               ; 9719: 48          H
+    lda #$c6                                                          ; 971a: a9 c6       ..
+    bne c9722                                                         ; 971c: d0 04       ..
+; $971e referenced 1 time by $9713
+c971e
+    tya                                                               ; 971e: 98          .
+    pha                                                               ; 971f: 48          H
+    lda #$c7                                                          ; 9720: a9 c7       ..
+; $9722 referenced 1 time by $971c
+c9722
+    jsr sub_c8e8c                                                     ; 9722: 20 8c 8e     ..
+    pla                                                               ; 9725: 68          h
+    tay                                                               ; 9726: a8          .
+    lda #0                                                            ; 9727: a9 00       ..
+    jsr osfind                                                        ; 9729: 20 ce ff     ..
+; $972c referenced 1 time by $9717
+c972c
+    pla                                                               ; 972c: 68          h
+    tax                                                               ; 972d: aa          .
+    ldy #$0a                                                          ; 972e: a0 0a       ..
+    lda l97ad,y                                                       ; 9730: b9 ad 97    ...
+    tay                                                               ; 9733: a8          .
+; $9734 referenced 1 time by $973e
+loop_c9734
+    lda l97b9,y                                                       ; 9734: b9 b9 97    ...
+    sta l0101,x                                                       ; 9737: 9d 01 01    ...
+    beq c9740                                                         ; 973a: f0 04       ..
+    inx                                                               ; 973c: e8          .
+    iny                                                               ; 973d: c8          .
+    bne loop_c9734                                                    ; 973e: d0 f4       ..
+; $9740 referenced 2 times by $96f8, $973a
+c9740
+    stx l00b2                                                         ; 9740: 86 b2       ..
+    pla                                                               ; 9742: 68          h
+    jsr sub_c9771                                                     ; 9743: 20 71 97     q.
+    lda #0                                                            ; 9746: a9 00       ..
+    sta l0102,x                                                       ; 9748: 9d 02 01    ...
+    beq c96fa                                                         ; 974b: f0 ad       ..
+; $974d referenced 2 times by $9636, $9674
+sub_c974d
+    lda #$20 ; ' '                                                    ; 974d: a9 20       .
+    sta l0101,x                                                       ; 974f: 9d 01 01    ...
+    inx                                                               ; 9752: e8          .
+    stx l00b2                                                         ; 9753: 86 b2       ..
+    ldy #3                                                            ; 9755: a0 03       ..
+    lda (l009a),y                                                     ; 9757: b1 9a       ..
+    beq c9767                                                         ; 9759: f0 0c       ..
+    jsr sub_c977c                                                     ; 975b: 20 7c 97     |.
+    ldx l00b2                                                         ; 975e: a6 b2       ..
+    lda #$2e ; '.'                                                    ; 9760: a9 2e       ..
+    sta l0101,x                                                       ; 9762: 9d 01 01    ...
+    inc l00b2                                                         ; 9765: e6 b2       ..
+; $9767 referenced 1 time by $9759
+c9767
+    ldy #2                                                            ; 9767: a0 02       ..
+    lda (l009a),y                                                     ; 9769: b1 9a       ..
+    jsr sub_c977c                                                     ; 976b: 20 7c 97     |.
+    ldx l00b2                                                         ; 976e: a6 b2       ..
+    rts                                                               ; 9770: 60          `
+
+; $9771 referenced 2 times by $9743, $b4da
+sub_c9771
+    tay                                                               ; 9771: a8          .
+    lda #$20 ; ' '                                                    ; 9772: a9 20       .
+    ldx l00b2                                                         ; 9774: a6 b2       ..
+    sta l0101,x                                                       ; 9776: 9d 01 01    ...
+    inc l00b2                                                         ; 9779: e6 b2       ..
+    tya                                                               ; 977b: 98          .
+; $977c referenced 2 times by $975b, $976b
+sub_c977c
+    tay                                                               ; 977c: a8          .
+    bit l9491                                                         ; 977d: 2c 91 94    ,..
+    lda #$64 ; 'd'                                                    ; 9780: a9 64       .d
+    jsr sub_c978d                                                     ; 9782: 20 8d 97     ..
+    lda #$0a                                                          ; 9785: a9 0a       ..
+    jsr sub_c978d                                                     ; 9787: 20 8d 97     ..
+    lda #1                                                            ; 978a: a9 01       ..
+    clv                                                               ; 978c: b8          .
+; $978d referenced 2 times by $9782, $9787
+sub_c978d
+    sta l00b3                                                         ; 978d: 85 b3       ..
+    tya                                                               ; 978f: 98          .
+    ldx #$2f ; '/'                                                    ; 9790: a2 2f       ./
+    php                                                               ; 9792: 08          .
+    sec                                                               ; 9793: 38          8
+; $9794 referenced 1 time by $9797
+loop_c9794
+    inx                                                               ; 9794: e8          .
+    sbc l00b3                                                         ; 9795: e5 b3       ..
+    bcs loop_c9794                                                    ; 9797: b0 fb       ..
+    adc l00b3                                                         ; 9799: 65 b3       e.
+    plp                                                               ; 979b: 28          (
+    tay                                                               ; 979c: a8          .
+    txa                                                               ; 979d: 8a          .
+    cmp #$30 ; '0'                                                    ; 979e: c9 30       .0
+    bne c97a4                                                         ; 97a0: d0 02       ..
+    bvs c97ac                                                         ; 97a2: 70 08       p.
+; $97a4 referenced 1 time by $97a0
+c97a4
+    clv                                                               ; 97a4: b8          .
+    ldx l00b2                                                         ; 97a5: a6 b2       ..
+    sta l0101,x                                                       ; 97a7: 9d 01 01    ...
+    inc l00b2                                                         ; 97aa: e6 b2       ..
+; $97ac referenced 1 time by $97a2
+c97ac
+    rts                                                               ; 97ac: 60          `
+
+; $97ad referenced 5 times by $961c, $965a, $9688, $969b, $9730
+l97ad
+    !byte   0, $0d, $18                                               ; 97ad: 00 0d 18    ...
+    !text "!+++3?Veq"                                                 ; 97b0: 21 2b 2b... !++
+; $97b9 referenced 8 times by $9624, $962a, $965d, $9668, $968c, $96a3, $96a9, $9734
+l97b9
+    !byte $a0                                                         ; 97b9: a0          .
+    !text "Line jammed"                                               ; 97ba: 4c 69 6e... Lin
+    !byte   0, $a1                                                    ; 97c5: 00 a1       ..
+    !text "Net error"                                                 ; 97c7: 4e 65 74... Net
+    !byte   0, $a2                                                    ; 97d0: 00 a2       ..
+    !text "Station"                                                   ; 97d2: 53 74 61... Sta
+    !byte   0, $a3                                                    ; 97d9: 00 a3       ..
+    !text "No clock"                                                  ; 97db: 4e 6f 20... No
+    !byte   0, $11                                                    ; 97e3: 00 11       ..
+    !text "Escape"                                                    ; 97e5: 45 73 63... Esc
+    !byte   0, $cb                                                    ; 97eb: 00 cb       ..
+    !text "Bad option"                                                ; 97ed: 42 61 64... Bad
+    !byte   0, $a5                                                    ; 97f7: 00 a5       ..
+    !text "No reply from station"                                     ; 97f9: 4e 6f 20... No
+    !byte 0                                                           ; 980e: 00          .
+    !text " not listening"                                            ; 980f: 20 6e 6f...  no
+    !byte 0                                                           ; 981d: 00          .
+    !text " on channel"                                               ; 981e: 20 6f 6e...  on
+    !byte 0                                                           ; 9829: 00          .
+    !text " not present"                                              ; 982a: 20 6e 6f...  no
+    !byte 0                                                           ; 9836: 00          .
+
+; $9837 referenced 2 times by $94ec, $9adb
+sub_c9837
+    ldx #$c0                                                          ; 9837: a2 c0       ..
+    stx l009a                                                         ; 9839: 86 9a       ..
+    ldx #0                                                            ; 983b: a2 00       ..
+    stx l009b                                                         ; 983d: 86 9b       ..
+; $983f referenced 5 times by $a9d4, $abc6, $ac51, $b05b, $b23a
+sub_c983f
+    lda l0d6d                                                         ; 983f: ad 6d 0d    .m.
+    bne c9846                                                         ; 9842: d0 02       ..
+    lda #$ff                                                          ; 9844: a9 ff       ..
+; $9846 referenced 1 time by $9842
+c9846
+    ldy #$60 ; '`'                                                    ; 9846: a0 60       .`
+    pha                                                               ; 9848: 48          H
+    tya                                                               ; 9849: 98          .
+    pha                                                               ; 984a: 48          H
+    ldx #0                                                            ; 984b: a2 00       ..
+    lda (l009a,x)                                                     ; 984d: a1 9a       ..
+; $984f referenced 1 time by $9871
+c984f
+    sta (l009a,x)                                                     ; 984f: 81 9a       ..
+    pha                                                               ; 9851: 48          H
+    jsr c98c9                                                         ; 9852: 20 c9 98     ..
+    asl                                                               ; 9855: 0a          .
+    bpl c9882                                                         ; 9856: 10 2a       .*
+    asl                                                               ; 9858: 0a          .
+    beq c987e                                                         ; 9859: f0 23       .#
+    jsr sub_c9570                                                     ; 985b: 20 70 95     p.
+    pla                                                               ; 985e: 68          h
+    tax                                                               ; 985f: aa          .
+    pla                                                               ; 9860: 68          h
+    tay                                                               ; 9861: a8          .
+    pla                                                               ; 9862: 68          h
+    beq c9873                                                         ; 9863: f0 0e       ..
+; $9865 referenced 1 time by $987c
+loop_c9865
+    sbc #1                                                            ; 9865: e9 01       ..
+    pha                                                               ; 9867: 48          H
+    tya                                                               ; 9868: 98          .
+    pha                                                               ; 9869: 48          H
+    txa                                                               ; 986a: 8a          .
+; $986b referenced 2 times by $986c, $986f
+c986b
+    dex                                                               ; 986b: ca          .
+    bne c986b                                                         ; 986c: d0 fd       ..
+    dey                                                               ; 986e: 88          .
+    bne c986b                                                         ; 986f: d0 fa       ..
+    beq c984f                                                         ; 9871: f0 dc       ..
+; $9873 referenced 1 time by $9863
+c9873
+    cmp l0d6d                                                         ; 9873: cd 6d 0d    .m.
+    bne c987e                                                         ; 9876: d0 06       ..
+    lda #$80                                                          ; 9878: a9 80       ..
+    sta l0098                                                         ; 987a: 85 98       ..
+    bne loop_c9865                                                    ; 987c: d0 e7       ..
+; $987e referenced 2 times by $9859, $9876
+c987e
+    tax                                                               ; 987e: aa          .
+    jmp c964c                                                         ; 987f: 4c 4c 96    LL.
+
+; $9882 referenced 1 time by $9856
+c9882
+    pla                                                               ; 9882: 68          h
+    pla                                                               ; 9883: 68          h
+    pla                                                               ; 9884: 68          h
+    jmp c929f                                                         ; 9885: 4c 9f 92    L..
+
+; $9888 referenced 2 times by $989e, $98f8
+l9888
+    !byte $88,   0, $fd, $fd, $3a, $0d, $ff, $ff, $3e, $0d, $ff, $ff  ; 9888: 88 00 fd... ...
+
+; $9894 referenced 1 time by $8dff
+sub_c9894
+    ldy #$c0                                                          ; 9894: a0 c0       ..
+    sty l009a                                                         ; 9896: 84 9a       ..
+    ldy #0                                                            ; 9898: a0 00       ..
+    sty l009b                                                         ; 989a: 84 9b       ..
+; $989c referenced 1 time by $abc3
+sub_c989c
+    ldy #$0b                                                          ; 989c: a0 0b       ..
+; $989e referenced 1 time by $98ac
+loop_c989e
+    ldx l9888,y                                                       ; 989e: be 88 98    ...
+    cpx #$fd                                                          ; 98a1: e0 fd       ..
+    beq c98ab                                                         ; 98a3: f0 06       ..
+    lda (l009a),y                                                     ; 98a5: b1 9a       ..
+    pha                                                               ; 98a7: 48          H
+    txa                                                               ; 98a8: 8a          .
+    sta (l009a),y                                                     ; 98a9: 91 9a       ..
+; $98ab referenced 1 time by $98a3
+c98ab
+    dey                                                               ; 98ab: 88          .
+    bpl loop_c989e                                                    ; 98ac: 10 f0       ..
+    lda l0d6f                                                         ; 98ae: ad 6f 0d    .o.
+    pha                                                               ; 98b1: 48          H
+    tya                                                               ; 98b2: 98          .
+    pha                                                               ; 98b3: 48          H
+    ldx #0                                                            ; 98b4: a2 00       ..
+    lda (l009a,x)                                                     ; 98b6: a1 9a       ..
+; $98b8 referenced 1 time by $98f1
+c98b8
+    sta (l009a,x)                                                     ; 98b8: 81 9a       ..
+    pha                                                               ; 98ba: 48          H
+    jsr c98c9                                                         ; 98bb: 20 c9 98     ..
+    asl                                                               ; 98be: 0a          .
+    bpl c98f3                                                         ; 98bf: 10 32       .2
+    asl                                                               ; 98c1: 0a          .
+    bne c98de                                                         ; 98c2: d0 1a       ..
+; $98c4 referenced 1 time by $98e3
+loop_c98c4
+    ldx #0                                                            ; 98c4: a2 00       ..
+    jmp c9641                                                         ; 98c6: 4c 41 96    LA.
+
+; $98c9 referenced 3 times by $9852, $98bb, $98cc
+c98c9
+    asl l0d60                                                         ; 98c9: 0e 60 0d    .`.
+    bcc c98c9                                                         ; 98cc: 90 fb       ..
+    lda l009a                                                         ; 98ce: a5 9a       ..
+    sta l00a0                                                         ; 98d0: 85 a0       ..
+    lda l009b                                                         ; 98d2: a5 9b       ..
+    sta l00a1                                                         ; 98d4: 85 a1       ..
+    jsr sub_c858c                                                     ; 98d6: 20 8c 85     ..
+; $98d9 referenced 1 time by $98db
+loop_c98d9
+    lda (l009a,x)                                                     ; 98d9: a1 9a       ..
+    bmi loop_c98d9                                                    ; 98db: 30 fc       0.
+    rts                                                               ; 98dd: 60          `
+
+; $98de referenced 1 time by $98c2
+c98de
+    pla                                                               ; 98de: 68          h
+    tax                                                               ; 98df: aa          .
+    pla                                                               ; 98e0: 68          h
+    tay                                                               ; 98e1: a8          .
+    pla                                                               ; 98e2: 68          h
+    beq loop_c98c4                                                    ; 98e3: f0 df       ..
+    sbc #1                                                            ; 98e5: e9 01       ..
+    pha                                                               ; 98e7: 48          H
+    tya                                                               ; 98e8: 98          .
+    pha                                                               ; 98e9: 48          H
+    txa                                                               ; 98ea: 8a          .
+; $98eb referenced 2 times by $98ec, $98ef
+c98eb
+    dex                                                               ; 98eb: ca          .
+    bne c98eb                                                         ; 98ec: d0 fd       ..
+    dey                                                               ; 98ee: 88          .
+    bne c98eb                                                         ; 98ef: d0 fa       ..
+    beq c98b8                                                         ; 98f1: f0 c5       ..
+; $98f3 referenced 1 time by $98bf
+c98f3
+    pla                                                               ; 98f3: 68          h
+    pla                                                               ; 98f4: 68          h
+    pla                                                               ; 98f5: 68          h
+    ldy #0                                                            ; 98f6: a0 00       ..
+; $98f8 referenced 1 time by $9905
+loop_c98f8
+    ldx l9888,y                                                       ; 98f8: be 88 98    ...
+    cpx #$fd                                                          ; 98fb: e0 fd       ..
+    beq c9902                                                         ; 98fd: f0 03       ..
+    pla                                                               ; 98ff: 68          h
+    sta (l009a),y                                                     ; 9900: 91 9a       ..
+; $9902 referenced 1 time by $98fd
+c9902
+    iny                                                               ; 9902: c8          .
+    cpy #$0c                                                          ; 9903: c0 0c       ..
+    bne loop_c98f8                                                    ; 9905: d0 f1       ..
+    rts                                                               ; 9907: 60          `
+
+    !byte $a0,   1, $b1, $bb, $99, $f2,   0, $88, $10, $f8, $c8       ; 9908: a0 01 b1... ...
+
+; $9913 referenced 1 time by $ae94
+sub_c9913
+    ldx #$ff                                                          ; 9913: a2 ff       ..
+    clc                                                               ; 9915: 18          .
+    jsr gsinit                                                        ; 9916: 20 c2 ff     ..
+    beq c9926                                                         ; 9919: f0 0b       ..
+; $991b referenced 1 time by $9924
+loop_c991b
+    jsr gsread                                                        ; 991b: 20 c5 ff     ..
+    bcs c9926                                                         ; 991e: b0 06       ..
+    inx                                                               ; 9920: e8          .
+    sta l0e30,x                                                       ; 9921: 9d 30 0e    .0.
+    bcc loop_c991b                                                    ; 9924: 90 f5       ..
+; $9926 referenced 2 times by $9919, $991e
+c9926
+    inx                                                               ; 9926: e8          .
+    lda #$0d                                                          ; 9927: a9 0d       ..
+    sta l0e30,x                                                       ; 9929: 9d 30 0e    .0.
+    lda #$30 ; '0'                                                    ; 992c: a9 30       .0
+    sta l00be                                                         ; 992e: 85 be       ..
+    lda #$0e                                                          ; 9930: a9 0e       ..
+    sta l00bf                                                         ; 9932: 85 bf       ..
+    rts                                                               ; 9934: 60          `
+
+    !byte $20, $95, $92, $20,   8, $99, $20, $32, $af, $20, $97, $ae  ; 9935: 20 95 92...  ..
+    !byte $a5, $bd, $10, $7e, $c9, $ff, $f0,   3, $4c, $c7, $9c, $20  ; 9941: a5 bd 10... ...
+    !byte   2, $af, $a0,   2                                          ; 994d: 02 af a0... ...
+
+; $9951 referenced 1 time by $a2d1
+sub_c9951
+    lda #$92                                                          ; 9951: a9 92       ..
+    sta l0098                                                         ; 9953: 85 98       ..
+    sta l0f02                                                         ; 9955: 8d 02 0f    ...
+    jsr sub_c949b                                                     ; 9958: 20 9b 94     ..
+    ldy #6                                                            ; 995b: a0 06       ..
+    lda (l00bb),y                                                     ; 995d: b1 bb       ..
+    bne c9969                                                         ; 995f: d0 08       ..
+    jsr sub_c9a72                                                     ; 9961: 20 72 9a     r.
+    jsr sub_c9a84                                                     ; 9964: 20 84 9a     ..
+    bcc c996f                                                         ; 9967: 90 06       ..
+; $9969 referenced 1 time by $995f
+c9969
+    jsr sub_c9a84                                                     ; 9969: 20 84 9a     ..
+    jsr sub_c9a72                                                     ; 996c: 20 72 9a     r.
+; $996f referenced 1 time by $9967
+c996f
+    ldy #4                                                            ; 996f: a0 04       ..
+; $9971 referenced 1 time by $997c
+loop_c9971
+    lda l00b0,x                                                       ; 9971: b5 b0       ..
+    sta l00c8,x                                                       ; 9973: 95 c8       ..
+    adc l0f0d,x                                                       ; 9975: 7d 0d 0f    }..
+    sta l00b4,x                                                       ; 9978: 95 b4       ..
+    inx                                                               ; 997a: e8          .
+    dey                                                               ; 997b: 88          .
+    bne loop_c9971                                                    ; 997c: d0 f3       ..
+    sec                                                               ; 997e: 38          8
+    sbc l0f10                                                         ; 997f: ed 10 0f    ...
+    sta l00b7                                                         ; 9982: 85 b7       ..
+    jsr sub_c9b95                                                     ; 9984: 20 95 9b     ..
+    jsr sub_c9998                                                     ; 9987: 20 98 99     ..
+    ldx #2                                                            ; 998a: a2 02       ..
+; $998c referenced 1 time by $9993
+loop_c998c
+    lda l0f10,x                                                       ; 998c: bd 10 0f    ...
+    sta l0f05,x                                                       ; 998f: 9d 05 0f    ...
+    dex                                                               ; 9992: ca          .
+    bpl loop_c998c                                                    ; 9993: 10 f7       ..
+    jmp c9a1f                                                         ; 9995: 4c 1f 9a    L..
+
+; $9998 referenced 2 times by $9987, $9f52
+sub_c9998
+    jsr sub_c92a4                                                     ; 9998: 20 a4 92     ..
+    beq c99c2                                                         ; 999b: f0 25       .%
+    lda #$92                                                          ; 999d: a9 92       ..
+    sta l00c1                                                         ; 999f: 85 c1       ..
+; $99a1 referenced 1 time by $99bd
+loop_c99a1
+    ldx #3                                                            ; 99a1: a2 03       ..
+; $99a3 referenced 1 time by $99ac
+loop_c99a3
+    lda l00c8,x                                                       ; 99a3: b5 c8       ..
+    sta l00c4,x                                                       ; 99a5: 95 c4       ..
+    lda l00b4,x                                                       ; 99a7: b5 b4       ..
+    sta l00c8,x                                                       ; 99a9: 95 c8       ..
+    dex                                                               ; 99ab: ca          .
+    bpl loop_c99a3                                                    ; 99ac: 10 f5       ..
+    lda #$7f                                                          ; 99ae: a9 7f       ..
+    sta l00c0                                                         ; 99b0: 85 c0       ..
+    jsr sub_c95dd                                                     ; 99b2: 20 dd 95     ..
+    ldy #3                                                            ; 99b5: a0 03       ..
+; $99b7 referenced 1 time by $99c0
+loop_c99b7
+    lda l00c8,y                                                       ; 99b7: b9 c8 00    ...
+    eor l00b4,y                                                       ; 99ba: 59 b4 00    Y..
+    bne loop_c99a1                                                    ; 99bd: d0 e2       ..
+    dey                                                               ; 99bf: 88          .
+    bpl loop_c99b7                                                    ; 99c0: 10 f5       ..
+; $99c2 referenced 1 time by $999b
+c99c2
+    rts                                                               ; 99c2: 60          `
+
+    !byte $f0,   3, $4c, $ef, $9a                                     ; 99c3: f0 03 4c... ..L
+
+; $99c8 referenced 1 time by $9af8
+c99c8
+    ldx #4                                                            ; 99c8: a2 04       ..
+    ldy #$0e                                                          ; 99ca: a0 0e       ..
+    sec                                                               ; 99cc: 38          8
+; $99cd referenced 1 time by $99e7
+loop_c99cd
+    lda (l00bb),y                                                     ; 99cd: b1 bb       ..
+    sta l00a6,y                                                       ; 99cf: 99 a6 00    ...
+    jsr sub_c9a91                                                     ; 99d2: 20 91 9a     ..
+    sbc (l00bb),y                                                     ; 99d5: f1 bb       ..
+    sta l0f03,y                                                       ; 99d7: 99 03 0f    ...
+    pha                                                               ; 99da: 48          H
+    lda (l00bb),y                                                     ; 99db: b1 bb       ..
+    sta l00a6,y                                                       ; 99dd: 99 a6 00    ...
+    pla                                                               ; 99e0: 68          h
+    sta (l00bb),y                                                     ; 99e1: 91 bb       ..
+    jsr sub_c9a7e                                                     ; 99e3: 20 7e 9a     ~.
+    dex                                                               ; 99e6: ca          .
+    bne loop_c99cd                                                    ; 99e7: d0 e4       ..
+    ldy #9                                                            ; 99e9: a0 09       ..
+; $99eb referenced 1 time by $99f1
+loop_c99eb
+    lda (l00bb),y                                                     ; 99eb: b1 bb       ..
+    sta l0f03,y                                                       ; 99ed: 99 03 0f    ...
+    dey                                                               ; 99f0: 88          .
+    bne loop_c99eb                                                    ; 99f1: d0 f8       ..
+    lda #$91                                                          ; 99f3: a9 91       ..
+    sta l0098                                                         ; 99f5: 85 98       ..
+    sta l0f02                                                         ; 99f7: 8d 02 0f    ...
+    sta l00b8                                                         ; 99fa: 85 b8       ..
+    ldx #$0b                                                          ; 99fc: a2 0b       ..
+    jsr sub_caf04                                                     ; 99fe: 20 04 af     ..
+    ldy #1                                                            ; 9a01: a0 01       ..
+    lda l00bd                                                         ; 9a03: a5 bd       ..
+    cmp #7                                                            ; 9a05: c9 07       ..
+    php                                                               ; 9a07: 08          .
+    bne c9a0c                                                         ; 9a08: d0 02       ..
+    ldy #$1d                                                          ; 9a0a: a0 1d       ..
+; $9a0c referenced 1 time by $9a08
+c9a0c
+    jsr sub_c949b                                                     ; 9a0c: 20 9b 94     ..
+    jsr sub_c9b95                                                     ; 9a0f: 20 95 9b     ..
+    plp                                                               ; 9a12: 28          (
+    bne c9a19                                                         ; 9a13: d0 04       ..
+    ldx #0                                                            ; 9a15: a2 00       ..
+    beq c9a22                                                         ; 9a17: f0 09       ..
+; $9a19 referenced 1 time by $9a13
+c9a19
+    lda l0f05                                                         ; 9a19: ad 05 0f    ...
+    jsr sub_c9a9a                                                     ; 9a1c: 20 9a 9a     ..
+; $9a1f referenced 1 time by $9995
+c9a1f
+    jsr sub_c94f0                                                     ; 9a1f: 20 f0 94     ..
+; $9a22 referenced 1 time by $9a17
+c9a22
+    stx l0f08                                                         ; 9a22: 8e 08 0f    ...
+    ldy #$0e                                                          ; 9a25: a0 0e       ..
+    lda l0f05                                                         ; 9a27: ad 05 0f    ...
+    jsr sub_c9273                                                     ; 9a2a: 20 73 92     s.
+    beq c9a32                                                         ; 9a2d: f0 03       ..
+; $9a2f referenced 1 time by $9a37
+loop_c9a2f
+    lda l0ef7,y                                                       ; 9a2f: b9 f7 0e    ...
+; $9a32 referenced 1 time by $9a2d
+c9a32
+    sta (l00bb),y                                                     ; 9a32: 91 bb       ..
+    iny                                                               ; 9a34: c8          .
+    cpy #$12                                                          ; 9a35: c0 12       ..
+    bne loop_c9a2f                                                    ; 9a37: d0 f6       ..
+    ldy l0e06                                                         ; 9a39: ac 06 0e    ...
+    beq c9a83                                                         ; 9a3c: f0 45       .E
+    ldy #$f4                                                          ; 9a3e: a0 f4       ..
+; $9a40 referenced 1 time by $9a47
+loop_c9a40
+    lda l0fff,y                                                       ; 9a40: b9 ff 0f    ...
+    jsr osasci                                                        ; 9a43: 20 e3 ff     ..
+    iny                                                               ; 9a46: c8          .
+    bne loop_c9a40                                                    ; 9a47: d0 f7       ..
+    ldy #5                                                            ; 9a49: a0 05       ..
+    jsr sub_c9a62                                                     ; 9a4b: 20 62 9a     b.
+    jsr sub_c9a57                                                     ; 9a4e: 20 57 9a     W.
+    jsr osnewl                                                        ; 9a51: 20 e7 ff     ..
+    jmp c9cc7                                                         ; 9a54: 4c c7 9c    L..
+
+; $9a57 referenced 1 time by $9a4e
+sub_c9a57
+    ldy #9                                                            ; 9a57: a0 09       ..
+    jsr sub_c9a62                                                     ; 9a59: 20 62 9a     b.
+    ldy #$0c                                                          ; 9a5c: a0 0c       ..
+    ldx #3                                                            ; 9a5e: a2 03       ..
+    bne c9a64                                                         ; 9a60: d0 02       ..
+; $9a62 referenced 2 times by $9a4b, $9a59
+sub_c9a62
+    ldx #4                                                            ; 9a62: a2 04       ..
+; $9a64 referenced 2 times by $9a60, $9a6b
+c9a64
+    lda (l00bb),y                                                     ; 9a64: b1 bb       ..
+    jsr sub_c912f                                                     ; 9a66: 20 2f 91     /.
+    dey                                                               ; 9a69: 88          .
+    dex                                                               ; 9a6a: ca          .
+    bne c9a64                                                         ; 9a6b: d0 f7       ..
+    lda #$20 ; ' '                                                    ; 9a6d: a9 20       .
+    jmp osasci                                                        ; 9a6f: 4c e3 ff    L..
+
+; $9a72 referenced 2 times by $9961, $996c
+sub_c9a72
+    ldy #5                                                            ; 9a72: a0 05       ..
+; $9a74 referenced 1 time by $9a7c
+loop_c9a74
+    lda (l00bb),y                                                     ; 9a74: b1 bb       ..
+    sta l00ae,y                                                       ; 9a76: 99 ae 00    ...
+    dey                                                               ; 9a79: 88          .
+    cpy #2                                                            ; 9a7a: c0 02       ..
+    bcs loop_c9a74                                                    ; 9a7c: b0 f6       ..
+; $9a7e referenced 1 time by $99e3
+sub_c9a7e
+    iny                                                               ; 9a7e: c8          .
+; $9a7f referenced 2 times by $9f2f, $b074
+sub_c9a7f
+    iny                                                               ; 9a7f: c8          .
+    iny                                                               ; 9a80: c8          .
+    iny                                                               ; 9a81: c8          .
+    iny                                                               ; 9a82: c8          .
+; $9a83 referenced 1 time by $9a3c
+c9a83
+    rts                                                               ; 9a83: 60          `
+
+; $9a84 referenced 2 times by $9964, $9969
+sub_c9a84
+    ldy #$0d                                                          ; 9a84: a0 0d       ..
+    txa                                                               ; 9a86: 8a          .
+; $9a87 referenced 1 time by $9a8f
+loop_c9a87
+    sta (l00bb),y                                                     ; 9a87: 91 bb       ..
+    lda l0f02,y                                                       ; 9a89: b9 02 0f    ...
+    dey                                                               ; 9a8c: 88          .
+    cpy #2                                                            ; 9a8d: c0 02       ..
+    bcs loop_c9a87                                                    ; 9a8f: b0 f6       ..
+; $9a91 referenced 1 time by $99d2
+sub_c9a91
+    dey                                                               ; 9a91: 88          .
+; $9a92 referenced 2 times by $9b0e, $9f37
+sub_c9a92
+    dey                                                               ; 9a92: 88          .
+    dey                                                               ; 9a93: 88          .
+    dey                                                               ; 9a94: 88          .
+    rts                                                               ; 9a95: 60          `
+
+; $9a96 referenced 2 times by $9a9e, $9ae4
+c9a96
+    pla                                                               ; 9a96: 68          h
+    ldy l00bc                                                         ; 9a97: a4 bc       ..
+    rts                                                               ; 9a99: 60          `
+
+; $9a9a referenced 2 times by $9a1c, $9f4d
+sub_c9a9a
+    pha                                                               ; 9a9a: 48          H
+    jsr sub_c92a4                                                     ; 9a9b: 20 a4 92     ..
+    beq c9a96                                                         ; 9a9e: f0 f6       ..
+; $9aa0 referenced 1 time by $9aed
+c9aa0
+    ldx #0                                                            ; 9aa0: a2 00       ..
+    ldy #4                                                            ; 9aa2: a0 04       ..
+    stx l0f08                                                         ; 9aa4: 8e 08 0f    ...
+    stx l0f09                                                         ; 9aa7: 8e 09 0f    ...
+    clc                                                               ; 9aaa: 18          .
+; $9aab referenced 1 time by $9ab8
+loop_c9aab
+    lda l00b0,x                                                       ; 9aab: b5 b0       ..
+    sta l00c4,x                                                       ; 9aad: 95 c4       ..
+    adc l0f06,x                                                       ; 9aaf: 7d 06 0f    }..
+    sta l00c8,x                                                       ; 9ab2: 95 c8       ..
+    sta l00b0,x                                                       ; 9ab4: 95 b0       ..
+    inx                                                               ; 9ab6: e8          .
+    dey                                                               ; 9ab7: 88          .
+    bne loop_c9aab                                                    ; 9ab8: d0 f1       ..
+    bcs c9ac9                                                         ; 9aba: b0 0d       ..
+    sec                                                               ; 9abc: 38          8
+; $9abd referenced 1 time by $9ac5
+loop_c9abd
+    lda l00b0,y                                                       ; 9abd: b9 b0 00    ...
+    sbc l00b4,y                                                       ; 9ac0: f9 b4 00    ...
+    iny                                                               ; 9ac3: c8          .
+    dex                                                               ; 9ac4: ca          .
+    bne loop_c9abd                                                    ; 9ac5: d0 f6       ..
+    bcc c9ad2                                                         ; 9ac7: 90 09       ..
+; $9ac9 referenced 1 time by $9aba
+c9ac9
+    ldx #3                                                            ; 9ac9: a2 03       ..
+; $9acb referenced 1 time by $9ad0
+loop_c9acb
+    lda l00b4,x                                                       ; 9acb: b5 b4       ..
+    sta l00c8,x                                                       ; 9acd: 95 c8       ..
+    dex                                                               ; 9acf: ca          .
+    bpl loop_c9acb                                                    ; 9ad0: 10 f9       ..
+; $9ad2 referenced 1 time by $9ac7
+c9ad2
+    pla                                                               ; 9ad2: 68          h
+    pha                                                               ; 9ad3: 48          H
+    php                                                               ; 9ad4: 08          .
+    sta l00c1                                                         ; 9ad5: 85 c1       ..
+    lda #$80                                                          ; 9ad7: a9 80       ..
+    sta l00c0                                                         ; 9ad9: 85 c0       ..
+    jsr sub_c9837                                                     ; 9adb: 20 37 98     7.
+    lda l00b8                                                         ; 9ade: a5 b8       ..
+    jsr sub_c9467                                                     ; 9ae0: 20 67 94     g.
+    plp                                                               ; 9ae3: 28          (
+    bcs c9a96                                                         ; 9ae4: b0 b0       ..
+    lda #$91                                                          ; 9ae6: a9 91       ..
+    sta l00c1                                                         ; 9ae8: 85 c1       ..
+    jsr sub_c95dd                                                     ; 9aea: 20 dd 95     ..
+    bne c9aa0                                                         ; 9aed: d0 b1       ..
+    sta l0f05                                                         ; 9aef: 8d 05 0f    ...
+    cmp #7                                                            ; 9af2: c9 07       ..
+    bcc c9afb                                                         ; 9af4: 90 05       ..
+    bne c9b47                                                         ; 9af6: d0 4f       .O
+    jmp c99c8                                                         ; 9af8: 4c c8 99    L..
+
+; $9afb referenced 1 time by $9af4
+c9afb
+    cmp #6                                                            ; 9afb: c9 06       ..
+    beq c9b3c                                                         ; 9afd: f0 3d       .=
+    cmp #5                                                            ; 9aff: c9 05       ..
+    beq c9b56                                                         ; 9b01: f0 53       .S
+    cmp #4                                                            ; 9b03: c9 04       ..
+    beq c9b4c                                                         ; 9b05: f0 45       .E
+    cmp #1                                                            ; 9b07: c9 01       ..
+    beq c9b20                                                         ; 9b09: f0 15       ..
+    asl                                                               ; 9b0b: 0a          .
+    asl                                                               ; 9b0c: 0a          .
+    tay                                                               ; 9b0d: a8          .
+    jsr sub_c9a92                                                     ; 9b0e: 20 92 9a     ..
+    ldx #3                                                            ; 9b11: a2 03       ..
+; $9b13 referenced 1 time by $9b1a
+loop_c9b13
+    lda (l00bb),y                                                     ; 9b13: b1 bb       ..
+    sta l0f06,x                                                       ; 9b15: 9d 06 0f    ...
+    dey                                                               ; 9b18: 88          .
+    dex                                                               ; 9b19: ca          .
+    bpl loop_c9b13                                                    ; 9b1a: 10 f7       ..
+    ldx #5                                                            ; 9b1c: a2 05       ..
+    bne c9b35                                                         ; 9b1e: d0 15       ..
+; $9b20 referenced 1 time by $9b09
+c9b20
+    jsr sub_c9269                                                     ; 9b20: 20 69 92     i.
+    sta l0f0e                                                         ; 9b23: 8d 0e 0f    ...
+    ldy #9                                                            ; 9b26: a0 09       ..
+    ldx #8                                                            ; 9b28: a2 08       ..
+; $9b2a referenced 1 time by $9b31
+loop_c9b2a
+    lda (l00bb),y                                                     ; 9b2a: b1 bb       ..
+    sta l0f05,x                                                       ; 9b2c: 9d 05 0f    ...
+    dey                                                               ; 9b2f: 88          .
+    dex                                                               ; 9b30: ca          .
+    bne loop_c9b2a                                                    ; 9b31: d0 f7       ..
+    ldx #$0a                                                          ; 9b33: a2 0a       ..
+; $9b35 referenced 2 times by $9b1e, $9b54
+c9b35
+    jsr sub_caf04                                                     ; 9b35: 20 04 af     ..
+    ldy #$13                                                          ; 9b38: a0 13       ..
+    bne c9b41                                                         ; 9b3a: d0 05       ..
+; $9b3c referenced 1 time by $9afd
+c9b3c
+    jsr sub_caf02                                                     ; 9b3c: 20 02 af     ..
+    ldy #$14                                                          ; 9b3f: a0 14       ..
+; $9b41 referenced 1 time by $9b3a
+c9b41
+    bit l9491                                                         ; 9b41: 2c 91 94    ,..
+    jsr c94ae                                                         ; 9b44: 20 ae 94     ..
+; $9b47 referenced 1 time by $9af6
+c9b47
+    bcs c9b92                                                         ; 9b47: b0 49       .I
+    jmp c9cc7                                                         ; 9b49: 4c c7 9c    L..
+
+; $9b4c referenced 1 time by $9b05
+c9b4c
+    jsr sub_c9269                                                     ; 9b4c: 20 69 92     i.
+    sta l0f06                                                         ; 9b4f: 8d 06 0f    ...
+    ldx #2                                                            ; 9b52: a2 02       ..
+    bne c9b35                                                         ; 9b54: d0 df       ..
+; $9b56 referenced 1 time by $9b01
+c9b56
+    ldx #1                                                            ; 9b56: a2 01       ..
+    jsr sub_caf04                                                     ; 9b58: 20 04 af     ..
+    ldy #$12                                                          ; 9b5b: a0 12       ..
+    jsr c94ad                                                         ; 9b5d: 20 ad 94     ..
+    lda l0f11                                                         ; 9b60: ad 11 0f    ...
+    stx l0f11                                                         ; 9b63: 8e 11 0f    ...
+    stx l0f14                                                         ; 9b66: 8e 14 0f    ...
+    jsr sub_c9273                                                     ; 9b69: 20 73 92     s.
+    ldx l0f05                                                         ; 9b6c: ae 05 0f    ...
+    beq c9b91                                                         ; 9b6f: f0 20       .
+    ldy #$0e                                                          ; 9b71: a0 0e       ..
+    sta (l00bb),y                                                     ; 9b73: 91 bb       ..
+    dey                                                               ; 9b75: 88          .
+    ldx #$0c                                                          ; 9b76: a2 0c       ..
+; $9b78 referenced 1 time by $9b7f
+loop_c9b78
+    lda l0f05,x                                                       ; 9b78: bd 05 0f    ...
+    sta (l00bb),y                                                     ; 9b7b: 91 bb       ..
+    dey                                                               ; 9b7d: 88          .
+    dex                                                               ; 9b7e: ca          .
+    bne loop_c9b78                                                    ; 9b7f: d0 f7       ..
+    inx                                                               ; 9b81: e8          .
+    inx                                                               ; 9b82: e8          .
+    ldy #$11                                                          ; 9b83: a0 11       ..
+; $9b85 referenced 1 time by $9b8c
+loop_c9b85
+    lda l0f12,x                                                       ; 9b85: bd 12 0f    ...
+    sta (l00bb),y                                                     ; 9b88: 91 bb       ..
+    dey                                                               ; 9b8a: 88          .
+    dex                                                               ; 9b8b: ca          .
+    bpl loop_c9b85                                                    ; 9b8c: 10 f7       ..
+    ldx l0f05                                                         ; 9b8e: ae 05 0f    ...
+; $9b91 referenced 1 time by $9b6f
+c9b91
+    txa                                                               ; 9b91: 8a          .
+; $9b92 referenced 1 time by $9b47
+c9b92
+    jmp c9cc9                                                         ; 9b92: 4c c9 9c    L..
+
+; $9b95 referenced 2 times by $9984, $9a0f
+sub_c9b95
+    ldy #0                                                            ; 9b95: a0 00       ..
+    ldx l0f03                                                         ; 9b97: ae 03 0f    ...
+    bne c9bb5                                                         ; 9b9a: d0 19       ..
+; $9b9c referenced 1 time by $9ba6
+loop_c9b9c
+    lda (l00be),y                                                     ; 9b9c: b1 be       ..
+    cmp #$21 ; '!'                                                    ; 9b9e: c9 21       .!
+    bcc c9ba8                                                         ; 9ba0: 90 06       ..
+    sta l10f3,y                                                       ; 9ba2: 99 f3 10    ...
+    iny                                                               ; 9ba5: c8          .
+    bne loop_c9b9c                                                    ; 9ba6: d0 f4       ..
+; $9ba8 referenced 2 times by $9ba0, $9bb0
+c9ba8
+    lda #$20 ; ' '                                                    ; 9ba8: a9 20       .
+    sta l10f3,y                                                       ; 9baa: 99 f3 10    ...
+    iny                                                               ; 9bad: c8          .
+    cpy #$0c                                                          ; 9bae: c0 0c       ..
+    bcc c9ba8                                                         ; 9bb0: 90 f6       ..
+    rts                                                               ; 9bb2: 60          `
+
+; $9bb3 referenced 1 time by $9bbb
+loop_c9bb3
+    inx                                                               ; 9bb3: e8          .
+    iny                                                               ; 9bb4: c8          .
+; $9bb5 referenced 1 time by $9b9a
+c9bb5
+    lda l0f05,x                                                       ; 9bb5: bd 05 0f    ...
+    sta l10f3,y                                                       ; 9bb8: 99 f3 10    ...
+    bpl loop_c9bb3                                                    ; 9bbb: 10 f6       ..
+    rts                                                               ; 9bbd: 60          `
+
+    !byte $20, $cb, $8f, $85, $bd, $20, $9b, $92,   9,   0, $10, $2e  ; 9bbe: 20 cb 8f...  ..
+    !byte $0a, $f0,   3, $4c, $c4, $9c, $98, $c9, $20, $b0,   3, $4c  ; 9bca: 0a f0 03... ...
+    !byte $82, $b4, $c9, $30, $b0, $f9, $20, $99, $b7, $98, $48, $aa  ; 9bd6: 82 b4 c9... ...
+    !byte $a0,   0, $84, $bd, $84, $bc, $bd, $10, $10, $91, $bb, $20  ; 9be2: a0 00 84... ...
+    !byte $86, $bc, $c8, $c0,   4, $d0, $f3, $68, $85, $bc, $c9,   5  ; 9bee: 86 bc c8... ...
+    !byte $b0, $4f, $c0,   0, $d0,   3, $4c, $d5, $9c, $48, $8a, $48  ; 9bfa: b0 4f c0... .O.
+    !byte $98, $48, $20, $f2, $b4, $68, $20, $8f, $b9, $bd, $30, $10  ; 9c06: 98 48 20... .H
+    !byte $8d,   5, $0f, $68, $aa, $68, $4a, $f0, $4f,   8, $48, $a6  ; 9c12: 8d 05 0f... ...
+    !byte $bb, $a4, $bc, $20, $99, $b7, $b9, $10, $10, $8d,   5, $0f  ; 9c1e: bb a4 bc... ...
+    !byte $68, $8d,   6, $0f, $28, $98, $48, $90, $1b, $a0,   3, $b5  ; 9c2a: 68 8d 06... h..
+    !byte   3, $99,   7, $0f, $ca, $88, $10, $f7, $a0, $0d, $a2,   5  ; 9c36: 03 99 07... ...
+    !byte $20, $ad, $94, $86, $bd, $68, $20, $b5, $92, $4c, $c7, $9c  ; 9c42: 20 ad 94...  ..
+    !byte $a0, $0c, $a2,   2, $20, $ad, $94, $85, $bd, $a6, $bb, $a0  ; 9c4e: a0 0c a2... ...
+    !byte   2, $95,   3, $b9,   5, $0f, $95,   2, $ca, $88, $10, $f7  ; 9c5a: 02 95 03... ...
+    !byte $68, $4c, $c7, $9c, $b0, $20, $a5, $bc, $20, $6b, $b4, $a4  ; 9c66: 68 4c c7... hL.
+    !byte $bb, $bd,   0, $10, $99,   0,   0, $bd, $10, $10, $99,   1  ; 9c72: bb bd 00... ...
+    !byte   0, $bd, $20, $10, $99,   2,   0, $a9,   0, $99,   3,   0  ; 9c7e: 00 bd 20... ..
+    !byte $f0, $3b, $8d,   6, $0f, $8a, $48, $a0,   3, $b5,   3, $99  ; 9c8a: f0 3b 8d... .;.
+    !byte   7, $0f, $ca, $88, $10, $f7, $a0, $0d, $a2,   5, $20, $ad  ; 9c96: 07 0f ca... ...
+    !byte $94, $86, $bd, $68, $a8, $a5, $bc, $20, $cc, $92, $20, $6b  ; 9ca2: 94 86 bd... ...
+    !byte $b4, $b9,   0,   0, $9d,   0, $10, $b9,   1,   0, $9d, $10  ; 9cae: b4 b9 00... ...
+    !byte $10, $b9,   2,   0, $9d, $20, $10, $4c, $c7, $9c, $20, $99  ; 9cba: 10 b9 02... ...
+    !byte $b7                                                         ; 9cc6: b7          .
+
+; $9cc7 referenced 6 times by $9a54, $9b49, $9dbb, $a2f7, $a2fd, $a3b1
+c9cc7
+    lda l00bd                                                         ; 9cc7: a5 bd       ..
+; $9cc9 referenced 2 times by $9b92, $a206
+c9cc9
+    pha                                                               ; 9cc9: 48          H
+    lda #0                                                            ; 9cca: a9 00       ..
+    jsr sub_cb98f                                                     ; 9ccc: 20 8f b9     ..
+    pla                                                               ; 9ccf: 68          h
+    ldx l00bb                                                         ; 9cd0: a6 bb       ..
+    ldy l00bc                                                         ; 9cd2: a4 bc       ..
+    rts                                                               ; 9cd4: 60          `
+
+    !byte $c9,   2, $b0, $13, $a8, $d0,   4, $a9,   5, $d0, $e9, $b9  ; 9cd5: c9 02 b0... ...
+    !byte $0a, $0e, $91, $bb, $88, $10, $f8, $94,   2, $94,   3, $f0  ; 9ce1: 0a 0e 91... ...
+    !byte   2, $a9,   0, $4a, $10, $d6, $29, $3f, $d0, $f7, $8a, $20  ; 9ced: 02 a9 00... ...
+    !byte $3d, $b5, $49, $80, $0a, $8d,   5, $0f, $2a, $8d,   6, $0f  ; 9cf9: 3d b5 49... =.I
+    !byte $20, $92, $ae, $a2,   2, $20,   4, $af, $a0,   6, $2c, $91  ; 9d05: 20 92 ae...  ..
+    !byte $94, $38, $66, $98, $20, $ae, $94, $b0, $6d, $a9, $ff, $20  ; 9d11: 94 38 66... .8f
+    !byte $8f, $b9, $ad,   5, $0f, $48, $a9,   4, $8d,   5, $0f, $a2  ; 9d1d: 8f b9 ad... ...
+    !byte   1, $bd,   6, $0f, $9d,   5, $0f, $e8, $c9, $0d, $d0, $f5  ; 9d29: 01 bd 06... ...
+    !byte $a0, $12, $20, $ad, $94, $a5, $bd, $29, $bf, $0d,   5, $0f  ; 9d35: a0 12 20... ..
+    !byte   9,   1, $a8, $29,   2, $f0                                ; 9d41: 09 01 a8... ...
+    !text "#h "                                                       ; 9d47: 23 68 20    #h
+    !byte   9, $b5, $d0, $33, $20, $cb, $8f, $20, $95, $92, $aa, $20  ; 9d4a: 09 b5 d0... ...
+    !byte $32, $af, $8a, $f0, $2f, $20, $b5, $af, $ac, $70, $10, $f0  ; 9d56: 32 af 8a... 2..
+    !byte $90, $98, $a2,   0, $8e, $70, $10, $f0, $1c, $ad,   6, $0f  ; 9d62: 90 98 a2... ...
+    !byte $6a, $b0, $0c, $6a, $90,   9, $2c,   7, $0f, $10,   4, $98  ; 9d6e: 6a b0 0c... j..
+    !byte   9, $20, $a8, $68, $20,   9, $b5, $aa, $98, $9d, $40, $10  ; 9d7a: 09 20 a8... . .
+    !byte $8a, $4c, $c9, $9c, $20, $99, $b7, $98, $d0, $13, $a5, $bb  ; 9d86: 8a 4c c9... .L.
+    !byte $48, $a9, $77, $20, $f4, $ff, $68, $85, $bb, $a9,   0, $85  ; 9d92: 48 a9 77... H.w
+    !byte $bd, $85, $bc, $f0,   6, $20, $7a, $b4, $bd, $30, $10, $8d  ; 9d9e: bd 85 bc... ...
+    !byte   5, $0f, $a2,   1, $a0,   7, $20, $ad, $94, $a4, $bc, $d0  ; 9daa: 05 0f a2... ...
+    !byte   7, $b8, $20, $5d, $b5                                     ; 9db6: 07 b8 20... ..
+
+; $9dbb referenced 2 times by $9dd8, $9dec
+c9dbb
+    jmp c9cc7                                                         ; 9dbb: 4c c7 9c    L..
+
+    !byte $a9,   0, $99, $10, $10, $99, $40, $10, $f0, $f3            ; 9dbe: a9 00 99... ...
+
+sub_c9dc8
+    beq c9dd5                                                         ; 9dc8: f0 0b       ..
+    cpx #4                                                            ; 9dca: e0 04       ..
+    bne c9dd2                                                         ; 9dcc: d0 04       ..
+    cpy #4                                                            ; 9dce: c0 04       ..
+    bcc c9ddf                                                         ; 9dd0: 90 0d       ..
+; $9dd2 referenced 1 time by $9dcc
+c9dd2
+    dex                                                               ; 9dd2: ca          .
+    bne c9dda                                                         ; 9dd3: d0 05       ..
+; $9dd5 referenced 1 time by $9dc8
+c9dd5
+    sty l0e06                                                         ; 9dd5: 8c 06 0e    ...
+    bcc c9dbb                                                         ; 9dd8: 90 e1       ..
+; $9dda referenced 1 time by $9dd3
+c9dda
+    lda #7                                                            ; 9dda: a9 07       ..
+    jmp c964e                                                         ; 9ddc: 4c 4e 96    LN.
+
+; $9ddf referenced 1 time by $9dd0
+c9ddf
+    sty l0f05                                                         ; 9ddf: 8c 05 0f    ...
+    ldy #$16                                                          ; 9de2: a0 16       ..
+    jsr c94ad                                                         ; 9de4: 20 ad 94     ..
+    ldy l00bc                                                         ; 9de7: a4 bc       ..
+    sty l0e05                                                         ; 9de9: 8c 05 0e    ...
+    bpl c9dbb                                                         ; 9dec: 10 cd       ..
+sub_c9dee
+    jsr sub_c8fcb                                                     ; 9dee: 20 cb 8f     ..
+    pha                                                               ; 9df1: 48          H
+    lda l00bc                                                         ; 9df2: a5 bc       ..
+    pha                                                               ; 9df4: 48          H
+    stx l10c9                                                         ; 9df5: 8e c9 10    ...
+    jsr sub_cb730                                                     ; 9df8: 20 30 b7     0.
+    beq c9e09                                                         ; 9dfb: f0 0c       ..
+    lda l1000,y                                                       ; 9dfd: b9 00 10    ...
+    cmp l1098,x                                                       ; 9e00: dd 98 10    ...
+    bcc c9e09                                                         ; 9e03: 90 04       ..
+    ldx #$ff                                                          ; 9e05: a2 ff       ..
+    bmi c9e0b                                                         ; 9e07: 30 02       0.
+; $9e09 referenced 2 times by $9dfb, $9e03
+c9e09
+    ldx #0                                                            ; 9e09: a2 00       ..
+; $9e0b referenced 1 time by $9e07
+c9e0b
+    pla                                                               ; 9e0b: 68          h
+    tay                                                               ; 9e0c: a8          .
+    pla                                                               ; 9e0d: 68          h
+    rts                                                               ; 9e0e: 60          `
+
+; $9e0f referenced 1 time by $9f5a
+sub_c9e0f
+    ldy #9                                                            ; 9e0f: a0 09       ..
+    jsr sub_c9e16                                                     ; 9e11: 20 16 9e     ..
+    ldy #1                                                            ; 9e14: a0 01       ..
+; $9e16 referenced 1 time by $9e11
+sub_c9e16
+    clc                                                               ; 9e16: 18          .
+; $9e17 referenced 1 time by $9f60
+sub_c9e17
+    ldx #$fc                                                          ; 9e17: a2 fc       ..
+; $9e19 referenced 1 time by $9e2c
+loop_c9e19
+    lda (l00bb),y                                                     ; 9e19: b1 bb       ..
+    bit l00b2                                                         ; 9e1b: 24 b2       $.
+    bmi c9e25                                                         ; 9e1d: 30 06       0.
+    adc l0e0a,x                                                       ; 9e1f: 7d 0a 0e    }..
+    jmp c9e28                                                         ; 9e22: 4c 28 9e    L(.
+
+; $9e25 referenced 1 time by $9e1d
+c9e25
+    sbc l0e0a,x                                                       ; 9e25: fd 0a 0e    ...
+; $9e28 referenced 1 time by $9e22
+c9e28
+    sta (l00bb),y                                                     ; 9e28: 91 bb       ..
+    iny                                                               ; 9e2a: c8          .
+    inx                                                               ; 9e2b: e8          .
+    bne loop_c9e19                                                    ; 9e2c: d0 eb       ..
+    rts                                                               ; 9e2e: 60          `
+
+    !byte $20, $cb, $8f, $20, $95, $92                                ; 9e2f: 20 cb 8f...  ..
+    !text "H 2"                                                       ; 9e35: 48 20 32    H 2
+    !byte $af, $68, $aa, $f0,   5, $ca, $e0,   8, $90,   3, $4c, $c7  ; 9e38: af 68 aa... .h.
+    !byte $9c, $8a, $a0,   0, $48, $c9,   4, $90,   3, $4c, $82, $9f  ; 9e44: 9c 8a a0... ...
+    !byte $b1, $bb, $48, $20, $f2, $b4, $68, $a8, $20, $99, $b7, $bd  ; 9e50: b1 bb 48... ..H
+    !byte $30, $10, $8d,   5, $0f, $a9,   0, $8d,   6, $0f, $bd,   0  ; 9e5c: 30 10 8d... 0..
+    !byte $10, $8d,   7, $0f, $bd, $10, $10, $8d,   8, $0f, $bd, $20  ; 9e68: 10 8d 07... ...
+    !byte $10, $8d,   9, $0f, $a0, $0d, $a2,   5, $20, $ad, $94, $68  ; 9e74: 10 8d 09... ...
+    !byte $20, $dd, $9e,   8, $a0,   0, $b1, $bb, $b0,   5, $20, $cc  ; 9e80: 20 dd 9e...  ..
+    !byte $92, $10,   3, $20, $b5, $92, $8c,   6, $0f, $20, $d6, $9e  ; 9e8c: 92 10 03... ...
+    !byte $8d,   5, $0f, $a0, $0c, $a2,   2, $20, $ad, $94, $20, $d2  ; 9e98: 8d 05 0f... ...
+    !byte $9e, $a0,   9, $ad,   5, $0f, $9d,   0, $10, $91, $bb, $c8  ; 9ea4: 9e a0 09... ...
+    !byte $ad,   6, $0f, $9d, $10, $10, $91, $bb, $c8, $ad,   7, $0f  ; 9eb0: ad 06 0f... ...
+    !byte $9d, $20, $10, $91, $bb, $a9,   0, $c8, $91, $bb, $28, $90  ; 9ebc: 9d 20 10... . .
+    !byte   4, $a5, $bd, $c9,   3, $a9,   0, $4c, $c9, $9c            ; 9ec8: 04 a5 bd... ...
+
+; $9ed2 referenced 1 time by $9ede
+sub_c9ed2
+    ldy #0                                                            ; 9ed2: a0 00       ..
+    lda (l00bb),y                                                     ; 9ed4: b1 bb       ..
+    jsr sub_cb4ad                                                     ; 9ed6: 20 ad b4     ..
+    lda l1030,x                                                       ; 9ed9: bd 30 10    .0.
+    rts                                                               ; 9edc: 60          `
+
+; $9edd referenced 1 time by $b987
+c9edd
+    pha                                                               ; 9edd: 48          H
+    jsr sub_c9ed2                                                     ; 9ede: 20 d2 9e     ..
+    sta l0f05                                                         ; 9ee1: 8d 05 0f    ...
+    ldy #$0b                                                          ; 9ee4: a0 0b       ..
+    ldx #6                                                            ; 9ee6: a2 06       ..
+; $9ee8 referenced 1 time by $9ef4
+loop_c9ee8
+    lda (l00bb),y                                                     ; 9ee8: b1 bb       ..
+    sta l0f06,x                                                       ; 9eea: 9d 06 0f    ...
+    dey                                                               ; 9eed: 88          .
+    cpy #8                                                            ; 9eee: c0 08       ..
+    bne c9ef3                                                         ; 9ef0: d0 01       ..
+    dey                                                               ; 9ef2: 88          .
+; $9ef3 referenced 1 time by $9ef0
+c9ef3
+    dex                                                               ; 9ef3: ca          .
+    bne loop_c9ee8                                                    ; 9ef4: d0 f2       ..
+    pla                                                               ; 9ef6: 68          h
+    lsr                                                               ; 9ef7: 4a          J
+    pha                                                               ; 9ef8: 48          H
+    bcc c9efc                                                         ; 9ef9: 90 01       ..
+    inx                                                               ; 9efb: e8          .
+; $9efc referenced 1 time by $9ef9
+c9efc
+    stx l0f06                                                         ; 9efc: 8e 06 0f    ...
+    ldy #$0b                                                          ; 9eff: a0 0b       ..
+    ldx #$91                                                          ; 9f01: a2 91       ..
+    pla                                                               ; 9f03: 68          h
+    pha                                                               ; 9f04: 48          H
+    beq c9f0a                                                         ; 9f05: f0 03       ..
+    ldx #$92                                                          ; 9f07: a2 92       ..
+    dey                                                               ; 9f09: 88          .
+; $9f0a referenced 1 time by $9f05
+c9f0a
+    stx l0f02                                                         ; 9f0a: 8e 02 0f    ...
+    stx l00b8                                                         ; 9f0d: 86 b8       ..
+    ldx #8                                                            ; 9f0f: a2 08       ..
+    lda l0f05                                                         ; 9f11: ad 05 0f    ...
+    jsr sub_c9497                                                     ; 9f14: 20 97 94     ..
+    ldx #0                                                            ; 9f17: a2 00       ..
+    lda (l00bb,x)                                                     ; 9f19: a1 bb       ..
+    tax                                                               ; 9f1b: aa          .
+    lda l1040,x                                                       ; 9f1c: bd 40 10    .@.
+    eor #1                                                            ; 9f1f: 49 01       I.
+    sta l1040,x                                                       ; 9f21: 9d 40 10    .@.
+    clc                                                               ; 9f24: 18          .
+    ldx #4                                                            ; 9f25: a2 04       ..
+; $9f27 referenced 1 time by $9f3b
+loop_c9f27
+    lda (l00bb),y                                                     ; 9f27: b1 bb       ..
+    sta l00af,y                                                       ; 9f29: 99 af 00    ...
+    sta l00c7,y                                                       ; 9f2c: 99 c7 00    ...
+    jsr sub_c9a7f                                                     ; 9f2f: 20 7f 9a     ..
+    adc (l00bb),y                                                     ; 9f32: 71 bb       q.
+    sta l00af,y                                                       ; 9f34: 99 af 00    ...
+    jsr sub_c9a92                                                     ; 9f37: 20 92 9a     ..
+    dex                                                               ; 9f3a: ca          .
+    bne loop_c9f27                                                    ; 9f3b: d0 ea       ..
+    inx                                                               ; 9f3d: e8          .
+; $9f3e referenced 1 time by $9f45
+loop_c9f3e
+    lda l0f03,x                                                       ; 9f3e: bd 03 0f    ...
+    sta l0f06,x                                                       ; 9f41: 9d 06 0f    ...
+    dex                                                               ; 9f44: ca          .
+    bpl loop_c9f3e                                                    ; 9f45: 10 f7       ..
+    pla                                                               ; 9f47: 68          h
+    bne c9f52                                                         ; 9f48: d0 08       ..
+    lda l0f02                                                         ; 9f4a: ad 02 0f    ...
+    jsr sub_c9a9a                                                     ; 9f4d: 20 9a 9a     ..
+    bcs c9f55                                                         ; 9f50: b0 03       ..
+; $9f52 referenced 1 time by $9f48
+c9f52
+    jsr sub_c9998                                                     ; 9f52: 20 98 99     ..
+; $9f55 referenced 1 time by $9f50
+c9f55
+    jsr sub_c9f67                                                     ; 9f55: 20 67 9f     g.
+    stx l00b2                                                         ; 9f58: 86 b2       ..
+    jsr sub_c9e0f                                                     ; 9f5a: 20 0f 9e     ..
+    dec l00b2                                                         ; 9f5d: c6 b2       ..
+    sec                                                               ; 9f5f: 38          8
+    jsr sub_c9e17                                                     ; 9f60: 20 17 9e     ..
+    asl l0f05                                                         ; 9f63: 0e 05 0f    ...
+    rts                                                               ; 9f66: 60          `
+
+; $9f67 referenced 1 time by $9f55
+sub_c9f67
+    php                                                               ; 9f67: 08          .
+    jsr sub_c94f0                                                     ; 9f68: 20 f0 94     ..
+    plp                                                               ; 9f6b: 28          (
+    rts                                                               ; 9f6c: 60          `
+
+    !byte $a0, $15, $20, $ad, $94, $ad,   5, $0e, $8d, $16, $0f, $86  ; 9f6d: a0 15 20... ..
+    !byte $b0, $86, $b1, $a9, $12, $85, $b2, $d0, $4e, $a0,   4, $ad  ; 9f79: b0 86 b1... ...
+    !byte $63, $0d, $f0,   7, $d1, $bb, $d0,   3, $88, $f1, $bb, $85  ; 9f85: 63 0d f0... c..
+    !byte $a9, $b1, $bb, $99, $bd,   0, $88, $d0, $f8, $68, $29,   3  ; 9f91: a9 b1 bb... ...
+    !byte $f0, $ce, $4a, $f0,   2, $b0, $6b, $a8, $b9,   3, $0e, $8d  ; 9f9d: f0 ce 4a... ..J
+    !byte   3, $0f, $ad,   4, $0e, $8d,   4, $0f, $ad,   2, $0e, $8d  ; 9fa9: 03 0f ad... ...
+    !byte   2, $0f, $a2, $12, $8e,   1, $0f, $a9, $0d, $8d,   6, $0f  ; 9fb5: 02 0f a2... ...
+    !byte $85, $b2, $4a, $8d,   5, $0f, $18, $20, $da, $94, $86, $b1  ; 9fc1: 85 b2 4a... ..J
+    !byte $e8, $86, $b0, $a5, $a9, $d0, $11, $a6, $b0, $a4, $b1, $bd  ; 9fcd: e8 86 b0... ...
+    !byte   5, $0f, $91, $be, $e8, $c8, $c6, $b2, $d0, $f5, $f0       ; 9fd9: 05 0f 91... ...
+    !text "' s"                                                       ; 9fe4: 27 20 73    ' s
+    !byte $a0, $a9,   1, $a6, $bb, $a4, $bc, $e8, $d0,   1, $c8, $20  ; 9fe7: a0 a9 01... ...
+    !byte   6,   4, $a6, $b0, $bd,   5, $0f, $8d, $e5, $fe, $e8, $a0  ; 9ff3: 06 04 a6... ...
+    !byte   6, $88, $d0, $fd, $c6, $b2, $d0, $f0, $a9, $83, $20,   6  ; 9fff: 06 88 d0... ...
+    !byte   4, $4c, $ee, $9c, $a0,   9, $b1, $bb, $8d,   6, $0f, $a0  ; a00b: 04 4c ee... .L.
+    !byte   5, $b1, $bb, $8d,   7, $0f, $a2, $0d, $8e,   8, $0f, $a0  ; a017: 05 b1 bb... ...
+    !byte   2, $84, $b0, $8c,   5, $0f, $c8, $20, $ad, $94, $86, $b1  ; a023: 02 84 b0... ...
+    !byte $ad,   6, $0f, $81, $bb, $ad,   5, $0f, $a0,   9, $71, $bb  ; a02f: ad 06 0f... ...
+    !byte $91, $bb, $a5, $c8, $e9,   7, $8d,   6, $0f, $85, $b2, $f0  ; a03b: 91 bb a5... ...
+    !byte   3, $20, $d0, $9f, $a2,   2, $9d,   7, $0f, $ca, $10, $fa  ; a047: 03 20 d0... . .
+    !byte $20, $14, $9e, $38, $c6, $b2, $ad,   5, $0f, $8d,   6, $0f  ; a053: 20 14 9e...  ..
+    !byte $20, $17, $9e, $a2,   3, $a0,   5, $38, $b1, $bb, $d0,   5  ; a05f: 20 17 9e...  ..
+    !byte $c8, $ca, $10, $f8, $18, $4c, $0c, $a0                      ; a06b: c8 ca 10... ...
+
+; $a073 referenced 2 times by $a078, $a2e3
+ca073
+    lda #$c3                                                          ; a073: a9 c3       ..
+    jsr c0406                                                         ; a075: 20 06 04     ..
+    bcc ca073                                                         ; a078: 90 f9       ..
+    rts                                                               ; a07a: 60          `
+
+sub_ca07b
+    lda l0e00                                                         ; a07b: ad 00 0e    ...
+    sta l00b5                                                         ; a07e: 85 b5       ..
+    lda l0e01                                                         ; a080: ad 01 0e    ...
+    sta l00b6                                                         ; a083: 85 b6       ..
+    lda (l00be),y                                                     ; a085: b1 be       ..
+    cmp #$0d                                                          ; a087: c9 0d       ..
+    beq ca09b                                                         ; a089: f0 10       ..
+    jsr sub_ca0a7                                                     ; a08b: 20 a7 a0     ..
+    lda #1                                                            ; a08e: a9 01       ..
+    sta l00b4                                                         ; a090: 85 b4       ..
+    lda #$13                                                          ; a092: a9 13       ..
+    ldx #<(l00b4)                                                     ; a094: a2 b4       ..
+    ldy #>(l00b4)                                                     ; a096: a0 00       ..
+    jmp osword                                                        ; a098: 4c f1 ff    L..
+
+; $a09b referenced 1 time by $a089
+ca09b
+    jsr sub_cb0c5                                                     ; a09b: 20 c5 b0     ..
+; $a09e referenced 1 time by $b0b6
+sub_ca09e
+    bit l9491                                                         ; a09e: 2c 91 94    ,..
+    jsr sub_cb198                                                     ; a0a1: 20 98 b1     ..
+    jmp osnewl                                                        ; a0a4: 4c e7 ff    L..
+
+; $a0a7 referenced 3 times by $a08b, $b011, $b1e8
+sub_ca0a7
+    txa                                                               ; a0a7: 8a          .
+    pha                                                               ; a0a8: 48          H
+    lda #0                                                            ; a0a9: a9 00       ..
+    sta l00b4                                                         ; a0ab: 85 b4       ..
+    jsr sub_c916e                                                     ; a0ad: 20 6e 91     n.
+    bcs ca0c5                                                         ; a0b0: b0 13       ..
+    tya                                                               ; a0b2: 98          .
+    pha                                                               ; a0b3: 48          H
+    jsr sub_ca865                                                     ; a0b4: 20 65 a8     e.
+    eor l00b2                                                         ; a0b7: 45 b2       E.
+    beq ca0bd                                                         ; a0b9: f0 02       ..
+    lda l00b2                                                         ; a0bb: a5 b2       ..
+; $a0bd referenced 1 time by $a0b9
+ca0bd
+    sta l00b6                                                         ; a0bd: 85 b6       ..
+    pla                                                               ; a0bf: 68          h
+    tay                                                               ; a0c0: a8          .
+    iny                                                               ; a0c1: c8          .
+    jsr sub_c916e                                                     ; a0c2: 20 6e 91     n.
+; $a0c5 referenced 1 time by $a0b0
+ca0c5
+    beq ca0c9                                                         ; a0c5: f0 02       ..
+    sta l00b5                                                         ; a0c7: 85 b5       ..
+; $a0c9 referenced 1 time by $a0c5
+ca0c9
+    pla                                                               ; a0c9: 68          h
+    tax                                                               ; a0ca: aa          .
+    rts                                                               ; a0cb: 60          `
+
+; $a0cc referenced 2 times by $a0ea, $a0fa
+sub_ca0cc
+    lda l00f0                                                         ; a0cc: a5 f0       ..
+; $a0ce referenced 2 times by $8f30, $b108
+sub_ca0ce
+    asl                                                               ; a0ce: 0a          .
+    asl                                                               ; a0cf: 0a          .
+    pha                                                               ; a0d0: 48          H
+    asl                                                               ; a0d1: 0a          .
+    tsx                                                               ; a0d2: ba          .
+    php                                                               ; a0d3: 08          .
+    adc l0101,x                                                       ; a0d4: 7d 01 01    }..
+    ror                                                               ; a0d7: 6a          j
+    plp                                                               ; a0d8: 28          (
+    asl                                                               ; a0d9: 0a          .
+    tay                                                               ; a0da: a8          .
+    pla                                                               ; a0db: 68          h
+    cmp #$48 ; 'H'                                                    ; a0dc: c9 48       .H
+    bcc ca0e3                                                         ; a0de: 90 03       ..
+    ldy #0                                                            ; a0e0: a0 00       ..
+    tya                                                               ; a0e2: 98          .
+; $a0e3 referenced 1 time by $a0de
+ca0e3
+    rts                                                               ; a0e3: 60          `
+
+sub_ca0e4
+    ldy #$6f ; 'o'                                                    ; a0e4: a0 6f       .o
+    lda (l009c),y                                                     ; a0e6: b1 9c       ..
+    bcc ca0f7                                                         ; a0e8: 90 0d       ..
+sub_ca0ea
+    jsr sub_ca0cc                                                     ; a0ea: 20 cc a0     ..
+    bcs ca0f5                                                         ; a0ed: b0 06       ..
+    lda (l009e),y                                                     ; a0ef: b1 9e       ..
+    cmp #$3f ; '?'                                                    ; a0f1: c9 3f       .?
+    bne ca0f7                                                         ; a0f3: d0 02       ..
+; $a0f5 referenced 1 time by $a0ed
+ca0f5
+    lda #0                                                            ; a0f5: a9 00       ..
+; $a0f7 referenced 2 times by $a0e8, $a0f3
+ca0f7
+    sta l00f0                                                         ; a0f7: 85 f0       ..
+    rts                                                               ; a0f9: 60          `
+
+sub_ca0fa
+    jsr sub_ca0cc                                                     ; a0fa: 20 cc a0     ..
+    bcc ca109                                                         ; a0fd: 90 0a       ..
+    ror l0d6c                                                         ; a0ff: 6e 6c 0d    nl.
+    lda l00f0                                                         ; a102: a5 f0       ..
+    rol                                                               ; a104: 2a          *
+    rol l0d6c                                                         ; a105: 2e 6c 0d    .l.
+    rts                                                               ; a108: 60          `
+
+; $a109 referenced 1 time by $a0fd
+ca109
+    ror l0d61                                                         ; a109: 6e 61 0d    na.
+    lda #$3f ; '?'                                                    ; a10c: a9 3f       .?
+    sta (l009e),y                                                     ; a10e: 91 9e       ..
+    rol l0d61                                                         ; a110: 2e 61 0d    .a.
+    rts                                                               ; a113: 60          `
+
+; $a114 referenced 1 time by $8cf9
+ca114
+    jsr sub_c9291                                                     ; a114: 20 91 92     ..
+    ldy #$ff                                                          ; a117: a0 ff       ..
+    sty l00ba                                                         ; a119: 84 ba       ..
+    sty l0098                                                         ; a11b: 84 98       ..
+    iny                                                               ; a11d: c8          .
+    ldx #$4a ; 'J'                                                    ; a11e: a2 4a       .J
+    jsr sub_ca140                                                     ; a120: 20 40 a1     @.
+    bcs ca133                                                         ; a123: b0 0e       ..
+; $a125 referenced 1 time by $8c5a
+ca125
+    bvc ca133                                                         ; a125: 50 0c       P.
+; $a127 referenced 1 time by $af6f
+ca127
+    lda #$dc                                                          ; a127: a9 dc       ..
+    jsr generate_error_inline2                                        ; a129: 20 d4 96     ..
+    !text "Syntax", 0                                                 ; a12c: 53 79 6e... Syn
+
+; $a133 referenced 2 times by $a123, $a125
+ca133
+    lda #0                                                            ; a133: a9 00       ..
+    sta l00a9                                                         ; a135: 85 a9       ..
+    lda la3f2,x                                                       ; a137: bd f2 a3    ...
+    pha                                                               ; a13a: 48          H
+    lda la3f1,x                                                       ; a13b: bd f1 a3    ...
+    pha                                                               ; a13e: 48          H
+    rts                                                               ; a13f: 60          `
+
+; $a140 referenced 5 times by $8c55, $8c83, $a120, $b320, $b34d
+sub_ca140
+    tya                                                               ; a140: 98          .
+    pha                                                               ; a141: 48          H
+; $a142 referenced 1 time by $a168
+ca142
+    pla                                                               ; a142: 68          h
+    pha                                                               ; a143: 48          H
+    tay                                                               ; a144: a8          .
+    lda la3f0,x                                                       ; a145: bd f0 a3    ...
+    bmi ca1a9                                                         ; a148: 30 5f       0_
+; $a14a referenced 1 time by $a157
+loop_ca14a
+    lda la3f0,x                                                       ; a14a: bd f0 a3    ...
+    bmi ca16a                                                         ; a14d: 30 1b       0.
+    eor (l00be),y                                                     ; a14f: 51 be       Q.
+    and #$df                                                          ; a151: 29 df       ).
+    bne ca159                                                         ; a153: d0 04       ..
+    iny                                                               ; a155: c8          .
+    inx                                                               ; a156: e8          .
+    bne loop_ca14a                                                    ; a157: d0 f1       ..
+; $a159 referenced 2 times by $a153, $a15d
+ca159
+    inx                                                               ; a159: e8          .
+    lda la3f0,x                                                       ; a15a: bd f0 a3    ...
+    bpl ca159                                                         ; a15d: 10 fa       ..
+    lda (l00be),y                                                     ; a15f: b1 be       ..
+    cmp #$2e ; '.'                                                    ; a161: c9 2e       ..
+    beq ca18d                                                         ; a163: f0 28       .(
+; $a165 referenced 1 time by $a17a
+loop_ca165
+    inx                                                               ; a165: e8          .
+    inx                                                               ; a166: e8          .
+    inx                                                               ; a167: e8          .
+    bne ca142                                                         ; a168: d0 d8       ..
+; $a16a referenced 1 time by $a14d
+ca16a
+    tya                                                               ; a16a: 98          .
+    pha                                                               ; a16b: 48          H
+    lda (l00be),y                                                     ; a16c: b1 be       ..
+    ldy #9                                                            ; a16e: a0 09       ..
+; $a170 referenced 1 time by $a176
+loop_ca170
+    cmp la17c,y                                                       ; a170: d9 7c a1    .|.
+    beq ca185                                                         ; a173: f0 10       ..
+    dey                                                               ; a175: 88          .
+    bpl loop_ca170                                                    ; a176: 10 f8       ..
+    pla                                                               ; a178: 68          h
+    tay                                                               ; a179: a8          .
+    bne loop_ca165                                                    ; a17a: d0 e9       ..
+; $a17c referenced 1 time by $a170
+la17c
+    !text " ", '"', "#$&*:@"                                          ; a17c: 20 22 23...  "#
+    !byte $0d                                                         ; a184: 0d          .
+
+; $a185 referenced 1 time by $a173
+ca185
+    pla                                                               ; a185: 68          h
+    tay                                                               ; a186: a8          .
+; $a187 referenced 1 time by $a18e
+loop_ca187
+    lda (l00be),y                                                     ; a187: b1 be       ..
+    cmp #$20 ; ' '                                                    ; a189: c9 20       .
+    bne ca191                                                         ; a18b: d0 04       ..
+; $a18d referenced 1 time by $a163
+ca18d
+    iny                                                               ; a18d: c8          .
+    jmp loop_ca187                                                    ; a18e: 4c 87 a1    L..
+
+; $a191 referenced 1 time by $a18b
+ca191
+    lda la3f0,x                                                       ; a191: bd f0 a3    ...
+    asl                                                               ; a194: 0a          .
+    bpl ca1a2                                                         ; a195: 10 0b       ..
+    lda (l00be),y                                                     ; a197: b1 be       ..
+    cmp #$0d                                                          ; a199: c9 0d       ..
+    bne ca1a2                                                         ; a19b: d0 05       ..
+    bit l9491                                                         ; a19d: 2c 91 94    ,..
+    bvs ca1a3                                                         ; a1a0: 70 01       p.
+; $a1a2 referenced 2 times by $a195, $a19b
+ca1a2
+    clv                                                               ; a1a2: b8          .
+; $a1a3 referenced 1 time by $a1a0
+ca1a3
+    clc                                                               ; a1a3: 18          .
+; $a1a4 referenced 1 time by $a1bf
+loop_ca1a4
+    pla                                                               ; a1a4: 68          h
+    lda (l00be),y                                                     ; a1a5: b1 be       ..
+    rts                                                               ; a1a7: 60          `
+
+; $a1a8 referenced 1 time by $a1b5
+loop_ca1a8
+    iny                                                               ; a1a8: c8          .
+; $a1a9 referenced 1 time by $a148
+ca1a9
+    lda (l00be),y                                                     ; a1a9: b1 be       ..
+    cmp #$0d                                                          ; a1ab: c9 0d       ..
+    beq ca1be                                                         ; a1ad: f0 0f       ..
+    cmp #$2e ; '.'                                                    ; a1af: c9 2e       ..
+    beq ca1b7                                                         ; a1b1: f0 04       ..
+    cmp #$20 ; ' '                                                    ; a1b3: c9 20       .
+    bne loop_ca1a8                                                    ; a1b5: d0 f1       ..
+; $a1b7 referenced 2 times by $a1b1, $a1bc
+ca1b7
+    iny                                                               ; a1b7: c8          .
+    lda (l00be),y                                                     ; a1b8: b1 be       ..
+    cmp #$20 ; ' '                                                    ; a1ba: c9 20       .
+    beq ca1b7                                                         ; a1bc: f0 f9       ..
+; $a1be referenced 1 time by $a1ad
+ca1be
+    sec                                                               ; a1be: 38          8
+    bcs loop_ca1a4                                                    ; a1bf: b0 e3       ..
+; $a1c1 referenced 1 time by $8e1d
+ca1c1
+    jsr sub_cafb5                                                     ; a1c1: 20 b5 af     ..
+    jsr sub_caf32                                                     ; a1c4: 20 32 af     2.
+    jsr sub_cae92                                                     ; a1c7: 20 92 ae     ..
+; $a1ca referenced 1 time by $a241
+ca1ca
+    ldx #1                                                            ; a1ca: a2 01       ..
+    jsr sub_caf04                                                     ; a1cc: 20 04 af     ..
+    lda #2                                                            ; a1cf: a9 02       ..
+    sta l0f05                                                         ; a1d1: 8d 05 0f    ...
+    ldy #$12                                                          ; a1d4: a0 12       ..
+    jsr c94ad                                                         ; a1d6: 20 ad 94     ..
+    lda l0f05                                                         ; a1d9: ad 05 0f    ...
+    cmp #1                                                            ; a1dc: c9 01       ..
+    bne ca209                                                         ; a1de: d0 29       .)
+    ldx #3                                                            ; a1e0: a2 03       ..
+; $a1e2 referenced 1 time by $a1eb
+loop_ca1e2
+    inc l0f0a,x                                                       ; a1e2: fe 0a 0f    ...
+    beq ca1ea                                                         ; a1e5: f0 03       ..
+    jmp ca26a                                                         ; a1e7: 4c 6a a2    Lj.
+
+; $a1ea referenced 1 time by $a1e5
+ca1ea
+    dex                                                               ; a1ea: ca          .
+    bpl loop_ca1e2                                                    ; a1eb: 10 f5       ..
+    jsr sub_cb53d                                                     ; a1ed: 20 3d b5     =.
+    ldx #1                                                            ; a1f0: a2 01       ..
+    stx l0f05                                                         ; a1f2: 8e 05 0f    ...
+    stx l0f06                                                         ; a1f5: 8e 06 0f    ...
+    inx                                                               ; a1f8: e8          .
+    jsr sub_caf04                                                     ; a1f9: 20 04 af     ..
+    ldy #6                                                            ; a1fc: a0 06       ..
+    jsr c94ad                                                         ; a1fe: 20 ad 94     ..
+    bcs ca206                                                         ; a201: b0 03       ..
+    jmp ca27d                                                         ; a203: 4c 7d a2    L}.
+
+; $a206 referenced 1 time by $a201
+ca206
+    jmp c9cc9                                                         ; a206: 4c c9 9c    L..
+
+; $a209 referenced 1 time by $a1de
+ca209
+    lda l0e30                                                         ; a209: ad 30 0e    .0.
+    cmp #$24 ; '$'                                                    ; a20c: c9 24       .$
+    beq ca25d                                                         ; a20e: f0 4d       .M
+    lda l1071                                                         ; a210: ad 71 10    .q.
+    bmi ca25a                                                         ; a213: 30 45       0E
+    rol                                                               ; a215: 2a          *
+    rol                                                               ; a216: 2a          *
+    bmi ca243                                                         ; a217: 30 2a       0*
+    bcs ca25d                                                         ; a219: b0 42       .B
+    ldx #$ff                                                          ; a21b: a2 ff       ..
+; $a21d referenced 1 time by $a223
+loop_ca21d
+    inx                                                               ; a21d: e8          .
+    lda l0e30,x                                                       ; a21e: bd 30 0e    .0.
+    cmp #$0d                                                          ; a221: c9 0d       ..
+    bne loop_ca21d                                                    ; a223: d0 f8       ..
+; $a225 referenced 1 time by $a22c
+loop_ca225
+    lda l0e30,x                                                       ; a225: bd 30 0e    .0.
+    sta l0e38,x                                                       ; a228: 9d 38 0e    .8.
+    dex                                                               ; a22b: ca          .
+    bpl loop_ca225                                                    ; a22c: 10 f7       ..
+    ldx #7                                                            ; a22e: a2 07       ..
+; $a230 referenced 1 time by $a237
+loop_ca230
+    lda la291,x                                                       ; a230: bd 91 a2    ...
+    sta l0e30,x                                                       ; a233: 9d 30 0e    .0.
+    dex                                                               ; a236: ca          .
+    bpl loop_ca230                                                    ; a237: 10 f7       ..
+    lda l1071                                                         ; a239: ad 71 10    .q.
+    ora #$60 ; '`'                                                    ; a23c: 09 60       .`
+    sta l1071                                                         ; a23e: 8d 71 10    .q.
+; $a241 referenced 1 time by $a258
+loop_ca241
+    bne ca1ca                                                         ; a241: d0 87       ..
+; $a243 referenced 1 time by $a217
+ca243
+    ldx #$ff                                                          ; a243: a2 ff       ..
+; $a245 referenced 1 time by $a24e
+loop_ca245
+    inx                                                               ; a245: e8          .
+    lda l0e38,x                                                       ; a246: bd 38 0e    .8.
+    sta l0e30,x                                                       ; a249: 9d 30 0e    .0.
+    eor #$0d                                                          ; a24c: 49 0d       I.
+    bne loop_ca245                                                    ; a24e: d0 f5       ..
+    jsr sub_caf32                                                     ; a250: 20 32 af     2.
+    ora #$80                                                          ; a253: 09 80       ..
+    sta l1071                                                         ; a255: 8d 71 10    .q.
+    bne loop_ca241                                                    ; a258: d0 e7       ..
+; $a25a referenced 1 time by $a213
+ca25a
+    jsr sub_caf32                                                     ; a25a: 20 32 af     2.
+; $a25d referenced 3 times by $a20e, $a219, $b332
+ca25d
+    lda #$fe                                                          ; a25d: a9 fe       ..
+    jsr generate_error_inline                                         ; a25f: 20 b8 96     ..
+    !text "command", 0                                                ; a262: 63 6f 6d... com
+
+; $a26a referenced 1 time by $a1e7
+ca26a
+    ldx #3                                                            ; a26a: a2 03       ..
+; $a26c referenced 1 time by $a272
+loop_ca26c
+    inc l0f06,x                                                       ; a26c: fe 06 0f    ...
+    bne ca299                                                         ; a26f: d0 28       .(
+    dex                                                               ; a271: ca          .
+    bne loop_ca26c                                                    ; a272: d0 f8       ..
+    lda #$93                                                          ; a274: a9 93       ..
+    jsr generate_error_inline3                                        ; a276: 20 d1 96     ..
+    !text "No!", 0                                                    ; a279: 4e 6f 21... No!
+
+; $a27d referenced 1 time by $a203
+ca27d
+    lda l0f05                                                         ; a27d: ad 05 0f    ...
+    jsr sub_cb509                                                     ; a280: 20 09 b5     ..
+    tay                                                               ; a283: a8          .
+    lda #0                                                            ; a284: a9 00       ..
+    sta l1060,x                                                       ; a286: 9d 60 10    .`.
+    sty l1070                                                         ; a289: 8c 70 10    .p.
+    ldy #3                                                            ; a28c: a0 03       ..
+    jmp ca3e8                                                         ; a28e: 4c e8 a3    L..
+
+; $a291 referenced 1 time by $a230
+la291
+    !text "Library."                                                  ; a291: 4c 69 62... Lib
+
+; $a299 referenced 1 time by $a26f
+ca299
+    jsr sub_caf02                                                     ; a299: 20 02 af     ..
+    ldy #0                                                            ; a29c: a0 00       ..
+    clc                                                               ; a29e: 18          .
+    jsr gsinit                                                        ; a29f: 20 c2 ff     ..
+; $a2a2 referenced 1 time by $a2a5
+loop_ca2a2
+    jsr gsread                                                        ; a2a2: 20 c5 ff     ..
+    bcc loop_ca2a2                                                    ; a2a5: 90 fb       ..
+    dey                                                               ; a2a7: 88          .
+; $a2a8 referenced 1 time by $a2ad
+loop_ca2a8
+    iny                                                               ; a2a8: c8          .
+    lda (os_text_ptr),y                                               ; a2a9: b1 f2       ..
+    cmp #$20 ; ' '                                                    ; a2ab: c9 20       .
+    beq loop_ca2a8                                                    ; a2ad: f0 f9       ..
+    eor #$0d                                                          ; a2af: 49 0d       I.
+    clc                                                               ; a2b1: 18          .
+    tya                                                               ; a2b2: 98          .
+    adc os_text_ptr                                                   ; a2b3: 65 f2       e.
+    sta l0e0a                                                         ; a2b5: 8d 0a 0e    ...
+    lda l00f3                                                         ; a2b8: a5 f3       ..
+    adc #0                                                            ; a2ba: 69 00       i.
+    sta l0e0b                                                         ; a2bc: 8d 0b 0e    ...
+    jsr sub_c8b02                                                     ; a2bf: 20 02 8b     ..
+    ldx #$0e                                                          ; a2c2: a2 0e       ..
+    stx l00bc                                                         ; a2c4: 86 bc       ..
+    lda #$0e                                                          ; a2c6: a9 0e       ..
+    sta l00bb                                                         ; a2c8: 85 bb       ..
+    sta l0e14                                                         ; a2ca: 8d 14 0e    ...
+    ldx #$4a ; 'J'                                                    ; a2cd: a2 4a       .J
+    ldy #5                                                            ; a2cf: a0 05       ..
+    jsr sub_c9951                                                     ; a2d1: 20 51 99     Q.
+    lda l0d63                                                         ; a2d4: ad 63 0d    .c.
+    beq ca2ef                                                         ; a2d7: f0 16       ..
+    and l0f0b                                                         ; a2d9: 2d 0b 0f    -..
+    and l0f0c                                                         ; a2dc: 2d 0c 0f    -..
+    cmp #$ff                                                          ; a2df: c9 ff       ..
+    beq ca2ef                                                         ; a2e1: f0 0c       ..
+    jsr ca073                                                         ; a2e3: 20 73 a0     s.
+    ldx #9                                                            ; a2e6: a2 09       ..
+    ldy #$0f                                                          ; a2e8: a0 0f       ..
+    lda #4                                                            ; a2ea: a9 04       ..
+    jmp c0406                                                         ; a2ec: 4c 06 04    L..
+
+; $a2ef referenced 2 times by $a2d7, $a2e1
+ca2ef
+    lda #1                                                            ; a2ef: a9 01       ..
+    jmp (l0f09)                                                       ; a2f1: 6c 09 0f    l..
+
+; $a2f4 referenced 1 time by $945f
+ca2f4
+    jsr sub_ca32b                                                     ; a2f4: 20 2b a3     +.
+    jmp c9cc7                                                         ; a2f7: 4c c7 9c    L..
+
+sub_ca2fa
+    jsr sub_ca362                                                     ; a2fa: 20 62 a3     b.
+    jmp c9cc7                                                         ; a2fd: 4c c7 9c    L..
+
+; $a300 referenced 1 time by $a39f
+sub_ca300
+    ldx #$10                                                          ; a300: a2 10       ..
+    clv                                                               ; a302: b8          .
+; $a303 referenced 2 times by $a309, $a310
+ca303
+    dex                                                               ; a303: ca          .
+    bmi ca319                                                         ; a304: 30 13       0.
+    jsr sub_cb586                                                     ; a306: 20 86 b5     ..
+    bne ca303                                                         ; a309: d0 f8       ..
+    lda l1060,x                                                       ; a30b: bd 60 10    .`.
+    and #4                                                            ; a30e: 29 04       ).
+    beq ca303                                                         ; a310: f0 f1       ..
+    tya                                                               ; a312: 98          .
+    sta l1030,x                                                       ; a313: 9d 30 10    .0.
+    bit l9491                                                         ; a316: 2c 91 94    ,..
+; $a319 referenced 1 time by $a304
+ca319
+    sty l0e02                                                         ; a319: 8c 02 0e    ...
+    bvs ca327                                                         ; a31c: 70 09       p.
+    tya                                                               ; a31e: 98          .
+    jsr sub_cb509                                                     ; a31f: 20 09 b5     ..
+    sta l1072                                                         ; a322: 8d 72 10    .r.
+    beq ca38e                                                         ; a325: f0 67       .g
+; $a327 referenced 1 time by $a31c
+ca327
+    lda #$26 ; '&'                                                    ; a327: a9 26       .&
+    bne ca38b                                                         ; a329: d0 60       .`
+; $a32b referenced 3 times by $a2f4, $a35d, $a3a5
+sub_ca32b
+    ldx #$10                                                          ; a32b: a2 10       ..
+    clv                                                               ; a32d: b8          .
+; $a32e referenced 2 times by $a334, $a33b
+ca32e
+    dex                                                               ; a32e: ca          .
+    bmi ca344                                                         ; a32f: 30 13       0.
+    jsr sub_cb586                                                     ; a331: 20 86 b5     ..
+    bne ca32e                                                         ; a334: d0 f8       ..
+    lda l1060,x                                                       ; a336: bd 60 10    .`.
+    and #8                                                            ; a339: 29 08       ).
+    beq ca32e                                                         ; a33b: f0 f1       ..
+    tya                                                               ; a33d: 98          .
+    sta l1030,x                                                       ; a33e: 9d 30 10    .0.
+    bit l9491                                                         ; a341: 2c 91 94    ,..
+; $a344 referenced 1 time by $a32f
+ca344
+    sty l0e03                                                         ; a344: 8c 03 0e    ...
+    bvs ca352                                                         ; a347: 70 09       p.
+    tya                                                               ; a349: 98          .
+    jsr sub_cb509                                                     ; a34a: 20 09 b5     ..
+    sta l1073                                                         ; a34d: 8d 73 10    .s.
+    beq ca38e                                                         ; a350: f0 3c       .<
+; $a352 referenced 1 time by $a347
+ca352
+    lda #$2a ; '*'                                                    ; a352: a9 2a       .*
+    bne ca38b                                                         ; a354: d0 35       .5
+sub_ca356
+    lda l0e03                                                         ; a356: ad 03 0e    ...
+    pha                                                               ; a359: 48          H
+    ldy l0e04                                                         ; a35a: ac 04 0e    ...
+    jsr sub_ca32b                                                     ; a35d: 20 2b a3     +.
+    pla                                                               ; a360: 68          h
+    tay                                                               ; a361: a8          .
+; $a362 referenced 2 times by $a2fa, $a3ab
+sub_ca362
+    ldx #$10                                                          ; a362: a2 10       ..
+    clv                                                               ; a364: b8          .
+; $a365 referenced 2 times by $a36b, $a372
+ca365
+    dex                                                               ; a365: ca          .
+    bmi ca37b                                                         ; a366: 30 13       0.
+    jsr sub_cb586                                                     ; a368: 20 86 b5     ..
+    bne ca365                                                         ; a36b: d0 f8       ..
+    lda l1060,x                                                       ; a36d: bd 60 10    .`.
+    and #$10                                                          ; a370: 29 10       ).
+    beq ca365                                                         ; a372: f0 f1       ..
+    tya                                                               ; a374: 98          .
+    sta l1030,x                                                       ; a375: 9d 30 10    .0.
+    bit l9491                                                         ; a378: 2c 91 94    ,..
+; $a37b referenced 1 time by $a366
+ca37b
+    sty l0e04                                                         ; a37b: 8c 04 0e    ...
+    bvs ca389                                                         ; a37e: 70 09       p.
+    tya                                                               ; a380: 98          .
+    jsr sub_cb509                                                     ; a381: 20 09 b5     ..
+    sta l1074                                                         ; a384: 8d 74 10    .t.
+    beq ca38e                                                         ; a387: f0 05       ..
+; $a389 referenced 1 time by $a37e
+ca389
+    lda #$32 ; '2'                                                    ; a389: a9 32       .2
+; $a38b referenced 2 times by $a329, $a354
+ca38b
+    sta l1060,x                                                       ; a38b: 9d 60 10    .`.
+; $a38e referenced 3 times by $a325, $a350, $a387
+ca38e
+    jmp c8f8c                                                         ; a38e: 4c 8c 8f    L..
+
+sub_ca391
+    jsr sub_cb559                                                     ; a391: 20 59 b5     Y.
+    sec                                                               ; a394: 38          8
+    lda l0f08                                                         ; a395: ad 08 0f    ...
+    sta l0e05                                                         ; a398: 8d 05 0e    ...
+sub_ca39b
+    php                                                               ; a39b: 08          .
+    ldy l0f05                                                         ; a39c: ac 05 0f    ...
+    jsr sub_ca300                                                     ; a39f: 20 00 a3     ..
+    ldy l0f06                                                         ; a3a2: ac 06 0f    ...
+    jsr sub_ca32b                                                     ; a3a5: 20 2b a3     +.
+    ldy l0f07                                                         ; a3a8: ac 07 0f    ...
+    jsr sub_ca362                                                     ; a3ab: 20 62 a3     b.
+    plp                                                               ; a3ae: 28          (
+    bcs ca3b4                                                         ; a3af: b0 03       ..
+    jmp c9cc7                                                         ; a3b1: 4c c7 9c    L..
+
+; $a3b4 referenced 1 time by $a3af
+ca3b4
+    lda l1071                                                         ; a3b4: ad 71 10    .q.
+    tax                                                               ; a3b7: aa          .
+    and #4                                                            ; a3b8: 29 04       ).
+    php                                                               ; a3ba: 08          .
+    txa                                                               ; a3bb: 8a          .
+    and #$fb                                                          ; a3bc: 29 fb       ).
+    sta l1071                                                         ; a3be: 8d 71 10    .q.
+    plp                                                               ; a3c1: 28          (
+    bne ca3e3                                                         ; a3c2: d0 1f       ..
+    lda #osbyte_scan_keyboard                                         ; a3c4: a9 79       .y
+    ldx #$81                                                          ; a3c6: a2 81       ..
+    jsr osbyte                                                        ; a3c8: 20 f4 ff     ..
+    txa                                                               ; a3cb: 8a          .
+    bpl ca3e3                                                         ; a3cc: 10 15       ..
+; $a3ce referenced 1 time by $a3e6
+loop_ca3ce
+    rts                                                               ; a3ce: 60          `
+
+    !text "L.!BOOT"                                                   ; a3cf: 4c 2e 21... L.!
+    !byte $0d                                                         ; a3d6: 0d          .
+    !text "E.!BOOT"                                                   ; a3d7: 45 2e 21... E.!
+    !byte $0d                                                         ; a3de: 0d          .
+; $a3df referenced 1 time by $a3e8
+la3df
+    !byte $de, $cf, $d1, $d7                                          ; a3df: de cf d1... ...
+
+; $a3e3 referenced 2 times by $a3c2, $a3cc
+ca3e3
+    ldy l0e05                                                         ; a3e3: ac 05 0e    ...
+    beq loop_ca3ce                                                    ; a3e6: f0 e6       ..
+; $a3e8 referenced 1 time by $a28e
+ca3e8
+    ldx la3df,y                                                       ; a3e8: be df a3    ...
+    ldy #$a3                                                          ; a3eb: a0 a3       ..
+    jmp oscli                                                         ; a3ed: 4c f7 ff    L..
+
+; $a3f0 referenced 12 times by $8bae, $8bbd, $8bc5, $8bd2, $8c00, $8c07, $932a, $9332, $a145, $a14a, $a15a, $a191
+la3f0
+la3f1 = la3f0+1
+la3f2 = la3f0+2
+    !text "Close"                                                     ; a3f0: 43 6c 6f... Clo
+; $a3f1 referenced 3 times by $8c93, $a13b, $b326
+; $a3f2 referenced 3 times by $8c8f, $a137, $b353
+    !byte $80                                                         ; a3f5: 80          .
+    !word sub_cb994-1                                                 ; a3f6: 93 b9       ..
+    !text "Dump"                                                      ; a3f8: 44 75 6d... Dum
+    !byte $c4                                                         ; a3fc: c4          .
+    !word sub_cba1b-1                                                 ; a3fd: 1a ba       ..
+    !text "Net"                                                       ; a3ff: 4e 65 74    Net
+    !byte $80                                                         ; a402: 80          .
+    !word sub_c8b1a-1                                                 ; a403: 19 8b       ..
+    !text "Pollps"                                                    ; a405: 50 6f 6c... Pol
+    !byte $88                                                         ; a40b: 88          .
+    !word sub_cb1c3-1                                                 ; a40c: c2 b1       ..
+    !text "Print"                                                     ; a40e: 50 72 69... Pri
+    !byte $cc                                                         ; a413: cc          .
+    !word sub_cb99d-1                                                 ; a414: 9c b9       ..
+    !text "Prot"                                                      ; a416: 50 72 6f... Pro
+    !byte $8e                                                         ; a41a: 8e          .
+    !word sub_cb30c-1                                                 ; a41b: 0b b3       ..
+    !text "PS"                                                        ; a41d: 50 53       PS
+    !byte $88                                                         ; a41f: 88          .
+    !word sub_cafee-1                                                 ; a420: ed af       ..
+    !text "Roff"                                                      ; a422: 52 6f 66... Rof
+    !byte $80                                                         ; a426: 80          .
+    !word sub_c8ad4-1                                                 ; a427: d3 8a       ..
+    !text "Type"                                                      ; a429: 54 79 70... Typ
+    !byte $cc                                                         ; a42d: cc          .
+    !word sub_cb99a-1                                                 ; a42e: 99 b9       ..
+    !text "Unprot"                                                    ; a430: 55 6e 70... Unp
+    !byte $8e                                                         ; a436: 8e          .
+    !word sub_cb33d-1                                                 ; a437: 3c b3       <.
+    !byte $80                                                         ; a439: 80          .
+    !text "Access"                                                    ; a43a: 41 63 63... Acc
+    !byte $c9                                                         ; a440: c9          .
+    !word sub_c92e6-1                                                 ; a441: e5 92       ..
+    !text "Bye"                                                       ; a443: 42 79 65    Bye
+    !byte $80                                                         ; a446: 80          .
+    !word sub_c949e-1                                                 ; a447: 9d 94       ..
+    !text "Cdir"                                                      ; a449: 43 64 69... Cdi
+    !byte $c6                                                         ; a44d: c6          .
+    !word sub_cad10-1                                                 ; a44e: 0f ad       ..
+    !text "Delete"                                                    ; a450: 44 65 6c... Del
+    !byte $c3                                                         ; a456: c3          .
+    !word sub_c92e6-1                                                 ; a457: e5 92       ..
+    !text "Dir"                                                       ; a459: 44 69 72    Dir
+    !byte $81                                                         ; a45c: 81          .
+    !word sub_c93dd-1                                                 ; a45d: dc 93       ..
+    !text "Ex"                                                        ; a45f: 45 78       Ex
+    !byte $81                                                         ; a461: 81          .
+    !word sub_cad6b-1                                                 ; a462: 6a ad       j.
+    !text "Flip"                                                      ; a464: 46 6c 69... Fli
+    !byte $80                                                         ; a468: 80          .
+    !word sub_ca356-1                                                 ; a469: 55 a3       U.
+    !text "FS"                                                        ; a46b: 46 53       FS
+    !byte $8b                                                         ; a46d: 8b          .
+    !word sub_ca07b-1                                                 ; a46e: 7a a0       z.
+    !text "Info"                                                      ; a470: 49 6e 66... Inf
+    !byte $c3                                                         ; a474: c3          .
+    !word sub_c92e6-1                                                 ; a475: e5 92       ..
+; $a477 referenced 1 time by $8daf
+la477
+    !text "I am"                                                      ; a477: 49 20 61... I a
+    !byte $c2                                                         ; a47b: c2          .
+    !word sub_c8d79-1                                                 ; a47c: 78 8d       x.
+    !text "Lcat"                                                      ; a47e: 4c 63 61... Lca
+    !byte $81                                                         ; a482: 81          .
+    !word sub_cad5f-1                                                 ; a483: 5e ad       ^.
+    !text "Lex"                                                       ; a485: 4c 65 78    Lex
+    !byte $81                                                         ; a488: 81          .
+    !word sub_cad65-1                                                 ; a489: 64 ad       d.
+    !text "Lib"                                                       ; a48b: 4c 69 62    Lib
+    !byte $c5                                                         ; a48e: c5          .
+    !word sub_c92e6-1                                                 ; a48f: e5 92       ..
+    !text "Pass"                                                      ; a491: 50 61 73... Pas
+    !byte $c7                                                         ; a495: c7          .
+    !word c8dbc-1                                                     ; a496: bb 8d       ..
+    !text "Remove"                                                    ; a498: 52 65 6d... Rem
+    !byte $c3                                                         ; a49e: c3          .
+    !word sub_caf66-1                                                 ; a49f: 65 af       e.
+    !text "Rename"                                                    ; a4a1: 52 65 6e... Ren
+    !byte $ca                                                         ; a4a7: ca          .
+    !word sub_c938b-1                                                 ; a4a8: 8a 93       ..
+    !text "Wipe"                                                      ; a4aa: 57 69 70... Wip
+    !byte $81                                                         ; a4ae: 81          .
+    !word sub_cb359-1                                                 ; a4af: 58 b3       X.
+    !byte $80                                                         ; a4b1: 80          .
+    !word c8e15-1                                                     ; a4b2: 14 8e       ..
+    !text "Net"                                                       ; a4b4: 4e 65 74    Net
+    !byte $80                                                         ; a4b7: 80          .
+    !word sub_c8b96-1                                                 ; a4b8: 95 8b       ..
+    !text "Utils"                                                     ; a4ba: 55 74 69... Uti
+    !byte $80                                                         ; a4bf: 80          .
+    !word sub_c8b92-1                                                 ; a4c0: 91 8b       ..
+    !byte $80                                                         ; a4c2: 80          .
+    !text "Halt"                                                      ; a4c3: 48 61 6c... Hal
+    !byte $fc, $20, $df                                               ; a4c7: fc 20 df    . .
+    !text "JSR"                                                       ; a4ca: 4a 53 52    JSR
+    !byte $fc,   4, $fb                                               ; a4cd: fc 04 fb    ...
+    !text "Peek"                                                      ; a4d0: 50 65 65... Pee
+    !byte $fc,   1, $fe                                               ; a4d4: fc 01 fe    ...
+    !text "Poke"                                                      ; a4d7: 50 6f 6b... Pok
+    !byte $fc,   2, $fd                                               ; a4db: fc 02 fd    ...
+    !text "Proc"                                                      ; a4de: 50 72 6f... Pro
+    !byte $fc,   8, $f7                                               ; a4e2: fc 08 f7    ...
+    !text "Utils"                                                     ; a4e5: 55 74 69... Uti
+    !byte $a9, $10, $ef, $80                                          ; a4ea: a9 10 ef... ...
+
+sub_ca4ee
+    clc                                                               ; a4ee: 18          .
+    lda l00ef                                                         ; a4ef: a5 ef       ..
+    sbc #$0d                                                          ; a4f1: e9 0d       ..
+    bmi ca522                                                         ; a4f3: 30 2d       0-
+    cmp #7                                                            ; a4f5: c9 07       ..
+    bcs ca522                                                         ; a4f7: b0 29       .)
+    tax                                                               ; a4f9: aa          .
+    ldy #6                                                            ; a4fa: a0 06       ..
+; $a4fc referenced 1 time by $a507
+loop_ca4fc
+    lda l00a9,y                                                       ; a4fc: b9 a9 00    ...
+    pha                                                               ; a4ff: 48          H
+    lda l00ed,y                                                       ; a500: b9 ed 00    ...
+    sta l00a9,y                                                       ; a503: 99 a9 00    ...
+    dey                                                               ; a506: 88          .
+    bne loop_ca4fc                                                    ; a507: d0 f3       ..
+    jsr sub_ca516                                                     ; a509: 20 16 a5     ..
+    ldy #$fa                                                          ; a50c: a0 fa       ..
+; $a50e referenced 1 time by $a513
+loop_ca50e
+    pla                                                               ; a50e: 68          h
+    sta lffb0,y                                                       ; a50f: 99 b0 ff    ...
+    iny                                                               ; a512: c8          .
+    bne loop_ca50e                                                    ; a513: d0 f9       ..
+    rts                                                               ; a515: 60          `
+
+; $a516 referenced 1 time by $a509
+sub_ca516
+    lda la52a,x                                                       ; a516: bd 2a a5    .*.
+    pha                                                               ; a519: 48          H
+    lda la523,x                                                       ; a51a: bd 23 a5    .#.
+    pha                                                               ; a51d: 48          H
+    lda (l00ac),y                                                     ; a51e: b1 ac       ..
+    sty l00a9                                                         ; a520: 84 a9       ..
+; $a522 referenced 2 times by $a4f3, $a4f7
+ca522
+    rts                                                               ; a522: 60          `
+
+; $a523 referenced 1 time by $a51a
+la523
+    !byte $30, $21, $a3, $c0, $18, $2d, $c4                           ; a523: 30 21 a3... 0!.
+; $a52a referenced 1 time by $a516
+la52a
+    !byte $a5, $a5, $a5, $a5, $a6, $a6, $a8, $2c, $6c, $0d, $10,   8  ; a52a: a5 a5 a5... ...
+    !byte $c9,   4, $f0,   5, $a9,   8, $85, $a9, $60, $a2,   0, $a0  ; a536: c9 04 f0... ...
+    !byte $10, $20, $ad, $94, $ad,   9, $0f, $20, $95, $a5, $8d, $0b  ; a542: 10 20 ad... . .
+    !byte $0f, $ad,   8, $0f, $20, $95, $a5, $8d, $0a, $0f, $ad,   7  ; a54e: 0f ad 08... ...
+    !byte $0f, $20, $95, $a5, $8d,   9, $0f, $a9,   0, $8d,   8, $0f  ; a55a: 0f 20 95... . .
+    !byte $ad,   6, $0f, $48, $ad,   5, $0f, $20, $95, $a5, $8d,   7  ; a566: ad 06 0f... ...
+    !byte $0f                                                         ; a572: 0f          .
+    !text "hH)"                                                       ; a573: 68 48 29    hH)
+    !byte $0f, $20, $95, $a5, $8d,   6, $0f                           ; a576: 0f 20 95... . .
+    !text "hJJJJiQ "                                                  ; a57d: 68 4a 4a... hJJ
+    !byte $95, $a5, $8d,   5, $0f, $a0,   6, $b9,   5, $0f, $91, $ac  ; a585: 95 a5 8d... ...
+    !byte $88, $10, $f8, $60,   8, $aa, $f0,   9, $f8, $a9,   0, $18  ; a591: 88 10 f8... ...
+    !byte $69,   1, $ca, $d0, $fa, $28, $60, $0e, $60, $0d, $98, $b0  ; a59d: 69 01 ca... i..
+    !byte   3, $91, $ac, $60, $a5, $9d, $85, $ab, $85, $a1, $a9, $6f  ; a5a9: 03 91 ac... ...
+    !byte $85, $aa, $85, $a0, $a2, $0f, $20, $f8, $a6, $4c, $8c, $85  ; a5b5: 85 aa 85... ...
+    !byte $a6, $9f, $86, $ab, $84, $aa, $6e, $61, $0d, $a8, $85, $ae  ; a5c1: a6 9f 86... ...
+    !byte $d0, $1b, $a9,   3, $20, $ce, $a0, $b0                      ; a5cd: d0 1b a9... ...
+    !text "=JJ"                                                       ; a5d5: 3d 4a 4a    =JJ
+    !byte $aa, $b1, $aa, $f0, $36, $c9, $3f, $f0,   4, $e8, $8a, $d0  ; a5d8: aa b1 aa... ...
+    !byte $ec, $8a, $a2,   0, $81, $ac, $20, $ce, $a0, $b0, $24, $88  ; a5e4: ec 8a a2... ...
+    !byte $84, $aa, $a9, $c0, $a0,   1, $a2, $0b, $c4, $ae, $71, $aa  ; a5f0: 84 aa a9... ...
+    !byte $f0,   3, $30, $0e, $18, $20, $f8, $a6, $b0, $0f, $a9, $3f  ; a5fc: f0 03 30... ..0
+    !byte $a0,   1, $91, $aa, $d0,   7, $69,   1, $d0, $ee, $88, $91  ; a608: a0 01 91... ...
+    !byte $ac, $2e, $61, $0d, $60, $a5, $9d, $85, $ab, $a0, $7f, $b1  ; a614: ac 2e 61... ..a
+    !byte $9c, $c8, $84, $aa, $aa, $ca, $a0,   0, $20, $f8, $a6, $4c  ; a620: 9c c8 84... ...
+    !byte $dd, $ac, $aa, $c9, $13, $b0,   8, $bd, $4e, $a6, $48, $bd  ; a62c: dd ac aa... ...
+    !byte $3c, $a6                                                    ; a638: 3c a6       <.
+    !text "H`_r"                                                      ; a63a: 48 60 5f... H`_
+    !byte   6, $12                                                    ; a63e: 06 12       ..
+    !text "'-3C"                                                      ; a640: 27 2d 33... '-3
+    !byte $e3, $ec, $fa,   1, $e7, $ea,   6, $0e, $19, $24, $a6, $a6  ; a644: e3 ec fa... ...
+    !byte $a7, $a7, $a7, $a7, $a7, $a7, $a7, $a7, $a7, $a8, $a6, $a6  ; a650: a7 a7 a7... ...
+    !byte $a8, $a8, $a8, $a8, $2c, $6c, $0d, $30,   3, $4c, $49, $a7  ; a65c: a8 a8 a8... ...
+    !byte $a0,   2, $b9, $ff, $0d, $91, $f0, $88, $d0, $f8            ; a668: a0 02 b9... ...
+    !text "`,l"                                                       ; a672: 60 2c 6c    `,l
+    !byte $0d, $10, $ed, $a0,   0, $20, $99, $b7, $a0,   2, $b1, $f0  ; a675: 0d 10 ed... ...
+    !byte $99, $ff, $0d, $88, $d0, $f8, $20,   9, $8e, $a2, $0f, $bd  ; a681: 99 ff 0d... ...
+    !byte $60, $10, $a8, $29,   2, $f0, $50, $98, $29, $df, $9d, $60  ; a68d: 60 10 a8... `..
+    !byte $10, $a8, $20, $86, $b5, $d0, $44, $18, $98, $29,   4, $f0  ; a699: 10 a8 20... ..
+    !byte $10, $98,   9, $20, $a8, $bd, $30, $10, $8d,   2, $0e, $8a  ; a6a5: 10 98 09... ...
+    !byte $69, $20, $8d, $72, $10, $98, $29,   8, $f0, $10, $98,   9  ; a6b1: 69 20 8d... i .
+    !byte $20, $a8, $bd, $30, $10, $8d,   3, $0e, $8a, $69, $20, $8d  ; a6bd: 20 a8 bd...  ..
+    !byte $73, $10, $98, $29, $10, $f0, $10, $98,   9, $20, $a8, $bd  ; a6c9: 73 10 98... s..
+    !byte $30, $10, $8d,   4, $0e, $8a, $69, $20, $8d, $74, $10, $98  ; a6d5: 30 10 8d... 0..
+    !byte $9d, $60, $10, $ca, $10, $a5, $60, $18, $90,   1, $38, $a9  ; a6e1: 9d 60 10... .`.
+    !byte $17, $85, $aa, $a5, $9d, $85, $ab, $a0,   1, $a2,   5, $90  ; a6ed: 17 85 aa... ...
+    !byte   4, $b1, $ac, $91, $aa, $b1, $aa, $91, $ac, $c8, $ca, $10  ; a6f9: 04 b1 ac... ...
+    !byte $f2, $60, $a5, $9f, $85, $ab, $c8, $98, $85, $aa, $aa, $18  ; a705: f2 60 a5... .`.
+    !byte $90, $e5, $c8, $b1, $ac, $c8, $91, $9e, $b1, $ac, $c8, $91  ; a711: 90 e5 c8... ...
+    !byte $9e, $20, $65, $a8, $51, $9e, $d0,   2, $91, $9e, $60, $ad  ; a71d: 9e 20 65... . e
+    !byte $68, $0d, $4c, $fe, $a7, $c8, $b1, $ac, $4c, $36, $b3, $2c  ; a729: 68 0d 4c... h.L
+    !byte $6c, $0d, $10, $10, $a0,   3, $b9, $71, $10, $91, $ac, $88  ; a735: 6c 0d 10... l..
+    !byte $d0, $f8                                                    ; a741: d0 f8       ..
+    !text "`,l"                                                       ; a743: 60 2c 6c    `,l
+    !byte $0d, $30,   6, $a9,   0, $a8, $91, $ac, $60, $a0,   1, $b1  ; a746: 0d 30 06... .0.
+    !byte $ac, $c9, $20, $90, $0a, $c9, $30, $b0,   6, $aa, $bd, $10  ; a752: ac c9 20... ..
+    !byte $10, $d0,   7, $a9,   0, $aa, $81, $ac, $f0, $26, $bd, $40  ; a75e: 10 d0 07... ...
+    !byte $10, $29,   2, $f0, $f2, $8a, $99, $71, $10, $bd, $10, $10  ; a76a: 10 29 02... .).
+    !byte $99,   1, $0e, $c0,   1, $d0, $18, $98, $48, $a0,   4, $20  ; a776: 99 01 0e... ...
+    !byte $bf, $a7, $68, $a8, $bd, $40, $10,   9, $24, $9d, $40, $10  ; a782: bf a7 68... ..h
+    !byte $c8, $c0,   4, $d0, $be, $88, $60, $c0,   2, $d0, $13, $98  ; a78e: c8 c0 04... ...
+    !byte $48, $a0,   8, $20, $bf, $a7, $68, $a8, $bd, $40, $10,   9  ; a79a: 48 a0 08... H..
+    !byte $28, $9d, $40, $10, $d0, $e2, $98, $48, $a0, $10, $20, $bf  ; a7a6: 28 9d 40... (.@
+    !byte $a7, $68, $a8, $bd, $40, $10,   9, $30, $9d, $40, $10, $d0  ; a7b2: a7 68 a8... .h.
+    !byte $cf, $8a, $48, $a2, $0f, $bd, $60, $10, $2a, $2a, $10, $14  ; a7be: cf 8a 48... ..H
+    !byte $98, $3d, $60, $10, $f0,   5, $98,   9, $20, $d0,   1, $98  ; a7ca: 98 3d 60... .=`
+    !byte $49, $ff, $3d, $60, $10, $9d, $60, $10, $ca, $10, $e2, $68  ; a7d6: 49 ff 3d... I.=
+    !byte $aa, $60, $a0,   1, $b1, $9c, $a0,   0, $4c, $fe, $a7, $a0  ; a7e2: aa 60 a0... .`.
+    !byte $7f, $b1, $9c, $a0,   1, $91, $ac, $c8, $a9, $80, $91, $ac  ; a7ee: 7f b1 9c... ...
+    !byte $60, $ad,   9, $0e, $c8, $91, $ac, $60, $ad,   8, $0e, $10  ; a7fa: 60 ad 09... `..
+    !byte $f7, $a9, $6f, $38, $ed, $6b, $0d, $b0, $ef, $c8, $b9, $6c  ; a806: f7 a9 6f... ..o
+    !byte $0d, $91, $ac, $c0,   3, $d0, $f6, $60, $c8, $b1, $ac, $99  ; a812: 0d 91 ac... ...
+    !byte $6c, $0d, $c0,   3, $d0, $f6                                ; a81e: 6c 0d c0... l..
+    !text "` e"                                                       ; a824: 60 20 65    ` e
+    !byte $a8, $a0,   0, $ad, $71, $0d, $c9, $ff, $d0,   6, $98, $91  ; a827: a8 a0 00... ...
+    !byte $ac, $c8, $d0, $13, $c8, $91, $ac, $c8, $c8, $b1, $ac, $f0  ; a833: ac c8 d0... ...
+    !byte   7, $4d                                                    ; a83f: 07 4d       .M
+; $a841 referenced 1 time by $a875
+la841
+    !byte $71, $0d, $d0,   7, $f0,   3, $ad,   1, $0e, $91, $ac, $60  ; a841: 71 0d d0... q..
+; $a84d referenced 1 time by $a87a
+la84d
+    !byte $82, $9c, $ff, $ff                                          ; a84d: 82 9c ff... ...
+    !text "BRIDGE"                                                    ; a851: 42 52 49... BRI
+    !byte $9c,   0, $7f, $9c,   0,   0, $71, $0d, $ff, $ff, $73, $0d  ; a857: 9c 00 7f... ...
+    !byte $ff, $ff                                                    ; a863: ff ff       ..
+
+; $a865 referenced 2 times by $8e09, $a0b4
+sub_ca865
+    lda l0d71                                                         ; a865: ad 71 0d    .q.
+    cmp #$ff                                                          ; a868: c9 ff       ..
+    bne ca8c4                                                         ; a86a: d0 58       .X
+    tya                                                               ; a86c: 98          .
+    pha                                                               ; a86d: 48          H
+    ldy #$18                                                          ; a86e: a0 18       ..
+    ldx #$0b                                                          ; a870: a2 0b       ..
+    ror l0d61                                                         ; a872: 6e 61 0d    na.
+; $a875 referenced 1 time by $a881
+loop_ca875
+    lda la841,y                                                       ; a875: b9 41 a8    .A.
+    sta (l009e),y                                                     ; a878: 91 9e       ..
+    lda la84d,x                                                       ; a87a: bd 4d a8    .M.
+    sta l00c0,x                                                       ; a87d: 95 c0       ..
+    iny                                                               ; a87f: c8          .
+    dex                                                               ; a880: ca          .
+    bpl loop_ca875                                                    ; a881: 10 f2       ..
+    stx l0d71                                                         ; a883: 8e 71 0d    .q.
+    rol l0d61                                                         ; a886: 2e 61 0d    .a.
+; $a889 referenced 2 times by $a88c, $a8b3
+ca889
+    asl l0d60                                                         ; a889: 0e 60 0d    .`.
+    bcc ca889                                                         ; a88c: 90 fb       ..
+    lda #$82                                                          ; a88e: a9 82       ..
+    sta l00c0                                                         ; a890: 85 c0       ..
+    lda #$c0                                                          ; a892: a9 c0       ..
+    sta l00a0                                                         ; a894: 85 a0       ..
+    lda #0                                                            ; a896: a9 00       ..
+    sta l00a1                                                         ; a898: 85 a1       ..
+    jsr sub_c858c                                                     ; a89a: 20 8c 85     ..
+; $a89d referenced 1 time by $a89f
+loop_ca89d
+    bit l00c0                                                         ; a89d: 24 c0       $.
+    bmi loop_ca89d                                                    ; a89f: 30 fc       0.
+    txa                                                               ; a8a1: 8a          .
+    pha                                                               ; a8a2: 48          H
+    lda #osbyte_vsync                                                 ; a8a3: a9 13       ..
+    jsr osbyte                                                        ; a8a5: 20 f4 ff     ..
+    pla                                                               ; a8a8: 68          h
+    tax                                                               ; a8a9: aa          .
+    ldy #$18                                                          ; a8aa: a0 18       ..
+    lda (l009e),y                                                     ; a8ac: b1 9e       ..
+    bmi ca8b5                                                         ; a8ae: 30 05       0.
+    jsr sub_cbc86                                                     ; a8b0: 20 86 bc     ..
+    bpl ca889                                                         ; a8b3: 10 d4       ..
+; $a8b5 referenced 1 time by $a8ae
+ca8b5
+    lda #$3f ; '?'                                                    ; a8b5: a9 3f       .?
+    sta (l009e),y                                                     ; a8b7: 91 9e       ..
+    pla                                                               ; a8b9: 68          h
+    tay                                                               ; a8ba: a8          .
+    lda l0d71                                                         ; a8bb: ad 71 0d    .q.
+    tax                                                               ; a8be: aa          .
+    eor #$ff                                                          ; a8bf: 49 ff       I.
+    beq ca8c4                                                         ; a8c1: f0 01       ..
+    txa                                                               ; a8c3: 8a          .
+; $a8c4 referenced 2 times by $a86a, $a8c1
+ca8c4
+    rts                                                               ; a8c4: 60          `
+
+    !byte $c9,   1, $b0                                               ; a8c5: c9 01 b0    ...
+    !text "l,l"                                                       ; a8c8: 6c 2c 6c    l,l
+    !byte $0d, $10, $f6, $a0                                          ; a8cb: 0d 10 f6... ...
+    !text "# 2"                                                       ; a8cf: 23 20 32    # 2
+    !byte $af, $b9, $73, $94, $d0,   3, $b9, $e6, $0d, $91, $9e, $88  ; a8d2: af b9 73... ..s
+    !byte $c0, $17, $d0, $f1, $c8, $84, $9a, $a0, $1c, $a5, $ac, $69  ; a8de: c0 17 d0... ...
+    !byte   1, $20, $2b, $a9, $a0,   1, $b1, $ac, $a0, $20, $65, $ac  ; a8ea: 01 20 2b... . +
+    !byte $20, $2b, $a9, $a0,   2, $a9, $90, $85, $98, $91, $ac, $c8  ; a8f6: 20 2b a9...  +.
+    !byte $c8, $b9, $fe, $0d, $91, $ac, $c8, $c0,   7, $d0, $f6, $a5  ; a902: c8 b9 fe... ...
+    !byte $9f, $85, $9b, $20, $76, $a9, $a0, $20, $a9, $ff, $91, $9e  ; a90e: 9f 85 9b... ...
+    !byte $c8, $91, $9e, $a0, $19, $a9, $90, $91, $9e, $88, $a9, $7f  ; a91a: c8 91 9e... ...
+    !byte $91, $9e, $4c, $dd, $95, $91, $9e, $c8, $a5, $ad, $69,   0  ; a926: 91 9e 4c... ..L
+    !byte $91, $9e, $60,   8, $a0,   1, $b1, $ac, $aa, $c8, $b1, $ac  ; a932: 91 9e 60... ..`
+    !byte $c8, $84, $aa, $a0, $72, $91, $9c, $88, $8a, $91, $9c, $28  ; a93e: c8 84 aa... ...
+    !byte $d0, $1f, $a4, $aa, $e6, $aa, $b1, $ac, $f0, $16, $a0, $7d  ; a94a: d0 1f a4... ...
+    !byte $91, $9c                                                    ; a956: 91 9c       ..
+    !text "H |"                                                       ; a958: 48 20 7c    H |
+    !byte $aa, $38, $66, $98, $20, $76, $a9, $ca, $d0, $fd, $68, $49  ; a95b: aa 38 66... .8f
+    !byte $0d, $d0, $e2                                               ; a967: 0d d0 e2    ...
+    !text "` |"                                                       ; a96a: 60 20 7c    ` |
+    !byte $aa, $a0, $7b, $b1, $9c, $69,   3, $91, $9c                 ; a96d: aa a0 7b... ..{
+    !text "XL?"                                                       ; a976: 58 4c 3f    XL?
+    !byte $98,   8, $48, $8a, $48, $98, $48, $ba, $bd,   3,   1, $c9  ; a979: 98 08 48... ..H
+    !byte   9, $b0,   4, $aa, $20, $93, $a9, $68, $a8, $68, $aa       ; a985: 09 b0 04... ...
+    !text "h(`"                                                       ; a990: 68 28 60    h(`
+    !byte $bd, $a7, $a9, $48, $bd, $9e, $a9, $48, $a5, $ef, $60, $57  ; a993: bd a7 a9... ...
+    !byte $ec, $ec, $ec, $af, $d7, $57, $e1, $50, $8e, $aa, $aa, $aa  ; a99f: ec ec ec... ...
+    !byte $a9, $aa, $8e, $a9, $aa, $ba, $7e,   6,   1, $1e,   6,   1  ; a9ab: a9 aa 8e... ...
+    !byte $98, $a0, $da, $91, $9e, $a9,   0                           ; a9b7: 98 a0 da... ...
+
+; $a9be referenced 1 time by $8ae7
+sub_ca9be
+    ldy #$d9                                                          ; a9be: a0 d9       ..
+    sta (l009e),y                                                     ; a9c0: 91 9e       ..
+    lda #$80                                                          ; a9c2: a9 80       ..
+    ldy #$0c                                                          ; a9c4: a0 0c       ..
+    sta (l009e),y                                                     ; a9c6: 91 9e       ..
+    lda l009a                                                         ; a9c8: a5 9a       ..
+    pha                                                               ; a9ca: 48          H
+    lda l009b                                                         ; a9cb: a5 9b       ..
+    pha                                                               ; a9cd: 48          H
+    sty l009a                                                         ; a9ce: 84 9a       ..
+    ldx l009f                                                         ; a9d0: a6 9f       ..
+    stx l009b                                                         ; a9d2: 86 9b       ..
+    jsr sub_c983f                                                     ; a9d4: 20 3f 98     ?.
+    lda #$3f ; '?'                                                    ; a9d7: a9 3f       .?
+    sta (l009a,x)                                                     ; a9d9: 81 9a       ..
+    pla                                                               ; a9db: 68          h
+    sta l009b                                                         ; a9dc: 85 9b       ..
+    pla                                                               ; a9de: 68          h
+    sta l009a                                                         ; a9df: 85 9a       ..
+    rts                                                               ; a9e1: 60          `
+
+    !byte $a4, $f1, $c9, $81, $f0, $13, $a0,   1, $a2, $0a, $20, $36  ; a9e2: a4 f1 c9... ...
+    !byte $aa, $f0, $0a, $88, $88, $a2, $11, $20, $36, $aa, $f0,   1  ; a9ee: aa f0 0a... ...
+    !byte $c8, $a2,   2, $98, $f0, $35,   8, $10,   1, $e8, $a0, $dc  ; a9fa: c8 a2 02... ...
+    !byte $b9, $15,   0, $91, $9e, $88, $c0, $da, $10, $f6, $8a, $20  ; aa06: b9 15 00... ...
+    !byte $be, $a9, $28, $10, $1e, $a9, $7f, $a0, $0c, $91, $9e, $b1  ; aa12: be a9 28... ..(
+    !byte $9e, $10, $fc, $ba, $a0, $dd, $b1, $9e,   9, $44, $d0,   4  ; aa1e: 9e 10 fc... ...
+    !byte $88, $ca, $b1, $9e, $9d,   6,   1, $c0, $da, $d0, $f5, $60  ; aa2a: 88 ca b1... ...
+    !byte $dd, $3f, $aa, $f0,   3, $ca, $10, $f8, $60,   4,   9, $0a  ; aa36: dd 3f aa... .?.
+    !byte $14, $15, $9a, $9b, $e1, $e2, $e3, $e4, $0b, $0c, $0f, $79  ; aa42: 14 15 9a... ...
+    !byte $7a, $86, $87, $a0, $0e, $c9,   7, $f0,   4, $c9,   8, $d0  ; aa4e: 7a 86 87... z..
+    !byte $e3, $a2, $db, $86, $9e, $b1, $f0, $91, $9e, $88, $10, $f9  ; aa5a: e3 a2 db... ...
+    !byte $c8, $c6, $9e, $a5, $ef, $91, $9e, $84, $9e, $a0, $14, $a9  ; aa66: c8 c6 9e... ...
+    !byte $e9, $91, $9e, $a9,   1, $20, $be, $a9, $86, $9e, $a2, $0d  ; aa72: e9 91 9e... ...
+    !byte $a0, $7c, $2c, $91, $94, $70,   5                           ; aa7e: a0 7c 2c... .|,
+
+; $aa85 referenced 1 time by $95a2
+sub_caa85
+    ldy #$17                                                          ; aa85: a0 17       ..
+    ldx #$1a                                                          ; aa87: a2 1a       ..
+; $aa89 referenced 1 time by $ab4a
+sub_caa89
+    clv                                                               ; aa89: b8          .
+; $aa8a referenced 1 time by $aaab
+caa8a
+    lda laab1,x                                                       ; aa8a: bd b1 aa    ...
+    cmp #$fe                                                          ; aa8d: c9 fe       ..
+    beq caaad                                                         ; aa8f: f0 1c       ..
+    cmp #$fd                                                          ; aa91: c9 fd       ..
+    beq caaa9                                                         ; aa93: f0 14       ..
+    cmp #$fc                                                          ; aa95: c9 fc       ..
+    bne caaa1                                                         ; aa97: d0 08       ..
+    lda l009d                                                         ; aa99: a5 9d       ..
+    bvs caa9f                                                         ; aa9b: 70 02       p.
+    lda l009f                                                         ; aa9d: a5 9f       ..
+; $aa9f referenced 1 time by $aa9b
+caa9f
+    sta l009b                                                         ; aa9f: 85 9b       ..
+; $aaa1 referenced 1 time by $aa97
+caaa1
+    bvs caaa7                                                         ; aaa1: 70 04       p.
+    sta (l009e),y                                                     ; aaa3: 91 9e       ..
+    bvc caaa9                                                         ; aaa5: 50 02       P.
+; $aaa7 referenced 1 time by $aaa1
+caaa7
+    sta (l009c),y                                                     ; aaa7: 91 9c       ..
+; $aaa9 referenced 2 times by $aa93, $aaa5
+caaa9
+    dey                                                               ; aaa9: 88          .
+    dex                                                               ; aaaa: ca          .
+    bpl caa8a                                                         ; aaab: 10 dd       ..
+; $aaad referenced 1 time by $aa8f
+caaad
+    iny                                                               ; aaad: c8          .
+    sty l009a                                                         ; aaae: 84 9a       ..
+    rts                                                               ; aab0: 60          `
+
+; $aab1 referenced 1 time by $aa8a
+laab1
+    !byte $85,   0, $fd, $fd, $7d, $fc, $ff, $ff, $7e, $fc, $ff, $ff  ; aab1: 85 00 fd... ...
+    !byte   0,   0, $fe, $80, $93, $fd, $fd, $d9, $fc, $ff, $ff, $de  ; aabd: 00 00 fe... ...
+    !byte $fc, $ff, $ff, $fe, $d1, $fd, $fd, $21, $fd, $ff, $ff, $fd  ; aac9: fc ff ff... ...
+    !byte $fd, $ff, $ff, $ca, $e4, $f0, $d0, $0f, $a5, $d0, $6a, $b0  ; aad5: fd ff ff... ...
+    !byte $0a                                                         ; aae1: 0a          .
+
+; $aae2 referenced 2 times by $8f27, $ab33
+caae2
+    lda #$21 ; '!'                                                    ; aae2: a9 21       .!
+    sta l0d6b                                                         ; aae4: 8d 6b 0d    .k.
+    lda #$41 ; 'A'                                                    ; aae7: a9 41       .A
+    sta l0d6a                                                         ; aae9: 8d 6a 0d    .j.
+    rts                                                               ; aaec: 60          `
+
+    !byte $c0,   4, $d0, $fb, $8a, $ca, $d0, $26, $ba, $1d,   6,   1  ; aaed: c0 04 d0... ...
+    !byte $9d,   6,   1, $a9, $91, $a2,   3, $20, $f4, $ff, $b0, $e7  ; aaf9: 9d 06 01... ...
+    !byte $98, $20, $12, $ab, $c0, $6e, $90, $ef, $20, $36, $ab, $90  ; ab05: 98 20 12... . .
+    !byte $ea                                                         ; ab11: ea          .
+
+; $ab12 referenced 2 times by $ab2d, $abe4
+sub_cab12
+    ldy l0d6b                                                         ; ab12: ac 6b 0d    .k.
+    sta (l009c),y                                                     ; ab15: 91 9c       ..
+    inc l0d6b                                                         ; ab17: ee 6b 0d    .k.
+    rts                                                               ; ab1a: 60          `
+
+; $ab1b referenced 1 time by $8f5a
+sub_cab1b
+    ror                                                               ; ab1b: 6a          j
+    bcc cab75                                                         ; ab1c: 90 57       .W
+    lda l0d6a                                                         ; ab1e: ad 6a 0d    .j.
+    pha                                                               ; ab21: 48          H
+    ror                                                               ; ab22: 6a          j
+    pla                                                               ; ab23: 68          h
+    bcs cab33                                                         ; ab24: b0 0d       ..
+    ora #3                                                            ; ab26: 09 03       ..
+    sta l0d6a                                                         ; ab28: 8d 6a 0d    .j.
+    lda #3                                                            ; ab2b: a9 03       ..
+    jsr sub_cab12                                                     ; ab2d: 20 12 ab     ..
+    jsr cab36                                                         ; ab30: 20 36 ab     6.
+; $ab33 referenced 1 time by $ab24
+cab33
+    jmp caae2                                                         ; ab33: 4c e2 aa    L..
+
+; $ab36 referenced 3 times by $ab30, $ab79, $abe7
+cab36
+    ldy #8                                                            ; ab36: a0 08       ..
+    lda l0d6b                                                         ; ab38: ad 6b 0d    .k.
+    sta (l009e),y                                                     ; ab3b: 91 9e       ..
+    lda l009d                                                         ; ab3d: a5 9d       ..
+    iny                                                               ; ab3f: c8          .
+    sta (l009e),y                                                     ; ab40: 91 9e       ..
+    ldy #5                                                            ; ab42: a0 05       ..
+    sta (l009e),y                                                     ; ab44: 91 9e       ..
+    ldy #$0b                                                          ; ab46: a0 0b       ..
+    ldx #$26 ; '&'                                                    ; ab48: a2 26       .&
+    jsr sub_caa89                                                     ; ab4a: 20 89 aa     ..
+    dey                                                               ; ab4d: 88          .
+    lda l0d6a                                                         ; ab4e: ad 6a 0d    .j.
+    pha                                                               ; ab51: 48          H
+    rol                                                               ; ab52: 2a          *
+    pla                                                               ; ab53: 68          h
+    eor #$80                                                          ; ab54: 49 80       I.
+    sta l0d6a                                                         ; ab56: 8d 6a 0d    .j.
+    rol                                                               ; ab59: 2a          *
+    sta (l009e),y                                                     ; ab5a: 91 9e       ..
+    lda l00d0                                                         ; ab5c: a5 d0       ..
+    pha                                                               ; ab5e: 48          H
+    and #$fe                                                          ; ab5f: 29 fe       ).
+    sta l00d0                                                         ; ab61: 85 d0       ..
+    ldy #$21 ; '!'                                                    ; ab63: a0 21       .!
+    sty l0d6b                                                         ; ab65: 8c 6b 0d    .k.
+    lda #0                                                            ; ab68: a9 00       ..
+    tax                                                               ; ab6a: aa          .
+    ldy l009f                                                         ; ab6b: a4 9f       ..
+    cli                                                               ; ab6d: 58          X
+    jsr sub_cac24                                                     ; ab6e: 20 24 ac     $.
+    pla                                                               ; ab71: 68          h
+    sta l00d0                                                         ; ab72: 85 d0       ..
+    rts                                                               ; ab74: 60          `
+
+; $ab75 referenced 1 time by $ab1c
+cab75
+    lda l0d6a                                                         ; ab75: ad 6a 0d    .j.
+    ror                                                               ; ab78: 6a          j
+    bcc cab36                                                         ; ab79: 90 bb       ..
+    lda l00d0                                                         ; ab7b: a5 d0       ..
+    pha                                                               ; ab7d: 48          H
+    and #$fe                                                          ; ab7e: 29 fe       ).
+    sta l00d0                                                         ; ab80: 85 d0       ..
+    lda #$14                                                          ; ab82: a9 14       ..
+; $ab84 referenced 1 time by $abf8
+cab84
+    pha                                                               ; ab84: 48          H
+    ldx #$0b                                                          ; ab85: a2 0b       ..
+    ldy #$2c ; ','                                                    ; ab87: a0 2c       .,
+; $ab89 referenced 1 time by $ab90
+loop_cab89
+    lda lac80,x                                                       ; ab89: bd 80 ac    ...
+    sta (l009c),y                                                     ; ab8c: 91 9c       ..
+    dey                                                               ; ab8e: 88          .
+    dex                                                               ; ab8f: ca          .
+    bpl loop_cab89                                                    ; ab90: 10 f7       ..
+    stx l0098                                                         ; ab92: 86 98       ..
+    ldy #2                                                            ; ab94: a0 02       ..
+    lda (l009e),y                                                     ; ab96: b1 9e       ..
+    pha                                                               ; ab98: 48          H
+    iny                                                               ; ab99: c8          .
+    lda (l009e),y                                                     ; ab9a: b1 9e       ..
+    ldy #$24 ; '$'                                                    ; ab9c: a0 24       .$
+    sta (l009c),y                                                     ; ab9e: 91 9c       ..
+    dey                                                               ; aba0: 88          .
+    pla                                                               ; aba1: 68          h
+    sta (l009c),y                                                     ; aba2: 91 9c       ..
+    ldx #$0b                                                          ; aba4: a2 0b       ..
+    ldy #$0b                                                          ; aba6: a0 0b       ..
+; $aba8 referenced 1 time by $abb9
+loop_caba8
+    lda lac8c,x                                                       ; aba8: bd 8c ac    ...
+    cmp #$fd                                                          ; abab: c9 fd       ..
+    beq cabb7                                                         ; abad: f0 08       ..
+    cmp #$fc                                                          ; abaf: c9 fc       ..
+    bne cabb5                                                         ; abb1: d0 02       ..
+    lda l009d                                                         ; abb3: a5 9d       ..
+; $abb5 referenced 1 time by $abb1
+cabb5
+    sta (l009e),y                                                     ; abb5: 91 9e       ..
+; $abb7 referenced 1 time by $abad
+cabb7
+    dey                                                               ; abb7: 88          .
+    dex                                                               ; abb8: ca          .
+    bpl loop_caba8                                                    ; abb9: 10 ed       ..
+    lda #$21 ; '!'                                                    ; abbb: a9 21       .!
+    sta l009a                                                         ; abbd: 85 9a       ..
+    lda l009d                                                         ; abbf: a5 9d       ..
+    sta l009b                                                         ; abc1: 85 9b       ..
+    jsr sub_c989c                                                     ; abc3: 20 9c 98     ..
+    jsr sub_c983f                                                     ; abc6: 20 3f 98     ?.
+    lda #0                                                            ; abc9: a9 00       ..
+    sta l009a                                                         ; abcb: 85 9a       ..
+    lda l009f                                                         ; abcd: a5 9f       ..
+    sta l009b                                                         ; abcf: 85 9b       ..
+    jsr sub_c95dd                                                     ; abd1: 20 dd 95     ..
+    ldy #$2d ; '-'                                                    ; abd4: a0 2d       .-
+    lda (l009c),y                                                     ; abd6: b1 9c       ..
+    beq cabde                                                         ; abd8: f0 04       ..
+    cmp #3                                                            ; abda: c9 03       ..
+    bne cabf3                                                         ; abdc: d0 15       ..
+; $abde referenced 1 time by $abd8
+cabde
+    pla                                                               ; abde: 68          h
+    pla                                                               ; abdf: 68          h
+    sta l00d0                                                         ; abe0: 85 d0       ..
+    lda #0                                                            ; abe2: a9 00       ..
+    jsr sub_cab12                                                     ; abe4: 20 12 ab     ..
+    jsr cab36                                                         ; abe7: 20 36 ab     6.
+    lda l0d6a                                                         ; abea: ad 6a 0d    .j.
+    and #$f0                                                          ; abed: 29 f0       ).
+    sta l0d6a                                                         ; abef: 8d 6a 0d    .j.
+    rts                                                               ; abf2: 60          `
+
+; $abf3 referenced 1 time by $abdc
+cabf3
+    tax                                                               ; abf3: aa          .
+    pla                                                               ; abf4: 68          h
+    sec                                                               ; abf5: 38          8
+    sbc #1                                                            ; abf6: e9 01       ..
+    bne cab84                                                         ; abf8: d0 8a       ..
+    cpx #1                                                            ; abfa: e0 01       ..
+    bne cac10                                                         ; abfc: d0 12       ..
+; $abfe referenced 1 time by $aff5
+cabfe
+    lda #$a6                                                          ; abfe: a9 a6       ..
+    jsr generate_error_inline3                                        ; ac00: 20 d1 96     ..
+    !text "Printer busy", 0                                           ; ac03: 50 72 69... Pri
+
+; $ac10 referenced 1 time by $abfc
+cac10
+    lda #$a7                                                          ; ac10: a9 a7       ..
+    jsr generate_error_inline3                                        ; ac12: 20 d1 96     ..
+    !text "Printer jammed", 0                                         ; ac15: 50 72 69... Pri
+
+; $ac24 referenced 3 times by $9509, $ab6e, $b951
+sub_cac24
+    stx l009a                                                         ; ac24: 86 9a       ..
+    sty l009b                                                         ; ac26: 84 9b       ..
+    pha                                                               ; ac28: 48          H
+    ora #0                                                            ; ac29: 09 00       ..
+    beq cac4a                                                         ; ac2b: f0 1d       ..
+    ldx #$ff                                                          ; ac2d: a2 ff       ..
+    tay                                                               ; ac2f: a8          .
+; $ac30 referenced 2 times by $ac39, $ac43
+cac30
+    tya                                                               ; ac30: 98          .
+    inx                                                               ; ac31: e8          .
+    cmp l1030,x                                                       ; ac32: dd 30 10    .0.
+    beq cac3f                                                         ; ac35: f0 08       ..
+    cpx #$0f                                                          ; ac37: e0 0f       ..
+    bne cac30                                                         ; ac39: d0 f5       ..
+    lda #0                                                            ; ac3b: a9 00       ..
+    beq cac4a                                                         ; ac3d: f0 0b       ..
+; $ac3f referenced 1 time by $ac35
+cac3f
+    tay                                                               ; ac3f: a8          .
+    jsr sub_cb586                                                     ; ac40: 20 86 b5     ..
+    bne cac30                                                         ; ac43: d0 eb       ..
+    lda l1060,x                                                       ; ac45: bd 60 10    .`.
+    and #1                                                            ; ac48: 29 01       ).
+; $ac4a referenced 2 times by $ac2b, $ac3d
+cac4a
+    ldy #0                                                            ; ac4a: a0 00       ..
+    ora (l009a),y                                                     ; ac4c: 11 9a       ..
+    pha                                                               ; ac4e: 48          H
+    sta (l009a),y                                                     ; ac4f: 91 9a       ..
+    jsr sub_c983f                                                     ; ac51: 20 3f 98     ?.
+    lda #$ff                                                          ; ac54: a9 ff       ..
+    ldy #8                                                            ; ac56: a0 08       ..
+    sta (l009a),y                                                     ; ac58: 91 9a       ..
+    iny                                                               ; ac5a: c8          .
+    sta (l009a),y                                                     ; ac5b: 91 9a       ..
+    pla                                                               ; ac5d: 68          h
+    tax                                                               ; ac5e: aa          .
+    ldy #$d1                                                          ; ac5f: a0 d1       ..
+    pla                                                               ; ac61: 68          h
+    pha                                                               ; ac62: 48          H
+    beq cac67                                                         ; ac63: f0 02       ..
+    ldy #$90                                                          ; ac65: a0 90       ..
+; $ac67 referenced 1 time by $ac63
+cac67
+    tya                                                               ; ac67: 98          .
+    ldy #1                                                            ; ac68: a0 01       ..
+    sta (l009a),y                                                     ; ac6a: 91 9a       ..
+    txa                                                               ; ac6c: 8a          .
+    dey                                                               ; ac6d: 88          .
+    pha                                                               ; ac6e: 48          H
+; $ac6f referenced 1 time by $ac7b
+loop_cac6f
+    lda #$7f                                                          ; ac6f: a9 7f       ..
+    sta (l009a),y                                                     ; ac71: 91 9a       ..
+    jsr sub_c95dd                                                     ; ac73: 20 dd 95     ..
+    pla                                                               ; ac76: 68          h
+    pha                                                               ; ac77: 48          H
+    eor (l009a),y                                                     ; ac78: 51 9a       Q.
+    ror                                                               ; ac7a: 6a          j
+    bcs loop_cac6f                                                    ; ac7b: b0 f2       ..
+    pla                                                               ; ac7d: 68          h
+    pla                                                               ; ac7e: 68          h
+    rts                                                               ; ac7f: 60          `
+
+; $ac80 referenced 1 time by $ab89
+lac80
+    !byte $80, $9f,   0,   0, $59, $8e, $ff, $ff, $61, $8e, $ff, $ff  ; ac80: 80 9f 00... ...
+; $ac8c referenced 1 time by $aba8
+lac8c
+    !byte $7f, $9e, $fd, $fd, $2d, $fc, $ff, $ff, $30, $fc, $ff, $ff  ; ac8c: 7f 9e fd... ...
+
+sub_cac98
+    lda l00aa                                                         ; ac98: a5 aa       ..
+    pha                                                               ; ac9a: 48          H
+    lda #$e9                                                          ; ac9b: a9 e9       ..
+    sta l009e                                                         ; ac9d: 85 9e       ..
+    ldy #0                                                            ; ac9f: a0 00       ..
+    sty l00aa                                                         ; aca1: 84 aa       ..
+    lda l0350                                                         ; aca3: ad 50 03    .P.
+    sta (l009e),y                                                     ; aca6: 91 9e       ..
+    inc l009e                                                         ; aca8: e6 9e       ..
+    lda l0351                                                         ; acaa: ad 51 03    .Q.
+    pha                                                               ; acad: 48          H
+    tya                                                               ; acae: 98          .
+; $acaf referenced 1 time by $acce
+loop_cacaf
+    sta (l009e),y                                                     ; acaf: 91 9e       ..
+    ldx l009e                                                         ; acb1: a6 9e       ..
+    ldy l009f                                                         ; acb3: a4 9f       ..
+    lda #osword_read_palette                                          ; acb5: a9 0b       ..
+    jsr osword                                                        ; acb7: 20 f1 ff     ..
+    pla                                                               ; acba: 68          h
+    ldy #0                                                            ; acbb: a0 00       ..
+    sta (l009e),y                                                     ; acbd: 91 9e       ..
+    iny                                                               ; acbf: c8          .
+    lda (l009e),y                                                     ; acc0: b1 9e       ..
+    pha                                                               ; acc2: 48          H
+    ldx l009e                                                         ; acc3: a6 9e       ..
+    inc l009e                                                         ; acc5: e6 9e       ..
+    inc l00aa                                                         ; acc7: e6 aa       ..
+    dey                                                               ; acc9: 88          .
+    lda l00aa                                                         ; acca: a5 aa       ..
+    cpx #$f9                                                          ; accc: e0 f9       ..
+    bne loop_cacaf                                                    ; acce: d0 df       ..
+    pla                                                               ; acd0: 68          h
+    sty l00aa                                                         ; acd1: 84 aa       ..
+    inc l009e                                                         ; acd3: e6 9e       ..
+    jsr sub_cace4                                                     ; acd5: 20 e4 ac     ..
+    inc l009e                                                         ; acd8: e6 9e       ..
+    pla                                                               ; acda: 68          h
+    sta l00aa                                                         ; acdb: 85 aa       ..
+; $acdd referenced 3 times by $9586, $95ae, $95d5
+cacdd
+    lda l0d69                                                         ; acdd: ad 69 0d    .i.
+    sta l0d68                                                         ; ace0: 8d 68 0d    .h.
+    rts                                                               ; ace3: 60          `
+
+; $ace4 referenced 1 time by $acd5
+sub_cace4
+    lda l0355                                                         ; ace4: ad 55 03    .U.
+    sta (l009e),y                                                     ; ace7: 91 9e       ..
+    ldx l0355                                                         ; ace9: ae 55 03    .U.
+    jsr sub_cacf9                                                     ; acec: 20 f9 ac     ..
+    inc l009e                                                         ; acef: e6 9e       ..
+    tya                                                               ; acf1: 98          .
+    sta (l009e,x)                                                     ; acf2: 81 9e       ..
+    jsr sub_cacf7                                                     ; acf4: 20 f7 ac     ..
+; $acf7 referenced 1 time by $acf4
+sub_cacf7
+    ldx #0                                                            ; acf7: a2 00       ..
+; $acf9 referenced 1 time by $acec
+sub_cacf9
+    ldy l00aa                                                         ; acf9: a4 aa       ..
+    inc l00aa                                                         ; acfb: e6 aa       ..
+    inc l009e                                                         ; acfd: e6 9e       ..
+    lda lad0d,y                                                       ; acff: b9 0d ad    ...
+    ldy #$ff                                                          ; ad02: a0 ff       ..
+    jsr osbyte                                                        ; ad04: 20 f4 ff     ..
+    txa                                                               ; ad07: 8a          .
+    ldx #0                                                            ; ad08: a2 00       ..
+    sta (l009e,x)                                                     ; ad0a: 81 9e       ..
+    rts                                                               ; ad0c: 60          `
+
+; $ad0d referenced 1 time by $acff
+lad0d
+    !byte $84, $c2, $c3                                               ; ad0d: 84 c2 c3    ...
+
+sub_cad10
+    tya                                                               ; ad10: 98          .
+    pha                                                               ; ad11: 48          H
+    jsr sub_caf32                                                     ; ad12: 20 32 af     2.
+    jsr sub_cafc1                                                     ; ad15: 20 c1 af     ..
+    cmp #$0d                                                          ; ad18: c9 0d       ..
+    bne cad20                                                         ; ad1a: d0 04       ..
+    ldx #2                                                            ; ad1c: a2 02       ..
+    bne cad2f                                                         ; ad1e: d0 0f       ..
+; $ad20 referenced 1 time by $ad1a
+cad20
+    lda #$ff                                                          ; ad20: a9 ff       ..
+    sta l00b4                                                         ; ad22: 85 b4       ..
+    jsr sub_c916e                                                     ; ad24: 20 6e 91     n.
+    ldx #$1b                                                          ; ad27: a2 1b       ..
+; $ad29 referenced 1 time by $ad2d
+loop_cad29
+    dex                                                               ; ad29: ca          .
+    cmp lad43,x                                                       ; ad2a: dd 43 ad    .C.
+    bcc loop_cad29                                                    ; ad2d: 90 fa       ..
+; $ad2f referenced 1 time by $ad1e
+cad2f
+    stx l0f05                                                         ; ad2f: 8e 05 0f    ...
+    pla                                                               ; ad32: 68          h
+    tay                                                               ; ad33: a8          .
+    jsr sub_cafb5                                                     ; ad34: 20 b5 af     ..
+    jsr sub_cae94                                                     ; ad37: 20 94 ae     ..
+    ldx #1                                                            ; ad3a: a2 01       ..
+    jsr sub_caf04                                                     ; ad3c: 20 04 af     ..
+    ldy #$1b                                                          ; ad3f: a0 1b       ..
+sub_cad41
+lad43 = sub_cad41+2
+    jmp c94ad                                                         ; ad41: 4c ad 94    L..
+
+; $ad43 referenced 1 time by $ad2a
+    !byte   0, $0a, $14, $1d                                          ; ad44: 00 0a 14... ...
+    !text "'1;EOXblv"                                                 ; ad48: 27 31 3b... '1;
+    !byte $80, $8a, $94, $9d, $a7, $b1, $bb, $c5, $cf, $d8, $e2, $ec  ; ad51: 80 8a 94... ...
+    !byte $f6, $ff                                                    ; ad5d: f6 ff       ..
+
+sub_cad5f
+    ror l1071                                                         ; ad5f: 6e 71 10    nq.
+    sec                                                               ; ad62: 38          8
+    bcs cad89                                                         ; ad63: b0 24       .$
+sub_cad65
+    ror l1071                                                         ; ad65: 6e 71 10    nq.
+    sec                                                               ; ad68: 38          8
+    bcs cad6f                                                         ; ad69: b0 04       ..
+sub_cad6b
+    ror l1071                                                         ; ad6b: 6e 71 10    nq.
+    clc                                                               ; ad6e: 18          .
+; $ad6f referenced 1 time by $ad69
+cad6f
+    rol l1071                                                         ; ad6f: 2e 71 10    .q.
+    lda #$ff                                                          ; ad72: a9 ff       ..
+    sta l00ba                                                         ; ad74: 85 ba       ..
+    lda #1                                                            ; ad76: a9 01       ..
+    sta l00b7                                                         ; ad78: 85 b7       ..
+    lda #3                                                            ; ad7a: a9 03       ..
+    sta l00b5                                                         ; ad7c: 85 b5       ..
+    bne cad96                                                         ; ad7e: d0 16       ..
+sub_cad80
+    jsr sub_c9295                                                     ; ad80: 20 95 92     ..
+    ldy #0                                                            ; ad83: a0 00       ..
+    ror l1071                                                         ; ad85: 6e 71 10    nq.
+    clc                                                               ; ad88: 18          .
+; $ad89 referenced 1 time by $ad63
+cad89
+    rol l1071                                                         ; ad89: 2e 71 10    .q.
+    lda #3                                                            ; ad8c: a9 03       ..
+    sta l00ba                                                         ; ad8e: 85 ba       ..
+    sta l00b7                                                         ; ad90: 85 b7       ..
+    lda #$0b                                                          ; ad92: a9 0b       ..
+    sta l00b5                                                         ; ad94: 85 b5       ..
+; $ad96 referenced 1 time by $ad7e
+cad96
+    jsr sub_cafb5                                                     ; ad96: 20 b5 af     ..
+    lda #$ff                                                          ; ad99: a9 ff       ..
+    sta l0098                                                         ; ad9b: 85 98       ..
+    lda #6                                                            ; ad9d: a9 06       ..
+    sta l0f05                                                         ; ad9f: 8d 05 0f    ...
+    jsr sub_cae94                                                     ; ada2: 20 94 ae     ..
+    ldx #1                                                            ; ada5: a2 01       ..
+    jsr sub_caf04                                                     ; ada7: 20 04 af     ..
+    lda l1071                                                         ; adaa: ad 71 10    .q.
+    lsr                                                               ; adad: 4a          J
+    bcc cadb2                                                         ; adae: 90 02       ..
+    ora #$40 ; '@'                                                    ; adb0: 09 40       .@
+; $adb2 referenced 1 time by $adae
+cadb2
+    rol                                                               ; adb2: 2a          *
+    sta l1071                                                         ; adb3: 8d 71 10    .q.
+    ldy #$12                                                          ; adb6: a0 12       ..
+    jsr c94ad                                                         ; adb8: 20 ad 94     ..
+    ldx #3                                                            ; adbb: a2 03       ..
+    jsr sub_cae82                                                     ; adbd: 20 82 ae     ..
+    jsr print_inline_top_bit_clear                                    ; adc0: 20 45 91     E.
+    !text "("                                                         ; adc3: 28          (
+
+    lda l0f13                                                         ; adc4: ad 13 0f    ...
+    jsr caf88                                                         ; adc7: 20 88 af     ..
+    jsr print_inline_top_bit_clear                                    ; adca: 20 45 91     E.
+    !text ")     "                                                    ; adcd: 29 20 20... )
+
+    ldy l0f12                                                         ; add3: ac 12 0f    ...
+    bne cade3                                                         ; add6: d0 0b       ..
+    jsr print_inline_top_bit_clear                                    ; add8: 20 45 91     E.
+    !text "Owner", $0d                                                ; addb: 4f 77 6e... Own
+
+    bne caded                                                         ; ade1: d0 0a       ..
+; $ade3 referenced 1 time by $add6
+cade3
+    jsr print_inline_top_bit_clear                                    ; ade3: 20 45 91     E.
+    !text "Public", $0d                                               ; ade6: 50 75 62... Pub
+
+; $aded referenced 1 time by $ade1
+caded
+    lda l1071                                                         ; aded: ad 71 10    .q.
+    pha                                                               ; adf0: 48          H
+    jsr sub_caf32                                                     ; adf1: 20 32 af     2.
+    ldy #$15                                                          ; adf4: a0 15       ..
+    jsr c94ad                                                         ; adf6: 20 ad 94     ..
+    inx                                                               ; adf9: e8          .
+    ldy #$10                                                          ; adfa: a0 10       ..
+    jsr cae84                                                         ; adfc: 20 84 ae     ..
+    jsr print_inline_top_bit_clear                                    ; adff: 20 45 91     E.
+    !text "    Option "                                               ; ae02: 20 20 20...
+
+    lda l0e05                                                         ; ae0d: ad 05 0e    ...
+    tax                                                               ; ae10: aa          .
+    jsr sub_c912f                                                     ; ae11: 20 2f 91     /.
+    jsr print_inline_top_bit_clear                                    ; ae14: 20 45 91     E.
+    !text " ("                                                        ; ae17: 20 28        (
+
+    ldy laefb,x                                                       ; ae19: bc fb ae    ...
+; $ae1c referenced 1 time by $ae25
+loop_cae1c
+    lda laeff,y                                                       ; ae1c: b9 ff ae    ...
+    bmi cae27                                                         ; ae1f: 30 06       0.
+    jsr osasci                                                        ; ae21: 20 e3 ff     ..
+    iny                                                               ; ae24: c8          .
+    bne loop_cae1c                                                    ; ae25: d0 f5       ..
+; $ae27 referenced 1 time by $ae1f
+cae27
+    jsr print_inline_top_bit_clear                                    ; ae27: 20 45 91     E.
+    !text ")", $0d, "Dir. "                                           ; ae2a: 29 0d 44... ).D
+
+    ldx #$11                                                          ; ae31: a2 11       ..
+    jsr sub_cae82                                                     ; ae33: 20 82 ae     ..
+    jsr print_inline_top_bit_clear                                    ; ae36: 20 45 91     E.
+    !text "     Lib. "                                                ; ae39: 20 20 20...
+
+    ldx #$1b                                                          ; ae43: a2 1b       ..
+    jsr sub_cae82                                                     ; ae45: 20 82 ae     ..
+    jsr osnewl                                                        ; ae48: 20 e7 ff     ..
+    pla                                                               ; ae4b: 68          h
+    sta l1071                                                         ; ae4c: 8d 71 10    .q.
+; $ae4f referenced 1 time by $ae80
+cae4f
+    sty l0f06                                                         ; ae4f: 8c 06 0f    ...
+    sty l00b4                                                         ; ae52: 84 b4       ..
+    ldx l00b5                                                         ; ae54: a6 b5       ..
+    stx l0f07                                                         ; ae56: 8e 07 0f    ...
+    ldx l00b7                                                         ; ae59: a6 b7       ..
+    stx l0f05                                                         ; ae5b: 8e 05 0f    ...
+    ldx #3                                                            ; ae5e: a2 03       ..
+    jsr sub_caf04                                                     ; ae60: 20 04 af     ..
+    ldy #3                                                            ; ae63: a0 03       ..
+    jsr c94ad                                                         ; ae65: 20 ad 94     ..
+    inx                                                               ; ae68: e8          .
+    lda l0f05                                                         ; ae69: ad 05 0f    ...
+    beq cae8f                                                         ; ae6c: f0 21       .!
+    pha                                                               ; ae6e: 48          H
+; $ae6f referenced 1 time by $ae73
+loop_cae6f
+    iny                                                               ; ae6f: c8          .
+    lda l0f05,y                                                       ; ae70: b9 05 0f    ...
+    bpl loop_cae6f                                                    ; ae73: 10 fa       ..
+    sta l0f04,y                                                       ; ae75: 99 04 0f    ...
+    jsr sub_caf47                                                     ; ae78: 20 47 af     G.
+    pla                                                               ; ae7b: 68          h
+    clc                                                               ; ae7c: 18          .
+    adc l00b4                                                         ; ae7d: 65 b4       e.
+    tay                                                               ; ae7f: a8          .
+    bne cae4f                                                         ; ae80: d0 cd       ..
+; $ae82 referenced 3 times by $adbd, $ae33, $ae45
+sub_cae82
+    ldy #$0a                                                          ; ae82: a0 0a       ..
+; $ae84 referenced 2 times by $adfc, $ae8c
+cae84
+    lda l0f05,x                                                       ; ae84: bd 05 0f    ...
+    jsr osasci                                                        ; ae87: 20 e3 ff     ..
+    inx                                                               ; ae8a: e8          .
+    dey                                                               ; ae8b: 88          .
+    bne cae84                                                         ; ae8c: d0 f6       ..
+    rts                                                               ; ae8e: 60          `
+
+; $ae8f referenced 1 time by $ae6c
+cae8f
+    jmp osnewl                                                        ; ae8f: 4c e7 ff    L..
+
+; $ae92 referenced 1 time by $a1c7
+sub_cae92
+    ldy #0                                                            ; ae92: a0 00       ..
+; $ae94 referenced 4 times by $ad37, $ada2, $af77, $b363
+sub_cae94
+    jsr sub_c9913                                                     ; ae94: 20 13 99     ..
+; $ae97 referenced 3 times by $92ee, $9396, $93cf
+sub_cae97
+    lda l0e30                                                         ; ae97: ad 30 0e    .0.
+    eor #$26 ; '&'                                                    ; ae9a: 49 26       I&
+    bne caee2                                                         ; ae9c: d0 44       .D
+    lda l1071                                                         ; ae9e: ad 71 10    .q.
+    ora #$40 ; '@'                                                    ; aea1: 09 40       .@
+    sta l1071                                                         ; aea3: 8d 71 10    .q.
+    jsr caeb7                                                         ; aea6: 20 b7 ae     ..
+    lda l0e30                                                         ; aea9: ad 30 0e    .0.
+    eor #$2e ; '.'                                                    ; aeac: 49 2e       I.
+    bne caedb                                                         ; aeae: d0 2b       .+
+    lda l0e31                                                         ; aeb0: ad 31 0e    .1.
+    eor #$0d                                                          ; aeb3: 49 0d       I.
+    beq caedf                                                         ; aeb5: f0 28       .(
+; $aeb7 referenced 5 times by $931c, $93b6, $93bc, $aea6, $aef9
+caeb7
+    txa                                                               ; aeb7: 8a          .
+    pha                                                               ; aeb8: 48          H
+    ldx #$ff                                                          ; aeb9: a2 ff       ..
+; $aebb referenced 1 time by $aec4
+loop_caebb
+    inx                                                               ; aebb: e8          .
+    lda l0e31,x                                                       ; aebc: bd 31 0e    .1.
+    sta l0e30,x                                                       ; aebf: 9d 30 0e    .0.
+    eor #$0d                                                          ; aec2: 49 0d       I.
+    bne loop_caebb                                                    ; aec4: d0 f5       ..
+    txa                                                               ; aec6: 8a          .
+    beq caed8                                                         ; aec7: f0 0f       ..
+; $aec9 referenced 1 time by $aed6
+loop_caec9
+    lda l0e2f,x                                                       ; aec9: bd 2f 0e    ./.
+    eor #$20 ; ' '                                                    ; aecc: 49 20       I
+    bne caed8                                                         ; aece: d0 08       ..
+    lda #$0d                                                          ; aed0: a9 0d       ..
+    sta l0e2f,x                                                       ; aed2: 9d 2f 0e    ./.
+    dex                                                               ; aed5: ca          .
+    bne loop_caec9                                                    ; aed6: d0 f1       ..
+; $aed8 referenced 2 times by $aec7, $aece
+caed8
+    pla                                                               ; aed8: 68          h
+    tax                                                               ; aed9: aa          .
+; $aeda referenced 3 times by $aedd, $aee4, $aeef
+caeda
+    rts                                                               ; aeda: 60          `
+
+; $aedb referenced 1 time by $aeae
+caedb
+    eor #$23 ; '#'                                                    ; aedb: 49 23       I#
+    beq caeda                                                         ; aedd: f0 fb       ..
+; $aedf referenced 2 times by $aeb5, $af12
+caedf
+    jmp c92fa                                                         ; aedf: 4c fa 92    L..
+
+; $aee2 referenced 1 time by $ae9c
+caee2
+    eor #$1c                                                          ; aee2: 49 1c       I.
+    bne caeda                                                         ; aee4: d0 f4       ..
+    lda l0e32                                                         ; aee6: ad 32 0e    .2.
+    eor #$2e ; '.'                                                    ; aee9: 49 2e       I.
+    beq caef1                                                         ; aeeb: f0 04       ..
+    eor #$23 ; '#'                                                    ; aeed: 49 23       I#
+    bne caeda                                                         ; aeef: d0 e9       ..
+; $aef1 referenced 1 time by $aeeb
+caef1
+    lda l1071                                                         ; aef1: ad 71 10    .q.
+    ora #$40 ; '@'                                                    ; aef4: 09 40       .@
+    sta l1071                                                         ; aef6: 8d 71 10    .q.
+    bne caeb7                                                         ; aef9: d0 bc       ..
+; $aefb referenced 1 time by $ae19
+laefb
+    !byte 0                                                           ; aefb: 00          .
+    !text "/<c"                                                       ; aefc: 2f 3c 63    /<c
+; $aeff referenced 1 time by $ae1c
+laeff
+    !text "Off"                                                       ; aeff: 4f 66 66    Off
+
+; $af02 referenced 5 times by $8dbc, $8e20, $9b3c, $a299, $af7a
+sub_caf02
+    ldx #0                                                            ; af02: a2 00       ..
+; $af04 referenced 9 times by $99fe, $9b35, $9b58, $a1cc, $a1f9, $ad3c, $ada7, $ae60, $b378
+sub_caf04
+    ldy #0                                                            ; af04: a0 00       ..
+; $af06 referenced 3 times by $8db7, $941e, $9454
+sub_caf06
+    sec                                                               ; af06: 38          8
+; $af07 referenced 1 time by $af1a
+loop_caf07
+    lda (l00be),y                                                     ; af07: b1 be       ..
+    sta l0f05,x                                                       ; af09: 9d 05 0f    ...
+    bcc caf16                                                         ; af0c: 90 08       ..
+    cmp #$21 ; '!'                                                    ; af0e: c9 21       .!
+    eor #$26 ; '&'                                                    ; af10: 49 26       I&
+    beq caedf                                                         ; af12: f0 cb       ..
+    eor #$26 ; '&'                                                    ; af14: 49 26       I&
+; $af16 referenced 1 time by $af0c
+caf16
+    inx                                                               ; af16: e8          .
+    iny                                                               ; af17: c8          .
+    eor #$0d                                                          ; af18: 49 0d       I.
+    bne loop_caf07                                                    ; af1a: d0 eb       ..
+; $af1c referenced 1 time by $af29
+loop_caf1c
+    lda l0f03,x                                                       ; af1c: bd 03 0f    ...
+    eor #$20 ; ' '                                                    ; af1f: 49 20       I
+    bne caf2b                                                         ; af21: d0 08       ..
+    dex                                                               ; af23: ca          .
+    lda #$0d                                                          ; af24: a9 0d       ..
+    sta l0f04,x                                                       ; af26: 9d 04 0f    ...
+    bne loop_caf1c                                                    ; af29: d0 f1       ..
+; $af2b referenced 1 time by $af21
+caf2b
+    lda #0                                                            ; af2b: a9 00       ..
+; $af2d referenced 1 time by $af43
+loop_caf2d
+    rts                                                               ; af2d: 60          `
+
+    !text "Load"                                                      ; af2e: 4c 6f 61... Loa
+
+; $af32 referenced 9 times by $8e3b, $9390, $93ca, $a1c4, $a250, $a25a, $ad12, $adf1, $b359
+sub_caf32
+    lda l1071                                                         ; af32: ad 71 10    .q.
+    and #$1f                                                          ; af35: 29 1f       ).
+    sta l1071                                                         ; af37: 8d 71 10    .q.
+    rts                                                               ; af3a: 60          `
+
+    !text "Run"                                                       ; af3b: 52 75 6e    Run
+
+sub_caf3e
+    ldx #0                                                            ; af3e: a2 00       ..
+; $af40 referenced 1 time by $af60
+caf40
+    lda l0f05,x                                                       ; af40: bd 05 0f    ...
+    bmi loop_caf2d                                                    ; af43: 30 e8       0.
+    bne caf5c                                                         ; af45: d0 15       ..
+; $af47 referenced 1 time by $ae78
+sub_caf47
+    ldy l00ba                                                         ; af47: a4 ba       ..
+    bmi caf5a                                                         ; af49: 30 0f       0.
+    iny                                                               ; af4b: c8          .
+    tya                                                               ; af4c: 98          .
+    and #3                                                            ; af4d: 29 03       ).
+    sta l00ba                                                         ; af4f: 85 ba       ..
+    beq caf5a                                                         ; af51: f0 07       ..
+    jsr print_inline_top_bit_clear                                    ; af53: 20 45 91     E.
+    !text "  "                                                        ; af56: 20 20
+
+    bne caf5f                                                         ; af58: d0 05       ..
+; $af5a referenced 2 times by $af49, $af51
+caf5a
+    lda #$0d                                                          ; af5a: a9 0d       ..
+; $af5c referenced 1 time by $af45
+caf5c
+    jsr osasci                                                        ; af5c: 20 e3 ff     ..
+; $af5f referenced 1 time by $af58
+caf5f
+    inx                                                               ; af5f: e8          .
+    bne caf40                                                         ; af60: d0 de       ..
+    eor l0078                                                         ; af62: 45 78       Ex
+    adc l0063                                                         ; af64: 65 63       ec
+sub_caf66
+    tya                                                               ; af66: 98          .
+    pha                                                               ; af67: 48          H
+    jsr sub_cafc1                                                     ; af68: 20 c1 af     ..
+    cmp #$0d                                                          ; af6b: c9 0d       ..
+    beq caf72                                                         ; af6d: f0 03       ..
+    jmp ca127                                                         ; af6f: 4c 27 a1    L'.
+
+; $af72 referenced 1 time by $af6d
+caf72
+    pla                                                               ; af72: 68          h
+    tay                                                               ; af73: a8          .
+    jsr sub_cafb5                                                     ; af74: 20 b5 af     ..
+    jsr sub_cae94                                                     ; af77: 20 94 ae     ..
+    jsr sub_caf02                                                     ; af7a: 20 02 af     ..
+    ldy #$14                                                          ; af7d: a0 14       ..
+    bit l9491                                                         ; af7f: 2c 91 94    ,..
+    jmp c94ae                                                         ; af82: 4c ae 94    L..
+
+; $af85 referenced 1 time by $9007
+sub_caf85
+    bit l9491                                                         ; af85: 2c 91 94    ,..
+; $af88 referenced 3 times by $adc7, $b19d, $b1b4
+caf88
+    tay                                                               ; af88: a8          .
+    lda #$64 ; 'd'                                                    ; af89: a9 64       .d
+    jsr sub_caf96                                                     ; af8b: 20 96 af     ..
+    lda #$0a                                                          ; af8e: a9 0a       ..
+    jsr sub_caf96                                                     ; af90: 20 96 af     ..
+    clv                                                               ; af93: b8          .
+    lda #1                                                            ; af94: a9 01       ..
+; $af96 referenced 2 times by $af8b, $af90
+sub_caf96
+    sta l00b8                                                         ; af96: 85 b8       ..
+    tya                                                               ; af98: 98          .
+    ldx #$2f ; '/'                                                    ; af99: a2 2f       ./
+    sec                                                               ; af9b: 38          8
+    php                                                               ; af9c: 08          .
+; $af9d referenced 1 time by $afa0
+loop_caf9d
+    inx                                                               ; af9d: e8          .
+    sbc l00b8                                                         ; af9e: e5 b8       ..
+    bcs loop_caf9d                                                    ; afa0: b0 fb       ..
+    adc l00b8                                                         ; afa2: 65 b8       e.
+    tay                                                               ; afa4: a8          .
+    txa                                                               ; afa5: 8a          .
+    plp                                                               ; afa6: 28          (
+    bvc cafad                                                         ; afa7: 50 04       P.
+    cmp #$30 ; '0'                                                    ; afa9: c9 30       .0
+    beq cafb4                                                         ; afab: f0 07       ..
+; $afad referenced 1 time by $afa7
+cafad
+    ldx l00b8                                                         ; afad: a6 b8       ..
+    jsr osasci                                                        ; afaf: 20 e3 ff     ..
+    stx l00b8                                                         ; afb2: 86 b8       ..
+; $afb4 referenced 1 time by $afab
+cafb4
+    rts                                                               ; afb4: 60          `
+
+; $afb5 referenced 7 times by $a1c1, $ad34, $ad96, $af74, $b038, $b216, $b360
+sub_cafb5
+    pha                                                               ; afb5: 48          H
+    lda l00be                                                         ; afb6: a5 be       ..
+    sta os_text_ptr                                                   ; afb8: 85 f2       ..
+    lda l00bf                                                         ; afba: a5 bf       ..
+    sta l00f3                                                         ; afbc: 85 f3       ..
+    pla                                                               ; afbe: 68          h
+    rts                                                               ; afbf: 60          `
+
+; $afc0 referenced 1 time by $afcb
+loop_cafc0
+    iny                                                               ; afc0: c8          .
+; $afc1 referenced 2 times by $ad15, $af68
+sub_cafc1
+    lda (l00be),y                                                     ; afc1: b1 be       ..
+    cmp #$20 ; ' '                                                    ; afc3: c9 20       .
+    beq cafcd                                                         ; afc5: f0 06       ..
+    cmp #$0d                                                          ; afc7: c9 0d       ..
+    beq cafd4                                                         ; afc9: f0 09       ..
+    bne loop_cafc0                                                    ; afcb: d0 f3       ..
+; $afcd referenced 2 times by $afc5, $afd2
+cafcd
+    iny                                                               ; afcd: c8          .
+    lda (l00be),y                                                     ; afce: b1 be       ..
+    cmp #$20 ; ' '                                                    ; afd0: c9 20       .
+    beq cafcd                                                         ; afd2: f0 f9       ..
+; $afd4 referenced 1 time by $afc9
+cafd4
+    rts                                                               ; afd4: 60          `
+
+; $afd5 referenced 2 times by $affb, $b1d2
+sub_cafd5
+    pha                                                               ; afd5: 48          H
+    lda l00be                                                         ; afd6: a5 be       ..
+    sta l00bb                                                         ; afd8: 85 bb       ..
+    lda l00bf                                                         ; afda: a5 bf       ..
+    sta l00bc                                                         ; afdc: 85 bc       ..
+    pla                                                               ; afde: 68          h
+    rts                                                               ; afdf: 60          `
+
+; $afe0 referenced 2 times by $aff8, $b1c5
+sub_cafe0
+    tya                                                               ; afe0: 98          .
+    pha                                                               ; afe1: 48          H
+    jsr sub_c8cb9                                                     ; afe2: 20 b9 8c     ..
+    sta l00af                                                         ; afe5: 85 af       ..
+    pla                                                               ; afe7: 68          h
+    tay                                                               ; afe8: a8          .
+    lda #0                                                            ; afe9: a9 00       ..
+    sta l00ae                                                         ; afeb: 85 ae       ..
+    rts                                                               ; afed: 60          `
+
+sub_cafee
+    lda #1                                                            ; afee: a9 01       ..
+    bit l0d6a                                                         ; aff0: 2c 6a 0d    ,j.
+    bne caff8                                                         ; aff3: d0 03       ..
+    jmp cabfe                                                         ; aff5: 4c fe ab    L..
+
+; $aff8 referenced 1 time by $aff3
+caff8
+    jsr sub_cafe0                                                     ; aff8: 20 e0 af     ..
+    jsr sub_cafd5                                                     ; affb: 20 d5 af     ..
+    lda (l00bb),y                                                     ; affe: b1 bb       ..
+    cmp #$0d                                                          ; b000: c9 0d       ..
+    beq cb025                                                         ; b002: f0 21       .!
+    clv                                                               ; b004: b8          .
+    jsr sub_c9258                                                     ; b005: 20 58 92     X.
+    bcc cb028                                                         ; b008: 90 1e       ..
+    tya                                                               ; b00a: 98          .
+    pha                                                               ; b00b: 48          H
+    jsr sub_cb0ea                                                     ; b00c: 20 ea b0     ..
+    pla                                                               ; b00f: 68          h
+    tay                                                               ; b010: a8          .
+    jsr sub_ca0a7                                                     ; b011: 20 a7 a0     ..
+    jmp cb0b9                                                         ; b014: 4c b9 b0    L..
+
+; $b017 referenced 1 time by $8ef9
+sub_cb017
+    ldy #$18                                                          ; b017: a0 18       ..
+; $b019 referenced 1 time by $b1f8
+sub_cb019
+    ldx #$f8                                                          ; b019: a2 f8       ..
+; $b01b referenced 1 time by $b022
+loop_cb01b
+    lda l8d61,x                                                       ; b01b: bd 61 8d    .a.
+    sta (l009c),y                                                     ; b01e: 91 9c       ..
+    iny                                                               ; b020: c8          .
+    inx                                                               ; b021: e8          .
+    bne loop_cb01b                                                    ; b022: d0 f7       ..
+    rts                                                               ; b024: 60          `
+
+; $b025 referenced 1 time by $b002
+cb025
+    bit l9491                                                         ; b025: 2c 91 94    ,..
+; $b028 referenced 1 time by $b008
+cb028
+    sty l00ac                                                         ; b028: 84 ac       ..
+    bvs cb058                                                         ; b02a: 70 2c       p,
+    ldx #6                                                            ; b02c: a2 06       ..
+    ldy #$18                                                          ; b02e: a0 18       ..
+    lda #$20 ; ' '                                                    ; b030: a9 20       .
+; $b032 referenced 1 time by $b036
+loop_cb032
+    sta (l009c),y                                                     ; b032: 91 9c       ..
+    iny                                                               ; b034: c8          .
+    dex                                                               ; b035: ca          .
+    bne loop_cb032                                                    ; b036: d0 fa       ..
+    jsr sub_cafb5                                                     ; b038: 20 b5 af     ..
+    ldy l00ac                                                         ; b03b: a4 ac       ..
+    jsr gsinit                                                        ; b03d: 20 c2 ff     ..
+    beq cb058                                                         ; b040: f0 16       ..
+    ldx #6                                                            ; b042: a2 06       ..
+    sty l00ac                                                         ; b044: 84 ac       ..
+    ldy #$18                                                          ; b046: a0 18       ..
+    sty l00ad                                                         ; b048: 84 ad       ..
+; $b04a referenced 1 time by $b056
+loop_cb04a
+    ldy l00ac                                                         ; b04a: a4 ac       ..
+    jsr gsread                                                        ; b04c: 20 c5 ff     ..
+    sty l00ac                                                         ; b04f: 84 ac       ..
+    bcs cb058                                                         ; b051: b0 05       ..
+    jsr sub_cb2f7                                                     ; b053: 20 f7 b2     ..
+    bne loop_cb04a                                                    ; b056: d0 f2       ..
+; $b058 referenced 3 times by $b02a, $b040, $b051
+cb058
+    jsr sub_cb16d                                                     ; b058: 20 6d b1     m.
+    jsr sub_c983f                                                     ; b05b: 20 3f 98     ?.
+    jsr sub_cb0f6                                                     ; b05e: 20 f6 b0     ..
+    jsr sub_cb0ea                                                     ; b061: 20 ea b0     ..
+    lda #0                                                            ; b064: a9 00       ..
+    tax                                                               ; b066: aa          .
+    ldy #$20 ; ' '                                                    ; b067: a0 20       .
+    sta (l009c),y                                                     ; b069: 91 9c       ..
+; $b06b referenced 1 time by $b097
+cb06b
+    pla                                                               ; b06b: 68          h
+    beq cb099                                                         ; b06c: f0 2b       .+
+    pha                                                               ; b06e: 48          H
+    tay                                                               ; b06f: a8          .
+    lda (l009e),y                                                     ; b070: b1 9e       ..
+    bpl cb091                                                         ; b072: 10 1d       ..
+    jsr sub_c9a7f                                                     ; b074: 20 7f 9a     ..
+    lda (l009e),y                                                     ; b077: b1 9e       ..
+    sta l00ae                                                         ; b079: 85 ae       ..
+    lda (l00ae,x)                                                     ; b07b: a1 ae       ..
+    beq cb083                                                         ; b07d: f0 04       ..
+    cmp #3                                                            ; b07f: c9 03       ..
+    bne cb091                                                         ; b081: d0 0e       ..
+; $b083 referenced 1 time by $b07d
+cb083
+    dey                                                               ; b083: 88          .
+    lda (l009e),y                                                     ; b084: b1 9e       ..
+    sta l00b6                                                         ; b086: 85 b6       ..
+    dey                                                               ; b088: 88          .
+    lda (l009e),y                                                     ; b089: b1 9e       ..
+    sta l00b5                                                         ; b08b: 85 b5       ..
+    ldy #$20 ; ' '                                                    ; b08d: a0 20       .
+    sta (l009c),y                                                     ; b08f: 91 9c       ..
+; $b091 referenced 2 times by $b072, $b081
+cb091
+    pla                                                               ; b091: 68          h
+    tay                                                               ; b092: a8          .
+    lda #$3f ; '?'                                                    ; b093: a9 3f       .?
+    sta (l009e),y                                                     ; b095: 91 9e       ..
+    bne cb06b                                                         ; b097: d0 d2       ..
+; $b099 referenced 1 time by $b06c
+cb099
+    jsr sub_cb0cf                                                     ; b099: 20 cf b0     ..
+    ldy #$20 ; ' '                                                    ; b09c: a0 20       .
+    lda (l009c),y                                                     ; b09e: b1 9c       ..
+    bne cb0ae                                                         ; b0a0: d0 0c       ..
+    jsr print_inline_top_bit_clear                                    ; b0a2: 20 45 91     E.
+    !text "still "                                                    ; b0a5: 73 74 69... sti
+
+    clv                                                               ; b0ab: b8          .
+    bvc cb0b6                                                         ; b0ac: 50 08       P.
+; $b0ae referenced 1 time by $b0a0
+cb0ae
+    jsr print_inline_top_bit_clear                                    ; b0ae: 20 45 91     E.
+    !text "now "                                                      ; b0b1: 6e 6f 77... now
+
+    nop                                                               ; b0b5: ea          .
+; $b0b6 referenced 1 time by $b0ac
+cb0b6
+    jsr sub_ca09e                                                     ; b0b6: 20 9e a0     ..
+; $b0b9 referenced 1 time by $b014
+cb0b9
+    ldy #2                                                            ; b0b9: a0 02       ..
+    lda l00b5                                                         ; b0bb: a5 b5       ..
+    sta (l009e),y                                                     ; b0bd: 91 9e       ..
+    iny                                                               ; b0bf: c8          .
+    lda l00b6                                                         ; b0c0: a5 b6       ..
+    sta (l009e),y                                                     ; b0c2: 91 9e       ..
+    rts                                                               ; b0c4: 60          `
+
+; $b0c5 referenced 1 time by $a09b
+sub_cb0c5
+    jsr print_inline_top_bit_clear                                    ; b0c5: 20 45 91     E.
+    !text "File"                                                      ; b0c8: 46 69 6c... Fil
+
+    clv                                                               ; b0cc: b8          .
+    bvc cb0da                                                         ; b0cd: 50 0b       P.
+; $b0cf referenced 2 times by $b099, $b240
+sub_cb0cf
+    jsr print_inline_top_bit_clear                                    ; b0cf: 20 45 91     E.
+    !text "Printer"                                                   ; b0d2: 50 72 69... Pri
+
+    nop                                                               ; b0d9: ea          .
+; $b0da referenced 1 time by $b0cd
+cb0da
+    jsr print_inline_top_bit_clear                                    ; b0da: 20 45 91     E.
+    !text " server is "                                               ; b0dd: 20 73 65...  se
+
+    nop                                                               ; b0e8: ea          .
+    rts                                                               ; b0e9: 60          `
+
+; $b0ea referenced 4 times by $b00c, $b061, $b1e3, $b243
+sub_cb0ea
+    ldy #2                                                            ; b0ea: a0 02       ..
+    lda (l009e),y                                                     ; b0ec: b1 9e       ..
+    sta l00b5                                                         ; b0ee: 85 b5       ..
+    iny                                                               ; b0f0: c8          .
+    lda (l009e),y                                                     ; b0f1: b1 9e       ..
+    sta l00b6                                                         ; b0f3: 85 b6       ..
+    rts                                                               ; b0f5: 60          `
+
+; $b0f6 referenced 2 times by $b05e, $b23d
+sub_cb0f6
+    pla                                                               ; b0f6: 68          h
+    sta l00aa                                                         ; b0f7: 85 aa       ..
+    pla                                                               ; b0f9: 68          h
+    sta l00ab                                                         ; b0fa: 85 ab       ..
+    lda #0                                                            ; b0fc: a9 00       ..
+    pha                                                               ; b0fe: 48          H
+    lda #$84                                                          ; b0ff: a9 84       ..
+    sta l00ac                                                         ; b101: 85 ac       ..
+    lsr l0d61                                                         ; b103: 4e 61 0d    Na.
+    lda #3                                                            ; b106: a9 03       ..
+; $b108 referenced 1 time by $b11a
+loop_cb108
+    jsr sub_ca0ce                                                     ; b108: 20 ce a0     ..
+    bcs cb144                                                         ; b10b: b0 37       .7
+    lsr                                                               ; b10d: 4a          J
+    lsr                                                               ; b10e: 4a          J
+    tax                                                               ; b10f: aa          .
+    lda (l009e),y                                                     ; b110: b1 9e       ..
+    beq cb144                                                         ; b112: f0 30       .0
+    cmp #$3f ; '?'                                                    ; b114: c9 3f       .?
+    beq cb11c                                                         ; b116: f0 04       ..
+; $b118 referenced 1 time by $b141
+cb118
+    inx                                                               ; b118: e8          .
+    txa                                                               ; b119: 8a          .
+    bne loop_cb108                                                    ; b11a: d0 ec       ..
+; $b11c referenced 1 time by $b116
+cb11c
+    tya                                                               ; b11c: 98          .
+    pha                                                               ; b11d: 48          H
+    lda #$7f                                                          ; b11e: a9 7f       ..
+    sta (l009e),y                                                     ; b120: 91 9e       ..
+    iny                                                               ; b122: c8          .
+    lda #$9e                                                          ; b123: a9 9e       ..
+    sta (l009e),y                                                     ; b125: 91 9e       ..
+    lda #0                                                            ; b127: a9 00       ..
+    jsr sub_cb165                                                     ; b129: 20 65 b1     e.
+    lda l00ac                                                         ; b12c: a5 ac       ..
+    sta (l009e),y                                                     ; b12e: 91 9e       ..
+    clc                                                               ; b130: 18          .
+    php                                                               ; b131: 08          .
+    adc #3                                                            ; b132: 69 03       i.
+    plp                                                               ; b134: 28          (
+    sta l00ac                                                         ; b135: 85 ac       ..
+    jsr sub_cb15e                                                     ; b137: 20 5e b1     ^.
+    lda l00ac                                                         ; b13a: a5 ac       ..
+    sta (l009e),y                                                     ; b13c: 91 9e       ..
+sub_cb13e
+lb13f = sub_cb13e+1
+    jsr sub_cb15e                                                     ; b13e: 20 5e b1     ^.
+; $b13f referenced 1 time by $b2e2
+    jmp cb118                                                         ; b141: 4c 18 b1    L..
+
+; $b144 referenced 2 times by $b10b, $b112
+cb144
+    asl l0d61                                                         ; b144: 0e 61 0d    .a.
+    lda l00ab                                                         ; b147: a5 ab       ..
+    pha                                                               ; b149: 48          H
+    lda l00aa                                                         ; b14a: a5 aa       ..
+    pha                                                               ; b14c: 48          H
+    lda #$0a                                                          ; b14d: a9 0a       ..
+    tay                                                               ; b14f: a8          .
+    tax                                                               ; b150: aa          .
+    sta l00b4                                                         ; b151: 85 b4       ..
+; $b153 referenced 3 times by $b154, $b157, $b15b
+cb153
+    dey                                                               ; b153: 88          .
+    bne cb153                                                         ; b154: d0 fd       ..
+    dex                                                               ; b156: ca          .
+    bne cb153                                                         ; b157: d0 fa       ..
+    dec l00b4                                                         ; b159: c6 b4       ..
+    bne cb153                                                         ; b15b: d0 f6       ..
+    rts                                                               ; b15d: 60          `
+
+; $b15e referenced 2 times by $b137, $b13e
+sub_cb15e
+    iny                                                               ; b15e: c8          .
+    lda l00af                                                         ; b15f: a5 af       ..
+    sta (l009e),y                                                     ; b161: 91 9e       ..
+    lda #$ff                                                          ; b163: a9 ff       ..
+; $b165 referenced 1 time by $b129
+sub_cb165
+    iny                                                               ; b165: c8          .
+    sta (l009e),y                                                     ; b166: 91 9e       ..
+    iny                                                               ; b168: c8          .
+    sta (l009e),y                                                     ; b169: 91 9e       ..
+    iny                                                               ; b16b: c8          .
+    rts                                                               ; b16c: 60          `
+
+; $b16d referenced 2 times by $b058, $b1ca
+sub_cb16d
+    ldy #$18                                                          ; b16d: a0 18       ..
+; $b16f referenced 1 time by $b175
+loop_cb16f
+    lda (l009c),y                                                     ; b16f: b1 9c       ..
+    pha                                                               ; b171: 48          H
+    iny                                                               ; b172: c8          .
+    cpy #$20 ; ' '                                                    ; b173: c0 20       .
+    bne loop_cb16f                                                    ; b175: d0 f8       ..
+    ldy #$17                                                          ; b177: a0 17       ..
+; $b179 referenced 1 time by $b17f
+loop_cb179
+    pla                                                               ; b179: 68          h
+    sta (l009c),y                                                     ; b17a: 91 9c       ..
+    dey                                                               ; b17c: 88          .
+    cpy #$0f                                                          ; b17d: c0 0f       ..
+    bne loop_cb179                                                    ; b17f: d0 f8       ..
+    lda l009d                                                         ; b181: a5 9d       ..
+    sta l009b                                                         ; b183: 85 9b       ..
+    lda #$0c                                                          ; b185: a9 0c       ..
+    sta l009a                                                         ; b187: 85 9a       ..
+    ldy #3                                                            ; b189: a0 03       ..
+; $b18b referenced 1 time by $b191
+loop_cb18b
+    lda lb194,y                                                       ; b18b: b9 94 b1    ...
+    sta (l009a),y                                                     ; b18e: 91 9a       ..
+    dey                                                               ; b190: 88          .
+    bpl loop_cb18b                                                    ; b191: 10 f8       ..
+    rts                                                               ; b193: 60          `
+
+; $b194 referenced 1 time by $b18b
+lb194
+    !byte $80, $9f, $ff, $ff                                          ; b194: 80 9f ff... ...
+
+; $b198 referenced 4 times by $a0a1, $b249, $b281, $b2d1
+sub_cb198
+    php                                                               ; b198: 08          .
+    lda l00b6                                                         ; b199: a5 b6       ..
+    beq cb1a8                                                         ; b19b: f0 0b       ..
+    jsr caf88                                                         ; b19d: 20 88 af     ..
+    lda #$2e ; '.'                                                    ; b1a0: a9 2e       ..
+    jsr osasci                                                        ; b1a2: 20 e3 ff     ..
+    bit l9491                                                         ; b1a5: 2c 91 94    ,..
+; $b1a8 referenced 1 time by $b19b
+cb1a8
+    bvs cb1b1                                                         ; b1a8: 70 07       p.
+    jsr print_inline_top_bit_clear                                    ; b1aa: 20 45 91     E.
+    !text "    "                                                      ; b1ad: 20 20 20...
+
+; $b1b1 referenced 1 time by $b1a8
+cb1b1
+    lda l00b5                                                         ; b1b1: a5 b5       ..
+    plp                                                               ; b1b3: 28          (
+    jmp caf88                                                         ; b1b4: 4c 88 af    L..
+
+    !byte $80, $9f,   0,   0, $10,   0, $ff, $ff, $18,   0, $ff, $ff  ; b1b7: 80 9f 00... ...
+
+sub_cb1c3
+    sty l00ac                                                         ; b1c3: 84 ac       ..
+    jsr sub_cafe0                                                     ; b1c5: 20 e0 af     ..
+    sta l00b4                                                         ; b1c8: 85 b4       ..
+    jsr sub_cb16d                                                     ; b1ca: 20 6d b1     m.
+    jsr sub_cb2e0                                                     ; b1cd: 20 e0 b2     ..
+    ldy l00ac                                                         ; b1d0: a4 ac       ..
+    jsr sub_cafd5                                                     ; b1d2: 20 d5 af     ..
+    lda (l00bb),y                                                     ; b1d5: b1 bb       ..
+    cmp #$0d                                                          ; b1d7: c9 0d       ..
+    beq cb205                                                         ; b1d9: f0 2a       .*
+    clv                                                               ; b1db: b8          .
+    jsr sub_c9258                                                     ; b1dc: 20 58 92     X.
+    bcc cb208                                                         ; b1df: 90 27       .'
+    tya                                                               ; b1e1: 98          .
+    pha                                                               ; b1e2: 48          H
+    jsr sub_cb0ea                                                     ; b1e3: 20 ea b0     ..
+    pla                                                               ; b1e6: 68          h
+    tay                                                               ; b1e7: a8          .
+    jsr sub_ca0a7                                                     ; b1e8: 20 a7 a0     ..
+    ldy #$7a ; 'z'                                                    ; b1eb: a0 7a       .z
+    lda l00b5                                                         ; b1ed: a5 b5       ..
+    sta (l00ae),y                                                     ; b1ef: 91 ae       ..
+    iny                                                               ; b1f1: c8          .
+    lda l00b6                                                         ; b1f2: a5 b6       ..
+    sta (l00ae),y                                                     ; b1f4: 91 ae       ..
+    ldy #$10                                                          ; b1f6: a0 10       ..
+    jsr sub_cb019                                                     ; b1f8: 20 19 b0     ..
+    lda l00af                                                         ; b1fb: a5 af       ..
+    sta l009b                                                         ; b1fd: 85 9b       ..
+    lda #$78 ; 'x'                                                    ; b1ff: a9 78       .x
+    sta l009a                                                         ; b201: 85 9a       ..
+    bne cb236                                                         ; b203: d0 31       .1
+; $b205 referenced 1 time by $b1d9
+cb205
+    bit l9491                                                         ; b205: 2c 91 94    ,..
+; $b208 referenced 1 time by $b1df
+cb208
+    bvs cb236                                                         ; b208: 70 2c       p,
+    ldx #6                                                            ; b20a: a2 06       ..
+    ldy #$10                                                          ; b20c: a0 10       ..
+    lda #$20 ; ' '                                                    ; b20e: a9 20       .
+; $b210 referenced 1 time by $b214
+loop_cb210
+    sta (l009c),y                                                     ; b210: 91 9c       ..
+    iny                                                               ; b212: c8          .
+    dex                                                               ; b213: ca          .
+    bne loop_cb210                                                    ; b214: d0 fa       ..
+    jsr sub_cafb5                                                     ; b216: 20 b5 af     ..
+    ldy l00ac                                                         ; b219: a4 ac       ..
+    jsr gsinit                                                        ; b21b: 20 c2 ff     ..
+    beq cb236                                                         ; b21e: f0 16       ..
+    ldx #6                                                            ; b220: a2 06       ..
+    sty l00ac                                                         ; b222: 84 ac       ..
+    ldy #$10                                                          ; b224: a0 10       ..
+    sty l00ad                                                         ; b226: 84 ad       ..
+; $b228 referenced 1 time by $b234
+loop_cb228
+    ldy l00ac                                                         ; b228: a4 ac       ..
+    jsr gsread                                                        ; b22a: 20 c5 ff     ..
+    sty l00ac                                                         ; b22d: 84 ac       ..
+    bcs cb236                                                         ; b22f: b0 05       ..
+    jsr sub_cb2f7                                                     ; b231: 20 f7 b2     ..
+    bne loop_cb228                                                    ; b234: d0 f2       ..
+; $b236 referenced 4 times by $b203, $b208, $b21e, $b22f
+cb236
+    lda #$80                                                          ; b236: a9 80       ..
+    sta l0098                                                         ; b238: 85 98       ..
+    jsr sub_c983f                                                     ; b23a: 20 3f 98     ?.
+    jsr sub_cb0f6                                                     ; b23d: 20 f6 b0     ..
+    jsr sub_cb0cf                                                     ; b240: 20 cf b0     ..
+    jsr sub_cb0ea                                                     ; b243: 20 ea b0     ..
+    bit l9491                                                         ; b246: 2c 91 94    ,..
+    jsr sub_cb198                                                     ; b249: 20 98 b1     ..
+    jsr print_inline_top_bit_clear                                    ; b24c: 20 45 91     E.
+    !text " ", '"'                                                    ; b24f: 20 22        "
+
+    ldy #$18                                                          ; b251: a0 18       ..
+; $b253 referenced 1 time by $b25f
+loop_cb253
+    lda (l009c),y                                                     ; b253: b1 9c       ..
+    cmp #$20 ; ' '                                                    ; b255: c9 20       .
+    beq cb261                                                         ; b257: f0 08       ..
+    jsr osasci                                                        ; b259: 20 e3 ff     ..
+    iny                                                               ; b25c: c8          .
+    cpy #$1e                                                          ; b25d: c0 1e       ..
+    bne loop_cb253                                                    ; b25f: d0 f2       ..
+; $b261 referenced 1 time by $b257
+cb261
+    jsr print_inline_top_bit_clear                                    ; b261: 20 45 91     E.
+    !text '"', $0d                                                    ; b264: 22 0d       ".
+
+    nop                                                               ; b266: ea          .
+; $b267 referenced 1 time by $b2dd
+cb267
+    pla                                                               ; b267: 68          h
+    beq cb2df                                                         ; b268: f0 75       .u
+    pha                                                               ; b26a: 48          H
+    tay                                                               ; b26b: a8          .
+    lda (l009e),y                                                     ; b26c: b1 9e       ..
+    bpl cb2d7                                                         ; b26e: 10 67       .g
+    iny                                                               ; b270: c8          .
+    iny                                                               ; b271: c8          .
+    lda (l009e),y                                                     ; b272: b1 9e       ..
+    sta l00b5                                                         ; b274: 85 b5       ..
+    iny                                                               ; b276: c8          .
+    lda (l009e),y                                                     ; b277: b1 9e       ..
+    sta l00b6                                                         ; b279: 85 b6       ..
+    iny                                                               ; b27b: c8          .
+    lda (l009e),y                                                     ; b27c: b1 9e       ..
+    sta l00ae                                                         ; b27e: 85 ae       ..
+    clv                                                               ; b280: b8          .
+    jsr sub_cb198                                                     ; b281: 20 98 b1     ..
+    jsr print_inline_top_bit_clear                                    ; b284: 20 45 91     E.
+    !text " is "                                                      ; b287: 20 69 73...  is
+
+    ldx #0                                                            ; b28b: a2 00       ..
+    lda (l00ae,x)                                                     ; b28d: a1 ae       ..
+    bne cb29c                                                         ; b28f: d0 0b       ..
+    jsr print_inline_top_bit_clear                                    ; b291: 20 45 91     E.
+    !text "ready"                                                     ; b294: 72 65 61... rea
+
+    clv                                                               ; b299: b8          .
+    bvc cb2d4                                                         ; b29a: 50 38       P8
+; $b29c referenced 1 time by $b28f
+cb29c
+    cmp #2                                                            ; b29c: c9 02       ..
+    bne cb2ac                                                         ; b29e: d0 0c       ..
+; $b2a0 referenced 1 time by $b2ae
+loop_cb2a0
+    jsr print_inline_top_bit_clear                                    ; b2a0: 20 45 91     E.
+    !text "jammed"                                                    ; b2a3: 6a 61 6d... jam
+
+    clv                                                               ; b2a9: b8          .
+    bvc cb2d4                                                         ; b2aa: 50 28       P(
+; $b2ac referenced 1 time by $b29e
+cb2ac
+    cmp #1                                                            ; b2ac: c9 01       ..
+    bne loop_cb2a0                                                    ; b2ae: d0 f0       ..
+    jsr print_inline_top_bit_clear                                    ; b2b0: 20 45 91     E.
+    !text "busy"                                                      ; b2b3: 62 75 73... bus
+
+    inc l00ae                                                         ; b2b7: e6 ae       ..
+    lda (l00ae,x)                                                     ; b2b9: a1 ae       ..
+    sta l00b5                                                         ; b2bb: 85 b5       ..
+    beq cb2d4                                                         ; b2bd: f0 15       ..
+    jsr print_inline_top_bit_clear                                    ; b2bf: 20 45 91     E.
+    !text " with "                                                    ; b2c2: 20 77 69...  wi
+
+    inc l00ae                                                         ; b2c8: e6 ae       ..
+    lda (l00ae,x)                                                     ; b2ca: a1 ae       ..
+    sta l00b6                                                         ; b2cc: 85 b6       ..
+    bit l9491                                                         ; b2ce: 2c 91 94    ,..
+    jsr sub_cb198                                                     ; b2d1: 20 98 b1     ..
+; $b2d4 referenced 3 times by $b29a, $b2aa, $b2bd
+cb2d4
+    jsr osnewl                                                        ; b2d4: 20 e7 ff     ..
+; $b2d7 referenced 1 time by $b26e
+cb2d7
+    pla                                                               ; b2d7: 68          h
+    tay                                                               ; b2d8: a8          .
+    lda #$3f ; '?'                                                    ; b2d9: a9 3f       .?
+    sta (l009e),y                                                     ; b2db: 91 9e       ..
+    bne cb267                                                         ; b2dd: d0 88       ..
+; $b2df referenced 1 time by $b268
+cb2df
+    rts                                                               ; b2df: 60          `
+
+; $b2e0 referenced 1 time by $b1cd
+sub_cb2e0
+    ldy #$78 ; 'x'                                                    ; b2e0: a0 78       .x
+; $b2e2 referenced 1 time by $b2f4
+loop_cb2e2
+    lda lb13f,y                                                       ; b2e2: b9 3f b1    .?.
+    cpy #$7d ; '}'                                                    ; b2e5: c0 7d       .}
+    beq cb2ed                                                         ; b2e7: f0 04       ..
+    cpy #$81                                                          ; b2e9: c0 81       ..
+    bne cb2ef                                                         ; b2eb: d0 02       ..
+; $b2ed referenced 1 time by $b2e7
+cb2ed
+    lda l009d                                                         ; b2ed: a5 9d       ..
+; $b2ef referenced 1 time by $b2eb
+cb2ef
+    sta (l00ae),y                                                     ; b2ef: 91 ae       ..
+    iny                                                               ; b2f1: c8          .
+    cpy #$84                                                          ; b2f2: c0 84       ..
+    bne loop_cb2e2                                                    ; b2f4: d0 ec       ..
+    rts                                                               ; b2f6: 60          `
+
+; $b2f7 referenced 2 times by $b053, $b231
+sub_cb2f7
+    ldy l00ad                                                         ; b2f7: a4 ad       ..
+    and #$7f                                                          ; b2f9: 29 7f       ).
+    cmp #$61 ; 'a'                                                    ; b2fb: c9 61       .a
+    bcc cb305                                                         ; b2fd: 90 06       ..
+    cmp #$7b ; '{'                                                    ; b2ff: c9 7b       .{
+    bcs cb305                                                         ; b301: b0 02       ..
+    and #$5f ; '_'                                                    ; b303: 29 5f       )_
+; $b305 referenced 2 times by $b2fd, $b301
+cb305
+    sta (l009c),y                                                     ; b305: 91 9c       ..
+    iny                                                               ; b307: c8          .
+    sty l00ad                                                         ; b308: 84 ad       ..
+    dex                                                               ; b30a: ca          .
+    rts                                                               ; b30b: 60          `
+
+sub_cb30c
+    lda (l00be),y                                                     ; b30c: b1 be       ..
+    eor #$0d                                                          ; b30e: 49 0d       I.
+    bne cb316                                                         ; b310: d0 04       ..
+    lda #$ff                                                          ; b312: a9 ff       ..
+    bne cb336                                                         ; b314: d0 20       .
+; $b316 referenced 1 time by $b310
+cb316
+    lda l0d68                                                         ; b316: ad 68 0d    .h.
+    pha                                                               ; b319: 48          H
+; $b31a referenced 1 time by $b32a
+loop_cb31a
+    ldx #$d3                                                          ; b31a: a2 d3       ..
+    lda (l00be),y                                                     ; b31c: b1 be       ..
+    sta l00a8                                                         ; b31e: 85 a8       ..
+    jsr sub_ca140                                                     ; b320: 20 40 a1     @.
+    bcs cb32c                                                         ; b323: b0 07       ..
+    pla                                                               ; b325: 68          h
+    ora la3f1,x                                                       ; b326: 1d f1 a3    ...
+    pha                                                               ; b329: 48          H
+    bne loop_cb31a                                                    ; b32a: d0 ee       ..
+; $b32c referenced 2 times by $b323, $b350
+cb32c
+    lda l00a8                                                         ; b32c: a5 a8       ..
+    eor #$0d                                                          ; b32e: 49 0d       I.
+    beq cb335                                                         ; b330: f0 03       ..
+    jmp ca25d                                                         ; b332: 4c 5d a2    L].
+
+; $b335 referenced 1 time by $b330
+cb335
+    pla                                                               ; b335: 68          h
+; $b336 referenced 2 times by $b314, $b341
+cb336
+    sta l0d68                                                         ; b336: 8d 68 0d    .h.
+    sta l0d69                                                         ; b339: 8d 69 0d    .i.
+    rts                                                               ; b33c: 60          `
+
+sub_cb33d
+    lda (l00be),y                                                     ; b33d: b1 be       ..
+    eor #$0d                                                          ; b33f: 49 0d       I.
+    beq cb336                                                         ; b341: f0 f3       ..
+    lda l0d68                                                         ; b343: ad 68 0d    .h.
+    pha                                                               ; b346: 48          H
+; $b347 referenced 1 time by $b357
+loop_cb347
+    ldx #$d3                                                          ; b347: a2 d3       ..
+    lda (l00be),y                                                     ; b349: b1 be       ..
+    sta l00a8                                                         ; b34b: 85 a8       ..
+    jsr sub_ca140                                                     ; b34d: 20 40 a1     @.
+    bcs cb32c                                                         ; b350: b0 da       ..
+    pla                                                               ; b352: 68          h
+    and la3f2,x                                                       ; b353: 3d f2 a3    =..
+    pha                                                               ; b356: 48          H
+    bcc loop_cb347                                                    ; b357: 90 ee       ..
+sub_cb359
+    jsr sub_caf32                                                     ; b359: 20 32 af     2.
+    lda #0                                                            ; b35c: a9 00       ..
+    sta l00b5                                                         ; b35e: 85 b5       ..
+    jsr sub_cafb5                                                     ; b360: 20 b5 af     ..
+    jsr sub_cae94                                                     ; b363: 20 94 ae     ..
+    inx                                                               ; b366: e8          .
+    stx l00b6                                                         ; b367: 86 b6       ..
+; $b369 referenced 1 time by $b3a5
+cb369
+    lda #1                                                            ; b369: a9 01       ..
+    sta l0f05                                                         ; b36b: 8d 05 0f    ...
+    sta l0f07                                                         ; b36e: 8d 07 0f    ...
+    ldx l00b5                                                         ; b371: a6 b5       ..
+    stx l0f06                                                         ; b373: 8e 06 0f    ...
+    ldx #3                                                            ; b376: a2 03       ..
+    jsr sub_caf04                                                     ; b378: 20 04 af     ..
+    ldy #3                                                            ; b37b: a0 03       ..
+    lda #$80                                                          ; b37d: a9 80       ..
+    sta l0098                                                         ; b37f: 85 98       ..
+    jsr c94ad                                                         ; b381: 20 ad 94     ..
+    lda l0f05                                                         ; b384: ad 05 0f    ...
+    bne cb39c                                                         ; b387: d0 13       ..
+    lda #osbyte_flush_buffer_class                                    ; b389: a9 0f       ..
+    ldx #1                                                            ; b38b: a2 01       ..
+    jsr osbyte                                                        ; b38d: 20 f4 ff     ..
+    lda #osbyte_scan_keyboard_from_16                                 ; b390: a9 7a       .z
+    jsr osbyte                                                        ; b392: 20 f4 ff     ..
+    ldy #0                                                            ; b395: a0 00       ..
+    lda #osbyte_write_keys_pressed                                    ; b397: a9 78       .x
+    jmp osbyte                                                        ; b399: 4c f4 ff    L..
+
+; $b39c referenced 1 time by $b387
+cb39c
+    lda l0f2f                                                         ; b39c: ad 2f 0f    ./.
+; $b39f referenced 1 time by $b3af
+loop_cb39f
+    cmp #$4c ; 'L'                                                    ; b39f: c9 4c       .L
+    bne cb3a8                                                         ; b3a1: d0 05       ..
+; $b3a3 referenced 1 time by $b420
+cb3a3
+    inc l00b5                                                         ; b3a3: e6 b5       ..
+    jmp cb369                                                         ; b3a5: 4c 69 b3    Li.
+
+; $b3a8 referenced 1 time by $b3a1
+cb3a8
+    cmp #$44 ; 'D'                                                    ; b3a8: c9 44       .D
+    bne cb3b1                                                         ; b3aa: d0 05       ..
+    lda l0f30                                                         ; b3ac: ad 30 0f    .0.
+    bne loop_cb39f                                                    ; b3af: d0 ee       ..
+; $b3b1 referenced 1 time by $b3aa
+cb3b1
+    ldx #1                                                            ; b3b1: a2 01       ..
+    ldy l00b6                                                         ; b3b3: a4 b6       ..
+; $b3b5 referenced 1 time by $b3c2
+loop_cb3b5
+    lda l0f06,x                                                       ; b3b5: bd 06 0f    ...
+    jsr osasci                                                        ; b3b8: 20 e3 ff     ..
+    sta l0e30,y                                                       ; b3bb: 99 30 0e    .0.
+    iny                                                               ; b3be: c8          .
+    inx                                                               ; b3bf: e8          .
+    cpx #$0c                                                          ; b3c0: e0 0c       ..
+    bne loop_cb3b5                                                    ; b3c2: d0 f1       ..
+    jsr print_inline_top_bit_clear                                    ; b3c4: 20 45 91     E.
+    !text "(?/"                                                       ; b3c7: 28 3f 2f    (?/
+
+    nop                                                               ; b3ca: ea          .
+    jsr sub_cb431                                                     ; b3cb: 20 31 b4     1.
+    cmp #$3f ; '?'                                                    ; b3ce: c9 3f       .?
+    bne cb3ed                                                         ; b3d0: d0 1b       ..
+    lda #$0d                                                          ; b3d2: a9 0d       ..
+    jsr oswrch                                                        ; b3d4: 20 ee ff     ..
+    ldx #2                                                            ; b3d7: a2 02       ..
+; $b3d9 referenced 1 time by $b3e2
+loop_cb3d9
+    lda l0f05,x                                                       ; b3d9: bd 05 0f    ...
+    jsr osasci                                                        ; b3dc: 20 e3 ff     ..
+    inx                                                               ; b3df: e8          .
+    cpx #$3e ; '>'                                                    ; b3e0: e0 3e       .>
+    bne loop_cb3d9                                                    ; b3e2: d0 f5       ..
+    jsr print_inline_top_bit_clear                                    ; b3e4: 20 45 91     E.
+    !text " ("                                                        ; b3e7: 20 28        (
+
+    nop                                                               ; b3e9: ea          .
+    jsr sub_cb431                                                     ; b3ea: 20 31 b4     1.
+; $b3ed referenced 1 time by $b3d0
+cb3ed
+    and #$df                                                          ; b3ed: 29 df       ).
+    cmp #$59 ; 'Y'                                                    ; b3ef: c9 59       .Y
+    bne cb41d                                                         ; b3f1: d0 2a       .*
+    jsr osasci                                                        ; b3f3: 20 e3 ff     ..
+    ldx #0                                                            ; b3f6: a2 00       ..
+    lda l0e30,x                                                       ; b3f8: bd 30 0e    .0.
+    cmp #$0d                                                          ; b3fb: c9 0d       ..
+    beq cb423                                                         ; b3fd: f0 24       .$
+; $b3ff referenced 1 time by $b414
+loop_cb3ff
+    lda l0e30,x                                                       ; b3ff: bd 30 0e    .0.
+    cmp #$0d                                                          ; b402: c9 0d       ..
+    bne cb408                                                         ; b404: d0 02       ..
+    lda #$2e ; '.'                                                    ; b406: a9 2e       ..
+; $b408 referenced 1 time by $b404
+cb408
+    cmp #$20 ; ' '                                                    ; b408: c9 20       .
+    bne cb40e                                                         ; b40a: d0 02       ..
+; $b40c referenced 1 time by $b42f
+cb40c
+    lda #$0d                                                          ; b40c: a9 0d       ..
+; $b40e referenced 1 time by $b40a
+cb40e
+    sta l0f05,x                                                       ; b40e: 9d 05 0f    ...
+    inx                                                               ; b411: e8          .
+    cmp #$0d                                                          ; b412: c9 0d       ..
+    bne loop_cb3ff                                                    ; b414: d0 e9       ..
+    ldy #$14                                                          ; b416: a0 14       ..
+    jsr c94ad                                                         ; b418: 20 ad 94     ..
+    dec l00b5                                                         ; b41b: c6 b5       ..
+; $b41d referenced 1 time by $b3f1
+cb41d
+    jsr osnewl                                                        ; b41d: 20 e7 ff     ..
+    jmp cb3a3                                                         ; b420: 4c a3 b3    L..
+
+; $b423 referenced 1 time by $b3fd
+cb423
+    dex                                                               ; b423: ca          .
+; $b424 referenced 1 time by $b42d
+loop_cb424
+    inx                                                               ; b424: e8          .
+    lda l0e31,x                                                       ; b425: bd 31 0e    .1.
+    sta l0f05,x                                                       ; b428: 9d 05 0f    ...
+    cmp #$20 ; ' '                                                    ; b42b: c9 20       .
+    bne loop_cb424                                                    ; b42d: d0 f5       ..
+    beq cb40c                                                         ; b42f: f0 db       ..
+; $b431 referenced 2 times by $b3cb, $b3ea
+sub_cb431
+    jsr print_inline_top_bit_clear                                    ; b431: 20 45 91     E.
+    !text "Y/N) "                                                     ; b434: 59 2f 4e... Y/N
+
+    lda #osbyte_flush_buffer_class                                    ; b439: a9 0f       ..
+    ldx #1                                                            ; b43b: a2 01       ..
+    jsr osbyte                                                        ; b43d: 20 f4 ff     ..
+    jsr osrdch                                                        ; b440: 20 e0 ff     ..
+    bcc cb448                                                         ; b443: 90 03       ..
+    jmp c9576                                                         ; b445: 4c 76 95    Lv.
+
+; $b448 referenced 1 time by $b443
+cb448
+    rts                                                               ; b448: 60          `
+
+; $b449 referenced 1 time by $8b75
+sub_cb449
+    lda #0                                                            ; b449: a9 00       ..
+    tay                                                               ; b44b: a8          .
+; $b44c referenced 1 time by $b450
+loop_cb44c
+    sta l1000,y                                                       ; b44c: 99 00 10    ...
+    iny                                                               ; b44f: c8          .
+    bne loop_cb44c                                                    ; b450: d0 fa       ..
+    ldy #$0b                                                          ; b452: a0 0b       ..
+    lda (l009c),y                                                     ; b454: b1 9c       ..
+    sec                                                               ; b456: 38          8
+    sbc #$5a ; 'Z'                                                    ; b457: e9 5a       .Z
+    tay                                                               ; b459: a8          .
+    lda #$40 ; '@'                                                    ; b45a: a9 40       .@
+; $b45c referenced 1 time by $b462
+loop_cb45c
+    sta l1000,y                                                       ; b45c: 99 00 10    ...
+    dey                                                               ; b45f: 88          .
+    cpy #$b8                                                          ; b460: c0 b8       ..
+    bpl loop_cb45c                                                    ; b462: 10 f8       ..
+    iny                                                               ; b464: c8          .
+    lda #$c0                                                          ; b465: a9 c0       ..
+    sta l1000,y                                                       ; b467: 99 00 10    ...
+    rts                                                               ; b46a: 60          `
+
+; $b46b referenced 1 time by $b73d
+sub_cb46b
+    php                                                               ; b46b: 08          .
+    sec                                                               ; b46c: 38          8
+    sbc #$20 ; ' '                                                    ; b46d: e9 20       .
+    bmi cb475                                                         ; b46f: 30 04       0.
+    cmp #$10                                                          ; b471: c9 10       ..
+    bcc cb477                                                         ; b473: 90 02       ..
+; $b475 referenced 1 time by $b46f
+cb475
+    lda #$ff                                                          ; b475: a9 ff       ..
+; $b477 referenced 1 time by $b473
+cb477
+    plp                                                               ; b477: 28          (
+    tax                                                               ; b478: aa          .
+    rts                                                               ; b479: 60          `
+
+    !byte $c9, $20, $90,   4, $c9, $30, $90, $2b, $48                 ; b47a: c9 20 90... . .
+
+; $b483 referenced 1 time by $b4b5
+cb483
+    lda #$de                                                          ; b483: a9 de       ..
+sub_cb485
+lb487 = sub_cb485+2
+    jsr generate_error_inline3                                        ; b485: 20 d1 96     ..
+; $b487 referenced 2 times by $b4cd, $b4e1
+    !text "Net channel", 0                                            ; b488: 4e 65 74... Net
+    !text " not on this file server"                                  ; b494: 20 6e 6f...  no
+    !byte 0                                                           ; b4ac: 00          .
+
+; $b4ad referenced 1 time by $9ed6
+sub_cb4ad
+    pha                                                               ; b4ad: 48          H
+    sec                                                               ; b4ae: 38          8
+    sbc #$20 ; ' '                                                    ; b4af: e9 20       .
+    tax                                                               ; b4b1: aa          .
+    lda l1030,x                                                       ; b4b2: bd 30 10    .0.
+    beq cb483                                                         ; b4b5: f0 cc       ..
+    jsr sub_cb586                                                     ; b4b7: 20 86 b5     ..
+    bne cb4c1                                                         ; b4ba: d0 05       ..
+    pla                                                               ; b4bc: 68          h
+    lda l1060,x                                                       ; b4bd: bd 60 10    .`.
+    rts                                                               ; b4c0: 60          `
+
+; $b4c1 referenced 1 time by $b4ba
+cb4c1
+    lda #$de                                                          ; b4c1: a9 de       ..
+    sta l0101                                                         ; b4c3: 8d 01 01    ...
+    lda #0                                                            ; b4c6: a9 00       ..
+    sta l0100                                                         ; b4c8: 8d 00 01    ...
+    tax                                                               ; b4cb: aa          .
+; $b4cc referenced 1 time by $b4d3
+loop_cb4cc
+    inx                                                               ; b4cc: e8          .
+    lda lb487,x                                                       ; b4cd: bd 87 b4    ...
+    sta l0101,x                                                       ; b4d0: 9d 01 01    ...
+    bne loop_cb4cc                                                    ; b4d3: d0 f7       ..
+    stx l00b2                                                         ; b4d5: 86 b2       ..
+    stx l00b4                                                         ; b4d7: 86 b4       ..
+    pla                                                               ; b4d9: 68          h
+    jsr sub_c9771                                                     ; b4da: 20 71 97     q.
+    ldy l00b4                                                         ; b4dd: a4 b4       ..
+; $b4df referenced 1 time by $b4e7
+loop_cb4df
+    iny                                                               ; b4df: c8          .
+    inx                                                               ; b4e0: e8          .
+    lda lb487,y                                                       ; b4e1: b9 87 b4    ...
+    sta l0101,x                                                       ; b4e4: 9d 01 01    ...
+    bne loop_cb4df                                                    ; b4e7: d0 f6       ..
+    jmp l0100                                                         ; b4e9: 4c 00 01    L..
+
+    !byte $ad, $c9, $10, $20, $8f, $b9, $20, $7a, $b4, $29,   2, $f0  ; b4ec: ad c9 10... ...
+    !byte $0f, $a9, $a8, $20, $d1, $96                                ; b4f8: 0f a9 a8... ...
+    !text "Is a dir."                                                 ; b4fe: 49 73 20... Is
+    !byte   0, $60                                                    ; b507: 00 60       .`
+
+; $b509 referenced 5 times by $a280, $a31f, $a34a, $a381, $b540
+sub_cb509
+    pha                                                               ; b509: 48          H
+    ldx #$20 ; ' '                                                    ; b50a: a2 20       .
+; $b50c referenced 1 time by $b514
+loop_cb50c
+    lda l1010,x                                                       ; b50c: bd 10 10    ...
+    beq cb51a                                                         ; b50f: f0 09       ..
+    inx                                                               ; b511: e8          .
+    cpx #$30 ; '0'                                                    ; b512: e0 30       .0
+    bne loop_cb50c                                                    ; b514: d0 f6       ..
+    pla                                                               ; b516: 68          h
+    lda #0                                                            ; b517: a9 00       ..
+    rts                                                               ; b519: 60          `
+
+; $b51a referenced 1 time by $b50f
+cb51a
+    pla                                                               ; b51a: 68          h
+    sta l1010,x                                                       ; b51b: 9d 10 10    ...
+    lda #0                                                            ; b51e: a9 00       ..
+    sta l0fe0,x                                                       ; b520: 9d e0 0f    ...
+    sta l0ff0,x                                                       ; b523: 9d f0 0f    ...
+    sta l1000,x                                                       ; b526: 9d 00 10    ...
+    lda l0e00                                                         ; b529: ad 00 0e    ...
+    sta l1020,x                                                       ; b52c: 9d 20 10    . .
+    lda l0e01                                                         ; b52f: ad 01 0e    ...
+    sta l1030,x                                                       ; b532: 9d 30 10    .0.
+    txa                                                               ; b535: 8a          .
+    pha                                                               ; b536: 48          H
+    sec                                                               ; b537: 38          8
+    sbc #$20 ; ' '                                                    ; b538: e9 20       .
+    tax                                                               ; b53a: aa          .
+    pla                                                               ; b53b: 68          h
+    rts                                                               ; b53c: 60          `
+
+; $b53d referenced 1 time by $a1ed
+sub_cb53d
+    pha                                                               ; b53d: 48          H
+    lda #0                                                            ; b53e: a9 00       ..
+    jsr sub_cb509                                                     ; b540: 20 09 b5     ..
+    bne cb557                                                         ; b543: d0 12       ..
+    lda #$c0                                                          ; b545: a9 c0       ..
+    jsr generate_error_inline3                                        ; b547: 20 d1 96     ..
+    !text "No more FCBs", 0                                           ; b54a: 4e 6f 20... No
+
+; $b557 referenced 1 time by $b543
+cb557
+    pla                                                               ; b557: 68          h
+    rts                                                               ; b558: 60          `
+
+; $b559 referenced 3 times by $94a8, $9533, $a391
+sub_cb559
+    clc                                                               ; b559: 18          .
+    bit l9491                                                         ; b55a: 2c 91 94    ,..
+    ldx #$10                                                          ; b55d: a2 10       ..
+; $b55f referenced 4 times by $b56b, $b575, $b57a, $b584
+cb55f
+    dex                                                               ; b55f: ca          .
+    bpl cb563                                                         ; b560: 10 01       ..
+    rts                                                               ; b562: 60          `
+
+; $b563 referenced 1 time by $b560
+cb563
+    lda l1060,x                                                       ; b563: bd 60 10    .`.
+    tay                                                               ; b566: a8          .
+    and #2                                                            ; b567: 29 02       ).
+    beq cb577                                                         ; b569: f0 0c       ..
+    bvc cb55f                                                         ; b56b: 50 f2       P.
+    bcc cb577                                                         ; b56d: 90 08       ..
+    tya                                                               ; b56f: 98          .
+    and #$df                                                          ; b570: 29 df       ).
+    sta l1060,x                                                       ; b572: 9d 60 10    .`.
+    bvs cb55f                                                         ; b575: 70 e8       p.
+; $b577 referenced 2 times by $b569, $b56d
+cb577
+    jsr sub_cb586                                                     ; b577: 20 86 b5     ..
+    bne cb55f                                                         ; b57a: d0 e3       ..
+    lda #0                                                            ; b57c: a9 00       ..
+    sta l1060,x                                                       ; b57e: 9d 60 10    .`.
+    sta l1030,x                                                       ; b581: 9d 30 10    .0.
+    beq cb55f                                                         ; b584: f0 d9       ..
+; $b586 referenced 6 times by $a306, $a331, $a368, $ac40, $b4b7, $b577
+sub_cb586
+    lda l1040,x                                                       ; b586: bd 40 10    .@.
+    eor l0e00                                                         ; b589: 4d 00 0e    M..
+    bne cb594                                                         ; b58c: d0 06       ..
+    lda l1050,x                                                       ; b58e: bd 50 10    .P.
+    eor l0e01                                                         ; b591: 4d 01 0e    M..
+; $b594 referenced 1 time by $b58c
+cb594
+    rts                                                               ; b594: 60          `
+
+; $b595 referenced 2 times by $b694, $b782
+sub_cb595
+    ldx l10c8                                                         ; b595: ae c8 10    ...
+    bit l9491                                                         ; b598: 2c 91 94    ,..
+; $b59b referenced 4 times by $b5aa, $b5b0, $b5cd, $b5d4
+cb59b
+    inx                                                               ; b59b: e8          .
+    cpx #$10                                                          ; b59c: e0 10       ..
+    bne cb5a2                                                         ; b59e: d0 02       ..
+    ldx #0                                                            ; b5a0: a2 00       ..
+; $b5a2 referenced 1 time by $b59e
+cb5a2
+    cpx l10c8                                                         ; b5a2: ec c8 10    ...
+    bne cb5ac                                                         ; b5a5: d0 05       ..
+    bvc cb5b7                                                         ; b5a7: 50 0e       P.
+    clv                                                               ; b5a9: b8          .
+    bvc cb59b                                                         ; b5aa: 50 ef       P.
+; $b5ac referenced 1 time by $b5a5
+cb5ac
+    lda l10b8,x                                                       ; b5ac: bd b8 10    ...
+    rol                                                               ; b5af: 2a          *
+    bpl cb59b                                                         ; b5b0: 10 e9       ..
+    and #4                                                            ; b5b2: 29 04       ).
+    bne cb5cd                                                         ; b5b4: d0 17       ..
+; $b5b6 referenced 1 time by $b5d6
+cb5b6
+    dex                                                               ; b5b6: ca          .
+; $b5b7 referenced 2 times by $b5a7, $b5c2
+cb5b7
+    inx                                                               ; b5b7: e8          .
+    cpx #$10                                                          ; b5b8: e0 10       ..
+    bne cb5be                                                         ; b5ba: d0 02       ..
+    ldx #0                                                            ; b5bc: a2 00       ..
+; $b5be referenced 1 time by $b5ba
+cb5be
+    lda l10b8,x                                                       ; b5be: bd b8 10    ...
+    rol                                                               ; b5c1: 2a          *
+    bpl cb5b7                                                         ; b5c2: 10 f3       ..
+    sec                                                               ; b5c4: 38          8
+    ror                                                               ; b5c5: 6a          j
+    sta l10b8,x                                                       ; b5c6: 9d b8 10    ...
+    ldx l10c8                                                         ; b5c9: ae c8 10    ...
+    rts                                                               ; b5cc: 60          `
+
+; $b5cd referenced 1 time by $b5b4
+cb5cd
+    bvs cb59b                                                         ; b5cd: 70 cc       p.
+    lda l10b8,x                                                       ; b5cf: bd b8 10    ...
+    and #$20 ; ' '                                                    ; b5d2: 29 20       )
+    bne cb59b                                                         ; b5d4: d0 c5       ..
+    beq cb5b6                                                         ; b5d6: f0 de       ..
+; $b5d8 referenced 2 times by $b61b, $b6c6
+sub_cb5d8
+    ldy #1                                                            ; b5d8: a0 01       ..
+    sty l10d0                                                         ; b5da: 8c d0 10    ...
+    dey                                                               ; b5dd: 88          .
+    sty l10cb                                                         ; b5de: 8c cb 10    ...
+    sty l10cf                                                         ; b5e1: 8c cf 10    ...
+    sty l10d6                                                         ; b5e4: 8c d6 10    ...
+    tya                                                               ; b5e7: 98          .
+    ldx #2                                                            ; b5e8: a2 02       ..
+; $b5ea referenced 1 time by $b5ee
+loop_cb5ea
+    sta l10d1,x                                                       ; b5ea: 9d d1 10    ...
+    dex                                                               ; b5ed: ca          .
+    bpl loop_cb5ea                                                    ; b5ee: 10 fa       ..
+    stx l10cd                                                         ; b5f0: 8e cd 10    ...
+    stx l10ce                                                         ; b5f3: 8e ce 10    ...
+    ldx #$ca                                                          ; b5f6: a2 ca       ..
+    ldy #$10                                                          ; b5f8: a0 10       ..
+    rts                                                               ; b5fa: 60          `
+
+; $b5fb referenced 2 times by $b68b, $b7b7
+sub_cb5fb
+    jsr sub_c8fcb                                                     ; b5fb: 20 cb 8f     ..
+    stx l10c8                                                         ; b5fe: 8e c8 10    ...
+    lda l10b8,x                                                       ; b601: bd b8 10    ...
+    ror                                                               ; b604: 6a          j
+    bcc cb661                                                         ; b605: 90 5a       .Z
+    lda l10d4                                                         ; b607: ad d4 10    ...
+    pha                                                               ; b60a: 48          H
+    lda l10d5                                                         ; b60b: ad d5 10    ...
+    pha                                                               ; b60e: 48          H
+    lda l1078,x                                                       ; b60f: bd 78 10    .x.
+    sta l10d4                                                         ; b612: 8d d4 10    ...
+    lda l1088,x                                                       ; b615: bd 88 10    ...
+    sta l10d5                                                         ; b618: 8d d5 10    ...
+    jsr sub_cb5d8                                                     ; b61b: 20 d8 b5     ..
+    dec l10cf                                                         ; b61e: ce cf 10    ...
+    dec l10d0                                                         ; b621: ce d0 10    ...
+    ldx l10c8                                                         ; b624: ae c8 10    ...
+    txa                                                               ; b627: 8a          .
+    clc                                                               ; b628: 18          .
+    adc #$11                                                          ; b629: 69 11       i.
+    sta l10cc                                                         ; b62b: 8d cc 10    ...
+    lda l10b8,x                                                       ; b62e: bd b8 10    ...
+    and #$20 ; ' '                                                    ; b631: 29 20       )
+    beq cb63b                                                         ; b633: f0 06       ..
+    lda l1098,x                                                       ; b635: bd 98 10    ...
+    sta l10cf                                                         ; b638: 8d cf 10    ...
+; $b63b referenced 1 time by $b633
+cb63b
+    lda l10a8,x                                                       ; b63b: bd a8 10    ...
+    sta l10ca                                                         ; b63e: 8d ca 10    ...
+    tax                                                               ; b641: aa          .
+    jsr sub_cb98a                                                     ; b642: 20 8a b9     ..
+    pha                                                               ; b645: 48          H
+    txa                                                               ; b646: 8a          .
+    sta (l009c),y                                                     ; b647: 91 9c       ..
+    ldx #$ca                                                          ; b649: a2 ca       ..
+    ldy #$10                                                          ; b64b: a0 10       ..
+    lda #0                                                            ; b64d: a9 00       ..
+    jsr sub_cb984                                                     ; b64f: 20 84 b9     ..
+    ldx l10c8                                                         ; b652: ae c8 10    ...
+    pla                                                               ; b655: 68          h
+    jsr sub_cb98f                                                     ; b656: 20 8f b9     ..
+    pla                                                               ; b659: 68          h
+    sta l10d5                                                         ; b65a: 8d d5 10    ...
+    pla                                                               ; b65d: 68          h
+    sta l10d4                                                         ; b65e: 8d d4 10    ...
+; $b661 referenced 1 time by $b605
+cb661
+    lda #$dc                                                          ; b661: a9 dc       ..
+    and l10b8,x                                                       ; b663: 3d b8 10    =..
+    sta l10b8,x                                                       ; b666: 9d b8 10    ...
+    rts                                                               ; b669: 60          `
+
+; $b66a referenced 2 times by $b72d, $b8ef
+sub_cb66a
+    ldx #$0c                                                          ; b66a: a2 0c       ..
+; $b66c referenced 1 time by $b676
+loop_cb66c
+    lda l0f00,x                                                       ; b66c: bd 00 0f    ...
+    sta l10d9,x                                                       ; b66f: 9d d9 10    ...
+    lda l00b0,x                                                       ; b672: b5 b0       ..
+    pha                                                               ; b674: 48          H
+    dex                                                               ; b675: ca          .
+    bpl loop_cb66c                                                    ; b676: 10 f4       ..
+    cpy #0                                                            ; b678: c0 00       ..
+    bne cb67f                                                         ; b67a: d0 03       ..
+    jmp cb718                                                         ; b67c: 4c 18 b7    L..
+
+; $b67f referenced 1 time by $b67a
+cb67f
+    php                                                               ; b67f: 08          .
+    ldx #$ff                                                          ; b680: a2 ff       ..
+; $b682 referenced 2 times by $b686, $b689
+cb682
+    inx                                                               ; b682: e8          .
+    lda l10b8,x                                                       ; b683: bd b8 10    ...
+    bpl cb682                                                         ; b686: 10 fa       ..
+    asl                                                               ; b688: 0a          .
+    bpl cb682                                                         ; b689: 10 f7       ..
+    jsr sub_cb5fb                                                     ; b68b: 20 fb b5     ..
+    lda #$40 ; '@'                                                    ; b68e: a9 40       .@
+    sta l10b8,x                                                       ; b690: 9d b8 10    ...
+    php                                                               ; b693: 08          .
+    jsr sub_cb595                                                     ; b694: 20 95 b5     ..
+    plp                                                               ; b697: 28          (
+    lda l10c9                                                         ; b698: ad c9 10    ...
+    sta l10ca                                                         ; b69b: 8d ca 10    ...
+    pha                                                               ; b69e: 48          H
+    sec                                                               ; b69f: 38          8
+    sbc #$20 ; ' '                                                    ; b6a0: e9 20       .
+    tay                                                               ; b6a2: a8          .
+    lda l1030,y                                                       ; b6a3: b9 30 10    .0.
+    sta l0f05                                                         ; b6a6: 8d 05 0f    ...
+    pla                                                               ; b6a9: 68          h
+    sta l10a8,x                                                       ; b6aa: 9d a8 10    ...
+    lda l10d4                                                         ; b6ad: ad d4 10    ...
+    sta l1078,x                                                       ; b6b0: 9d 78 10    .x.
+    lda l10d5                                                         ; b6b3: ad d5 10    ...
+    sta l1088,x                                                       ; b6b6: 9d 88 10    ...
+    txa                                                               ; b6b9: 8a          .
+    clc                                                               ; b6ba: 18          .
+    adc #$11                                                          ; b6bb: 69 11       i.
+    sta l10cc                                                         ; b6bd: 8d cc 10    ...
+    plp                                                               ; b6c0: 28          (
+    bvc cb6c6                                                         ; b6c1: 50 03       P.
+    jsr sub_cb8da                                                     ; b6c3: 20 da b8     ..
+; $b6c6 referenced 1 time by $b6c1
+cb6c6
+    jsr sub_cb5d8                                                     ; b6c6: 20 d8 b5     ..
+    jsr sub_cb98a                                                     ; b6c9: 20 8a b9     ..
+    pha                                                               ; b6cc: 48          H
+    lda l10ca                                                         ; b6cd: ad ca 10    ...
+    sta (l009c),y                                                     ; b6d0: 91 9c       ..
+    ldy #$10                                                          ; b6d2: a0 10       ..
+    lda #2                                                            ; b6d4: a9 02       ..
+    jsr sub_cb984                                                     ; b6d6: 20 84 b9     ..
+    pla                                                               ; b6d9: 68          h
+    jsr sub_cb98f                                                     ; b6da: 20 8f b9     ..
+    ldx l10c8                                                         ; b6dd: ae c8 10    ...
+    lda l10d0                                                         ; b6e0: ad d0 10    ...
+    bne cb6ea                                                         ; b6e3: d0 05       ..
+    lda l10cf                                                         ; b6e5: ad cf 10    ...
+    beq cb70e                                                         ; b6e8: f0 24       .$
+; $b6ea referenced 1 time by $b6e3
+cb6ea
+    lda l10cf                                                         ; b6ea: ad cf 10    ...
+    eor #$ff                                                          ; b6ed: 49 ff       I.
+    clc                                                               ; b6ef: 18          .
+    adc #1                                                            ; b6f0: 69 01       i.
+    sta l1098,x                                                       ; b6f2: 9d 98 10    ...
+    lda #$20 ; ' '                                                    ; b6f5: a9 20       .
+    ora l10b8,x                                                       ; b6f7: 1d b8 10    ...
+    sta l10b8,x                                                       ; b6fa: 9d b8 10    ...
+    lda l10cc                                                         ; b6fd: ad cc 10    ...
+    sta l00b3                                                         ; b700: 85 b3       ..
+    lda #0                                                            ; b702: a9 00       ..
+    sta l00b2                                                         ; b704: 85 b2       ..
+    ldy l1098,x                                                       ; b706: bc 98 10    ...
+; $b709 referenced 1 time by $b70c
+loop_cb709
+    sta (l00b2),y                                                     ; b709: 91 b2       ..
+    iny                                                               ; b70b: c8          .
+    bne loop_cb709                                                    ; b70c: d0 fb       ..
+; $b70e referenced 1 time by $b6e8
+cb70e
+    lda #2                                                            ; b70e: a9 02       ..
+    ora l10b8,x                                                       ; b710: 1d b8 10    ...
+    sta l10b8,x                                                       ; b713: 9d b8 10    ...
+    ldy #0                                                            ; b716: a0 00       ..
+; $b718 referenced 2 times by $b67c, $b71f
+cb718
+    pla                                                               ; b718: 68          h
+    sta l00b0,y                                                       ; b719: 99 b0 00    ...
+    iny                                                               ; b71c: c8          .
+    cpy #$0d                                                          ; b71d: c0 0d       ..
+    bne cb718                                                         ; b71f: d0 f7       ..
+; $b721 referenced 1 time by $b922
+sub_cb721
+    ldy #$0c                                                          ; b721: a0 0c       ..
+; $b723 referenced 1 time by $b72a
+loop_cb723
+    lda l10d9,y                                                       ; b723: b9 d9 10    ...
+    sta l0f00,y                                                       ; b726: 99 00 0f    ...
+    dey                                                               ; b729: 88          .
+    bpl loop_cb723                                                    ; b72a: 10 f7       ..
+    rts                                                               ; b72c: 60          `
+
+; $b72d referenced 1 time by $b74c
+loop_cb72d
+    jsr sub_cb66a                                                     ; b72d: 20 6a b6     j.
+; $b730 referenced 1 time by $9df8
+sub_cb730
+    ldx #$ff                                                          ; b730: a2 ff       ..
+; $b732 referenced 2 times by $b76e, $b776
+cb732
+    ldy l10c9                                                         ; b732: ac c9 10    ...
+; $b735 referenced 2 times by $b754, $b75a
+cb735
+    inx                                                               ; b735: e8          .
+    cpx #$10                                                          ; b736: e0 10       ..
+    bne cb74f                                                         ; b738: d0 15       ..
+    lda l10c9                                                         ; b73a: ad c9 10    ...
+    jsr sub_cb46b                                                     ; b73d: 20 6b b4     k.
+    lda l1020,x                                                       ; b740: bd 20 10    . .
+    sta l10d5                                                         ; b743: 8d d5 10    ...
+    lda l1010,x                                                       ; b746: bd 10 10    ...
+    sta l10d4                                                         ; b749: 8d d4 10    ...
+    jmp loop_cb72d                                                    ; b74c: 4c 2d b7    L-.
+
+; $b74f referenced 1 time by $b738
+cb74f
+    lda l10b8,x                                                       ; b74f: bd b8 10    ...
+    and #2                                                            ; b752: 29 02       ).
+    beq cb735                                                         ; b754: f0 df       ..
+    tya                                                               ; b756: 98          .
+    cmp l10a8,x                                                       ; b757: dd a8 10    ...
+    bne cb735                                                         ; b75a: d0 d9       ..
+    stx l10c8                                                         ; b75c: 8e c8 10    ...
+    php                                                               ; b75f: 08          .
+    sec                                                               ; b760: 38          8
+    sbc #$20 ; ' '                                                    ; b761: e9 20       .
+    plp                                                               ; b763: 28          (
+    tay                                                               ; b764: a8          .
+    ldx l10c8                                                         ; b765: ae c8 10    ...
+    lda l1010,y                                                       ; b768: b9 10 10    ...
+    cmp l1078,x                                                       ; b76b: dd 78 10    .x.
+    bne cb732                                                         ; b76e: d0 c2       ..
+    lda l1020,y                                                       ; b770: b9 20 10    . .
+    cmp l1088,x                                                       ; b773: dd 88 10    ...
+    bne cb732                                                         ; b776: d0 ba       ..
+    lda l10b8,x                                                       ; b778: bd b8 10    ...
+    bpl cb788                                                         ; b77b: 10 0b       ..
+    and #$7f                                                          ; b77d: 29 7f       ).
+    sta l10b8,x                                                       ; b77f: 9d b8 10    ...
+    jsr sub_cb595                                                     ; b782: 20 95 b5     ..
+    lda l10b8,x                                                       ; b785: bd b8 10    ...
+; $b788 referenced 1 time by $b77b
+cb788
+    and #$20 ; ' '                                                    ; b788: 29 20       )
+    rts                                                               ; b78a: 60          `
+
+    !byte $fe,   0, $10, $d0,   8, $fe, $10, $10, $d0,   3, $fe, $20  ; b78b: fe 00 10... ...
+    !byte $10, $60                                                    ; b797: 10 60       .`
+
+; $b799 referenced 3 times by $8d87, $8fa0, $94a0
+sub_cb799
+    txa                                                               ; b799: 8a          .
+    pha                                                               ; b79a: 48          H
+    tya                                                               ; b79b: 98          .
+    pha                                                               ; b79c: 48          H
+    ldx #$f7                                                          ; b79d: a2 f7       ..
+; $b79f referenced 1 time by $b7a4
+loop_cb79f
+    lda lffbd,x                                                       ; b79f: bd bd ff    ...
+    pha                                                               ; b7a2: 48          H
+    inx                                                               ; b7a3: e8          .
+    bmi loop_cb79f                                                    ; b7a4: 30 f9       0.
+    ldx #$0f                                                          ; b7a6: a2 0f       ..
+    stx l10c8                                                         ; b7a8: 8e c8 10    ...
+; $b7ab referenced 1 time by $b7bf
+loop_cb7ab
+    ldx l10c8                                                         ; b7ab: ae c8 10    ...
+    tya                                                               ; b7ae: 98          .
+    beq cb7b6                                                         ; b7af: f0 05       ..
+    cmp l10a8,x                                                       ; b7b1: dd a8 10    ...
+    bne cb7bc                                                         ; b7b4: d0 06       ..
+; $b7b6 referenced 1 time by $b7af
+cb7b6
+    pha                                                               ; b7b6: 48          H
+    jsr sub_cb5fb                                                     ; b7b7: 20 fb b5     ..
+    pla                                                               ; b7ba: 68          h
+    tay                                                               ; b7bb: a8          .
+; $b7bc referenced 1 time by $b7b4
+cb7bc
+    dec l10c8                                                         ; b7bc: ce c8 10    ...
+    bpl loop_cb7ab                                                    ; b7bf: 10 ea       ..
+    ldx #8                                                            ; b7c1: a2 08       ..
+; $b7c3 referenced 1 time by $b7c7
+loop_cb7c3
+    pla                                                               ; b7c3: 68          h
+    sta l00b4,x                                                       ; b7c4: 95 b4       ..
+    dex                                                               ; b7c6: ca          .
+    bpl loop_cb7c3                                                    ; b7c7: 10 fa       ..
+    pla                                                               ; b7c9: 68          h
+    tay                                                               ; b7ca: a8          .
+    pla                                                               ; b7cb: 68          h
+    tax                                                               ; b7cc: aa          .
+    rts                                                               ; b7cd: 60          `
+
+    !byte $8c, $c9, $10, $8a, $48, $20, $ec, $b4, $bd, $60, $10, $29  ; b7ce: 8c c9 10... ...
+    !byte $20, $f0, $10, $a9, $d4, $20, $d1, $96                      ; b7da: 20 f0 10...  ..
+    !text "Write only"                                                ; b7e2: 57 72 69... Wri
+    !byte   0, $b8, $20, $30, $b7, $f0, $35, $b9,   0, $10, $dd, $98  ; b7ec: 00 b8 20... ..
+    !byte $10, $90, $2d, $b9, $60, $10, $aa, $29, $40, $d0, $14, $8a  ; b7f8: 10 90 2d... ..-
+    !byte   9, $40, $99, $60, $10, $a9,   0, $20, $8f, $b9, $68, $aa  ; b804: 09 40 99... .@.
+    !byte $a9, $fe, $ac, $c9, $10, $38, $60, $a9, $df, $20, $d1, $96  ; b810: a9 fe ac... ...
+    !text "End of file"                                               ; b81c: 45 6e 64... End
+    !byte   0, $b9,   0, $10, $48, $98, $aa, $a9,   0, $20, $8f, $b9  ; b827: 00 b9 00... ...
+    !byte $20, $8b, $b7, $68, $a8, $ad, $c8, $10, $18, $69, $11, $85  ; b833: 20 8b b7...  ..
+    !byte $b3, $a9,   0, $85, $b2, $68, $aa, $b1, $b2, $ac, $c9, $10  ; b83f: b3 a9 00... ...
+    !byte $18, $60, $8c, $c9, $10, $48, $a8, $8a, $48, $98, $48, $8d  ; b84b: 18 60 8c... .`.
+    !byte $d7, $10, $20, $ec, $b4, $bd, $60, $10, $30, $19, $a9, $c1  ; b857: d7 10 20... ..
+    !byte $20, $d1, $96                                               ; b863: 20 d1 96     ..
+    !text "Not open for update"                                       ; b866: 4e 6f 74... Not
+    !byte   0, $29, $20, $f0, $0a, $bc, $30, $10                      ; b879: 00 29 20... .)
+    !text "h +"                                                       ; b881: 68 20 2b    h +
+    !byte $b9, $4c, $cb, $b8, $2c, $91, $94, $20, $30, $b7, $b9,   0  ; b884: b9 4c cb... .L.
+    !byte $10, $c9, $ff, $d0,   3, $20, $e4, $b8, $dd, $98, $10, $90  ; b890: 10 c9 ff... ...
+    !byte $0f, $69,   0, $9d, $98, $10, $d0,   8, $a9, $df, $3d, $b8  ; b89c: 0f 69 00... .i.
+    !byte $10, $9d, $b8, $10, $a9,   1, $1d, $b8, $10, $9d, $b8, $10  ; b8a8: 10 9d b8... ...
+    !byte $b9,   0, $10, $48, $98, $aa, $68, $a8, $ad, $c8, $10, $18  ; b8b4: b9 00 10... ...
+    !byte $69, $11, $85, $b3, $a9,   0, $85, $b2, $68, $91, $b2, $20  ; b8c0: 69 11 85... i..
+    !byte $8b, $b7, $a9,   0, $20, $8f, $b9, $68, $aa, $68, $ac, $c9  ; b8cc: 8b b7 a9... ...
+    !byte $10, $60                                                    ; b8d8: 10 60       .`
+
+; $b8da referenced 1 time by $b6c3
+sub_cb8da
+    pha                                                               ; b8da: 48          H
+    txa                                                               ; b8db: 8a          .
+    pha                                                               ; b8dc: 48          H
+    tya                                                               ; b8dd: 98          .
+    pha                                                               ; b8de: 48          H
+    lda l1030,y                                                       ; b8df: b9 30 10    .0.
+    bne cb8f3                                                         ; b8e2: d0 0f       ..
+    pha                                                               ; b8e4: 48          H
+    txa                                                               ; b8e5: 8a          .
+    pha                                                               ; b8e6: 48          H
+    tya                                                               ; b8e7: 98          .
+    pha                                                               ; b8e8: 48          H
+    lda l1030,y                                                       ; b8e9: b9 30 10    .0.
+    pha                                                               ; b8ec: 48          H
+    ldy #0                                                            ; b8ed: a0 00       ..
+    jsr sub_cb66a                                                     ; b8ef: 20 6a b6     j.
+    pla                                                               ; b8f2: 68          h
+; $b8f3 referenced 1 time by $b8e2
+cb8f3
+    sta l0f05                                                         ; b8f3: 8d 05 0f    ...
+    tax                                                               ; b8f6: aa          .
+    pla                                                               ; b8f7: 68          h
+    tay                                                               ; b8f8: a8          .
+    pha                                                               ; b8f9: 48          H
+    txa                                                               ; b8fa: 8a          .
+    pha                                                               ; b8fb: 48          H
+    ldx #0                                                            ; b8fc: a2 00       ..
+    stx l0f06                                                         ; b8fe: 8e 06 0f    ...
+    lda l1000,y                                                       ; b901: b9 00 10    ...
+    sta l0f07                                                         ; b904: 8d 07 0f    ...
+    lda l1010,y                                                       ; b907: b9 10 10    ...
+    sta l0f08                                                         ; b90a: 8d 08 0f    ...
+    lda l1020,y                                                       ; b90d: b9 20 10    . .
+    sta l0f09                                                         ; b910: 8d 09 0f    ...
+    ldy #$0d                                                          ; b913: a0 0d       ..
+    ldx #5                                                            ; b915: a2 05       ..
+    jsr c94ad                                                         ; b917: 20 ad 94     ..
+    pla                                                               ; b91a: 68          h
+    tay                                                               ; b91b: a8          .
+    lda l10d7                                                         ; b91c: ad d7 10    ...
+    jsr sub_cb92b                                                     ; b91f: 20 2b b9     +.
+    jsr sub_cb721                                                     ; b922: 20 21 b7     !.
+    pla                                                               ; b925: 68          h
+    tay                                                               ; b926: a8          .
+    pla                                                               ; b927: 68          h
+    tax                                                               ; b928: aa          .
+    pla                                                               ; b929: 68          h
+    rts                                                               ; b92a: 60          `
+
+; $b92b referenced 1 time by $b91f
+sub_cb92b
+    sty l0fde                                                         ; b92b: 8c de 0f    ...
+    sta l0fdf                                                         ; b92e: 8d df 0f    ...
+    tya                                                               ; b931: 98          .
+    pha                                                               ; b932: 48          H
+    txa                                                               ; b933: 8a          .
+    pha                                                               ; b934: 48          H
+    lda #$90                                                          ; b935: a9 90       ..
+    sta l0fdc                                                         ; b937: 8d dc 0f    ...
+    jsr sub_c9473                                                     ; b93a: 20 73 94     s.
+    lda #$dc                                                          ; b93d: a9 dc       ..
+    sta l00c4                                                         ; b93f: 85 c4       ..
+    lda #$e0                                                          ; b941: a9 e0       ..
+    sta l00c8                                                         ; b943: 85 c8       ..
+    lda #9                                                            ; b945: a9 09       ..
+    sta l0fdd                                                         ; b947: 8d dd 0f    ...
+    ldx #$c0                                                          ; b94a: a2 c0       ..
+    ldy #0                                                            ; b94c: a0 00       ..
+    lda l0fde                                                         ; b94e: ad de 0f    ...
+    jsr sub_cac24                                                     ; b951: 20 24 ac     $.
+    lda l0fdd                                                         ; b954: ad dd 0f    ...
+    beq cb974                                                         ; b957: f0 1b       ..
+    sta l0e09                                                         ; b959: 8d 09 0e    ...
+    ldx #0                                                            ; b95c: a2 00       ..
+; $b95e referenced 1 time by $b969
+loop_cb95e
+    lda l0fdc,x                                                       ; b95e: bd dc 0f    ...
+    sta l0100,x                                                       ; b961: 9d 00 01    ...
+    cmp #$0d                                                          ; b964: c9 0d       ..
+    beq cb96b                                                         ; b966: f0 03       ..
+    inx                                                               ; b968: e8          .
+    bne loop_cb95e                                                    ; b969: d0 f3       ..
+; $b96b referenced 1 time by $b966
+cb96b
+    lda #0                                                            ; b96b: a9 00       ..
+    sta l0100,x                                                       ; b96d: 9d 00 01    ...
+    dex                                                               ; b970: ca          .
+    jmp c96f0                                                         ; b971: 4c f0 96    L..
+
+; $b974 referenced 1 time by $b957
+cb974
+    ldx l10c9                                                         ; b974: ae c9 10    ...
+    lda l1040,x                                                       ; b977: bd 40 10    .@.
+    eor #1                                                            ; b97a: 49 01       I.
+    sta l1040,x                                                       ; b97c: 9d 40 10    .@.
+    pla                                                               ; b97f: 68          h
+    tax                                                               ; b980: aa          .
+    pla                                                               ; b981: 68          h
+    tay                                                               ; b982: a8          .
+    rts                                                               ; b983: 60          `
+
+; $b984 referenced 2 times by $b64f, $b6d6
+sub_cb984
+    jsr sub_c929b                                                     ; b984: 20 9b 92     ..
+    jmp c9edd                                                         ; b987: 4c dd 9e    L..
+
+; $b98a referenced 4 times by $96f0, $9703, $b642, $b6c9
+sub_cb98a
+    ldy #$0a                                                          ; b98a: a0 0a       ..
+    lda (l009c),y                                                     ; b98c: b1 9c       ..
+    rts                                                               ; b98e: 60          `
+
+; $b98f referenced 4 times by $8b6c, $9ccc, $b656, $b6da
+sub_cb98f
+    ldy #$0a                                                          ; b98f: a0 0a       ..
+    sta (l009c),y                                                     ; b991: 91 9c       ..
+    rts                                                               ; b993: 60          `
+
+sub_cb994
+    lda #0                                                            ; b994: a9 00       ..
+    tay                                                               ; b996: a8          .
+    jmp osfind                                                        ; b997: 4c ce ff    L..
+
+sub_cb99a
+    clv                                                               ; b99a: b8          .
+    bvc cb9a0                                                         ; b99b: 50 03       P.
+sub_cb99d
+    bit l9491                                                         ; b99d: 2c 91 94    ,..
+; $b9a0 referenced 1 time by $b99b
+cb9a0
+    jsr sub_cbc44                                                     ; b9a0: 20 44 bc     D.
+    ldy l00a8                                                         ; b9a3: a4 a8       ..
+    lda #0                                                            ; b9a5: a9 00       ..
+    sta l00ad                                                         ; b9a7: 85 ad       ..
+    php                                                               ; b9a9: 08          .
+; $b9aa referenced 3 times by $b9ca, $b9ea, $b9fd
+cb9aa
+    jsr osbget                                                        ; b9aa: 20 d7 ff     ..
+    bcc cb9b6                                                         ; b9ad: 90 07       ..
+    plp                                                               ; b9af: 28          (
+    jsr cbc3d                                                         ; b9b0: 20 3d bc     =.
+    jmp osnewl                                                        ; b9b3: 4c e7 ff    L..
+
+; $b9b6 referenced 1 time by $b9ad
+cb9b6
+    jsr sub_cb9ff                                                     ; b9b6: 20 ff b9     ..
+    plp                                                               ; b9b9: 28          (
+    php                                                               ; b9ba: 08          .
+    bvs cb9c5                                                         ; b9bb: 70 08       p.
+    cmp #$0d                                                          ; b9bd: c9 0d       ..
+    beq cb9cd                                                         ; b9bf: f0 0c       ..
+    cmp #$0a                                                          ; b9c1: c9 0a       ..
+    beq cb9cd                                                         ; b9c3: f0 08       ..
+; $b9c5 referenced 1 time by $b9bb
+cb9c5
+    sta l00ad                                                         ; b9c5: 85 ad       ..
+; $b9c7 referenced 1 time by $b9d8
+loop_cb9c7
+    jsr oswrch                                                        ; b9c7: 20 ee ff     ..
+    jmp cb9aa                                                         ; b9ca: 4c aa b9    L..
+
+; $b9cd referenced 2 times by $b9bf, $b9c3
+cb9cd
+    pha                                                               ; b9cd: 48          H
+    ldx l026a                                                         ; b9ce: ae 6a 02    .j.
+    beq cb9da                                                         ; b9d1: f0 07       ..
+    lda #0                                                            ; b9d3: a9 00       ..
+    sta l00ad                                                         ; b9d5: 85 ad       ..
+    pla                                                               ; b9d7: 68          h
+    bne loop_cb9c7                                                    ; b9d8: d0 ed       ..
+; $b9da referenced 1 time by $b9d1
+cb9da
+    lda l00ad                                                         ; b9da: a5 ad       ..
+    cmp #$0d                                                          ; b9dc: c9 0d       ..
+    beq cb9ed                                                         ; b9de: f0 0d       ..
+    cmp #$0a                                                          ; b9e0: c9 0a       ..
+    beq cb9f4                                                         ; b9e2: f0 10       ..
+    pla                                                               ; b9e4: 68          h
+    sta l00ad                                                         ; b9e5: 85 ad       ..
+; $b9e7 referenced 2 times by $b9f2, $b9f7
+cb9e7
+    jsr osnewl                                                        ; b9e7: 20 e7 ff     ..
+    jmp cb9aa                                                         ; b9ea: 4c aa b9    L..
+
+; $b9ed referenced 1 time by $b9de
+cb9ed
+    pla                                                               ; b9ed: 68          h
+    cmp #$0a                                                          ; b9ee: c9 0a       ..
+    beq cb9f9                                                         ; b9f0: f0 07       ..
+    bne cb9e7                                                         ; b9f2: d0 f3       ..
+; $b9f4 referenced 1 time by $b9e2
+cb9f4
+    pla                                                               ; b9f4: 68          h
+    cmp #$0d                                                          ; b9f5: c9 0d       ..
+    bne cb9e7                                                         ; b9f7: d0 ee       ..
+; $b9f9 referenced 1 time by $b9f0
+cb9f9
+    lda #0                                                            ; b9f9: a9 00       ..
+    sta l00ad                                                         ; b9fb: 85 ad       ..
+    beq cb9aa                                                         ; b9fd: f0 ab       ..
+; $b9ff referenced 2 times by $b9b6, $ba33
+sub_cb9ff
+    bit l00ff                                                         ; b9ff: 24 ff       $.
+    bmi cba04                                                         ; ba01: 30 01       0.
+    rts                                                               ; ba03: 60          `
+
+; $ba04 referenced 1 time by $ba01
+cba04
+    jsr cbc3d                                                         ; ba04: 20 3d bc     =.
+    jsr osnewl                                                        ; ba07: 20 e7 ff     ..
+    lda #osbyte_acknowledge_escape                                    ; ba0a: a9 7e       .~
+    jsr osbyte                                                        ; ba0c: 20 f4 ff     ..
+    lda #$11                                                          ; ba0f: a9 11       ..
+    jsr generate_error_inline2                                        ; ba11: 20 d4 96     ..
+    !text "Escape", 0                                                 ; ba14: 45 73 63... Esc
+
+sub_cba1b
+    jsr sub_cbc44                                                     ; ba1b: 20 44 bc     D.
+    ldx #$14                                                          ; ba1e: a2 14       ..
+    lda #0                                                            ; ba20: a9 00       ..
+; $ba22 referenced 1 time by $ba24
+loop_cba22
+    pha                                                               ; ba22: 48          H
+    dex                                                               ; ba23: ca          .
+    bpl loop_cba22                                                    ; ba24: 10 fc       ..
+    tsx                                                               ; ba26: ba          .
+    jsr sub_cbb77                                                     ; ba27: 20 77 bb     w.
+    lda (l00ae),y                                                     ; ba2a: b1 ae       ..
+    and #$f0                                                          ; ba2c: 29 f0       ).
+    beq cba33                                                         ; ba2e: f0 03       ..
+    jsr sub_cbadd                                                     ; ba30: 20 dd ba     ..
+; $ba33 referenced 2 times by $ba2e, $bad5
+cba33
+    jsr sub_cb9ff                                                     ; ba33: 20 ff b9     ..
+    lda #$ff                                                          ; ba36: a9 ff       ..
+    sta l00aa                                                         ; ba38: 85 aa       ..
+; $ba3a referenced 1 time by $ba49
+loop_cba3a
+    ldy l00a8                                                         ; ba3a: a4 a8       ..
+    jsr osbget                                                        ; ba3c: 20 d7 ff     ..
+    bcs cba4c                                                         ; ba3f: b0 0b       ..
+    inc l00aa                                                         ; ba41: e6 aa       ..
+    ldy l00aa                                                         ; ba43: a4 aa       ..
+    sta (l00ae),y                                                     ; ba45: 91 ae       ..
+    cpy #$0f                                                          ; ba47: c0 0f       ..
+    bne loop_cba3a                                                    ; ba49: d0 ef       ..
+    clc                                                               ; ba4b: 18          .
+; $ba4c referenced 1 time by $ba3f
+cba4c
+    php                                                               ; ba4c: 08          .
+    lda l00aa                                                         ; ba4d: a5 aa       ..
+    bpl cba5a                                                         ; ba4f: 10 09       ..
+    ldx #$15                                                          ; ba51: a2 15       ..
+; $ba53 referenced 2 times by $ba55, $bada
+cba53
+    pla                                                               ; ba53: 68          h
+    dex                                                               ; ba54: ca          .
+    bpl cba53                                                         ; ba55: 10 fc       ..
+    jmp cbc3d                                                         ; ba57: 4c 3d bc    L=.
+
+; $ba5a referenced 1 time by $ba4f
+cba5a
+    ldy #$10                                                          ; ba5a: a0 10       ..
+    lda (l00ae),y                                                     ; ba5c: b1 ae       ..
+    and #$f0                                                          ; ba5e: 29 f0       ).
+    bne cba65                                                         ; ba60: d0 03       ..
+    jsr sub_cbadd                                                     ; ba62: 20 dd ba     ..
+; $ba65 referenced 1 time by $ba60
+cba65
+    ldy #$13                                                          ; ba65: a0 13       ..
+; $ba67 referenced 1 time by $ba71
+loop_cba67
+    lda (l00ae),y                                                     ; ba67: b1 ae       ..
+    pha                                                               ; ba69: 48          H
+    jsr sub_c912f                                                     ; ba6a: 20 2f 91     /.
+    pla                                                               ; ba6d: 68          h
+    dey                                                               ; ba6e: 88          .
+    cpy #$0f                                                          ; ba6f: c0 0f       ..
+    bne loop_cba67                                                    ; ba71: d0 f4       ..
+    iny                                                               ; ba73: c8          .
+    clc                                                               ; ba74: 18          .
+    adc #$10                                                          ; ba75: 69 10       i.
+    php                                                               ; ba77: 08          .
+; $ba78 referenced 1 time by $ba83
+loop_cba78
+    plp                                                               ; ba78: 28          (
+    sta (l00ae),y                                                     ; ba79: 91 ae       ..
+    iny                                                               ; ba7b: c8          .
+    lda (l00ae),y                                                     ; ba7c: b1 ae       ..
+    adc #0                                                            ; ba7e: 69 00       i.
+    php                                                               ; ba80: 08          .
+    cpy #$14                                                          ; ba81: c0 14       ..
+    bne loop_cba78                                                    ; ba83: d0 f3       ..
+    plp                                                               ; ba85: 28          (
+    jsr print_inline_top_bit_clear                                    ; ba86: 20 45 91     E.
+    !text " : "                                                       ; ba89: 20 3a 20     :
+
+    ldy #0                                                            ; ba8c: a0 00       ..
+    ldx l00aa                                                         ; ba8e: a6 aa       ..
+; $ba90 referenced 1 time by $ba9b
+loop_cba90
+    lda (l00ae),y                                                     ; ba90: b1 ae       ..
+    jsr sub_cbb03                                                     ; ba92: 20 03 bb     ..
+; $ba95 referenced 1 time by $baa8
+loop_cba95
+    iny                                                               ; ba95: c8          .
+    cpy #$10                                                          ; ba96: c0 10       ..
+    beq cbaab                                                         ; ba98: f0 11       ..
+    dex                                                               ; ba9a: ca          .
+    bpl loop_cba90                                                    ; ba9b: 10 f3       ..
+    tya                                                               ; ba9d: 98          .
+    pha                                                               ; ba9e: 48          H
+    jsr print_inline_top_bit_clear                                    ; ba9f: 20 45 91     E.
+    !text "   "                                                       ; baa2: 20 20 20
+
+    nop                                                               ; baa5: ea          .
+    pla                                                               ; baa6: 68          h
+    tay                                                               ; baa7: a8          .
+    jmp loop_cba95                                                    ; baa8: 4c 95 ba    L..
+
+; $baab referenced 1 time by $ba98
+cbaab
+    dex                                                               ; baab: ca          .
+    jsr print_inline_top_bit_clear                                    ; baac: 20 45 91     E.
+    !text ": "                                                        ; baaf: 3a 20       :
+
+    ldy #0                                                            ; bab1: a0 00       ..
+    jsr sub_cbc86                                                     ; bab3: 20 86 bc     ..
+; $bab6 referenced 1 time by $bacd
+loop_cbab6
+    lda (l00ae),y                                                     ; bab6: b1 ae       ..
+    and #$7f                                                          ; bab8: 29 7f       ).
+    cmp #$20 ; ' '                                                    ; baba: c9 20       .
+    bcs cbac0                                                         ; babc: b0 02       ..
+; $babe referenced 1 time by $bac2
+loop_cbabe
+    lda #$2e ; '.'                                                    ; babe: a9 2e       ..
+; $bac0 referenced 1 time by $babc
+cbac0
+    cmp #$7f                                                          ; bac0: c9 7f       ..
+    beq loop_cbabe                                                    ; bac2: f0 fa       ..
+    jsr osasci                                                        ; bac4: 20 e3 ff     ..
+    iny                                                               ; bac7: c8          .
+    cpy #$10                                                          ; bac8: c0 10       ..
+    beq cbacf                                                         ; baca: f0 03       ..
+    dex                                                               ; bacc: ca          .
+    bpl loop_cbab6                                                    ; bacd: 10 e7       ..
+; $bacf referenced 1 time by $baca
+cbacf
+    jsr osnewl                                                        ; bacf: 20 e7 ff     ..
+    plp                                                               ; bad2: 28          (
+    bcs cbad8                                                         ; bad3: b0 03       ..
+    jmp cba33                                                         ; bad5: 4c 33 ba    L3.
+
+; $bad8 referenced 1 time by $bad3
+cbad8
+    ldx #$14                                                          ; bad8: a2 14       ..
+    jmp cba53                                                         ; bada: 4c 53 ba    LS.
+
+; $badd referenced 2 times by $ba30, $ba62
+sub_cbadd
+    lda (l00ae),y                                                     ; badd: b1 ae       ..
+    pha                                                               ; badf: 48          H
+    jsr print_inline_top_bit_clear                                    ; bae0: 20 45 91     E.
+    !text $0d, "Address  : "                                          ; bae3: 0d 41 64... .Ad
+
+    ldx #$0f                                                          ; baef: a2 0f       ..
+    pla                                                               ; baf1: 68          h
+; $baf2 referenced 1 time by $bafb
+loop_cbaf2
+    jsr sub_cbb03                                                     ; baf2: 20 03 bb     ..
+    sec                                                               ; baf5: 38          8
+    adc #0                                                            ; baf6: 69 00       i.
+    and #$0f                                                          ; baf8: 29 0f       ).
+    dex                                                               ; bafa: ca          .
+    bpl loop_cbaf2                                                    ; bafb: 10 f5       ..
+    jsr osnewl                                                        ; bafd: 20 e7 ff     ..
+    jmp osnewl                                                        ; bb00: 4c e7 ff    L..
+
+; $bb03 referenced 2 times by $ba92, $baf2
+sub_cbb03
+    pha                                                               ; bb03: 48          H
+    jsr sub_c912f                                                     ; bb04: 20 2f 91     /.
+    lda #$20 ; ' '                                                    ; bb07: a9 20       .
+    jsr osasci                                                        ; bb09: 20 e3 ff     ..
+    pla                                                               ; bb0c: 68          h
+    rts                                                               ; bb0d: 60          `
+
+; $bb0e referenced 2 times by $bb7e, $bc0a
+sub_cbb0e
+    tya                                                               ; bb0e: 98          .
+    tax                                                               ; bb0f: aa          .
+    lda #0                                                            ; bb10: a9 00       ..
+    tay                                                               ; bb12: a8          .
+; $bb13 referenced 1 time by $bb18
+loop_cbb13
+    sta (l00ae),y                                                     ; bb13: 91 ae       ..
+    iny                                                               ; bb15: c8          .
+    cpy #4                                                            ; bb16: c0 04       ..
+    bne loop_cbb13                                                    ; bb18: d0 f9       ..
+; $bb1a referenced 1 time by $bb61
+cbb1a
+    txa                                                               ; bb1a: 8a          .
+    inx                                                               ; bb1b: e8          .
+    tay                                                               ; bb1c: a8          .
+    lda (os_text_ptr),y                                               ; bb1d: b1 f2       ..
+    cmp #$0d                                                          ; bb1f: c9 0d       ..
+    beq cbb6f                                                         ; bb21: f0 4c       .L
+    cmp #$20 ; ' '                                                    ; bb23: c9 20       .
+    beq cbb6f                                                         ; bb25: f0 48       .H
+    cmp #$30 ; '0'                                                    ; bb27: c9 30       .0
+    bcc cbb68                                                         ; bb29: 90 3d       .=
+    cmp #$3a ; ':'                                                    ; bb2b: c9 3a       .:
+    bcc cbb39                                                         ; bb2d: 90 0a       ..
+    and #$5f ; '_'                                                    ; bb2f: 29 5f       )_
+    adc #$b8                                                          ; bb31: 69 b8       i.
+    bcs cbb68                                                         ; bb33: b0 33       .3
+    cmp #$fa                                                          ; bb35: c9 fa       ..
+    bcc cbb68                                                         ; bb37: 90 2f       ./
+; $bb39 referenced 1 time by $bb2d
+cbb39
+    and #$0f                                                          ; bb39: 29 0f       ).
+    pha                                                               ; bb3b: 48          H
+    txa                                                               ; bb3c: 8a          .
+    pha                                                               ; bb3d: 48          H
+    ldx #4                                                            ; bb3e: a2 04       ..
+; $bb40 referenced 1 time by $bb56
+loop_cbb40
+    ldy #0                                                            ; bb40: a0 00       ..
+    tya                                                               ; bb42: 98          .
+; $bb43 referenced 1 time by $bb4f
+loop_cbb43
+    pha                                                               ; bb43: 48          H
+    plp                                                               ; bb44: 28          (
+    lda (l00ae),y                                                     ; bb45: b1 ae       ..
+    rol                                                               ; bb47: 2a          *
+    sta (l00ae),y                                                     ; bb48: 91 ae       ..
+    php                                                               ; bb4a: 08          .
+    pla                                                               ; bb4b: 68          h
+    iny                                                               ; bb4c: c8          .
+    cpy #4                                                            ; bb4d: c0 04       ..
+    bne loop_cbb43                                                    ; bb4f: d0 f2       ..
+    pha                                                               ; bb51: 48          H
+    plp                                                               ; bb52: 28          (
+    bcs cbb64                                                         ; bb53: b0 0f       ..
+    dex                                                               ; bb55: ca          .
+    bne loop_cbb40                                                    ; bb56: d0 e8       ..
+    pla                                                               ; bb58: 68          h
+    tax                                                               ; bb59: aa          .
+    pla                                                               ; bb5a: 68          h
+    ldy #0                                                            ; bb5b: a0 00       ..
+    ora (l00ae),y                                                     ; bb5d: 11 ae       ..
+    sta (l00ae),y                                                     ; bb5f: 91 ae       ..
+    jmp cbb1a                                                         ; bb61: 4c 1a bb    L..
+
+; $bb64 referenced 1 time by $bb53
+cbb64
+    pla                                                               ; bb64: 68          h
+    pla                                                               ; bb65: 68          h
+    sec                                                               ; bb66: 38          8
+    rts                                                               ; bb67: 60          `
+
+; $bb68 referenced 3 times by $bb29, $bb33, $bb37
+cbb68
+    jsr cbc3d                                                         ; bb68: 20 3d bc     =.
+    jmp c9208                                                         ; bb6b: 4c 08 92    L..
+
+; $bb6e referenced 1 time by $bb73
+loop_cbb6e
+    iny                                                               ; bb6e: c8          .
+; $bb6f referenced 2 times by $bb21, $bb25
+cbb6f
+    lda (os_text_ptr),y                                               ; bb6f: b1 f2       ..
+    cmp #$20 ; ' '                                                    ; bb71: c9 20       .
+    beq loop_cbb6e                                                    ; bb73: f0 f9       ..
+    clc                                                               ; bb75: 18          .
+    rts                                                               ; bb76: 60          `
+
+; $bb77 referenced 1 time by $ba27
+sub_cbb77
+    inx                                                               ; bb77: e8          .
+    stx l00ae                                                         ; bb78: 86 ae       ..
+    ldx #1                                                            ; bb7a: a2 01       ..
+    stx l00af                                                         ; bb7c: 86 af       ..
+    jsr sub_cbb0e                                                     ; bb7e: 20 0e bb     ..
+    bcs cbba2                                                         ; bb81: b0 1f       ..
+    tya                                                               ; bb83: 98          .
+    pha                                                               ; bb84: 48          H
+    ldy l00a8                                                         ; bb85: a4 a8       ..
+    ldx #$aa                                                          ; bb87: a2 aa       ..
+    lda #2                                                            ; bb89: a9 02       ..
+    jsr osargs                                                        ; bb8b: 20 da ff     ..
+    ldy #3                                                            ; bb8e: a0 03       ..
+; $bb90 referenced 1 time by $bb98
+loop_cbb90
+    lda l00aa,y                                                       ; bb90: b9 aa 00    ...
+    cmp (l00ae),y                                                     ; bb93: d1 ae       ..
+    bne cbb9c                                                         ; bb95: d0 05       ..
+    dey                                                               ; bb97: 88          .
+    bpl loop_cbb90                                                    ; bb98: 10 f6       ..
+    bmi cbbbc                                                         ; bb9a: 30 20       0
+; $bb9c referenced 1 time by $bb95
+cbb9c
+    bcc cbba2                                                         ; bb9c: 90 04       ..
+    ldy #$ff                                                          ; bb9e: a0 ff       ..
+    bne cbbbc                                                         ; bba0: d0 1a       ..
+; $bba2 referenced 2 times by $bb81, $bb9c
+cbba2
+    jsr cbc3d                                                         ; bba2: 20 3d bc     =.
+    lda #$b7                                                          ; bba5: a9 b7       ..
+    jsr generate_error_inline2                                        ; bba7: 20 d4 96     ..
+    !text "Outside file", 0                                           ; bbaa: 4f 75 74... Out
+
+; $bbb7 referenced 1 time by $bbbf
+loop_cbbb7
+    lda (l00ae),y                                                     ; bbb7: b1 ae       ..
+    sta l00aa,y                                                       ; bbb9: 99 aa 00    ...
+; $bbbc referenced 2 times by $bb9a, $bba0
+cbbbc
+    iny                                                               ; bbbc: c8          .
+    cpy #4                                                            ; bbbd: c0 04       ..
+    bne loop_cbbb7                                                    ; bbbf: d0 f6       ..
+    ldx #$aa                                                          ; bbc1: a2 aa       ..
+    ldy l00a8                                                         ; bbc3: a4 a8       ..
+    lda #1                                                            ; bbc5: a9 01       ..
+    jsr osargs                                                        ; bbc7: 20 da ff     ..
+    pla                                                               ; bbca: 68          h
+    tay                                                               ; bbcb: a8          .
+    lda (os_text_ptr),y                                               ; bbcc: b1 f2       ..
+    cmp #$0d                                                          ; bbce: c9 0d       ..
+    bne cbc0a                                                         ; bbd0: d0 38       .8
+    ldy #1                                                            ; bbd2: a0 01       ..
+; $bbd4 referenced 1 time by $bbda
+loop_cbbd4
+    lda os_text_ptr,y                                                 ; bbd4: b9 f2 00    ...
+    sta (l00ae),y                                                     ; bbd7: 91 ae       ..
+    dey                                                               ; bbd9: 88          .
+    bpl loop_cbbd4                                                    ; bbda: 10 f8       ..
+    lda #osfile_read_catalogue_info                                   ; bbdc: a9 05       ..
+    ldx l00ae                                                         ; bbde: a6 ae       ..
+    ldy l00af                                                         ; bbe0: a4 af       ..
+    jsr osfile                                                        ; bbe2: 20 dd ff     ..
+    ldy #2                                                            ; bbe5: a0 02       ..
+; $bbe7 referenced 1 time by $bbf2
+loop_cbbe7
+    lda (l00ae),y                                                     ; bbe7: b1 ae       ..
+    dey                                                               ; bbe9: 88          .
+    dey                                                               ; bbea: 88          .
+    sta (l00ae),y                                                     ; bbeb: 91 ae       ..
+    iny                                                               ; bbed: c8          .
+    iny                                                               ; bbee: c8          .
+    iny                                                               ; bbef: c8          .
+    cpy #6                                                            ; bbf0: c0 06       ..
+    bne loop_cbbe7                                                    ; bbf2: d0 f3       ..
+    dey                                                               ; bbf4: 88          .
+    dey                                                               ; bbf5: 88          .
+; $bbf6 referenced 1 time by $bbfd
+loop_cbbf6
+    lda (l00ae),y                                                     ; bbf6: b1 ae       ..
+    cmp #$ff                                                          ; bbf8: c9 ff       ..
+    bne cbc1f                                                         ; bbfa: d0 23       .#
+    dey                                                               ; bbfc: 88          .
+    bne loop_cbbf6                                                    ; bbfd: d0 f7       ..
+    ldy #3                                                            ; bbff: a0 03       ..
+    lda #0                                                            ; bc01: a9 00       ..
+; $bc03 referenced 1 time by $bc06
+loop_cbc03
+    sta (l00ae),y                                                     ; bc03: 91 ae       ..
+    dey                                                               ; bc05: 88          .
+    bpl loop_cbc03                                                    ; bc06: 10 fb       ..
+    bmi cbc1f                                                         ; bc08: 30 15       0.
+; $bc0a referenced 1 time by $bbd0
+cbc0a
+    jsr sub_cbb0e                                                     ; bc0a: 20 0e bb     ..
+    bcc cbc1f                                                         ; bc0d: 90 10       ..
+    jsr cbc3d                                                         ; bc0f: 20 3d bc     =.
+    lda #$fc                                                          ; bc12: a9 fc       ..
+    jsr generate_error_inline                                         ; bc14: 20 b8 96     ..
+    !text "address", 0                                                ; bc17: 61 64 64... add
+
+; $bc1f referenced 3 times by $bbfa, $bc08, $bc0d
+cbc1f
+    ldy #0                                                            ; bc1f: a0 00       ..
+    ldx #4                                                            ; bc21: a2 04       ..
+    clc                                                               ; bc23: 18          .
+; $bc24 referenced 1 time by $bc2e
+loop_cbc24
+    lda (l00ae),y                                                     ; bc24: b1 ae       ..
+    adc l00aa,y                                                       ; bc26: 79 aa 00    y..
+    sta l00aa,y                                                       ; bc29: 99 aa 00    ...
+    iny                                                               ; bc2c: c8          .
+    dex                                                               ; bc2d: ca          .
+    bne loop_cbc24                                                    ; bc2e: d0 f4       ..
+    ldy #$14                                                          ; bc30: a0 14       ..
+    ldx #3                                                            ; bc32: a2 03       ..
+; $bc34 referenced 1 time by $bc3a
+loop_cbc34
+    dey                                                               ; bc34: 88          .
+    lda l00aa,x                                                       ; bc35: b5 aa       ..
+    sta (l00ae),y                                                     ; bc37: 91 ae       ..
+    dex                                                               ; bc39: ca          .
+    bpl loop_cbc34                                                    ; bc3a: 10 f8       ..
+    rts                                                               ; bc3c: 60          `
+
+; $bc3d referenced 6 times by $b9b0, $ba04, $ba57, $bb68, $bba2, $bc0f
+cbc3d
+    ldy l00a8                                                         ; bc3d: a4 a8       ..
+    lda #0                                                            ; bc3f: a9 00       ..
+    jmp osfind                                                        ; bc41: 4c ce ff    L..
+
+; $bc44 referenced 2 times by $b9a0, $ba1b
+sub_cbc44
+    php                                                               ; bc44: 08          .
+    tya                                                               ; bc45: 98          .
+    clc                                                               ; bc46: 18          .
+    adc os_text_ptr                                                   ; bc47: 65 f2       e.
+    pha                                                               ; bc49: 48          H
+    tax                                                               ; bc4a: aa          .
+    lda #0                                                            ; bc4b: a9 00       ..
+    adc l00f3                                                         ; bc4d: 65 f3       e.
+    pha                                                               ; bc4f: 48          H
+    tay                                                               ; bc50: a8          .
+    lda #$40 ; '@'                                                    ; bc51: a9 40       .@
+    jsr osfind                                                        ; bc53: 20 ce ff     ..
+    tay                                                               ; bc56: a8          .
+    sta l00a8                                                         ; bc57: 85 a8       ..
+    bne cbc6a                                                         ; bc59: d0 0f       ..
+    lda #$d6                                                          ; bc5b: a9 d6       ..
+    jsr generate_error_inline2                                        ; bc5d: 20 d4 96     ..
+    !text "Not found", 0                                              ; bc60: 4e 6f 74... Not
+
+; $bc6a referenced 1 time by $bc59
+cbc6a
+    pla                                                               ; bc6a: 68          h
+    sta l00f3                                                         ; bc6b: 85 f3       ..
+    pla                                                               ; bc6d: 68          h
+    sta os_text_ptr                                                   ; bc6e: 85 f2       ..
+    ldy #0                                                            ; bc70: a0 00       ..
+; $bc72 referenced 1 time by $bc7b
+loop_cbc72
+    iny                                                               ; bc72: c8          .
+    lda (os_text_ptr),y                                               ; bc73: b1 f2       ..
+    cmp #$0d                                                          ; bc75: c9 0d       ..
+    beq cbc84                                                         ; bc77: f0 0b       ..
+    cmp #$20 ; ' '                                                    ; bc79: c9 20       .
+    bne loop_cbc72                                                    ; bc7b: d0 f5       ..
+; $bc7d referenced 1 time by $bc82
+loop_cbc7d
+    iny                                                               ; bc7d: c8          .
+    lda (os_text_ptr),y                                               ; bc7e: b1 f2       ..
+    cmp #$20 ; ' '                                                    ; bc80: c9 20       .
+    beq loop_cbc7d                                                    ; bc82: f0 f9       ..
+; $bc84 referenced 1 time by $bc77
+cbc84
+    plp                                                               ; bc84: 28          (
+    rts                                                               ; bc85: 60          `
+
+; $bc86 referenced 2 times by $a8b0, $bab3
+sub_cbc86
+    jsr sub_cbc89                                                     ; bc86: 20 89 bc     ..
+; $bc89 referenced 1 time by $bc86
+sub_cbc89
+    jsr sub_cbc8c                                                     ; bc89: 20 8c bc     ..
+; $bc8c referenced 1 time by $bc89
+sub_cbc8c
+    inx                                                               ; bc8c: e8          .
+    inx                                                               ; bc8d: e8          .
+    inx                                                               ; bc8e: e8          .
+    inx                                                               ; bc8f: e8          .
+    rts                                                               ; bc90: 60          `
+
+    !byte $ff, $ff, $ff                                               ; bc91: ff ff ff    ...
+; $bc94 referenced 1 time by $bea4
+lbc94
+    !byte $37,   5, $96,   5, $f2,   5,   7,   6, $27,   6, $68,   6  ; bc94: 37 05 96... 7..
+    !byte $5e,   5, $2d,   5, $20,   5, $42,   5, $a9,   5, $d1,   5  ; bca0: 5e 05 2d... ^.-
+    !byte $86, $88, $96, $98, $18, $18, $82, $18, $20, $c5,   6, $a8  ; bcac: 86 88 96... ...
+    !byte $20, $c5,   6, $20, $d4, $ff, $4c, $9c,   5, $20, $c5,   6  ; bcb8: 20 c5 06...  ..
+    !byte $a8, $20, $d7, $ff, $4c, $3a,   5, $20, $e0, $ff, $6a, $20  ; bcc4: a8 20 d7... . .
+    !byte $95,   6, $2a, $4c, $9e,   5, $20, $c5,   6, $f0, $0b, $48  ; bcd0: 95 06 2a... ..*
+    !byte $20, $82,   5, $68, $20, $ce, $ff, $4c, $9e,   5, $20, $c5  ; bcdc: 20 82 05...  ..
+    !byte   6, $a8, $a9,   0, $20, $ce, $ff, $4c, $9c,   5, $20, $c5  ; bce8: 06 a8 a9... ...
+    !byte   6, $a8, $a2,   4, $20, $c5,   6, $95, $ff, $ca, $d0, $f8  ; bcf4: 06 a8 a2... ...
+    !byte $20, $c5,   6, $20, $da, $ff, $20, $95,   6, $a2,   3, $b5  ; bd00: 20 c5 06...  ..
+    !byte   0, $20, $95,   6, $ca, $10, $f8, $4c, $36,   0, $a2,   0  ; bd0c: 00 20 95... . .
+    !byte $a0,   0, $20, $c5,   6, $99,   0,   7, $c8, $f0,   4, $c9  ; bd18: a0 00 20... ..
+    !byte $0d, $d0, $f3, $a0,   7, $60, $20, $82,   5, $20, $f7, $ff  ; bd24: 0d d0 f3... ...
+    !byte $a9, $7f, $2c, $e2, $fe, $50, $fb, $8d, $e3, $fe, $4c, $36  ; bd30: a9 7f 2c... ..,
+    !byte   0, $a2, $10, $20, $c5,   6, $95,   1, $ca, $d0, $f8, $20  ; bd3c: 00 a2 10... ...
+    !byte $82,   5, $86,   0, $84,   1, $a0,   0, $20, $c5,   6, $20  ; bd48: 82 05 86... ...
+    !byte $dd, $ff, $20, $95,   6, $a2, $10, $b5,   1, $20, $95,   6  ; bd54: dd ff 20... ..
+    !byte $ca, $d0, $f8, $f0, $d5, $a2, $0d, $20, $c5,   6, $95, $ff  ; bd60: ca d0 f8... ...
+    !byte $ca, $d0, $f8, $20, $c5,   6, $a0,   0, $20, $d1, $ff, $48  ; bd6c: ca d0 f8... ...
+    !byte $a2, $0c, $b5,   0, $20, $95,   6, $ca, $10, $f8            ; bd78: a2 0c b5... ...
+    !text "hL:"                                                       ; bd82: 68 4c 3a    hL:
+    !byte   5, $20, $c5,   6, $aa, $20, $c5,   6, $20, $f4, $ff, $2c  ; bd85: 05 20 c5... . .
+    !byte $e2, $fe, $50                                               ; bd91: e2 fe 50    ..P
+; $bd94 referenced 1 time by $beaa
+lbd94
+    !byte $fb, $8e, $e3, $fe, $4c, $36,   0, $20, $c5,   6, $aa, $20  ; bd94: fb 8e e3... ...
+    !byte $c5,   6, $a8, $20, $c5,   6, $20, $f4, $ff, $49, $9d, $f0  ; bda0: c5 06 a8... ...
+    !byte $eb, $6a, $20, $95,   6, $2c, $e2, $fe, $50, $fb, $8c, $e3  ; bdac: eb 6a 20... .j
+    !byte $fe, $70, $d5, $20, $c5,   6, $a8, $2c, $e2, $fe, $10, $fb  ; bdb8: fe 70 d5... .p.
+    !byte $ae, $e3, $fe, $ca, $30, $0f, $2c, $e2, $fe, $10, $fb, $ad  ; bdc4: ae e3 fe... ...
+    !byte $e3, $fe, $9d, $28,   1, $ca, $10, $f2, $98, $a2, $28, $a0  ; bdd0: e3 fe 9d... ...
+    !byte   1, $20, $f1, $ff, $2c, $e2, $fe, $10, $fb, $ae, $e3, $fe  ; bddc: 01 20 f1... . .
+    !byte $ca, $30, $0e, $bc, $28,   1, $2c, $e2, $fe, $50, $fb, $8c  ; bde8: ca 30 0e... .0.
+    !byte $e3, $fe, $ca, $10, $f2, $4c, $36,   0, $a2,   4, $20, $c5  ; bdf4: e3 fe ca... ...
+    !byte   6, $95,   0, $ca, $10, $f8, $e8, $a0,   0, $8a, $20, $f1  ; be00: 06 95 00... ...
+    !byte $ff, $90,   5, $a9, $ff, $4c, $9e,   5, $a2,   0, $a9, $7f  ; be0c: ff 90 05... ...
+    !byte $20, $95,   6, $bd,   0,   7, $20, $95,   6, $e8, $c9, $0d  ; be18: 20 95 06...  ..
+    !byte $d0, $f5, $4c, $36,   0, $2c, $e2, $fe, $50, $fb, $8d, $e3  ; be24: d0 f5 4c... ..L
+    !byte $fe, $60, $2c, $e6, $fe, $50, $fb, $8d, $e7, $fe, $60, $a5  ; be30: fe 60 2c... .`,
+    !byte $ff                                                         ; be3c: ff          .
+    !text "8j0"                                                       ; be3d: 38 6a 30    8j0
+    !byte $0f, $48, $a9,   0, $20, $bc,   6, $98, $20, $bc,   6, $8a  ; be40: 0f 48 a9... .H.
+    !byte $20, $bc,   6, $68, $2c, $e0, $fe, $50, $fb, $8d, $e1, $fe  ; be4c: 20 bc 06...  ..
+    !byte $60, $2c, $e2, $fe, $10, $fb, $ad, $e3, $fe, $60            ; be58: 60 2c e2... `,.
+
+; $be62 referenced 1 time by $8a3d
+service_handler_tube_service_calls
+    cmp #$fe                                                          ; be62: c9 fe       ..
+    bcc cbec2                                                         ; be64: 90 5c       .\
+    bne cbe83                                                         ; be66: d0 1b       ..
+    cpy #0                                                            ; be68: c0 00       ..
+    beq cbec2                                                         ; be6a: f0 56       .V
+    ldx #6                                                            ; be6c: a2 06       ..
+    lda #osbyte_explode_chars                                         ; be6e: a9 14       ..
+    jsr osbyte                                                        ; be70: 20 f4 ff     ..
+; $be73 referenced 2 times by $be76, $be80
+cbe73
+    bit tube_host_r1_status                                           ; be73: 2c e0 fe    ,..
+    bpl cbe73                                                         ; be76: 10 fb       ..
+    lda tube_host_r1_data                                             ; be78: ad e1 fe    ...
+    beq cbec0                                                         ; be7b: f0 43       .C
+    jsr oswrch                                                        ; be7d: 20 ee ff     ..
+    jmp cbe73                                                         ; be80: 4c 73 be    Ls.
+
+; $be83 referenced 1 time by $be66
+cbe83
+    lda #$ad                                                          ; be83: a9 ad       ..
+    sta evntv                                                         ; be85: 8d 20 02    . .
+    lda #6                                                            ; be88: a9 06       ..
+    sta evntv+1                                                       ; be8a: 8d 21 02    .!.
+    lda #$16                                                          ; be8d: a9 16       ..
+    sta brkv                                                          ; be8f: 8d 02 02    ...
+    lda #0                                                            ; be92: a9 00       ..
+    sta brkv+1                                                        ; be94: 8d 03 02    ...
+    lda #$8e                                                          ; be97: a9 8e       ..
+    sta tube_host_r1_status                                           ; be99: 8d e0 fe    ...
+    ldy #0                                                            ; be9c: a0 00       ..
+; $be9e referenced 1 time by $beb1
+loop_cbe9e
+    lda lbf04,y                                                       ; be9e: b9 04 bf    ...
+    sta l0400,y                                                       ; bea1: 99 00 04    ...
+    lda lbc94,y                                                       ; bea4: b9 94 bc    ...
+    sta l0500,y                                                       ; bea7: 99 00 05    ...
+    lda lbd94,y                                                       ; beaa: b9 94 bd    ...
+    sta l0600,y                                                       ; bead: 99 00 06    ...
+    dey                                                               ; beb0: 88          .
+    bne loop_cbe9e                                                    ; beb1: d0 eb       ..
+    jsr sub_c0421                                                     ; beb3: 20 21 04     !.
+    ldx #$41 ; 'A'                                                    ; beb6: a2 41       .A
+; $beb8 referenced 1 time by $bebe
+loop_cbeb8
+    lda lbec3,x                                                       ; beb8: bd c3 be    ...
+    sta l0016,x                                                       ; bebb: 95 16       ..
+    dex                                                               ; bebd: ca          .
+    bpl loop_cbeb8                                                    ; bebe: 10 f8       ..
+; $bec0 referenced 1 time by $be7b
+cbec0
+    lda #0                                                            ; bec0: a9 00       ..
+; $bec2 referenced 2 times by $be64, $be6a
+cbec2
+    rts                                                               ; bec2: 60          `
+
+; $bec3 referenced 1 time by $beb8
+lbec3
+    !byte $a9, $ff, $20, $9e,   6, $ad, $e3, $fe, $a9,   0, $20, $95  ; bec3: a9 ff 20... ..
+    !byte   6, $a8, $b1, $fd, $20, $95,   6, $c8, $b1, $fd, $20, $95  ; becf: 06 a8 b1... ...
+    !byte   6, $aa, $d0, $f7, $a2, $ff, $9a, $58, $2c, $e0, $fe, $10  ; bedb: 06 aa d0... ...
+    !byte   6, $ad, $e1, $fe, $20, $ee, $ff, $2c, $e2, $fe, $10, $f0  ; bee7: 06 ad e1... ...
+    !byte $2c, $e0, $fe, $30, $f0, $ae, $e3, $fe, $86, $51, $6c,   0  ; bef3: 2c e0 fe... ,..
+    !byte   5,   0, $80,   0,   0                                     ; beff: 05 00 80... ...
+; $bf04 referenced 2 times by $be9e, $bea1
+lbf04
+; $bf04 referenced 2 times by $be9e, $bea1
+
+!pseudopc $0400 {
+; $bf04 referenced 2 times by $be9e, $bea1
+l0400
+    !byte $4c, $84,   4, $4c, $a7,   6                                ; bf04: 4c 84 04... L.. :0400[1]
+
+; $bf0a referenced 7 times by $844f, $8933, $893b, $a075, $a2ec, $bf97, $bfcf
+c0406
+    cmp #$80                                                          ; bf0a: c9 80       ..  :0406[1]
+    bcc c0435                                                         ; bf0c: 90 2b       .+  :0408[1]
+    cmp #$c0                                                          ; bf0e: c9 c0       ..  :040a[1]
+    bcs c0428                                                         ; bf10: b0 1a       ..  :040c[1]
+    ora #$40 ; '@'                                                    ; bf12: 09 40       .@  :040e[1]
+    cmp l0015                                                         ; bf14: c5 15       ..  :0410[1]
+    bne c0434                                                         ; bf16: d0 20       .   :0412[1]
+; $bf18 referenced 1 time by $0471
+sub_c0414
+    php                                                               ; bf18: 08          .   :0414[1]
+    sei                                                               ; bf19: 78          x   :0415[1]
+    lda #5                                                            ; bf1a: a9 05       ..  :0416[1]
+    jsr l069e                                                         ; bf1c: 20 9e 06     .. :0418[1]
+    lda l0015                                                         ; bf1f: a5 15       ..  :041b[1]
+    jsr l069e                                                         ; bf21: 20 9e 06     .. :041d[1]
+    plp                                                               ; bf24: 28          (   :0420[1]
+; $bf25 referenced 1 time by $beb3
+sub_c0421
+    lda #$80                                                          ; bf25: a9 80       ..  :0421[1]
+    sta l0015                                                         ; bf27: 85 15       ..  :0423[1]
+    sta l0014                                                         ; bf29: 85 14       ..  :0425[1]
+    rts                                                               ; bf2b: 60          `   :0427[1]
+
+; $bf2c referenced 1 time by $040c
+c0428
+    asl l0014                                                         ; bf2c: 06 14       ..  :0428[1]
+    bcs c0432                                                         ; bf2e: b0 06       ..  :042a[1]
+    cmp l0015                                                         ; bf30: c5 15       ..  :042c[1]
+    beq c0434                                                         ; bf32: f0 04       ..  :042e[1]
+    clc                                                               ; bf34: 18          .   :0430[1]
+    rts                                                               ; bf35: 60          `   :0431[1]
+
+; $bf36 referenced 1 time by $042a
+c0432
+    sta l0015                                                         ; bf36: 85 15       ..  :0432[1]
+; $bf38 referenced 2 times by $0412, $042e
+c0434
+    rts                                                               ; bf38: 60          `   :0434[1]
+
+; $bf39 referenced 1 time by $0408
+c0435
+    php                                                               ; bf39: 08          .   :0435[1]
+    sei                                                               ; bf3a: 78          x   :0436[1]
+    sty l0013                                                         ; bf3b: 84 13       ..  :0437[1]
+    stx l0012                                                         ; bf3d: 86 12       ..  :0439[1]
+    jsr l069e                                                         ; bf3f: 20 9e 06     .. :043b[1]
+    tax                                                               ; bf42: aa          .   :043e[1]
+    ldy #3                                                            ; bf43: a0 03       ..  :043f[1]
+    lda l0015                                                         ; bf45: a5 15       ..  :0441[1]
+    jsr l069e                                                         ; bf47: 20 9e 06     .. :0443[1]
+; $bf4a referenced 1 time by $044c
+loop_c0446
+    lda (l0012),y                                                     ; bf4a: b1 12       ..  :0446[1]
+    jsr l069e                                                         ; bf4c: 20 9e 06     .. :0448[1]
+    dey                                                               ; bf4f: 88          .   :044b[1]
+    bpl loop_c0446                                                    ; bf50: 10 f8       ..  :044c[1]
+    ldy #$18                                                          ; bf52: a0 18       ..  :044e[1]
+    sty tube_host_r1_status                                           ; bf54: 8c e0 fe    ... :0450[1]
+    lda l0518,x                                                       ; bf57: bd 18 05    ... :0453[1]
+    sta tube_host_r1_status                                           ; bf5a: 8d e0 fe    ... :0456[1]
+    lsr                                                               ; bf5d: 4a          J   :0459[1]
+    lsr                                                               ; bf5e: 4a          J   :045a[1]
+    bcc c0463                                                         ; bf5f: 90 06       ..  :045b[1]
+    bit tube_host_r3_data                                             ; bf61: 2c e5 fe    ,.. :045d[1]
+    bit tube_host_r3_data                                             ; bf64: 2c e5 fe    ,.. :0460[1]
+; $bf67 referenced 1 time by $045b
+c0463
+    jsr l069e                                                         ; bf67: 20 9e 06     .. :0463[1]
+; $bf6a referenced 1 time by $0469
+loop_c0466
+    bit tube_host_r4_status                                           ; bf6a: 2c e6 fe    ,.. :0466[1]
+    bvc loop_c0466                                                    ; bf6d: 50 fb       P.  :0469[1]
+    bcs c047a                                                         ; bf6f: b0 0d       ..  :046b[1]
+    cpx #4                                                            ; bf71: e0 04       ..  :046d[1]
+    bne c0482                                                         ; bf73: d0 11       ..  :046f[1]
+    jsr sub_c0414                                                     ; bf75: 20 14 04     .. :0471[1]
+    jsr l0695                                                         ; bf78: 20 95 06     .. :0474[1]
+    jmp l0032                                                         ; bf7b: 4c 32 00    L2. :0477[1]
+
+; $bf7e referenced 1 time by $046b
+c047a
+    lsr                                                               ; bf7e: 4a          J   :047a[1]
+    bcc c0482                                                         ; bf7f: 90 05       ..  :047b[1]
+    ldy #$88                                                          ; bf81: a0 88       ..  :047d[1]
+    sty tube_host_r1_status                                           ; bf83: 8c e0 fe    ... :047f[1]
+; $bf86 referenced 2 times by $046f, $047b
+c0482
+    plp                                                               ; bf86: 28          (   :0482[1]
+    rts                                                               ; bf87: 60          `   :0483[1]
+
+    !byte $58, $b0, $0a, $d0,   3, $4c, $9c,   5, $ae, $8d,   2, $f0  ; bf88: 58 b0 0a... X.. :0484[1]
+    !byte $e0                                                         ; bf94: e0          .   :0490[1]
+; $bf95 referenced 1 time by $bf9a
+}
+
+; $bf95 referenced 1 time by $bf9a
+loop_cbf95
+; $bf95 referenced 1 time by $bf9a
+    lda #$ff                                                          ; bf95: a9 ff       ..
+    jsr c0406                                                         ; bf97: 20 06 04     ..
+    bcc loop_cbf95                                                    ; bf9a: 90 f9       ..
+    jsr l04ce                                                         ; bf9c: 20 ce 04     ..
+; $bf9f referenced 1 time by $bfc4
+cbf9f
+    php                                                               ; bf9f: 08          .
+    sei                                                               ; bfa0: 78          x
+    lda #7                                                            ; bfa1: a9 07       ..
+    jsr l04c7                                                         ; bfa3: 20 c7 04     ..
+    ldy #0                                                            ; bfa6: a0 00       ..
+    sty l0000                                                         ; bfa8: 84 00       ..
+; $bfaa referenced 1 time by $bfb3
+loop_cbfaa
+    lda (l0000),y                                                     ; bfaa: b1 00       ..
+    sta tube_host_r3_data                                             ; bfac: 8d e5 fe    ...
+    nop                                                               ; bfaf: ea          .
+    nop                                                               ; bfb0: ea          .
+    nop                                                               ; bfb1: ea          .
+    iny                                                               ; bfb2: c8          .
+    bne loop_cbfaa                                                    ; bfb3: d0 f5       ..
+    plp                                                               ; bfb5: 28          (
+    inc l0054                                                         ; bfb6: e6 54       .T
+    bne cbfc0                                                         ; bfb8: d0 06       ..
+    inc l0055                                                         ; bfba: e6 55       .U
+    bne cbfc0                                                         ; bfbc: d0 02       ..
+    inc l0056                                                         ; bfbe: e6 56       .V
+; $bfc0 referenced 2 times by $bfb8, $bfbc
+cbfc0
+    inc l0001                                                         ; bfc0: e6 01       ..
+    bit l0001                                                         ; bfc2: 24 01       $.
+    bvc cbf9f                                                         ; bfc4: 50 d9       P.
+    jsr l04ce                                                         ; bfc6: 20 ce 04     ..
+    lda #4                                                            ; bfc9: a9 04       ..
+    ldy #0                                                            ; bfcb: a0 00       ..
+    ldx #$53 ; 'S'                                                    ; bfcd: a2 53       .S
+    jmp c0406                                                         ; bfcf: 4c 06 04    L..
+
+    lda #$80                                                          ; bfd2: a9 80       ..
+    sta l0054                                                         ; bfd4: 85 54       .T
+    sta l0001                                                         ; bfd6: 85 01       ..
+    lda #$20 ; ' '                                                    ; bfd8: a9 20       .
+    and rom_type                                                      ; bfda: 2d 06 80    -..
+    tay                                                               ; bfdd: a8          .
+    sty l0053                                                         ; bfde: 84 53       .S
+    beq cbffb                                                         ; bfe0: f0 19       ..
+    ldx copyright_offset                                              ; bfe2: ae 07 80    ...
+; $bfe5 referenced 1 time by $bfe9
+loop_cbfe5
+    inx                                                               ; bfe5: e8          .
+    lda rom_header,x                                                  ; bfe6: bd 00 80    ...
+    bne loop_cbfe5                                                    ; bfe9: d0 fa       ..
+    lda l8001,x                                                       ; bfeb: bd 01 80    ...
+    sta l0053                                                         ; bfee: 85 53       .S
+    lda l8002,x                                                       ; bff0: bd 02 80    ...
+    sta l0054                                                         ; bff3: 85 54       .T
+    ldy service_entry,x                                               ; bff5: bc 03 80    ...
+    lda l8004,x                                                       ; bff8: bd 04 80    ...
+; $bffb referenced 1 time by $bfe0
+cbffb
+    sta l0056                                                         ; bffb: 85 56       .V
+    sty l0055                                                         ; bffd: 84 55       .U
+    rts                                                               ; bfff: 60          `
+
+pydis_end
+
+; Label references by decreasing frequency:
+;     l009e:                                64
+;     l0f05:                                48
+;     l009c:                                42
+;     l00ae:                                38
+;     l009a:                                35
+;     print_inline_top_bit_clear:           35
+;     l00be:                                33
+;     l00bb:                                31
+;     l1071:                                30
+;     l00b2:                                28
+;     l00b4:                                25
+;     osbyte:                               23
+;     osasci:                               22
+;     l00b8:                                21
+;     l00a8:                                20
+;     l00aa:                                20
+;     l00ac:                                20
+;     l0101:                                20
+;     l9491:                                19
+;     l10b8:                                18
+;     osnewl:                               18
+;     l00b0:                                17
+;     l0e30:                                17
+;     l00b5:                                16
+;     os_text_ptr:                          15
+;     c94ad:                                15
+;     l0f06:                                14
+;     l009b:                                13
+;     l00a0:                                13
+;     l00a6:                                13
+;     l0d6c:                                13
+;     l00a9:                                12
+;     l10c8:                                12
+;     la3f0:                                12
+;     l0098:                                11
+;     l00b6:                                11
+;     l0100:                                11
+;     l1030:                                11
+;     generate_error_inline:                11
+;     lfea1:                                11
+;     l00ad:                                10
+;     l0d61:                                10
+;     l0d6a:                                10
+;     l1060:                                10
+;     l00b3:                                 9
+;     l0f03:                                 9
+;     l1000:                                 9
+;     sub_caf04:                             9
+;     sub_caf32:                             9
+;     lfe18:                                 9
+;     l00af:                                 8
+;     l00c8:                                 8
+;     romsel_copy:                           8
+;     l97b9:                                 8
+;     l009d:                                 7
+;     l00bc:                                 7
+;     l00c0:                                 7
+;     l00c4:                                 7
+;     l0d68:                                 7
+;     l0df0:                                 7
+;     l0e01:                                 7
+;     generate_error_inline3:                7
+;     sub_cafb5:                             7
+;     cbf0a:                                 7
+;     lfea0:                                 7
+;     l0015:                                 6
+;     l009f:                                 6
+;     l00cc:                                 6
+;     l00d0:                                 6
+;     l00f3:                                 6
+;     l069e:                                 6
+;     l0d3e:                                 6
+;     l0d60:                                 6
+;     l0e00:                                 6
+;     l0f02:                                 6
+;     l10c9:                                 6
+;     l10d8:                                 6
+;     c9211:                                 6
+;     sta_e09_if_d6c_b7_set:                 6
+;     c9cc7:                                 6
+;     sub_cb586:                             6
+;     cbc3d:                                 6
+;     l00b9:                                 5
+;     l00ba:                                 5
+;     l00bf:                                 5
+;     l0d6b:                                 5
+;     l0e05:                                 5
+;     l0e07:                                 5
+;     l1010:                                 5
+;     l1040:                                 5
+;     l10cf:                                 5
+;     l10d4:                                 5
+;     l10d5:                                 5
+;     jump_table_dispatch_x_plus_y:          5
+;     sub_c916e:                             5
+;     sub_c95dd:                             5
+;     l97ad:                                 5
+;     sub_c983f:                             5
+;     sub_ca140:                             5
+;     caeb7:                                 5
+;     sub_caf02:                             5
+;     sub_cb509:                             5
+;     tube_host_r1_status:                   5
+;     l0099:                                 4
+;     l00b7:                                 4
+;     l00c1:                                 4
+;     l0d62:                                 4
+;     l0d71:                                 4
+;     l0e03:                                 4
+;     l0e09:                                 4
+;     l0f07:                                 4
+;     l0f08:                                 4
+;     l1020:                                 4
+;     l1098:                                 4
+;     l10a8:                                 4
+;     sub_c8cb9:                             4
+;     c8dd2:                                 4
+;     sub_c912f:                             4
+;     c9215:                                 4
+;     sub_c9473:                             4
+;     generate_error_inline2:                4
+;     c96f0:                                 4
+;     sub_cae94:                             4
+;     sub_cb0ea:                             4
+;     sub_cb198:                             4
+;     cb236:                                 4
+;     cb55f:                                 4
+;     cb59b:                                 4
+;     sub_cb98a:                             4
+;     sub_cb98f:                             4
+;     video_ula_control:                     4
+;     gsinit:                                4
+;     gsread:                                4
+;     osfind:                                4
+;     oswrch:                                4
+;     l0001:                                 3
+;     l0054:                                 3
+;     l00a1:                                 3
+;     l00b1:                                 3
+;     l00bd:                                 3
+;     l00f0:                                 3
+;     l0102:                                 3
+;     l0355:                                 3
+;     l0d0c:                                 3
+;     l0d0d:                                 3
+;     l0d3f:                                 3
+;     l0d40:                                 3
+;     l0d63:                                 3
+;     l0d69:                                 3
+;     l0e02:                                 3
+;     l0e04:                                 3
+;     l0e0a:                                 3
+;     l0e31:                                 3
+;     l0f00:                                 3
+;     l0f09:                                 3
+;     l0fc8:                                 3
+;     l1078:                                 3
+;     l1088:                                 3
+;     l10ca:                                 3
+;     l10cc:                                 3
+;     l10d0:                                 3
+;     l10f3:                                 3
+;     c85fb:                                 3
+;     c862f:                                 3
+;     c8a98:                                 3
+;     sub_c8aa0:                             3
+;     sub_c8b02:                             3
+;     c8c70:                                 3
+;     just_rts:                              3
+;     sub_c8e83:                             3
+;     c8f8c:                                 3
+;     c9208:                                 3
+;     sub_c9258:                             3
+;     c92fa:                                 3
+;     c9311:                                 3
+;     c95f4:                                 3
+;     c98c9:                                 3
+;     sub_ca0a7:                             3
+;     ca25d:                                 3
+;     sub_ca32b:                             3
+;     ca38e:                                 3
+;     la3f1:                                 3
+;     la3f2:                                 3
+;     cab36:                                 3
+;     sub_cac24:                             3
+;     cacdd:                                 3
+;     sub_cae82:                             3
+;     sub_cae97:                             3
+;     caeda:                                 3
+;     sub_caf06:                             3
+;     caf88:                                 3
+;     cb058:                                 3
+;     cb153:                                 3
+;     cb2d4:                                 3
+;     sub_cb559:                             3
+;     sub_cb799:                             3
+;     cb9aa:                                 3
+;     cbb68:                                 3
+;     cbc1f:                                 3
+;     tube_host_r3_data:                     3
+;     l0000:                                 2
+;     l0012:                                 2
+;     l0014:                                 2
+;     l0053:                                 2
+;     l0055:                                 2
+;     l0056:                                 2
+;     l00a5:                                 2
+;     l00a7:                                 2
+;     l00ab:                                 2
+;     l00ef:                                 2
+;     osrdsc_ptr:                            2
+;     l00ff:                                 2
+;     evntv:                                 2
+;     l028d:                                 2
+;     l04ce:                                 2
+;     l0d1e:                                 2
+;     l0d20:                                 2
+;     l0d21:                                 2
+;     l0d22:                                 2
+;     l0d24:                                 2
+;     l0d25:                                 2
+;     l0d65:                                 2
+;     l0d6d:                                 2
+;     l0dfe:                                 2
+;     l0e06:                                 2
+;     l0e08:                                 2
+;     l0e2f:                                 2
+;     l0e38:                                 2
+;     l0f04:                                 2
+;     l0f10:                                 2
+;     l0f11:                                 2
+;     l0f12:                                 2
+;     l0fdc:                                 2
+;     l0fdd:                                 2
+;     l0fde:                                 2
+;     l10d9:                                 2
+;     c83fb:                                 2
+;     sub_c858c:                             2
+;     c8641:                                 2
+;     c8945:                                 2
+;     sub_c8969:                             2
+;     c8978:                                 2
+;     c8988:                                 2
+;     c8a38:                                 2
+;     service_handler_common2:               2
+;     c8aba:                                 2
+;     c8b0c:                                 2
+;     c8b98:                                 2
+;     c8bab:                                 2
+;     c8be0:                                 2
+;     sub_c8c33:                             2
+;     c8c4d:                                 2
+;     sub_c8c9f:                             2
+;     sub_c8cc0:                             2
+;     c8d37:                                 2
+;     l8d38:                                 2
+;     c8dbc:                                 2
+;     c8e24:                                 2
+;     l8e54:                                 2
+;     c8eab:                                 2
+;     c8f70:                                 2
+;     sub_c8fcb:                             2
+;     c8fe4:                                 2
+;     c8ff1:                                 2
+;     c91ae:                                 2
+;     c91da:                                 2
+;     c91fb:                                 2
+;     c9229:                                 2
+;     c9235:                                 2
+;     c9266:                                 2
+;     sub_c9269:                             2
+;     sub_c9273:                             2
+;     sub_c9295:                             2
+;     sub_c92a4:                             2
+;     sub_c9309:                             2
+;     c9322:                                 2
+;     sub_c9327:                             2
+;     sub_c9349:                             2
+;     c9363:                                 2
+;     c93bc:                                 2
+;     sub_c949b:                             2
+;     c94ae:                                 2
+;     c94d9:                                 2
+;     sub_c94f0:                             2
+;     c9504:                                 2
+;     c9551:                                 2
+;     sub_c9570:                             2
+;     c9589:                                 2
+;     c964e:                                 2
+;     c9740:                                 2
+;     sub_c974d:                             2
+;     sub_c9771:                             2
+;     sub_c977c:                             2
+;     sub_c978d:                             2
+;     sub_c9837:                             2
+;     c986b:                                 2
+;     c987e:                                 2
+;     l9888:                                 2
+;     c98eb:                                 2
+;     c9926:                                 2
+;     sub_c9998:                             2
+;     sub_c9a62:                             2
+;     c9a64:                                 2
+;     sub_c9a72:                             2
+;     sub_c9a7f:                             2
+;     sub_c9a84:                             2
+;     sub_c9a92:                             2
+;     c9a96:                                 2
+;     sub_c9a9a:                             2
+;     c9b35:                                 2
+;     sub_c9b95:                             2
+;     c9ba8:                                 2
+;     c9cc9:                                 2
+;     c9dbb:                                 2
+;     c9e09:                                 2
+;     ca073:                                 2
+;     sub_ca0cc:                             2
+;     sub_ca0ce:                             2
+;     ca0f7:                                 2
+;     ca133:                                 2
+;     ca159:                                 2
+;     ca1a2:                                 2
+;     ca1b7:                                 2
+;     ca2ef:                                 2
+;     ca303:                                 2
+;     ca32e:                                 2
+;     sub_ca362:                             2
+;     ca365:                                 2
+;     ca38b:                                 2
+;     ca3e3:                                 2
+;     ca522:                                 2
+;     sub_ca865:                             2
+;     ca889:                                 2
+;     ca8c4:                                 2
+;     caaa9:                                 2
+;     caae2:                                 2
+;     sub_cab12:                             2
+;     cac30:                                 2
+;     cac4a:                                 2
+;     cae84:                                 2
+;     caed8:                                 2
+;     caedf:                                 2
+;     caf5a:                                 2
+;     sub_caf96:                             2
+;     sub_cafc1:                             2
+;     cafcd:                                 2
+;     sub_cafd5:                             2
+;     sub_cafe0:                             2
+;     cb091:                                 2
+;     sub_cb0cf:                             2
+;     sub_cb0f6:                             2
+;     cb144:                                 2
+;     sub_cb15e:                             2
+;     sub_cb16d:                             2
+;     sub_cb2f7:                             2
+;     cb305:                                 2
+;     cb32c:                                 2
+;     cb336:                                 2
+;     sub_cb431:                             2
+;     lb487:                                 2
+;     cb577:                                 2
+;     sub_cb595:                             2
+;     cb5b7:                                 2
+;     sub_cb5d8:                             2
+;     sub_cb5fb:                             2
+;     sub_cb66a:                             2
+;     cb682:                                 2
+;     cb718:                                 2
+;     cb732:                                 2
+;     cb735:                                 2
+;     sub_cb984:                             2
+;     cb9cd:                                 2
+;     cb9e7:                                 2
+;     sub_cb9ff:                             2
+;     cba33:                                 2
+;     cba53:                                 2
+;     sub_cbadd:                             2
+;     sub_cbb03:                             2
+;     sub_cbb0e:                             2
+;     cbb6f:                                 2
+;     cbba2:                                 2
+;     cbbbc:                                 2
+;     sub_cbc44:                             2
+;     sub_cbc86:                             2
+;     cbe73:                                 2
+;     cbec2:                                 2
+;     lbf04:                                 2
+;     cbf38:                                 2
+;     cbf86:                                 2
+;     cbfc0:                                 2
+;     romsel:                                2
+;     system_via_acr:                        2
+;     system_via_ifr:                        2
+;     osbget:                                2
+;     osargs:                                2
+;     osrdch:                                2
+;     osword:                                2
+;     l0013:                                 1
+;     l0016:                                 1
+;     l0032:                                 1
+;     l0063:                                 1
+;     l0078:                                 1
+;     l00a2:                                 1
+;     l00a3:                                 1
+;     l00a4:                                 1
+;     l00c2:                                 1
+;     l00c7:                                 1
+;     l00cd:                                 1
+;     l00ed:                                 1
+;     l00f7:                                 1
+;     l00fd:                                 1
+;     l0103:                                 1
+;     l0104:                                 1
+;     brkv:                                  1
+;     brkv+1:                                1
+;     filev:                                 1
+;     fscv:                                  1
+;     evntv+1:                               1
+;     netv:                                  1
+;     l026a:                                 1
+;     l02a0:                                 1
+;     l0350:                                 1
+;     l0351:                                 1
+;     l04c7:                                 1
+;     l0500:                                 1
+;     l0518:                                 1
+;     l0600:                                 1
+;     l0695:                                 1
+;     l0cff:                                 1
+;     l0d07:                                 1
+;     l0d0e:                                 1
+;     l0d11:                                 1
+;     l0d1a:                                 1
+;     l0d23:                                 1
+;     l0d26:                                 1
+;     l0d41:                                 1
+;     l0d64:                                 1
+;     l0d6e:                                 1
+;     l0d6f:                                 1
+;     l0e0b:                                 1
+;     l0e14:                                 1
+;     l0e32:                                 1
+;     l0ef7:                                 1
+;     l0f01:                                 1
+;     l0f0a:                                 1
+;     l0f0b:                                 1
+;     l0f0c:                                 1
+;     l0f0d:                                 1
+;     l0f0e:                                 1
+;     l0f13:                                 1
+;     l0f14:                                 1
+;     l0f2f:                                 1
+;     l0f30:                                 1
+;     l0fdf:                                 1
+;     l0fe0:                                 1
+;     l0ff0:                                 1
+;     l0fff:                                 1
+;     l1050:                                 1
+;     l1070:                                 1
+;     l1072:                                 1
+;     l1073:                                 1
+;     l1074:                                 1
+;     l10cb:                                 1
+;     l10cd:                                 1
+;     l10ce:                                 1
+;     l10d1:                                 1
+;     l10d6:                                 1
+;     l10d7:                                 1
+;     rom_header:                            1
+;     l8001:                                 1
+;     l8002:                                 1
+;     service_entry:                         1
+;     l8004:                                 1
+;     rom_type:                              1
+;     copyright_offset:                      1
+;     c8032:                                 1
+;     sub_c805a:                             1
+;     c805d:                                 1
+;     c806c:                                 1
+;     sub_c8074:                             1
+;     loop_c8096:                            1
+;     c80bd:                                 1
+;     c80be:                                 1
+;     c80d6:                                 1
+;     c80e9:                                 1
+;     c80fd:                                 1
+;     c810a:                                 1
+;     c83f8:                                 1
+;     sub_c8449:                             1
+;     c8452:                                 1
+;     l84bb:                                 1
+;     c8585:                                 1
+;     c85a4:                                 1
+;     loop_c85b8:                            1
+;     c85cf:                                 1
+;     loop_c85d9:                            1
+;     c85e3:                                 1
+;     l8600:                                 1
+;     c8619:                                 1
+;     c8633:                                 1
+;     c863f:                                 1
+;     c864d:                                 1
+;     c8693:                                 1
+;     loop_c869a:                            1
+;     c86ac:                                 1
+;     loop_c86c2:                            1
+;     c86ce:                                 1
+;     c86d5:                                 1
+;     c86d8:                                 1
+;     c86e3:                                 1
+;     l8861:                                 1
+;     l8869:                                 1
+;     sub_c88f2:                             1
+;     c8901:                                 1
+;     loop_c8912:                            1
+;     c8942:                                 1
+;     c89a4:                                 1
+;     l89a6:                                 1
+;     jump_table_low:                        1
+;     jump_table_high:                       1
+;     service_handler:                       1
+;     c8a33:                                 1
+;     service_handler_common1:               1
+;     c8a53:                                 1
+;     c8a62:                                 1
+;     c8a6f:                                 1
+;     c8a71:                                 1
+;     service_handler_not_vectors_changed:   1
+;     c8acb:                                 1
+;     c8ad1:                                 1
+;     sub_c8aea:                             1
+;     loop_c8aee:                            1
+;     c8afb:                                 1
+;     sub_c8b1a:                             1
+;     loop_c8b26:                            1
+;     c8b34:                                 1
+;     loop_c8b39:                            1
+;     loop_c8b4c:                            1
+;     loop_c8b7a:                            1
+;     c8b8d:                                 1
+;     c8ba8:                                 1
+;     c8bae:                                 1
+;     c8bb6:                                 1
+;     loop_c8bc0:                            1
+;     loop_c8bca:                            1
+;     c8bf0:                                 1
+;     c8bf6:                                 1
+;     c8c00:                                 1
+;     loop_c8c06:                            1
+;     c8c12:                                 1
+;     c8c1f:                                 1
+;     c8c24:                                 1
+;     c8c26:                                 1
+;     c8c2f:                                 1
+;     loop_c8c45:                            1
+;     c8c73:                                 1
+;     c8c7d:                                 1
+;     loop_c8c80:                            1
+;     c8c98:                                 1
+;     c8cc9:                                 1
+;     c8cda:                                 1
+;     c8ce0:                                 1
+;     sub_c8cfc:                             1
+;     sub_c8d05:                             1
+;     c8d08:                                 1
+;     c8d0a:                                 1
+;     sub_c8d17:                             1
+;     loop_c8d1b:                            1
+;     c8d26:                                 1
+;     loop_c8d2c:                            1
+;     l8d61:                                 1
+;     c8da7:                                 1
+;     loop_c8dae:                            1
+;     c8dbf:                                 1
+;     loop_c8dc1:                            1
+;     loop_c8de4:                            1
+;     c8deb:                                 1
+;     c8dfa:                                 1
+;     sub_c8e09:                             1
+;     c8e14:                                 1
+;     c8e15:                                 1
+;     c8e20:                                 1
+;     l8e61:                                 1
+;     sub_c8e85:                             1
+;     loop_c8e87:                            1
+;     sub_c8e8c:                             1
+;     clamp_absolute_workspace_and_save:     1
+;     c8eb3:                                 1
+;     loop_c8eee:                            1
+;     loop_c8f18:                            1
+;     loop_c8f2e:                            1
+;     c8f3d:                                 1
+;     c8f40:                                 1
+;     loop_c8f46:                            1
+;     l8f48:                                 1
+;     c8f4c:                                 1
+;     sub_c8f5d:                             1
+;     loop_c8f8e:                            1
+;     sub_c8f99:                             1
+;     loop_c8fb0:                            1
+;     loop_c8fba:                            1
+;     c8fbd:                                 1
+;     c8fca:                                 1
+;     loop_c8fd4:                            1
+;     c901e:                                 1
+;     l9022:                                 1
+;     l9122:                                 1
+;     sub_c9138:                             1
+;     c9140:                                 1
+;     loop_c914d:                            1
+;     c9153:                                 1
+;     c916b:                                 1
+;     c917d:                                 1
+;     c9188:                                 1
+;     c9198:                                 1
+;     c919a:                                 1
+;     c91e3:                                 1
+;     c91f9:                                 1
+;     c9244:                                 1
+;     sub_c9260:                             1
+;     c9267:                                 1
+;     c9277:                                 1
+;     loop_c927b:                            1
+;     c9283:                                 1
+;     l9286:                                 1
+;     sub_c9291:                             1
+;     sub_c929b:                             1
+;     c929f:                                 1
+;     loop_c92a6:                            1
+;     c92af:                                 1
+;     loop_c9329:                            1
+;     loop_c9332:                            1
+;     c933e:                                 1
+;     c9348:                                 1
+;     loop_c934f:                            1
+;     c9358:                                 1
+;     c9371:                                 1
+;     loop_c939b:                            1
+;     c93a2:                                 1
+;     c93ae:                                 1
+;     c93ee:                                 1
+;     loop_c93f0:                            1
+;     c9405:                                 1
+;     c940c:                                 1
+;     c943c:                                 1
+;     c9462:                                 1
+;     sub_c9465:                             1
+;     sub_c9467:                             1
+;     loop_c9476:                            1
+;     c9486:                                 1
+;     l948b:                                 1
+;     sub_c9497:                             1
+;     c94b4:                                 1
+;     c94b5:                                 1
+;     loop_c94bb:                            1
+;     c94d3:                                 1
+;     loop_c94f8:                            1
+;     c9502:                                 1
+;     c9505:                                 1
+;     c950e:                                 1
+;     c951b:                                 1
+;     loop_c9520:                            1
+;     c9547:                                 1
+;     c955b:                                 1
+;     loop_c955d:                            1
+;     c9576:                                 1
+;     c9586:                                 1
+;     c95ee:                                 1
+;     c9607:                                 1
+;     c9619:                                 1
+;     c961a:                                 1
+;     loop_c962a:                            1
+;     c9636:                                 1
+;     c9641:                                 1
+;     c9649:                                 1
+;     c964c:                                 1
+;     c9651:                                 1
+;     loop_c9668:                            1
+;     c9674:                                 1
+;     c9686:                                 1
+;     c9688:                                 1
+;     loop_c968c:                            1
+;     c9698:                                 1
+;     c969a:                                 1
+;     loop_c96a9:                            1
+;     c96af:                                 1
+;     error_template_minus_1:                1
+;     loop_c96c4:                            1
+;     c96dd:                                 1
+;     loop_c96e7:                            1
+;     c96fa:                                 1
+;     c96fd:                                 1
+;     c971e:                                 1
+;     c9722:                                 1
+;     c972c:                                 1
+;     loop_c9734:                            1
+;     c9767:                                 1
+;     loop_c9794:                            1
+;     c97a4:                                 1
+;     c97ac:                                 1
+;     c9846:                                 1
+;     c984f:                                 1
+;     loop_c9865:                            1
+;     c9873:                                 1
+;     c9882:                                 1
+;     sub_c9894:                             1
+;     sub_c989c:                             1
+;     loop_c989e:                            1
+;     c98ab:                                 1
+;     c98b8:                                 1
+;     loop_c98c4:                            1
+;     loop_c98d9:                            1
+;     c98de:                                 1
+;     c98f3:                                 1
+;     loop_c98f8:                            1
+;     c9902:                                 1
+;     sub_c9913:                             1
+;     loop_c991b:                            1
+;     sub_c9951:                             1
+;     c9969:                                 1
+;     c996f:                                 1
+;     loop_c9971:                            1
+;     loop_c998c:                            1
+;     loop_c99a1:                            1
+;     loop_c99a3:                            1
+;     loop_c99b7:                            1
+;     c99c2:                                 1
+;     c99c8:                                 1
+;     loop_c99cd:                            1
+;     loop_c99eb:                            1
+;     c9a0c:                                 1
+;     c9a19:                                 1
+;     c9a1f:                                 1
+;     c9a22:                                 1
+;     loop_c9a2f:                            1
+;     c9a32:                                 1
+;     loop_c9a40:                            1
+;     sub_c9a57:                             1
+;     loop_c9a74:                            1
+;     sub_c9a7e:                             1
+;     c9a83:                                 1
+;     loop_c9a87:                            1
+;     sub_c9a91:                             1
+;     c9aa0:                                 1
+;     loop_c9aab:                            1
+;     loop_c9abd:                            1
+;     c9ac9:                                 1
+;     loop_c9acb:                            1
+;     c9ad2:                                 1
+;     c9afb:                                 1
+;     loop_c9b13:                            1
+;     c9b20:                                 1
+;     loop_c9b2a:                            1
+;     c9b3c:                                 1
+;     c9b41:                                 1
+;     c9b47:                                 1
+;     c9b4c:                                 1
+;     c9b56:                                 1
+;     loop_c9b78:                            1
+;     loop_c9b85:                            1
+;     c9b91:                                 1
+;     c9b92:                                 1
+;     loop_c9b9c:                            1
+;     loop_c9bb3:                            1
+;     c9bb5:                                 1
+;     c9dd2:                                 1
+;     c9dd5:                                 1
+;     c9dda:                                 1
+;     c9ddf:                                 1
+;     c9e0b:                                 1
+;     sub_c9e0f:                             1
+;     sub_c9e16:                             1
+;     sub_c9e17:                             1
+;     loop_c9e19:                            1
+;     c9e25:                                 1
+;     c9e28:                                 1
+;     sub_c9ed2:                             1
+;     c9edd:                                 1
+;     loop_c9ee8:                            1
+;     c9ef3:                                 1
+;     c9efc:                                 1
+;     c9f0a:                                 1
+;     loop_c9f27:                            1
+;     loop_c9f3e:                            1
+;     c9f52:                                 1
+;     c9f55:                                 1
+;     sub_c9f67:                             1
+;     ca09b:                                 1
+;     sub_ca09e:                             1
+;     ca0bd:                                 1
+;     ca0c5:                                 1
+;     ca0c9:                                 1
+;     ca0e3:                                 1
+;     ca0f5:                                 1
+;     ca109:                                 1
+;     ca114:                                 1
+;     ca125:                                 1
+;     ca127:                                 1
+;     ca142:                                 1
+;     loop_ca14a:                            1
+;     loop_ca165:                            1
+;     ca16a:                                 1
+;     loop_ca170:                            1
+;     la17c:                                 1
+;     ca185:                                 1
+;     loop_ca187:                            1
+;     ca18d:                                 1
+;     ca191:                                 1
+;     ca1a3:                                 1
+;     loop_ca1a4:                            1
+;     loop_ca1a8:                            1
+;     ca1a9:                                 1
+;     ca1be:                                 1
+;     ca1c1:                                 1
+;     ca1ca:                                 1
+;     loop_ca1e2:                            1
+;     ca1ea:                                 1
+;     ca206:                                 1
+;     ca209:                                 1
+;     loop_ca21d:                            1
+;     loop_ca225:                            1
+;     loop_ca230:                            1
+;     loop_ca241:                            1
+;     ca243:                                 1
+;     loop_ca245:                            1
+;     ca25a:                                 1
+;     ca26a:                                 1
+;     loop_ca26c:                            1
+;     ca27d:                                 1
+;     la291:                                 1
+;     ca299:                                 1
+;     loop_ca2a2:                            1
+;     loop_ca2a8:                            1
+;     ca2f4:                                 1
+;     sub_ca300:                             1
+;     ca319:                                 1
+;     ca327:                                 1
+;     ca344:                                 1
+;     ca352:                                 1
+;     ca37b:                                 1
+;     ca389:                                 1
+;     ca3b4:                                 1
+;     loop_ca3ce:                            1
+;     la3df:                                 1
+;     ca3e8:                                 1
+;     la477:                                 1
+;     loop_ca4fc:                            1
+;     loop_ca50e:                            1
+;     sub_ca516:                             1
+;     la523:                                 1
+;     la52a:                                 1
+;     la841:                                 1
+;     la84d:                                 1
+;     loop_ca875:                            1
+;     loop_ca89d:                            1
+;     ca8b5:                                 1
+;     sub_ca9be:                             1
+;     sub_caa85:                             1
+;     sub_caa89:                             1
+;     caa8a:                                 1
+;     caa9f:                                 1
+;     caaa1:                                 1
+;     caaa7:                                 1
+;     caaad:                                 1
+;     laab1:                                 1
+;     sub_cab1b:                             1
+;     cab33:                                 1
+;     cab75:                                 1
+;     cab84:                                 1
+;     loop_cab89:                            1
+;     loop_caba8:                            1
+;     cabb5:                                 1
+;     cabb7:                                 1
+;     cabde:                                 1
+;     cabf3:                                 1
+;     cabfe:                                 1
+;     cac10:                                 1
+;     cac3f:                                 1
+;     cac67:                                 1
+;     loop_cac6f:                            1
+;     lac80:                                 1
+;     lac8c:                                 1
+;     loop_cacaf:                            1
+;     sub_cace4:                             1
+;     sub_cacf7:                             1
+;     sub_cacf9:                             1
+;     lad0d:                                 1
+;     cad20:                                 1
+;     loop_cad29:                            1
+;     cad2f:                                 1
+;     lad43:                                 1
+;     cad6f:                                 1
+;     cad89:                                 1
+;     cad96:                                 1
+;     cadb2:                                 1
+;     cade3:                                 1
+;     caded:                                 1
+;     loop_cae1c:                            1
+;     cae27:                                 1
+;     cae4f:                                 1
+;     loop_cae6f:                            1
+;     cae8f:                                 1
+;     sub_cae92:                             1
+;     loop_caebb:                            1
+;     loop_caec9:                            1
+;     caedb:                                 1
+;     caee2:                                 1
+;     caef1:                                 1
+;     laefb:                                 1
+;     laeff:                                 1
+;     loop_caf07:                            1
+;     caf16:                                 1
+;     loop_caf1c:                            1
+;     caf2b:                                 1
+;     loop_caf2d:                            1
+;     caf40:                                 1
+;     sub_caf47:                             1
+;     caf5c:                                 1
+;     caf5f:                                 1
+;     caf72:                                 1
+;     sub_caf85:                             1
+;     loop_caf9d:                            1
+;     cafad:                                 1
+;     cafb4:                                 1
+;     loop_cafc0:                            1
+;     cafd4:                                 1
+;     caff8:                                 1
+;     sub_cb017:                             1
+;     sub_cb019:                             1
+;     loop_cb01b:                            1
+;     cb025:                                 1
+;     cb028:                                 1
+;     loop_cb032:                            1
+;     loop_cb04a:                            1
+;     cb06b:                                 1
+;     cb083:                                 1
+;     cb099:                                 1
+;     cb0ae:                                 1
+;     cb0b6:                                 1
+;     cb0b9:                                 1
+;     sub_cb0c5:                             1
+;     cb0da:                                 1
+;     loop_cb108:                            1
+;     cb118:                                 1
+;     cb11c:                                 1
+;     lb13f:                                 1
+;     sub_cb165:                             1
+;     loop_cb16f:                            1
+;     loop_cb179:                            1
+;     loop_cb18b:                            1
+;     lb194:                                 1
+;     cb1a8:                                 1
+;     cb1b1:                                 1
+;     cb205:                                 1
+;     cb208:                                 1
+;     loop_cb210:                            1
+;     loop_cb228:                            1
+;     loop_cb253:                            1
+;     cb261:                                 1
+;     cb267:                                 1
+;     cb29c:                                 1
+;     loop_cb2a0:                            1
+;     cb2ac:                                 1
+;     cb2d7:                                 1
+;     cb2df:                                 1
+;     sub_cb2e0:                             1
+;     loop_cb2e2:                            1
+;     cb2ed:                                 1
+;     cb2ef:                                 1
+;     cb316:                                 1
+;     loop_cb31a:                            1
+;     cb335:                                 1
+;     loop_cb347:                            1
+;     cb369:                                 1
+;     cb39c:                                 1
+;     loop_cb39f:                            1
+;     cb3a3:                                 1
+;     cb3a8:                                 1
+;     cb3b1:                                 1
+;     loop_cb3b5:                            1
+;     loop_cb3d9:                            1
+;     cb3ed:                                 1
+;     loop_cb3ff:                            1
+;     cb408:                                 1
+;     cb40c:                                 1
+;     cb40e:                                 1
+;     cb41d:                                 1
+;     cb423:                                 1
+;     loop_cb424:                            1
+;     cb448:                                 1
+;     sub_cb449:                             1
+;     loop_cb44c:                            1
+;     loop_cb45c:                            1
+;     sub_cb46b:                             1
+;     cb475:                                 1
+;     cb477:                                 1
+;     cb483:                                 1
+;     sub_cb4ad:                             1
+;     cb4c1:                                 1
+;     loop_cb4cc:                            1
+;     loop_cb4df:                            1
+;     loop_cb50c:                            1
+;     cb51a:                                 1
+;     sub_cb53d:                             1
+;     cb557:                                 1
+;     cb563:                                 1
+;     cb594:                                 1
+;     cb5a2:                                 1
+;     cb5ac:                                 1
+;     cb5b6:                                 1
+;     cb5be:                                 1
+;     cb5cd:                                 1
+;     loop_cb5ea:                            1
+;     cb63b:                                 1
+;     cb661:                                 1
+;     loop_cb66c:                            1
+;     cb67f:                                 1
+;     cb6c6:                                 1
+;     cb6ea:                                 1
+;     loop_cb709:                            1
+;     cb70e:                                 1
+;     sub_cb721:                             1
+;     loop_cb723:                            1
+;     loop_cb72d:                            1
+;     sub_cb730:                             1
+;     cb74f:                                 1
+;     cb788:                                 1
+;     loop_cb79f:                            1
+;     loop_cb7ab:                            1
+;     cb7b6:                                 1
+;     cb7bc:                                 1
+;     loop_cb7c3:                            1
+;     sub_cb8da:                             1
+;     cb8f3:                                 1
+;     sub_cb92b:                             1
+;     loop_cb95e:                            1
+;     cb96b:                                 1
+;     cb974:                                 1
+;     cb9a0:                                 1
+;     cb9b6:                                 1
+;     cb9c5:                                 1
+;     loop_cb9c7:                            1
+;     cb9da:                                 1
+;     cb9ed:                                 1
+;     cb9f4:                                 1
+;     cb9f9:                                 1
+;     cba04:                                 1
+;     loop_cba22:                            1
+;     loop_cba3a:                            1
+;     cba4c:                                 1
+;     cba5a:                                 1
+;     cba65:                                 1
+;     loop_cba67:                            1
+;     loop_cba78:                            1
+;     loop_cba90:                            1
+;     loop_cba95:                            1
+;     cbaab:                                 1
+;     loop_cbab6:                            1
+;     loop_cbabe:                            1
+;     cbac0:                                 1
+;     cbacf:                                 1
+;     cbad8:                                 1
+;     loop_cbaf2:                            1
+;     loop_cbb13:                            1
+;     cbb1a:                                 1
+;     cbb39:                                 1
+;     loop_cbb40:                            1
+;     loop_cbb43:                            1
+;     cbb64:                                 1
+;     loop_cbb6e:                            1
+;     sub_cbb77:                             1
+;     loop_cbb90:                            1
+;     cbb9c:                                 1
+;     loop_cbbb7:                            1
+;     loop_cbbd4:                            1
+;     loop_cbbe7:                            1
+;     loop_cbbf6:                            1
+;     loop_cbc03:                            1
+;     cbc0a:                                 1
+;     loop_cbc24:                            1
+;     loop_cbc34:                            1
+;     cbc6a:                                 1
+;     loop_cbc72:                            1
+;     loop_cbc7d:                            1
+;     cbc84:                                 1
+;     sub_cbc89:                             1
+;     sub_cbc8c:                             1
+;     lbc94:                                 1
+;     lbd94:                                 1
+;     service_handler_tube_service_calls:    1
+;     cbe83:                                 1
+;     loop_cbe9e:                            1
+;     loop_cbeb8:                            1
+;     cbec0:                                 1
+;     lbec3:                                 1
+;     sub_cbf18:                             1
+;     sub_cbf25:                             1
+;     cbf2c:                                 1
+;     cbf36:                                 1
+;     cbf39:                                 1
+;     cbf4a:                                 1
+;     cbf67:                                 1
+;     cbf6a:                                 1
+;     cbf7e:                                 1
+;     loop_cbf95:                            1
+;     cbf9f:                                 1
+;     loop_cbfaa:                            1
+;     loop_cbfe5:                            1
+;     cbffb:                                 1
+;     system_via_sr:                         1
+;     system_via_ier:                        1
+;     lfe87:                                 1
+;     lfea2:                                 1
+;     lfea3:                                 1
+;     tube_host_r1_data:                     1
+;     tube_host_r4_status:                   1
+;     lffb0:                                 1
+;     osrdsc:                                1
+;     lffbd:                                 1
+;     osfile:                                1
+;     oscli:                                 1
+
+; Automatically generated labels:
+;     c0406
+;     c0428
+;     c0432
+;     c0434
+;     c0435
+;     c0463
+;     c047a
+;     c0482
+;     c8032
+;     c805d
+;     c806c
+;     c80bd
+;     c80be
+;     c80d6
+;     c80e9
+;     c80fd
+;     c810a
+;     c83f8
+;     c83fb
+;     c8452
+;     c8585
+;     c85a4
+;     c85cf
+;     c85e3
+;     c85fb
+;     c8619
+;     c862f
+;     c8633
+;     c863f
+;     c8641
+;     c864d
+;     c8693
+;     c86ac
+;     c86ce
+;     c86d5
+;     c86d8
+;     c86e3
+;     c8901
+;     c8942
+;     c8945
+;     c8978
+;     c8988
+;     c89a4
+;     c8a33
+;     c8a38
+;     c8a53
+;     c8a62
+;     c8a6f
+;     c8a71
+;     c8a98
+;     c8aba
+;     c8acb
+;     c8ad1
+;     c8afb
+;     c8b0c
+;     c8b34
+;     c8b8d
+;     c8b98
+;     c8ba8
+;     c8bab
+;     c8bae
+;     c8bb6
+;     c8be0
+;     c8bf0
+;     c8bf6
+;     c8c00
+;     c8c12
+;     c8c1f
+;     c8c24
+;     c8c26
+;     c8c2f
+;     c8c4d
+;     c8c70
+;     c8c73
+;     c8c7d
+;     c8c98
+;     c8cc9
+;     c8cda
+;     c8ce0
+;     c8d08
+;     c8d0a
+;     c8d26
+;     c8d37
+;     c8da7
+;     c8dbc
+;     c8dbf
+;     c8dd2
+;     c8deb
+;     c8dfa
+;     c8e14
+;     c8e15
+;     c8e20
+;     c8e24
+;     c8eab
+;     c8eb3
+;     c8f3d
+;     c8f40
+;     c8f4c
+;     c8f70
+;     c8f8c
+;     c8fbd
+;     c8fca
+;     c8fe4
+;     c8ff1
+;     c901e
+;     c9140
+;     c9153
+;     c916b
+;     c917d
+;     c9188
+;     c9198
+;     c919a
+;     c91ae
+;     c91da
+;     c91e3
+;     c91f9
+;     c91fb
+;     c9208
+;     c9211
+;     c9215
+;     c9229
+;     c9235
+;     c9244
+;     c9266
+;     c9267
+;     c9277
+;     c9283
+;     c929f
+;     c92af
+;     c92fa
+;     c9311
+;     c9322
+;     c933e
+;     c9348
+;     c9358
+;     c9363
+;     c9371
+;     c93a2
+;     c93ae
+;     c93bc
+;     c93ee
+;     c9405
+;     c940c
+;     c943c
+;     c9462
+;     c9486
+;     c94ad
+;     c94ae
+;     c94b4
+;     c94b5
+;     c94d3
+;     c94d9
+;     c9502
+;     c9504
+;     c9505
+;     c950e
+;     c951b
+;     c9547
+;     c9551
+;     c955b
+;     c9576
+;     c9586
+;     c9589
+;     c95ee
+;     c95f4
+;     c9607
+;     c9619
+;     c961a
+;     c9636
+;     c9641
+;     c9649
+;     c964c
+;     c964e
+;     c9651
+;     c9674
+;     c9686
+;     c9688
+;     c9698
+;     c969a
+;     c96af
+;     c96dd
+;     c96f0
+;     c96fa
+;     c96fd
+;     c971e
+;     c9722
+;     c972c
+;     c9740
+;     c9767
+;     c97a4
+;     c97ac
+;     c9846
+;     c984f
+;     c986b
+;     c9873
+;     c987e
+;     c9882
+;     c98ab
+;     c98b8
+;     c98c9
+;     c98de
+;     c98eb
+;     c98f3
+;     c9902
+;     c9926
+;     c9969
+;     c996f
+;     c99c2
+;     c99c8
+;     c9a0c
+;     c9a19
+;     c9a1f
+;     c9a22
+;     c9a32
+;     c9a64
+;     c9a83
+;     c9a96
+;     c9aa0
+;     c9ac9
+;     c9ad2
+;     c9afb
+;     c9b20
+;     c9b35
+;     c9b3c
+;     c9b41
+;     c9b47
+;     c9b4c
+;     c9b56
+;     c9b91
+;     c9b92
+;     c9ba8
+;     c9bb5
+;     c9cc7
+;     c9cc9
+;     c9dbb
+;     c9dd2
+;     c9dd5
+;     c9dda
+;     c9ddf
+;     c9e09
+;     c9e0b
+;     c9e25
+;     c9e28
+;     c9edd
+;     c9ef3
+;     c9efc
+;     c9f0a
+;     c9f52
+;     c9f55
+;     ca073
+;     ca09b
+;     ca0bd
+;     ca0c5
+;     ca0c9
+;     ca0e3
+;     ca0f5
+;     ca0f7
+;     ca109
+;     ca114
+;     ca125
+;     ca127
+;     ca133
+;     ca142
+;     ca159
+;     ca16a
+;     ca185
+;     ca18d
+;     ca191
+;     ca1a2
+;     ca1a3
+;     ca1a9
+;     ca1b7
+;     ca1be
+;     ca1c1
+;     ca1ca
+;     ca1ea
+;     ca206
+;     ca209
+;     ca243
+;     ca25a
+;     ca25d
+;     ca26a
+;     ca27d
+;     ca299
+;     ca2ef
+;     ca2f4
+;     ca303
+;     ca319
+;     ca327
+;     ca32e
+;     ca344
+;     ca352
+;     ca365
+;     ca37b
+;     ca389
+;     ca38b
+;     ca38e
+;     ca3b4
+;     ca3e3
+;     ca3e8
+;     ca522
+;     ca889
+;     ca8b5
+;     ca8c4
+;     caa8a
+;     caa9f
+;     caaa1
+;     caaa7
+;     caaa9
+;     caaad
+;     caae2
+;     cab33
+;     cab36
+;     cab75
+;     cab84
+;     cabb5
+;     cabb7
+;     cabde
+;     cabf3
+;     cabfe
+;     cac10
+;     cac30
+;     cac3f
+;     cac4a
+;     cac67
+;     cacdd
+;     cad20
+;     cad2f
+;     cad6f
+;     cad89
+;     cad96
+;     cadb2
+;     cade3
+;     caded
+;     cae27
+;     cae4f
+;     cae84
+;     cae8f
+;     caeb7
+;     caed8
+;     caeda
+;     caedb
+;     caedf
+;     caee2
+;     caef1
+;     caf16
+;     caf2b
+;     caf40
+;     caf5a
+;     caf5c
+;     caf5f
+;     caf72
+;     caf88
+;     cafad
+;     cafb4
+;     cafcd
+;     cafd4
+;     caff8
+;     cb025
+;     cb028
+;     cb058
+;     cb06b
+;     cb083
+;     cb091
+;     cb099
+;     cb0ae
+;     cb0b6
+;     cb0b9
+;     cb0da
+;     cb118
+;     cb11c
+;     cb144
+;     cb153
+;     cb1a8
+;     cb1b1
+;     cb205
+;     cb208
+;     cb236
+;     cb261
+;     cb267
+;     cb29c
+;     cb2ac
+;     cb2d4
+;     cb2d7
+;     cb2df
+;     cb2ed
+;     cb2ef
+;     cb305
+;     cb316
+;     cb32c
+;     cb335
+;     cb336
+;     cb369
+;     cb39c
+;     cb3a3
+;     cb3a8
+;     cb3b1
+;     cb3ed
+;     cb408
+;     cb40c
+;     cb40e
+;     cb41d
+;     cb423
+;     cb448
+;     cb475
+;     cb477
+;     cb483
+;     cb4c1
+;     cb51a
+;     cb557
+;     cb55f
+;     cb563
+;     cb577
+;     cb594
+;     cb59b
+;     cb5a2
+;     cb5ac
+;     cb5b6
+;     cb5b7
+;     cb5be
+;     cb5cd
+;     cb63b
+;     cb661
+;     cb67f
+;     cb682
+;     cb6c6
+;     cb6ea
+;     cb70e
+;     cb718
+;     cb732
+;     cb735
+;     cb74f
+;     cb788
+;     cb7b6
+;     cb7bc
+;     cb8f3
+;     cb96b
+;     cb974
+;     cb9a0
+;     cb9aa
+;     cb9b6
+;     cb9c5
+;     cb9cd
+;     cb9da
+;     cb9e7
+;     cb9ed
+;     cb9f4
+;     cb9f9
+;     cba04
+;     cba33
+;     cba4c
+;     cba53
+;     cba5a
+;     cba65
+;     cbaab
+;     cbac0
+;     cbacf
+;     cbad8
+;     cbb1a
+;     cbb39
+;     cbb64
+;     cbb68
+;     cbb6f
+;     cbb9c
+;     cbba2
+;     cbbbc
+;     cbc0a
+;     cbc1f
+;     cbc3d
+;     cbc6a
+;     cbc84
+;     cbe73
+;     cbe83
+;     cbec0
+;     cbec2
+;     cbf0a
+;     cbf2c
+;     cbf36
+;     cbf38
+;     cbf39
+;     cbf4a
+;     cbf67
+;     cbf6a
+;     cbf7e
+;     cbf86
+;     cbf9f
+;     cbfc0
+;     cbffb
+;     l0000
+;     l0001
+;     l0012
+;     l0013
+;     l0014
+;     l0015
+;     l0016
+;     l0032
+;     l0053
+;     l0054
+;     l0055
+;     l0056
+;     l0063
+;     l0078
+;     l0098
+;     l0099
+;     l009a
+;     l009b
+;     l009c
+;     l009d
+;     l009e
+;     l009f
+;     l00a0
+;     l00a1
+;     l00a2
+;     l00a3
+;     l00a4
+;     l00a5
+;     l00a6
+;     l00a7
+;     l00a8
+;     l00a9
+;     l00aa
+;     l00ab
+;     l00ac
+;     l00ad
+;     l00ae
+;     l00af
+;     l00b0
+;     l00b1
+;     l00b2
+;     l00b3
+;     l00b4
+;     l00b5
+;     l00b6
+;     l00b7
+;     l00b8
+;     l00b9
+;     l00ba
+;     l00bb
+;     l00bc
+;     l00bd
+;     l00be
+;     l00bf
+;     l00c0
+;     l00c1
+;     l00c2
+;     l00c4
+;     l00c7
+;     l00c8
+;     l00cc
+;     l00cd
+;     l00d0
+;     l00ed
+;     l00ef
+;     l00f0
+;     l00f3
+;     l00f7
+;     l00fd
+;     l00ff
+;     l0100
+;     l0101
+;     l0102
+;     l0103
+;     l0104
+;     l026a
+;     l028d
+;     l02a0
+;     l0350
+;     l0351
+;     l0355
+;     l0400
+;     l04c7
+;     l04ce
+;     l0500
+;     l0518
+;     l0600
+;     l0601
+;     l0695
+;     l069e
+;     l0a00
+;     l0a81
+;     l0cff
+;     l0d07
+;     l0d0c
+;     l0d0d
+;     l0d0e
+;     l0d11
+;     l0d1a
+;     l0d1e
+;     l0d20
+;     l0d21
+;     l0d22
+;     l0d23
+;     l0d24
+;     l0d25
+;     l0d26
+;     l0d3e
+;     l0d3f
+;     l0d40
+;     l0d41
+;     l0d60
+;     l0d61
+;     l0d62
+;     l0d63
+;     l0d64
+;     l0d65
+;     l0d68
+;     l0d69
+;     l0d6a
+;     l0d6b
+;     l0d6c
+;     l0d6d
+;     l0d6e
+;     l0d6f
+;     l0d71
+;     l0df0
+;     l0dfe
+;     l0e00
+;     l0e01
+;     l0e02
+;     l0e03
+;     l0e04
+;     l0e05
+;     l0e06
+;     l0e07
+;     l0e08
+;     l0e09
+;     l0e0a
+;     l0e0b
+;     l0e14
+;     l0e2f
+;     l0e30
+;     l0e31
+;     l0e32
+;     l0e38
+;     l0e81
+;     l0ef7
+;     l0f00
+;     l0f01
+;     l0f02
+;     l0f03
+;     l0f04
+;     l0f05
+;     l0f06
+;     l0f07
+;     l0f08
+;     l0f09
+;     l0f0a
+;     l0f0b
+;     l0f0c
+;     l0f0d
+;     l0f0e
+;     l0f10
+;     l0f11
+;     l0f12
+;     l0f13
+;     l0f14
+;     l0f2f
+;     l0f30
+;     l0fc8
+;     l0fdc
+;     l0fdd
+;     l0fde
+;     l0fdf
+;     l0fe0
+;     l0ff0
+;     l0fff
+;     l1000
+;     l1010
+;     l1020
+;     l1030
+;     l1040
+;     l1050
+;     l1060
+;     l1070
+;     l1071
+;     l1072
+;     l1073
+;     l1074
+;     l1078
+;     l1088
+;     l1098
+;     l10a8
+;     l10b8
+;     l10c8
+;     l10c9
+;     l10ca
+;     l10cb
+;     l10cc
+;     l10cd
+;     l10ce
+;     l10cf
+;     l10d0
+;     l10d1
+;     l10d4
+;     l10d5
+;     l10d6
+;     l10d7
+;     l10d8
+;     l10d9
+;     l10f3
+;     l8001
+;     l8002
+;     l8004
+;     l84bb
+;     l8600
+;     l8861
+;     l8869
+;     l89a6
+;     l8d38
+;     l8d61
+;     l8e54
+;     l8e61
+;     l8f48
+;     l9022
+;     l9122
+;     l9286
+;     l948b
+;     l9491
+;     l97ad
+;     l97b9
+;     l9888
+;     la17c
+;     la291
+;     la3df
+;     la3f0
+;     la3f1
+;     la3f2
+;     la477
+;     la523
+;     la52a
+;     la841
+;     la84d
+;     laab1
+;     lac80
+;     lac8c
+;     lad0d
+;     lad43
+;     laefb
+;     laeff
+;     lb13f
+;     lb194
+;     lb487
+;     lbc94
+;     lbd94
+;     lbec3
+;     lbf04
+;     lfe18
+;     lfe87
+;     lfea0
+;     lfea1
+;     lfea2
+;     lfea3
+;     lffb0
+;     lffbd
+;     loop_c0446
+;     loop_c0466
+;     loop_c8096
+;     loop_c85b8
+;     loop_c85d9
+;     loop_c869a
+;     loop_c86c2
+;     loop_c8912
+;     loop_c8aee
+;     loop_c8b26
+;     loop_c8b39
+;     loop_c8b4c
+;     loop_c8b7a
+;     loop_c8bc0
+;     loop_c8bca
+;     loop_c8c06
+;     loop_c8c45
+;     loop_c8c80
+;     loop_c8d1b
+;     loop_c8d2c
+;     loop_c8dae
+;     loop_c8dc1
+;     loop_c8de4
+;     loop_c8e87
+;     loop_c8eee
+;     loop_c8f18
+;     loop_c8f2e
+;     loop_c8f46
+;     loop_c8f8e
+;     loop_c8fb0
+;     loop_c8fba
+;     loop_c8fd4
+;     loop_c914d
+;     loop_c927b
+;     loop_c92a6
+;     loop_c9329
+;     loop_c9332
+;     loop_c934f
+;     loop_c939b
+;     loop_c93f0
+;     loop_c9476
+;     loop_c94bb
+;     loop_c94f8
+;     loop_c9520
+;     loop_c955d
+;     loop_c962a
+;     loop_c9668
+;     loop_c968c
+;     loop_c96a9
+;     loop_c96c4
+;     loop_c96e7
+;     loop_c9734
+;     loop_c9794
+;     loop_c9865
+;     loop_c989e
+;     loop_c98c4
+;     loop_c98d9
+;     loop_c98f8
+;     loop_c991b
+;     loop_c9971
+;     loop_c998c
+;     loop_c99a1
+;     loop_c99a3
+;     loop_c99b7
+;     loop_c99cd
+;     loop_c99eb
+;     loop_c9a2f
+;     loop_c9a40
+;     loop_c9a74
+;     loop_c9a87
+;     loop_c9aab
+;     loop_c9abd
+;     loop_c9acb
+;     loop_c9b13
+;     loop_c9b2a
+;     loop_c9b78
+;     loop_c9b85
+;     loop_c9b9c
+;     loop_c9bb3
+;     loop_c9e19
+;     loop_c9ee8
+;     loop_c9f27
+;     loop_c9f3e
+;     loop_ca14a
+;     loop_ca165
+;     loop_ca170
+;     loop_ca187
+;     loop_ca1a4
+;     loop_ca1a8
+;     loop_ca1e2
+;     loop_ca21d
+;     loop_ca225
+;     loop_ca230
+;     loop_ca241
+;     loop_ca245
+;     loop_ca26c
+;     loop_ca2a2
+;     loop_ca2a8
+;     loop_ca3ce
+;     loop_ca4fc
+;     loop_ca50e
+;     loop_ca875
+;     loop_ca89d
+;     loop_cab89
+;     loop_caba8
+;     loop_cac6f
+;     loop_cacaf
+;     loop_cad29
+;     loop_cae1c
+;     loop_cae6f
+;     loop_caebb
+;     loop_caec9
+;     loop_caf07
+;     loop_caf1c
+;     loop_caf2d
+;     loop_caf9d
+;     loop_cafc0
+;     loop_cb01b
+;     loop_cb032
+;     loop_cb04a
+;     loop_cb108
+;     loop_cb16f
+;     loop_cb179
+;     loop_cb18b
+;     loop_cb210
+;     loop_cb228
+;     loop_cb253
+;     loop_cb2a0
+;     loop_cb2e2
+;     loop_cb31a
+;     loop_cb347
+;     loop_cb39f
+;     loop_cb3b5
+;     loop_cb3d9
+;     loop_cb3ff
+;     loop_cb424
+;     loop_cb44c
+;     loop_cb45c
+;     loop_cb4cc
+;     loop_cb4df
+;     loop_cb50c
+;     loop_cb5ea
+;     loop_cb66c
+;     loop_cb709
+;     loop_cb723
+;     loop_cb72d
+;     loop_cb79f
+;     loop_cb7ab
+;     loop_cb7c3
+;     loop_cb95e
+;     loop_cb9c7
+;     loop_cba22
+;     loop_cba3a
+;     loop_cba67
+;     loop_cba78
+;     loop_cba90
+;     loop_cba95
+;     loop_cbab6
+;     loop_cbabe
+;     loop_cbaf2
+;     loop_cbb13
+;     loop_cbb40
+;     loop_cbb43
+;     loop_cbb6e
+;     loop_cbb90
+;     loop_cbbb7
+;     loop_cbbd4
+;     loop_cbbe7
+;     loop_cbbf6
+;     loop_cbc03
+;     loop_cbc24
+;     loop_cbc34
+;     loop_cbc72
+;     loop_cbc7d
+;     loop_cbe9e
+;     loop_cbeb8
+;     loop_cbf95
+;     loop_cbfaa
+;     loop_cbfe5
+;     sub_c0414
+;     sub_c0421
+;     sub_c8028
+;     sub_c805a
+;     sub_c8074
+;     sub_c8090
+;     sub_c8449
+;     sub_c858c
+;     sub_c85ff
+;     sub_c8689
+;     sub_c868d
+;     sub_c8691
+;     sub_c86d3
+;     sub_c88f2
+;     sub_c8969
+;     sub_c8983
+;     sub_c8aa0
+;     sub_c8ad4
+;     sub_c8aea
+;     sub_c8b02
+;     sub_c8b0d
+;     sub_c8b1a
+;     sub_c8b92
+;     sub_c8b96
+;     sub_c8c33
+;     sub_c8c4e
+;     sub_c8c5d
+;     sub_c8c9f
+;     sub_c8cb9
+;     sub_c8cc0
+;     sub_c8cca
+;     sub_c8cfc
+;     sub_c8d05
+;     sub_c8d17
+;     sub_c8d79
+;     sub_c8e09
+;     sub_c8e52
+;     sub_c8e83
+;     sub_c8e85
+;     sub_c8e8c
+;     sub_c8e92
+;     sub_c8f5d
+;     sub_c8f99
+;     sub_c8fcb
+;     sub_c912f
+;     sub_c9138
+;     sub_c916e
+;     sub_c9258
+;     sub_c9260
+;     sub_c9269
+;     sub_c9273
+;     sub_c9291
+;     sub_c9295
+;     sub_c929b
+;     sub_c92a4
+;     sub_c92b0
+;     sub_c92e6
+;     sub_c9309
+;     sub_c9327
+;     sub_c9349
+;     sub_c938b
+;     sub_c93dd
+;     sub_c9465
+;     sub_c9467
+;     sub_c9473
+;     sub_c9497
+;     sub_c949b
+;     sub_c949e
+;     sub_c94f0
+;     sub_c9570
+;     sub_c9580
+;     sub_c95ae
+;     sub_c95be
+;     sub_c95ce
+;     sub_c95dd
+;     sub_c96b3
+;     sub_c974d
+;     sub_c9771
+;     sub_c977c
+;     sub_c978d
+;     sub_c9837
+;     sub_c983f
+;     sub_c9894
+;     sub_c989c
+;     sub_c9913
+;     sub_c9951
+;     sub_c9998
+;     sub_c9a57
+;     sub_c9a62
+;     sub_c9a72
+;     sub_c9a7e
+;     sub_c9a7f
+;     sub_c9a84
+;     sub_c9a91
+;     sub_c9a92
+;     sub_c9a9a
+;     sub_c9b95
+;     sub_c9dc8
+;     sub_c9dee
+;     sub_c9e0f
+;     sub_c9e16
+;     sub_c9e17
+;     sub_c9ed2
+;     sub_c9f67
+;     sub_ca07b
+;     sub_ca09e
+;     sub_ca0a7
+;     sub_ca0cc
+;     sub_ca0ce
+;     sub_ca0e4
+;     sub_ca0ea
+;     sub_ca0fa
+;     sub_ca140
+;     sub_ca2fa
+;     sub_ca300
+;     sub_ca32b
+;     sub_ca356
+;     sub_ca362
+;     sub_ca391
+;     sub_ca39b
+;     sub_ca4ee
+;     sub_ca516
+;     sub_ca865
+;     sub_ca9be
+;     sub_caa85
+;     sub_caa89
+;     sub_cab12
+;     sub_cab1b
+;     sub_cac24
+;     sub_cac98
+;     sub_cace4
+;     sub_cacf7
+;     sub_cacf9
+;     sub_cad10
+;     sub_cad41
+;     sub_cad5f
+;     sub_cad65
+;     sub_cad6b
+;     sub_cad80
+;     sub_cae82
+;     sub_cae92
+;     sub_cae94
+;     sub_cae97
+;     sub_caf02
+;     sub_caf04
+;     sub_caf06
+;     sub_caf32
+;     sub_caf3e
+;     sub_caf47
+;     sub_caf66
+;     sub_caf85
+;     sub_caf96
+;     sub_cafb5
+;     sub_cafc1
+;     sub_cafd5
+;     sub_cafe0
+;     sub_cafee
+;     sub_cb017
+;     sub_cb019
+;     sub_cb0c5
+;     sub_cb0cf
+;     sub_cb0ea
+;     sub_cb0f6
+;     sub_cb13e
+;     sub_cb15e
+;     sub_cb165
+;     sub_cb16d
+;     sub_cb198
+;     sub_cb1c3
+;     sub_cb2e0
+;     sub_cb2f7
+;     sub_cb30c
+;     sub_cb33d
+;     sub_cb359
+;     sub_cb431
+;     sub_cb449
+;     sub_cb46b
+;     sub_cb485
+;     sub_cb4ad
+;     sub_cb509
+;     sub_cb53d
+;     sub_cb559
+;     sub_cb586
+;     sub_cb595
+;     sub_cb5d8
+;     sub_cb5fb
+;     sub_cb66a
+;     sub_cb721
+;     sub_cb730
+;     sub_cb799
+;     sub_cb8da
+;     sub_cb92b
+;     sub_cb984
+;     sub_cb98a
+;     sub_cb98f
+;     sub_cb994
+;     sub_cb99a
+;     sub_cb99d
+;     sub_cb9ff
+;     sub_cba1b
+;     sub_cbadd
+;     sub_cbb03
+;     sub_cbb0e
+;     sub_cbb77
+;     sub_cbc44
+;     sub_cbc86
+;     sub_cbc89
+;     sub_cbc8c
+;     sub_cbf18
+;     sub_cbf25
+!if (<((c86e3)-1)) != $e2 {
+    !error "Assertion failed: <((c86e3)-1) == $e2"
+}
+!if (<((c86e3)-1)) != $e2 {
+    !error "Assertion failed: <((c86e3)-1) == $e2"
+}
+!if (<((sub_c8689)-1)) != $88 {
+    !error "Assertion failed: <((sub_c8689)-1) == $88"
+}
+!if (<((sub_c868d)-1)) != $8c {
+    !error "Assertion failed: <((sub_c868d)-1) == $8c"
+}
+!if (<((sub_c8691)-1)) != $90 {
+    !error "Assertion failed: <((sub_c8691)-1) == $90"
+}
+!if (<((sub_c86d3)-1)) != $d2 {
+    !error "Assertion failed: <((sub_c86d3)-1) == $d2"
+}
+!if (<((sub_c86d3)-1)) != $d2 {
+    !error "Assertion failed: <((sub_c86d3)-1) == $d2"
+}
+!if (<((sub_c86d3)-1)) != $d2 {
+    !error "Assertion failed: <((sub_c86d3)-1) == $d2"
+}
+!if (<(ca114-1)) != $13 {
+    !error "Assertion failed: <(ca114-1) == $13"
+}
+!if (<(ca1c1-1)) != $c0 {
+    !error "Assertion failed: <(ca1c1-1) == $c0"
+}
+!if (<(ca1c1-1)) != $c0 {
+    !error "Assertion failed: <(ca1c1-1) == $c0"
+}
+!if (<(ca1c1-1)) != $c0 {
+    !error "Assertion failed: <(ca1c1-1) == $c0"
+}
+!if (<(ca2f4-1)) != $f3 {
+    !error "Assertion failed: <(ca2f4-1) == $f3"
+}
+!if (<(just_rts-1)) != $57 {
+    !error "Assertion failed: <(just_rts-1) == $57"
+}
+!if (<(just_rts-1)) != $57 {
+    !error "Assertion failed: <(just_rts-1) == $57"
+}
+!if (<(just_rts-1)) != $57 {
+    !error "Assertion failed: <(just_rts-1) == $57"
+}
+!if (<(l00b4)) != $b4 {
+    !error "Assertion failed: <(l00b4) == $b4"
+}
+!if (<(l0601)) != $01 {
+    !error "Assertion failed: <(l0601) == $01"
+}
+!if (<(l0601)) != $01 {
+    !error "Assertion failed: <(l0601) == $01"
+}
+!if (<(l0a00)) != $00 {
+    !error "Assertion failed: <(l0a00) == $00"
+}
+!if (<(l0a00)) != $00 {
+    !error "Assertion failed: <(l0a00) == $00"
+}
+!if (<(l0a00)) != $00 {
+    !error "Assertion failed: <(l0a00) == $00"
+}
+!if (<(l0a81)) != $81 {
+    !error "Assertion failed: <(l0a81) == $81"
+}
+!if (<(l0e00)) != $00 {
+    !error "Assertion failed: <(l0e00) == $00"
+}
+!if (<(l0e81)) != $81 {
+    !error "Assertion failed: <(l0e81) == $81"
+}
+!if (<(service_handler_claim_absolute_workspace-1)) != $a4 {
+    !error "Assertion failed: <(service_handler_claim_absolute_workspace-1) == $a4"
+}
+!if (<(service_handler_claim_private_workspace-1)) != $b7 {
+    !error "Assertion failed: <(service_handler_claim_private_workspace-1) == $b7"
+}
+!if (<(sub_c8028-1)) != $27 {
+    !error "Assertion failed: <(sub_c8028-1) == $27"
+}
+!if (<(sub_c8090-1)) != $8f {
+    !error "Assertion failed: <(sub_c8090-1) == $8f"
+}
+!if (<(sub_c8983-1)) != $82 {
+    !error "Assertion failed: <(sub_c8983-1) == $82"
+}
+!if (<(sub_c8b0d-1)) != $0c {
+    !error "Assertion failed: <(sub_c8b0d-1) == $0c"
+}
+!if (<(sub_c8c4e-1)) != $4d {
+    !error "Assertion failed: <(sub_c8c4e-1) == $4d"
+}
+!if (<(sub_c8c5d-1)) != $5c {
+    !error "Assertion failed: <(sub_c8c5d-1) == $5c"
+}
+!if (<(sub_c8cca-1)) != $c9 {
+    !error "Assertion failed: <(sub_c8cca-1) == $c9"
+}
+!if (<(sub_c8e92-1)) != $91 {
+    !error "Assertion failed: <(sub_c8e92-1) == $91"
+}
+!if (<(sub_c8f99-1)) != $98 {
+    !error "Assertion failed: <(sub_c8f99-1) == $98"
+}
+!if (<(sub_c92b0-1)) != $af {
+    !error "Assertion failed: <(sub_c92b0-1) == $af"
+}
+!if (<(sub_c9580-1)) != $7f {
+    !error "Assertion failed: <(sub_c9580-1) == $7f"
+}
+!if (<(sub_c95ae-1)) != $ad {
+    !error "Assertion failed: <(sub_c95ae-1) == $ad"
+}
+!if (<(sub_c95be-1)) != $bd {
+    !error "Assertion failed: <(sub_c95be-1) == $bd"
+}
+!if (<(sub_c95ce-1)) != $cd {
+    !error "Assertion failed: <(sub_c95ce-1) == $cd"
+}
+!if (<(sub_c9dc8-1)) != $c7 {
+    !error "Assertion failed: <(sub_c9dc8-1) == $c7"
+}
+!if (<(sub_c9dee-1)) != $ed {
+    !error "Assertion failed: <(sub_c9dee-1) == $ed"
+}
+!if (<(sub_ca0e4-1)) != $e3 {
+    !error "Assertion failed: <(sub_ca0e4-1) == $e3"
+}
+!if (<(sub_ca0ea-1)) != $e9 {
+    !error "Assertion failed: <(sub_ca0ea-1) == $e9"
+}
+!if (<(sub_ca0fa-1)) != $f9 {
+    !error "Assertion failed: <(sub_ca0fa-1) == $f9"
+}
+!if (<(sub_ca2fa-1)) != $f9 {
+    !error "Assertion failed: <(sub_ca2fa-1) == $f9"
+}
+!if (<(sub_ca391-1)) != $90 {
+    !error "Assertion failed: <(sub_ca391-1) == $90"
+}
+!if (<(sub_ca39b-1)) != $9a {
+    !error "Assertion failed: <(sub_ca39b-1) == $9a"
+}
+!if (<(sub_ca4ee-1)) != $ed {
+    !error "Assertion failed: <(sub_ca4ee-1) == $ed"
+}
+!if (<(sub_cac98-1)) != $97 {
+    !error "Assertion failed: <(sub_cac98-1) == $97"
+}
+!if (<(sub_cad80-1)) != $7f {
+    !error "Assertion failed: <(sub_cad80-1) == $7f"
+}
+!if (<(sub_caf3e-1)) != $3d {
+    !error "Assertion failed: <(sub_caf3e-1) == $3d"
+}
+!if (>(ca114-1)) != $a1 {
+    !error "Assertion failed: >(ca114-1) == $a1"
+}
+!if (>(ca1c1-1)) != $a1 {
+    !error "Assertion failed: >(ca1c1-1) == $a1"
+}
+!if (>(ca1c1-1)) != $a1 {
+    !error "Assertion failed: >(ca1c1-1) == $a1"
+}
+!if (>(ca1c1-1)) != $a1 {
+    !error "Assertion failed: >(ca1c1-1) == $a1"
+}
+!if (>(ca2f4-1)) != $a2 {
+    !error "Assertion failed: >(ca2f4-1) == $a2"
+}
+!if (>(just_rts-1)) != $8e {
+    !error "Assertion failed: >(just_rts-1) == $8e"
+}
+!if (>(just_rts-1)) != $8e {
+    !error "Assertion failed: >(just_rts-1) == $8e"
+}
+!if (>(just_rts-1)) != $8e {
+    !error "Assertion failed: >(just_rts-1) == $8e"
+}
+!if (>(l00b4)) != $00 {
+    !error "Assertion failed: >(l00b4) == $00"
+}
+!if (>(l0601)) != $06 {
+    !error "Assertion failed: >(l0601) == $06"
+}
+!if (>(l0601)) != $06 {
+    !error "Assertion failed: >(l0601) == $06"
+}
+!if (>(l0a00)) != $0a {
+    !error "Assertion failed: >(l0a00) == $0a"
+}
+!if (>(l0a00)) != $0a {
+    !error "Assertion failed: >(l0a00) == $0a"
+}
+!if (>(l0a00)) != $0a {
+    !error "Assertion failed: >(l0a00) == $0a"
+}
+!if (>(l0a81)) != $0a {
+    !error "Assertion failed: >(l0a81) == $0a"
+}
+!if (>(l0e00)) != $0e {
+    !error "Assertion failed: >(l0e00) == $0e"
+}
+!if (>(l0e81)) != $0e {
+    !error "Assertion failed: >(l0e81) == $0e"
+}
+!if (>(service_handler_claim_absolute_workspace-1)) != $8e {
+    !error "Assertion failed: >(service_handler_claim_absolute_workspace-1) == $8e"
+}
+!if (>(service_handler_claim_private_workspace-1)) != $8e {
+    !error "Assertion failed: >(service_handler_claim_private_workspace-1) == $8e"
+}
+!if (>(sub_c8028-1)) != $80 {
+    !error "Assertion failed: >(sub_c8028-1) == $80"
+}
+!if (>(sub_c8090-1)) != $80 {
+    !error "Assertion failed: >(sub_c8090-1) == $80"
+}
+!if (>(sub_c8983-1)) != $89 {
+    !error "Assertion failed: >(sub_c8983-1) == $89"
+}
+!if (>(sub_c8b0d-1)) != $8b {
+    !error "Assertion failed: >(sub_c8b0d-1) == $8b"
+}
+!if (>(sub_c8c4e-1)) != $8c {
+    !error "Assertion failed: >(sub_c8c4e-1) == $8c"
+}
+!if (>(sub_c8c5d-1)) != $8c {
+    !error "Assertion failed: >(sub_c8c5d-1) == $8c"
+}
+!if (>(sub_c8cca-1)) != $8c {
+    !error "Assertion failed: >(sub_c8cca-1) == $8c"
+}
+!if (>(sub_c8e92-1)) != $8e {
+    !error "Assertion failed: >(sub_c8e92-1) == $8e"
+}
+!if (>(sub_c8f99-1)) != $8f {
+    !error "Assertion failed: >(sub_c8f99-1) == $8f"
+}
+!if (>(sub_c92b0-1)) != $92 {
+    !error "Assertion failed: >(sub_c92b0-1) == $92"
+}
+!if (>(sub_c9580-1)) != $95 {
+    !error "Assertion failed: >(sub_c9580-1) == $95"
+}
+!if (>(sub_c95ae-1)) != $95 {
+    !error "Assertion failed: >(sub_c95ae-1) == $95"
+}
+!if (>(sub_c95be-1)) != $95 {
+    !error "Assertion failed: >(sub_c95be-1) == $95"
+}
+!if (>(sub_c95ce-1)) != $95 {
+    !error "Assertion failed: >(sub_c95ce-1) == $95"
+}
+!if (>(sub_c9dc8-1)) != $9d {
+    !error "Assertion failed: >(sub_c9dc8-1) == $9d"
+}
+!if (>(sub_c9dee-1)) != $9d {
+    !error "Assertion failed: >(sub_c9dee-1) == $9d"
+}
+!if (>(sub_ca0e4-1)) != $a0 {
+    !error "Assertion failed: >(sub_ca0e4-1) == $a0"
+}
+!if (>(sub_ca0ea-1)) != $a0 {
+    !error "Assertion failed: >(sub_ca0ea-1) == $a0"
+}
+!if (>(sub_ca0fa-1)) != $a0 {
+    !error "Assertion failed: >(sub_ca0fa-1) == $a0"
+}
+!if (>(sub_ca2fa-1)) != $a2 {
+    !error "Assertion failed: >(sub_ca2fa-1) == $a2"
+}
+!if (>(sub_ca391-1)) != $a3 {
+    !error "Assertion failed: >(sub_ca391-1) == $a3"
+}
+!if (>(sub_ca39b-1)) != $a3 {
+    !error "Assertion failed: >(sub_ca39b-1) == $a3"
+}
+!if (>(sub_ca4ee-1)) != $a4 {
+    !error "Assertion failed: >(sub_ca4ee-1) == $a4"
+}
+!if (>(sub_cac98-1)) != $ac {
+    !error "Assertion failed: >(sub_cac98-1) == $ac"
+}
+!if (>(sub_cad80-1)) != $ad {
+    !error "Assertion failed: >(sub_cad80-1) == $ad"
+}
+!if (>(sub_caf3e-1)) != $af {
+    !error "Assertion failed: >(sub_caf3e-1) == $af"
+}
+!if (c8dbc-1) != $8dbb {
+    !error "Assertion failed: c8dbc-1 == $8dbb"
+}
+!if (c8e15-1) != $8e14 {
+    !error "Assertion failed: c8e15-1 == $8e14"
+}
+!if (copyright - rom_header) != $19 {
+    !error "Assertion failed: copyright - rom_header == $19"
+}
+!if (osbyte_acknowledge_escape) != $7e {
+    !error "Assertion failed: osbyte_acknowledge_escape == $7e"
+}
+!if (osbyte_close_spool_exec) != $77 {
+    !error "Assertion failed: osbyte_close_spool_exec == $77"
+}
+!if (osbyte_explode_chars) != $14 {
+    !error "Assertion failed: osbyte_explode_chars == $14"
+}
+!if (osbyte_flush_buffer_class) != $0f {
+    !error "Assertion failed: osbyte_flush_buffer_class == $0f"
+}
+!if (osbyte_insert_input_buffer) != $99 {
+    !error "Assertion failed: osbyte_insert_input_buffer == $99"
+}
+!if (osbyte_issue_service_request) != $8f {
+    !error "Assertion failed: osbyte_issue_service_request == $8f"
+}
+!if (osbyte_read_os_version) != $00 {
+    !error "Assertion failed: osbyte_read_os_version == $00"
+}
+!if (osbyte_read_write_econet_keyboard_disable) != $c9 {
+    !error "Assertion failed: osbyte_read_write_econet_keyboard_disable == $c9"
+}
+!if (osbyte_read_write_econet_os_call_interception) != $ce {
+    !error "Assertion failed: osbyte_read_write_econet_os_call_interception == $ce"
+}
+!if (osbyte_scan_keyboard) != $79 {
+    !error "Assertion failed: osbyte_scan_keyboard == $79"
+}
+!if (osbyte_scan_keyboard_from_16) != $7a {
+    !error "Assertion failed: osbyte_scan_keyboard_from_16 == $7a"
+}
+!if (osbyte_vsync) != $13 {
+    !error "Assertion failed: osbyte_vsync == $13"
+}
+!if (osbyte_write_keys_pressed) != $78 {
+    !error "Assertion failed: osbyte_write_keys_pressed == $78"
+}
+!if (osfile_read_catalogue_info) != $05 {
+    !error "Assertion failed: osfile_read_catalogue_info == $05"
+}
+!if (osword_read_palette) != $0b {
+    !error "Assertion failed: osword_read_palette == $0b"
+}
+!if (service_claim_absolute_workspace) != $01 {
+    !error "Assertion failed: service_claim_absolute_workspace == $01"
+}
+!if (service_vectors_changed) != $0f {
+    !error "Assertion failed: service_vectors_changed == $0f"
+}
+!if (sub_c8ad4-1) != $8ad3 {
+    !error "Assertion failed: sub_c8ad4-1 == $8ad3"
+}
+!if (sub_c8b1a-1) != $8b19 {
+    !error "Assertion failed: sub_c8b1a-1 == $8b19"
+}
+!if (sub_c8b92-1) != $8b91 {
+    !error "Assertion failed: sub_c8b92-1 == $8b91"
+}
+!if (sub_c8b96-1) != $8b95 {
+    !error "Assertion failed: sub_c8b96-1 == $8b95"
+}
+!if (sub_c8d79-1) != $8d78 {
+    !error "Assertion failed: sub_c8d79-1 == $8d78"
+}
+!if (sub_c92e6-1) != $92e5 {
+    !error "Assertion failed: sub_c92e6-1 == $92e5"
+}
+!if (sub_c92e6-1) != $92e5 {
+    !error "Assertion failed: sub_c92e6-1 == $92e5"
+}
+!if (sub_c92e6-1) != $92e5 {
+    !error "Assertion failed: sub_c92e6-1 == $92e5"
+}
+!if (sub_c92e6-1) != $92e5 {
+    !error "Assertion failed: sub_c92e6-1 == $92e5"
+}
+!if (sub_c938b-1) != $938a {
+    !error "Assertion failed: sub_c938b-1 == $938a"
+}
+!if (sub_c93dd-1) != $93dc {
+    !error "Assertion failed: sub_c93dd-1 == $93dc"
+}
+!if (sub_c949e-1) != $949d {
+    !error "Assertion failed: sub_c949e-1 == $949d"
+}
+!if (sub_ca07b-1) != $a07a {
+    !error "Assertion failed: sub_ca07b-1 == $a07a"
+}
+!if (sub_ca356-1) != $a355 {
+    !error "Assertion failed: sub_ca356-1 == $a355"
+}
+!if (sub_cad10-1) != $ad0f {
+    !error "Assertion failed: sub_cad10-1 == $ad0f"
+}
+!if (sub_cad5f-1) != $ad5e {
+    !error "Assertion failed: sub_cad5f-1 == $ad5e"
+}
+!if (sub_cad65-1) != $ad64 {
+    !error "Assertion failed: sub_cad65-1 == $ad64"
+}
+!if (sub_cad6b-1) != $ad6a {
+    !error "Assertion failed: sub_cad6b-1 == $ad6a"
+}
+!if (sub_caf66-1) != $af65 {
+    !error "Assertion failed: sub_caf66-1 == $af65"
+}
+!if (sub_cafee-1) != $afed {
+    !error "Assertion failed: sub_cafee-1 == $afed"
+}
+!if (sub_cb1c3-1) != $b1c2 {
+    !error "Assertion failed: sub_cb1c3-1 == $b1c2"
+}
+!if (sub_cb30c-1) != $b30b {
+    !error "Assertion failed: sub_cb30c-1 == $b30b"
+}
+!if (sub_cb33d-1) != $b33c {
+    !error "Assertion failed: sub_cb33d-1 == $b33c"
+}
+!if (sub_cb359-1) != $b358 {
+    !error "Assertion failed: sub_cb359-1 == $b358"
+}
+!if (sub_cb994-1) != $b993 {
+    !error "Assertion failed: sub_cb994-1 == $b993"
+}
+!if (sub_cb99a-1) != $b999 {
+    !error "Assertion failed: sub_cb99a-1 == $b999"
+}
+!if (sub_cb99d-1) != $b99c {
+    !error "Assertion failed: sub_cb99d-1 == $b99c"
+}
+!if (sub_cba1b-1) != $ba1a {
+    !error "Assertion failed: sub_cba1b-1 == $ba1a"
+}

--- a/examples/known_good/anfs418_beebasm.asm
+++ b/examples/known_good/anfs418_beebasm.asm
@@ -1,0 +1,10688 @@
+; Constants
+osbyte_acknowledge_escape                       = 126
+osbyte_close_spool_exec                         = 119
+osbyte_explode_chars                            = 20
+osbyte_flush_buffer_class                       = 15
+osbyte_insert_input_buffer                      = 153
+osbyte_issue_service_request                    = 143
+osbyte_read_os_version                          = 0
+osbyte_read_write_econet_keyboard_disable       = 201
+osbyte_read_write_econet_os_call_interception   = 206
+osbyte_scan_keyboard                            = 121
+osbyte_scan_keyboard_from_16                    = 122
+osbyte_vsync                                    = 19
+osbyte_write_keys_pressed                       = 120
+osfile_read_catalogue_info                      = 5
+osword_read_palette                             = 11
+service_claim_absolute_workspace                = 1
+service_vectors_changed                         = 15
+
+; Memory locations
+l0000               = &0000
+l0001               = &0001
+l0012               = &0012
+l0013               = &0013
+l0014               = &0014
+l0015               = &0015
+l0016               = &0016
+l0032               = &0032
+l0053               = &0053
+l0054               = &0054
+l0055               = &0055
+l0056               = &0056
+l0063               = &0063
+l0078               = &0078
+l0098               = &0098
+l0099               = &0099
+l009a               = &009a
+l009b               = &009b
+l009c               = &009c
+l009d               = &009d
+l009e               = &009e
+l009f               = &009f
+l00a0               = &00a0
+l00a1               = &00a1
+l00a2               = &00a2
+l00a3               = &00a3
+l00a4               = &00a4
+l00a5               = &00a5
+l00a6               = &00a6
+l00a7               = &00a7
+l00a8               = &00a8
+l00a9               = &00a9
+l00aa               = &00aa
+l00ab               = &00ab
+l00ac               = &00ac
+l00ad               = &00ad
+l00ae               = &00ae
+l00af               = &00af
+l00b0               = &00b0
+l00b1               = &00b1
+l00b2               = &00b2
+l00b3               = &00b3
+l00b4               = &00b4
+l00b5               = &00b5
+l00b6               = &00b6
+l00b7               = &00b7
+l00b8               = &00b8
+l00b9               = &00b9
+l00ba               = &00ba
+l00bb               = &00bb
+l00bc               = &00bc
+l00bd               = &00bd
+l00be               = &00be
+l00bf               = &00bf
+l00c0               = &00c0
+l00c1               = &00c1
+l00c2               = &00c2
+l00c4               = &00c4
+l00c7               = &00c7
+l00c8               = &00c8
+l00cc               = &00cc
+l00cd               = &00cd
+l00d0               = &00d0
+l00ed               = &00ed
+l00ef               = &00ef
+l00f0               = &00f0
+os_text_ptr         = &00f2
+l00f3               = &00f3
+romsel_copy         = &00f4
+osrdsc_ptr          = &00f6
+l00f7               = &00f7
+l00fd               = &00fd
+l00ff               = &00ff
+l0100               = &0100
+l0101               = &0101
+l0102               = &0102
+l0103               = &0103
+l0104               = &0104
+brkv                = &0202
+filev               = &0212
+fscv                = &021e
+evntv               = &0220
+netv                = &0224
+l026a               = &026a
+l028d               = &028d
+l02a0               = &02a0
+l0350               = &0350
+l0351               = &0351
+l0355               = &0355
+l0491               = &0491
+l04c7               = &04c7
+l04ce               = &04ce
+l0500               = &0500
+l0518               = &0518
+l0600               = &0600
+l0601               = &0601
+l0695               = &0695
+l069e               = &069e
+l0a00               = &0a00
+l0a81               = &0a81
+l0cff               = &0cff
+l0d07               = &0d07
+l0d0c               = &0d0c
+l0d0d               = &0d0d
+l0d0e               = &0d0e
+l0d11               = &0d11
+l0d1a               = &0d1a
+l0d1e               = &0d1e
+l0d20               = &0d20
+l0d21               = &0d21
+l0d22               = &0d22
+l0d23               = &0d23
+l0d24               = &0d24
+l0d25               = &0d25
+l0d26               = &0d26
+l0d3e               = &0d3e
+l0d3f               = &0d3f
+l0d40               = &0d40
+l0d41               = &0d41
+l0d60               = &0d60
+l0d61               = &0d61
+l0d62               = &0d62
+l0d63               = &0d63
+l0d64               = &0d64
+l0d65               = &0d65
+l0d68               = &0d68
+l0d69               = &0d69
+l0d6a               = &0d6a
+l0d6b               = &0d6b
+l0d6c               = &0d6c
+l0d6d               = &0d6d
+l0d6e               = &0d6e
+l0d6f               = &0d6f
+l0d71               = &0d71
+l0df0               = &0df0
+l0dfe               = &0dfe
+l0e00               = &0e00
+l0e01               = &0e01
+l0e02               = &0e02
+l0e03               = &0e03
+l0e04               = &0e04
+l0e05               = &0e05
+l0e06               = &0e06
+l0e07               = &0e07
+l0e08               = &0e08
+l0e09               = &0e09
+l0e0a               = &0e0a
+l0e0b               = &0e0b
+l0e14               = &0e14
+l0e2f               = &0e2f
+l0e30               = &0e30
+l0e31               = &0e31
+l0e32               = &0e32
+l0e38               = &0e38
+l0e81               = &0e81
+l0ef7               = &0ef7
+l0f00               = &0f00
+l0f01               = &0f01
+l0f02               = &0f02
+l0f03               = &0f03
+l0f04               = &0f04
+l0f05               = &0f05
+l0f06               = &0f06
+l0f07               = &0f07
+l0f08               = &0f08
+l0f09               = &0f09
+l0f0a               = &0f0a
+l0f0b               = &0f0b
+l0f0c               = &0f0c
+l0f0d               = &0f0d
+l0f0e               = &0f0e
+l0f10               = &0f10
+l0f11               = &0f11
+l0f12               = &0f12
+l0f13               = &0f13
+l0f14               = &0f14
+l0f2f               = &0f2f
+l0f30               = &0f30
+l0fc8               = &0fc8
+l0fdc               = &0fdc
+l0fdd               = &0fdd
+l0fde               = &0fde
+l0fdf               = &0fdf
+l0fe0               = &0fe0
+l0ff0               = &0ff0
+l0fff               = &0fff
+l1000               = &1000
+l1010               = &1010
+l1020               = &1020
+l1030               = &1030
+l1040               = &1040
+l1050               = &1050
+l1060               = &1060
+l1070               = &1070
+l1071               = &1071
+l1072               = &1072
+l1073               = &1073
+l1074               = &1074
+l1078               = &1078
+l1088               = &1088
+l1098               = &1098
+l10a8               = &10a8
+l10b8               = &10b8
+l10c8               = &10c8
+l10c9               = &10c9
+l10ca               = &10ca
+l10cb               = &10cb
+l10cc               = &10cc
+l10cd               = &10cd
+l10ce               = &10ce
+l10cf               = &10cf
+l10d0               = &10d0
+l10d1               = &10d1
+l10d4               = &10d4
+l10d5               = &10d5
+l10d6               = &10d6
+l10d7               = &10d7
+l10d8               = &10d8
+l10d9               = &10d9
+l10f3               = &10f3
+lfe18               = &fe18
+video_ula_control   = &fe20
+romsel              = &fe30
+system_via_sr       = &fe4a
+system_via_acr      = &fe4b
+system_via_ifr      = &fe4d
+system_via_ier      = &fe4e
+lfe87               = &fe87
+lfea0               = &fea0
+lfea1               = &fea1
+lfea2               = &fea2
+lfea3               = &fea3
+tube_host_r1_status = &fee0
+tube_host_r1_data   = &fee1
+tube_host_r3_data   = &fee5
+tube_host_r4_status = &fee6
+lffb0               = &ffb0
+osrdsc              = &ffb9
+lffbd               = &ffbd
+gsinit              = &ffc2
+gsread              = &ffc5
+osfind              = &ffce
+osbget              = &ffd7
+osargs              = &ffda
+osfile              = &ffdd
+osrdch              = &ffe0
+osasci              = &ffe3
+osnewl              = &ffe7
+oswrch              = &ffee
+osword              = &fff1
+osbyte              = &fff4
+oscli               = &fff7
+
+    org &8000
+
+; Sideways ROM header
+; &8000 referenced 1 time by &bfe6
+.rom_header
+.language_entry
+.pydis_start
+l8001 = rom_header+1
+l8002 = rom_header+2
+    equb   0, &42, &43                                                ; 8000: 00 42 43    .BC
+; &8001 referenced 1 time by &bfeb
+; &8002 referenced 1 time by &bff0
+
+; &8003 referenced 1 time by &bff5
+.service_entry
+l8004 = service_entry+1
+    jmp service_handler                                               ; 8003: 4c 15 8a    L..
+
+; &8004 referenced 1 time by &bff8
+; &8006 referenced 1 time by &bfda
+.rom_type
+    equb &82                                                          ; 8006: 82          .
+; &8007 referenced 1 time by &bfe2
+.copyright_offset
+    equb copyright - rom_header                                       ; 8007: 19          .
+.binary_version
+    equb 4                                                            ; 8008: 04          .
+.title
+    equs "Acorn ANFS 4.18"                                            ; 8009: 41 63 6f... Aco
+.version
+    equb 0                                                            ; 8018: 00          .
+.copyright
+    equb 0                                                            ; 8019: 00          .
+    equs "(C)1985 Acorn", 0                                           ; 801a: 28 43 29... (C)
+
+.sub_c8028
+    lda #4                                                            ; 8028: a9 04       ..
+    bit system_via_ifr                                                ; 802a: 2c 4d fe    ,M.
+    bne c8032                                                         ; 802d: d0 03       ..
+    lda #5                                                            ; 802f: a9 05       ..
+    rts                                                               ; 8031: 60          `
+
+; &8032 referenced 1 time by &802d
+.c8032
+    txa                                                               ; 8032: 8a          .
+    pha                                                               ; 8033: 48          H
+    tya                                                               ; 8034: 98          .
+    pha                                                               ; 8035: 48          H
+    lda system_via_acr                                                ; 8036: ad 4b fe    .K.
+    and #&e3                                                          ; 8039: 29 e3       ).
+    ora l0d64                                                         ; 803b: 0d 64 0d    .d.
+    sta system_via_acr                                                ; 803e: 8d 4b fe    .K.
+    lda system_via_sr                                                 ; 8041: ad 4a fe    .J.
+    lda #4                                                            ; 8044: a9 04       ..
+    sta system_via_ifr                                                ; 8046: 8d 4d fe    .M.
+    sta system_via_ier                                                ; 8049: 8d 4e fe    .N.
+    ldy l0d65                                                         ; 804c: ac 65 0d    .e.
+    tya                                                               ; 804f: 98          .
+    bmi c805d                                                         ; 8050: 30 0b       0.
+    lda #&fe                                                          ; 8052: a9 fe       ..
+    jsr sub_c805a                                                     ; 8054: 20 5a 80     Z.
+    jmp c8585                                                         ; 8057: 4c 85 85    L..
+
+; &805a referenced 1 time by &8054
+.sub_c805a
+    jmp (evntv)                                                       ; 805a: 6c 20 02    l .
+
+; &805d referenced 1 time by &8050
+.c805d
+    cpy #&86                                                          ; 805d: c0 86       ..
+    bcs c806c                                                         ; 805f: b0 0b       ..
+    lda l0d68                                                         ; 8061: ad 68 0d    .h.
+    sta l0d69                                                         ; 8064: 8d 69 0d    .i.
+    ora #&1c                                                          ; 8067: 09 1c       ..
+    sta l0d68                                                         ; 8069: 8d 68 0d    .h.
+; &806c referenced 1 time by &805f
+.c806c
+    lda #&85                                                          ; 806c: a9 85       ..
+    pha                                                               ; 806e: 48          H
+    lda l84bb,y                                                       ; 806f: b9 bb 84    ...
+    pha                                                               ; 8072: 48          H
+    rts                                                               ; 8073: 60          `
+
+; &8074 referenced 1 time by &8f5d
+.sub_c8074
+    bit lfe18                                                         ; 8074: 2c 18 fe    ,..
+    jsr sub_c8969                                                     ; 8077: 20 69 89     i.
+    lda #&ea                                                          ; 807a: a9 ea       ..
+    ldx #0                                                            ; 807c: a2 00       ..
+    stx l0d62                                                         ; 807e: 8e 62 0d    .b.
+    jsr sub_c8e83                                                     ; 8081: 20 83 8e     ..
+    stx l0d63                                                         ; 8084: 8e 63 0d    .c.
+    lda #&8f                                                          ; 8087: a9 8f       ..
+    ldx #&0c                                                          ; 8089: a2 0c       ..
+    jsr sub_c8e85                                                     ; 808b: 20 85 8e     ..
+    ldy #5                                                            ; 808e: a0 05       ..
+.sub_c8090
+    cpy #5                                                            ; 8090: c0 05       ..
+    bne c80bd                                                         ; 8092: d0 29       .)
+    ldy #&20 ; ' '                                                    ; 8094: a0 20       .
+; &8096 referenced 1 time by &809d
+.loop_c8096
+    lda l89a6,y                                                       ; 8096: b9 a6 89    ...
+    sta l0cff,y                                                       ; 8099: 99 ff 0c    ...
+    dey                                                               ; 809c: 88          .
+    bne loop_c8096                                                    ; 809d: d0 f7       ..
+    lda romsel_copy                                                   ; 809f: a5 f4       ..
+    sta l0d07                                                         ; 80a1: 8d 07 0d    ...
+    sty l0d23                                                         ; 80a4: 8c 23 0d    .#.
+    sty l0099                                                         ; 80a7: 84 99       ..
+    sty l0d65                                                         ; 80a9: 8c 65 0d    .e.
+    ldy lfe18                                                         ; 80ac: ac 18 fe    ...
+    sty l0d22                                                         ; 80af: 8c 22 0d    .".
+    lda #&80                                                          ; 80b2: a9 80       ..
+    sta l0d60                                                         ; 80b4: 8d 60 0d    .`.
+    sta l0d62                                                         ; 80b7: 8d 62 0d    .b.
+    bit video_ula_control                                             ; 80ba: 2c 20 fe    , .
+; &80bd referenced 1 time by &8092
+.c80bd
+    rts                                                               ; 80bd: 60          `
+
+; &80be referenced 1 time by &89b2
+.c80be
+    lda #1                                                            ; 80be: a9 01       ..
+    bit lfea1                                                         ; 80c0: 2c a1 fe    ,..
+    beq c80fd                                                         ; 80c3: f0 38       .8
+    lda lfea2                                                         ; 80c5: ad a2 fe    ...
+    cmp lfe18                                                         ; 80c8: cd 18 fe    ...
+    beq c80d6                                                         ; 80cb: f0 09       ..
+    cmp #&ff                                                          ; 80cd: c9 ff       ..
+    bne c80e9                                                         ; 80cf: d0 18       ..
+    lda #&40 ; '@'                                                    ; 80d1: a9 40       .@
+    sta l0d3e                                                         ; 80d3: 8d 3e 0d    .>.
+; &80d6 referenced 1 time by &80cb
+.c80d6
+    lda #&db                                                          ; 80d6: a9 db       ..
+    jmp l0d11                                                         ; 80d8: 4c 11 0d    L..
+
+    equb &2c, &a1, &fe, &10, &1d, &ad, &a2, &fe, &f0, &0c, &49, &ff   ; 80db: 2c a1 fe... ,..
+    equb &f0, &0b                                                     ; 80e7: f0 0b       ..
+
+; &80e9 referenced 1 time by &80cf
+.c80e9
+    lda #&a2                                                          ; 80e9: a9 a2       ..
+    sta lfea0                                                         ; 80eb: 8d a0 fe    ...
+    jmp c83fb                                                         ; 80ee: 4c fb 83    L..
+
+    equb &8d, &3e, &0d, &85, &a2, &a9, &0d, &a0, &81, &4c, &0e, &0d   ; 80f1: 8d 3e 0d... .>.
+
+; &80fd referenced 1 time by &80c3
+.c80fd
+    lda lfea1                                                         ; 80fd: ad a1 fe    ...
+    and #&81                                                          ; 8100: 29 81       ).
+    beq c810a                                                         ; 8102: f0 06       ..
+    jsr sub_c8969                                                     ; 8104: 20 69 89     i.
+    jmp c83fb                                                         ; 8107: 4c fb 83    L..
+
+; &810a referenced 1 time by &8102
+.c810a
+    jmp c83f8                                                         ; 810a: 4c f8 83    L..
+
+    equb &a4, &a2, &ad, &a1, &fe, &10, &e9, &ad, &a2, &fe, &99, &2e   ; 810d: a4 a2 ad... ...
+    equb &0d, &c8, &ad, &a1, &fe, &30,   2, &d0, &15, &ad, &a2, &fe   ; 8119: 0d c8 ad... ...
+    equb &99, &2e, &0d, &c8, &c0, &0c, &f0, &0a, &84, &a2, &ad, &a1   ; 8125: 99 2e 0d... ...
+    equb &fe, &d0, &de, &4c, &14, &0d, &a9,   0, &8d, &a0, &fe, &a9   ; 8131: fe d0 de... ...
+    equb &84, &8d, &a1, &fe, &a9,   2, &2c, &a1, &fe, &f0, &b5, &10   ; 813d: 84 8d a1... ...
+    equb &b3, &ad, &a2, &fe, &99, &2e, &0d, &a9, &44, &8d, &a0, &fe   ; 8149: b3 ad a2... ...
+    equb &38, &66, &99, &ad, &31, &0d, &d0,   3, &4c, &55, &84, &2c   ; 8155: 38 66 99... 8f.
+    equb &3e, &0d, &50,   5, &a9,   7, &8d, &a1, &fe, &2c, &61, &0d   ; 8161: 3e 0d 50... >.P
+    equb &10, &40, &a9, &c0, &a0,   0, &85, &a6, &84, &a7, &a0,   0   ; 816d: 10 40 a9... .@.
+    equb &b1, &a6, &f0, &2f, &c9, &7f, &d0, &1e, &c8, &b1, &a6, &f0   ; 8179: b1 a6 f0... ...
+    equb   5, &cd, &31, &0d, &d0, &14, &c8, &b1, &a6, &f0, &2a, &cd   ; 8185: 05 cd 31... ..1
+    equb &2e, &0d, &d0, &0a, &c8, &b1, &a6, &f0, &20, &cd, &2f, &0d   ; 8191: 2e 0d d0... ...
+    equb &f0, &1b, &a5, &a7, &f0, &0c, &a5, &a6, &18, &69, &0c, &85   ; 819d: f0 1b a5... ...
+    equb &a6, &90, &cb, &4c, &36, &82, &2c, &61, &0d, &50, &f8, &a9   ; 81a9: a6 90 cb... ...
+    equb   0, &a4, &9f, &d0, &b9, &a9,   3, &8d, &40, &0d, &20, &f2   ; 81b5: 00 a4 9f... ...
+    equb &88, &90                                                     ; 81c1: 88 90       ..
+    equs "r,>"                                                        ; 81c3: 72 2c 3e    r,>
+    equb &0d, &50,   3, &4c, &10, &84, &a9, &44, &8d, &a0, &fe, &a9   ; 81c6: 0d 50 03... .P.
+    equb &a7, &8d, &a1, &fe, &a9, &dd, &a0, &81, &4c,   8, &83, &a9   ; 81d2: a7 8d a1... ...
+    equb &82, &8d, &a0, &fe, &a9, &e7, &4c, &11, &0d, &a9,   1, &2c   ; 81de: 82 8d a0... ...
+    equb &a1, &fe, &f0, &48, &ad, &a2, &fe, &cd, &18, &fe, &d0, &40   ; 81ea: a1 fe f0... ...
+    equb &a9, &fb, &4c, &11, &0d, &2c, &a1, &fe, &10, &36, &ad, &a2   ; 81f6: a9 fb 4c... ..L
+    equb &fe, &d0, &31, &a9, &11, &a0, &82, &2c, &a0, &fe, &30,   3   ; 8202: fe d0 31... ..1
+    equb &4c, &0e, &0d, &2c, &a1, &fe, &10, &20, &ad, &a2, &fe, &ad   ; 820e: 4c 0e 0d... L..
+    equb &a2, &fe, &a9,   2, &2c, &3e, &0d, &d0, &0c, &a9, &44, &a0   ; 821a: a2 fe a9... ...
+    equb &82, &2c, &a0, &fe, &30, &18, &4c, &0e, &0d, &a9, &a1, &a0   ; 8226: 82 2c a0... .,.
+    equb &82, &4c, &0e, &0d, &ad, &3e, &0d, &10,   3, &4c, &d4, &88   ; 8232: 82 4c 0e... .L.
+    equb &20, &69, &89, &4c, &f5, &83, &a4, &a2, &ad, &a1, &fe, &10   ; 823e: 20 69 89...  i.
+    equb &2d, &ad, &a2, &fe, &91, &a4, &c8, &d0,   6, &e6, &a5, &c6   ; 824a: 2d ad a2... -..
+    equb &a3, &f0, &dd, &ad, &a1, &fe, &30,   2, &d0, &18, &ad, &a2   ; 8256: a3 f0 dd... ...
+    equb &fe, &91, &a4, &c8, &84, &a2, &d0,   6, &e6, &a5, &c6, &a3   ; 8262: fe 91 a4... ...
+    equb &f0,   8, &ad, &a1, &fe, &d0, &d4, &4c, &14, &0d, &a9, &84   ; 826e: f0 08 ad... ...
+    equb &8d, &a1, &fe, &a9,   0, &8d, &a0, &fe, &84, &a2, &a9,   2   ; 827a: 8d a1 fe... ...
+    equb &2c, &a1, &fe, &f0, &ab, &10, &11, &a5, &a3, &f0, &a5, &ad   ; 8286: 2c a1 fe... ,..
+    equb &a2, &fe, &a4, &a2, &91, &a4, &e6, &a2, &d0,   2, &e6, &a5   ; 8292: a2 fe a4... ...
+    equb &4c, &ef, &82, &ad, &a1, &fe, &10, &1e, &ad, &a2, &fe, &20   ; 829e: 4c ef 82... L..
+    equb &2f, &85, &f0, &e1, &8d, &e5, &fe, &ad, &a2, &fe, &8d, &e5   ; 82aa: 2f 85 f0... /..
+    equb &fe, &20, &2f, &85, &f0,   8, &ad, &a1, &fe, &d0, &e3, &4c   ; 82b6: fe 20 2f... . /
+    equb &14, &0d, &a9,   0, &8d, &a0, &fe, &a9, &84, &8d, &a1, &fe   ; 82c2: 14 0d a9... ...
+    equb &a9,   2, &2c, &a1, &fe, &f0, &ba, &10, &18, &a5, &a2,   5   ; 82ce: a9 02 2c... ..,
+    equb &a3,   5, &a4,   5, &a5, &f0, &ae, &ad, &a2, &fe, &8d, &42   ; 82da: a3 05 a4... ...
+    equb &0d, &a9, &20, &0d, &3e, &0d, &8d, &3e, &0d, &ad, &3e, &0d   ; 82e6: 0d a9 20... ..
+    equb &10,   6, &20, &4f, &83, &4c, &d0, &88, &a9, &44, &8d, &a0   ; 82f2: 10 06 20... ..
+    equb &fe, &a9, &a7, &8d, &a1, &fe, &a9, &96, &a0, &83, &8d, &43   ; 82fe: fe a9 a7... ...
+    equb &0d, &8c, &44, &0d, &ad, &2e, &0d, &2c, &a0, &fe, &50, &36   ; 830a: 0d 8c 44... ..D
+    equb &8d, &a2, &fe, &ad, &2f, &0d, &8d, &a2, &fe, &a9, &26, &a0   ; 8316: 8d a2 fe... ...
+    equb &83, &4c, &0e, &0d, &ad, &18, &fe, &2c, &a0, &fe, &50, &1e   ; 8322: 83 4c 0e... .L.
+    equb &8d, &a2, &fe, &a9,   0, &8d, &a2, &fe, &ad, &3e, &0d, &30   ; 832e: 8d a2 fe... ...
+    equb &0e, &a9, &3f, &8d, &a1, &fe, &ad, &43, &0d, &ac, &44, &0d   ; 833a: 0e a9 3f... ..?
+    equb &4c, &0e, &0d, &4c, &d1, &87, &4c, &36, &82, &a9,   2, &2c   ; 8346: 4c 0e 0d... L..
+    equb &3e, &0d, &f0, &3f, &18,   8, &a0,   8, &b1, &a6, &28, &79   ; 8352: 3e 0d f0... >..
+    equb &9a,   0, &91, &a6, &c8,   8, &c0, &0c, &90, &f2, &28, &a9   ; 835e: 9a 00 91... ...
+    equs " ,>"                                                        ; 836a: 20 2c 3e     ,>
+    equb &0d, &f0, &23, &8a, &48, &a9,   8, &18, &65, &a6, &aa, &a4   ; 836d: 0d f0 23... ..#
+    equb &a7, &a9,   1, &20,   6,   4, &ad, &42, &0d, &8d, &e5, &fe   ; 8379: a7 a9 01... ...
+    equb &38, &a0,   8, &a9,   0, &71, &a6, &91, &a6, &c8, &b0, &f7   ; 8385: 38 a0 08... 8..
+    equb &68, &aa, &a9, &ff, &60, &ad, &31, &0d, &d0, &0a, &ac, &30   ; 8391: 68 aa a9... h..
+    equb &0d, &c0, &82, &f0,   3, &4c, &f6, &84, &20, &4f, &83, &d0   ; 839d: 0d c0 82... ...
+    equb &12, &a5, &a2, &18, &65, &a4, &90,   2, &e6, &a5, &a0,   8   ; 83a9: 12 a5 a2... ...
+    equb &91, &a6, &c8, &a5, &a5, &91, &a6, &ad, &31, &0d, &f0, &34   ; 83b5: 91 a6 c8... ...
+    equb &ad, &2f, &0d, &a0,   3, &91, &a6, &88, &ad, &2e, &0d, &91   ; 83c1: ad 2f 0d... ./.
+    equb &a6, &88, &ad, &31, &0d, &91, &a6, &88, &ad, &30, &0d,   9   ; 83cd: a6 88 ad... ...
+    equb &80, &91, &a6, &ad, &6c, &0d, &6a, &90, &13, &a5, &a6, &c8   ; 83d9: 80 91 a6... ...
+    equb &e9, &0c, &b0, &fb, &88, &c0,   3, &90,   7, &20,   2, &84   ; 83e5: e9 0c b0... ...
+    equb &98, &4c, &0f, &85, &20,   2, &84                            ; 83f1: 98 4c 0f... .L.
+
+; &83f8 referenced 1 time by &810a
+.c83f8
+    jsr c8978                                                         ; 83f8: 20 78 89     x.
+; &83fb referenced 2 times by &80ee, &8107
+.c83fb
+    lda #&be                                                          ; 83fb: a9 be       ..
+    ldy #&80                                                          ; 83fd: a0 80       ..
+    jmp l0d0e                                                         ; 83ff: 4c 0e 0d    L..
+
+    equb &a9,   2, &2d, &63, &0d, &2c, &3e, &0d, &f0,   3, &20, &49   ; 8402: a9 02 2d... ..-
+    equb &84, &60, &8a, &48, &a2,   4, &a9,   2, &2c, &3e, &0d, &d0   ; 840e: 84 60 8a... .`.
+    equb &1c, &a4, &a2, &bd, &2e, &0d, &91, &a4, &c8, &d0,   6, &e6   ; 841a: 1c a4 a2... ...
+    equb &a5, &c6, &a3, &f0, &52, &e8, &84, &a2, &e0, &0c, &d0, &eb   ; 8426: a5 c6 a3... ...
+    equb &68, &aa, &4c, &a5, &83, &bd, &2e, &0d, &8d, &e5, &fe, &20   ; 8432: 68 aa 4c... h.L
+    equb &2f, &85, &f0, &3d, &e8, &e0, &0c, &d0, &f0, &f0, &e9        ; 843e: 2f 85 f0... /..
+
+; &8449 referenced 1 time by &893e
+.sub_c8449
+    bit l0099                                                         ; 8449: 24 99       $.
+    bmi c8452                                                         ; 844b: 30 05       0.
+    lda #&82                                                          ; 844d: a9 82       ..
+    jsr c0406                                                         ; 844f: 20 06 04     ..
+; &8452 referenced 1 time by &844b
+.c8452
+    lsr l0099                                                         ; 8452: 46 99       F.
+    rts                                                               ; 8454: 60          `
+
+    equb &ac, &30, &0d, &c0, &81, &90, &29, &c0, &89, &b0, &25, &c0   ; 8455: ac 30 0d... .0.
+    equb &87, &b0, &0e, &98, &38, &e9, &81, &a8, &ad, &68, &0d, &6a   ; 8461: 87 b0 0e... ...
+    equb &88, &10, &fc, &b0, &86, &ac, &30, &0d, &a9, &84, &48, &b9   ; 846d: 88 10 fc... ...
+    equb   7, &84, &48, &60, &e6, &a2, &e0, &0b, &f0, &af, &68, &aa   ; 8479: 07 84 48... ..H
+    equb &4c, &36, &82, &ca, &ad, &8f, &8f, &8f, &e4, &e4, &b8, &a9   ; 8485: 4c 36 82... L6.
+    equb   0, &85, &a4, &a9, &82, &85, &a2, &a9,   1, &85, &a3, &a5   ; 8491: 00 85 a4... ...
+    equb &9d, &85, &a5, &a0,   1, &b9, &32, &0d, &99, &66, &0d, &88   ; 849d: 9d 85 a5... ...
+    equb &10, &f7, &4c, &cc, &81, &a9, &2e, &85, &a6, &a9, &0d, &85   ; 84a9: 10 f7 4c... ..L
+    equb &a7, &4c, &ba, &81, &a9,   1                                 ; 84b5: a7 4c ba... .L.
+; &84bb referenced 1 time by &806f
+.l84bb
+    equb &85, &a3, &a9, &fc, &85, &a2, &a9, &cb, &85, &a4, &a9, &88   ; 84bb: 85 a3 a9... ...
+    equb &85, &a5, &d0, &12, &a9, &2e, &85, &a6, &a9, &0d, &85, &a7   ; 84c7: 85 a5 d0... ...
+    equb &a9,   2, &8d, &40, &0d, &20, &f2, &88, &90, &4f, &ad, &3e   ; 84d3: a9 02 8d... ...
+    equb &0d,   9, &80, &8d, &3e, &0d, &a9, &44, &8d, &a0, &fe, &a9   ; 84df: 0d 09 80... ...
+    equb &a7, &8d, &a1, &fe, &a9, &0c, &a0, &85, &4c,   8, &83, &a5   ; 84eb: a7 8d a1... ...
+    equb &a2, &18, &69, &80, &a0, &7f, &91, &9c, &a0, &80, &ad, &2e   ; 84f7: a2 18 69... ..i
+    equb &0d, &91, &9c, &c8, &ad, &2f, &0d, &91, &9c, &ad, &30, &0d   ; 8503: 0d 91 9c... ...
+    equb &8d, &65, &0d, &a9, &84, &8d, &4e, &fe, &ad, &4b, &fe, &29   ; 850f: 8d 65 0d... .e.
+    equb &1c, &8d, &64, &0d, &ad, &4b, &fe, &29, &e3,   9,   8, &8d   ; 851b: 1c 8d 64... ..d
+    equb &4b, &fe, &2c, &4a, &fe, &4c, &f8, &83, &e6, &a2, &d0, &0a   ; 8527: 4b fe 2c... K.,
+    equb &e6, &a3, &d0,   6, &e6, &a4, &d0,   2, &e6, &a5             ; 8533: e6 a3 d0... ...
+    equs "`BKYe|"                                                     ; 853d: 60 42 4b... `BK
+    equb &a9, &85, &48, &a9, &84                                      ; 8543: a9 85 48... ..H
+    equs "Hlf"                                                        ; 8548: 48 6c 66    Hlf
+    equb &0d, &ae, &66, &0d, &ad, &67, &0d, &a0,   8, &20, &bf, &ff   ; 854b: 0d ae 66... ..f
+    equb &4c, &85, &85, &ae, &66, &0d, &ac, &67, &0d, &20, &43, &8e   ; 8557: 4c 85 85... L..
+    equb &4c, &85, &85, &a9,   4, &2c, &61, &0d, &d0, &18, &0d, &61   ; 8563: 4c 85 85... L..
+    equb &0d, &8d, &61, &0d, &a9,   4                                 ; 856f: 0d 8d 61... ..a
+    equs "X,a"                                                        ; 8575: 58 2c 61    X,a
+    equb &0d, &d0, &fb, &f0,   8, &ad, &61, &0d, &29, &fb, &8d, &61   ; 8578: 0d d0 fb... ...
+    equb &0d                                                          ; 8584: 0d          .
+
+; &8585 referenced 1 time by &8057
+.c8585
+    pla                                                               ; 8585: 68          h
+    tay                                                               ; 8586: a8          .
+    pla                                                               ; 8587: 68          h
+    tax                                                               ; 8588: aa          .
+    lda #0                                                            ; 8589: a9 00       ..
+    rts                                                               ; 858b: 60          `
+
+; &858c referenced 2 times by &98d6, &a89a
+.sub_c858c
+    txa                                                               ; 858c: 8a          .
+    pha                                                               ; 858d: 48          H
+    ldy #2                                                            ; 858e: a0 02       ..
+    lda (l00a0),y                                                     ; 8590: b1 a0       ..
+    sta l0d20                                                         ; 8592: 8d 20 0d    . .
+    iny                                                               ; 8595: c8          .
+    lda (l00a0),y                                                     ; 8596: b1 a0       ..
+    sta l0d21                                                         ; 8598: 8d 21 0d    .!.
+    ldy #0                                                            ; 859b: a0 00       ..
+    lda (l00a0),y                                                     ; 859d: b1 a0       ..
+    bmi c85a4                                                         ; 859f: 30 03       0.
+    jmp c862f                                                         ; 85a1: 4c 2f 86    L/.
+
+; &85a4 referenced 1 time by &859f
+.c85a4
+    sta l0d24                                                         ; 85a4: 8d 24 0d    .$.
+    tax                                                               ; 85a7: aa          .
+    iny                                                               ; 85a8: c8          .
+    lda (l00a0),y                                                     ; 85a9: b1 a0       ..
+    sta l0d25                                                         ; 85ab: 8d 25 0d    .%.
+    bne c85e3                                                         ; 85ae: d0 33       .3
+    cpx #&83                                                          ; 85b0: e0 83       ..
+    bcs c85cf                                                         ; 85b2: b0 1b       ..
+    sec                                                               ; 85b4: 38          8
+    php                                                               ; 85b5: 08          .
+    ldy #8                                                            ; 85b6: a0 08       ..
+; &85b8 referenced 1 time by &85cc
+.loop_c85b8
+    lda (l00a0),y                                                     ; 85b8: b1 a0       ..
+    dey                                                               ; 85ba: 88          .
+    dey                                                               ; 85bb: 88          .
+    dey                                                               ; 85bc: 88          .
+    dey                                                               ; 85bd: 88          .
+    plp                                                               ; 85be: 28          (
+    sbc (l00a0),y                                                     ; 85bf: f1 a0       ..
+    sta l0d26,y                                                       ; 85c1: 99 26 0d    .&.
+    iny                                                               ; 85c4: c8          .
+    iny                                                               ; 85c5: c8          .
+    iny                                                               ; 85c6: c8          .
+    iny                                                               ; 85c7: c8          .
+    iny                                                               ; 85c8: c8          .
+    php                                                               ; 85c9: 08          .
+    cpy #&0c                                                          ; 85ca: c0 0c       ..
+    bcc loop_c85b8                                                    ; 85cc: 90 ea       ..
+    plp                                                               ; 85ce: 28          (
+; &85cf referenced 1 time by &85b2
+.c85cf
+    cpx #&81                                                          ; 85cf: e0 81       ..
+    bcc c862f                                                         ; 85d1: 90 5c       .\
+    cpx #&89                                                          ; 85d3: e0 89       ..
+    bcs c862f                                                         ; 85d5: b0 58       .X
+    ldy #&0c                                                          ; 85d7: a0 0c       ..
+; &85d9 referenced 1 time by &85e1
+.loop_c85d9
+    lda (l00a0),y                                                     ; 85d9: b1 a0       ..
+    sta l0d1a,y                                                       ; 85db: 99 1a 0d    ...
+    iny                                                               ; 85de: c8          .
+    cpy #&10                                                          ; 85df: c0 10       ..
+    bcc loop_c85d9                                                    ; 85e1: 90 f6       ..
+; &85e3 referenced 1 time by &85ae
+.c85e3
+    lda #&20 ; ' '                                                    ; 85e3: a9 20       .
+    bit lfea1                                                         ; 85e5: 2c a1 fe    ,..
+    bne c863f                                                         ; 85e8: d0 55       .U
+    lda #&fd                                                          ; 85ea: a9 fd       ..
+    pha                                                               ; 85ec: 48          H
+    lda #6                                                            ; 85ed: a9 06       ..
+    sta l0d3f                                                         ; 85ef: 8d 3f 0d    .?.
+    lda #0                                                            ; 85f2: a9 00       ..
+    sta l0d41                                                         ; 85f4: 8d 41 0d    .A.
+    pha                                                               ; 85f7: 48          H
+    pha                                                               ; 85f8: 48          H
+    ldy #&e7                                                          ; 85f9: a0 e7       ..
+; &85fb referenced 3 times by &8621, &8626, &862b
+.c85fb
+    lda #4                                                            ; 85fb: a9 04       ..
+    php                                                               ; 85fd: 08          .
+    sei                                                               ; 85fe: 78          x
+.sub_c85ff
+l8600 = sub_c85ff+1
+    bit lfe18                                                         ; 85ff: 2c 18 fe    ,..
+; &8600 referenced 1 time by &867c
+    bit lfe18                                                         ; 8602: 2c 18 fe    ,..
+    bit lfea1                                                         ; 8605: 2c a1 fe    ,..
+    beq c8619                                                         ; 8608: f0 0f       ..
+    lda lfea0                                                         ; 860a: ad a0 fe    ...
+    lda #&67 ; 'g'                                                    ; 860d: a9 67       .g
+    sta lfea1                                                         ; 860f: 8d a1 fe    ...
+    lda #&10                                                          ; 8612: a9 10       ..
+    bit lfea0                                                         ; 8614: 2c a0 fe    ,..
+    bne c864d                                                         ; 8617: d0 34       .4
+; &8619 referenced 1 time by &8608
+.c8619
+    bit video_ula_control                                             ; 8619: 2c 20 fe    , .
+    plp                                                               ; 861c: 28          (
+    tsx                                                               ; 861d: ba          .
+    inc l0101,x                                                       ; 861e: fe 01 01    ...
+    bne c85fb                                                         ; 8621: d0 d8       ..
+    inc l0102,x                                                       ; 8623: fe 02 01    ...
+    bne c85fb                                                         ; 8626: d0 d3       ..
+    inc l0103,x                                                       ; 8628: fe 03 01    ...
+    bne c85fb                                                         ; 862b: d0 ce       ..
+    beq c8633                                                         ; 862d: f0 04       ..
+; &862f referenced 3 times by &85a1, &85d1, &85d5
+.c862f
+    lda #&44 ; 'D'                                                    ; 862f: a9 44       .D
+    bne c8641                                                         ; 8631: d0 0e       ..
+; &8633 referenced 1 time by &862d
+.c8633
+    lda #7                                                            ; 8633: a9 07       ..
+    sta lfea1                                                         ; 8635: 8d a1 fe    ...
+    pla                                                               ; 8638: 68          h
+    pla                                                               ; 8639: 68          h
+    pla                                                               ; 863a: 68          h
+    lda #&40 ; '@'                                                    ; 863b: a9 40       .@
+    bne c8641                                                         ; 863d: d0 02       ..
+; &863f referenced 1 time by &85e8
+.c863f
+    lda #&43 ; 'C'                                                    ; 863f: a9 43       .C
+; &8641 referenced 2 times by &8631, &863d
+.c8641
+    ldy #0                                                            ; 8641: a0 00       ..
+    sta (l00a0),y                                                     ; 8643: 91 a0       ..
+    lda #&80                                                          ; 8645: a9 80       ..
+    sta l0d60                                                         ; 8647: 8d 60 0d    .`.
+    pla                                                               ; 864a: 68          h
+    tax                                                               ; 864b: aa          .
+    rts                                                               ; 864c: 60          `
+
+; &864d referenced 1 time by &8617
+.c864d
+    sty lfea1                                                         ; 864d: 8c a1 fe    ...
+    ldx #&44 ; 'D'                                                    ; 8650: a2 44       .D
+    stx lfea0                                                         ; 8652: 8e a0 fe    ...
+    ldx #&ea                                                          ; 8655: a2 ea       ..
+    ldy #&86                                                          ; 8657: a0 86       ..
+    stx l0d0c                                                         ; 8659: 8e 0c 0d    ...
+    sty l0d0d                                                         ; 865c: 8c 0d 0d    ...
+    sec                                                               ; 865f: 38          8
+    ror l0099                                                         ; 8660: 66 99       f.
+    bit video_ula_control                                             ; 8662: 2c 20 fe    , .
+    lda l0d25                                                         ; 8665: ad 25 0d    .%.
+    bne c86ac                                                         ; 8668: d0 42       .B
+    ldy l0d24                                                         ; 866a: ac 24 0d    .$.
+    lda l8869,y                                                       ; 866d: b9 69 88    .i.
+    sta l0d3e                                                         ; 8670: 8d 3e 0d    .>.
+    lda l8861,y                                                       ; 8673: b9 61 88    .a.
+    sta l0d3f                                                         ; 8676: 8d 3f 0d    .?.
+    lda #&86                                                          ; 8679: a9 86       ..
+    pha                                                               ; 867b: 48          H
+    lda l8600,y                                                       ; 867c: b9 00 86    ...
+    pha                                                               ; 867f: 48          H
+    rts                                                               ; 8680: 60          `
+
+    equb <((sub_c868d)-1), <((sub_c8691)-1), <((sub_c86d3)-1)         ; 8681: 8c 90 d2    ...
+    equb <((sub_c86d3)-1), <((sub_c86d3)-1),     <((c86e3)-1)         ; 8684: d2 d2 e2    ...
+    equb     <((c86e3)-1), <((sub_c8689)-1)                           ; 8687: e2 88       ..
+
+.sub_c8689
+    lda #3                                                            ; 8689: a9 03       ..
+    bne c86d5                                                         ; 868b: d0 48       .H
+.sub_c868d
+    lda #3                                                            ; 868d: a9 03       ..
+    bne c8693                                                         ; 868f: d0 02       ..
+.sub_c8691
+    lda #2                                                            ; 8691: a9 02       ..
+; &8693 referenced 1 time by &868f
+.c8693
+    sta l0d40                                                         ; 8693: 8d 40 0d    .@.
+    clc                                                               ; 8696: 18          .
+    php                                                               ; 8697: 08          .
+    ldy #&0c                                                          ; 8698: a0 0c       ..
+; &869a referenced 1 time by &86a7
+.loop_c869a
+    lda l0d1e,y                                                       ; 869a: b9 1e 0d    ...
+    plp                                                               ; 869d: 28          (
+    adc (l00a0),y                                                     ; 869e: 71 a0       q.
+    sta l0d1e,y                                                       ; 86a0: 99 1e 0d    ...
+    iny                                                               ; 86a3: c8          .
+    php                                                               ; 86a4: 08          .
+    cpy #&10                                                          ; 86a5: c0 10       ..
+    bcc loop_c869a                                                    ; 86a7: 90 f1       ..
+    plp                                                               ; 86a9: 28          (
+    bne c86d8                                                         ; 86aa: d0 2c       .,
+; &86ac referenced 1 time by &8668
+.c86ac
+    lda l0d20                                                         ; 86ac: ad 20 0d    . .
+    and l0d21                                                         ; 86af: 2d 21 0d    -!.
+    cmp #&ff                                                          ; 86b2: c9 ff       ..
+    bne c86ce                                                         ; 86b4: d0 18       ..
+    lda #&0e                                                          ; 86b6: a9 0e       ..
+    sta l0d3f                                                         ; 86b8: 8d 3f 0d    .?.
+    lda #&40 ; '@'                                                    ; 86bb: a9 40       .@
+    sta l0d3e                                                         ; 86bd: 8d 3e 0d    .>.
+    ldy #4                                                            ; 86c0: a0 04       ..
+; &86c2 referenced 1 time by &86ca
+.loop_c86c2
+    lda (l00a0),y                                                     ; 86c2: b1 a0       ..
+    sta l0d22,y                                                       ; 86c4: 99 22 0d    .".
+    iny                                                               ; 86c7: c8          .
+    cpy #&0c                                                          ; 86c8: c0 0c       ..
+    bcc loop_c86c2                                                    ; 86ca: 90 f6       ..
+    bcs c86e3                                                         ; 86cc: b0 15       ..
+; &86ce referenced 1 time by &86b4
+.c86ce
+    lda #0                                                            ; 86ce: a9 00       ..
+    sta l0d3e                                                         ; 86d0: 8d 3e 0d    .>.
+.sub_c86d3
+    lda #2                                                            ; 86d3: a9 02       ..
+; &86d5 referenced 1 time by &868b
+.c86d5
+    sta l0d40                                                         ; 86d5: 8d 40 0d    .@.
+; &86d8 referenced 1 time by &86aa
+.c86d8
+    lda l00a0                                                         ; 86d8: a5 a0       ..
+    sta l00a6                                                         ; 86da: 85 a6       ..
+    lda l00a1                                                         ; 86dc: a5 a1       ..
+    sta l00a7                                                         ; 86de: 85 a7       ..
+    jsr sub_c88f2                                                     ; 86e0: 20 f2 88     ..
+; &86e3 referenced 1 time by &86cc
+.c86e3
+    plp                                                               ; 86e3: 28          (
+    pla                                                               ; 86e4: 68          h
+    pla                                                               ; 86e5: 68          h
+    pla                                                               ; 86e6: 68          h
+    pla                                                               ; 86e7: 68          h
+    tax                                                               ; 86e8: aa          .
+    rts                                                               ; 86e9: 60          `
+
+    equb &ac, &41, &0d, &2c, &a0, &fe, &50, &22, &b9, &20, &0d, &8d   ; 86ea: ac 41 0d... .A.
+    equb &a2, &fe, &c8, &b9, &20, &0d, &c8, &8c, &41, &0d, &8d, &a2   ; 86f6: a2 fe c8... ...
+    equb &fe, &cc, &3f, &0d, &b0, &1e, &2c, &a0, &fe, &30, &e3, &4c   ; 8702: fe cc 3f... ..?
+    equb &14, &0d, &a9, &42, &d0,   7, &a9, &67, &8d, &a1, &fe, &a9   ; 870e: 14 0d a9... ...
+    equb &41, &ac, &18, &fe, &48, &68, &c8, &d0, &fb, &4c, &d6, &88   ; 871a: 41 ac 18... A..
+    equb &a9, &3f, &8d, &a1, &fe, &a9, &32, &a0, &87, &4c, &0e, &0d   ; 8726: a9 3f 8d... .?.
+    equb &a9, &82, &8d, &a0, &fe, &2c, &3e, &0d, &50,   3, &4c, &d0   ; 8732: a9 82 8d... ...
+    equb &88, &a9,   1, &2c, &3e, &0d, &f0,   3, &4c, &78, &88, &a9   ; 873e: 88 a9 01... ...
+    equb &4e, &4c, &11, &0d, &a9,   1, &2c, &a1, &fe, &f0, &bb, &ad   ; 874a: 4e 4c 11... NL.
+    equb &a2, &fe, &cd, &18, &fe, &d0, &19, &a9, &62, &4c, &11, &0d   ; 8756: a2 fe cd... ...
+    equb &2c, &a1, &fe, &10, &0f, &ad, &a2, &fe, &d0, &0a, &a9, &79   ; 8762: 2c a1 fe... ,..
+    equb &2c, &a0, &fe, &30,   6, &4c, &11, &0d, &4c, &d4, &88, &2c   ; 876e: 2c a0 fe... ,..
+    equb &a1, &fe, &10, &f8, &ad, &a2, &fe, &cd, &20, &0d, &d0, &f0   ; 877a: a1 fe 10... ...
+    equb &ad, &a2, &fe, &cd, &21, &0d, &d0, &e8, &a9,   2, &2c, &a1   ; 8786: ad a2 fe... ...
+    equb &fe, &f0, &e1, &a9, &a7, &8d, &a1, &fe, &a9, &44, &8d, &a0   ; 8792: fe f0 e1... ...
+    equb &fe, &a9, &78, &a0, &88, &8d, &43, &0d, &8c, &44, &0d, &ad   ; 879e: fe a9 78... ..x
+    equb &20, &0d, &2c, &a0, &fe, &50, &16, &8d, &a2, &fe, &ad, &21   ; 87aa: 20 0d 2c...  .,
+    equb &0d, &8d, &a2, &fe, &a9, &c1, &a0, &87, &4c, &0e, &0d, &ad   ; 87b6: 0d 8d a2... ...
+    equb &18, &fe, &2c, &a0, &fe, &50, &2c, &8d, &a2, &fe, &a9,   0   ; 87c2: 18 fe 2c... ..,
+    equb &8d, &a2, &fe, &a9,   2, &2c, &3e, &0d, &d0,   7, &a9, &ee   ; 87ce: 8d a2 fe... ...
+    equb &a0, &87, &4c, &0e, &0d, &a9, &37, &a0, &88, &4c, &0e, &0d   ; 87da: a0 87 4c... ..L
+    equb &a4, &a3, &f0, &33, &a4, &a2, &f0,   4, &a4, &a2, &f0, &f4   ; 87e6: a4 a3 f0... ...
+    equb &2c, &a0, &fe, &50, &43, &b1, &a4, &8d, &a2, &fe, &c8, &d0   ; 87f2: 2c a0 fe... ,..
+    equb   6, &c6, &a3, &f0, &1a, &e6, &a5, &b1, &a4, &8d, &a2, &fe   ; 87fe: 06 c6 a3... ...
+    equb &c8, &84, &a2, &d0,   6, &c6, &a3, &f0, &0a, &e6, &a5, &2c   ; 880a: c8 84 a2... ...
+    equb &a0, &fe, &30, &db, &4c, &14, &0d, &a9, &3f, &8d, &a1, &fe   ; 8816: a0 fe 30... ..0
+    equb &ad, &3e, &0d, &10,   7, &a9, &f5, &a0, &83, &4c, &0e, &0d   ; 8822: ad 3e 0d... .>.
+    equb &ad, &43, &0d, &ac, &44, &0d, &4c, &0e, &0d, &2c, &a0, &fe   ; 882e: ad 43 0d... .C.
+    equb &50, &34, &ad, &e5, &fe, &8d, &a2, &fe, &e6, &a2, &d0, &0c   ; 883a: 50 34 ad... P4.
+    equb &e6, &a3, &d0,   8, &e6, &a4, &d0,   4, &e6, &a5, &f0, &cb   ; 8846: e6 a3 d0... ...
+    equb &ad, &e5, &fe, &8d, &a2, &fe, &e6, &a2, &d0, &0c, &e6, &a3   ; 8852: ad e5 fe... ...
+    equb &d0,   8, &e6                                                ; 885e: d0 08 e6    ...
+; &8861 referenced 1 time by &8673
+.l8861
+    equb &a4, &d0,   4, &e6, &a5, &f0, &b5, &2c                       ; 8861: a4 d0 04... ...
+; &8869 referenced 1 time by &866d
+.l8869
+    equb &a0, &fe, &30, &cd, &4c, &14, &0d, &ad, &3e, &0d, &10, &5f   ; 8869: a0 fe 30... ..0
+    equb &4c, &f5, &83, &a9, &82, &8d, &a0, &fe, &a9, &84, &a0, &88   ; 8875: 4c f5 83... L..
+    equb &4c, &0e, &0d, &a9,   1, &2c, &a1, &fe, &f0, &49, &ad, &a2   ; 8881: 4c 0e 0d... L..
+    equb &fe, &cd, &18, &fe, &d0, &41, &a9, &98, &4c, &11, &0d, &2c   ; 888d: fe cd 18... ...
+    equb &a1, &fe, &10, &37, &ad, &a2, &fe, &d0, &32, &a9, &ac, &2c   ; 8899: a1 fe 10... ...
+    equb &a0, &fe, &30,   3, &4c, &11, &0d, &2c, &a1, &fe, &10, &23   ; 88a5: a0 fe 30... ..0
+    equb &ad, &a2, &fe, &cd, &20, &0d, &d0, &1b, &ad, &a2, &fe, &cd   ; 88b1: ad a2 fe... ...
+    equb &21, &0d, &d0, &13, &ad, &3e, &0d, &10,   3, &4c, &1c, &82   ; 88bd: 21 0d d0... !..
+    equb &a9,   2, &2c, &a1, &fe, &f0,   4, &a9,   0, &f0,   2, &a9   ; 88c9: a9 02 2c... ..,
+    equb &41, &a0,   0, &91, &a0, &a9, &80, &8d, &60, &0d, &4c, &f5   ; 88d5: 41 a0 00... A..
+    equb &83                                                          ; 88e1: 83          .
+    equb >(l0e81)                                                     ; 88e2: 0e          .
+    equb >(l0e00)                                                     ; 88e3: 0e          .
+    equb >(l0a00)                                                     ; 88e4: 0a          .
+    equb >(l0a00)                                                     ; 88e5: 0a          .
+    equb >(l0a00)                                                     ; 88e6: 0a          .
+    equb >(l0601)                                                     ; 88e7: 06          .
+    equb >(l0601)                                                     ; 88e8: 06          .
+    equb >(l0a81)                                                     ; 88e9: 0a          .
+    equb <(l0e81)                                                     ; 88ea: 81          .
+    equb <(l0e00)                                                     ; 88eb: 00          .
+    equb <(l0a00)                                                     ; 88ec: 00          .
+    equb <(l0a00)                                                     ; 88ed: 00          .
+    equb <(l0a00)                                                     ; 88ee: 00          .
+    equb <(l0601)                                                     ; 88ef: 01          .
+    equb <(l0601)                                                     ; 88f0: 01          .
+    equb <(l0a81)                                                     ; 88f1: 81          .
+
+; &88f2 referenced 1 time by &86e0
+.sub_c88f2
+    ldy #7                                                            ; 88f2: a0 07       ..
+    lda (l00a6),y                                                     ; 88f4: b1 a6       ..
+    cmp #&ff                                                          ; 88f6: c9 ff       ..
+    bne c8901                                                         ; 88f8: d0 07       ..
+    dey                                                               ; 88fa: 88          .
+    lda (l00a6),y                                                     ; 88fb: b1 a6       ..
+    cmp #&fe                                                          ; 88fd: c9 fe       ..
+    bcs c8945                                                         ; 88ff: b0 44       .D
+; &8901 referenced 1 time by &88f8
+.c8901
+    lda l0d63                                                         ; 8901: ad 63 0d    .c.
+    beq c8945                                                         ; 8904: f0 3f       .?
+    lda l0d3e                                                         ; 8906: ad 3e 0d    .>.
+    ora #2                                                            ; 8909: 09 02       ..
+    sta l0d3e                                                         ; 890b: 8d 3e 0d    .>.
+    sec                                                               ; 890e: 38          8
+    php                                                               ; 890f: 08          .
+    ldy #4                                                            ; 8910: a0 04       ..
+; &8912 referenced 1 time by &8924
+.loop_c8912
+    lda (l00a6),y                                                     ; 8912: b1 a6       ..
+    iny                                                               ; 8914: c8          .
+    iny                                                               ; 8915: c8          .
+    iny                                                               ; 8916: c8          .
+    iny                                                               ; 8917: c8          .
+    plp                                                               ; 8918: 28          (
+    sbc (l00a6),y                                                     ; 8919: f1 a6       ..
+    sta l009a,y                                                       ; 891b: 99 9a 00    ...
+    dey                                                               ; 891e: 88          .
+    dey                                                               ; 891f: 88          .
+    dey                                                               ; 8920: 88          .
+    php                                                               ; 8921: 08          .
+    cpy #8                                                            ; 8922: c0 08       ..
+    bcc loop_c8912                                                    ; 8924: 90 ec       ..
+    plp                                                               ; 8926: 28          (
+    txa                                                               ; 8927: 8a          .
+    pha                                                               ; 8928: 48          H
+    lda #4                                                            ; 8929: a9 04       ..
+    clc                                                               ; 892b: 18          .
+    adc l00a6                                                         ; 892c: 65 a6       e.
+    tax                                                               ; 892e: aa          .
+    ldy l00a7                                                         ; 892f: a4 a7       ..
+    lda #&c2                                                          ; 8931: a9 c2       ..
+    jsr c0406                                                         ; 8933: 20 06 04     ..
+    bcc c8942                                                         ; 8936: 90 0a       ..
+    lda l0d40                                                         ; 8938: ad 40 0d    .@.
+    jsr c0406                                                         ; 893b: 20 06 04     ..
+    jsr sub_c8449                                                     ; 893e: 20 49 84     I.
+    sec                                                               ; 8941: 38          8
+; &8942 referenced 1 time by &8936
+.c8942
+    pla                                                               ; 8942: 68          h
+    tax                                                               ; 8943: aa          .
+    rts                                                               ; 8944: 60          `
+
+; &8945 referenced 2 times by &88ff, &8904
+.c8945
+    ldy #4                                                            ; 8945: a0 04       ..
+    lda (l00a6),y                                                     ; 8947: b1 a6       ..
+    ldy #8                                                            ; 8949: a0 08       ..
+    sec                                                               ; 894b: 38          8
+    sbc (l00a6),y                                                     ; 894c: f1 a6       ..
+    sta l00a2                                                         ; 894e: 85 a2       ..
+    ldy #5                                                            ; 8950: a0 05       ..
+    lda (l00a6),y                                                     ; 8952: b1 a6       ..
+    sbc #0                                                            ; 8954: e9 00       ..
+    sta l00a5                                                         ; 8956: 85 a5       ..
+    ldy #8                                                            ; 8958: a0 08       ..
+    lda (l00a6),y                                                     ; 895a: b1 a6       ..
+    sta l00a4                                                         ; 895c: 85 a4       ..
+    ldy #9                                                            ; 895e: a0 09       ..
+    lda (l00a6),y                                                     ; 8960: b1 a6       ..
+    sec                                                               ; 8962: 38          8
+    sbc l00a5                                                         ; 8963: e5 a5       ..
+    sta l00a3                                                         ; 8965: 85 a3       ..
+    sec                                                               ; 8967: 38          8
+    rts                                                               ; 8968: 60          `
+
+; &8969 referenced 2 times by &8077, &8104
+.sub_c8969
+    lda #&c1                                                          ; 8969: a9 c1       ..
+    sta lfea0                                                         ; 896b: 8d a0 fe    ...
+    lda #&1e                                                          ; 896e: a9 1e       ..
+    sta lfea3                                                         ; 8970: 8d a3 fe    ...
+    lda #0                                                            ; 8973: a9 00       ..
+    sta lfea1                                                         ; 8975: 8d a1 fe    ...
+; &8978 referenced 2 times by &83f8, &89a4
+.c8978
+    lda #&82                                                          ; 8978: a9 82       ..
+    sta lfea0                                                         ; 897a: 8d a0 fe    ...
+    lda #&67 ; 'g'                                                    ; 897d: a9 67       .g
+    sta lfea1                                                         ; 897f: 8d a1 fe    ...
+    rts                                                               ; 8982: 60          `
+
+.sub_c8983
+    bit l0d62                                                         ; 8983: 2c 62 0d    ,b.
+    bpl c89a4                                                         ; 8986: 10 1c       ..
+; &8988 referenced 2 times by &898d, &8994
+.c8988
+    lda l0d0c                                                         ; 8988: ad 0c 0d    ...
+    cmp #&be                                                          ; 898b: c9 be       ..
+    bne c8988                                                         ; 898d: d0 f9       ..
+    lda l0d0d                                                         ; 898f: ad 0d 0d    ...
+    eor #&80                                                          ; 8992: 49 80       I.
+    bne c8988                                                         ; 8994: d0 f2       ..
+    bit lfe18                                                         ; 8996: 2c 18 fe    ,..
+    bit lfe18                                                         ; 8999: 2c 18 fe    ,..
+    sta l0d60                                                         ; 899c: 8d 60 0d    .`.
+    sta l0d62                                                         ; 899f: 8d 62 0d    .b.
+    ldy #5                                                            ; 89a2: a0 05       ..
+; &89a4 referenced 1 time by &8986
+.c89a4
+l89a6 = c89a4+2
+    jmp c8978                                                         ; 89a4: 4c 78 89    Lx.
+
+; &89a6 referenced 1 time by &8096
+    bit lfe18                                                         ; 89a7: 2c 18 fe    ,..
+    pha                                                               ; 89aa: 48          H
+    tya                                                               ; 89ab: 98          .
+    pha                                                               ; 89ac: 48          H
+    lda #0                                                            ; 89ad: a9 00       ..
+    sta romsel                                                        ; 89af: 8d 30 fe    .0.
+    jmp c80be                                                         ; 89b2: 4c be 80    L..
+
+    sty l0d0d                                                         ; 89b5: 8c 0d 0d    ...
+    sta l0d0c                                                         ; 89b8: 8d 0c 0d    ...
+    lda romsel_copy                                                   ; 89bb: a5 f4       ..
+    sta romsel                                                        ; 89bd: 8d 30 fe    .0.
+    pla                                                               ; 89c0: 68          h
+    tay                                                               ; 89c1: a8          .
+    pla                                                               ; 89c2: 68          h
+    bit video_ula_control                                             ; 89c3: 2c 20 fe    , .
+    rti                                                               ; 89c6: 40          @
+
+    equb   1,   0, &18                                                ; 89c7: 01 00 18    ...
+; &89ca referenced 1 time by &8e52
+.jump_table_low
+    equb 4                                                            ; 89ca: 04          .
+    equb <(just_rts-1)                                                ; 89cb: 57          W
+    equb <(service_handler_claim_absolute_workspace-1)                ; 89cc: a4          .
+    equb <(service_handler_claim_private_workspace-1)                 ; 89cd: b7          .
+    equb <(sub_c8cca-1)                                               ; 89ce: c9          .
+    equb <(sub_c8c4e-1)                                               ; 89cf: 4d          M
+    equb <(sub_c8028-1)                                               ; 89d0: 27          '
+    equb <(just_rts-1)                                                ; 89d1: 57          W
+    equb <(sub_c8e92-1)                                               ; 89d2: 91          .
+    equb <(sub_ca4ee-1)                                               ; 89d3: ed          .
+    equb <(sub_c8c5d-1)                                               ; 89d4: 5c          \
+    equb <(just_rts-1)                                                ; 89d5: 57          W
+    equb <(sub_c8090-1)                                               ; 89d6: 8f          .
+    equb <(sub_c8983-1)                                               ; 89d7: 82          .
+    equb <(sub_c8b0d-1)                                               ; 89d8: 0c          .
+    equb <(sub_c95ce-1)                                               ; 89d9: cd          .
+    equb <(sub_c9580-1)                                               ; 89da: 7f          .
+    equb <(sub_cac98-1)                                               ; 89db: 97          .
+    equb <(sub_c95ae-1)                                               ; 89dc: ad          .
+    equb <(sub_c95be-1)                                               ; 89dd: bd          .
+    equb <(sub_c9dc8-1)                                               ; 89de: c7          .
+    equb <(sub_c9dee-1)                                               ; 89df: ed          .
+    equb <(ca1c1-1)                                                   ; 89e0: c0          .
+    equb <(ca114-1)                                                   ; 89e1: 13          .
+    equb <(ca1c1-1)                                                   ; 89e2: c0          .
+    equb <(sub_cad80-1)                                               ; 89e3: 7f          .
+    equb <(sub_c8f99-1)                                               ; 89e4: 98          .
+    equb <(sub_c92b0-1)                                               ; 89e5: af          .
+    equb <(sub_caf3e-1)                                               ; 89e6: 3d          =
+    equb <(sub_ca391-1)                                               ; 89e7: 90          .
+    equb <(sub_ca39b-1)                                               ; 89e8: 9a          .
+    equb <(ca2f4-1)                                                   ; 89e9: f3          .
+    equb <(ca1c1-1)                                                   ; 89ea: c0          .
+    equb <(sub_ca2fa-1)                                               ; 89eb: f9          .
+    equb <(sub_ca0e4-1)                                               ; 89ec: e3          .
+    equb <(sub_ca0ea-1)                                               ; 89ed: e9          .
+    equb <(sub_ca0fa-1)                                               ; 89ee: f9          .
+; &89ef referenced 1 time by &8e4e
+.jump_table_high
+    equb &d3                                                          ; 89ef: d3          .
+    equb >(just_rts-1)                                                ; 89f0: 8e          .
+    equb >(service_handler_claim_absolute_workspace-1)                ; 89f1: 8e          .
+    equb >(service_handler_claim_private_workspace-1)                 ; 89f2: 8e          .
+    equb >(sub_c8cca-1)                                               ; 89f3: 8c          .
+    equb >(sub_c8c4e-1)                                               ; 89f4: 8c          .
+    equb >(sub_c8028-1)                                               ; 89f5: 80          .
+    equb >(just_rts-1)                                                ; 89f6: 8e          .
+    equb >(sub_c8e92-1)                                               ; 89f7: 8e          .
+    equb >(sub_ca4ee-1)                                               ; 89f8: a4          .
+    equb >(sub_c8c5d-1)                                               ; 89f9: 8c          .
+    equb >(just_rts-1)                                                ; 89fa: 8e          .
+    equb >(sub_c8090-1)                                               ; 89fb: 80          .
+    equb >(sub_c8983-1)                                               ; 89fc: 89          .
+    equb >(sub_c8b0d-1)                                               ; 89fd: 8b          .
+    equb >(sub_c95ce-1)                                               ; 89fe: 95          .
+    equb >(sub_c9580-1)                                               ; 89ff: 95          .
+    equb >(sub_cac98-1)                                               ; 8a00: ac          .
+    equb >(sub_c95ae-1)                                               ; 8a01: 95          .
+    equb >(sub_c95be-1)                                               ; 8a02: 95          .
+    equb >(sub_c9dc8-1)                                               ; 8a03: 9d          .
+    equb >(sub_c9dee-1)                                               ; 8a04: 9d          .
+    equb >(ca1c1-1)                                                   ; 8a05: a1          .
+    equb >(ca114-1)                                                   ; 8a06: a1          .
+    equb >(ca1c1-1)                                                   ; 8a07: a1          .
+    equb >(sub_cad80-1)                                               ; 8a08: ad          .
+    equb >(sub_c8f99-1)                                               ; 8a09: 8f          .
+    equb >(sub_c92b0-1)                                               ; 8a0a: 92          .
+    equb >(sub_caf3e-1)                                               ; 8a0b: af          .
+    equb >(sub_ca391-1)                                               ; 8a0c: a3          .
+    equb >(sub_ca39b-1)                                               ; 8a0d: a3          .
+    equb >(ca2f4-1)                                                   ; 8a0e: a2          .
+    equb >(ca1c1-1)                                                   ; 8a0f: a1          .
+    equb >(sub_ca2fa-1)                                               ; 8a10: a2          .
+    equb >(sub_ca0e4-1)                                               ; 8a11: a0          .
+    equb >(sub_ca0ea-1)                                               ; 8a12: a0          .
+    equb >(sub_ca0fa-1)                                               ; 8a13: a0          .
+    equb &8a                                                          ; 8a14: 8a          .
+
+; &8a15 referenced 1 time by &8003
+.service_handler
+    pha                                                               ; 8a15: 48          H
+    cmp #service_vectors_changed                                      ; 8a16: c9 0f       ..
+    bne service_handler_common1                                       ; 8a18: d0 22       ."
+; Extra processing for vectors changed service call
+    tya                                                               ; 8a1a: 98          .
+    pha                                                               ; 8a1b: 48          H
+    lda #osbyte_read_os_version                                       ; 8a1c: a9 00       ..
+    ldx #1                                                            ; 8a1e: a2 01       ..
+    jsr osbyte                                                        ; 8a20: 20 f4 ff     ..
+    cpx #1                                                            ; 8a23: e0 01       ..
+    beq c8a38                                                         ; 8a25: f0 11       ..
+    cpx #2                                                            ; 8a27: e0 02       ..
+    beq c8a38                                                         ; 8a29: f0 0d       ..
+    txa                                                               ; 8a2b: 8a          .
+    php                                                               ; 8a2c: 08          .
+    ldx romsel_copy                                                   ; 8a2d: a6 f4       ..
+    plp                                                               ; 8a2f: 28          (
+    beq c8a33                                                         ; 8a30: f0 01       ..
+    inx                                                               ; 8a32: e8          .
+; &8a33 referenced 1 time by &8a30
+.c8a33
+    lda #0                                                            ; 8a33: a9 00       ..
+    sta l02a0,x                                                       ; 8a35: 9d a0 02    ...
+; &8a38 referenced 2 times by &8a25, &8a29
+.c8a38
+    ldx romsel_copy                                                   ; 8a38: a6 f4       ..
+    pla                                                               ; 8a3a: 68          h
+    tay                                                               ; 8a3b: a8          .
+; &8a3c referenced 1 time by &8a18
+.service_handler_common1
+    pla                                                               ; 8a3c: 68          h
+    jsr service_handler_tube_service_calls                            ; 8a3d: 20 62 be     b.
+    pha                                                               ; 8a40: 48          H
+    cmp #service_claim_absolute_workspace                             ; 8a41: c9 01       ..
+    bne service_handler_common2                                       ; 8a43: d0 15       ..
+; Extra processing for absolute workspace claim service call
+    lda lfea0                                                         ; 8a45: ad a0 fe    ...
+    and #&ed                                                          ; 8a48: 29 ed       ).
+    bne c8a53                                                         ; 8a4a: d0 07       ..
+    lda lfea1                                                         ; 8a4c: ad a1 fe    ...
+    and #&db                                                          ; 8a4f: 29 db       ).
+    beq service_handler_common2                                       ; 8a51: f0 07       ..
+; &8a53 referenced 1 time by &8a4a
+.c8a53
+    rol l0df0,x                                                       ; 8a53: 3e f0 0d    >..
+    sec                                                               ; 8a56: 38          8
+    ror l0df0,x                                                       ; 8a57: 7e f0 0d    ~..
+; &8a5a referenced 2 times by &8a43, &8a51
+.service_handler_common2
+    lda l0df0,x                                                       ; 8a5a: bd f0 0d    ...
+    asl a                                                             ; 8a5d: 0a          .
+    pla                                                               ; 8a5e: 68          h
+    bcc c8a62                                                         ; 8a5f: 90 01       ..
+    rts                                                               ; 8a61: 60          `
+
+; &8a62 referenced 1 time by &8a5f
+.c8a62
+    cmp #service_vectors_changed                                      ; 8a62: c9 0f       ..
+    bne service_handler_not_vectors_changed                           ; 8a64: d0 41       .A
+    ldx l0d6a                                                         ; 8a66: ae 6a 0d    .j.
+    bne c8a6f                                                         ; 8a69: d0 04       ..
+    inx                                                               ; 8a6b: e8          .
+    stx l028d                                                         ; 8a6c: 8e 8d 02    ...
+; &8a6f referenced 1 time by &8a69
+.c8a6f
+    sta l00ac                                                         ; 8a6f: 85 ac       ..
+; &8a71 referenced 1 time by &8a9a
+.c8a71
+    lda #&80                                                          ; 8a71: a9 80       ..
+    sta l00f7                                                         ; 8a73: 85 f7       ..
+    lda #&0c                                                          ; 8a75: a9 0c       ..
+    sta osrdsc_ptr                                                    ; 8a77: 85 f6       ..
+    jsr sub_c8aa0                                                     ; 8a79: 20 a0 8a     ..
+    cmp #&4e ; 'N'                                                    ; 8a7c: c9 4e       .N
+    bne c8a98                                                         ; 8a7e: d0 18       ..
+    jsr sub_c8aa0                                                     ; 8a80: 20 a0 8a     ..
+    cmp #&45 ; 'E'                                                    ; 8a83: c9 45       .E
+    bne c8a98                                                         ; 8a85: d0 11       ..
+    jsr sub_c8aa0                                                     ; 8a87: 20 a0 8a     ..
+    cmp #&54 ; 'T'                                                    ; 8a8a: c9 54       .T
+    bne c8a98                                                         ; 8a8c: d0 0a       ..
+    ldx l00ac                                                         ; 8a8e: a6 ac       ..
+    lda l0df0,x                                                       ; 8a90: bd f0 0d    ...
+    ora #&80                                                          ; 8a93: 09 80       ..
+    sta l0df0,x                                                       ; 8a95: 9d f0 0d    ...
+; &8a98 referenced 3 times by &8a7e, &8a85, &8a8c
+.c8a98
+    dec l00ac                                                         ; 8a98: c6 ac       ..
+    bpl c8a71                                                         ; 8a9a: 10 d5       ..
+    lda #&0f                                                          ; 8a9c: a9 0f       ..
+    bne c8ad1                                                         ; 8a9e: d0 31       .1
+; &8aa0 referenced 3 times by &8a79, &8a80, &8a87
+.sub_c8aa0
+    inc osrdsc_ptr                                                    ; 8aa0: e6 f6       ..
+    ldy l00ac                                                         ; 8aa2: a4 ac       ..
+    jmp osrdsc                                                        ; 8aa4: 4c b9 ff    L..
+
+; &8aa7 referenced 1 time by &8a64
+.service_handler_not_vectors_changed
+    tax                                                               ; 8aa7: aa          .
+    lda l00a9                                                         ; 8aa8: a5 a9       ..
+    pha                                                               ; 8aaa: 48          H
+    txa                                                               ; 8aab: 8a          .
+    sta l00a9                                                         ; 8aac: 85 a9       ..
+; Call dispatch table entry X+1 for service calls 1<=X<&D.
+; Call dispatch table entry &D+1 for service call &12.
+; Don't handle any other service call.
+; (+1 because jump_table_dispatch_x_plus_y adds 1 if Y=0.)
+    cmp #&0d                                                          ; 8aae: c9 0d       ..
+    bcc c8aba                                                         ; 8ab0: 90 08       ..
+    sbc #5                                                            ; 8ab2: e9 05       ..
+    cmp #&0d                                                          ; 8ab4: c9 0d       ..
+    beq c8aba                                                         ; 8ab6: f0 02       ..
+    lda #0                                                            ; 8ab8: a9 00       ..
+; &8aba referenced 2 times by &8ab0, &8ab6
+.c8aba
+    tax                                                               ; 8aba: aa          .
+    beq c8acb                                                         ; 8abb: f0 0e       ..
+    lda l00a8                                                         ; 8abd: a5 a8       ..
+    pha                                                               ; 8abf: 48          H
+    sty l00a8                                                         ; 8ac0: 84 a8       ..
+    tya                                                               ; 8ac2: 98          .
+    ldy #0                                                            ; 8ac3: a0 00       ..
+    jsr jump_table_dispatch_x_plus_y                                  ; 8ac5: 20 49 8e     I.
+    pla                                                               ; 8ac8: 68          h
+    sta l00a8                                                         ; 8ac9: 85 a8       ..
+; &8acb referenced 1 time by &8abb
+.c8acb
+    ldx l00a9                                                         ; 8acb: a6 a9       ..
+    pla                                                               ; 8acd: 68          h
+    sta l00a9                                                         ; 8ace: 85 a9       ..
+    txa                                                               ; 8ad0: 8a          .
+; &8ad1 referenced 1 time by &8a9e
+.c8ad1
+    ldx romsel_copy                                                   ; 8ad1: a6 f4       ..
+    rts                                                               ; 8ad3: 60          `
+
+.sub_c8ad4
+    ldy #0                                                            ; 8ad4: a0 00       ..
+    lda (l009c),y                                                     ; 8ad6: b1 9c       ..
+    beq c8afb                                                         ; 8ad8: f0 21       .!
+    lda #0                                                            ; 8ada: a9 00       ..
+    tax                                                               ; 8adc: aa          .
+    sta (l009c),y                                                     ; 8add: 91 9c       ..
+    tay                                                               ; 8adf: a8          .
+    lda #osbyte_read_write_econet_keyboard_disable                    ; 8ae0: a9 c9       ..
+    jsr osbyte                                                        ; 8ae2: 20 f4 ff     ..
+    lda #&0a                                                          ; 8ae5: a9 0a       ..
+    jsr sub_ca9be                                                     ; 8ae7: 20 be a9     ..
+; &8aea referenced 1 time by &959f
+.sub_c8aea
+    stx l009e                                                         ; 8aea: 86 9e       ..
+    lda #osbyte_read_write_econet_os_call_interception                ; 8aec: a9 ce       ..
+; &8aee referenced 1 time by &8af9
+.loop_c8aee
+    ldx l009e                                                         ; 8aee: a6 9e       ..
+    ldy #&7f                                                          ; 8af0: a0 7f       ..
+    jsr osbyte                                                        ; 8af2: 20 f4 ff     ..
+    adc #1                                                            ; 8af5: 69 01       i.
+    cmp #&d0                                                          ; 8af7: c9 d0       ..
+    beq loop_c8aee                                                    ; 8af9: f0 f3       ..
+; &8afb referenced 1 time by &8ad8
+.c8afb
+    lda #0                                                            ; 8afb: a9 00       ..
+    sta l00a9                                                         ; 8afd: 85 a9       ..
+    sta l009e                                                         ; 8aff: 85 9e       ..
+    rts                                                               ; 8b01: 60          `
+
+; &8b02 referenced 3 times by &8c52, &8c7d, &a2bf
+.sub_c8b02
+    pha                                                               ; 8b02: 48          H
+    lda os_text_ptr                                                   ; 8b03: a5 f2       ..
+    sta l00be                                                         ; 8b05: 85 be       ..
+    lda l00f3                                                         ; 8b07: a5 f3       ..
+    sta l00bf                                                         ; 8b09: 85 bf       ..
+    pla                                                               ; 8b0b: 68          h
+; &8b0c referenced 2 times by &8b0f, &8b18
+.c8b0c
+    rts                                                               ; 8b0c: 60          `
+
+.sub_c8b0d
+    cpy #5                                                            ; 8b0d: c0 05       ..
+    bne c8b0c                                                         ; 8b0f: d0 fb       ..
+    lda #0                                                            ; 8b11: a9 00       ..
+    sta l00a9                                                         ; 8b13: 85 a9       ..
+    bit l0d6c                                                         ; 8b15: 2c 6c 0d    ,l.
+    bmi c8b0c                                                         ; 8b18: 30 f2       0.
+; &8b1a referenced 1 time by &8ce0
+.sub_c8b1a
+    jsr sub_c8cb9                                                     ; 8b1a: 20 b9 8c     ..
+    sta l00b1                                                         ; 8b1d: 85 b1       ..
+    lda #0                                                            ; 8b1f: a9 00       ..
+    sta l00b0                                                         ; 8b21: 85 b0       ..
+    clc                                                               ; 8b23: 18          .
+    ldy #&76 ; 'v'                                                    ; 8b24: a0 76       .v
+; &8b26 referenced 1 time by &8b29
+.loop_c8b26
+    adc (l00b0),y                                                     ; 8b26: 71 b0       q.
+    dey                                                               ; 8b28: 88          .
+    bpl loop_c8b26                                                    ; 8b29: 10 fb       ..
+    ldy #&77 ; 'w'                                                    ; 8b2b: a0 77       .w
+    eor (l00b0),y                                                     ; 8b2d: 51 b0       Q.
+    beq c8b34                                                         ; 8b2f: f0 03       ..
+    jmp c8fe4                                                         ; 8b31: 4c e4 8f    L..
+
+; &8b34 referenced 1 time by &8b2f
+.c8b34
+    jsr sub_c8cfc                                                     ; 8b34: 20 fc 8c     ..
+    ldy #9                                                            ; 8b37: a0 09       ..
+; &8b39 referenced 1 time by &8b41
+.loop_c8b39
+    lda (l009c),y                                                     ; 8b39: b1 9c       ..
+    sta l0dfe,y                                                       ; 8b3b: 99 fe 0d    ...
+    dey                                                               ; 8b3e: 88          .
+    cpy #1                                                            ; 8b3f: c0 01       ..
+    bne loop_c8b39                                                    ; 8b41: d0 f6       ..
+    rol l0d6c                                                         ; 8b43: 2e 6c 0d    .l.
+    clc                                                               ; 8b46: 18          .
+    ror l0d6c                                                         ; 8b47: 6e 6c 0d    nl.
+    ldy #&0d                                                          ; 8b4a: a0 0d       ..
+; &8b4c referenced 1 time by &8b53
+.loop_c8b4c
+    lda l8e61,y                                                       ; 8b4c: b9 61 8e    .a.
+    sta filev,y                                                       ; 8b4f: 99 12 02    ...
+    dey                                                               ; 8b52: 88          .
+    bpl loop_c8b4c                                                    ; 8b53: 10 f7       ..
+    jsr sub_c8f5d                                                     ; 8b55: 20 5d 8f     ].
+    ldy #&1b                                                          ; 8b58: a0 1b       ..
+    ldx #7                                                            ; 8b5a: a2 07       ..
+    jsr c8f70                                                         ; 8b5c: 20 70 8f     p.
+    lda #0                                                            ; 8b5f: a9 00       ..
+    sta l0e07                                                         ; 8b61: 8d 07 0e    ...
+    sta l10c9                                                         ; 8b64: 8d c9 10    ...
+    sta l1071                                                         ; 8b67: 8d 71 10    .q.
+    sta l00a9                                                         ; 8b6a: 85 a9       ..
+    jsr sub_cb98f                                                     ; 8b6c: 20 8f b9     ..
+    sta l0e08                                                         ; 8b6f: 8d 08 0e    ...
+    jsr sub_c8cc0                                                     ; 8b72: 20 c0 8c     ..
+    jsr sub_cb449                                                     ; 8b75: 20 49 b4     I.
+    ldy #&77 ; 'w'                                                    ; 8b78: a0 77       .w
+; &8b7a referenced 1 time by &8b80
+.loop_c8b7a
+    lda (l00cc),y                                                     ; 8b7a: b1 cc       ..
+    sta l1000,y                                                       ; 8b7c: 99 00 10    ...
+    dey                                                               ; 8b7f: 88          .
+    bpl loop_c8b7a                                                    ; 8b80: 10 f8       ..
+    lda #&80                                                          ; 8b82: a9 80       ..
+    ora l0d6c                                                         ; 8b84: 0d 6c 0d    .l.
+    sta l0d6c                                                         ; 8b87: 8d 6c 0d    .l.
+    jmp c8d08                                                         ; 8b8a: 4c 08 8d    L..
+
+; &8b8d referenced 1 time by &8c7a
+.c8b8d
+    ldx #&4a ; 'J'                                                    ; 8b8d: a2 4a       .J
+    jsr c8b98                                                         ; 8b8f: 20 98 8b     ..
+.sub_c8b92
+    ldx #0                                                            ; 8b92: a2 00       ..
+    beq c8b98                                                         ; 8b94: f0 02       ..
+.sub_c8b96
+    ldx #&4a ; 'J'                                                    ; 8b96: a2 4a       .J
+; &8b98 referenced 2 times by &8b8f, &8b94
+.c8b98
+    bvc c8ba8                                                         ; 8b98: 50 0e       P.
+    txa                                                               ; 8b9a: 8a          .
+    pha                                                               ; 8b9b: 48          H
+    tya                                                               ; 8b9c: 98          .
+    pha                                                               ; 8b9d: 48          H
+    jsr sub_c8c9f                                                     ; 8b9e: 20 9f 8c     ..
+    pla                                                               ; 8ba1: 68          h
+    tay                                                               ; 8ba2: a8          .
+    pla                                                               ; 8ba3: 68          h
+    tax                                                               ; 8ba4: aa          .
+    clv                                                               ; 8ba5: b8          .
+    bvc c8bab                                                         ; 8ba6: 50 03       P.
+; &8ba8 referenced 1 time by &8b98
+.c8ba8
+    jsr osnewl                                                        ; 8ba8: 20 e7 ff     ..
+; &8bab referenced 2 times by &8ba6, &8c6d
+.c8bab
+    tya                                                               ; 8bab: 98          .
+    pha                                                               ; 8bac: 48          H
+    php                                                               ; 8bad: 08          .
+; &8bae referenced 1 time by &8c2c
+.c8bae
+    lda la3f0,x                                                       ; 8bae: bd f0 a3    ...
+    bpl c8bb6                                                         ; 8bb1: 10 03       ..
+    jmp c8c2f                                                         ; 8bb3: 4c 2f 8c    L/.
+
+; &8bb6 referenced 1 time by &8bb1
+.c8bb6
+    jsr print_inline_top_bit_clear                                    ; 8bb6: 20 45 91     E.
+    equs "  "                                                         ; 8bb9: 20 20
+
+    ldy #9                                                            ; 8bbb: a0 09       ..
+    lda la3f0,x                                                       ; 8bbd: bd f0 a3    ...
+; &8bc0 referenced 1 time by &8bc8
+.loop_c8bc0
+    jsr osasci                                                        ; 8bc0: 20 e3 ff     ..
+    inx                                                               ; 8bc3: e8          .
+    dey                                                               ; 8bc4: 88          .
+    lda la3f0,x                                                       ; 8bc5: bd f0 a3    ...
+    bpl loop_c8bc0                                                    ; 8bc8: 10 f6       ..
+; &8bca referenced 1 time by &8bd0
+.loop_c8bca
+    lda #&20 ; ' '                                                    ; 8bca: a9 20       .
+    jsr osasci                                                        ; 8bcc: 20 e3 ff     ..
+    dey                                                               ; 8bcf: 88          .
+    bpl loop_c8bca                                                    ; 8bd0: 10 f8       ..
+    lda la3f0,x                                                       ; 8bd2: bd f0 a3    ...
+    and #&1f                                                          ; 8bd5: 29 1f       ).
+    cmp #&0e                                                          ; 8bd7: c9 0e       ..
+    beq c8bf6                                                         ; 8bd9: f0 1b       ..
+    tay                                                               ; 8bdb: a8          .
+    lda l9122,y                                                       ; 8bdc: b9 22 91    .".
+    tay                                                               ; 8bdf: a8          .
+; &8be0 referenced 2 times by &8bed, &8bf3
+.c8be0
+    iny                                                               ; 8be0: c8          .
+    lda l9022,y                                                       ; 8be1: b9 22 90    .".
+    beq c8c26                                                         ; 8be4: f0 40       .@
+    cmp #&0d                                                          ; 8be6: c9 0d       ..
+    bne c8bf0                                                         ; 8be8: d0 06       ..
+    jsr sub_c8c33                                                     ; 8bea: 20 33 8c     3.
+    jmp c8be0                                                         ; 8bed: 4c e0 8b    L..
+
+; &8bf0 referenced 1 time by &8be8
+.c8bf0
+    jsr osasci                                                        ; 8bf0: 20 e3 ff     ..
+    jmp c8be0                                                         ; 8bf3: 4c e0 8b    L..
+
+; &8bf6 referenced 1 time by &8bd9
+.c8bf6
+    txa                                                               ; 8bf6: 8a          .
+    pha                                                               ; 8bf7: 48          H
+    jsr print_inline_top_bit_clear                                    ; 8bf8: 20 45 91     E.
+    equs "("                                                          ; 8bfb: 28          (
+
+    ldy #0                                                            ; 8bfc: a0 00       ..
+    ldx #&d3                                                          ; 8bfe: a2 d3       ..
+; &8c00 referenced 1 time by &8c22
+.c8c00
+    lda la3f0,x                                                       ; 8c00: bd f0 a3    ...
+    bmi c8c24                                                         ; 8c03: 30 1f       0.
+    dex                                                               ; 8c05: ca          .
+; &8c06 referenced 1 time by &8c0f
+.loop_c8c06
+    inx                                                               ; 8c06: e8          .
+    lda la3f0,x                                                       ; 8c07: bd f0 a3    ...
+    bmi c8c12                                                         ; 8c0a: 30 06       0.
+    jsr osasci                                                        ; 8c0c: 20 e3 ff     ..
+    jmp loop_c8c06                                                    ; 8c0f: 4c 06 8c    L..
+
+; &8c12 referenced 1 time by &8c0a
+.c8c12
+    and #&7f                                                          ; 8c12: 29 7f       ).
+    jsr osasci                                                        ; 8c14: 20 e3 ff     ..
+    iny                                                               ; 8c17: c8          .
+    cpy #4                                                            ; 8c18: c0 04       ..
+    bne c8c1f                                                         ; 8c1a: d0 03       ..
+    jsr sub_c8c33                                                     ; 8c1c: 20 33 8c     3.
+; &8c1f referenced 1 time by &8c1a
+.c8c1f
+    inx                                                               ; 8c1f: e8          .
+    inx                                                               ; 8c20: e8          .
+    inx                                                               ; 8c21: e8          .
+    bne c8c00                                                         ; 8c22: d0 dc       ..
+; &8c24 referenced 1 time by &8c03
+.c8c24
+    pla                                                               ; 8c24: 68          h
+    tax                                                               ; 8c25: aa          .
+; &8c26 referenced 1 time by &8be4
+.c8c26
+    jsr osnewl                                                        ; 8c26: 20 e7 ff     ..
+    inx                                                               ; 8c29: e8          .
+    inx                                                               ; 8c2a: e8          .
+    inx                                                               ; 8c2b: e8          .
+    jmp c8bae                                                         ; 8c2c: 4c ae 8b    L..
+
+; &8c2f referenced 1 time by &8bb3
+.c8c2f
+    plp                                                               ; 8c2f: 28          (
+    pla                                                               ; 8c30: 68          h
+    tay                                                               ; 8c31: a8          .
+    rts                                                               ; 8c32: 60          `
+
+; &8c33 referenced 2 times by &8bea, &8c1c
+.sub_c8c33
+    lda l0355                                                         ; 8c33: ad 55 03    .U.
+    beq c8c4d                                                         ; 8c36: f0 15       ..
+    cmp #3                                                            ; 8c38: c9 03       ..
+    beq c8c4d                                                         ; 8c3a: f0 11       ..
+    tya                                                               ; 8c3c: 98          .
+    pha                                                               ; 8c3d: 48          H
+    jsr osnewl                                                        ; 8c3e: 20 e7 ff     ..
+    ldy #&0b                                                          ; 8c41: a0 0b       ..
+    lda #&20 ; ' '                                                    ; 8c43: a9 20       .
+; &8c45 referenced 1 time by &8c49
+.loop_c8c45
+    jsr osasci                                                        ; 8c45: 20 e3 ff     ..
+    dey                                                               ; 8c48: 88          .
+    bpl loop_c8c45                                                    ; 8c49: 10 fa       ..
+    pla                                                               ; 8c4b: 68          h
+    tay                                                               ; 8c4c: a8          .
+; &8c4d referenced 2 times by &8c36, &8c3a
+.c8c4d
+    rts                                                               ; 8c4d: 60          `
+
+.sub_c8c4e
+    ldx #0                                                            ; 8c4e: a2 00       ..
+    ldy l00a8                                                         ; 8c50: a4 a8       ..
+    jsr sub_c8b02                                                     ; 8c52: 20 02 8b     ..
+    jsr sub_ca140                                                     ; 8c55: 20 40 a1     @.
+    bcs c8c70                                                         ; 8c58: b0 16       ..
+    jmp ca125                                                         ; 8c5a: 4c 25 a1    L%.
+
+.sub_c8c5d
+    jsr sub_c8d17                                                     ; 8c5d: 20 17 8d     ..
+    ldy l00a8                                                         ; 8c60: a4 a8       ..
+    lda (os_text_ptr),y                                               ; 8c62: b1 f2       ..
+    cmp #&0d                                                          ; 8c64: c9 0d       ..
+    bne c8c73                                                         ; 8c66: d0 0b       ..
+    jsr sub_c8c9f                                                     ; 8c68: 20 9f 8c     ..
+    ldx #&c4                                                          ; 8c6b: a2 c4       ..
+    jsr c8bab                                                         ; 8c6d: 20 ab 8b     ..
+; &8c70 referenced 3 times by &8c58, &8c9d, &8cd8
+.c8c70
+    ldy l00a8                                                         ; 8c70: a4 a8       ..
+    rts                                                               ; 8c72: 60          `
+
+; &8c73 referenced 1 time by &8c66
+.c8c73
+    bit l9491                                                         ; 8c73: 2c 91 94    ,..
+    cmp #&2e ; '.'                                                    ; 8c76: c9 2e       ..
+    bne c8c7d                                                         ; 8c78: d0 03       ..
+    jmp c8b8d                                                         ; 8c7a: 4c 8d 8b    L..
+
+; &8c7d referenced 1 time by &8c78
+.c8c7d
+    jsr sub_c8b02                                                     ; 8c7d: 20 02 8b     ..
+; &8c80 referenced 1 time by &8c9b
+.loop_c8c80
+    php                                                               ; 8c80: 08          .
+    ldx #&c4                                                          ; 8c81: a2 c4       ..
+    jsr sub_ca140                                                     ; 8c83: 20 40 a1     @.
+    bcs c8c98                                                         ; 8c86: b0 10       ..
+    plp                                                               ; 8c88: 28          (
+    lda #&8c                                                          ; 8c89: a9 8c       ..
+    pha                                                               ; 8c8b: 48          H
+    lda #&7f                                                          ; 8c8c: a9 7f       ..
+    pha                                                               ; 8c8e: 48          H
+    lda la3f2,x                                                       ; 8c8f: bd f2 a3    ...
+    pha                                                               ; 8c92: 48          H
+    lda la3f1,x                                                       ; 8c93: bd f1 a3    ...
+    pha                                                               ; 8c96: 48          H
+    rts                                                               ; 8c97: 60          `
+
+; &8c98 referenced 1 time by &8c86
+.c8c98
+    plp                                                               ; 8c98: 28          (
+    cmp #&0d                                                          ; 8c99: c9 0d       ..
+    bne loop_c8c80                                                    ; 8c9b: d0 e3       ..
+    beq c8c70                                                         ; 8c9d: f0 d1       ..
+; &8c9f referenced 2 times by &8b9e, &8c68
+.sub_c8c9f
+    jsr print_inline_top_bit_clear                                    ; 8c9f: 20 45 91     E.
+    equs &0d, "Advanced NFS 4.18", &0d                                ; 8ca2: 0d 41 64... .Ad
+
+    nop                                                               ; 8cb5: ea          .
+    jmp c8ff1                                                         ; 8cb6: 4c f1 8f    L..
+
+; &8cb9 referenced 4 times by &8b1a, &8cc0, &8f87, &afe2
+.sub_c8cb9
+    ldy romsel_copy                                                   ; 8cb9: a4 f4       ..
+    lda l0df0,y                                                       ; 8cbb: b9 f0 0d    ...
+    tay                                                               ; 8cbe: a8          .
+    rts                                                               ; 8cbf: 60          `
+
+; &8cc0 referenced 2 times by &8b72, &8ee7
+.sub_c8cc0
+    jsr sub_c8cb9                                                     ; 8cc0: 20 b9 8c     ..
+    sty l00cd                                                         ; 8cc3: 84 cd       ..
+    lda #0                                                            ; 8cc5: a9 00       ..
+    sta l00cc                                                         ; 8cc7: 85 cc       ..
+; &8cc9 referenced 1 time by &8ceb
+.c8cc9
+    rts                                                               ; 8cc9: 60          `
+
+.sub_c8cca
+    lda #osbyte_scan_keyboard_from_16                                 ; 8cca: a9 7a       .z
+    jsr osbyte                                                        ; 8ccc: 20 f4 ff     ..
+    txa                                                               ; 8ccf: 8a          .
+    bmi c8ce0                                                         ; 8cd0: 30 0e       0.
+    cmp #&19                                                          ; 8cd2: c9 19       ..
+    beq c8cda                                                         ; 8cd4: f0 04       ..
+    eor #&55 ; 'U'                                                    ; 8cd6: 49 55       IU
+    bne c8c70                                                         ; 8cd8: d0 96       ..
+; &8cda referenced 1 time by &8cd4
+.c8cda
+    tay                                                               ; 8cda: a8          .
+    lda #osbyte_write_keys_pressed                                    ; 8cdb: a9 78       .x
+    jsr osbyte                                                        ; 8cdd: 20 f4 ff     ..
+; &8ce0 referenced 1 time by &8cd0
+.c8ce0
+    jsr sub_c8b1a                                                     ; 8ce0: 20 1a 8b     ..
+    jsr c8ff1                                                         ; 8ce3: 20 f1 8f     ..
+    jsr osnewl                                                        ; 8ce6: 20 e7 ff     ..
+    ldx l00a8                                                         ; 8ce9: a6 a8       ..
+    bne c8cc9                                                         ; 8ceb: d0 dc       ..
+    lda l1071                                                         ; 8ced: ad 71 10    .q.
+    ora #4                                                            ; 8cf0: 09 04       ..
+    sta l1071                                                         ; 8cf2: 8d 71 10    .q.
+    ldx #&0f                                                          ; 8cf5: a2 0f       ..
+    ldy #&8d                                                          ; 8cf7: a0 8d       ..
+    jmp ca114                                                         ; 8cf9: 4c 14 a1    L..
+
+; &8cfc referenced 1 time by &8b34
+.sub_c8cfc
+    lda #6                                                            ; 8cfc: a9 06       ..
+    jsr sub_c8d05                                                     ; 8cfe: 20 05 8d     ..
+    ldx #&0a                                                          ; 8d01: a2 0a       ..
+    bne c8d0a                                                         ; 8d03: d0 05       ..
+; &8d05 referenced 1 time by &8cfe
+.sub_c8d05
+    jmp (fscv)                                                        ; 8d05: 6c 1e 02    l..
+
+; &8d08 referenced 1 time by &8b8a
+.c8d08
+    ldx #&0f                                                          ; 8d08: a2 0f       ..
+; &8d0a referenced 1 time by &8d03
+.c8d0a
+    lda #osbyte_issue_service_request                                 ; 8d0a: a9 8f       ..
+    jmp osbyte                                                        ; 8d0c: 4c f4 ff    L..
+
+    equs "i .boot"                                                    ; 8d0f: 69 20 2e... i .
+    equb &0d                                                          ; 8d16: 0d          .
+
+; &8d17 referenced 1 time by &8c5d
+.sub_c8d17
+    ldy l00a8                                                         ; 8d17: a4 a8       ..
+    ldx #5                                                            ; 8d19: a2 05       ..
+; &8d1b referenced 1 time by &8d24
+.loop_c8d1b
+    lda (os_text_ptr),y                                               ; 8d1b: b1 f2       ..
+    cmp l8d38,x                                                       ; 8d1d: dd 38 8d    .8.
+    bne c8d26                                                         ; 8d20: d0 04       ..
+    iny                                                               ; 8d22: c8          .
+    inx                                                               ; 8d23: e8          .
+    bne loop_c8d1b                                                    ; 8d24: d0 f5       ..
+; &8d26 referenced 1 time by &8d20
+.c8d26
+    cpx #&0d                                                          ; 8d26: e0 0d       ..
+    bne c8d37                                                         ; 8d28: d0 0d       ..
+    ldx #0                                                            ; 8d2a: a2 00       ..
+; &8d2c referenced 1 time by &8d35
+.loop_c8d2c
+    lda l8d38,x                                                       ; 8d2c: bd 38 8d    .8.
+    beq c8d37                                                         ; 8d2f: f0 06       ..
+    jsr osasci                                                        ; 8d31: 20 e3 ff     ..
+    inx                                                               ; 8d34: e8          .
+    bne loop_c8d2c                                                    ; 8d35: d0 f5       ..
+; &8d37 referenced 2 times by &8d28, &8d2f
+.c8d37
+    rts                                                               ; 8d37: 60          `
+
+; &8d38 referenced 2 times by &8d1d, &8d2c
+.l8d38
+    equb &0d                                                          ; 8d38: 0d          .
+    equs "The authors of ANFS are;"                                   ; 8d39: 54 68 65... The
+    equb &0d                                                          ; 8d51: 0d          .
+    equs "B Cockburn"                                                 ; 8d52: 42 20 43... B C
+    equb &0d                                                          ; 8d5c: 0d          .
+    equs "J Du"                                                       ; 8d5d: 4a 20 44... J D
+; &8d61 referenced 1 time by &b01b
+.l8d61
+    equb &6e, &6e, &0d                                                ; 8d61: 6e 6e 0d    nn.
+    equs "B Robertson"                                                ; 8d64: 42 20 52... B R
+    equb &0d                                                          ; 8d6f: 0d          .
+    equs "J Wills"                                                    ; 8d70: 4a 20 57... J W
+    equb &0d,   0                                                     ; 8d77: 0d 00       ..
+
+.sub_c8d79
+    tya                                                               ; 8d79: 98          .
+    pha                                                               ; 8d7a: 48          H
+    lda #osbyte_close_spool_exec                                      ; 8d7b: a9 77       .w
+    sta l0e07                                                         ; 8d7d: 8d 07 0e    ...
+    jsr osbyte                                                        ; 8d80: 20 f4 ff     ..
+    ldy #0                                                            ; 8d83: a0 00       ..
+    sty l00b4                                                         ; 8d85: 84 b4       ..
+    jsr sub_cb799                                                     ; 8d87: 20 99 b7     ..
+    lda #0                                                            ; 8d8a: a9 00       ..
+    sta l0e07                                                         ; 8d8c: 8d 07 0e    ...
+    pla                                                               ; 8d8f: 68          h
+    tay                                                               ; 8d90: a8          .
+    lda (l00bb),y                                                     ; 8d91: b1 bb       ..
+    jsr sub_c9258                                                     ; 8d93: 20 58 92     X.
+    bcc c8dbc                                                         ; 8d96: 90 24       .$
+    jsr sub_c916e                                                     ; 8d98: 20 6e 91     n.
+    bcs c8da7                                                         ; 8d9b: b0 0a       ..
+    sta l0e01                                                         ; 8d9d: 8d 01 0e    ...
+    jsr sub_c8e09                                                     ; 8da0: 20 09 8e     ..
+    iny                                                               ; 8da3: c8          .
+    jsr sub_c916e                                                     ; 8da4: 20 6e 91     n.
+; &8da7 referenced 1 time by &8d9b
+.c8da7
+    beq c8dbc                                                         ; 8da7: f0 13       ..
+    sta l0e00                                                         ; 8da9: 8d 00 0e    ...
+    ldx #&ff                                                          ; 8dac: a2 ff       ..
+; &8dae referenced 1 time by &8db5
+.loop_c8dae
+    inx                                                               ; 8dae: e8          .
+    lda la477,x                                                       ; 8daf: bd 77 a4    .w.
+    sta l0f05,x                                                       ; 8db2: 9d 05 0f    ...
+    bpl loop_c8dae                                                    ; 8db5: 10 f7       ..
+    jsr sub_caf06                                                     ; 8db7: 20 06 af     ..
+    beq c8dbf                                                         ; 8dba: f0 03       ..
+; &8dbc referenced 2 times by &8d96, &8da7
+.c8dbc
+    jsr sub_caf02                                                     ; 8dbc: 20 02 af     ..
+; &8dbf referenced 1 time by &8dba
+.c8dbf
+    ldy #&ff                                                          ; 8dbf: a0 ff       ..
+; &8dc1 referenced 1 time by &8dcb
+.loop_c8dc1
+    iny                                                               ; 8dc1: c8          .
+    lda l0f05,y                                                       ; 8dc2: b9 05 0f    ...
+    cmp #&0d                                                          ; 8dc5: c9 0d       ..
+    beq c8dfa                                                         ; 8dc7: f0 31       .1
+    cmp #&3a ; ':'                                                    ; 8dc9: c9 3a       .:
+    bne loop_c8dc1                                                    ; 8dcb: d0 f4       ..
+    jsr oswrch                                                        ; 8dcd: 20 ee ff     ..
+    sty l00b4                                                         ; 8dd0: 84 b4       ..
+; &8dd2 referenced 4 times by &8de2, &8de6, &8de9, &8df5
+.c8dd2
+    lda #&ff                                                          ; 8dd2: a9 ff       ..
+    sta l0098                                                         ; 8dd4: 85 98       ..
+    jsr sub_c9570                                                     ; 8dd6: 20 70 95     p.
+    jsr osrdch                                                        ; 8dd9: 20 e0 ff     ..
+    cmp #&15                                                          ; 8ddc: c9 15       ..
+    bne c8deb                                                         ; 8dde: d0 0b       ..
+    ldy l00b4                                                         ; 8de0: a4 b4       ..
+    bne c8dd2                                                         ; 8de2: d0 ee       ..
+; &8de4 referenced 1 time by &8ded
+.loop_c8de4
+    cpy l00b4                                                         ; 8de4: c4 b4       ..
+    beq c8dd2                                                         ; 8de6: f0 ea       ..
+    dey                                                               ; 8de8: 88          .
+    bne c8dd2                                                         ; 8de9: d0 e7       ..
+; &8deb referenced 1 time by &8dde
+.c8deb
+    cmp #&7f                                                          ; 8deb: c9 7f       ..
+    beq loop_c8de4                                                    ; 8ded: f0 f5       ..
+    sta l0f05,y                                                       ; 8def: 99 05 0f    ...
+    iny                                                               ; 8df2: c8          .
+    cmp #&0d                                                          ; 8df3: c9 0d       ..
+    bne c8dd2                                                         ; 8df5: d0 db       ..
+    jsr osnewl                                                        ; 8df7: 20 e7 ff     ..
+; &8dfa referenced 1 time by &8dc7
+.c8dfa
+    tya                                                               ; 8dfa: 98          .
+    pha                                                               ; 8dfb: 48          H
+    jsr sub_c9473                                                     ; 8dfc: 20 73 94     s.
+    jsr sub_c9894                                                     ; 8dff: 20 94 98     ..
+    pla                                                               ; 8e02: 68          h
+    tax                                                               ; 8e03: aa          .
+    inx                                                               ; 8e04: e8          .
+    ldy #0                                                            ; 8e05: a0 00       ..
+    beq c8e24                                                         ; 8e07: f0 1b       ..
+; &8e09 referenced 1 time by &8da0
+.sub_c8e09
+    jsr sub_ca865                                                     ; 8e09: 20 65 a8     e.
+    eor l0e01                                                         ; 8e0c: 4d 01 0e    M..
+    bne c8e14                                                         ; 8e0f: d0 03       ..
+    sta l0e01                                                         ; 8e11: 8d 01 0e    ...
+; &8e14 referenced 1 time by &8e0f
+.c8e14
+    rts                                                               ; 8e14: 60          `
+
+; &8e15 referenced 1 time by &9462
+.c8e15
+    ldy #0                                                            ; 8e15: a0 00       ..
+    lda (l00be),y                                                     ; 8e17: b1 be       ..
+    cmp #&26 ; '&'                                                    ; 8e19: c9 26       .&
+    bne c8e20                                                         ; 8e1b: d0 03       ..
+    jmp ca1c1                                                         ; 8e1d: 4c c1 a1    L..
+
+; &8e20 referenced 1 time by &8e1b
+.c8e20
+    jsr sub_caf02                                                     ; 8e20: 20 02 af     ..
+    tay                                                               ; 8e23: a8          .
+; &8e24 referenced 2 times by &8e07, &9324
+.c8e24
+    jsr c94ad                                                         ; 8e24: 20 ad 94     ..
+    ldx l0f03                                                         ; 8e27: ae 03 0f    ...
+    beq just_rts                                                      ; 8e2a: f0 2c       .,
+    lda l0f05                                                         ; 8e2c: ad 05 0f    ...
+    ldy #&17                                                          ; 8e2f: a0 17       ..
+    bne jump_table_dispatch_x_plus_y                                  ; 8e31: d0 16       ..
+    jsr sub_c9295                                                     ; 8e33: 20 95 92     ..
+    cmp #8                                                            ; 8e36: c9 08       ..
+    bcs just_rts                                                      ; 8e38: b0 1e       ..
+    tax                                                               ; 8e3a: aa          .
+    jsr sub_caf32                                                     ; 8e3b: 20 32 af     2.
+    tya                                                               ; 8e3e: 98          .
+    ldy #&13                                                          ; 8e3f: a0 13       ..
+    bne jump_table_dispatch_x_plus_y                                  ; 8e41: d0 06       ..
+    cpx #5                                                            ; 8e43: e0 05       ..
+    bcs just_rts                                                      ; 8e45: b0 11       ..
+    ldy #&0e                                                          ; 8e47: a0 0e       ..
+; Note that if Y=0, this will add 1 instead of 0.
+; &8e49 referenced 5 times by &8ac5, &8e31, &8e41, &8e4b, &8ea2
+.jump_table_dispatch_x_plus_y
+    inx                                                               ; 8e49: e8          .
+    dey                                                               ; 8e4a: 88          .
+    bpl jump_table_dispatch_x_plus_y                                  ; 8e4b: 10 fc       ..
+    tay                                                               ; 8e4d: a8          .
+    lda jump_table_high,x                                             ; 8e4e: bd ef 89    ...
+    pha                                                               ; 8e51: 48          H
+.sub_c8e52
+l8e54 = sub_c8e52+2
+    lda jump_table_low,x                                              ; 8e52: bd ca 89    ...
+; &8e54 referenced 2 times by &8f70, &8f76
+    pha                                                               ; 8e55: 48          H
+    ldx l00bb                                                         ; 8e56: a6 bb       ..
+; &8e58 referenced 3 times by &8e2a, &8e38, &8e45
+.just_rts
+    rts                                                               ; 8e58: 60          `
+
+    equs "PRINT "                                                     ; 8e59: 50 52 49... PRI
+    equb 1, 0                                                         ; 8e5f: 01 00       ..
+; &8e61 referenced 1 time by &8b4c
+.l8e61
+    equb &1b, &ff, &1e, &ff, &21, &ff, &24, &ff, &27, &ff, &2a, &ff   ; 8e61: 1b ff 1e... ...
+    equb &2d, &ff, &35, &99, &4a, &be, &9b, &44, &ce, &b7, &57, &4d   ; 8e6d: 2d ff 35... -.5
+    equb &b8, &42, &2f, &9e, &41, &4e, &9d, &52, &33, &8e             ; 8e79: b8 42 2f... .B/
+
+; &8e83 referenced 3 times by &8081, &8f62, &970e
+.sub_c8e83
+    ldx #0                                                            ; 8e83: a2 00       ..
+; &8e85 referenced 1 time by &808b
+.sub_c8e85
+    ldy #&ff                                                          ; 8e85: a0 ff       ..
+; &8e87 referenced 1 time by &8e90
+.loop_c8e87
+    jmp osbyte                                                        ; 8e87: 4c f4 ff    L..
+
+    equb &7a, &a9                                                     ; 8e8a: 7a a9       z.
+
+; &8e8c referenced 1 time by &9722
+.sub_c8e8c
+    ldx #0                                                            ; 8e8c: a2 00       ..
+    ldy #0                                                            ; 8e8e: a0 00       ..
+    beq loop_c8e87                                                    ; 8e90: f0 f5       ..
+.sub_c8e92
+    lda l00ef                                                         ; 8e92: a5 ef       ..
+    sbc #&31 ; '1'                                                    ; 8e94: e9 31       .1
+    cmp #4                                                            ; 8e96: c9 04       ..
+    bcs c8eab                                                         ; 8e98: b0 11       ..
+    tax                                                               ; 8e9a: aa          .
+    lda #0                                                            ; 8e9b: a9 00       ..
+    sta l00a9                                                         ; 8e9d: 85 a9       ..
+    tya                                                               ; 8e9f: 98          .
+    ldy #&21 ; '!'                                                    ; 8ea0: a0 21       .!
+    jmp jump_table_dispatch_x_plus_y                                  ; 8ea2: 4c 49 8e    LI.
+
+.service_handler_claim_absolute_workspace
+    cpy #&16                                                          ; 8ea5: c0 16       ..
+    bcs c8eab                                                         ; 8ea7: b0 02       ..
+    ldy #&16                                                          ; 8ea9: a0 16       ..
+; &8eab referenced 2 times by &8e98, &8ea7
+.c8eab
+    rts                                                               ; 8eab: 60          `
+
+; &8eac referenced 1 time by &8edf
+.clamp_absolute_workspace_and_save
+    tya                                                               ; 8eac: 98          .
+    cmp #&21 ; '!'                                                    ; 8ead: c9 21       .!
+    bcc c8eb3                                                         ; 8eaf: 90 02       ..
+    lda #&21 ; '!'                                                    ; 8eb1: a9 21       .!
+; &8eb3 referenced 1 time by &8eaf
+.c8eb3
+    ldy #&0b                                                          ; 8eb3: a0 0b       ..
+    sta (l009c),y                                                     ; 8eb5: 91 9c       ..
+    rts                                                               ; 8eb7: 60          `
+
+.service_handler_claim_private_workspace
+    sty l009d                                                         ; 8eb8: 84 9d       ..
+    iny                                                               ; 8eba: c8          .
+    sty l009f                                                         ; 8ebb: 84 9f       ..
+    iny                                                               ; 8ebd: c8          .
+    tya                                                               ; 8ebe: 98          .
+    ldy romsel_copy                                                   ; 8ebf: a4 f4       ..
+    sta l0df0,y                                                       ; 8ec1: 99 f0 0d    ...
+    ldy lfe87                                                         ; 8ec4: ac 87 fe    ...
+    lda #0                                                            ; 8ec7: a9 00       ..
+    sta l009c                                                         ; 8ec9: 85 9c       ..
+    sta l009e                                                         ; 8ecb: 85 9e       ..
+    sta l00a8                                                         ; 8ecd: 85 a8       ..
+    sta l0d60                                                         ; 8ecf: 8d 60 0d    .`.
+    ldy #0                                                            ; 8ed2: a0 00       ..
+    sta (l009c),y                                                     ; 8ed4: 91 9c       ..
+    lda #osbyte_issue_service_request                                 ; 8ed6: a9 8f       ..
+    ldx #service_claim_absolute_workspace                             ; 8ed8: a2 01       ..
+    ldy #&0e                                                          ; 8eda: a0 0e       ..
+    jsr osbyte                                                        ; 8edc: 20 f4 ff     ..
+    jsr clamp_absolute_workspace_and_save                             ; 8edf: 20 ac 8e     ..
+    lda l028d                                                         ; 8ee2: ad 8d 02    ...
+    beq c8f40                                                         ; 8ee5: f0 59       .Y
+    jsr sub_c8cc0                                                     ; 8ee7: 20 c0 8c     ..
+    sta l0d6c                                                         ; 8eea: 8d 6c 0d    .l.
+    tay                                                               ; 8eed: a8          .
+; &8eee referenced 1 time by &8ef3
+.loop_c8eee
+    sta (l00cc),y                                                     ; 8eee: 91 cc       ..
+    sta (l009e),y                                                     ; 8ef0: 91 9e       ..
+    iny                                                               ; 8ef2: c8          .
+    bne loop_c8eee                                                    ; 8ef3: d0 f9       ..
+    ldy #8                                                            ; 8ef5: a0 08       ..
+    sta (l009c),y                                                     ; 8ef7: 91 9c       ..
+    jsr sub_cb017                                                     ; 8ef9: 20 17 b0     ..
+    ldy #2                                                            ; 8efc: a0 02       ..
+    lda #&fe                                                          ; 8efe: a9 fe       ..
+    sta l0e00                                                         ; 8f00: 8d 00 0e    ...
+    sta (l009c),y                                                     ; 8f03: 91 9c       ..
+    lda #0                                                            ; 8f05: a9 00       ..
+    sta l0e01                                                         ; 8f07: 8d 01 0e    ...
+    iny                                                               ; 8f0a: c8          .
+    sta (l009c),y                                                     ; 8f0b: 91 9c       ..
+    ldy #3                                                            ; 8f0d: a0 03       ..
+    sta (l009e),y                                                     ; 8f0f: 91 9e       ..
+    dey                                                               ; 8f11: 88          .
+    lda #&eb                                                          ; 8f12: a9 eb       ..
+    sta (l009e),y                                                     ; 8f14: 91 9e       ..
+    ldx #3                                                            ; 8f16: a2 03       ..
+; &8f18 referenced 1 time by &8f1f
+.loop_c8f18
+    lda l8f48,x                                                       ; 8f18: bd 48 8f    .H.
+    sta l0d6c,x                                                       ; 8f1b: 9d 6c 0d    .l.
+    dex                                                               ; 8f1e: ca          .
+    bne loop_c8f18                                                    ; 8f1f: d0 f7       ..
+    stx l0d68                                                         ; 8f21: 8e 68 0d    .h.
+    stx l0e05                                                         ; 8f24: 8e 05 0e    ...
+    jsr caae2                                                         ; 8f27: 20 e2 aa     ..
+    dex                                                               ; 8f2a: ca          .
+    stx l0d71                                                         ; 8f2b: 8e 71 0d    .q.
+; &8f2e referenced 1 time by &8f3b
+.loop_c8f2e
+    lda l00a8                                                         ; 8f2e: a5 a8       ..
+    jsr sub_ca0ce                                                     ; 8f30: 20 ce a0     ..
+    bcs c8f3d                                                         ; 8f33: b0 08       ..
+    lda #&3f ; '?'                                                    ; 8f35: a9 3f       .?
+    sta (l009e),y                                                     ; 8f37: 91 9e       ..
+    inc l00a8                                                         ; 8f39: e6 a8       ..
+    bne loop_c8f2e                                                    ; 8f3b: d0 f1       ..
+; &8f3d referenced 1 time by &8f33
+.c8f3d
+    jsr c8f8c                                                         ; 8f3d: 20 8c 8f     ..
+; &8f40 referenced 1 time by &8ee5
+.c8f40
+    ldy lfe18                                                         ; 8f40: ac 18 fe    ...
+    tya                                                               ; 8f43: 98          .
+    bne c8f4c                                                         ; 8f44: d0 06       ..
+; &8f46 referenced 1 time by &8f4d
+.loop_c8f46
+l8f48 = loop_c8f46+2
+    jmp c9215                                                         ; 8f46: 4c 15 92    L..
+
+; &8f48 referenced 1 time by &8f18
+    equb &ff, &28, &0a                                                ; 8f49: ff 28 0a    .(.
+
+; &8f4c referenced 1 time by &8f44
+.c8f4c
+    iny                                                               ; 8f4c: c8          .
+    beq loop_c8f46                                                    ; 8f4d: f0 f7       ..
+    ldy #1                                                            ; 8f4f: a0 01       ..
+    sta (l009c),y                                                     ; 8f51: 91 9c       ..
+    ldx #&40 ; '@'                                                    ; 8f53: a2 40       .@
+    stx l0d61                                                         ; 8f55: 8e 61 0d    .a.
+    lda #3                                                            ; 8f58: a9 03       ..
+    jsr sub_cab1b                                                     ; 8f5a: 20 1b ab     ..
+; &8f5d referenced 1 time by &8b55
+.sub_c8f5d
+    jsr sub_c8074                                                     ; 8f5d: 20 74 80     t.
+    lda #&a8                                                          ; 8f60: a9 a8       ..
+    jsr sub_c8e83                                                     ; 8f62: 20 83 8e     ..
+    stx l00b8                                                         ; 8f65: 86 b8       ..
+    sty l00b9                                                         ; 8f67: 84 b9       ..
+    ldy #&36 ; '6'                                                    ; 8f69: a0 36       .6
+    sty netv                                                          ; 8f6b: 8c 24 02    .$.
+    ldx #1                                                            ; 8f6e: a2 01       ..
+; &8f70 referenced 2 times by &8b5c, &8f82
+.c8f70
+    lda l8e54,y                                                       ; 8f70: b9 54 8e    .T.
+    sta (l00b8),y                                                     ; 8f73: 91 b8       ..
+    iny                                                               ; 8f75: c8          .
+    lda l8e54,y                                                       ; 8f76: b9 54 8e    .T.
+    sta (l00b8),y                                                     ; 8f79: 91 b8       ..
+    iny                                                               ; 8f7b: c8          .
+    lda romsel_copy                                                   ; 8f7c: a5 f4       ..
+    sta (l00b8),y                                                     ; 8f7e: 91 b8       ..
+    iny                                                               ; 8f80: c8          .
+    dex                                                               ; 8f81: ca          .
+    bne c8f70                                                         ; 8f82: d0 ec       ..
+    jsr sub_c8f99                                                     ; 8f84: 20 99 8f     ..
+    jsr sub_c8cb9                                                     ; 8f87: 20 b9 8c     ..
+    iny                                                               ; 8f8a: c8          .
+    rts                                                               ; 8f8b: 60          `
+
+; &8f8c referenced 3 times by &8f3d, &8fa8, &a38e
+.c8f8c
+    ldy #9                                                            ; 8f8c: a0 09       ..
+; &8f8e referenced 1 time by &8f96
+.loop_c8f8e
+    lda l0dfe,y                                                       ; 8f8e: b9 fe 0d    ...
+    sta (l009c),y                                                     ; 8f91: 91 9c       ..
+    dey                                                               ; 8f93: 88          .
+    cpy #1                                                            ; 8f94: c0 01       ..
+    bne loop_c8f8e                                                    ; 8f96: d0 f6       ..
+    rts                                                               ; 8f98: 60          `
+
+; &8f99 referenced 1 time by &8f84
+.sub_c8f99
+    bit l0d6c                                                         ; 8f99: 2c 6c 0d    ,l.
+    bpl c8fca                                                         ; 8f9c: 10 2c       .,
+    ldy #0                                                            ; 8f9e: a0 00       ..
+    jsr sub_cb799                                                     ; 8fa0: 20 99 b7     ..
+    lda #osbyte_close_spool_exec                                      ; 8fa3: a9 77       .w
+    jsr osbyte                                                        ; 8fa5: 20 f4 ff     ..
+    jsr c8f8c                                                         ; 8fa8: 20 8c 8f     ..
+    ldy #&76 ; 'v'                                                    ; 8fab: a0 76       .v
+    lda #0                                                            ; 8fad: a9 00       ..
+    clc                                                               ; 8faf: 18          .
+; &8fb0 referenced 1 time by &8fb4
+.loop_c8fb0
+    adc l1000,y                                                       ; 8fb0: 79 00 10    y..
+    dey                                                               ; 8fb3: 88          .
+    bpl loop_c8fb0                                                    ; 8fb4: 10 fa       ..
+    ldy #&77 ; 'w'                                                    ; 8fb6: a0 77       .w
+    bpl c8fbd                                                         ; 8fb8: 10 03       ..
+; &8fba referenced 1 time by &8fc0
+.loop_c8fba
+    lda l1000,y                                                       ; 8fba: b9 00 10    ...
+; &8fbd referenced 1 time by &8fb8
+.c8fbd
+    sta (l00cc),y                                                     ; 8fbd: 91 cc       ..
+    dey                                                               ; 8fbf: 88          .
+    bpl loop_c8fba                                                    ; 8fc0: 10 f8       ..
+    lda l0d6c                                                         ; 8fc2: ad 6c 0d    .l.
+    and #&7f                                                          ; 8fc5: 29 7f       ).
+    sta l0d6c                                                         ; 8fc7: 8d 6c 0d    .l.
+; &8fca referenced 1 time by &8f9c
+.c8fca
+    rts                                                               ; 8fca: 60          `
+
+; &8fcb referenced 2 times by &9dee, &b5fb
+.sub_c8fcb
+    php                                                               ; 8fcb: 08          .
+    pha                                                               ; 8fcc: 48          H
+    tya                                                               ; 8fcd: 98          .
+    pha                                                               ; 8fce: 48          H
+    ldy #&76 ; 'v'                                                    ; 8fcf: a0 76       .v
+    lda #0                                                            ; 8fd1: a9 00       ..
+    clc                                                               ; 8fd3: 18          .
+; &8fd4 referenced 1 time by &8fd7
+.loop_c8fd4
+    adc (l00cc),y                                                     ; 8fd4: 71 cc       q.
+    dey                                                               ; 8fd6: 88          .
+    bpl loop_c8fd4                                                    ; 8fd7: 10 fb       ..
+    ldy #&77 ; 'w'                                                    ; 8fd9: a0 77       .w
+    cmp (l00cc),y                                                     ; 8fdb: d1 cc       ..
+    bne c8fe4                                                         ; 8fdd: d0 05       ..
+    pla                                                               ; 8fdf: 68          h
+    tay                                                               ; 8fe0: a8          .
+    pla                                                               ; 8fe1: 68          h
+    plp                                                               ; 8fe2: 28          (
+    rts                                                               ; 8fe3: 60          `
+
+; &8fe4 referenced 2 times by &8b31, &8fdd
+.c8fe4
+    lda #&aa                                                          ; 8fe4: a9 aa       ..
+    jsr generate_error_inline                                         ; 8fe6: 20 b8 96     ..
+    equs "net sum", 0                                                 ; 8fe9: 6e 65 74... net
+
+; &8ff1 referenced 2 times by &8cb6, &8ce3
+.c8ff1
+    jsr print_inline_top_bit_clear                                    ; 8ff1: 20 45 91     E.
+    equs "Econet Station "                                            ; 8ff4: 45 63 6f... Eco
+
+    ldy #1                                                            ; 9003: a0 01       ..
+    lda (l009c),y                                                     ; 9005: b1 9c       ..
+    jsr sub_caf85                                                     ; 9007: 20 85 af     ..
+    lda #&20 ; ' '                                                    ; 900a: a9 20       .
+    bit lfea1                                                         ; 900c: 2c a1 fe    ,..
+    beq c901e                                                         ; 900f: f0 0d       ..
+    jsr print_inline_top_bit_clear                                    ; 9011: 20 45 91     E.
+    equs " No Clock"                                                  ; 9014: 20 4e 6f...  No
+
+    nop                                                               ; 901d: ea          .
+; &901e referenced 1 time by &900f
+.c901e
+    jsr osnewl                                                        ; 901e: 20 e7 ff     ..
+    rts                                                               ; 9021: 60          `
+
+; &9022 referenced 1 time by &8be1
+.l9022
+    equs "(<dir>)"                                                    ; 9022: 28 3c 64... (<d
+    equb 0                                                            ; 9029: 00          .
+    equs "(<stn. id.>) <user id.> "                                   ; 902a: 28 3c 73... (<s
+    equb &0d                                                          ; 9042: 0d          .
+    equs "((:<CR>)<password>)"                                        ; 9043: 28 28 3a... ((:
+    equb 0                                                            ; 9056: 00          .
+    equs "<object>"                                                   ; 9057: 3c 6f 62... <ob
+    equb 0                                                            ; 905f: 00          .
+    equs "<filename> (<offset> "                                      ; 9060: 3c 66 69... <fi
+    equb &0d                                                          ; 9075: 0d          .
+    equs "(<address>))"                                               ; 9076: 28 3c 61... (<a
+    equb 0                                                            ; 9082: 00          .
+    equs "<dir>"                                                      ; 9083: 3c 64 69... <di
+    equb 0                                                            ; 9088: 00          .
+    equs "<dir> (<number>)"                                           ; 9089: 3c 64 69... <di
+    equb 0                                                            ; 9099: 00          .
+    equs "(:<CR>) <password> "                                        ; 909a: 28 3a 3c... (:<
+    equb &0d                                                          ; 90ad: 0d          .
+    equs "<new password>"                                             ; 90ae: 3c 6e 65... <ne
+    equb 0                                                            ; 90bc: 00          .
+    equs "(<stn. id.>|<ps type>)"                                     ; 90bd: 28 3c 73... (<s
+    equb 0                                                            ; 90d3: 00          .
+    equs "<object> (L)(W)(R)(/(W)(R))"                                ; 90d4: 3c 6f 62... <ob
+    equb 0                                                            ; 90ef: 00          .
+    equs "<filename> <new filename>"                                  ; 90f0: 3c 66 69... <fi
+    equb 0                                                            ; 9109: 00          .
+    equs "(<stn. id.>)"                                               ; 910a: 28 3c 73... (<s
+    equb 0                                                            ; 9116: 00          .
+    equs "<filename>"                                                 ; 9117: 3c 66 69... <fi
+    equb 0                                                            ; 9121: 00          .
+; &9122 referenced 1 time by &8bdc
+.l9122
+    equb   6, &ff,   7                                                ; 9122: 06 ff 07    ...
+    equs "4=`fw"                                                      ; 9125: 34 3d 60... 4=`
+    equb &9a, &b1, &cd, &e7, &f4                                      ; 912a: 9a b1 cd... ...
+
+; &912f referenced 4 times by &9a66, &ae11, &ba6a, &bb04
+.sub_c912f
+    pha                                                               ; 912f: 48          H
+    lsr a                                                             ; 9130: 4a          J
+    lsr a                                                             ; 9131: 4a          J
+    lsr a                                                             ; 9132: 4a          J
+    lsr a                                                             ; 9133: 4a          J
+    jsr sub_c9138                                                     ; 9134: 20 38 91     8.
+    pla                                                               ; 9137: 68          h
+; &9138 referenced 1 time by &9134
+.sub_c9138
+    and #&0f                                                          ; 9138: 29 0f       ).
+    cmp #&0a                                                          ; 913a: c9 0a       ..
+    bcc c9140                                                         ; 913c: 90 02       ..
+    adc #6                                                            ; 913e: 69 06       i.
+; &9140 referenced 1 time by &913c
+.c9140
+    adc #&30 ; '0'                                                    ; 9140: 69 30       i0
+    jmp osasci                                                        ; 9142: 4c e3 ff    L..
+
+; &9145 referenced 35 times by &8bb6, &8bf8, &8c9f, &8ff1, &9011, &953a, &adc0, &adca, &add8, &ade3, &adff, &ae14, &ae27, &ae36, &af53, &b0a2, &b0ae, &b0c5, &b0cf, &b0da, &b1aa, &b24c, &b261, &b284, &b291, &b2a0, &b2b0, &b2bf, &b3c4, &b3e4, &b431, &ba86, &ba9f, &baac, &bae0
+.print_inline_top_bit_clear
+    pla                                                               ; 9145: 68          h
+    sta l00b8                                                         ; 9146: 85 b8       ..
+    pla                                                               ; 9148: 68          h
+    sta l00b9                                                         ; 9149: 85 b9       ..
+    ldy #0                                                            ; 914b: a0 00       ..
+; &914d referenced 1 time by &9168
+.loop_c914d
+    inc l00b8                                                         ; 914d: e6 b8       ..
+    bne c9153                                                         ; 914f: d0 02       ..
+    inc l00b9                                                         ; 9151: e6 b9       ..
+; &9153 referenced 1 time by &914f
+.c9153
+    lda (l00b8),y                                                     ; 9153: b1 b8       ..
+    bmi c916b                                                         ; 9155: 30 14       0.
+    lda l00b8                                                         ; 9157: a5 b8       ..
+    pha                                                               ; 9159: 48          H
+    lda l00b9                                                         ; 915a: a5 b9       ..
+    pha                                                               ; 915c: 48          H
+    lda (l00b8),y                                                     ; 915d: b1 b8       ..
+    jsr osasci                                                        ; 915f: 20 e3 ff     ..
+    pla                                                               ; 9162: 68          h
+    sta l00b9                                                         ; 9163: 85 b9       ..
+    pla                                                               ; 9165: 68          h
+    sta l00b8                                                         ; 9166: 85 b8       ..
+    jmp loop_c914d                                                    ; 9168: 4c 4d 91    LM.
+
+; &916b referenced 1 time by &9155
+.c916b
+    jmp (l00b8)                                                       ; 916b: 6c b8 00    l..
+
+; &916e referenced 5 times by &8d98, &8da4, &a0ad, &a0c2, &ad24
+.sub_c916e
+    lda #0                                                            ; 916e: a9 00       ..
+    sta l00b2                                                         ; 9170: 85 b2       ..
+    lda (l00be),y                                                     ; 9172: b1 be       ..
+    cmp #&26 ; '&'                                                    ; 9174: c9 26       .&
+    bne c91ae                                                         ; 9176: d0 36       .6
+    iny                                                               ; 9178: c8          .
+    lda (l00be),y                                                     ; 9179: b1 be       ..
+    bcs c9188                                                         ; 917b: b0 0b       ..
+; &917d referenced 1 time by &91ac
+.c917d
+    iny                                                               ; 917d: c8          .
+    lda (l00be),y                                                     ; 917e: b1 be       ..
+    cmp #&2e ; '.'                                                    ; 9180: c9 2e       ..
+    beq c91fb                                                         ; 9182: f0 77       .w
+    cmp #&21 ; '!'                                                    ; 9184: c9 21       .!
+    bcc c91da                                                         ; 9186: 90 52       .R
+; &9188 referenced 1 time by &917b
+.c9188
+    cmp #&30 ; '0'                                                    ; 9188: c9 30       .0
+    bcc c9198                                                         ; 918a: 90 0c       ..
+    cmp #&3a ; ':'                                                    ; 918c: c9 3a       .:
+    bcc c919a                                                         ; 918e: 90 0a       ..
+    and #&5f ; '_'                                                    ; 9190: 29 5f       )_
+    adc #&b8                                                          ; 9192: 69 b8       i.
+    bcs c9208                                                         ; 9194: b0 72       .r
+    cmp #&fa                                                          ; 9196: c9 fa       ..
+; &9198 referenced 1 time by &918a
+.c9198
+    bcc c9208                                                         ; 9198: 90 6e       .n
+; &919a referenced 1 time by &918e
+.c919a
+    and #&0f                                                          ; 919a: 29 0f       ).
+    sta l00b3                                                         ; 919c: 85 b3       ..
+    lda l00b2                                                         ; 919e: a5 b2       ..
+    cmp #&10                                                          ; 91a0: c9 10       ..
+    bcs c9211                                                         ; 91a2: b0 6d       .m
+    asl a                                                             ; 91a4: 0a          .
+    asl a                                                             ; 91a5: 0a          .
+    asl a                                                             ; 91a6: 0a          .
+    asl a                                                             ; 91a7: 0a          .
+    adc l00b3                                                         ; 91a8: 65 b3       e.
+    sta l00b2                                                         ; 91aa: 85 b2       ..
+    bcc c917d                                                         ; 91ac: 90 cf       ..
+; &91ae referenced 2 times by &9176, &91d8
+.c91ae
+    lda (l00be),y                                                     ; 91ae: b1 be       ..
+    cmp #&2e ; '.'                                                    ; 91b0: c9 2e       ..
+    beq c91fb                                                         ; 91b2: f0 47       .G
+    cmp #&21 ; '!'                                                    ; 91b4: c9 21       .!
+    bcc c91da                                                         ; 91b6: 90 22       ."
+    jsr sub_c9260                                                     ; 91b8: 20 60 92     `.
+    bcc c9229                                                         ; 91bb: 90 6c       .l
+    and #&0f                                                          ; 91bd: 29 0f       ).
+    sta l00b3                                                         ; 91bf: 85 b3       ..
+    asl l00b2                                                         ; 91c1: 06 b2       ..
+    bcs c9211                                                         ; 91c3: b0 4c       .L
+    lda l00b2                                                         ; 91c5: a5 b2       ..
+    asl a                                                             ; 91c7: 0a          .
+    bcs c9211                                                         ; 91c8: b0 47       .G
+    asl a                                                             ; 91ca: 0a          .
+    bcs c9211                                                         ; 91cb: b0 44       .D
+    adc l00b2                                                         ; 91cd: 65 b2       e.
+    bcs c9211                                                         ; 91cf: b0 40       .@
+    adc l00b3                                                         ; 91d1: 65 b3       e.
+    bcs c9211                                                         ; 91d3: b0 3c       .<
+    sta l00b2                                                         ; 91d5: 85 b2       ..
+    iny                                                               ; 91d7: c8          .
+    bne c91ae                                                         ; 91d8: d0 d4       ..
+; &91da referenced 2 times by &9186, &91b6
+.c91da
+    lda l00b4                                                         ; 91da: a5 b4       ..
+    bpl c91e3                                                         ; 91dc: 10 05       ..
+    lda l00b2                                                         ; 91de: a5 b2       ..
+    beq c9235                                                         ; 91e0: f0 53       .S
+    rts                                                               ; 91e2: 60          `
+
+; &91e3 referenced 1 time by &91dc
+.c91e3
+    lda l00b2                                                         ; 91e3: a5 b2       ..
+    cmp #&ff                                                          ; 91e5: c9 ff       ..
+    beq c9215                                                         ; 91e7: f0 2c       .,
+    lda l00b2                                                         ; 91e9: a5 b2       ..
+    bne c91f9                                                         ; 91eb: d0 0c       ..
+    lda l00b4                                                         ; 91ed: a5 b4       ..
+    beq c9215                                                         ; 91ef: f0 24       .$
+    dey                                                               ; 91f1: 88          .
+    lda (l00be),y                                                     ; 91f2: b1 be       ..
+    iny                                                               ; 91f4: c8          .
+    eor #&2e ; '.'                                                    ; 91f5: 49 2e       I.
+    bne c9215                                                         ; 91f7: d0 1c       ..
+; &91f9 referenced 1 time by &91eb
+.c91f9
+    sec                                                               ; 91f9: 38          8
+    rts                                                               ; 91fa: 60          `
+
+; &91fb referenced 2 times by &9182, &91b2
+.c91fb
+    lda l00b4                                                         ; 91fb: a5 b4       ..
+    bne c9229                                                         ; 91fd: d0 2a       .*
+    inc l00b4                                                         ; 91ff: e6 b4       ..
+    lda l00b2                                                         ; 9201: a5 b2       ..
+    cmp #&ff                                                          ; 9203: c9 ff       ..
+    beq c9244                                                         ; 9205: f0 3d       .=
+    rts                                                               ; 9207: 60          `
+
+; &9208 referenced 3 times by &9194, &9198, &bb6b
+.c9208
+    lda #&f1                                                          ; 9208: a9 f1       ..
+    jsr generate_error_inline                                         ; 920a: 20 b8 96     ..
+    equs "hex", 0                                                     ; 920d: 68 65 78... hex
+
+; &9211 referenced 6 times by &91a2, &91c3, &91c8, &91cb, &91cf, &91d3
+.c9211
+    bit l00b4                                                         ; 9211: 24 b4       $.
+    bmi c9235                                                         ; 9213: 30 20       0
+; &9215 referenced 4 times by &8f46, &91e7, &91ef, &91f7
+.c9215
+    lda #&d0                                                          ; 9215: a9 d0       ..
+    jsr generate_error_inline                                         ; 9217: 20 b8 96     ..
+    equs "station number", 0                                          ; 921a: 73 74 61... sta
+
+; &9229 referenced 2 times by &91bb, &91fd
+.c9229
+    lda #&f0                                                          ; 9229: a9 f0       ..
+    jsr generate_error_inline                                         ; 922b: 20 b8 96     ..
+    equs "number", 0                                                  ; 922e: 6e 75 6d... num
+
+; &9235 referenced 2 times by &91e0, &9213
+.c9235
+    lda #&94                                                          ; 9235: a9 94       ..
+    jsr generate_error_inline                                         ; 9237: 20 b8 96     ..
+    equs "parameter", 0                                               ; 923a: 70 61 72... par
+
+; &9244 referenced 1 time by &9205
+.c9244
+    lda #&d1                                                          ; 9244: a9 d1       ..
+    jsr generate_error_inline                                         ; 9246: 20 b8 96     ..
+    equs "network number", 0                                          ; 9249: 6e 65 74... net
+
+; &9258 referenced 3 times by &8d93, &b005, &b1dc
+.sub_c9258
+    cmp #&26 ; '&'                                                    ; 9258: c9 26       .&
+    beq c9266                                                         ; 925a: f0 0a       ..
+    cmp #&2e ; '.'                                                    ; 925c: c9 2e       ..
+    beq c9266                                                         ; 925e: f0 06       ..
+; &9260 referenced 1 time by &91b8
+.sub_c9260
+    cmp #&3a ; ':'                                                    ; 9260: c9 3a       .:
+    bcs c9267                                                         ; 9262: b0 03       ..
+    cmp #&30 ; '0'                                                    ; 9264: c9 30       .0
+; &9266 referenced 2 times by &925a, &925e
+.c9266
+    rts                                                               ; 9266: 60          `
+
+; &9267 referenced 1 time by &9262
+.c9267
+    clc                                                               ; 9267: 18          .
+    rts                                                               ; 9268: 60          `
+
+; &9269 referenced 2 times by &9b20, &9b4c
+.sub_c9269
+    ldy #&0e                                                          ; 9269: a0 0e       ..
+    lda (l00bb),y                                                     ; 926b: b1 bb       ..
+    and #&3f ; '?'                                                    ; 926d: 29 3f       )?
+    ldx #4                                                            ; 926f: a2 04       ..
+    bne c9277                                                         ; 9271: d0 04       ..
+; &9273 referenced 2 times by &9a2a, &9b69
+.sub_c9273
+    and #&1f                                                          ; 9273: 29 1f       ).
+    ldx #&ff                                                          ; 9275: a2 ff       ..
+; &9277 referenced 1 time by &9271
+.c9277
+    sta l00b8                                                         ; 9277: 85 b8       ..
+    lda #0                                                            ; 9279: a9 00       ..
+; &927b referenced 1 time by &9283
+.loop_c927b
+    inx                                                               ; 927b: e8          .
+    lsr l00b8                                                         ; 927c: 46 b8       F.
+    bcc c9283                                                         ; 927e: 90 03       ..
+    ora l9286,x                                                       ; 9280: 1d 86 92    ...
+; &9283 referenced 1 time by &927e
+.c9283
+    bne loop_c927b                                                    ; 9283: d0 f6       ..
+    rts                                                               ; 9285: 60          `
+
+; &9286 referenced 1 time by &9280
+.l9286
+    equb &50, &20,   5,   2, &88,   4,   8, &80, &10,   1,   2        ; 9286: 50 20 05... P .
+
+; &9291 referenced 1 time by &a114
+.sub_c9291
+    stx os_text_ptr                                                   ; 9291: 86 f2       ..
+    sty l00f3                                                         ; 9293: 84 f3       ..
+; &9295 referenced 2 times by &8e33, &ad80
+.sub_c9295
+    sta l00bd                                                         ; 9295: 85 bd       ..
+    stx l00be                                                         ; 9297: 86 be       ..
+    sty l00bf                                                         ; 9299: 84 bf       ..
+; &929b referenced 1 time by &b984
+.sub_c929b
+    stx l00bb                                                         ; 929b: 86 bb       ..
+    sty l00bc                                                         ; 929d: 84 bc       ..
+; &929f referenced 1 time by &9885
+.c929f
+    php                                                               ; 929f: 08          .
+    lsr l0098                                                         ; 92a0: 46 98       F.
+    plp                                                               ; 92a2: 28          (
+    rts                                                               ; 92a3: 60          `
+
+; &92a4 referenced 2 times by &9998, &9a9b
+.sub_c92a4
+    ldx #4                                                            ; 92a4: a2 04       ..
+; &92a6 referenced 1 time by &92ad
+.loop_c92a6
+    lda l00af,x                                                       ; 92a6: b5 af       ..
+    eor l00b3,x                                                       ; 92a8: 55 b3       U.
+    bne c92af                                                         ; 92aa: d0 03       ..
+    dex                                                               ; 92ac: ca          .
+    bne loop_c92a6                                                    ; 92ad: d0 f7       ..
+; &92af referenced 1 time by &92aa
+.c92af
+    rts                                                               ; 92af: 60          `
+
+.sub_c92b0
+    ldx #&20 ; ' '                                                    ; 92b0: a2 20       .
+    ldy #&2f ; '/'                                                    ; 92b2: a0 2f       ./
+    rts                                                               ; 92b4: 60          `
+
+    equb   8, &48, &8a, &48, &ba, &bd,   2,   1, &20, &6b, &b4, &30   ; 92b5: 08 48 8a... .H.
+    equb &1f, &a9, &40, &1d, &60, &10, &9d, &60, &10, &d0, &15,   8   ; 92c1: 1f a9 40... ..@
+    equb &48, &8a, &48, &ba, &bd,   2,   1, &20, &6b, &b4, &30,   8   ; 92cd: 48 8a 48... H.H
+    equb &a9, &bf, &3d, &60, &10, &9d, &60, &10, &68, &aa             ; 92d9: a9 bf 3d... ..=
+    equs "h(`"                                                        ; 92e3: 68 28 60    h(`
+
+.sub_c92e6
+    jsr sub_c9327                                                     ; 92e6: 20 27 93     '.
+    txa                                                               ; 92e9: 8a          .
+    pha                                                               ; 92ea: 48          H
+    jsr sub_c9349                                                     ; 92eb: 20 49 93     I.
+    jsr sub_cae97                                                     ; 92ee: 20 97 ae     ..
+    pla                                                               ; 92f1: 68          h
+    tax                                                               ; 92f2: aa          .
+    jsr sub_c9309                                                     ; 92f3: 20 09 93     ..
+    cmp #&0d                                                          ; 92f6: c9 0d       ..
+    bne c9311                                                         ; 92f8: d0 17       ..
+; &92fa referenced 3 times by &930e, &9409, &aedf
+.c92fa
+    lda #&cc                                                          ; 92fa: a9 cc       ..
+    jsr generate_error_inline                                         ; 92fc: 20 b8 96     ..
+    equs "file name", 0                                               ; 92ff: 66 69 6c... fil
+
+; &9309 referenced 2 times by &92f3, &9311
+.sub_c9309
+    lda l0e30                                                         ; 9309: ad 30 0e    .0.
+    cmp #&26 ; '&'                                                    ; 930c: c9 26       .&
+    beq c92fa                                                         ; 930e: f0 ea       ..
+    rts                                                               ; 9310: 60          `
+
+; &9311 referenced 3 times by &92f8, &931f, &93da
+.c9311
+    jsr sub_c9309                                                     ; 9311: 20 09 93     ..
+    sta l0f05,x                                                       ; 9314: 9d 05 0f    ...
+    inx                                                               ; 9317: e8          .
+    cmp #&0d                                                          ; 9318: c9 0d       ..
+    beq c9322                                                         ; 931a: f0 06       ..
+    jsr caeb7                                                         ; 931c: 20 b7 ae     ..
+    jmp c9311                                                         ; 931f: 4c 11 93    L..
+
+; &9322 referenced 2 times by &931a, &9402
+.c9322
+    ldy #0                                                            ; 9322: a0 00       ..
+    jmp c8e24                                                         ; 9324: 4c 24 8e    L$.
+
+; &9327 referenced 2 times by &92e6, &938b
+.sub_c9327
+    tya                                                               ; 9327: 98          .
+    pha                                                               ; 9328: 48          H
+; &9329 referenced 1 time by &932d
+.loop_c9329
+    dex                                                               ; 9329: ca          .
+    lda la3f0,x                                                       ; 932a: bd f0 a3    ...
+    bpl loop_c9329                                                    ; 932d: 10 fa       ..
+    inx                                                               ; 932f: e8          .
+    ldy #0                                                            ; 9330: a0 00       ..
+; &9332 referenced 1 time by &933c
+.loop_c9332
+    lda la3f0,x                                                       ; 9332: bd f0 a3    ...
+    bmi c933e                                                         ; 9335: 30 07       0.
+    sta l0f05,y                                                       ; 9337: 99 05 0f    ...
+    inx                                                               ; 933a: e8          .
+    iny                                                               ; 933b: c8          .
+    bne loop_c9332                                                    ; 933c: d0 f4       ..
+; &933e referenced 1 time by &9335
+.c933e
+    lda #&20 ; ' '                                                    ; 933e: a9 20       .
+    sta l0f05,y                                                       ; 9340: 99 05 0f    ...
+    iny                                                               ; 9343: c8          .
+    tya                                                               ; 9344: 98          .
+    tax                                                               ; 9345: aa          .
+    pla                                                               ; 9346: 68          h
+    tay                                                               ; 9347: a8          .
+; &9348 referenced 1 time by &937d
+.c9348
+    rts                                                               ; 9348: 60          `
+
+; &9349 referenced 2 times by &92eb, &9393
+.sub_c9349
+    lda #0                                                            ; 9349: a9 00       ..
+    tax                                                               ; 934b: aa          .
+    sta l10d8                                                         ; 934c: 8d d8 10    ...
+; &934f referenced 1 time by &9356
+.loop_c934f
+    lda (l00be),y                                                     ; 934f: b1 be       ..
+    cmp #&20 ; ' '                                                    ; 9351: c9 20       .
+    bne c9358                                                         ; 9353: d0 03       ..
+    iny                                                               ; 9355: c8          .
+    bne loop_c934f                                                    ; 9356: d0 f7       ..
+; &9358 referenced 1 time by &9353
+.c9358
+    cmp #&22 ; '"'                                                    ; 9358: c9 22       ."
+    bne c9363                                                         ; 935a: d0 07       ..
+    iny                                                               ; 935c: c8          .
+    eor l10d8                                                         ; 935d: 4d d8 10    M..
+    sta l10d8                                                         ; 9360: 8d d8 10    ...
+; &9363 referenced 2 times by &935a, &9378
+.c9363
+    lda (l00be),y                                                     ; 9363: b1 be       ..
+    cmp #&22 ; '"'                                                    ; 9365: c9 22       ."
+    bne c9371                                                         ; 9367: d0 08       ..
+    eor l10d8                                                         ; 9369: 4d d8 10    M..
+    sta l10d8                                                         ; 936c: 8d d8 10    ...
+    lda #&20 ; ' '                                                    ; 936f: a9 20       .
+; &9371 referenced 1 time by &9367
+.c9371
+    sta l0e30,x                                                       ; 9371: 9d 30 0e    .0.
+    iny                                                               ; 9374: c8          .
+    inx                                                               ; 9375: e8          .
+    cmp #&0d                                                          ; 9376: c9 0d       ..
+    bne c9363                                                         ; 9378: d0 e9       ..
+    lda l10d8                                                         ; 937a: ad d8 10    ...
+    beq c9348                                                         ; 937d: f0 c9       ..
+    lda l00fd                                                         ; 937f: a5 fd       ..
+    jsr generate_error_inline                                         ; 9381: 20 b8 96     ..
+    equs "string", 0                                                  ; 9384: 73 74 72... str
+
+.sub_c938b
+    jsr sub_c9327                                                     ; 938b: 20 27 93     '.
+    txa                                                               ; 938e: 8a          .
+    pha                                                               ; 938f: 48          H
+    jsr sub_caf32                                                     ; 9390: 20 32 af     2.
+    jsr sub_c9349                                                     ; 9393: 20 49 93     I.
+    jsr sub_cae97                                                     ; 9396: 20 97 ae     ..
+    pla                                                               ; 9399: 68          h
+    tax                                                               ; 939a: aa          .
+; &939b referenced 1 time by &93b9
+.loop_c939b
+    lda l0e30                                                         ; 939b: ad 30 0e    .0.
+    cmp #&0d                                                          ; 939e: c9 0d       ..
+    bne c93ae                                                         ; 93a0: d0 0c       ..
+; &93a2 referenced 1 time by &93d8
+.c93a2
+    lda #&b0                                                          ; 93a2: a9 b0       ..
+    jsr generate_error_inline                                         ; 93a4: 20 b8 96     ..
+    equs "rename", 0                                                  ; 93a7: 72 65 6e... ren
+
+; &93ae referenced 1 time by &93a0
+.c93ae
+    sta l0f05,x                                                       ; 93ae: 9d 05 0f    ...
+    inx                                                               ; 93b1: e8          .
+    cmp #&20 ; ' '                                                    ; 93b2: c9 20       .
+    beq c93bc                                                         ; 93b4: f0 06       ..
+    jsr caeb7                                                         ; 93b6: 20 b7 ae     ..
+    jmp loop_c939b                                                    ; 93b9: 4c 9b 93    L..
+
+; &93bc referenced 2 times by &93b4, &93c4
+.c93bc
+    jsr caeb7                                                         ; 93bc: 20 b7 ae     ..
+    lda l0e30                                                         ; 93bf: ad 30 0e    .0.
+    cmp #&20 ; ' '                                                    ; 93c2: c9 20       .
+    beq c93bc                                                         ; 93c4: f0 f6       ..
+    lda l1071                                                         ; 93c6: ad 71 10    .q.
+    pha                                                               ; 93c9: 48          H
+    jsr sub_caf32                                                     ; 93ca: 20 32 af     2.
+    txa                                                               ; 93cd: 8a          .
+    pha                                                               ; 93ce: 48          H
+    jsr sub_cae97                                                     ; 93cf: 20 97 ae     ..
+    pla                                                               ; 93d2: 68          h
+    tax                                                               ; 93d3: aa          .
+    pla                                                               ; 93d4: 68          h
+    cmp l1071                                                         ; 93d5: cd 71 10    .q.
+    bne c93a2                                                         ; 93d8: d0 c8       ..
+    jmp c9311                                                         ; 93da: 4c 11 93    L..
+
+.sub_c93dd
+    lda (l00be),y                                                     ; 93dd: b1 be       ..
+    cmp #&26 ; '&'                                                    ; 93df: c9 26       .&
+    bne c9462                                                         ; 93e1: d0 7f       ..
+    iny                                                               ; 93e3: c8          .
+    lda (l00be),y                                                     ; 93e4: b1 be       ..
+    cmp #&0d                                                          ; 93e6: c9 0d       ..
+    beq c93ee                                                         ; 93e8: f0 04       ..
+    cmp #&20 ; ' '                                                    ; 93ea: c9 20       .
+    bne c9405                                                         ; 93ec: d0 17       ..
+; &93ee referenced 1 time by &93e8
+.c93ee
+    ldy #&ff                                                          ; 93ee: a0 ff       ..
+; &93f0 referenced 1 time by &93f8
+.loop_c93f0
+    iny                                                               ; 93f0: c8          .
+    lda (l00be),y                                                     ; 93f1: b1 be       ..
+    sta l0f05,y                                                       ; 93f3: 99 05 0f    ...
+    cmp #&26 ; '&'                                                    ; 93f6: c9 26       .&
+    bne loop_c93f0                                                    ; 93f8: d0 f6       ..
+    lda #&0d                                                          ; 93fa: a9 0d       ..
+    sta l0f05,y                                                       ; 93fc: 99 05 0f    ...
+    iny                                                               ; 93ff: c8          .
+    tya                                                               ; 9400: 98          .
+    tax                                                               ; 9401: aa          .
+    jmp c9322                                                         ; 9402: 4c 22 93    L".
+
+; &9405 referenced 1 time by &93ec
+.c9405
+    cmp #&2e ; '.'                                                    ; 9405: c9 2e       ..
+    beq c940c                                                         ; 9407: f0 03       ..
+    jmp c92fa                                                         ; 9409: 4c fa 92    L..
+
+; &940c referenced 1 time by &9407
+.c940c
+    iny                                                               ; 940c: c8          .
+    sty l00b0                                                         ; 940d: 84 b0       ..
+    lda #4                                                            ; 940f: a9 04       ..
+    sta l0f05                                                         ; 9411: 8d 05 0f    ...
+    lda l1071                                                         ; 9414: ad 71 10    .q.
+    ora #&40 ; '@'                                                    ; 9417: 09 40       .@
+    sta l1071                                                         ; 9419: 8d 71 10    .q.
+    ldx #1                                                            ; 941c: a2 01       ..
+    jsr sub_caf06                                                     ; 941e: 20 06 af     ..
+    ldy #&12                                                          ; 9421: a0 12       ..
+    jsr c94ad                                                         ; 9423: 20 ad 94     ..
+    lda l0f05                                                         ; 9426: ad 05 0f    ...
+    cmp #2                                                            ; 9429: c9 02       ..
+    beq c943c                                                         ; 942b: f0 0f       ..
+    lda #&d6                                                          ; 942d: a9 d6       ..
+    jsr generate_error_inline3                                        ; 942f: 20 d1 96     ..
+    equs "Not found", 0                                               ; 9432: 4e 6f 74... Not
+
+; &943c referenced 1 time by &942b
+.c943c
+    lda l0e03                                                         ; 943c: ad 03 0e    ...
+    sta l0f05                                                         ; 943f: 8d 05 0f    ...
+    ldx #1                                                            ; 9442: a2 01       ..
+    ldy #7                                                            ; 9444: a0 07       ..
+    jsr c94ad                                                         ; 9446: 20 ad 94     ..
+    ldx #1                                                            ; 9449: a2 01       ..
+    stx l0f05                                                         ; 944b: 8e 05 0f    ...
+    stx l0f06                                                         ; 944e: 8e 06 0f    ...
+    inx                                                               ; 9451: e8          .
+    ldy l00b0                                                         ; 9452: a4 b0       ..
+    jsr sub_caf06                                                     ; 9454: 20 06 af     ..
+    ldy #6                                                            ; 9457: a0 06       ..
+    jsr c94ad                                                         ; 9459: 20 ad 94     ..
+    ldy l0f05                                                         ; 945c: ac 05 0f    ...
+    jmp ca2f4                                                         ; 945f: 4c f4 a2    L..
+
+; &9462 referenced 1 time by &93e1
+.c9462
+    jmp c8e15                                                         ; 9462: 4c 15 8e    L..
+
+; &9465 referenced 1 time by &94f1
+.sub_c9465
+    lda #&90                                                          ; 9465: a9 90       ..
+; &9467 referenced 1 time by &9ae0
+.sub_c9467
+    jsr sub_c9473                                                     ; 9467: 20 73 94     s.
+    sta l00c1                                                         ; 946a: 85 c1       ..
+    lda #3                                                            ; 946c: a9 03       ..
+    sta l00c4                                                         ; 946e: 85 c4       ..
+    dec l00c0                                                         ; 9470: c6 c0       ..
+    rts                                                               ; 9472: 60          `
+
+; &9473 referenced 4 times by &8dfc, &9467, &94e0, &b93a
+.sub_c9473
+    pha                                                               ; 9473: 48          H
+    ldy #&0b                                                          ; 9474: a0 0b       ..
+; &9476 referenced 1 time by &9487
+.loop_c9476
+    lda l948b,y                                                       ; 9476: b9 8b 94    ...
+    sta l00c0,y                                                       ; 9479: 99 c0 00    ...
+    cpy #2                                                            ; 947c: c0 02       ..
+    bpl c9486                                                         ; 947e: 10 06       ..
+    lda l0e00,y                                                       ; 9480: b9 00 0e    ...
+    sta l00c2,y                                                       ; 9483: 99 c2 00    ...
+; &9486 referenced 1 time by &947e
+.c9486
+    dey                                                               ; 9486: 88          .
+    bpl loop_c9476                                                    ; 9487: 10 ed       ..
+    pla                                                               ; 9489: 68          h
+    rts                                                               ; 948a: 60          `
+
+; &948b referenced 1 time by &9476
+.l948b
+    equb &80, &99,   0,   0,   0, &0f                                 ; 948b: 80 99 00... ...
+; &9491 referenced 19 times by &8c73, &964e, &977d, &9b41, &a09e, &a19d, &a316, &a341, &a378, &af7f, &af85, &b025, &b1a5, &b205, &b246, &b2ce, &b55a, &b598, &b99d
+.l9491
+    equb &ff, &ff, &ff, &0f, &ff, &ff                                 ; 9491: ff ff ff... ...
+
+; &9497 referenced 1 time by &9f14
+.sub_c9497
+    pha                                                               ; 9497: 48          H
+    sec                                                               ; 9498: 38          8
+    bcs c94b5                                                         ; 9499: b0 1a       ..
+; &949b referenced 2 times by &9958, &9a0c
+.sub_c949b
+    clv                                                               ; 949b: b8          .
+    bvc c94b4                                                         ; 949c: 50 16       P.
+.sub_c949e
+    ldy #0                                                            ; 949e: a0 00       ..
+    jsr sub_cb799                                                     ; 94a0: 20 99 b7     ..
+    lda #osbyte_close_spool_exec                                      ; 94a3: a9 77       .w
+    jsr osbyte                                                        ; 94a5: 20 f4 ff     ..
+    jsr sub_cb559                                                     ; 94a8: 20 59 b5     Y.
+    ldy #&17                                                          ; 94ab: a0 17       ..
+; &94ad referenced 15 times by &8e24, &9423, &9446, &9459, &9b5d, &9de4, &a1d6, &a1fe, &ad41, &adb8, &adf6, &ae65, &b381, &b418, &b917
+.c94ad
+    clv                                                               ; 94ad: b8          .
+; &94ae referenced 2 times by &9b44, &af82
+.c94ae
+    lda l0e02                                                         ; 94ae: ad 02 0e    ...
+    sta l0f02                                                         ; 94b1: 8d 02 0f    ...
+; &94b4 referenced 1 time by &949c
+.c94b4
+    clc                                                               ; 94b4: 18          .
+; &94b5 referenced 1 time by &9499
+.c94b5
+    php                                                               ; 94b5: 08          .
+    sty l0f01                                                         ; 94b6: 8c 01 0f    ...
+    ldy #1                                                            ; 94b9: a0 01       ..
+; &94bb referenced 1 time by &94c2
+.loop_c94bb
+    lda l0e03,y                                                       ; 94bb: b9 03 0e    ...
+    sta l0f03,y                                                       ; 94be: 99 03 0f    ...
+    dey                                                               ; 94c1: 88          .
+    bpl loop_c94bb                                                    ; 94c2: 10 f7       ..
+    bit l1071                                                         ; 94c4: 2c 71 10    ,q.
+    bvs c94d3                                                         ; 94c7: 70 0a       p.
+    bpl c94d9                                                         ; 94c9: 10 0e       ..
+    lda l0e04                                                         ; 94cb: ad 04 0e    ...
+    sta l0f03                                                         ; 94ce: 8d 03 0f    ...
+    bvc c94d9                                                         ; 94d1: 50 06       P.
+; &94d3 referenced 1 time by &94c7
+.c94d3
+    lda l0e02                                                         ; 94d3: ad 02 0e    ...
+    sta l0f03                                                         ; 94d6: 8d 03 0f    ...
+; &94d9 referenced 2 times by &94c9, &94d1
+.c94d9
+    plp                                                               ; 94d9: 28          (
+    php                                                               ; 94da: 08          .
+    lda #&90                                                          ; 94db: a9 90       ..
+    sta l0f00                                                         ; 94dd: 8d 00 0f    ...
+    jsr sub_c9473                                                     ; 94e0: 20 73 94     s.
+    txa                                                               ; 94e3: 8a          .
+    adc #5                                                            ; 94e4: 69 05       i.
+    sta l00c8                                                         ; 94e6: 85 c8       ..
+    plp                                                               ; 94e8: 28          (
+    bcs c9505                                                         ; 94e9: b0 1a       ..
+    php                                                               ; 94eb: 08          .
+    jsr sub_c9837                                                     ; 94ec: 20 37 98     7.
+    plp                                                               ; 94ef: 28          (
+; &94f0 referenced 2 times by &9a1f, &9f68
+.sub_c94f0
+    php                                                               ; 94f0: 08          .
+    jsr sub_c9465                                                     ; 94f1: 20 65 94     e.
+    jsr sub_c95dd                                                     ; 94f4: 20 dd 95     ..
+    plp                                                               ; 94f7: 28          (
+; &94f8 referenced 1 time by &950c
+.loop_c94f8
+    iny                                                               ; 94f8: c8          .
+    lda (l00c4),y                                                     ; 94f9: b1 c4       ..
+    tax                                                               ; 94fb: aa          .
+    beq c9504                                                         ; 94fc: f0 06       ..
+    bvc c9502                                                         ; 94fe: 50 02       P.
+    adc #&2a ; '*'                                                    ; 9500: 69 2a       i*
+; &9502 referenced 1 time by &94fe
+.c9502
+    bne c950e                                                         ; 9502: d0 0a       ..
+; &9504 referenced 2 times by &94fc, &9574
+.c9504
+    rts                                                               ; 9504: 60          `
+
+; &9505 referenced 1 time by &94e9
+.c9505
+    pla                                                               ; 9505: 68          h
+    ldx #&c0                                                          ; 9506: a2 c0       ..
+    iny                                                               ; 9508: c8          .
+    jsr sub_cac24                                                     ; 9509: 20 24 ac     $.
+    bcc loop_c94f8                                                    ; 950c: 90 ea       ..
+; &950e referenced 1 time by &9502
+.c950e
+    stx l0e09                                                         ; 950e: 8e 09 0e    ...
+    lda l0e07                                                         ; 9511: ad 07 0e    ...
+    php                                                               ; 9514: 08          .
+    bne c951b                                                         ; 9515: d0 04       ..
+    cpx #&bf                                                          ; 9517: e0 bf       ..
+    bne c9551                                                         ; 9519: d0 36       .6
+; &951b referenced 1 time by &9515
+.c951b
+    lda #&40 ; '@'                                                    ; 951b: a9 40       .@
+    pha                                                               ; 951d: 48          H
+    ldx #&f0                                                          ; 951e: a2 f0       ..
+; &9520 referenced 1 time by &952e
+.loop_c9520
+    pla                                                               ; 9520: 68          h
+    ora l0fc8,x                                                       ; 9521: 1d c8 0f    ...
+    pha                                                               ; 9524: 48          H
+    lda l0fc8,x                                                       ; 9525: bd c8 0f    ...
+    and #&c0                                                          ; 9528: 29 c0       ).
+    sta l0fc8,x                                                       ; 952a: 9d c8 0f    ...
+    inx                                                               ; 952d: e8          .
+    bmi loop_c9520                                                    ; 952e: 30 f0       0.
+    stx l0e07                                                         ; 9530: 8e 07 0e    ...
+    jsr sub_cb559                                                     ; 9533: 20 59 b5     Y.
+    pla                                                               ; 9536: 68          h
+    ror a                                                             ; 9537: 6a          j
+    bcc c9547                                                         ; 9538: 90 0d       ..
+    jsr print_inline_top_bit_clear                                    ; 953a: 20 45 91     E.
+    equs "Data Lost", &0d                                             ; 953d: 44 61 74... Dat
+
+; &9547 referenced 1 time by &9538
+.c9547
+    ldx l0e09                                                         ; 9547: ae 09 0e    ...
+    plp                                                               ; 954a: 28          (
+    beq c9551                                                         ; 954b: f0 04       ..
+    pla                                                               ; 954d: 68          h
+    pla                                                               ; 954e: 68          h
+    pla                                                               ; 954f: 68          h
+    rts                                                               ; 9550: 60          `
+
+; &9551 referenced 2 times by &9519, &954b
+.c9551
+    ldy #1                                                            ; 9551: a0 01       ..
+    cpx #&a8                                                          ; 9553: e0 a8       ..
+    bcs c955b                                                         ; 9555: b0 04       ..
+    lda #&a8                                                          ; 9557: a9 a8       ..
+    sta (l00c4),y                                                     ; 9559: 91 c4       ..
+; &955b referenced 1 time by &9555
+.c955b
+    ldy #&ff                                                          ; 955b: a0 ff       ..
+; &955d referenced 1 time by &9565
+.loop_c955d
+    iny                                                               ; 955d: c8          .
+    lda (l00c4),y                                                     ; 955e: b1 c4       ..
+    sta l0100,y                                                       ; 9560: 99 00 01    ...
+    eor #&0d                                                          ; 9563: 49 0d       I.
+    bne loop_c955d                                                    ; 9565: d0 f6       ..
+    sta l0100,y                                                       ; 9567: 99 00 01    ...
+    dey                                                               ; 956a: 88          .
+    tya                                                               ; 956b: 98          .
+    tax                                                               ; 956c: aa          .
+    jmp c96f0                                                         ; 956d: 4c f0 96    L..
+
+; &9570 referenced 2 times by &8dd6, &985b
+.sub_c9570
+    lda l00ff                                                         ; 9570: a5 ff       ..
+    and l0098                                                         ; 9572: 25 98       %.
+    bpl c9504                                                         ; 9574: 10 8e       ..
+; &9576 referenced 1 time by &b445
+.c9576
+    lda #osbyte_acknowledge_escape                                    ; 9576: a9 7e       .~
+    jsr osbyte                                                        ; 9578: 20 f4 ff     ..
+    lda #6                                                            ; 957b: a9 06       ..
+    jmp c964e                                                         ; 957d: 4c 4e 96    LN.
+
+.sub_c9580
+    ldy #0                                                            ; 9580: a0 00       ..
+    lda (l009c),y                                                     ; 9582: b1 9c       ..
+    beq c9589                                                         ; 9584: f0 03       ..
+; &9586 referenced 1 time by &95cc
+.c9586
+    jmp cacdd                                                         ; 9586: 4c dd ac    L..
+
+; &9589 referenced 2 times by &9584, &95c2
+.c9589
+    ora #9                                                            ; 9589: 09 09       ..
+    sta (l009c),y                                                     ; 958b: 91 9c       ..
+    ldx #&80                                                          ; 958d: a2 80       ..
+    ldy #&80                                                          ; 958f: a0 80       ..
+    lda (l009c),y                                                     ; 9591: b1 9c       ..
+    pha                                                               ; 9593: 48          H
+    iny                                                               ; 9594: c8          .
+    lda (l009c),y                                                     ; 9595: b1 9c       ..
+    ldy #&0f                                                          ; 9597: a0 0f       ..
+    sta (l009e),y                                                     ; 9599: 91 9e       ..
+    dey                                                               ; 959b: 88          .
+    pla                                                               ; 959c: 68          h
+    sta (l009e),y                                                     ; 959d: 91 9e       ..
+    jsr sub_c8aea                                                     ; 959f: 20 ea 8a     ..
+    jsr sub_caa85                                                     ; 95a2: 20 85 aa     ..
+    ldx #1                                                            ; 95a5: a2 01       ..
+    ldy #0                                                            ; 95a7: a0 00       ..
+    lda #osbyte_read_write_econet_keyboard_disable                    ; 95a9: a9 c9       ..
+    jsr osbyte                                                        ; 95ab: 20 f4 ff     ..
+.sub_c95ae
+    jsr cacdd                                                         ; 95ae: 20 dd ac     ..
+    lda #0                                                            ; 95b1: a9 00       ..
+    jsr generate_error_inline3                                        ; 95b3: 20 d1 96     ..
+    equs "Remoted", 0                                                 ; 95b6: 52 65 6d... Rem
+
+.sub_c95be
+    ldy #0                                                            ; 95be: a0 00       ..
+    lda (l009c),y                                                     ; 95c0: b1 9c       ..
+    beq c9589                                                         ; 95c2: f0 c5       ..
+    ldy #&80                                                          ; 95c4: a0 80       ..
+    lda (l009c),y                                                     ; 95c6: b1 9c       ..
+    ldy #&0e                                                          ; 95c8: a0 0e       ..
+    cmp (l009e),y                                                     ; 95ca: d1 9e       ..
+    bne c9586                                                         ; 95cc: d0 b8       ..
+.sub_c95ce
+    ldy #&82                                                          ; 95ce: a0 82       ..
+    lda (l009c),y                                                     ; 95d0: b1 9c       ..
+    tay                                                               ; 95d2: a8          .
+    ldx #0                                                            ; 95d3: a2 00       ..
+    jsr cacdd                                                         ; 95d5: 20 dd ac     ..
+    lda #osbyte_insert_input_buffer                                   ; 95d8: a9 99       ..
+    jmp osbyte                                                        ; 95da: 4c f4 ff    L..
+
+; &95dd referenced 5 times by &94f4, &99b2, &9aea, &abd1, &ac73
+.sub_c95dd
+    lda l0d6e                                                         ; 95dd: ad 6e 0d    .n.
+    pha                                                               ; 95e0: 48          H
+    lda l0d61                                                         ; 95e1: ad 61 0d    .a.
+    pha                                                               ; 95e4: 48          H
+    lda l009b                                                         ; 95e5: a5 9b       ..
+    bne c95ee                                                         ; 95e7: d0 05       ..
+    ora #&80                                                          ; 95e9: 09 80       ..
+    sta l0d61                                                         ; 95eb: 8d 61 0d    .a.
+; &95ee referenced 1 time by &95e7
+.c95ee
+    lda #0                                                            ; 95ee: a9 00       ..
+    pha                                                               ; 95f0: 48          H
+    pha                                                               ; 95f1: 48          H
+    tay                                                               ; 95f2: a8          .
+    tsx                                                               ; 95f3: ba          .
+; &95f4 referenced 3 times by &95fb, &9600, &9605
+.c95f4
+    lda (l009a),y                                                     ; 95f4: b1 9a       ..
+    bmi c9607                                                         ; 95f6: 30 0f       0.
+    dec l0101,x                                                       ; 95f8: de 01 01    ...
+    bne c95f4                                                         ; 95fb: d0 f7       ..
+    dec l0102,x                                                       ; 95fd: de 02 01    ...
+    bne c95f4                                                         ; 9600: d0 f2       ..
+    dec l0104,x                                                       ; 9602: de 04 01    ...
+    bne c95f4                                                         ; 9605: d0 ed       ..
+; &9607 referenced 1 time by &95f6
+.c9607
+    pla                                                               ; 9607: 68          h
+    pla                                                               ; 9608: 68          h
+    pla                                                               ; 9609: 68          h
+    sta l0d61                                                         ; 960a: 8d 61 0d    .a.
+    pla                                                               ; 960d: 68          h
+    beq c961a                                                         ; 960e: f0 0a       ..
+    rts                                                               ; 9610: 60          `
+
+; &9611 referenced 6 times by &9627, &9660, &967c, &96a6, &96b8, &96d1
+.sta_e09_if_d6c_b7_set
+    bit l0d6c                                                         ; 9611: 2c 6c 0d    ,l.
+    bpl c9619                                                         ; 9614: 10 03       ..
+    sta l0e09                                                         ; 9616: 8d 09 0e    ...
+; &9619 referenced 1 time by &9614
+.c9619
+    rts                                                               ; 9619: 60          `
+
+; &961a referenced 1 time by &960e
+.c961a
+    ldx #8                                                            ; 961a: a2 08       ..
+    ldy l97ad,x                                                       ; 961c: bc ad 97    ...
+    ldx #0                                                            ; 961f: a2 00       ..
+    stx l0100                                                         ; 9621: 8e 00 01    ...
+    lda l97b9,y                                                       ; 9624: b9 b9 97    ...
+    jsr sta_e09_if_d6c_b7_set                                         ; 9627: 20 11 96     ..
+; &962a referenced 1 time by &9634
+.loop_c962a
+    lda l97b9,y                                                       ; 962a: b9 b9 97    ...
+    sta l0101,x                                                       ; 962d: 9d 01 01    ...
+    beq c9636                                                         ; 9630: f0 04       ..
+    inx                                                               ; 9632: e8          .
+    iny                                                               ; 9633: c8          .
+    bne loop_c962a                                                    ; 9634: d0 f4       ..
+; &9636 referenced 1 time by &9630
+.c9636
+    jsr sub_c974d                                                     ; 9636: 20 4d 97     M.
+    lda #0                                                            ; 9639: a9 00       ..
+    sta l0101,x                                                       ; 963b: 9d 01 01    ...
+    jmp c96f0                                                         ; 963e: 4c f0 96    L..
+
+; &9641 referenced 1 time by &98c6
+.c9641
+    lda (l009a,x)                                                     ; 9641: a1 9a       ..
+    cmp #&41 ; 'A'                                                    ; 9643: c9 41       .A
+    bne c9649                                                         ; 9645: d0 02       ..
+    lda #&42 ; 'B'                                                    ; 9647: a9 42       .B
+; &9649 referenced 1 time by &9645
+.c9649
+    clv                                                               ; 9649: b8          .
+    bvc c9651                                                         ; 964a: 50 05       P.
+; &964c referenced 1 time by &987f
+.c964c
+    lda (l009a,x)                                                     ; 964c: a1 9a       ..
+; &964e referenced 2 times by &957d, &9ddc
+.c964e
+    bit l9491                                                         ; 964e: 2c 91 94    ,..
+; &9651 referenced 1 time by &964a
+.c9651
+    and #7                                                            ; 9651: 29 07       ).
+    pha                                                               ; 9653: 48          H
+    cmp #2                                                            ; 9654: c9 02       ..
+    bne c969a                                                         ; 9656: d0 42       .B
+    php                                                               ; 9658: 08          .
+    tax                                                               ; 9659: aa          .
+    ldy l97ad,x                                                       ; 965a: bc ad 97    ...
+    lda l97b9,y                                                       ; 965d: b9 b9 97    ...
+    jsr sta_e09_if_d6c_b7_set                                         ; 9660: 20 11 96     ..
+    ldx #0                                                            ; 9663: a2 00       ..
+    stx l0100                                                         ; 9665: 8e 00 01    ...
+; &9668 referenced 1 time by &9672
+.loop_c9668
+    lda l97b9,y                                                       ; 9668: b9 b9 97    ...
+    sta l0101,x                                                       ; 966b: 9d 01 01    ...
+    beq c9674                                                         ; 966e: f0 04       ..
+    iny                                                               ; 9670: c8          .
+    inx                                                               ; 9671: e8          .
+    bne loop_c9668                                                    ; 9672: d0 f4       ..
+; &9674 referenced 1 time by &966e
+.c9674
+    jsr sub_c974d                                                     ; 9674: 20 4d 97     M.
+    plp                                                               ; 9677: 28          (
+    bvs c9686                                                         ; 9678: 70 0c       p.
+    lda #&a4                                                          ; 967a: a9 a4       ..
+    jsr sta_e09_if_d6c_b7_set                                         ; 967c: 20 11 96     ..
+    sta l0101                                                         ; 967f: 8d 01 01    ...
+    ldy #&0b                                                          ; 9682: a0 0b       ..
+    bne c9688                                                         ; 9684: d0 02       ..
+; &9686 referenced 1 time by &9678
+.c9686
+    ldy #9                                                            ; 9686: a0 09       ..
+; &9688 referenced 1 time by &9684
+.c9688
+    lda l97ad,y                                                       ; 9688: b9 ad 97    ...
+    tay                                                               ; 968b: a8          .
+; &968c referenced 1 time by &9696
+.loop_c968c
+    lda l97b9,y                                                       ; 968c: b9 b9 97    ...
+    sta l0101,x                                                       ; 968f: 9d 01 01    ...
+    beq c9698                                                         ; 9692: f0 04       ..
+    iny                                                               ; 9694: c8          .
+    inx                                                               ; 9695: e8          .
+    bne loop_c968c                                                    ; 9696: d0 f4       ..
+; &9698 referenced 1 time by &9692
+.c9698
+    beq c96af                                                         ; 9698: f0 15       ..
+; &969a referenced 1 time by &9656
+.c969a
+    tax                                                               ; 969a: aa          .
+    ldy l97ad,x                                                       ; 969b: bc ad 97    ...
+    ldx #0                                                            ; 969e: a2 00       ..
+    stx l0100                                                         ; 96a0: 8e 00 01    ...
+    lda l97b9,y                                                       ; 96a3: b9 b9 97    ...
+    jsr sta_e09_if_d6c_b7_set                                         ; 96a6: 20 11 96     ..
+; &96a9 referenced 1 time by &96b3
+.loop_c96a9
+    lda l97b9,y                                                       ; 96a9: b9 b9 97    ...
+    sta l0101,x                                                       ; 96ac: 9d 01 01    ...
+; &96af referenced 1 time by &9698
+.c96af
+    beq c96f0                                                         ; 96af: f0 3f       .?
+    iny                                                               ; 96b1: c8          .
+    inx                                                               ; 96b2: e8          .
+.sub_c96b3
+error_template_minus_1 = sub_c96b3+1
+    bne loop_c96a9                                                    ; 96b3: d0 f4       ..
+; &96b4 referenced 1 time by &96c5
+    equs "Bad"                                                        ; 96b5: 42 61 64    Bad
+
+; &96b8 referenced 11 times by &8fe6, &920a, &9217, &922b, &9237, &9246, &92fc, &9381, &93a4, &a25f, &bc14
+.generate_error_inline
+    jsr sta_e09_if_d6c_b7_set                                         ; 96b8: 20 11 96     ..
+    tay                                                               ; 96bb: a8          .
+    pla                                                               ; 96bc: 68          h
+    sta l00b0                                                         ; 96bd: 85 b0       ..
+    pla                                                               ; 96bf: 68          h
+    sta l00b1                                                         ; 96c0: 85 b1       ..
+    ldx #0                                                            ; 96c2: a2 00       ..
+; &96c4 referenced 1 time by &96cd
+.loop_c96c4
+    inx                                                               ; 96c4: e8          .
+    lda error_template_minus_1,x                                      ; 96c5: bd b4 96    ...
+    sta l0101,x                                                       ; 96c8: 9d 01 01    ...
+    cmp #&20 ; ' '                                                    ; 96cb: c9 20       .
+    bne loop_c96c4                                                    ; 96cd: d0 f5       ..
+    beq c96dd                                                         ; 96cf: f0 0c       ..
+; &96d1 referenced 7 times by &942f, &95b3, &a276, &ac00, &ac12, &b485, &b547
+.generate_error_inline3
+    jsr sta_e09_if_d6c_b7_set                                         ; 96d1: 20 11 96     ..
+; &96d4 referenced 4 times by &a129, &ba11, &bba7, &bc5d
+.generate_error_inline2
+    tay                                                               ; 96d4: a8          .
+    pla                                                               ; 96d5: 68          h
+    sta l00b0                                                         ; 96d6: 85 b0       ..
+    pla                                                               ; 96d8: 68          h
+    sta l00b1                                                         ; 96d9: 85 b1       ..
+    ldx #0                                                            ; 96db: a2 00       ..
+; &96dd referenced 1 time by &96cf
+.c96dd
+    sty l0101                                                         ; 96dd: 8c 01 01    ...
+    tya                                                               ; 96e0: 98          .
+    pha                                                               ; 96e1: 48          H
+    ldy #0                                                            ; 96e2: a0 00       ..
+    sty l0100                                                         ; 96e4: 8c 00 01    ...
+; &96e7 referenced 1 time by &96ee
+.loop_c96e7
+    inx                                                               ; 96e7: e8          .
+    iny                                                               ; 96e8: c8          .
+    lda (l00b0),y                                                     ; 96e9: b1 b0       ..
+    sta l0101,x                                                       ; 96eb: 9d 01 01    ...
+    bne loop_c96e7                                                    ; 96ee: d0 f7       ..
+; &96f0 referenced 4 times by &956d, &963e, &96af, &b971
+.c96f0
+    jsr sub_cb98a                                                     ; 96f0: 20 8a b9     ..
+    bne c96fd                                                         ; 96f3: d0 08       ..
+    pla                                                               ; 96f5: 68          h
+    cmp #&de                                                          ; 96f6: c9 de       ..
+    beq c9740                                                         ; 96f8: f0 46       .F
+; &96fa referenced 1 time by &974b
+.c96fa
+    jmp l0100                                                         ; 96fa: 4c 00 01    L..
+
+; &96fd referenced 1 time by &96f3
+.c96fd
+    sta l0e08                                                         ; 96fd: 8d 08 0e    ...
+    pha                                                               ; 9700: 48          H
+    txa                                                               ; 9701: 8a          .
+    pha                                                               ; 9702: 48          H
+    jsr sub_cb98a                                                     ; 9703: 20 8a b9     ..
+    sta l00b0                                                         ; 9706: 85 b0       ..
+    lda #0                                                            ; 9708: a9 00       ..
+    sta (l009c),y                                                     ; 970a: 91 9c       ..
+    lda #&c6                                                          ; 970c: a9 c6       ..
+    jsr sub_c8e83                                                     ; 970e: 20 83 8e     ..
+    cpy l00b0                                                         ; 9711: c4 b0       ..
+    beq c971e                                                         ; 9713: f0 09       ..
+    cpx l00b0                                                         ; 9715: e4 b0       ..
+    bne c972c                                                         ; 9717: d0 13       ..
+    pha                                                               ; 9719: 48          H
+    lda #&c6                                                          ; 971a: a9 c6       ..
+    bne c9722                                                         ; 971c: d0 04       ..
+; &971e referenced 1 time by &9713
+.c971e
+    tya                                                               ; 971e: 98          .
+    pha                                                               ; 971f: 48          H
+    lda #&c7                                                          ; 9720: a9 c7       ..
+; &9722 referenced 1 time by &971c
+.c9722
+    jsr sub_c8e8c                                                     ; 9722: 20 8c 8e     ..
+    pla                                                               ; 9725: 68          h
+    tay                                                               ; 9726: a8          .
+    lda #0                                                            ; 9727: a9 00       ..
+    jsr osfind                                                        ; 9729: 20 ce ff     ..
+; &972c referenced 1 time by &9717
+.c972c
+    pla                                                               ; 972c: 68          h
+    tax                                                               ; 972d: aa          .
+    ldy #&0a                                                          ; 972e: a0 0a       ..
+    lda l97ad,y                                                       ; 9730: b9 ad 97    ...
+    tay                                                               ; 9733: a8          .
+; &9734 referenced 1 time by &973e
+.loop_c9734
+    lda l97b9,y                                                       ; 9734: b9 b9 97    ...
+    sta l0101,x                                                       ; 9737: 9d 01 01    ...
+    beq c9740                                                         ; 973a: f0 04       ..
+    inx                                                               ; 973c: e8          .
+    iny                                                               ; 973d: c8          .
+    bne loop_c9734                                                    ; 973e: d0 f4       ..
+; &9740 referenced 2 times by &96f8, &973a
+.c9740
+    stx l00b2                                                         ; 9740: 86 b2       ..
+    pla                                                               ; 9742: 68          h
+    jsr sub_c9771                                                     ; 9743: 20 71 97     q.
+    lda #0                                                            ; 9746: a9 00       ..
+    sta l0102,x                                                       ; 9748: 9d 02 01    ...
+    beq c96fa                                                         ; 974b: f0 ad       ..
+; &974d referenced 2 times by &9636, &9674
+.sub_c974d
+    lda #&20 ; ' '                                                    ; 974d: a9 20       .
+    sta l0101,x                                                       ; 974f: 9d 01 01    ...
+    inx                                                               ; 9752: e8          .
+    stx l00b2                                                         ; 9753: 86 b2       ..
+    ldy #3                                                            ; 9755: a0 03       ..
+    lda (l009a),y                                                     ; 9757: b1 9a       ..
+    beq c9767                                                         ; 9759: f0 0c       ..
+    jsr sub_c977c                                                     ; 975b: 20 7c 97     |.
+    ldx l00b2                                                         ; 975e: a6 b2       ..
+    lda #&2e ; '.'                                                    ; 9760: a9 2e       ..
+    sta l0101,x                                                       ; 9762: 9d 01 01    ...
+    inc l00b2                                                         ; 9765: e6 b2       ..
+; &9767 referenced 1 time by &9759
+.c9767
+    ldy #2                                                            ; 9767: a0 02       ..
+    lda (l009a),y                                                     ; 9769: b1 9a       ..
+    jsr sub_c977c                                                     ; 976b: 20 7c 97     |.
+    ldx l00b2                                                         ; 976e: a6 b2       ..
+    rts                                                               ; 9770: 60          `
+
+; &9771 referenced 2 times by &9743, &b4da
+.sub_c9771
+    tay                                                               ; 9771: a8          .
+    lda #&20 ; ' '                                                    ; 9772: a9 20       .
+    ldx l00b2                                                         ; 9774: a6 b2       ..
+    sta l0101,x                                                       ; 9776: 9d 01 01    ...
+    inc l00b2                                                         ; 9779: e6 b2       ..
+    tya                                                               ; 977b: 98          .
+; &977c referenced 2 times by &975b, &976b
+.sub_c977c
+    tay                                                               ; 977c: a8          .
+    bit l9491                                                         ; 977d: 2c 91 94    ,..
+    lda #&64 ; 'd'                                                    ; 9780: a9 64       .d
+    jsr sub_c978d                                                     ; 9782: 20 8d 97     ..
+    lda #&0a                                                          ; 9785: a9 0a       ..
+    jsr sub_c978d                                                     ; 9787: 20 8d 97     ..
+    lda #1                                                            ; 978a: a9 01       ..
+    clv                                                               ; 978c: b8          .
+; &978d referenced 2 times by &9782, &9787
+.sub_c978d
+    sta l00b3                                                         ; 978d: 85 b3       ..
+    tya                                                               ; 978f: 98          .
+    ldx #&2f ; '/'                                                    ; 9790: a2 2f       ./
+    php                                                               ; 9792: 08          .
+    sec                                                               ; 9793: 38          8
+; &9794 referenced 1 time by &9797
+.loop_c9794
+    inx                                                               ; 9794: e8          .
+    sbc l00b3                                                         ; 9795: e5 b3       ..
+    bcs loop_c9794                                                    ; 9797: b0 fb       ..
+    adc l00b3                                                         ; 9799: 65 b3       e.
+    plp                                                               ; 979b: 28          (
+    tay                                                               ; 979c: a8          .
+    txa                                                               ; 979d: 8a          .
+    cmp #&30 ; '0'                                                    ; 979e: c9 30       .0
+    bne c97a4                                                         ; 97a0: d0 02       ..
+    bvs c97ac                                                         ; 97a2: 70 08       p.
+; &97a4 referenced 1 time by &97a0
+.c97a4
+    clv                                                               ; 97a4: b8          .
+    ldx l00b2                                                         ; 97a5: a6 b2       ..
+    sta l0101,x                                                       ; 97a7: 9d 01 01    ...
+    inc l00b2                                                         ; 97aa: e6 b2       ..
+; &97ac referenced 1 time by &97a2
+.c97ac
+    rts                                                               ; 97ac: 60          `
+
+; &97ad referenced 5 times by &961c, &965a, &9688, &969b, &9730
+.l97ad
+    equb   0, &0d, &18                                                ; 97ad: 00 0d 18    ...
+    equs "!+++3?Veq"                                                  ; 97b0: 21 2b 2b... !++
+; &97b9 referenced 8 times by &9624, &962a, &965d, &9668, &968c, &96a3, &96a9, &9734
+.l97b9
+    equb &a0                                                          ; 97b9: a0          .
+    equs "Line jammed"                                                ; 97ba: 4c 69 6e... Lin
+    equb   0, &a1                                                     ; 97c5: 00 a1       ..
+    equs "Net error"                                                  ; 97c7: 4e 65 74... Net
+    equb   0, &a2                                                     ; 97d0: 00 a2       ..
+    equs "Station"                                                    ; 97d2: 53 74 61... Sta
+    equb   0, &a3                                                     ; 97d9: 00 a3       ..
+    equs "No clock"                                                   ; 97db: 4e 6f 20... No
+    equb   0, &11                                                     ; 97e3: 00 11       ..
+    equs "Escape"                                                     ; 97e5: 45 73 63... Esc
+    equb   0, &cb                                                     ; 97eb: 00 cb       ..
+    equs "Bad option"                                                 ; 97ed: 42 61 64... Bad
+    equb   0, &a5                                                     ; 97f7: 00 a5       ..
+    equs "No reply from station"                                      ; 97f9: 4e 6f 20... No
+    equb 0                                                            ; 980e: 00          .
+    equs " not listening"                                             ; 980f: 20 6e 6f...  no
+    equb 0                                                            ; 981d: 00          .
+    equs " on channel"                                                ; 981e: 20 6f 6e...  on
+    equb 0                                                            ; 9829: 00          .
+    equs " not present"                                               ; 982a: 20 6e 6f...  no
+    equb 0                                                            ; 9836: 00          .
+
+; &9837 referenced 2 times by &94ec, &9adb
+.sub_c9837
+    ldx #&c0                                                          ; 9837: a2 c0       ..
+    stx l009a                                                         ; 9839: 86 9a       ..
+    ldx #0                                                            ; 983b: a2 00       ..
+    stx l009b                                                         ; 983d: 86 9b       ..
+; &983f referenced 5 times by &a9d4, &abc6, &ac51, &b05b, &b23a
+.sub_c983f
+    lda l0d6d                                                         ; 983f: ad 6d 0d    .m.
+    bne c9846                                                         ; 9842: d0 02       ..
+    lda #&ff                                                          ; 9844: a9 ff       ..
+; &9846 referenced 1 time by &9842
+.c9846
+    ldy #&60 ; '`'                                                    ; 9846: a0 60       .`
+    pha                                                               ; 9848: 48          H
+    tya                                                               ; 9849: 98          .
+    pha                                                               ; 984a: 48          H
+    ldx #0                                                            ; 984b: a2 00       ..
+    lda (l009a,x)                                                     ; 984d: a1 9a       ..
+; &984f referenced 1 time by &9871
+.c984f
+    sta (l009a,x)                                                     ; 984f: 81 9a       ..
+    pha                                                               ; 9851: 48          H
+    jsr c98c9                                                         ; 9852: 20 c9 98     ..
+    asl a                                                             ; 9855: 0a          .
+    bpl c9882                                                         ; 9856: 10 2a       .*
+    asl a                                                             ; 9858: 0a          .
+    beq c987e                                                         ; 9859: f0 23       .#
+    jsr sub_c9570                                                     ; 985b: 20 70 95     p.
+    pla                                                               ; 985e: 68          h
+    tax                                                               ; 985f: aa          .
+    pla                                                               ; 9860: 68          h
+    tay                                                               ; 9861: a8          .
+    pla                                                               ; 9862: 68          h
+    beq c9873                                                         ; 9863: f0 0e       ..
+; &9865 referenced 1 time by &987c
+.loop_c9865
+    sbc #1                                                            ; 9865: e9 01       ..
+    pha                                                               ; 9867: 48          H
+    tya                                                               ; 9868: 98          .
+    pha                                                               ; 9869: 48          H
+    txa                                                               ; 986a: 8a          .
+; &986b referenced 2 times by &986c, &986f
+.c986b
+    dex                                                               ; 986b: ca          .
+    bne c986b                                                         ; 986c: d0 fd       ..
+    dey                                                               ; 986e: 88          .
+    bne c986b                                                         ; 986f: d0 fa       ..
+    beq c984f                                                         ; 9871: f0 dc       ..
+; &9873 referenced 1 time by &9863
+.c9873
+    cmp l0d6d                                                         ; 9873: cd 6d 0d    .m.
+    bne c987e                                                         ; 9876: d0 06       ..
+    lda #&80                                                          ; 9878: a9 80       ..
+    sta l0098                                                         ; 987a: 85 98       ..
+    bne loop_c9865                                                    ; 987c: d0 e7       ..
+; &987e referenced 2 times by &9859, &9876
+.c987e
+    tax                                                               ; 987e: aa          .
+    jmp c964c                                                         ; 987f: 4c 4c 96    LL.
+
+; &9882 referenced 1 time by &9856
+.c9882
+    pla                                                               ; 9882: 68          h
+    pla                                                               ; 9883: 68          h
+    pla                                                               ; 9884: 68          h
+    jmp c929f                                                         ; 9885: 4c 9f 92    L..
+
+; &9888 referenced 2 times by &989e, &98f8
+.l9888
+    equb &88,   0, &fd, &fd, &3a, &0d, &ff, &ff, &3e, &0d, &ff, &ff   ; 9888: 88 00 fd... ...
+
+; &9894 referenced 1 time by &8dff
+.sub_c9894
+    ldy #&c0                                                          ; 9894: a0 c0       ..
+    sty l009a                                                         ; 9896: 84 9a       ..
+    ldy #0                                                            ; 9898: a0 00       ..
+    sty l009b                                                         ; 989a: 84 9b       ..
+; &989c referenced 1 time by &abc3
+.sub_c989c
+    ldy #&0b                                                          ; 989c: a0 0b       ..
+; &989e referenced 1 time by &98ac
+.loop_c989e
+    ldx l9888,y                                                       ; 989e: be 88 98    ...
+    cpx #&fd                                                          ; 98a1: e0 fd       ..
+    beq c98ab                                                         ; 98a3: f0 06       ..
+    lda (l009a),y                                                     ; 98a5: b1 9a       ..
+    pha                                                               ; 98a7: 48          H
+    txa                                                               ; 98a8: 8a          .
+    sta (l009a),y                                                     ; 98a9: 91 9a       ..
+; &98ab referenced 1 time by &98a3
+.c98ab
+    dey                                                               ; 98ab: 88          .
+    bpl loop_c989e                                                    ; 98ac: 10 f0       ..
+    lda l0d6f                                                         ; 98ae: ad 6f 0d    .o.
+    pha                                                               ; 98b1: 48          H
+    tya                                                               ; 98b2: 98          .
+    pha                                                               ; 98b3: 48          H
+    ldx #0                                                            ; 98b4: a2 00       ..
+    lda (l009a,x)                                                     ; 98b6: a1 9a       ..
+; &98b8 referenced 1 time by &98f1
+.c98b8
+    sta (l009a,x)                                                     ; 98b8: 81 9a       ..
+    pha                                                               ; 98ba: 48          H
+    jsr c98c9                                                         ; 98bb: 20 c9 98     ..
+    asl a                                                             ; 98be: 0a          .
+    bpl c98f3                                                         ; 98bf: 10 32       .2
+    asl a                                                             ; 98c1: 0a          .
+    bne c98de                                                         ; 98c2: d0 1a       ..
+; &98c4 referenced 1 time by &98e3
+.loop_c98c4
+    ldx #0                                                            ; 98c4: a2 00       ..
+    jmp c9641                                                         ; 98c6: 4c 41 96    LA.
+
+; &98c9 referenced 3 times by &9852, &98bb, &98cc
+.c98c9
+    asl l0d60                                                         ; 98c9: 0e 60 0d    .`.
+    bcc c98c9                                                         ; 98cc: 90 fb       ..
+    lda l009a                                                         ; 98ce: a5 9a       ..
+    sta l00a0                                                         ; 98d0: 85 a0       ..
+    lda l009b                                                         ; 98d2: a5 9b       ..
+    sta l00a1                                                         ; 98d4: 85 a1       ..
+    jsr sub_c858c                                                     ; 98d6: 20 8c 85     ..
+; &98d9 referenced 1 time by &98db
+.loop_c98d9
+    lda (l009a,x)                                                     ; 98d9: a1 9a       ..
+    bmi loop_c98d9                                                    ; 98db: 30 fc       0.
+    rts                                                               ; 98dd: 60          `
+
+; &98de referenced 1 time by &98c2
+.c98de
+    pla                                                               ; 98de: 68          h
+    tax                                                               ; 98df: aa          .
+    pla                                                               ; 98e0: 68          h
+    tay                                                               ; 98e1: a8          .
+    pla                                                               ; 98e2: 68          h
+    beq loop_c98c4                                                    ; 98e3: f0 df       ..
+    sbc #1                                                            ; 98e5: e9 01       ..
+    pha                                                               ; 98e7: 48          H
+    tya                                                               ; 98e8: 98          .
+    pha                                                               ; 98e9: 48          H
+    txa                                                               ; 98ea: 8a          .
+; &98eb referenced 2 times by &98ec, &98ef
+.c98eb
+    dex                                                               ; 98eb: ca          .
+    bne c98eb                                                         ; 98ec: d0 fd       ..
+    dey                                                               ; 98ee: 88          .
+    bne c98eb                                                         ; 98ef: d0 fa       ..
+    beq c98b8                                                         ; 98f1: f0 c5       ..
+; &98f3 referenced 1 time by &98bf
+.c98f3
+    pla                                                               ; 98f3: 68          h
+    pla                                                               ; 98f4: 68          h
+    pla                                                               ; 98f5: 68          h
+    ldy #0                                                            ; 98f6: a0 00       ..
+; &98f8 referenced 1 time by &9905
+.loop_c98f8
+    ldx l9888,y                                                       ; 98f8: be 88 98    ...
+    cpx #&fd                                                          ; 98fb: e0 fd       ..
+    beq c9902                                                         ; 98fd: f0 03       ..
+    pla                                                               ; 98ff: 68          h
+    sta (l009a),y                                                     ; 9900: 91 9a       ..
+; &9902 referenced 1 time by &98fd
+.c9902
+    iny                                                               ; 9902: c8          .
+    cpy #&0c                                                          ; 9903: c0 0c       ..
+    bne loop_c98f8                                                    ; 9905: d0 f1       ..
+    rts                                                               ; 9907: 60          `
+
+    equb &a0,   1, &b1, &bb, &99, &f2,   0, &88, &10, &f8, &c8        ; 9908: a0 01 b1... ...
+
+; &9913 referenced 1 time by &ae94
+.sub_c9913
+    ldx #&ff                                                          ; 9913: a2 ff       ..
+    clc                                                               ; 9915: 18          .
+    jsr gsinit                                                        ; 9916: 20 c2 ff     ..
+    beq c9926                                                         ; 9919: f0 0b       ..
+; &991b referenced 1 time by &9924
+.loop_c991b
+    jsr gsread                                                        ; 991b: 20 c5 ff     ..
+    bcs c9926                                                         ; 991e: b0 06       ..
+    inx                                                               ; 9920: e8          .
+    sta l0e30,x                                                       ; 9921: 9d 30 0e    .0.
+    bcc loop_c991b                                                    ; 9924: 90 f5       ..
+; &9926 referenced 2 times by &9919, &991e
+.c9926
+    inx                                                               ; 9926: e8          .
+    lda #&0d                                                          ; 9927: a9 0d       ..
+    sta l0e30,x                                                       ; 9929: 9d 30 0e    .0.
+    lda #&30 ; '0'                                                    ; 992c: a9 30       .0
+    sta l00be                                                         ; 992e: 85 be       ..
+    lda #&0e                                                          ; 9930: a9 0e       ..
+    sta l00bf                                                         ; 9932: 85 bf       ..
+    rts                                                               ; 9934: 60          `
+
+    equb &20, &95, &92, &20,   8, &99, &20, &32, &af, &20, &97, &ae   ; 9935: 20 95 92...  ..
+    equb &a5, &bd, &10, &7e, &c9, &ff, &f0,   3, &4c, &c7, &9c, &20   ; 9941: a5 bd 10... ...
+    equb   2, &af, &a0,   2                                           ; 994d: 02 af a0... ...
+
+; &9951 referenced 1 time by &a2d1
+.sub_c9951
+    lda #&92                                                          ; 9951: a9 92       ..
+    sta l0098                                                         ; 9953: 85 98       ..
+    sta l0f02                                                         ; 9955: 8d 02 0f    ...
+    jsr sub_c949b                                                     ; 9958: 20 9b 94     ..
+    ldy #6                                                            ; 995b: a0 06       ..
+    lda (l00bb),y                                                     ; 995d: b1 bb       ..
+    bne c9969                                                         ; 995f: d0 08       ..
+    jsr sub_c9a72                                                     ; 9961: 20 72 9a     r.
+    jsr sub_c9a84                                                     ; 9964: 20 84 9a     ..
+    bcc c996f                                                         ; 9967: 90 06       ..
+; &9969 referenced 1 time by &995f
+.c9969
+    jsr sub_c9a84                                                     ; 9969: 20 84 9a     ..
+    jsr sub_c9a72                                                     ; 996c: 20 72 9a     r.
+; &996f referenced 1 time by &9967
+.c996f
+    ldy #4                                                            ; 996f: a0 04       ..
+; &9971 referenced 1 time by &997c
+.loop_c9971
+    lda l00b0,x                                                       ; 9971: b5 b0       ..
+    sta l00c8,x                                                       ; 9973: 95 c8       ..
+    adc l0f0d,x                                                       ; 9975: 7d 0d 0f    }..
+    sta l00b4,x                                                       ; 9978: 95 b4       ..
+    inx                                                               ; 997a: e8          .
+    dey                                                               ; 997b: 88          .
+    bne loop_c9971                                                    ; 997c: d0 f3       ..
+    sec                                                               ; 997e: 38          8
+    sbc l0f10                                                         ; 997f: ed 10 0f    ...
+    sta l00b7                                                         ; 9982: 85 b7       ..
+    jsr sub_c9b95                                                     ; 9984: 20 95 9b     ..
+    jsr sub_c9998                                                     ; 9987: 20 98 99     ..
+    ldx #2                                                            ; 998a: a2 02       ..
+; &998c referenced 1 time by &9993
+.loop_c998c
+    lda l0f10,x                                                       ; 998c: bd 10 0f    ...
+    sta l0f05,x                                                       ; 998f: 9d 05 0f    ...
+    dex                                                               ; 9992: ca          .
+    bpl loop_c998c                                                    ; 9993: 10 f7       ..
+    jmp c9a1f                                                         ; 9995: 4c 1f 9a    L..
+
+; &9998 referenced 2 times by &9987, &9f52
+.sub_c9998
+    jsr sub_c92a4                                                     ; 9998: 20 a4 92     ..
+    beq c99c2                                                         ; 999b: f0 25       .%
+    lda #&92                                                          ; 999d: a9 92       ..
+    sta l00c1                                                         ; 999f: 85 c1       ..
+; &99a1 referenced 1 time by &99bd
+.loop_c99a1
+    ldx #3                                                            ; 99a1: a2 03       ..
+; &99a3 referenced 1 time by &99ac
+.loop_c99a3
+    lda l00c8,x                                                       ; 99a3: b5 c8       ..
+    sta l00c4,x                                                       ; 99a5: 95 c4       ..
+    lda l00b4,x                                                       ; 99a7: b5 b4       ..
+    sta l00c8,x                                                       ; 99a9: 95 c8       ..
+    dex                                                               ; 99ab: ca          .
+    bpl loop_c99a3                                                    ; 99ac: 10 f5       ..
+    lda #&7f                                                          ; 99ae: a9 7f       ..
+    sta l00c0                                                         ; 99b0: 85 c0       ..
+    jsr sub_c95dd                                                     ; 99b2: 20 dd 95     ..
+    ldy #3                                                            ; 99b5: a0 03       ..
+; &99b7 referenced 1 time by &99c0
+.loop_c99b7
+    lda l00c8,y                                                       ; 99b7: b9 c8 00    ...
+    eor l00b4,y                                                       ; 99ba: 59 b4 00    Y..
+    bne loop_c99a1                                                    ; 99bd: d0 e2       ..
+    dey                                                               ; 99bf: 88          .
+    bpl loop_c99b7                                                    ; 99c0: 10 f5       ..
+; &99c2 referenced 1 time by &999b
+.c99c2
+    rts                                                               ; 99c2: 60          `
+
+    equb &f0,   3, &4c, &ef, &9a                                      ; 99c3: f0 03 4c... ..L
+
+; &99c8 referenced 1 time by &9af8
+.c99c8
+    ldx #4                                                            ; 99c8: a2 04       ..
+    ldy #&0e                                                          ; 99ca: a0 0e       ..
+    sec                                                               ; 99cc: 38          8
+; &99cd referenced 1 time by &99e7
+.loop_c99cd
+    lda (l00bb),y                                                     ; 99cd: b1 bb       ..
+    sta l00a6,y                                                       ; 99cf: 99 a6 00    ...
+    jsr sub_c9a91                                                     ; 99d2: 20 91 9a     ..
+    sbc (l00bb),y                                                     ; 99d5: f1 bb       ..
+    sta l0f03,y                                                       ; 99d7: 99 03 0f    ...
+    pha                                                               ; 99da: 48          H
+    lda (l00bb),y                                                     ; 99db: b1 bb       ..
+    sta l00a6,y                                                       ; 99dd: 99 a6 00    ...
+    pla                                                               ; 99e0: 68          h
+    sta (l00bb),y                                                     ; 99e1: 91 bb       ..
+    jsr sub_c9a7e                                                     ; 99e3: 20 7e 9a     ~.
+    dex                                                               ; 99e6: ca          .
+    bne loop_c99cd                                                    ; 99e7: d0 e4       ..
+    ldy #9                                                            ; 99e9: a0 09       ..
+; &99eb referenced 1 time by &99f1
+.loop_c99eb
+    lda (l00bb),y                                                     ; 99eb: b1 bb       ..
+    sta l0f03,y                                                       ; 99ed: 99 03 0f    ...
+    dey                                                               ; 99f0: 88          .
+    bne loop_c99eb                                                    ; 99f1: d0 f8       ..
+    lda #&91                                                          ; 99f3: a9 91       ..
+    sta l0098                                                         ; 99f5: 85 98       ..
+    sta l0f02                                                         ; 99f7: 8d 02 0f    ...
+    sta l00b8                                                         ; 99fa: 85 b8       ..
+    ldx #&0b                                                          ; 99fc: a2 0b       ..
+    jsr sub_caf04                                                     ; 99fe: 20 04 af     ..
+    ldy #1                                                            ; 9a01: a0 01       ..
+    lda l00bd                                                         ; 9a03: a5 bd       ..
+    cmp #7                                                            ; 9a05: c9 07       ..
+    php                                                               ; 9a07: 08          .
+    bne c9a0c                                                         ; 9a08: d0 02       ..
+    ldy #&1d                                                          ; 9a0a: a0 1d       ..
+; &9a0c referenced 1 time by &9a08
+.c9a0c
+    jsr sub_c949b                                                     ; 9a0c: 20 9b 94     ..
+    jsr sub_c9b95                                                     ; 9a0f: 20 95 9b     ..
+    plp                                                               ; 9a12: 28          (
+    bne c9a19                                                         ; 9a13: d0 04       ..
+    ldx #0                                                            ; 9a15: a2 00       ..
+    beq c9a22                                                         ; 9a17: f0 09       ..
+; &9a19 referenced 1 time by &9a13
+.c9a19
+    lda l0f05                                                         ; 9a19: ad 05 0f    ...
+    jsr sub_c9a9a                                                     ; 9a1c: 20 9a 9a     ..
+; &9a1f referenced 1 time by &9995
+.c9a1f
+    jsr sub_c94f0                                                     ; 9a1f: 20 f0 94     ..
+; &9a22 referenced 1 time by &9a17
+.c9a22
+    stx l0f08                                                         ; 9a22: 8e 08 0f    ...
+    ldy #&0e                                                          ; 9a25: a0 0e       ..
+    lda l0f05                                                         ; 9a27: ad 05 0f    ...
+    jsr sub_c9273                                                     ; 9a2a: 20 73 92     s.
+    beq c9a32                                                         ; 9a2d: f0 03       ..
+; &9a2f referenced 1 time by &9a37
+.loop_c9a2f
+    lda l0ef7,y                                                       ; 9a2f: b9 f7 0e    ...
+; &9a32 referenced 1 time by &9a2d
+.c9a32
+    sta (l00bb),y                                                     ; 9a32: 91 bb       ..
+    iny                                                               ; 9a34: c8          .
+    cpy #&12                                                          ; 9a35: c0 12       ..
+    bne loop_c9a2f                                                    ; 9a37: d0 f6       ..
+    ldy l0e06                                                         ; 9a39: ac 06 0e    ...
+    beq c9a83                                                         ; 9a3c: f0 45       .E
+    ldy #&f4                                                          ; 9a3e: a0 f4       ..
+; &9a40 referenced 1 time by &9a47
+.loop_c9a40
+    lda l0fff,y                                                       ; 9a40: b9 ff 0f    ...
+    jsr osasci                                                        ; 9a43: 20 e3 ff     ..
+    iny                                                               ; 9a46: c8          .
+    bne loop_c9a40                                                    ; 9a47: d0 f7       ..
+    ldy #5                                                            ; 9a49: a0 05       ..
+    jsr sub_c9a62                                                     ; 9a4b: 20 62 9a     b.
+    jsr sub_c9a57                                                     ; 9a4e: 20 57 9a     W.
+    jsr osnewl                                                        ; 9a51: 20 e7 ff     ..
+    jmp c9cc7                                                         ; 9a54: 4c c7 9c    L..
+
+; &9a57 referenced 1 time by &9a4e
+.sub_c9a57
+    ldy #9                                                            ; 9a57: a0 09       ..
+    jsr sub_c9a62                                                     ; 9a59: 20 62 9a     b.
+    ldy #&0c                                                          ; 9a5c: a0 0c       ..
+    ldx #3                                                            ; 9a5e: a2 03       ..
+    bne c9a64                                                         ; 9a60: d0 02       ..
+; &9a62 referenced 2 times by &9a4b, &9a59
+.sub_c9a62
+    ldx #4                                                            ; 9a62: a2 04       ..
+; &9a64 referenced 2 times by &9a60, &9a6b
+.c9a64
+    lda (l00bb),y                                                     ; 9a64: b1 bb       ..
+    jsr sub_c912f                                                     ; 9a66: 20 2f 91     /.
+    dey                                                               ; 9a69: 88          .
+    dex                                                               ; 9a6a: ca          .
+    bne c9a64                                                         ; 9a6b: d0 f7       ..
+    lda #&20 ; ' '                                                    ; 9a6d: a9 20       .
+    jmp osasci                                                        ; 9a6f: 4c e3 ff    L..
+
+; &9a72 referenced 2 times by &9961, &996c
+.sub_c9a72
+    ldy #5                                                            ; 9a72: a0 05       ..
+; &9a74 referenced 1 time by &9a7c
+.loop_c9a74
+    lda (l00bb),y                                                     ; 9a74: b1 bb       ..
+    sta l00ae,y                                                       ; 9a76: 99 ae 00    ...
+    dey                                                               ; 9a79: 88          .
+    cpy #2                                                            ; 9a7a: c0 02       ..
+    bcs loop_c9a74                                                    ; 9a7c: b0 f6       ..
+; &9a7e referenced 1 time by &99e3
+.sub_c9a7e
+    iny                                                               ; 9a7e: c8          .
+; &9a7f referenced 2 times by &9f2f, &b074
+.sub_c9a7f
+    iny                                                               ; 9a7f: c8          .
+    iny                                                               ; 9a80: c8          .
+    iny                                                               ; 9a81: c8          .
+    iny                                                               ; 9a82: c8          .
+; &9a83 referenced 1 time by &9a3c
+.c9a83
+    rts                                                               ; 9a83: 60          `
+
+; &9a84 referenced 2 times by &9964, &9969
+.sub_c9a84
+    ldy #&0d                                                          ; 9a84: a0 0d       ..
+    txa                                                               ; 9a86: 8a          .
+; &9a87 referenced 1 time by &9a8f
+.loop_c9a87
+    sta (l00bb),y                                                     ; 9a87: 91 bb       ..
+    lda l0f02,y                                                       ; 9a89: b9 02 0f    ...
+    dey                                                               ; 9a8c: 88          .
+    cpy #2                                                            ; 9a8d: c0 02       ..
+    bcs loop_c9a87                                                    ; 9a8f: b0 f6       ..
+; &9a91 referenced 1 time by &99d2
+.sub_c9a91
+    dey                                                               ; 9a91: 88          .
+; &9a92 referenced 2 times by &9b0e, &9f37
+.sub_c9a92
+    dey                                                               ; 9a92: 88          .
+    dey                                                               ; 9a93: 88          .
+    dey                                                               ; 9a94: 88          .
+    rts                                                               ; 9a95: 60          `
+
+; &9a96 referenced 2 times by &9a9e, &9ae4
+.c9a96
+    pla                                                               ; 9a96: 68          h
+    ldy l00bc                                                         ; 9a97: a4 bc       ..
+    rts                                                               ; 9a99: 60          `
+
+; &9a9a referenced 2 times by &9a1c, &9f4d
+.sub_c9a9a
+    pha                                                               ; 9a9a: 48          H
+    jsr sub_c92a4                                                     ; 9a9b: 20 a4 92     ..
+    beq c9a96                                                         ; 9a9e: f0 f6       ..
+; &9aa0 referenced 1 time by &9aed
+.c9aa0
+    ldx #0                                                            ; 9aa0: a2 00       ..
+    ldy #4                                                            ; 9aa2: a0 04       ..
+    stx l0f08                                                         ; 9aa4: 8e 08 0f    ...
+    stx l0f09                                                         ; 9aa7: 8e 09 0f    ...
+    clc                                                               ; 9aaa: 18          .
+; &9aab referenced 1 time by &9ab8
+.loop_c9aab
+    lda l00b0,x                                                       ; 9aab: b5 b0       ..
+    sta l00c4,x                                                       ; 9aad: 95 c4       ..
+    adc l0f06,x                                                       ; 9aaf: 7d 06 0f    }..
+    sta l00c8,x                                                       ; 9ab2: 95 c8       ..
+    sta l00b0,x                                                       ; 9ab4: 95 b0       ..
+    inx                                                               ; 9ab6: e8          .
+    dey                                                               ; 9ab7: 88          .
+    bne loop_c9aab                                                    ; 9ab8: d0 f1       ..
+    bcs c9ac9                                                         ; 9aba: b0 0d       ..
+    sec                                                               ; 9abc: 38          8
+; &9abd referenced 1 time by &9ac5
+.loop_c9abd
+    lda l00b0,y                                                       ; 9abd: b9 b0 00    ...
+    sbc l00b4,y                                                       ; 9ac0: f9 b4 00    ...
+    iny                                                               ; 9ac3: c8          .
+    dex                                                               ; 9ac4: ca          .
+    bne loop_c9abd                                                    ; 9ac5: d0 f6       ..
+    bcc c9ad2                                                         ; 9ac7: 90 09       ..
+; &9ac9 referenced 1 time by &9aba
+.c9ac9
+    ldx #3                                                            ; 9ac9: a2 03       ..
+; &9acb referenced 1 time by &9ad0
+.loop_c9acb
+    lda l00b4,x                                                       ; 9acb: b5 b4       ..
+    sta l00c8,x                                                       ; 9acd: 95 c8       ..
+    dex                                                               ; 9acf: ca          .
+    bpl loop_c9acb                                                    ; 9ad0: 10 f9       ..
+; &9ad2 referenced 1 time by &9ac7
+.c9ad2
+    pla                                                               ; 9ad2: 68          h
+    pha                                                               ; 9ad3: 48          H
+    php                                                               ; 9ad4: 08          .
+    sta l00c1                                                         ; 9ad5: 85 c1       ..
+    lda #&80                                                          ; 9ad7: a9 80       ..
+    sta l00c0                                                         ; 9ad9: 85 c0       ..
+    jsr sub_c9837                                                     ; 9adb: 20 37 98     7.
+    lda l00b8                                                         ; 9ade: a5 b8       ..
+    jsr sub_c9467                                                     ; 9ae0: 20 67 94     g.
+    plp                                                               ; 9ae3: 28          (
+    bcs c9a96                                                         ; 9ae4: b0 b0       ..
+    lda #&91                                                          ; 9ae6: a9 91       ..
+    sta l00c1                                                         ; 9ae8: 85 c1       ..
+    jsr sub_c95dd                                                     ; 9aea: 20 dd 95     ..
+    bne c9aa0                                                         ; 9aed: d0 b1       ..
+    sta l0f05                                                         ; 9aef: 8d 05 0f    ...
+    cmp #7                                                            ; 9af2: c9 07       ..
+    bcc c9afb                                                         ; 9af4: 90 05       ..
+    bne c9b47                                                         ; 9af6: d0 4f       .O
+    jmp c99c8                                                         ; 9af8: 4c c8 99    L..
+
+; &9afb referenced 1 time by &9af4
+.c9afb
+    cmp #6                                                            ; 9afb: c9 06       ..
+    beq c9b3c                                                         ; 9afd: f0 3d       .=
+    cmp #5                                                            ; 9aff: c9 05       ..
+    beq c9b56                                                         ; 9b01: f0 53       .S
+    cmp #4                                                            ; 9b03: c9 04       ..
+    beq c9b4c                                                         ; 9b05: f0 45       .E
+    cmp #1                                                            ; 9b07: c9 01       ..
+    beq c9b20                                                         ; 9b09: f0 15       ..
+    asl a                                                             ; 9b0b: 0a          .
+    asl a                                                             ; 9b0c: 0a          .
+    tay                                                               ; 9b0d: a8          .
+    jsr sub_c9a92                                                     ; 9b0e: 20 92 9a     ..
+    ldx #3                                                            ; 9b11: a2 03       ..
+; &9b13 referenced 1 time by &9b1a
+.loop_c9b13
+    lda (l00bb),y                                                     ; 9b13: b1 bb       ..
+    sta l0f06,x                                                       ; 9b15: 9d 06 0f    ...
+    dey                                                               ; 9b18: 88          .
+    dex                                                               ; 9b19: ca          .
+    bpl loop_c9b13                                                    ; 9b1a: 10 f7       ..
+    ldx #5                                                            ; 9b1c: a2 05       ..
+    bne c9b35                                                         ; 9b1e: d0 15       ..
+; &9b20 referenced 1 time by &9b09
+.c9b20
+    jsr sub_c9269                                                     ; 9b20: 20 69 92     i.
+    sta l0f0e                                                         ; 9b23: 8d 0e 0f    ...
+    ldy #9                                                            ; 9b26: a0 09       ..
+    ldx #8                                                            ; 9b28: a2 08       ..
+; &9b2a referenced 1 time by &9b31
+.loop_c9b2a
+    lda (l00bb),y                                                     ; 9b2a: b1 bb       ..
+    sta l0f05,x                                                       ; 9b2c: 9d 05 0f    ...
+    dey                                                               ; 9b2f: 88          .
+    dex                                                               ; 9b30: ca          .
+    bne loop_c9b2a                                                    ; 9b31: d0 f7       ..
+    ldx #&0a                                                          ; 9b33: a2 0a       ..
+; &9b35 referenced 2 times by &9b1e, &9b54
+.c9b35
+    jsr sub_caf04                                                     ; 9b35: 20 04 af     ..
+    ldy #&13                                                          ; 9b38: a0 13       ..
+    bne c9b41                                                         ; 9b3a: d0 05       ..
+; &9b3c referenced 1 time by &9afd
+.c9b3c
+    jsr sub_caf02                                                     ; 9b3c: 20 02 af     ..
+    ldy #&14                                                          ; 9b3f: a0 14       ..
+; &9b41 referenced 1 time by &9b3a
+.c9b41
+    bit l9491                                                         ; 9b41: 2c 91 94    ,..
+    jsr c94ae                                                         ; 9b44: 20 ae 94     ..
+; &9b47 referenced 1 time by &9af6
+.c9b47
+    bcs c9b92                                                         ; 9b47: b0 49       .I
+    jmp c9cc7                                                         ; 9b49: 4c c7 9c    L..
+
+; &9b4c referenced 1 time by &9b05
+.c9b4c
+    jsr sub_c9269                                                     ; 9b4c: 20 69 92     i.
+    sta l0f06                                                         ; 9b4f: 8d 06 0f    ...
+    ldx #2                                                            ; 9b52: a2 02       ..
+    bne c9b35                                                         ; 9b54: d0 df       ..
+; &9b56 referenced 1 time by &9b01
+.c9b56
+    ldx #1                                                            ; 9b56: a2 01       ..
+    jsr sub_caf04                                                     ; 9b58: 20 04 af     ..
+    ldy #&12                                                          ; 9b5b: a0 12       ..
+    jsr c94ad                                                         ; 9b5d: 20 ad 94     ..
+    lda l0f11                                                         ; 9b60: ad 11 0f    ...
+    stx l0f11                                                         ; 9b63: 8e 11 0f    ...
+    stx l0f14                                                         ; 9b66: 8e 14 0f    ...
+    jsr sub_c9273                                                     ; 9b69: 20 73 92     s.
+    ldx l0f05                                                         ; 9b6c: ae 05 0f    ...
+    beq c9b91                                                         ; 9b6f: f0 20       .
+    ldy #&0e                                                          ; 9b71: a0 0e       ..
+    sta (l00bb),y                                                     ; 9b73: 91 bb       ..
+    dey                                                               ; 9b75: 88          .
+    ldx #&0c                                                          ; 9b76: a2 0c       ..
+; &9b78 referenced 1 time by &9b7f
+.loop_c9b78
+    lda l0f05,x                                                       ; 9b78: bd 05 0f    ...
+    sta (l00bb),y                                                     ; 9b7b: 91 bb       ..
+    dey                                                               ; 9b7d: 88          .
+    dex                                                               ; 9b7e: ca          .
+    bne loop_c9b78                                                    ; 9b7f: d0 f7       ..
+    inx                                                               ; 9b81: e8          .
+    inx                                                               ; 9b82: e8          .
+    ldy #&11                                                          ; 9b83: a0 11       ..
+; &9b85 referenced 1 time by &9b8c
+.loop_c9b85
+    lda l0f12,x                                                       ; 9b85: bd 12 0f    ...
+    sta (l00bb),y                                                     ; 9b88: 91 bb       ..
+    dey                                                               ; 9b8a: 88          .
+    dex                                                               ; 9b8b: ca          .
+    bpl loop_c9b85                                                    ; 9b8c: 10 f7       ..
+    ldx l0f05                                                         ; 9b8e: ae 05 0f    ...
+; &9b91 referenced 1 time by &9b6f
+.c9b91
+    txa                                                               ; 9b91: 8a          .
+; &9b92 referenced 1 time by &9b47
+.c9b92
+    jmp c9cc9                                                         ; 9b92: 4c c9 9c    L..
+
+; &9b95 referenced 2 times by &9984, &9a0f
+.sub_c9b95
+    ldy #0                                                            ; 9b95: a0 00       ..
+    ldx l0f03                                                         ; 9b97: ae 03 0f    ...
+    bne c9bb5                                                         ; 9b9a: d0 19       ..
+; &9b9c referenced 1 time by &9ba6
+.loop_c9b9c
+    lda (l00be),y                                                     ; 9b9c: b1 be       ..
+    cmp #&21 ; '!'                                                    ; 9b9e: c9 21       .!
+    bcc c9ba8                                                         ; 9ba0: 90 06       ..
+    sta l10f3,y                                                       ; 9ba2: 99 f3 10    ...
+    iny                                                               ; 9ba5: c8          .
+    bne loop_c9b9c                                                    ; 9ba6: d0 f4       ..
+; &9ba8 referenced 2 times by &9ba0, &9bb0
+.c9ba8
+    lda #&20 ; ' '                                                    ; 9ba8: a9 20       .
+    sta l10f3,y                                                       ; 9baa: 99 f3 10    ...
+    iny                                                               ; 9bad: c8          .
+    cpy #&0c                                                          ; 9bae: c0 0c       ..
+    bcc c9ba8                                                         ; 9bb0: 90 f6       ..
+    rts                                                               ; 9bb2: 60          `
+
+; &9bb3 referenced 1 time by &9bbb
+.loop_c9bb3
+    inx                                                               ; 9bb3: e8          .
+    iny                                                               ; 9bb4: c8          .
+; &9bb5 referenced 1 time by &9b9a
+.c9bb5
+    lda l0f05,x                                                       ; 9bb5: bd 05 0f    ...
+    sta l10f3,y                                                       ; 9bb8: 99 f3 10    ...
+    bpl loop_c9bb3                                                    ; 9bbb: 10 f6       ..
+    rts                                                               ; 9bbd: 60          `
+
+    equb &20, &cb, &8f, &85, &bd, &20, &9b, &92,   9,   0, &10, &2e   ; 9bbe: 20 cb 8f...  ..
+    equb &0a, &f0,   3, &4c, &c4, &9c, &98, &c9, &20, &b0,   3, &4c   ; 9bca: 0a f0 03... ...
+    equb &82, &b4, &c9, &30, &b0, &f9, &20, &99, &b7, &98, &48, &aa   ; 9bd6: 82 b4 c9... ...
+    equb &a0,   0, &84, &bd, &84, &bc, &bd, &10, &10, &91, &bb, &20   ; 9be2: a0 00 84... ...
+    equb &86, &bc, &c8, &c0,   4, &d0, &f3, &68, &85, &bc, &c9,   5   ; 9bee: 86 bc c8... ...
+    equb &b0, &4f, &c0,   0, &d0,   3, &4c, &d5, &9c, &48, &8a, &48   ; 9bfa: b0 4f c0... .O.
+    equb &98, &48, &20, &f2, &b4, &68, &20, &8f, &b9, &bd, &30, &10   ; 9c06: 98 48 20... .H
+    equb &8d,   5, &0f, &68, &aa, &68, &4a, &f0, &4f,   8, &48, &a6   ; 9c12: 8d 05 0f... ...
+    equb &bb, &a4, &bc, &20, &99, &b7, &b9, &10, &10, &8d,   5, &0f   ; 9c1e: bb a4 bc... ...
+    equb &68, &8d,   6, &0f, &28, &98, &48, &90, &1b, &a0,   3, &b5   ; 9c2a: 68 8d 06... h..
+    equb   3, &99,   7, &0f, &ca, &88, &10, &f7, &a0, &0d, &a2,   5   ; 9c36: 03 99 07... ...
+    equb &20, &ad, &94, &86, &bd, &68, &20, &b5, &92, &4c, &c7, &9c   ; 9c42: 20 ad 94...  ..
+    equb &a0, &0c, &a2,   2, &20, &ad, &94, &85, &bd, &a6, &bb, &a0   ; 9c4e: a0 0c a2... ...
+    equb   2, &95,   3, &b9,   5, &0f, &95,   2, &ca, &88, &10, &f7   ; 9c5a: 02 95 03... ...
+    equb &68, &4c, &c7, &9c, &b0, &20, &a5, &bc, &20, &6b, &b4, &a4   ; 9c66: 68 4c c7... hL.
+    equb &bb, &bd,   0, &10, &99,   0,   0, &bd, &10, &10, &99,   1   ; 9c72: bb bd 00... ...
+    equb   0, &bd, &20, &10, &99,   2,   0, &a9,   0, &99,   3,   0   ; 9c7e: 00 bd 20... ..
+    equb &f0, &3b, &8d,   6, &0f, &8a, &48, &a0,   3, &b5,   3, &99   ; 9c8a: f0 3b 8d... .;.
+    equb   7, &0f, &ca, &88, &10, &f7, &a0, &0d, &a2,   5, &20, &ad   ; 9c96: 07 0f ca... ...
+    equb &94, &86, &bd, &68, &a8, &a5, &bc, &20, &cc, &92, &20, &6b   ; 9ca2: 94 86 bd... ...
+    equb &b4, &b9,   0,   0, &9d,   0, &10, &b9,   1,   0, &9d, &10   ; 9cae: b4 b9 00... ...
+    equb &10, &b9,   2,   0, &9d, &20, &10, &4c, &c7, &9c, &20, &99   ; 9cba: 10 b9 02... ...
+    equb &b7                                                          ; 9cc6: b7          .
+
+; &9cc7 referenced 6 times by &9a54, &9b49, &9dbb, &a2f7, &a2fd, &a3b1
+.c9cc7
+    lda l00bd                                                         ; 9cc7: a5 bd       ..
+; &9cc9 referenced 2 times by &9b92, &a206
+.c9cc9
+    pha                                                               ; 9cc9: 48          H
+    lda #0                                                            ; 9cca: a9 00       ..
+    jsr sub_cb98f                                                     ; 9ccc: 20 8f b9     ..
+    pla                                                               ; 9ccf: 68          h
+    ldx l00bb                                                         ; 9cd0: a6 bb       ..
+    ldy l00bc                                                         ; 9cd2: a4 bc       ..
+    rts                                                               ; 9cd4: 60          `
+
+    equb &c9,   2, &b0, &13, &a8, &d0,   4, &a9,   5, &d0, &e9, &b9   ; 9cd5: c9 02 b0... ...
+    equb &0a, &0e, &91, &bb, &88, &10, &f8, &94,   2, &94,   3, &f0   ; 9ce1: 0a 0e 91... ...
+    equb   2, &a9,   0, &4a, &10, &d6, &29, &3f, &d0, &f7, &8a, &20   ; 9ced: 02 a9 00... ...
+    equb &3d, &b5, &49, &80, &0a, &8d,   5, &0f, &2a, &8d,   6, &0f   ; 9cf9: 3d b5 49... =.I
+    equb &20, &92, &ae, &a2,   2, &20,   4, &af, &a0,   6, &2c, &91   ; 9d05: 20 92 ae...  ..
+    equb &94, &38, &66, &98, &20, &ae, &94, &b0, &6d, &a9, &ff, &20   ; 9d11: 94 38 66... .8f
+    equb &8f, &b9, &ad,   5, &0f, &48, &a9,   4, &8d,   5, &0f, &a2   ; 9d1d: 8f b9 ad... ...
+    equb   1, &bd,   6, &0f, &9d,   5, &0f, &e8, &c9, &0d, &d0, &f5   ; 9d29: 01 bd 06... ...
+    equb &a0, &12, &20, &ad, &94, &a5, &bd, &29, &bf, &0d,   5, &0f   ; 9d35: a0 12 20... ..
+    equb   9,   1, &a8, &29,   2, &f0                                 ; 9d41: 09 01 a8... ...
+    equs "#h "                                                        ; 9d47: 23 68 20    #h
+    equb   9, &b5, &d0, &33, &20, &cb, &8f, &20, &95, &92, &aa, &20   ; 9d4a: 09 b5 d0... ...
+    equb &32, &af, &8a, &f0, &2f, &20, &b5, &af, &ac, &70, &10, &f0   ; 9d56: 32 af 8a... 2..
+    equb &90, &98, &a2,   0, &8e, &70, &10, &f0, &1c, &ad,   6, &0f   ; 9d62: 90 98 a2... ...
+    equb &6a, &b0, &0c, &6a, &90,   9, &2c,   7, &0f, &10,   4, &98   ; 9d6e: 6a b0 0c... j..
+    equb   9, &20, &a8, &68, &20,   9, &b5, &aa, &98, &9d, &40, &10   ; 9d7a: 09 20 a8... . .
+    equb &8a, &4c, &c9, &9c, &20, &99, &b7, &98, &d0, &13, &a5, &bb   ; 9d86: 8a 4c c9... .L.
+    equb &48, &a9, &77, &20, &f4, &ff, &68, &85, &bb, &a9,   0, &85   ; 9d92: 48 a9 77... H.w
+    equb &bd, &85, &bc, &f0,   6, &20, &7a, &b4, &bd, &30, &10, &8d   ; 9d9e: bd 85 bc... ...
+    equb   5, &0f, &a2,   1, &a0,   7, &20, &ad, &94, &a4, &bc, &d0   ; 9daa: 05 0f a2... ...
+    equb   7, &b8, &20, &5d, &b5                                      ; 9db6: 07 b8 20... ..
+
+; &9dbb referenced 2 times by &9dd8, &9dec
+.c9dbb
+    jmp c9cc7                                                         ; 9dbb: 4c c7 9c    L..
+
+    equb &a9,   0, &99, &10, &10, &99, &40, &10, &f0, &f3             ; 9dbe: a9 00 99... ...
+
+.sub_c9dc8
+    beq c9dd5                                                         ; 9dc8: f0 0b       ..
+    cpx #4                                                            ; 9dca: e0 04       ..
+    bne c9dd2                                                         ; 9dcc: d0 04       ..
+    cpy #4                                                            ; 9dce: c0 04       ..
+    bcc c9ddf                                                         ; 9dd0: 90 0d       ..
+; &9dd2 referenced 1 time by &9dcc
+.c9dd2
+    dex                                                               ; 9dd2: ca          .
+    bne c9dda                                                         ; 9dd3: d0 05       ..
+; &9dd5 referenced 1 time by &9dc8
+.c9dd5
+    sty l0e06                                                         ; 9dd5: 8c 06 0e    ...
+    bcc c9dbb                                                         ; 9dd8: 90 e1       ..
+; &9dda referenced 1 time by &9dd3
+.c9dda
+    lda #7                                                            ; 9dda: a9 07       ..
+    jmp c964e                                                         ; 9ddc: 4c 4e 96    LN.
+
+; &9ddf referenced 1 time by &9dd0
+.c9ddf
+    sty l0f05                                                         ; 9ddf: 8c 05 0f    ...
+    ldy #&16                                                          ; 9de2: a0 16       ..
+    jsr c94ad                                                         ; 9de4: 20 ad 94     ..
+    ldy l00bc                                                         ; 9de7: a4 bc       ..
+    sty l0e05                                                         ; 9de9: 8c 05 0e    ...
+    bpl c9dbb                                                         ; 9dec: 10 cd       ..
+.sub_c9dee
+    jsr sub_c8fcb                                                     ; 9dee: 20 cb 8f     ..
+    pha                                                               ; 9df1: 48          H
+    lda l00bc                                                         ; 9df2: a5 bc       ..
+    pha                                                               ; 9df4: 48          H
+    stx l10c9                                                         ; 9df5: 8e c9 10    ...
+    jsr sub_cb730                                                     ; 9df8: 20 30 b7     0.
+    beq c9e09                                                         ; 9dfb: f0 0c       ..
+    lda l1000,y                                                       ; 9dfd: b9 00 10    ...
+    cmp l1098,x                                                       ; 9e00: dd 98 10    ...
+    bcc c9e09                                                         ; 9e03: 90 04       ..
+    ldx #&ff                                                          ; 9e05: a2 ff       ..
+    bmi c9e0b                                                         ; 9e07: 30 02       0.
+; &9e09 referenced 2 times by &9dfb, &9e03
+.c9e09
+    ldx #0                                                            ; 9e09: a2 00       ..
+; &9e0b referenced 1 time by &9e07
+.c9e0b
+    pla                                                               ; 9e0b: 68          h
+    tay                                                               ; 9e0c: a8          .
+    pla                                                               ; 9e0d: 68          h
+    rts                                                               ; 9e0e: 60          `
+
+; &9e0f referenced 1 time by &9f5a
+.sub_c9e0f
+    ldy #9                                                            ; 9e0f: a0 09       ..
+    jsr sub_c9e16                                                     ; 9e11: 20 16 9e     ..
+    ldy #1                                                            ; 9e14: a0 01       ..
+; &9e16 referenced 1 time by &9e11
+.sub_c9e16
+    clc                                                               ; 9e16: 18          .
+; &9e17 referenced 1 time by &9f60
+.sub_c9e17
+    ldx #&fc                                                          ; 9e17: a2 fc       ..
+; &9e19 referenced 1 time by &9e2c
+.loop_c9e19
+    lda (l00bb),y                                                     ; 9e19: b1 bb       ..
+    bit l00b2                                                         ; 9e1b: 24 b2       $.
+    bmi c9e25                                                         ; 9e1d: 30 06       0.
+    adc l0e0a,x                                                       ; 9e1f: 7d 0a 0e    }..
+    jmp c9e28                                                         ; 9e22: 4c 28 9e    L(.
+
+; &9e25 referenced 1 time by &9e1d
+.c9e25
+    sbc l0e0a,x                                                       ; 9e25: fd 0a 0e    ...
+; &9e28 referenced 1 time by &9e22
+.c9e28
+    sta (l00bb),y                                                     ; 9e28: 91 bb       ..
+    iny                                                               ; 9e2a: c8          .
+    inx                                                               ; 9e2b: e8          .
+    bne loop_c9e19                                                    ; 9e2c: d0 eb       ..
+    rts                                                               ; 9e2e: 60          `
+
+    equb &20, &cb, &8f, &20, &95, &92                                 ; 9e2f: 20 cb 8f...  ..
+    equs "H 2"                                                        ; 9e35: 48 20 32    H 2
+    equb &af, &68, &aa, &f0,   5, &ca, &e0,   8, &90,   3, &4c, &c7   ; 9e38: af 68 aa... .h.
+    equb &9c, &8a, &a0,   0, &48, &c9,   4, &90,   3, &4c, &82, &9f   ; 9e44: 9c 8a a0... ...
+    equb &b1, &bb, &48, &20, &f2, &b4, &68, &a8, &20, &99, &b7, &bd   ; 9e50: b1 bb 48... ..H
+    equb &30, &10, &8d,   5, &0f, &a9,   0, &8d,   6, &0f, &bd,   0   ; 9e5c: 30 10 8d... 0..
+    equb &10, &8d,   7, &0f, &bd, &10, &10, &8d,   8, &0f, &bd, &20   ; 9e68: 10 8d 07... ...
+    equb &10, &8d,   9, &0f, &a0, &0d, &a2,   5, &20, &ad, &94, &68   ; 9e74: 10 8d 09... ...
+    equb &20, &dd, &9e,   8, &a0,   0, &b1, &bb, &b0,   5, &20, &cc   ; 9e80: 20 dd 9e...  ..
+    equb &92, &10,   3, &20, &b5, &92, &8c,   6, &0f, &20, &d6, &9e   ; 9e8c: 92 10 03... ...
+    equb &8d,   5, &0f, &a0, &0c, &a2,   2, &20, &ad, &94, &20, &d2   ; 9e98: 8d 05 0f... ...
+    equb &9e, &a0,   9, &ad,   5, &0f, &9d,   0, &10, &91, &bb, &c8   ; 9ea4: 9e a0 09... ...
+    equb &ad,   6, &0f, &9d, &10, &10, &91, &bb, &c8, &ad,   7, &0f   ; 9eb0: ad 06 0f... ...
+    equb &9d, &20, &10, &91, &bb, &a9,   0, &c8, &91, &bb, &28, &90   ; 9ebc: 9d 20 10... . .
+    equb   4, &a5, &bd, &c9,   3, &a9,   0, &4c, &c9, &9c             ; 9ec8: 04 a5 bd... ...
+
+; &9ed2 referenced 1 time by &9ede
+.sub_c9ed2
+    ldy #0                                                            ; 9ed2: a0 00       ..
+    lda (l00bb),y                                                     ; 9ed4: b1 bb       ..
+    jsr sub_cb4ad                                                     ; 9ed6: 20 ad b4     ..
+    lda l1030,x                                                       ; 9ed9: bd 30 10    .0.
+    rts                                                               ; 9edc: 60          `
+
+; &9edd referenced 1 time by &b987
+.c9edd
+    pha                                                               ; 9edd: 48          H
+    jsr sub_c9ed2                                                     ; 9ede: 20 d2 9e     ..
+    sta l0f05                                                         ; 9ee1: 8d 05 0f    ...
+    ldy #&0b                                                          ; 9ee4: a0 0b       ..
+    ldx #6                                                            ; 9ee6: a2 06       ..
+; &9ee8 referenced 1 time by &9ef4
+.loop_c9ee8
+    lda (l00bb),y                                                     ; 9ee8: b1 bb       ..
+    sta l0f06,x                                                       ; 9eea: 9d 06 0f    ...
+    dey                                                               ; 9eed: 88          .
+    cpy #8                                                            ; 9eee: c0 08       ..
+    bne c9ef3                                                         ; 9ef0: d0 01       ..
+    dey                                                               ; 9ef2: 88          .
+; &9ef3 referenced 1 time by &9ef0
+.c9ef3
+    dex                                                               ; 9ef3: ca          .
+    bne loop_c9ee8                                                    ; 9ef4: d0 f2       ..
+    pla                                                               ; 9ef6: 68          h
+    lsr a                                                             ; 9ef7: 4a          J
+    pha                                                               ; 9ef8: 48          H
+    bcc c9efc                                                         ; 9ef9: 90 01       ..
+    inx                                                               ; 9efb: e8          .
+; &9efc referenced 1 time by &9ef9
+.c9efc
+    stx l0f06                                                         ; 9efc: 8e 06 0f    ...
+    ldy #&0b                                                          ; 9eff: a0 0b       ..
+    ldx #&91                                                          ; 9f01: a2 91       ..
+    pla                                                               ; 9f03: 68          h
+    pha                                                               ; 9f04: 48          H
+    beq c9f0a                                                         ; 9f05: f0 03       ..
+    ldx #&92                                                          ; 9f07: a2 92       ..
+    dey                                                               ; 9f09: 88          .
+; &9f0a referenced 1 time by &9f05
+.c9f0a
+    stx l0f02                                                         ; 9f0a: 8e 02 0f    ...
+    stx l00b8                                                         ; 9f0d: 86 b8       ..
+    ldx #8                                                            ; 9f0f: a2 08       ..
+    lda l0f05                                                         ; 9f11: ad 05 0f    ...
+    jsr sub_c9497                                                     ; 9f14: 20 97 94     ..
+    ldx #0                                                            ; 9f17: a2 00       ..
+    lda (l00bb,x)                                                     ; 9f19: a1 bb       ..
+    tax                                                               ; 9f1b: aa          .
+    lda l1040,x                                                       ; 9f1c: bd 40 10    .@.
+    eor #1                                                            ; 9f1f: 49 01       I.
+    sta l1040,x                                                       ; 9f21: 9d 40 10    .@.
+    clc                                                               ; 9f24: 18          .
+    ldx #4                                                            ; 9f25: a2 04       ..
+; &9f27 referenced 1 time by &9f3b
+.loop_c9f27
+    lda (l00bb),y                                                     ; 9f27: b1 bb       ..
+    sta l00af,y                                                       ; 9f29: 99 af 00    ...
+    sta l00c7,y                                                       ; 9f2c: 99 c7 00    ...
+    jsr sub_c9a7f                                                     ; 9f2f: 20 7f 9a     ..
+    adc (l00bb),y                                                     ; 9f32: 71 bb       q.
+    sta l00af,y                                                       ; 9f34: 99 af 00    ...
+    jsr sub_c9a92                                                     ; 9f37: 20 92 9a     ..
+    dex                                                               ; 9f3a: ca          .
+    bne loop_c9f27                                                    ; 9f3b: d0 ea       ..
+    inx                                                               ; 9f3d: e8          .
+; &9f3e referenced 1 time by &9f45
+.loop_c9f3e
+    lda l0f03,x                                                       ; 9f3e: bd 03 0f    ...
+    sta l0f06,x                                                       ; 9f41: 9d 06 0f    ...
+    dex                                                               ; 9f44: ca          .
+    bpl loop_c9f3e                                                    ; 9f45: 10 f7       ..
+    pla                                                               ; 9f47: 68          h
+    bne c9f52                                                         ; 9f48: d0 08       ..
+    lda l0f02                                                         ; 9f4a: ad 02 0f    ...
+    jsr sub_c9a9a                                                     ; 9f4d: 20 9a 9a     ..
+    bcs c9f55                                                         ; 9f50: b0 03       ..
+; &9f52 referenced 1 time by &9f48
+.c9f52
+    jsr sub_c9998                                                     ; 9f52: 20 98 99     ..
+; &9f55 referenced 1 time by &9f50
+.c9f55
+    jsr sub_c9f67                                                     ; 9f55: 20 67 9f     g.
+    stx l00b2                                                         ; 9f58: 86 b2       ..
+    jsr sub_c9e0f                                                     ; 9f5a: 20 0f 9e     ..
+    dec l00b2                                                         ; 9f5d: c6 b2       ..
+    sec                                                               ; 9f5f: 38          8
+    jsr sub_c9e17                                                     ; 9f60: 20 17 9e     ..
+    asl l0f05                                                         ; 9f63: 0e 05 0f    ...
+    rts                                                               ; 9f66: 60          `
+
+; &9f67 referenced 1 time by &9f55
+.sub_c9f67
+    php                                                               ; 9f67: 08          .
+    jsr sub_c94f0                                                     ; 9f68: 20 f0 94     ..
+    plp                                                               ; 9f6b: 28          (
+    rts                                                               ; 9f6c: 60          `
+
+    equb &a0, &15, &20, &ad, &94, &ad,   5, &0e, &8d, &16, &0f, &86   ; 9f6d: a0 15 20... ..
+    equb &b0, &86, &b1, &a9, &12, &85, &b2, &d0, &4e, &a0,   4, &ad   ; 9f79: b0 86 b1... ...
+    equb &63, &0d, &f0,   7, &d1, &bb, &d0,   3, &88, &f1, &bb, &85   ; 9f85: 63 0d f0... c..
+    equb &a9, &b1, &bb, &99, &bd,   0, &88, &d0, &f8, &68, &29,   3   ; 9f91: a9 b1 bb... ...
+    equb &f0, &ce, &4a, &f0,   2, &b0, &6b, &a8, &b9,   3, &0e, &8d   ; 9f9d: f0 ce 4a... ..J
+    equb   3, &0f, &ad,   4, &0e, &8d,   4, &0f, &ad,   2, &0e, &8d   ; 9fa9: 03 0f ad... ...
+    equb   2, &0f, &a2, &12, &8e,   1, &0f, &a9, &0d, &8d,   6, &0f   ; 9fb5: 02 0f a2... ...
+    equb &85, &b2, &4a, &8d,   5, &0f, &18, &20, &da, &94, &86, &b1   ; 9fc1: 85 b2 4a... ..J
+    equb &e8, &86, &b0, &a5, &a9, &d0, &11, &a6, &b0, &a4, &b1, &bd   ; 9fcd: e8 86 b0... ...
+    equb   5, &0f, &91, &be, &e8, &c8, &c6, &b2, &d0, &f5, &f0        ; 9fd9: 05 0f 91... ...
+    equs "' s"                                                        ; 9fe4: 27 20 73    ' s
+    equb &a0, &a9,   1, &a6, &bb, &a4, &bc, &e8, &d0,   1, &c8, &20   ; 9fe7: a0 a9 01... ...
+    equb   6,   4, &a6, &b0, &bd,   5, &0f, &8d, &e5, &fe, &e8, &a0   ; 9ff3: 06 04 a6... ...
+    equb   6, &88, &d0, &fd, &c6, &b2, &d0, &f0, &a9, &83, &20,   6   ; 9fff: 06 88 d0... ...
+    equb   4, &4c, &ee, &9c, &a0,   9, &b1, &bb, &8d,   6, &0f, &a0   ; a00b: 04 4c ee... .L.
+    equb   5, &b1, &bb, &8d,   7, &0f, &a2, &0d, &8e,   8, &0f, &a0   ; a017: 05 b1 bb... ...
+    equb   2, &84, &b0, &8c,   5, &0f, &c8, &20, &ad, &94, &86, &b1   ; a023: 02 84 b0... ...
+    equb &ad,   6, &0f, &81, &bb, &ad,   5, &0f, &a0,   9, &71, &bb   ; a02f: ad 06 0f... ...
+    equb &91, &bb, &a5, &c8, &e9,   7, &8d,   6, &0f, &85, &b2, &f0   ; a03b: 91 bb a5... ...
+    equb   3, &20, &d0, &9f, &a2,   2, &9d,   7, &0f, &ca, &10, &fa   ; a047: 03 20 d0... . .
+    equb &20, &14, &9e, &38, &c6, &b2, &ad,   5, &0f, &8d,   6, &0f   ; a053: 20 14 9e...  ..
+    equb &20, &17, &9e, &a2,   3, &a0,   5, &38, &b1, &bb, &d0,   5   ; a05f: 20 17 9e...  ..
+    equb &c8, &ca, &10, &f8, &18, &4c, &0c, &a0                       ; a06b: c8 ca 10... ...
+
+; &a073 referenced 2 times by &a078, &a2e3
+.ca073
+    lda #&c3                                                          ; a073: a9 c3       ..
+    jsr c0406                                                         ; a075: 20 06 04     ..
+    bcc ca073                                                         ; a078: 90 f9       ..
+    rts                                                               ; a07a: 60          `
+
+.sub_ca07b
+    lda l0e00                                                         ; a07b: ad 00 0e    ...
+    sta l00b5                                                         ; a07e: 85 b5       ..
+    lda l0e01                                                         ; a080: ad 01 0e    ...
+    sta l00b6                                                         ; a083: 85 b6       ..
+    lda (l00be),y                                                     ; a085: b1 be       ..
+    cmp #&0d                                                          ; a087: c9 0d       ..
+    beq ca09b                                                         ; a089: f0 10       ..
+    jsr sub_ca0a7                                                     ; a08b: 20 a7 a0     ..
+    lda #1                                                            ; a08e: a9 01       ..
+    sta l00b4                                                         ; a090: 85 b4       ..
+    lda #&13                                                          ; a092: a9 13       ..
+    ldx #<(l00b4)                                                     ; a094: a2 b4       ..
+    ldy #>(l00b4)                                                     ; a096: a0 00       ..
+    jmp osword                                                        ; a098: 4c f1 ff    L..
+
+; &a09b referenced 1 time by &a089
+.ca09b
+    jsr sub_cb0c5                                                     ; a09b: 20 c5 b0     ..
+; &a09e referenced 1 time by &b0b6
+.sub_ca09e
+    bit l9491                                                         ; a09e: 2c 91 94    ,..
+    jsr sub_cb198                                                     ; a0a1: 20 98 b1     ..
+    jmp osnewl                                                        ; a0a4: 4c e7 ff    L..
+
+; &a0a7 referenced 3 times by &a08b, &b011, &b1e8
+.sub_ca0a7
+    txa                                                               ; a0a7: 8a          .
+    pha                                                               ; a0a8: 48          H
+    lda #0                                                            ; a0a9: a9 00       ..
+    sta l00b4                                                         ; a0ab: 85 b4       ..
+    jsr sub_c916e                                                     ; a0ad: 20 6e 91     n.
+    bcs ca0c5                                                         ; a0b0: b0 13       ..
+    tya                                                               ; a0b2: 98          .
+    pha                                                               ; a0b3: 48          H
+    jsr sub_ca865                                                     ; a0b4: 20 65 a8     e.
+    eor l00b2                                                         ; a0b7: 45 b2       E.
+    beq ca0bd                                                         ; a0b9: f0 02       ..
+    lda l00b2                                                         ; a0bb: a5 b2       ..
+; &a0bd referenced 1 time by &a0b9
+.ca0bd
+    sta l00b6                                                         ; a0bd: 85 b6       ..
+    pla                                                               ; a0bf: 68          h
+    tay                                                               ; a0c0: a8          .
+    iny                                                               ; a0c1: c8          .
+    jsr sub_c916e                                                     ; a0c2: 20 6e 91     n.
+; &a0c5 referenced 1 time by &a0b0
+.ca0c5
+    beq ca0c9                                                         ; a0c5: f0 02       ..
+    sta l00b5                                                         ; a0c7: 85 b5       ..
+; &a0c9 referenced 1 time by &a0c5
+.ca0c9
+    pla                                                               ; a0c9: 68          h
+    tax                                                               ; a0ca: aa          .
+    rts                                                               ; a0cb: 60          `
+
+; &a0cc referenced 2 times by &a0ea, &a0fa
+.sub_ca0cc
+    lda l00f0                                                         ; a0cc: a5 f0       ..
+; &a0ce referenced 2 times by &8f30, &b108
+.sub_ca0ce
+    asl a                                                             ; a0ce: 0a          .
+    asl a                                                             ; a0cf: 0a          .
+    pha                                                               ; a0d0: 48          H
+    asl a                                                             ; a0d1: 0a          .
+    tsx                                                               ; a0d2: ba          .
+    php                                                               ; a0d3: 08          .
+    adc l0101,x                                                       ; a0d4: 7d 01 01    }..
+    ror a                                                             ; a0d7: 6a          j
+    plp                                                               ; a0d8: 28          (
+    asl a                                                             ; a0d9: 0a          .
+    tay                                                               ; a0da: a8          .
+    pla                                                               ; a0db: 68          h
+    cmp #&48 ; 'H'                                                    ; a0dc: c9 48       .H
+    bcc ca0e3                                                         ; a0de: 90 03       ..
+    ldy #0                                                            ; a0e0: a0 00       ..
+    tya                                                               ; a0e2: 98          .
+; &a0e3 referenced 1 time by &a0de
+.ca0e3
+    rts                                                               ; a0e3: 60          `
+
+.sub_ca0e4
+    ldy #&6f ; 'o'                                                    ; a0e4: a0 6f       .o
+    lda (l009c),y                                                     ; a0e6: b1 9c       ..
+    bcc ca0f7                                                         ; a0e8: 90 0d       ..
+.sub_ca0ea
+    jsr sub_ca0cc                                                     ; a0ea: 20 cc a0     ..
+    bcs ca0f5                                                         ; a0ed: b0 06       ..
+    lda (l009e),y                                                     ; a0ef: b1 9e       ..
+    cmp #&3f ; '?'                                                    ; a0f1: c9 3f       .?
+    bne ca0f7                                                         ; a0f3: d0 02       ..
+; &a0f5 referenced 1 time by &a0ed
+.ca0f5
+    lda #0                                                            ; a0f5: a9 00       ..
+; &a0f7 referenced 2 times by &a0e8, &a0f3
+.ca0f7
+    sta l00f0                                                         ; a0f7: 85 f0       ..
+    rts                                                               ; a0f9: 60          `
+
+.sub_ca0fa
+    jsr sub_ca0cc                                                     ; a0fa: 20 cc a0     ..
+    bcc ca109                                                         ; a0fd: 90 0a       ..
+    ror l0d6c                                                         ; a0ff: 6e 6c 0d    nl.
+    lda l00f0                                                         ; a102: a5 f0       ..
+    rol a                                                             ; a104: 2a          *
+    rol l0d6c                                                         ; a105: 2e 6c 0d    .l.
+    rts                                                               ; a108: 60          `
+
+; &a109 referenced 1 time by &a0fd
+.ca109
+    ror l0d61                                                         ; a109: 6e 61 0d    na.
+    lda #&3f ; '?'                                                    ; a10c: a9 3f       .?
+    sta (l009e),y                                                     ; a10e: 91 9e       ..
+    rol l0d61                                                         ; a110: 2e 61 0d    .a.
+    rts                                                               ; a113: 60          `
+
+; &a114 referenced 1 time by &8cf9
+.ca114
+    jsr sub_c9291                                                     ; a114: 20 91 92     ..
+    ldy #&ff                                                          ; a117: a0 ff       ..
+    sty l00ba                                                         ; a119: 84 ba       ..
+    sty l0098                                                         ; a11b: 84 98       ..
+    iny                                                               ; a11d: c8          .
+    ldx #&4a ; 'J'                                                    ; a11e: a2 4a       .J
+    jsr sub_ca140                                                     ; a120: 20 40 a1     @.
+    bcs ca133                                                         ; a123: b0 0e       ..
+; &a125 referenced 1 time by &8c5a
+.ca125
+    bvc ca133                                                         ; a125: 50 0c       P.
+; &a127 referenced 1 time by &af6f
+.ca127
+    lda #&dc                                                          ; a127: a9 dc       ..
+    jsr generate_error_inline2                                        ; a129: 20 d4 96     ..
+    equs "Syntax", 0                                                  ; a12c: 53 79 6e... Syn
+
+; &a133 referenced 2 times by &a123, &a125
+.ca133
+    lda #0                                                            ; a133: a9 00       ..
+    sta l00a9                                                         ; a135: 85 a9       ..
+    lda la3f2,x                                                       ; a137: bd f2 a3    ...
+    pha                                                               ; a13a: 48          H
+    lda la3f1,x                                                       ; a13b: bd f1 a3    ...
+    pha                                                               ; a13e: 48          H
+    rts                                                               ; a13f: 60          `
+
+; &a140 referenced 5 times by &8c55, &8c83, &a120, &b320, &b34d
+.sub_ca140
+    tya                                                               ; a140: 98          .
+    pha                                                               ; a141: 48          H
+; &a142 referenced 1 time by &a168
+.ca142
+    pla                                                               ; a142: 68          h
+    pha                                                               ; a143: 48          H
+    tay                                                               ; a144: a8          .
+    lda la3f0,x                                                       ; a145: bd f0 a3    ...
+    bmi ca1a9                                                         ; a148: 30 5f       0_
+; &a14a referenced 1 time by &a157
+.loop_ca14a
+    lda la3f0,x                                                       ; a14a: bd f0 a3    ...
+    bmi ca16a                                                         ; a14d: 30 1b       0.
+    eor (l00be),y                                                     ; a14f: 51 be       Q.
+    and #&df                                                          ; a151: 29 df       ).
+    bne ca159                                                         ; a153: d0 04       ..
+    iny                                                               ; a155: c8          .
+    inx                                                               ; a156: e8          .
+    bne loop_ca14a                                                    ; a157: d0 f1       ..
+; &a159 referenced 2 times by &a153, &a15d
+.ca159
+    inx                                                               ; a159: e8          .
+    lda la3f0,x                                                       ; a15a: bd f0 a3    ...
+    bpl ca159                                                         ; a15d: 10 fa       ..
+    lda (l00be),y                                                     ; a15f: b1 be       ..
+    cmp #&2e ; '.'                                                    ; a161: c9 2e       ..
+    beq ca18d                                                         ; a163: f0 28       .(
+; &a165 referenced 1 time by &a17a
+.loop_ca165
+    inx                                                               ; a165: e8          .
+    inx                                                               ; a166: e8          .
+    inx                                                               ; a167: e8          .
+    bne ca142                                                         ; a168: d0 d8       ..
+; &a16a referenced 1 time by &a14d
+.ca16a
+    tya                                                               ; a16a: 98          .
+    pha                                                               ; a16b: 48          H
+    lda (l00be),y                                                     ; a16c: b1 be       ..
+    ldy #9                                                            ; a16e: a0 09       ..
+; &a170 referenced 1 time by &a176
+.loop_ca170
+    cmp la17c,y                                                       ; a170: d9 7c a1    .|.
+    beq ca185                                                         ; a173: f0 10       ..
+    dey                                                               ; a175: 88          .
+    bpl loop_ca170                                                    ; a176: 10 f8       ..
+    pla                                                               ; a178: 68          h
+    tay                                                               ; a179: a8          .
+    bne loop_ca165                                                    ; a17a: d0 e9       ..
+; &a17c referenced 1 time by &a170
+.la17c
+    equs " ", '"', "#$&*:@"                                           ; a17c: 20 22 23...  "#
+    equb &0d                                                          ; a184: 0d          .
+
+; &a185 referenced 1 time by &a173
+.ca185
+    pla                                                               ; a185: 68          h
+    tay                                                               ; a186: a8          .
+; &a187 referenced 1 time by &a18e
+.loop_ca187
+    lda (l00be),y                                                     ; a187: b1 be       ..
+    cmp #&20 ; ' '                                                    ; a189: c9 20       .
+    bne ca191                                                         ; a18b: d0 04       ..
+; &a18d referenced 1 time by &a163
+.ca18d
+    iny                                                               ; a18d: c8          .
+    jmp loop_ca187                                                    ; a18e: 4c 87 a1    L..
+
+; &a191 referenced 1 time by &a18b
+.ca191
+    lda la3f0,x                                                       ; a191: bd f0 a3    ...
+    asl a                                                             ; a194: 0a          .
+    bpl ca1a2                                                         ; a195: 10 0b       ..
+    lda (l00be),y                                                     ; a197: b1 be       ..
+    cmp #&0d                                                          ; a199: c9 0d       ..
+    bne ca1a2                                                         ; a19b: d0 05       ..
+    bit l9491                                                         ; a19d: 2c 91 94    ,..
+    bvs ca1a3                                                         ; a1a0: 70 01       p.
+; &a1a2 referenced 2 times by &a195, &a19b
+.ca1a2
+    clv                                                               ; a1a2: b8          .
+; &a1a3 referenced 1 time by &a1a0
+.ca1a3
+    clc                                                               ; a1a3: 18          .
+; &a1a4 referenced 1 time by &a1bf
+.loop_ca1a4
+    pla                                                               ; a1a4: 68          h
+    lda (l00be),y                                                     ; a1a5: b1 be       ..
+    rts                                                               ; a1a7: 60          `
+
+; &a1a8 referenced 1 time by &a1b5
+.loop_ca1a8
+    iny                                                               ; a1a8: c8          .
+; &a1a9 referenced 1 time by &a148
+.ca1a9
+    lda (l00be),y                                                     ; a1a9: b1 be       ..
+    cmp #&0d                                                          ; a1ab: c9 0d       ..
+    beq ca1be                                                         ; a1ad: f0 0f       ..
+    cmp #&2e ; '.'                                                    ; a1af: c9 2e       ..
+    beq ca1b7                                                         ; a1b1: f0 04       ..
+    cmp #&20 ; ' '                                                    ; a1b3: c9 20       .
+    bne loop_ca1a8                                                    ; a1b5: d0 f1       ..
+; &a1b7 referenced 2 times by &a1b1, &a1bc
+.ca1b7
+    iny                                                               ; a1b7: c8          .
+    lda (l00be),y                                                     ; a1b8: b1 be       ..
+    cmp #&20 ; ' '                                                    ; a1ba: c9 20       .
+    beq ca1b7                                                         ; a1bc: f0 f9       ..
+; &a1be referenced 1 time by &a1ad
+.ca1be
+    sec                                                               ; a1be: 38          8
+    bcs loop_ca1a4                                                    ; a1bf: b0 e3       ..
+; &a1c1 referenced 1 time by &8e1d
+.ca1c1
+    jsr sub_cafb5                                                     ; a1c1: 20 b5 af     ..
+    jsr sub_caf32                                                     ; a1c4: 20 32 af     2.
+    jsr sub_cae92                                                     ; a1c7: 20 92 ae     ..
+; &a1ca referenced 1 time by &a241
+.ca1ca
+    ldx #1                                                            ; a1ca: a2 01       ..
+    jsr sub_caf04                                                     ; a1cc: 20 04 af     ..
+    lda #2                                                            ; a1cf: a9 02       ..
+    sta l0f05                                                         ; a1d1: 8d 05 0f    ...
+    ldy #&12                                                          ; a1d4: a0 12       ..
+    jsr c94ad                                                         ; a1d6: 20 ad 94     ..
+    lda l0f05                                                         ; a1d9: ad 05 0f    ...
+    cmp #1                                                            ; a1dc: c9 01       ..
+    bne ca209                                                         ; a1de: d0 29       .)
+    ldx #3                                                            ; a1e0: a2 03       ..
+; &a1e2 referenced 1 time by &a1eb
+.loop_ca1e2
+    inc l0f0a,x                                                       ; a1e2: fe 0a 0f    ...
+    beq ca1ea                                                         ; a1e5: f0 03       ..
+    jmp ca26a                                                         ; a1e7: 4c 6a a2    Lj.
+
+; &a1ea referenced 1 time by &a1e5
+.ca1ea
+    dex                                                               ; a1ea: ca          .
+    bpl loop_ca1e2                                                    ; a1eb: 10 f5       ..
+    jsr sub_cb53d                                                     ; a1ed: 20 3d b5     =.
+    ldx #1                                                            ; a1f0: a2 01       ..
+    stx l0f05                                                         ; a1f2: 8e 05 0f    ...
+    stx l0f06                                                         ; a1f5: 8e 06 0f    ...
+    inx                                                               ; a1f8: e8          .
+    jsr sub_caf04                                                     ; a1f9: 20 04 af     ..
+    ldy #6                                                            ; a1fc: a0 06       ..
+    jsr c94ad                                                         ; a1fe: 20 ad 94     ..
+    bcs ca206                                                         ; a201: b0 03       ..
+    jmp ca27d                                                         ; a203: 4c 7d a2    L}.
+
+; &a206 referenced 1 time by &a201
+.ca206
+    jmp c9cc9                                                         ; a206: 4c c9 9c    L..
+
+; &a209 referenced 1 time by &a1de
+.ca209
+    lda l0e30                                                         ; a209: ad 30 0e    .0.
+    cmp #&24 ; '$'                                                    ; a20c: c9 24       .$
+    beq ca25d                                                         ; a20e: f0 4d       .M
+    lda l1071                                                         ; a210: ad 71 10    .q.
+    bmi ca25a                                                         ; a213: 30 45       0E
+    rol a                                                             ; a215: 2a          *
+    rol a                                                             ; a216: 2a          *
+    bmi ca243                                                         ; a217: 30 2a       0*
+    bcs ca25d                                                         ; a219: b0 42       .B
+    ldx #&ff                                                          ; a21b: a2 ff       ..
+; &a21d referenced 1 time by &a223
+.loop_ca21d
+    inx                                                               ; a21d: e8          .
+    lda l0e30,x                                                       ; a21e: bd 30 0e    .0.
+    cmp #&0d                                                          ; a221: c9 0d       ..
+    bne loop_ca21d                                                    ; a223: d0 f8       ..
+; &a225 referenced 1 time by &a22c
+.loop_ca225
+    lda l0e30,x                                                       ; a225: bd 30 0e    .0.
+    sta l0e38,x                                                       ; a228: 9d 38 0e    .8.
+    dex                                                               ; a22b: ca          .
+    bpl loop_ca225                                                    ; a22c: 10 f7       ..
+    ldx #7                                                            ; a22e: a2 07       ..
+; &a230 referenced 1 time by &a237
+.loop_ca230
+    lda la291,x                                                       ; a230: bd 91 a2    ...
+    sta l0e30,x                                                       ; a233: 9d 30 0e    .0.
+    dex                                                               ; a236: ca          .
+    bpl loop_ca230                                                    ; a237: 10 f7       ..
+    lda l1071                                                         ; a239: ad 71 10    .q.
+    ora #&60 ; '`'                                                    ; a23c: 09 60       .`
+    sta l1071                                                         ; a23e: 8d 71 10    .q.
+; &a241 referenced 1 time by &a258
+.loop_ca241
+    bne ca1ca                                                         ; a241: d0 87       ..
+; &a243 referenced 1 time by &a217
+.ca243
+    ldx #&ff                                                          ; a243: a2 ff       ..
+; &a245 referenced 1 time by &a24e
+.loop_ca245
+    inx                                                               ; a245: e8          .
+    lda l0e38,x                                                       ; a246: bd 38 0e    .8.
+    sta l0e30,x                                                       ; a249: 9d 30 0e    .0.
+    eor #&0d                                                          ; a24c: 49 0d       I.
+    bne loop_ca245                                                    ; a24e: d0 f5       ..
+    jsr sub_caf32                                                     ; a250: 20 32 af     2.
+    ora #&80                                                          ; a253: 09 80       ..
+    sta l1071                                                         ; a255: 8d 71 10    .q.
+    bne loop_ca241                                                    ; a258: d0 e7       ..
+; &a25a referenced 1 time by &a213
+.ca25a
+    jsr sub_caf32                                                     ; a25a: 20 32 af     2.
+; &a25d referenced 3 times by &a20e, &a219, &b332
+.ca25d
+    lda #&fe                                                          ; a25d: a9 fe       ..
+    jsr generate_error_inline                                         ; a25f: 20 b8 96     ..
+    equs "command", 0                                                 ; a262: 63 6f 6d... com
+
+; &a26a referenced 1 time by &a1e7
+.ca26a
+    ldx #3                                                            ; a26a: a2 03       ..
+; &a26c referenced 1 time by &a272
+.loop_ca26c
+    inc l0f06,x                                                       ; a26c: fe 06 0f    ...
+    bne ca299                                                         ; a26f: d0 28       .(
+    dex                                                               ; a271: ca          .
+    bne loop_ca26c                                                    ; a272: d0 f8       ..
+    lda #&93                                                          ; a274: a9 93       ..
+    jsr generate_error_inline3                                        ; a276: 20 d1 96     ..
+    equs "No!", 0                                                     ; a279: 4e 6f 21... No!
+
+; &a27d referenced 1 time by &a203
+.ca27d
+    lda l0f05                                                         ; a27d: ad 05 0f    ...
+    jsr sub_cb509                                                     ; a280: 20 09 b5     ..
+    tay                                                               ; a283: a8          .
+    lda #0                                                            ; a284: a9 00       ..
+    sta l1060,x                                                       ; a286: 9d 60 10    .`.
+    sty l1070                                                         ; a289: 8c 70 10    .p.
+    ldy #3                                                            ; a28c: a0 03       ..
+    jmp ca3e8                                                         ; a28e: 4c e8 a3    L..
+
+; &a291 referenced 1 time by &a230
+.la291
+    equs "Library."                                                   ; a291: 4c 69 62... Lib
+
+; &a299 referenced 1 time by &a26f
+.ca299
+    jsr sub_caf02                                                     ; a299: 20 02 af     ..
+    ldy #0                                                            ; a29c: a0 00       ..
+    clc                                                               ; a29e: 18          .
+    jsr gsinit                                                        ; a29f: 20 c2 ff     ..
+; &a2a2 referenced 1 time by &a2a5
+.loop_ca2a2
+    jsr gsread                                                        ; a2a2: 20 c5 ff     ..
+    bcc loop_ca2a2                                                    ; a2a5: 90 fb       ..
+    dey                                                               ; a2a7: 88          .
+; &a2a8 referenced 1 time by &a2ad
+.loop_ca2a8
+    iny                                                               ; a2a8: c8          .
+    lda (os_text_ptr),y                                               ; a2a9: b1 f2       ..
+    cmp #&20 ; ' '                                                    ; a2ab: c9 20       .
+    beq loop_ca2a8                                                    ; a2ad: f0 f9       ..
+    eor #&0d                                                          ; a2af: 49 0d       I.
+    clc                                                               ; a2b1: 18          .
+    tya                                                               ; a2b2: 98          .
+    adc os_text_ptr                                                   ; a2b3: 65 f2       e.
+    sta l0e0a                                                         ; a2b5: 8d 0a 0e    ...
+    lda l00f3                                                         ; a2b8: a5 f3       ..
+    adc #0                                                            ; a2ba: 69 00       i.
+    sta l0e0b                                                         ; a2bc: 8d 0b 0e    ...
+    jsr sub_c8b02                                                     ; a2bf: 20 02 8b     ..
+    ldx #&0e                                                          ; a2c2: a2 0e       ..
+    stx l00bc                                                         ; a2c4: 86 bc       ..
+    lda #&0e                                                          ; a2c6: a9 0e       ..
+    sta l00bb                                                         ; a2c8: 85 bb       ..
+    sta l0e14                                                         ; a2ca: 8d 14 0e    ...
+    ldx #&4a ; 'J'                                                    ; a2cd: a2 4a       .J
+    ldy #5                                                            ; a2cf: a0 05       ..
+    jsr sub_c9951                                                     ; a2d1: 20 51 99     Q.
+    lda l0d63                                                         ; a2d4: ad 63 0d    .c.
+    beq ca2ef                                                         ; a2d7: f0 16       ..
+    and l0f0b                                                         ; a2d9: 2d 0b 0f    -..
+    and l0f0c                                                         ; a2dc: 2d 0c 0f    -..
+    cmp #&ff                                                          ; a2df: c9 ff       ..
+    beq ca2ef                                                         ; a2e1: f0 0c       ..
+    jsr ca073                                                         ; a2e3: 20 73 a0     s.
+    ldx #9                                                            ; a2e6: a2 09       ..
+    ldy #&0f                                                          ; a2e8: a0 0f       ..
+    lda #4                                                            ; a2ea: a9 04       ..
+    jmp c0406                                                         ; a2ec: 4c 06 04    L..
+
+; &a2ef referenced 2 times by &a2d7, &a2e1
+.ca2ef
+    lda #1                                                            ; a2ef: a9 01       ..
+    jmp (l0f09)                                                       ; a2f1: 6c 09 0f    l..
+
+; &a2f4 referenced 1 time by &945f
+.ca2f4
+    jsr sub_ca32b                                                     ; a2f4: 20 2b a3     +.
+    jmp c9cc7                                                         ; a2f7: 4c c7 9c    L..
+
+.sub_ca2fa
+    jsr sub_ca362                                                     ; a2fa: 20 62 a3     b.
+    jmp c9cc7                                                         ; a2fd: 4c c7 9c    L..
+
+; &a300 referenced 1 time by &a39f
+.sub_ca300
+    ldx #&10                                                          ; a300: a2 10       ..
+    clv                                                               ; a302: b8          .
+; &a303 referenced 2 times by &a309, &a310
+.ca303
+    dex                                                               ; a303: ca          .
+    bmi ca319                                                         ; a304: 30 13       0.
+    jsr sub_cb586                                                     ; a306: 20 86 b5     ..
+    bne ca303                                                         ; a309: d0 f8       ..
+    lda l1060,x                                                       ; a30b: bd 60 10    .`.
+    and #4                                                            ; a30e: 29 04       ).
+    beq ca303                                                         ; a310: f0 f1       ..
+    tya                                                               ; a312: 98          .
+    sta l1030,x                                                       ; a313: 9d 30 10    .0.
+    bit l9491                                                         ; a316: 2c 91 94    ,..
+; &a319 referenced 1 time by &a304
+.ca319
+    sty l0e02                                                         ; a319: 8c 02 0e    ...
+    bvs ca327                                                         ; a31c: 70 09       p.
+    tya                                                               ; a31e: 98          .
+    jsr sub_cb509                                                     ; a31f: 20 09 b5     ..
+    sta l1072                                                         ; a322: 8d 72 10    .r.
+    beq ca38e                                                         ; a325: f0 67       .g
+; &a327 referenced 1 time by &a31c
+.ca327
+    lda #&26 ; '&'                                                    ; a327: a9 26       .&
+    bne ca38b                                                         ; a329: d0 60       .`
+; &a32b referenced 3 times by &a2f4, &a35d, &a3a5
+.sub_ca32b
+    ldx #&10                                                          ; a32b: a2 10       ..
+    clv                                                               ; a32d: b8          .
+; &a32e referenced 2 times by &a334, &a33b
+.ca32e
+    dex                                                               ; a32e: ca          .
+    bmi ca344                                                         ; a32f: 30 13       0.
+    jsr sub_cb586                                                     ; a331: 20 86 b5     ..
+    bne ca32e                                                         ; a334: d0 f8       ..
+    lda l1060,x                                                       ; a336: bd 60 10    .`.
+    and #8                                                            ; a339: 29 08       ).
+    beq ca32e                                                         ; a33b: f0 f1       ..
+    tya                                                               ; a33d: 98          .
+    sta l1030,x                                                       ; a33e: 9d 30 10    .0.
+    bit l9491                                                         ; a341: 2c 91 94    ,..
+; &a344 referenced 1 time by &a32f
+.ca344
+    sty l0e03                                                         ; a344: 8c 03 0e    ...
+    bvs ca352                                                         ; a347: 70 09       p.
+    tya                                                               ; a349: 98          .
+    jsr sub_cb509                                                     ; a34a: 20 09 b5     ..
+    sta l1073                                                         ; a34d: 8d 73 10    .s.
+    beq ca38e                                                         ; a350: f0 3c       .<
+; &a352 referenced 1 time by &a347
+.ca352
+    lda #&2a ; '*'                                                    ; a352: a9 2a       .*
+    bne ca38b                                                         ; a354: d0 35       .5
+.sub_ca356
+    lda l0e03                                                         ; a356: ad 03 0e    ...
+    pha                                                               ; a359: 48          H
+    ldy l0e04                                                         ; a35a: ac 04 0e    ...
+    jsr sub_ca32b                                                     ; a35d: 20 2b a3     +.
+    pla                                                               ; a360: 68          h
+    tay                                                               ; a361: a8          .
+; &a362 referenced 2 times by &a2fa, &a3ab
+.sub_ca362
+    ldx #&10                                                          ; a362: a2 10       ..
+    clv                                                               ; a364: b8          .
+; &a365 referenced 2 times by &a36b, &a372
+.ca365
+    dex                                                               ; a365: ca          .
+    bmi ca37b                                                         ; a366: 30 13       0.
+    jsr sub_cb586                                                     ; a368: 20 86 b5     ..
+    bne ca365                                                         ; a36b: d0 f8       ..
+    lda l1060,x                                                       ; a36d: bd 60 10    .`.
+    and #&10                                                          ; a370: 29 10       ).
+    beq ca365                                                         ; a372: f0 f1       ..
+    tya                                                               ; a374: 98          .
+    sta l1030,x                                                       ; a375: 9d 30 10    .0.
+    bit l9491                                                         ; a378: 2c 91 94    ,..
+; &a37b referenced 1 time by &a366
+.ca37b
+    sty l0e04                                                         ; a37b: 8c 04 0e    ...
+    bvs ca389                                                         ; a37e: 70 09       p.
+    tya                                                               ; a380: 98          .
+    jsr sub_cb509                                                     ; a381: 20 09 b5     ..
+    sta l1074                                                         ; a384: 8d 74 10    .t.
+    beq ca38e                                                         ; a387: f0 05       ..
+; &a389 referenced 1 time by &a37e
+.ca389
+    lda #&32 ; '2'                                                    ; a389: a9 32       .2
+; &a38b referenced 2 times by &a329, &a354
+.ca38b
+    sta l1060,x                                                       ; a38b: 9d 60 10    .`.
+; &a38e referenced 3 times by &a325, &a350, &a387
+.ca38e
+    jmp c8f8c                                                         ; a38e: 4c 8c 8f    L..
+
+.sub_ca391
+    jsr sub_cb559                                                     ; a391: 20 59 b5     Y.
+    sec                                                               ; a394: 38          8
+    lda l0f08                                                         ; a395: ad 08 0f    ...
+    sta l0e05                                                         ; a398: 8d 05 0e    ...
+.sub_ca39b
+    php                                                               ; a39b: 08          .
+    ldy l0f05                                                         ; a39c: ac 05 0f    ...
+    jsr sub_ca300                                                     ; a39f: 20 00 a3     ..
+    ldy l0f06                                                         ; a3a2: ac 06 0f    ...
+    jsr sub_ca32b                                                     ; a3a5: 20 2b a3     +.
+    ldy l0f07                                                         ; a3a8: ac 07 0f    ...
+    jsr sub_ca362                                                     ; a3ab: 20 62 a3     b.
+    plp                                                               ; a3ae: 28          (
+    bcs ca3b4                                                         ; a3af: b0 03       ..
+    jmp c9cc7                                                         ; a3b1: 4c c7 9c    L..
+
+; &a3b4 referenced 1 time by &a3af
+.ca3b4
+    lda l1071                                                         ; a3b4: ad 71 10    .q.
+    tax                                                               ; a3b7: aa          .
+    and #4                                                            ; a3b8: 29 04       ).
+    php                                                               ; a3ba: 08          .
+    txa                                                               ; a3bb: 8a          .
+    and #&fb                                                          ; a3bc: 29 fb       ).
+    sta l1071                                                         ; a3be: 8d 71 10    .q.
+    plp                                                               ; a3c1: 28          (
+    bne ca3e3                                                         ; a3c2: d0 1f       ..
+    lda #osbyte_scan_keyboard                                         ; a3c4: a9 79       .y
+    ldx #&81                                                          ; a3c6: a2 81       ..
+    jsr osbyte                                                        ; a3c8: 20 f4 ff     ..
+    txa                                                               ; a3cb: 8a          .
+    bpl ca3e3                                                         ; a3cc: 10 15       ..
+; &a3ce referenced 1 time by &a3e6
+.loop_ca3ce
+    rts                                                               ; a3ce: 60          `
+
+    equs "L.!BOOT"                                                    ; a3cf: 4c 2e 21... L.!
+    equb &0d                                                          ; a3d6: 0d          .
+    equs "E.!BOOT"                                                    ; a3d7: 45 2e 21... E.!
+    equb &0d                                                          ; a3de: 0d          .
+; &a3df referenced 1 time by &a3e8
+.la3df
+    equb &de, &cf, &d1, &d7                                           ; a3df: de cf d1... ...
+
+; &a3e3 referenced 2 times by &a3c2, &a3cc
+.ca3e3
+    ldy l0e05                                                         ; a3e3: ac 05 0e    ...
+    beq loop_ca3ce                                                    ; a3e6: f0 e6       ..
+; &a3e8 referenced 1 time by &a28e
+.ca3e8
+    ldx la3df,y                                                       ; a3e8: be df a3    ...
+    ldy #&a3                                                          ; a3eb: a0 a3       ..
+    jmp oscli                                                         ; a3ed: 4c f7 ff    L..
+
+; &a3f0 referenced 12 times by &8bae, &8bbd, &8bc5, &8bd2, &8c00, &8c07, &932a, &9332, &a145, &a14a, &a15a, &a191
+.la3f0
+la3f1 = la3f0+1
+la3f2 = la3f0+2
+    equs "Close"                                                      ; a3f0: 43 6c 6f... Clo
+; &a3f1 referenced 3 times by &8c93, &a13b, &b326
+; &a3f2 referenced 3 times by &8c8f, &a137, &b353
+    equb &80                                                          ; a3f5: 80          .
+    equw sub_cb994-1                                                  ; a3f6: 93 b9       ..
+    equs "Dump"                                                       ; a3f8: 44 75 6d... Dum
+    equb &c4                                                          ; a3fc: c4          .
+    equw sub_cba1b-1                                                  ; a3fd: 1a ba       ..
+    equs "Net"                                                        ; a3ff: 4e 65 74    Net
+    equb &80                                                          ; a402: 80          .
+    equw sub_c8b1a-1                                                  ; a403: 19 8b       ..
+    equs "Pollps"                                                     ; a405: 50 6f 6c... Pol
+    equb &88                                                          ; a40b: 88          .
+    equw sub_cb1c3-1                                                  ; a40c: c2 b1       ..
+    equs "Print"                                                      ; a40e: 50 72 69... Pri
+    equb &cc                                                          ; a413: cc          .
+    equw sub_cb99d-1                                                  ; a414: 9c b9       ..
+    equs "Prot"                                                       ; a416: 50 72 6f... Pro
+    equb &8e                                                          ; a41a: 8e          .
+    equw sub_cb30c-1                                                  ; a41b: 0b b3       ..
+    equs "PS"                                                         ; a41d: 50 53       PS
+    equb &88                                                          ; a41f: 88          .
+    equw sub_cafee-1                                                  ; a420: ed af       ..
+    equs "Roff"                                                       ; a422: 52 6f 66... Rof
+    equb &80                                                          ; a426: 80          .
+    equw sub_c8ad4-1                                                  ; a427: d3 8a       ..
+    equs "Type"                                                       ; a429: 54 79 70... Typ
+    equb &cc                                                          ; a42d: cc          .
+    equw sub_cb99a-1                                                  ; a42e: 99 b9       ..
+    equs "Unprot"                                                     ; a430: 55 6e 70... Unp
+    equb &8e                                                          ; a436: 8e          .
+    equw sub_cb33d-1                                                  ; a437: 3c b3       <.
+    equb &80                                                          ; a439: 80          .
+    equs "Access"                                                     ; a43a: 41 63 63... Acc
+    equb &c9                                                          ; a440: c9          .
+    equw sub_c92e6-1                                                  ; a441: e5 92       ..
+    equs "Bye"                                                        ; a443: 42 79 65    Bye
+    equb &80                                                          ; a446: 80          .
+    equw sub_c949e-1                                                  ; a447: 9d 94       ..
+    equs "Cdir"                                                       ; a449: 43 64 69... Cdi
+    equb &c6                                                          ; a44d: c6          .
+    equw sub_cad10-1                                                  ; a44e: 0f ad       ..
+    equs "Delete"                                                     ; a450: 44 65 6c... Del
+    equb &c3                                                          ; a456: c3          .
+    equw sub_c92e6-1                                                  ; a457: e5 92       ..
+    equs "Dir"                                                        ; a459: 44 69 72    Dir
+    equb &81                                                          ; a45c: 81          .
+    equw sub_c93dd-1                                                  ; a45d: dc 93       ..
+    equs "Ex"                                                         ; a45f: 45 78       Ex
+    equb &81                                                          ; a461: 81          .
+    equw sub_cad6b-1                                                  ; a462: 6a ad       j.
+    equs "Flip"                                                       ; a464: 46 6c 69... Fli
+    equb &80                                                          ; a468: 80          .
+    equw sub_ca356-1                                                  ; a469: 55 a3       U.
+    equs "FS"                                                         ; a46b: 46 53       FS
+    equb &8b                                                          ; a46d: 8b          .
+    equw sub_ca07b-1                                                  ; a46e: 7a a0       z.
+    equs "Info"                                                       ; a470: 49 6e 66... Inf
+    equb &c3                                                          ; a474: c3          .
+    equw sub_c92e6-1                                                  ; a475: e5 92       ..
+; &a477 referenced 1 time by &8daf
+.la477
+    equs "I am"                                                       ; a477: 49 20 61... I a
+    equb &c2                                                          ; a47b: c2          .
+    equw sub_c8d79-1                                                  ; a47c: 78 8d       x.
+    equs "Lcat"                                                       ; a47e: 4c 63 61... Lca
+    equb &81                                                          ; a482: 81          .
+    equw sub_cad5f-1                                                  ; a483: 5e ad       ^.
+    equs "Lex"                                                        ; a485: 4c 65 78    Lex
+    equb &81                                                          ; a488: 81          .
+    equw sub_cad65-1                                                  ; a489: 64 ad       d.
+    equs "Lib"                                                        ; a48b: 4c 69 62    Lib
+    equb &c5                                                          ; a48e: c5          .
+    equw sub_c92e6-1                                                  ; a48f: e5 92       ..
+    equs "Pass"                                                       ; a491: 50 61 73... Pas
+    equb &c7                                                          ; a495: c7          .
+    equw c8dbc-1                                                      ; a496: bb 8d       ..
+    equs "Remove"                                                     ; a498: 52 65 6d... Rem
+    equb &c3                                                          ; a49e: c3          .
+    equw sub_caf66-1                                                  ; a49f: 65 af       e.
+    equs "Rename"                                                     ; a4a1: 52 65 6e... Ren
+    equb &ca                                                          ; a4a7: ca          .
+    equw sub_c938b-1                                                  ; a4a8: 8a 93       ..
+    equs "Wipe"                                                       ; a4aa: 57 69 70... Wip
+    equb &81                                                          ; a4ae: 81          .
+    equw sub_cb359-1                                                  ; a4af: 58 b3       X.
+    equb &80                                                          ; a4b1: 80          .
+    equw c8e15-1                                                      ; a4b2: 14 8e       ..
+    equs "Net"                                                        ; a4b4: 4e 65 74    Net
+    equb &80                                                          ; a4b7: 80          .
+    equw sub_c8b96-1                                                  ; a4b8: 95 8b       ..
+    equs "Utils"                                                      ; a4ba: 55 74 69... Uti
+    equb &80                                                          ; a4bf: 80          .
+    equw sub_c8b92-1                                                  ; a4c0: 91 8b       ..
+    equb &80                                                          ; a4c2: 80          .
+    equs "Halt"                                                       ; a4c3: 48 61 6c... Hal
+    equb &fc, &20, &df                                                ; a4c7: fc 20 df    . .
+    equs "JSR"                                                        ; a4ca: 4a 53 52    JSR
+    equb &fc,   4, &fb                                                ; a4cd: fc 04 fb    ...
+    equs "Peek"                                                       ; a4d0: 50 65 65... Pee
+    equb &fc,   1, &fe                                                ; a4d4: fc 01 fe    ...
+    equs "Poke"                                                       ; a4d7: 50 6f 6b... Pok
+    equb &fc,   2, &fd                                                ; a4db: fc 02 fd    ...
+    equs "Proc"                                                       ; a4de: 50 72 6f... Pro
+    equb &fc,   8, &f7                                                ; a4e2: fc 08 f7    ...
+    equs "Utils"                                                      ; a4e5: 55 74 69... Uti
+    equb &a9, &10, &ef, &80                                           ; a4ea: a9 10 ef... ...
+
+.sub_ca4ee
+    clc                                                               ; a4ee: 18          .
+    lda l00ef                                                         ; a4ef: a5 ef       ..
+    sbc #&0d                                                          ; a4f1: e9 0d       ..
+    bmi ca522                                                         ; a4f3: 30 2d       0-
+    cmp #7                                                            ; a4f5: c9 07       ..
+    bcs ca522                                                         ; a4f7: b0 29       .)
+    tax                                                               ; a4f9: aa          .
+    ldy #6                                                            ; a4fa: a0 06       ..
+; &a4fc referenced 1 time by &a507
+.loop_ca4fc
+    lda l00a9,y                                                       ; a4fc: b9 a9 00    ...
+    pha                                                               ; a4ff: 48          H
+    lda l00ed,y                                                       ; a500: b9 ed 00    ...
+    sta l00a9,y                                                       ; a503: 99 a9 00    ...
+    dey                                                               ; a506: 88          .
+    bne loop_ca4fc                                                    ; a507: d0 f3       ..
+    jsr sub_ca516                                                     ; a509: 20 16 a5     ..
+    ldy #&fa                                                          ; a50c: a0 fa       ..
+; &a50e referenced 1 time by &a513
+.loop_ca50e
+    pla                                                               ; a50e: 68          h
+    sta lffb0,y                                                       ; a50f: 99 b0 ff    ...
+    iny                                                               ; a512: c8          .
+    bne loop_ca50e                                                    ; a513: d0 f9       ..
+    rts                                                               ; a515: 60          `
+
+; &a516 referenced 1 time by &a509
+.sub_ca516
+    lda la52a,x                                                       ; a516: bd 2a a5    .*.
+    pha                                                               ; a519: 48          H
+    lda la523,x                                                       ; a51a: bd 23 a5    .#.
+    pha                                                               ; a51d: 48          H
+    lda (l00ac),y                                                     ; a51e: b1 ac       ..
+    sty l00a9                                                         ; a520: 84 a9       ..
+; &a522 referenced 2 times by &a4f3, &a4f7
+.ca522
+    rts                                                               ; a522: 60          `
+
+; &a523 referenced 1 time by &a51a
+.la523
+    equb &30, &21, &a3, &c0, &18, &2d, &c4                            ; a523: 30 21 a3... 0!.
+; &a52a referenced 1 time by &a516
+.la52a
+    equb &a5, &a5, &a5, &a5, &a6, &a6, &a8, &2c, &6c, &0d, &10,   8   ; a52a: a5 a5 a5... ...
+    equb &c9,   4, &f0,   5, &a9,   8, &85, &a9, &60, &a2,   0, &a0   ; a536: c9 04 f0... ...
+    equb &10, &20, &ad, &94, &ad,   9, &0f, &20, &95, &a5, &8d, &0b   ; a542: 10 20 ad... . .
+    equb &0f, &ad,   8, &0f, &20, &95, &a5, &8d, &0a, &0f, &ad,   7   ; a54e: 0f ad 08... ...
+    equb &0f, &20, &95, &a5, &8d,   9, &0f, &a9,   0, &8d,   8, &0f   ; a55a: 0f 20 95... . .
+    equb &ad,   6, &0f, &48, &ad,   5, &0f, &20, &95, &a5, &8d,   7   ; a566: ad 06 0f... ...
+    equb &0f                                                          ; a572: 0f          .
+    equs "hH)"                                                        ; a573: 68 48 29    hH)
+    equb &0f, &20, &95, &a5, &8d,   6, &0f                            ; a576: 0f 20 95... . .
+    equs "hJJJJiQ "                                                   ; a57d: 68 4a 4a... hJJ
+    equb &95, &a5, &8d,   5, &0f, &a0,   6, &b9,   5, &0f, &91, &ac   ; a585: 95 a5 8d... ...
+    equb &88, &10, &f8, &60,   8, &aa, &f0,   9, &f8, &a9,   0, &18   ; a591: 88 10 f8... ...
+    equb &69,   1, &ca, &d0, &fa, &28, &60, &0e, &60, &0d, &98, &b0   ; a59d: 69 01 ca... i..
+    equb   3, &91, &ac, &60, &a5, &9d, &85, &ab, &85, &a1, &a9, &6f   ; a5a9: 03 91 ac... ...
+    equb &85, &aa, &85, &a0, &a2, &0f, &20, &f8, &a6, &4c, &8c, &85   ; a5b5: 85 aa 85... ...
+    equb &a6, &9f, &86, &ab, &84, &aa, &6e, &61, &0d, &a8, &85, &ae   ; a5c1: a6 9f 86... ...
+    equb &d0, &1b, &a9,   3, &20, &ce, &a0, &b0                       ; a5cd: d0 1b a9... ...
+    equs "=JJ"                                                        ; a5d5: 3d 4a 4a    =JJ
+    equb &aa, &b1, &aa, &f0, &36, &c9, &3f, &f0,   4, &e8, &8a, &d0   ; a5d8: aa b1 aa... ...
+    equb &ec, &8a, &a2,   0, &81, &ac, &20, &ce, &a0, &b0, &24, &88   ; a5e4: ec 8a a2... ...
+    equb &84, &aa, &a9, &c0, &a0,   1, &a2, &0b, &c4, &ae, &71, &aa   ; a5f0: 84 aa a9... ...
+    equb &f0,   3, &30, &0e, &18, &20, &f8, &a6, &b0, &0f, &a9, &3f   ; a5fc: f0 03 30... ..0
+    equb &a0,   1, &91, &aa, &d0,   7, &69,   1, &d0, &ee, &88, &91   ; a608: a0 01 91... ...
+    equb &ac, &2e, &61, &0d, &60, &a5, &9d, &85, &ab, &a0, &7f, &b1   ; a614: ac 2e 61... ..a
+    equb &9c, &c8, &84, &aa, &aa, &ca, &a0,   0, &20, &f8, &a6, &4c   ; a620: 9c c8 84... ...
+    equb &dd, &ac, &aa, &c9, &13, &b0,   8, &bd, &4e, &a6, &48, &bd   ; a62c: dd ac aa... ...
+    equb &3c, &a6                                                     ; a638: 3c a6       <.
+    equs "H`_r"                                                       ; a63a: 48 60 5f... H`_
+    equb   6, &12                                                     ; a63e: 06 12       ..
+    equs "'-3C"                                                       ; a640: 27 2d 33... '-3
+    equb &e3, &ec, &fa,   1, &e7, &ea,   6, &0e, &19, &24, &a6, &a6   ; a644: e3 ec fa... ...
+    equb &a7, &a7, &a7, &a7, &a7, &a7, &a7, &a7, &a7, &a8, &a6, &a6   ; a650: a7 a7 a7... ...
+    equb &a8, &a8, &a8, &a8, &2c, &6c, &0d, &30,   3, &4c, &49, &a7   ; a65c: a8 a8 a8... ...
+    equb &a0,   2, &b9, &ff, &0d, &91, &f0, &88, &d0, &f8             ; a668: a0 02 b9... ...
+    equs "`,l"                                                        ; a672: 60 2c 6c    `,l
+    equb &0d, &10, &ed, &a0,   0, &20, &99, &b7, &a0,   2, &b1, &f0   ; a675: 0d 10 ed... ...
+    equb &99, &ff, &0d, &88, &d0, &f8, &20,   9, &8e, &a2, &0f, &bd   ; a681: 99 ff 0d... ...
+    equb &60, &10, &a8, &29,   2, &f0, &50, &98, &29, &df, &9d, &60   ; a68d: 60 10 a8... `..
+    equb &10, &a8, &20, &86, &b5, &d0, &44, &18, &98, &29,   4, &f0   ; a699: 10 a8 20... ..
+    equb &10, &98,   9, &20, &a8, &bd, &30, &10, &8d,   2, &0e, &8a   ; a6a5: 10 98 09... ...
+    equb &69, &20, &8d, &72, &10, &98, &29,   8, &f0, &10, &98,   9   ; a6b1: 69 20 8d... i .
+    equb &20, &a8, &bd, &30, &10, &8d,   3, &0e, &8a, &69, &20, &8d   ; a6bd: 20 a8 bd...  ..
+    equb &73, &10, &98, &29, &10, &f0, &10, &98,   9, &20, &a8, &bd   ; a6c9: 73 10 98... s..
+    equb &30, &10, &8d,   4, &0e, &8a, &69, &20, &8d, &74, &10, &98   ; a6d5: 30 10 8d... 0..
+    equb &9d, &60, &10, &ca, &10, &a5, &60, &18, &90,   1, &38, &a9   ; a6e1: 9d 60 10... .`.
+    equb &17, &85, &aa, &a5, &9d, &85, &ab, &a0,   1, &a2,   5, &90   ; a6ed: 17 85 aa... ...
+    equb   4, &b1, &ac, &91, &aa, &b1, &aa, &91, &ac, &c8, &ca, &10   ; a6f9: 04 b1 ac... ...
+    equb &f2, &60, &a5, &9f, &85, &ab, &c8, &98, &85, &aa, &aa, &18   ; a705: f2 60 a5... .`.
+    equb &90, &e5, &c8, &b1, &ac, &c8, &91, &9e, &b1, &ac, &c8, &91   ; a711: 90 e5 c8... ...
+    equb &9e, &20, &65, &a8, &51, &9e, &d0,   2, &91, &9e, &60, &ad   ; a71d: 9e 20 65... . e
+    equb &68, &0d, &4c, &fe, &a7, &c8, &b1, &ac, &4c, &36, &b3, &2c   ; a729: 68 0d 4c... h.L
+    equb &6c, &0d, &10, &10, &a0,   3, &b9, &71, &10, &91, &ac, &88   ; a735: 6c 0d 10... l..
+    equb &d0, &f8                                                     ; a741: d0 f8       ..
+    equs "`,l"                                                        ; a743: 60 2c 6c    `,l
+    equb &0d, &30,   6, &a9,   0, &a8, &91, &ac, &60, &a0,   1, &b1   ; a746: 0d 30 06... .0.
+    equb &ac, &c9, &20, &90, &0a, &c9, &30, &b0,   6, &aa, &bd, &10   ; a752: ac c9 20... ..
+    equb &10, &d0,   7, &a9,   0, &aa, &81, &ac, &f0, &26, &bd, &40   ; a75e: 10 d0 07... ...
+    equb &10, &29,   2, &f0, &f2, &8a, &99, &71, &10, &bd, &10, &10   ; a76a: 10 29 02... .).
+    equb &99,   1, &0e, &c0,   1, &d0, &18, &98, &48, &a0,   4, &20   ; a776: 99 01 0e... ...
+    equb &bf, &a7, &68, &a8, &bd, &40, &10,   9, &24, &9d, &40, &10   ; a782: bf a7 68... ..h
+    equb &c8, &c0,   4, &d0, &be, &88, &60, &c0,   2, &d0, &13, &98   ; a78e: c8 c0 04... ...
+    equb &48, &a0,   8, &20, &bf, &a7, &68, &a8, &bd, &40, &10,   9   ; a79a: 48 a0 08... H..
+    equb &28, &9d, &40, &10, &d0, &e2, &98, &48, &a0, &10, &20, &bf   ; a7a6: 28 9d 40... (.@
+    equb &a7, &68, &a8, &bd, &40, &10,   9, &30, &9d, &40, &10, &d0   ; a7b2: a7 68 a8... .h.
+    equb &cf, &8a, &48, &a2, &0f, &bd, &60, &10, &2a, &2a, &10, &14   ; a7be: cf 8a 48... ..H
+    equb &98, &3d, &60, &10, &f0,   5, &98,   9, &20, &d0,   1, &98   ; a7ca: 98 3d 60... .=`
+    equb &49, &ff, &3d, &60, &10, &9d, &60, &10, &ca, &10, &e2, &68   ; a7d6: 49 ff 3d... I.=
+    equb &aa, &60, &a0,   1, &b1, &9c, &a0,   0, &4c, &fe, &a7, &a0   ; a7e2: aa 60 a0... .`.
+    equb &7f, &b1, &9c, &a0,   1, &91, &ac, &c8, &a9, &80, &91, &ac   ; a7ee: 7f b1 9c... ...
+    equb &60, &ad,   9, &0e, &c8, &91, &ac, &60, &ad,   8, &0e, &10   ; a7fa: 60 ad 09... `..
+    equb &f7, &a9, &6f, &38, &ed, &6b, &0d, &b0, &ef, &c8, &b9, &6c   ; a806: f7 a9 6f... ..o
+    equb &0d, &91, &ac, &c0,   3, &d0, &f6, &60, &c8, &b1, &ac, &99   ; a812: 0d 91 ac... ...
+    equb &6c, &0d, &c0,   3, &d0, &f6                                 ; a81e: 6c 0d c0... l..
+    equs "` e"                                                        ; a824: 60 20 65    ` e
+    equb &a8, &a0,   0, &ad, &71, &0d, &c9, &ff, &d0,   6, &98, &91   ; a827: a8 a0 00... ...
+    equb &ac, &c8, &d0, &13, &c8, &91, &ac, &c8, &c8, &b1, &ac, &f0   ; a833: ac c8 d0... ...
+    equb   7, &4d                                                     ; a83f: 07 4d       .M
+; &a841 referenced 1 time by &a875
+.la841
+    equb &71, &0d, &d0,   7, &f0,   3, &ad,   1, &0e, &91, &ac, &60   ; a841: 71 0d d0... q..
+; &a84d referenced 1 time by &a87a
+.la84d
+    equb &82, &9c, &ff, &ff                                           ; a84d: 82 9c ff... ...
+    equs "BRIDGE"                                                     ; a851: 42 52 49... BRI
+    equb &9c,   0, &7f, &9c,   0,   0, &71, &0d, &ff, &ff, &73, &0d   ; a857: 9c 00 7f... ...
+    equb &ff, &ff                                                     ; a863: ff ff       ..
+
+; &a865 referenced 2 times by &8e09, &a0b4
+.sub_ca865
+    lda l0d71                                                         ; a865: ad 71 0d    .q.
+    cmp #&ff                                                          ; a868: c9 ff       ..
+    bne ca8c4                                                         ; a86a: d0 58       .X
+    tya                                                               ; a86c: 98          .
+    pha                                                               ; a86d: 48          H
+    ldy #&18                                                          ; a86e: a0 18       ..
+    ldx #&0b                                                          ; a870: a2 0b       ..
+    ror l0d61                                                         ; a872: 6e 61 0d    na.
+; &a875 referenced 1 time by &a881
+.loop_ca875
+    lda la841,y                                                       ; a875: b9 41 a8    .A.
+    sta (l009e),y                                                     ; a878: 91 9e       ..
+    lda la84d,x                                                       ; a87a: bd 4d a8    .M.
+    sta l00c0,x                                                       ; a87d: 95 c0       ..
+    iny                                                               ; a87f: c8          .
+    dex                                                               ; a880: ca          .
+    bpl loop_ca875                                                    ; a881: 10 f2       ..
+    stx l0d71                                                         ; a883: 8e 71 0d    .q.
+    rol l0d61                                                         ; a886: 2e 61 0d    .a.
+; &a889 referenced 2 times by &a88c, &a8b3
+.ca889
+    asl l0d60                                                         ; a889: 0e 60 0d    .`.
+    bcc ca889                                                         ; a88c: 90 fb       ..
+    lda #&82                                                          ; a88e: a9 82       ..
+    sta l00c0                                                         ; a890: 85 c0       ..
+    lda #&c0                                                          ; a892: a9 c0       ..
+    sta l00a0                                                         ; a894: 85 a0       ..
+    lda #0                                                            ; a896: a9 00       ..
+    sta l00a1                                                         ; a898: 85 a1       ..
+    jsr sub_c858c                                                     ; a89a: 20 8c 85     ..
+; &a89d referenced 1 time by &a89f
+.loop_ca89d
+    bit l00c0                                                         ; a89d: 24 c0       $.
+    bmi loop_ca89d                                                    ; a89f: 30 fc       0.
+    txa                                                               ; a8a1: 8a          .
+    pha                                                               ; a8a2: 48          H
+    lda #osbyte_vsync                                                 ; a8a3: a9 13       ..
+    jsr osbyte                                                        ; a8a5: 20 f4 ff     ..
+    pla                                                               ; a8a8: 68          h
+    tax                                                               ; a8a9: aa          .
+    ldy #&18                                                          ; a8aa: a0 18       ..
+    lda (l009e),y                                                     ; a8ac: b1 9e       ..
+    bmi ca8b5                                                         ; a8ae: 30 05       0.
+    jsr sub_cbc86                                                     ; a8b0: 20 86 bc     ..
+    bpl ca889                                                         ; a8b3: 10 d4       ..
+; &a8b5 referenced 1 time by &a8ae
+.ca8b5
+    lda #&3f ; '?'                                                    ; a8b5: a9 3f       .?
+    sta (l009e),y                                                     ; a8b7: 91 9e       ..
+    pla                                                               ; a8b9: 68          h
+    tay                                                               ; a8ba: a8          .
+    lda l0d71                                                         ; a8bb: ad 71 0d    .q.
+    tax                                                               ; a8be: aa          .
+    eor #&ff                                                          ; a8bf: 49 ff       I.
+    beq ca8c4                                                         ; a8c1: f0 01       ..
+    txa                                                               ; a8c3: 8a          .
+; &a8c4 referenced 2 times by &a86a, &a8c1
+.ca8c4
+    rts                                                               ; a8c4: 60          `
+
+    equb &c9,   1, &b0                                                ; a8c5: c9 01 b0    ...
+    equs "l,l"                                                        ; a8c8: 6c 2c 6c    l,l
+    equb &0d, &10, &f6, &a0                                           ; a8cb: 0d 10 f6... ...
+    equs "# 2"                                                        ; a8cf: 23 20 32    # 2
+    equb &af, &b9, &73, &94, &d0,   3, &b9, &e6, &0d, &91, &9e, &88   ; a8d2: af b9 73... ..s
+    equb &c0, &17, &d0, &f1, &c8, &84, &9a, &a0, &1c, &a5, &ac, &69   ; a8de: c0 17 d0... ...
+    equb   1, &20, &2b, &a9, &a0,   1, &b1, &ac, &a0, &20, &65, &ac   ; a8ea: 01 20 2b... . +
+    equb &20, &2b, &a9, &a0,   2, &a9, &90, &85, &98, &91, &ac, &c8   ; a8f6: 20 2b a9...  +.
+    equb &c8, &b9, &fe, &0d, &91, &ac, &c8, &c0,   7, &d0, &f6, &a5   ; a902: c8 b9 fe... ...
+    equb &9f, &85, &9b, &20, &76, &a9, &a0, &20, &a9, &ff, &91, &9e   ; a90e: 9f 85 9b... ...
+    equb &c8, &91, &9e, &a0, &19, &a9, &90, &91, &9e, &88, &a9, &7f   ; a91a: c8 91 9e... ...
+    equb &91, &9e, &4c, &dd, &95, &91, &9e, &c8, &a5, &ad, &69,   0   ; a926: 91 9e 4c... ..L
+    equb &91, &9e, &60,   8, &a0,   1, &b1, &ac, &aa, &c8, &b1, &ac   ; a932: 91 9e 60... ..`
+    equb &c8, &84, &aa, &a0, &72, &91, &9c, &88, &8a, &91, &9c, &28   ; a93e: c8 84 aa... ...
+    equb &d0, &1f, &a4, &aa, &e6, &aa, &b1, &ac, &f0, &16, &a0, &7d   ; a94a: d0 1f a4... ...
+    equb &91, &9c                                                     ; a956: 91 9c       ..
+    equs "H |"                                                        ; a958: 48 20 7c    H |
+    equb &aa, &38, &66, &98, &20, &76, &a9, &ca, &d0, &fd, &68, &49   ; a95b: aa 38 66... .8f
+    equb &0d, &d0, &e2                                                ; a967: 0d d0 e2    ...
+    equs "` |"                                                        ; a96a: 60 20 7c    ` |
+    equb &aa, &a0, &7b, &b1, &9c, &69,   3, &91, &9c                  ; a96d: aa a0 7b... ..{
+    equs "XL?"                                                        ; a976: 58 4c 3f    XL?
+    equb &98,   8, &48, &8a, &48, &98, &48, &ba, &bd,   3,   1, &c9   ; a979: 98 08 48... ..H
+    equb   9, &b0,   4, &aa, &20, &93, &a9, &68, &a8, &68, &aa        ; a985: 09 b0 04... ...
+    equs "h(`"                                                        ; a990: 68 28 60    h(`
+    equb &bd, &a7, &a9, &48, &bd, &9e, &a9, &48, &a5, &ef, &60, &57   ; a993: bd a7 a9... ...
+    equb &ec, &ec, &ec, &af, &d7, &57, &e1, &50, &8e, &aa, &aa, &aa   ; a99f: ec ec ec... ...
+    equb &a9, &aa, &8e, &a9, &aa, &ba, &7e,   6,   1, &1e,   6,   1   ; a9ab: a9 aa 8e... ...
+    equb &98, &a0, &da, &91, &9e, &a9,   0                            ; a9b7: 98 a0 da... ...
+
+; &a9be referenced 1 time by &8ae7
+.sub_ca9be
+    ldy #&d9                                                          ; a9be: a0 d9       ..
+    sta (l009e),y                                                     ; a9c0: 91 9e       ..
+    lda #&80                                                          ; a9c2: a9 80       ..
+    ldy #&0c                                                          ; a9c4: a0 0c       ..
+    sta (l009e),y                                                     ; a9c6: 91 9e       ..
+    lda l009a                                                         ; a9c8: a5 9a       ..
+    pha                                                               ; a9ca: 48          H
+    lda l009b                                                         ; a9cb: a5 9b       ..
+    pha                                                               ; a9cd: 48          H
+    sty l009a                                                         ; a9ce: 84 9a       ..
+    ldx l009f                                                         ; a9d0: a6 9f       ..
+    stx l009b                                                         ; a9d2: 86 9b       ..
+    jsr sub_c983f                                                     ; a9d4: 20 3f 98     ?.
+    lda #&3f ; '?'                                                    ; a9d7: a9 3f       .?
+    sta (l009a,x)                                                     ; a9d9: 81 9a       ..
+    pla                                                               ; a9db: 68          h
+    sta l009b                                                         ; a9dc: 85 9b       ..
+    pla                                                               ; a9de: 68          h
+    sta l009a                                                         ; a9df: 85 9a       ..
+    rts                                                               ; a9e1: 60          `
+
+    equb &a4, &f1, &c9, &81, &f0, &13, &a0,   1, &a2, &0a, &20, &36   ; a9e2: a4 f1 c9... ...
+    equb &aa, &f0, &0a, &88, &88, &a2, &11, &20, &36, &aa, &f0,   1   ; a9ee: aa f0 0a... ...
+    equb &c8, &a2,   2, &98, &f0, &35,   8, &10,   1, &e8, &a0, &dc   ; a9fa: c8 a2 02... ...
+    equb &b9, &15,   0, &91, &9e, &88, &c0, &da, &10, &f6, &8a, &20   ; aa06: b9 15 00... ...
+    equb &be, &a9, &28, &10, &1e, &a9, &7f, &a0, &0c, &91, &9e, &b1   ; aa12: be a9 28... ..(
+    equb &9e, &10, &fc, &ba, &a0, &dd, &b1, &9e,   9, &44, &d0,   4   ; aa1e: 9e 10 fc... ...
+    equb &88, &ca, &b1, &9e, &9d,   6,   1, &c0, &da, &d0, &f5, &60   ; aa2a: 88 ca b1... ...
+    equb &dd, &3f, &aa, &f0,   3, &ca, &10, &f8, &60,   4,   9, &0a   ; aa36: dd 3f aa... .?.
+    equb &14, &15, &9a, &9b, &e1, &e2, &e3, &e4, &0b, &0c, &0f, &79   ; aa42: 14 15 9a... ...
+    equb &7a, &86, &87, &a0, &0e, &c9,   7, &f0,   4, &c9,   8, &d0   ; aa4e: 7a 86 87... z..
+    equb &e3, &a2, &db, &86, &9e, &b1, &f0, &91, &9e, &88, &10, &f9   ; aa5a: e3 a2 db... ...
+    equb &c8, &c6, &9e, &a5, &ef, &91, &9e, &84, &9e, &a0, &14, &a9   ; aa66: c8 c6 9e... ...
+    equb &e9, &91, &9e, &a9,   1, &20, &be, &a9, &86, &9e, &a2, &0d   ; aa72: e9 91 9e... ...
+    equb &a0, &7c, &2c, &91, &94, &70,   5                            ; aa7e: a0 7c 2c... .|,
+
+; &aa85 referenced 1 time by &95a2
+.sub_caa85
+    ldy #&17                                                          ; aa85: a0 17       ..
+    ldx #&1a                                                          ; aa87: a2 1a       ..
+; &aa89 referenced 1 time by &ab4a
+.sub_caa89
+    clv                                                               ; aa89: b8          .
+; &aa8a referenced 1 time by &aaab
+.caa8a
+    lda laab1,x                                                       ; aa8a: bd b1 aa    ...
+    cmp #&fe                                                          ; aa8d: c9 fe       ..
+    beq caaad                                                         ; aa8f: f0 1c       ..
+    cmp #&fd                                                          ; aa91: c9 fd       ..
+    beq caaa9                                                         ; aa93: f0 14       ..
+    cmp #&fc                                                          ; aa95: c9 fc       ..
+    bne caaa1                                                         ; aa97: d0 08       ..
+    lda l009d                                                         ; aa99: a5 9d       ..
+    bvs caa9f                                                         ; aa9b: 70 02       p.
+    lda l009f                                                         ; aa9d: a5 9f       ..
+; &aa9f referenced 1 time by &aa9b
+.caa9f
+    sta l009b                                                         ; aa9f: 85 9b       ..
+; &aaa1 referenced 1 time by &aa97
+.caaa1
+    bvs caaa7                                                         ; aaa1: 70 04       p.
+    sta (l009e),y                                                     ; aaa3: 91 9e       ..
+    bvc caaa9                                                         ; aaa5: 50 02       P.
+; &aaa7 referenced 1 time by &aaa1
+.caaa7
+    sta (l009c),y                                                     ; aaa7: 91 9c       ..
+; &aaa9 referenced 2 times by &aa93, &aaa5
+.caaa9
+    dey                                                               ; aaa9: 88          .
+    dex                                                               ; aaaa: ca          .
+    bpl caa8a                                                         ; aaab: 10 dd       ..
+; &aaad referenced 1 time by &aa8f
+.caaad
+    iny                                                               ; aaad: c8          .
+    sty l009a                                                         ; aaae: 84 9a       ..
+    rts                                                               ; aab0: 60          `
+
+; &aab1 referenced 1 time by &aa8a
+.laab1
+    equb &85,   0, &fd, &fd, &7d, &fc, &ff, &ff, &7e, &fc, &ff, &ff   ; aab1: 85 00 fd... ...
+    equb   0,   0, &fe, &80, &93, &fd, &fd, &d9, &fc, &ff, &ff, &de   ; aabd: 00 00 fe... ...
+    equb &fc, &ff, &ff, &fe, &d1, &fd, &fd, &21, &fd, &ff, &ff, &fd   ; aac9: fc ff ff... ...
+    equb &fd, &ff, &ff, &ca, &e4, &f0, &d0, &0f, &a5, &d0, &6a, &b0   ; aad5: fd ff ff... ...
+    equb &0a                                                          ; aae1: 0a          .
+
+; &aae2 referenced 2 times by &8f27, &ab33
+.caae2
+    lda #&21 ; '!'                                                    ; aae2: a9 21       .!
+    sta l0d6b                                                         ; aae4: 8d 6b 0d    .k.
+    lda #&41 ; 'A'                                                    ; aae7: a9 41       .A
+    sta l0d6a                                                         ; aae9: 8d 6a 0d    .j.
+    rts                                                               ; aaec: 60          `
+
+    equb &c0,   4, &d0, &fb, &8a, &ca, &d0, &26, &ba, &1d,   6,   1   ; aaed: c0 04 d0... ...
+    equb &9d,   6,   1, &a9, &91, &a2,   3, &20, &f4, &ff, &b0, &e7   ; aaf9: 9d 06 01... ...
+    equb &98, &20, &12, &ab, &c0, &6e, &90, &ef, &20, &36, &ab, &90   ; ab05: 98 20 12... . .
+    equb &ea                                                          ; ab11: ea          .
+
+; &ab12 referenced 2 times by &ab2d, &abe4
+.sub_cab12
+    ldy l0d6b                                                         ; ab12: ac 6b 0d    .k.
+    sta (l009c),y                                                     ; ab15: 91 9c       ..
+    inc l0d6b                                                         ; ab17: ee 6b 0d    .k.
+    rts                                                               ; ab1a: 60          `
+
+; &ab1b referenced 1 time by &8f5a
+.sub_cab1b
+    ror a                                                             ; ab1b: 6a          j
+    bcc cab75                                                         ; ab1c: 90 57       .W
+    lda l0d6a                                                         ; ab1e: ad 6a 0d    .j.
+    pha                                                               ; ab21: 48          H
+    ror a                                                             ; ab22: 6a          j
+    pla                                                               ; ab23: 68          h
+    bcs cab33                                                         ; ab24: b0 0d       ..
+    ora #3                                                            ; ab26: 09 03       ..
+    sta l0d6a                                                         ; ab28: 8d 6a 0d    .j.
+    lda #3                                                            ; ab2b: a9 03       ..
+    jsr sub_cab12                                                     ; ab2d: 20 12 ab     ..
+    jsr cab36                                                         ; ab30: 20 36 ab     6.
+; &ab33 referenced 1 time by &ab24
+.cab33
+    jmp caae2                                                         ; ab33: 4c e2 aa    L..
+
+; &ab36 referenced 3 times by &ab30, &ab79, &abe7
+.cab36
+    ldy #8                                                            ; ab36: a0 08       ..
+    lda l0d6b                                                         ; ab38: ad 6b 0d    .k.
+    sta (l009e),y                                                     ; ab3b: 91 9e       ..
+    lda l009d                                                         ; ab3d: a5 9d       ..
+    iny                                                               ; ab3f: c8          .
+    sta (l009e),y                                                     ; ab40: 91 9e       ..
+    ldy #5                                                            ; ab42: a0 05       ..
+    sta (l009e),y                                                     ; ab44: 91 9e       ..
+    ldy #&0b                                                          ; ab46: a0 0b       ..
+    ldx #&26 ; '&'                                                    ; ab48: a2 26       .&
+    jsr sub_caa89                                                     ; ab4a: 20 89 aa     ..
+    dey                                                               ; ab4d: 88          .
+    lda l0d6a                                                         ; ab4e: ad 6a 0d    .j.
+    pha                                                               ; ab51: 48          H
+    rol a                                                             ; ab52: 2a          *
+    pla                                                               ; ab53: 68          h
+    eor #&80                                                          ; ab54: 49 80       I.
+    sta l0d6a                                                         ; ab56: 8d 6a 0d    .j.
+    rol a                                                             ; ab59: 2a          *
+    sta (l009e),y                                                     ; ab5a: 91 9e       ..
+    lda l00d0                                                         ; ab5c: a5 d0       ..
+    pha                                                               ; ab5e: 48          H
+    and #&fe                                                          ; ab5f: 29 fe       ).
+    sta l00d0                                                         ; ab61: 85 d0       ..
+    ldy #&21 ; '!'                                                    ; ab63: a0 21       .!
+    sty l0d6b                                                         ; ab65: 8c 6b 0d    .k.
+    lda #0                                                            ; ab68: a9 00       ..
+    tax                                                               ; ab6a: aa          .
+    ldy l009f                                                         ; ab6b: a4 9f       ..
+    cli                                                               ; ab6d: 58          X
+    jsr sub_cac24                                                     ; ab6e: 20 24 ac     $.
+    pla                                                               ; ab71: 68          h
+    sta l00d0                                                         ; ab72: 85 d0       ..
+    rts                                                               ; ab74: 60          `
+
+; &ab75 referenced 1 time by &ab1c
+.cab75
+    lda l0d6a                                                         ; ab75: ad 6a 0d    .j.
+    ror a                                                             ; ab78: 6a          j
+    bcc cab36                                                         ; ab79: 90 bb       ..
+    lda l00d0                                                         ; ab7b: a5 d0       ..
+    pha                                                               ; ab7d: 48          H
+    and #&fe                                                          ; ab7e: 29 fe       ).
+    sta l00d0                                                         ; ab80: 85 d0       ..
+    lda #&14                                                          ; ab82: a9 14       ..
+; &ab84 referenced 1 time by &abf8
+.cab84
+    pha                                                               ; ab84: 48          H
+    ldx #&0b                                                          ; ab85: a2 0b       ..
+    ldy #&2c ; ','                                                    ; ab87: a0 2c       .,
+; &ab89 referenced 1 time by &ab90
+.loop_cab89
+    lda lac80,x                                                       ; ab89: bd 80 ac    ...
+    sta (l009c),y                                                     ; ab8c: 91 9c       ..
+    dey                                                               ; ab8e: 88          .
+    dex                                                               ; ab8f: ca          .
+    bpl loop_cab89                                                    ; ab90: 10 f7       ..
+    stx l0098                                                         ; ab92: 86 98       ..
+    ldy #2                                                            ; ab94: a0 02       ..
+    lda (l009e),y                                                     ; ab96: b1 9e       ..
+    pha                                                               ; ab98: 48          H
+    iny                                                               ; ab99: c8          .
+    lda (l009e),y                                                     ; ab9a: b1 9e       ..
+    ldy #&24 ; '$'                                                    ; ab9c: a0 24       .$
+    sta (l009c),y                                                     ; ab9e: 91 9c       ..
+    dey                                                               ; aba0: 88          .
+    pla                                                               ; aba1: 68          h
+    sta (l009c),y                                                     ; aba2: 91 9c       ..
+    ldx #&0b                                                          ; aba4: a2 0b       ..
+    ldy #&0b                                                          ; aba6: a0 0b       ..
+; &aba8 referenced 1 time by &abb9
+.loop_caba8
+    lda lac8c,x                                                       ; aba8: bd 8c ac    ...
+    cmp #&fd                                                          ; abab: c9 fd       ..
+    beq cabb7                                                         ; abad: f0 08       ..
+    cmp #&fc                                                          ; abaf: c9 fc       ..
+    bne cabb5                                                         ; abb1: d0 02       ..
+    lda l009d                                                         ; abb3: a5 9d       ..
+; &abb5 referenced 1 time by &abb1
+.cabb5
+    sta (l009e),y                                                     ; abb5: 91 9e       ..
+; &abb7 referenced 1 time by &abad
+.cabb7
+    dey                                                               ; abb7: 88          .
+    dex                                                               ; abb8: ca          .
+    bpl loop_caba8                                                    ; abb9: 10 ed       ..
+    lda #&21 ; '!'                                                    ; abbb: a9 21       .!
+    sta l009a                                                         ; abbd: 85 9a       ..
+    lda l009d                                                         ; abbf: a5 9d       ..
+    sta l009b                                                         ; abc1: 85 9b       ..
+    jsr sub_c989c                                                     ; abc3: 20 9c 98     ..
+    jsr sub_c983f                                                     ; abc6: 20 3f 98     ?.
+    lda #0                                                            ; abc9: a9 00       ..
+    sta l009a                                                         ; abcb: 85 9a       ..
+    lda l009f                                                         ; abcd: a5 9f       ..
+    sta l009b                                                         ; abcf: 85 9b       ..
+    jsr sub_c95dd                                                     ; abd1: 20 dd 95     ..
+    ldy #&2d ; '-'                                                    ; abd4: a0 2d       .-
+    lda (l009c),y                                                     ; abd6: b1 9c       ..
+    beq cabde                                                         ; abd8: f0 04       ..
+    cmp #3                                                            ; abda: c9 03       ..
+    bne cabf3                                                         ; abdc: d0 15       ..
+; &abde referenced 1 time by &abd8
+.cabde
+    pla                                                               ; abde: 68          h
+    pla                                                               ; abdf: 68          h
+    sta l00d0                                                         ; abe0: 85 d0       ..
+    lda #0                                                            ; abe2: a9 00       ..
+    jsr sub_cab12                                                     ; abe4: 20 12 ab     ..
+    jsr cab36                                                         ; abe7: 20 36 ab     6.
+    lda l0d6a                                                         ; abea: ad 6a 0d    .j.
+    and #&f0                                                          ; abed: 29 f0       ).
+    sta l0d6a                                                         ; abef: 8d 6a 0d    .j.
+    rts                                                               ; abf2: 60          `
+
+; &abf3 referenced 1 time by &abdc
+.cabf3
+    tax                                                               ; abf3: aa          .
+    pla                                                               ; abf4: 68          h
+    sec                                                               ; abf5: 38          8
+    sbc #1                                                            ; abf6: e9 01       ..
+    bne cab84                                                         ; abf8: d0 8a       ..
+    cpx #1                                                            ; abfa: e0 01       ..
+    bne cac10                                                         ; abfc: d0 12       ..
+; &abfe referenced 1 time by &aff5
+.cabfe
+    lda #&a6                                                          ; abfe: a9 a6       ..
+    jsr generate_error_inline3                                        ; ac00: 20 d1 96     ..
+    equs "Printer busy", 0                                            ; ac03: 50 72 69... Pri
+
+; &ac10 referenced 1 time by &abfc
+.cac10
+    lda #&a7                                                          ; ac10: a9 a7       ..
+    jsr generate_error_inline3                                        ; ac12: 20 d1 96     ..
+    equs "Printer jammed", 0                                          ; ac15: 50 72 69... Pri
+
+; &ac24 referenced 3 times by &9509, &ab6e, &b951
+.sub_cac24
+    stx l009a                                                         ; ac24: 86 9a       ..
+    sty l009b                                                         ; ac26: 84 9b       ..
+    pha                                                               ; ac28: 48          H
+    ora #0                                                            ; ac29: 09 00       ..
+    beq cac4a                                                         ; ac2b: f0 1d       ..
+    ldx #&ff                                                          ; ac2d: a2 ff       ..
+    tay                                                               ; ac2f: a8          .
+; &ac30 referenced 2 times by &ac39, &ac43
+.cac30
+    tya                                                               ; ac30: 98          .
+    inx                                                               ; ac31: e8          .
+    cmp l1030,x                                                       ; ac32: dd 30 10    .0.
+    beq cac3f                                                         ; ac35: f0 08       ..
+    cpx #&0f                                                          ; ac37: e0 0f       ..
+    bne cac30                                                         ; ac39: d0 f5       ..
+    lda #0                                                            ; ac3b: a9 00       ..
+    beq cac4a                                                         ; ac3d: f0 0b       ..
+; &ac3f referenced 1 time by &ac35
+.cac3f
+    tay                                                               ; ac3f: a8          .
+    jsr sub_cb586                                                     ; ac40: 20 86 b5     ..
+    bne cac30                                                         ; ac43: d0 eb       ..
+    lda l1060,x                                                       ; ac45: bd 60 10    .`.
+    and #1                                                            ; ac48: 29 01       ).
+; &ac4a referenced 2 times by &ac2b, &ac3d
+.cac4a
+    ldy #0                                                            ; ac4a: a0 00       ..
+    ora (l009a),y                                                     ; ac4c: 11 9a       ..
+    pha                                                               ; ac4e: 48          H
+    sta (l009a),y                                                     ; ac4f: 91 9a       ..
+    jsr sub_c983f                                                     ; ac51: 20 3f 98     ?.
+    lda #&ff                                                          ; ac54: a9 ff       ..
+    ldy #8                                                            ; ac56: a0 08       ..
+    sta (l009a),y                                                     ; ac58: 91 9a       ..
+    iny                                                               ; ac5a: c8          .
+    sta (l009a),y                                                     ; ac5b: 91 9a       ..
+    pla                                                               ; ac5d: 68          h
+    tax                                                               ; ac5e: aa          .
+    ldy #&d1                                                          ; ac5f: a0 d1       ..
+    pla                                                               ; ac61: 68          h
+    pha                                                               ; ac62: 48          H
+    beq cac67                                                         ; ac63: f0 02       ..
+    ldy #&90                                                          ; ac65: a0 90       ..
+; &ac67 referenced 1 time by &ac63
+.cac67
+    tya                                                               ; ac67: 98          .
+    ldy #1                                                            ; ac68: a0 01       ..
+    sta (l009a),y                                                     ; ac6a: 91 9a       ..
+    txa                                                               ; ac6c: 8a          .
+    dey                                                               ; ac6d: 88          .
+    pha                                                               ; ac6e: 48          H
+; &ac6f referenced 1 time by &ac7b
+.loop_cac6f
+    lda #&7f                                                          ; ac6f: a9 7f       ..
+    sta (l009a),y                                                     ; ac71: 91 9a       ..
+    jsr sub_c95dd                                                     ; ac73: 20 dd 95     ..
+    pla                                                               ; ac76: 68          h
+    pha                                                               ; ac77: 48          H
+    eor (l009a),y                                                     ; ac78: 51 9a       Q.
+    ror a                                                             ; ac7a: 6a          j
+    bcs loop_cac6f                                                    ; ac7b: b0 f2       ..
+    pla                                                               ; ac7d: 68          h
+    pla                                                               ; ac7e: 68          h
+    rts                                                               ; ac7f: 60          `
+
+; &ac80 referenced 1 time by &ab89
+.lac80
+    equb &80, &9f,   0,   0, &59, &8e, &ff, &ff, &61, &8e, &ff, &ff   ; ac80: 80 9f 00... ...
+; &ac8c referenced 1 time by &aba8
+.lac8c
+    equb &7f, &9e, &fd, &fd, &2d, &fc, &ff, &ff, &30, &fc, &ff, &ff   ; ac8c: 7f 9e fd... ...
+
+.sub_cac98
+    lda l00aa                                                         ; ac98: a5 aa       ..
+    pha                                                               ; ac9a: 48          H
+    lda #&e9                                                          ; ac9b: a9 e9       ..
+    sta l009e                                                         ; ac9d: 85 9e       ..
+    ldy #0                                                            ; ac9f: a0 00       ..
+    sty l00aa                                                         ; aca1: 84 aa       ..
+    lda l0350                                                         ; aca3: ad 50 03    .P.
+    sta (l009e),y                                                     ; aca6: 91 9e       ..
+    inc l009e                                                         ; aca8: e6 9e       ..
+    lda l0351                                                         ; acaa: ad 51 03    .Q.
+    pha                                                               ; acad: 48          H
+    tya                                                               ; acae: 98          .
+; &acaf referenced 1 time by &acce
+.loop_cacaf
+    sta (l009e),y                                                     ; acaf: 91 9e       ..
+    ldx l009e                                                         ; acb1: a6 9e       ..
+    ldy l009f                                                         ; acb3: a4 9f       ..
+    lda #osword_read_palette                                          ; acb5: a9 0b       ..
+    jsr osword                                                        ; acb7: 20 f1 ff     ..
+    pla                                                               ; acba: 68          h
+    ldy #0                                                            ; acbb: a0 00       ..
+    sta (l009e),y                                                     ; acbd: 91 9e       ..
+    iny                                                               ; acbf: c8          .
+    lda (l009e),y                                                     ; acc0: b1 9e       ..
+    pha                                                               ; acc2: 48          H
+    ldx l009e                                                         ; acc3: a6 9e       ..
+    inc l009e                                                         ; acc5: e6 9e       ..
+    inc l00aa                                                         ; acc7: e6 aa       ..
+    dey                                                               ; acc9: 88          .
+    lda l00aa                                                         ; acca: a5 aa       ..
+    cpx #&f9                                                          ; accc: e0 f9       ..
+    bne loop_cacaf                                                    ; acce: d0 df       ..
+    pla                                                               ; acd0: 68          h
+    sty l00aa                                                         ; acd1: 84 aa       ..
+    inc l009e                                                         ; acd3: e6 9e       ..
+    jsr sub_cace4                                                     ; acd5: 20 e4 ac     ..
+    inc l009e                                                         ; acd8: e6 9e       ..
+    pla                                                               ; acda: 68          h
+    sta l00aa                                                         ; acdb: 85 aa       ..
+; &acdd referenced 3 times by &9586, &95ae, &95d5
+.cacdd
+    lda l0d69                                                         ; acdd: ad 69 0d    .i.
+    sta l0d68                                                         ; ace0: 8d 68 0d    .h.
+    rts                                                               ; ace3: 60          `
+
+; &ace4 referenced 1 time by &acd5
+.sub_cace4
+    lda l0355                                                         ; ace4: ad 55 03    .U.
+    sta (l009e),y                                                     ; ace7: 91 9e       ..
+    ldx l0355                                                         ; ace9: ae 55 03    .U.
+    jsr sub_cacf9                                                     ; acec: 20 f9 ac     ..
+    inc l009e                                                         ; acef: e6 9e       ..
+    tya                                                               ; acf1: 98          .
+    sta (l009e,x)                                                     ; acf2: 81 9e       ..
+    jsr sub_cacf7                                                     ; acf4: 20 f7 ac     ..
+; &acf7 referenced 1 time by &acf4
+.sub_cacf7
+    ldx #0                                                            ; acf7: a2 00       ..
+; &acf9 referenced 1 time by &acec
+.sub_cacf9
+    ldy l00aa                                                         ; acf9: a4 aa       ..
+    inc l00aa                                                         ; acfb: e6 aa       ..
+    inc l009e                                                         ; acfd: e6 9e       ..
+    lda lad0d,y                                                       ; acff: b9 0d ad    ...
+    ldy #&ff                                                          ; ad02: a0 ff       ..
+    jsr osbyte                                                        ; ad04: 20 f4 ff     ..
+    txa                                                               ; ad07: 8a          .
+    ldx #0                                                            ; ad08: a2 00       ..
+    sta (l009e,x)                                                     ; ad0a: 81 9e       ..
+    rts                                                               ; ad0c: 60          `
+
+; &ad0d referenced 1 time by &acff
+.lad0d
+    equb &84, &c2, &c3                                                ; ad0d: 84 c2 c3    ...
+
+.sub_cad10
+    tya                                                               ; ad10: 98          .
+    pha                                                               ; ad11: 48          H
+    jsr sub_caf32                                                     ; ad12: 20 32 af     2.
+    jsr sub_cafc1                                                     ; ad15: 20 c1 af     ..
+    cmp #&0d                                                          ; ad18: c9 0d       ..
+    bne cad20                                                         ; ad1a: d0 04       ..
+    ldx #2                                                            ; ad1c: a2 02       ..
+    bne cad2f                                                         ; ad1e: d0 0f       ..
+; &ad20 referenced 1 time by &ad1a
+.cad20
+    lda #&ff                                                          ; ad20: a9 ff       ..
+    sta l00b4                                                         ; ad22: 85 b4       ..
+    jsr sub_c916e                                                     ; ad24: 20 6e 91     n.
+    ldx #&1b                                                          ; ad27: a2 1b       ..
+; &ad29 referenced 1 time by &ad2d
+.loop_cad29
+    dex                                                               ; ad29: ca          .
+    cmp lad43,x                                                       ; ad2a: dd 43 ad    .C.
+    bcc loop_cad29                                                    ; ad2d: 90 fa       ..
+; &ad2f referenced 1 time by &ad1e
+.cad2f
+    stx l0f05                                                         ; ad2f: 8e 05 0f    ...
+    pla                                                               ; ad32: 68          h
+    tay                                                               ; ad33: a8          .
+    jsr sub_cafb5                                                     ; ad34: 20 b5 af     ..
+    jsr sub_cae94                                                     ; ad37: 20 94 ae     ..
+    ldx #1                                                            ; ad3a: a2 01       ..
+    jsr sub_caf04                                                     ; ad3c: 20 04 af     ..
+    ldy #&1b                                                          ; ad3f: a0 1b       ..
+.sub_cad41
+lad43 = sub_cad41+2
+    jmp c94ad                                                         ; ad41: 4c ad 94    L..
+
+; &ad43 referenced 1 time by &ad2a
+    equb   0, &0a, &14, &1d                                           ; ad44: 00 0a 14... ...
+    equs "'1;EOXblv"                                                  ; ad48: 27 31 3b... '1;
+    equb &80, &8a, &94, &9d, &a7, &b1, &bb, &c5, &cf, &d8, &e2, &ec   ; ad51: 80 8a 94... ...
+    equb &f6, &ff                                                     ; ad5d: f6 ff       ..
+
+.sub_cad5f
+    ror l1071                                                         ; ad5f: 6e 71 10    nq.
+    sec                                                               ; ad62: 38          8
+    bcs cad89                                                         ; ad63: b0 24       .$
+.sub_cad65
+    ror l1071                                                         ; ad65: 6e 71 10    nq.
+    sec                                                               ; ad68: 38          8
+    bcs cad6f                                                         ; ad69: b0 04       ..
+.sub_cad6b
+    ror l1071                                                         ; ad6b: 6e 71 10    nq.
+    clc                                                               ; ad6e: 18          .
+; &ad6f referenced 1 time by &ad69
+.cad6f
+    rol l1071                                                         ; ad6f: 2e 71 10    .q.
+    lda #&ff                                                          ; ad72: a9 ff       ..
+    sta l00ba                                                         ; ad74: 85 ba       ..
+    lda #1                                                            ; ad76: a9 01       ..
+    sta l00b7                                                         ; ad78: 85 b7       ..
+    lda #3                                                            ; ad7a: a9 03       ..
+    sta l00b5                                                         ; ad7c: 85 b5       ..
+    bne cad96                                                         ; ad7e: d0 16       ..
+.sub_cad80
+    jsr sub_c9295                                                     ; ad80: 20 95 92     ..
+    ldy #0                                                            ; ad83: a0 00       ..
+    ror l1071                                                         ; ad85: 6e 71 10    nq.
+    clc                                                               ; ad88: 18          .
+; &ad89 referenced 1 time by &ad63
+.cad89
+    rol l1071                                                         ; ad89: 2e 71 10    .q.
+    lda #3                                                            ; ad8c: a9 03       ..
+    sta l00ba                                                         ; ad8e: 85 ba       ..
+    sta l00b7                                                         ; ad90: 85 b7       ..
+    lda #&0b                                                          ; ad92: a9 0b       ..
+    sta l00b5                                                         ; ad94: 85 b5       ..
+; &ad96 referenced 1 time by &ad7e
+.cad96
+    jsr sub_cafb5                                                     ; ad96: 20 b5 af     ..
+    lda #&ff                                                          ; ad99: a9 ff       ..
+    sta l0098                                                         ; ad9b: 85 98       ..
+    lda #6                                                            ; ad9d: a9 06       ..
+    sta l0f05                                                         ; ad9f: 8d 05 0f    ...
+    jsr sub_cae94                                                     ; ada2: 20 94 ae     ..
+    ldx #1                                                            ; ada5: a2 01       ..
+    jsr sub_caf04                                                     ; ada7: 20 04 af     ..
+    lda l1071                                                         ; adaa: ad 71 10    .q.
+    lsr a                                                             ; adad: 4a          J
+    bcc cadb2                                                         ; adae: 90 02       ..
+    ora #&40 ; '@'                                                    ; adb0: 09 40       .@
+; &adb2 referenced 1 time by &adae
+.cadb2
+    rol a                                                             ; adb2: 2a          *
+    sta l1071                                                         ; adb3: 8d 71 10    .q.
+    ldy #&12                                                          ; adb6: a0 12       ..
+    jsr c94ad                                                         ; adb8: 20 ad 94     ..
+    ldx #3                                                            ; adbb: a2 03       ..
+    jsr sub_cae82                                                     ; adbd: 20 82 ae     ..
+    jsr print_inline_top_bit_clear                                    ; adc0: 20 45 91     E.
+    equs "("                                                          ; adc3: 28          (
+
+    lda l0f13                                                         ; adc4: ad 13 0f    ...
+    jsr caf88                                                         ; adc7: 20 88 af     ..
+    jsr print_inline_top_bit_clear                                    ; adca: 20 45 91     E.
+    equs ")     "                                                     ; adcd: 29 20 20... )
+
+    ldy l0f12                                                         ; add3: ac 12 0f    ...
+    bne cade3                                                         ; add6: d0 0b       ..
+    jsr print_inline_top_bit_clear                                    ; add8: 20 45 91     E.
+    equs "Owner", &0d                                                 ; addb: 4f 77 6e... Own
+
+    bne caded                                                         ; ade1: d0 0a       ..
+; &ade3 referenced 1 time by &add6
+.cade3
+    jsr print_inline_top_bit_clear                                    ; ade3: 20 45 91     E.
+    equs "Public", &0d                                                ; ade6: 50 75 62... Pub
+
+; &aded referenced 1 time by &ade1
+.caded
+    lda l1071                                                         ; aded: ad 71 10    .q.
+    pha                                                               ; adf0: 48          H
+    jsr sub_caf32                                                     ; adf1: 20 32 af     2.
+    ldy #&15                                                          ; adf4: a0 15       ..
+    jsr c94ad                                                         ; adf6: 20 ad 94     ..
+    inx                                                               ; adf9: e8          .
+    ldy #&10                                                          ; adfa: a0 10       ..
+    jsr cae84                                                         ; adfc: 20 84 ae     ..
+    jsr print_inline_top_bit_clear                                    ; adff: 20 45 91     E.
+    equs "    Option "                                                ; ae02: 20 20 20...
+
+    lda l0e05                                                         ; ae0d: ad 05 0e    ...
+    tax                                                               ; ae10: aa          .
+    jsr sub_c912f                                                     ; ae11: 20 2f 91     /.
+    jsr print_inline_top_bit_clear                                    ; ae14: 20 45 91     E.
+    equs " ("                                                         ; ae17: 20 28        (
+
+    ldy laefb,x                                                       ; ae19: bc fb ae    ...
+; &ae1c referenced 1 time by &ae25
+.loop_cae1c
+    lda laeff,y                                                       ; ae1c: b9 ff ae    ...
+    bmi cae27                                                         ; ae1f: 30 06       0.
+    jsr osasci                                                        ; ae21: 20 e3 ff     ..
+    iny                                                               ; ae24: c8          .
+    bne loop_cae1c                                                    ; ae25: d0 f5       ..
+; &ae27 referenced 1 time by &ae1f
+.cae27
+    jsr print_inline_top_bit_clear                                    ; ae27: 20 45 91     E.
+    equs ")", &0d, "Dir. "                                            ; ae2a: 29 0d 44... ).D
+
+    ldx #&11                                                          ; ae31: a2 11       ..
+    jsr sub_cae82                                                     ; ae33: 20 82 ae     ..
+    jsr print_inline_top_bit_clear                                    ; ae36: 20 45 91     E.
+    equs "     Lib. "                                                 ; ae39: 20 20 20...
+
+    ldx #&1b                                                          ; ae43: a2 1b       ..
+    jsr sub_cae82                                                     ; ae45: 20 82 ae     ..
+    jsr osnewl                                                        ; ae48: 20 e7 ff     ..
+    pla                                                               ; ae4b: 68          h
+    sta l1071                                                         ; ae4c: 8d 71 10    .q.
+; &ae4f referenced 1 time by &ae80
+.cae4f
+    sty l0f06                                                         ; ae4f: 8c 06 0f    ...
+    sty l00b4                                                         ; ae52: 84 b4       ..
+    ldx l00b5                                                         ; ae54: a6 b5       ..
+    stx l0f07                                                         ; ae56: 8e 07 0f    ...
+    ldx l00b7                                                         ; ae59: a6 b7       ..
+    stx l0f05                                                         ; ae5b: 8e 05 0f    ...
+    ldx #3                                                            ; ae5e: a2 03       ..
+    jsr sub_caf04                                                     ; ae60: 20 04 af     ..
+    ldy #3                                                            ; ae63: a0 03       ..
+    jsr c94ad                                                         ; ae65: 20 ad 94     ..
+    inx                                                               ; ae68: e8          .
+    lda l0f05                                                         ; ae69: ad 05 0f    ...
+    beq cae8f                                                         ; ae6c: f0 21       .!
+    pha                                                               ; ae6e: 48          H
+; &ae6f referenced 1 time by &ae73
+.loop_cae6f
+    iny                                                               ; ae6f: c8          .
+    lda l0f05,y                                                       ; ae70: b9 05 0f    ...
+    bpl loop_cae6f                                                    ; ae73: 10 fa       ..
+    sta l0f04,y                                                       ; ae75: 99 04 0f    ...
+    jsr sub_caf47                                                     ; ae78: 20 47 af     G.
+    pla                                                               ; ae7b: 68          h
+    clc                                                               ; ae7c: 18          .
+    adc l00b4                                                         ; ae7d: 65 b4       e.
+    tay                                                               ; ae7f: a8          .
+    bne cae4f                                                         ; ae80: d0 cd       ..
+; &ae82 referenced 3 times by &adbd, &ae33, &ae45
+.sub_cae82
+    ldy #&0a                                                          ; ae82: a0 0a       ..
+; &ae84 referenced 2 times by &adfc, &ae8c
+.cae84
+    lda l0f05,x                                                       ; ae84: bd 05 0f    ...
+    jsr osasci                                                        ; ae87: 20 e3 ff     ..
+    inx                                                               ; ae8a: e8          .
+    dey                                                               ; ae8b: 88          .
+    bne cae84                                                         ; ae8c: d0 f6       ..
+    rts                                                               ; ae8e: 60          `
+
+; &ae8f referenced 1 time by &ae6c
+.cae8f
+    jmp osnewl                                                        ; ae8f: 4c e7 ff    L..
+
+; &ae92 referenced 1 time by &a1c7
+.sub_cae92
+    ldy #0                                                            ; ae92: a0 00       ..
+; &ae94 referenced 4 times by &ad37, &ada2, &af77, &b363
+.sub_cae94
+    jsr sub_c9913                                                     ; ae94: 20 13 99     ..
+; &ae97 referenced 3 times by &92ee, &9396, &93cf
+.sub_cae97
+    lda l0e30                                                         ; ae97: ad 30 0e    .0.
+    eor #&26 ; '&'                                                    ; ae9a: 49 26       I&
+    bne caee2                                                         ; ae9c: d0 44       .D
+    lda l1071                                                         ; ae9e: ad 71 10    .q.
+    ora #&40 ; '@'                                                    ; aea1: 09 40       .@
+    sta l1071                                                         ; aea3: 8d 71 10    .q.
+    jsr caeb7                                                         ; aea6: 20 b7 ae     ..
+    lda l0e30                                                         ; aea9: ad 30 0e    .0.
+    eor #&2e ; '.'                                                    ; aeac: 49 2e       I.
+    bne caedb                                                         ; aeae: d0 2b       .+
+    lda l0e31                                                         ; aeb0: ad 31 0e    .1.
+    eor #&0d                                                          ; aeb3: 49 0d       I.
+    beq caedf                                                         ; aeb5: f0 28       .(
+; &aeb7 referenced 5 times by &931c, &93b6, &93bc, &aea6, &aef9
+.caeb7
+    txa                                                               ; aeb7: 8a          .
+    pha                                                               ; aeb8: 48          H
+    ldx #&ff                                                          ; aeb9: a2 ff       ..
+; &aebb referenced 1 time by &aec4
+.loop_caebb
+    inx                                                               ; aebb: e8          .
+    lda l0e31,x                                                       ; aebc: bd 31 0e    .1.
+    sta l0e30,x                                                       ; aebf: 9d 30 0e    .0.
+    eor #&0d                                                          ; aec2: 49 0d       I.
+    bne loop_caebb                                                    ; aec4: d0 f5       ..
+    txa                                                               ; aec6: 8a          .
+    beq caed8                                                         ; aec7: f0 0f       ..
+; &aec9 referenced 1 time by &aed6
+.loop_caec9
+    lda l0e2f,x                                                       ; aec9: bd 2f 0e    ./.
+    eor #&20 ; ' '                                                    ; aecc: 49 20       I
+    bne caed8                                                         ; aece: d0 08       ..
+    lda #&0d                                                          ; aed0: a9 0d       ..
+    sta l0e2f,x                                                       ; aed2: 9d 2f 0e    ./.
+    dex                                                               ; aed5: ca          .
+    bne loop_caec9                                                    ; aed6: d0 f1       ..
+; &aed8 referenced 2 times by &aec7, &aece
+.caed8
+    pla                                                               ; aed8: 68          h
+    tax                                                               ; aed9: aa          .
+; &aeda referenced 3 times by &aedd, &aee4, &aeef
+.caeda
+    rts                                                               ; aeda: 60          `
+
+; &aedb referenced 1 time by &aeae
+.caedb
+    eor #&23 ; '#'                                                    ; aedb: 49 23       I#
+    beq caeda                                                         ; aedd: f0 fb       ..
+; &aedf referenced 2 times by &aeb5, &af12
+.caedf
+    jmp c92fa                                                         ; aedf: 4c fa 92    L..
+
+; &aee2 referenced 1 time by &ae9c
+.caee2
+    eor #&1c                                                          ; aee2: 49 1c       I.
+    bne caeda                                                         ; aee4: d0 f4       ..
+    lda l0e32                                                         ; aee6: ad 32 0e    .2.
+    eor #&2e ; '.'                                                    ; aee9: 49 2e       I.
+    beq caef1                                                         ; aeeb: f0 04       ..
+    eor #&23 ; '#'                                                    ; aeed: 49 23       I#
+    bne caeda                                                         ; aeef: d0 e9       ..
+; &aef1 referenced 1 time by &aeeb
+.caef1
+    lda l1071                                                         ; aef1: ad 71 10    .q.
+    ora #&40 ; '@'                                                    ; aef4: 09 40       .@
+    sta l1071                                                         ; aef6: 8d 71 10    .q.
+    bne caeb7                                                         ; aef9: d0 bc       ..
+; &aefb referenced 1 time by &ae19
+.laefb
+    equb 0                                                            ; aefb: 00          .
+    equs "/<c"                                                        ; aefc: 2f 3c 63    /<c
+; &aeff referenced 1 time by &ae1c
+.laeff
+    equs "Off"                                                        ; aeff: 4f 66 66    Off
+
+; &af02 referenced 5 times by &8dbc, &8e20, &9b3c, &a299, &af7a
+.sub_caf02
+    ldx #0                                                            ; af02: a2 00       ..
+; &af04 referenced 9 times by &99fe, &9b35, &9b58, &a1cc, &a1f9, &ad3c, &ada7, &ae60, &b378
+.sub_caf04
+    ldy #0                                                            ; af04: a0 00       ..
+; &af06 referenced 3 times by &8db7, &941e, &9454
+.sub_caf06
+    sec                                                               ; af06: 38          8
+; &af07 referenced 1 time by &af1a
+.loop_caf07
+    lda (l00be),y                                                     ; af07: b1 be       ..
+    sta l0f05,x                                                       ; af09: 9d 05 0f    ...
+    bcc caf16                                                         ; af0c: 90 08       ..
+    cmp #&21 ; '!'                                                    ; af0e: c9 21       .!
+    eor #&26 ; '&'                                                    ; af10: 49 26       I&
+    beq caedf                                                         ; af12: f0 cb       ..
+    eor #&26 ; '&'                                                    ; af14: 49 26       I&
+; &af16 referenced 1 time by &af0c
+.caf16
+    inx                                                               ; af16: e8          .
+    iny                                                               ; af17: c8          .
+    eor #&0d                                                          ; af18: 49 0d       I.
+    bne loop_caf07                                                    ; af1a: d0 eb       ..
+; &af1c referenced 1 time by &af29
+.loop_caf1c
+    lda l0f03,x                                                       ; af1c: bd 03 0f    ...
+    eor #&20 ; ' '                                                    ; af1f: 49 20       I
+    bne caf2b                                                         ; af21: d0 08       ..
+    dex                                                               ; af23: ca          .
+    lda #&0d                                                          ; af24: a9 0d       ..
+    sta l0f04,x                                                       ; af26: 9d 04 0f    ...
+    bne loop_caf1c                                                    ; af29: d0 f1       ..
+; &af2b referenced 1 time by &af21
+.caf2b
+    lda #0                                                            ; af2b: a9 00       ..
+; &af2d referenced 1 time by &af43
+.loop_caf2d
+    rts                                                               ; af2d: 60          `
+
+    equs "Load"                                                       ; af2e: 4c 6f 61... Loa
+
+; &af32 referenced 9 times by &8e3b, &9390, &93ca, &a1c4, &a250, &a25a, &ad12, &adf1, &b359
+.sub_caf32
+    lda l1071                                                         ; af32: ad 71 10    .q.
+    and #&1f                                                          ; af35: 29 1f       ).
+    sta l1071                                                         ; af37: 8d 71 10    .q.
+    rts                                                               ; af3a: 60          `
+
+    equs "Run"                                                        ; af3b: 52 75 6e    Run
+
+.sub_caf3e
+    ldx #0                                                            ; af3e: a2 00       ..
+; &af40 referenced 1 time by &af60
+.caf40
+    lda l0f05,x                                                       ; af40: bd 05 0f    ...
+    bmi loop_caf2d                                                    ; af43: 30 e8       0.
+    bne caf5c                                                         ; af45: d0 15       ..
+; &af47 referenced 1 time by &ae78
+.sub_caf47
+    ldy l00ba                                                         ; af47: a4 ba       ..
+    bmi caf5a                                                         ; af49: 30 0f       0.
+    iny                                                               ; af4b: c8          .
+    tya                                                               ; af4c: 98          .
+    and #3                                                            ; af4d: 29 03       ).
+    sta l00ba                                                         ; af4f: 85 ba       ..
+    beq caf5a                                                         ; af51: f0 07       ..
+    jsr print_inline_top_bit_clear                                    ; af53: 20 45 91     E.
+    equs "  "                                                         ; af56: 20 20
+
+    bne caf5f                                                         ; af58: d0 05       ..
+; &af5a referenced 2 times by &af49, &af51
+.caf5a
+    lda #&0d                                                          ; af5a: a9 0d       ..
+; &af5c referenced 1 time by &af45
+.caf5c
+    jsr osasci                                                        ; af5c: 20 e3 ff     ..
+; &af5f referenced 1 time by &af58
+.caf5f
+    inx                                                               ; af5f: e8          .
+    bne caf40                                                         ; af60: d0 de       ..
+    eor l0078                                                         ; af62: 45 78       Ex
+    adc l0063                                                         ; af64: 65 63       ec
+.sub_caf66
+    tya                                                               ; af66: 98          .
+    pha                                                               ; af67: 48          H
+    jsr sub_cafc1                                                     ; af68: 20 c1 af     ..
+    cmp #&0d                                                          ; af6b: c9 0d       ..
+    beq caf72                                                         ; af6d: f0 03       ..
+    jmp ca127                                                         ; af6f: 4c 27 a1    L'.
+
+; &af72 referenced 1 time by &af6d
+.caf72
+    pla                                                               ; af72: 68          h
+    tay                                                               ; af73: a8          .
+    jsr sub_cafb5                                                     ; af74: 20 b5 af     ..
+    jsr sub_cae94                                                     ; af77: 20 94 ae     ..
+    jsr sub_caf02                                                     ; af7a: 20 02 af     ..
+    ldy #&14                                                          ; af7d: a0 14       ..
+    bit l9491                                                         ; af7f: 2c 91 94    ,..
+    jmp c94ae                                                         ; af82: 4c ae 94    L..
+
+; &af85 referenced 1 time by &9007
+.sub_caf85
+    bit l9491                                                         ; af85: 2c 91 94    ,..
+; &af88 referenced 3 times by &adc7, &b19d, &b1b4
+.caf88
+    tay                                                               ; af88: a8          .
+    lda #&64 ; 'd'                                                    ; af89: a9 64       .d
+    jsr sub_caf96                                                     ; af8b: 20 96 af     ..
+    lda #&0a                                                          ; af8e: a9 0a       ..
+    jsr sub_caf96                                                     ; af90: 20 96 af     ..
+    clv                                                               ; af93: b8          .
+    lda #1                                                            ; af94: a9 01       ..
+; &af96 referenced 2 times by &af8b, &af90
+.sub_caf96
+    sta l00b8                                                         ; af96: 85 b8       ..
+    tya                                                               ; af98: 98          .
+    ldx #&2f ; '/'                                                    ; af99: a2 2f       ./
+    sec                                                               ; af9b: 38          8
+    php                                                               ; af9c: 08          .
+; &af9d referenced 1 time by &afa0
+.loop_caf9d
+    inx                                                               ; af9d: e8          .
+    sbc l00b8                                                         ; af9e: e5 b8       ..
+    bcs loop_caf9d                                                    ; afa0: b0 fb       ..
+    adc l00b8                                                         ; afa2: 65 b8       e.
+    tay                                                               ; afa4: a8          .
+    txa                                                               ; afa5: 8a          .
+    plp                                                               ; afa6: 28          (
+    bvc cafad                                                         ; afa7: 50 04       P.
+    cmp #&30 ; '0'                                                    ; afa9: c9 30       .0
+    beq cafb4                                                         ; afab: f0 07       ..
+; &afad referenced 1 time by &afa7
+.cafad
+    ldx l00b8                                                         ; afad: a6 b8       ..
+    jsr osasci                                                        ; afaf: 20 e3 ff     ..
+    stx l00b8                                                         ; afb2: 86 b8       ..
+; &afb4 referenced 1 time by &afab
+.cafb4
+    rts                                                               ; afb4: 60          `
+
+; &afb5 referenced 7 times by &a1c1, &ad34, &ad96, &af74, &b038, &b216, &b360
+.sub_cafb5
+    pha                                                               ; afb5: 48          H
+    lda l00be                                                         ; afb6: a5 be       ..
+    sta os_text_ptr                                                   ; afb8: 85 f2       ..
+    lda l00bf                                                         ; afba: a5 bf       ..
+    sta l00f3                                                         ; afbc: 85 f3       ..
+    pla                                                               ; afbe: 68          h
+    rts                                                               ; afbf: 60          `
+
+; &afc0 referenced 1 time by &afcb
+.loop_cafc0
+    iny                                                               ; afc0: c8          .
+; &afc1 referenced 2 times by &ad15, &af68
+.sub_cafc1
+    lda (l00be),y                                                     ; afc1: b1 be       ..
+    cmp #&20 ; ' '                                                    ; afc3: c9 20       .
+    beq cafcd                                                         ; afc5: f0 06       ..
+    cmp #&0d                                                          ; afc7: c9 0d       ..
+    beq cafd4                                                         ; afc9: f0 09       ..
+    bne loop_cafc0                                                    ; afcb: d0 f3       ..
+; &afcd referenced 2 times by &afc5, &afd2
+.cafcd
+    iny                                                               ; afcd: c8          .
+    lda (l00be),y                                                     ; afce: b1 be       ..
+    cmp #&20 ; ' '                                                    ; afd0: c9 20       .
+    beq cafcd                                                         ; afd2: f0 f9       ..
+; &afd4 referenced 1 time by &afc9
+.cafd4
+    rts                                                               ; afd4: 60          `
+
+; &afd5 referenced 2 times by &affb, &b1d2
+.sub_cafd5
+    pha                                                               ; afd5: 48          H
+    lda l00be                                                         ; afd6: a5 be       ..
+    sta l00bb                                                         ; afd8: 85 bb       ..
+    lda l00bf                                                         ; afda: a5 bf       ..
+    sta l00bc                                                         ; afdc: 85 bc       ..
+    pla                                                               ; afde: 68          h
+    rts                                                               ; afdf: 60          `
+
+; &afe0 referenced 2 times by &aff8, &b1c5
+.sub_cafe0
+    tya                                                               ; afe0: 98          .
+    pha                                                               ; afe1: 48          H
+    jsr sub_c8cb9                                                     ; afe2: 20 b9 8c     ..
+    sta l00af                                                         ; afe5: 85 af       ..
+    pla                                                               ; afe7: 68          h
+    tay                                                               ; afe8: a8          .
+    lda #0                                                            ; afe9: a9 00       ..
+    sta l00ae                                                         ; afeb: 85 ae       ..
+    rts                                                               ; afed: 60          `
+
+.sub_cafee
+    lda #1                                                            ; afee: a9 01       ..
+    bit l0d6a                                                         ; aff0: 2c 6a 0d    ,j.
+    bne caff8                                                         ; aff3: d0 03       ..
+    jmp cabfe                                                         ; aff5: 4c fe ab    L..
+
+; &aff8 referenced 1 time by &aff3
+.caff8
+    jsr sub_cafe0                                                     ; aff8: 20 e0 af     ..
+    jsr sub_cafd5                                                     ; affb: 20 d5 af     ..
+    lda (l00bb),y                                                     ; affe: b1 bb       ..
+    cmp #&0d                                                          ; b000: c9 0d       ..
+    beq cb025                                                         ; b002: f0 21       .!
+    clv                                                               ; b004: b8          .
+    jsr sub_c9258                                                     ; b005: 20 58 92     X.
+    bcc cb028                                                         ; b008: 90 1e       ..
+    tya                                                               ; b00a: 98          .
+    pha                                                               ; b00b: 48          H
+    jsr sub_cb0ea                                                     ; b00c: 20 ea b0     ..
+    pla                                                               ; b00f: 68          h
+    tay                                                               ; b010: a8          .
+    jsr sub_ca0a7                                                     ; b011: 20 a7 a0     ..
+    jmp cb0b9                                                         ; b014: 4c b9 b0    L..
+
+; &b017 referenced 1 time by &8ef9
+.sub_cb017
+    ldy #&18                                                          ; b017: a0 18       ..
+; &b019 referenced 1 time by &b1f8
+.sub_cb019
+    ldx #&f8                                                          ; b019: a2 f8       ..
+; &b01b referenced 1 time by &b022
+.loop_cb01b
+    lda l8d61,x                                                       ; b01b: bd 61 8d    .a.
+    sta (l009c),y                                                     ; b01e: 91 9c       ..
+    iny                                                               ; b020: c8          .
+    inx                                                               ; b021: e8          .
+    bne loop_cb01b                                                    ; b022: d0 f7       ..
+    rts                                                               ; b024: 60          `
+
+; &b025 referenced 1 time by &b002
+.cb025
+    bit l9491                                                         ; b025: 2c 91 94    ,..
+; &b028 referenced 1 time by &b008
+.cb028
+    sty l00ac                                                         ; b028: 84 ac       ..
+    bvs cb058                                                         ; b02a: 70 2c       p,
+    ldx #6                                                            ; b02c: a2 06       ..
+    ldy #&18                                                          ; b02e: a0 18       ..
+    lda #&20 ; ' '                                                    ; b030: a9 20       .
+; &b032 referenced 1 time by &b036
+.loop_cb032
+    sta (l009c),y                                                     ; b032: 91 9c       ..
+    iny                                                               ; b034: c8          .
+    dex                                                               ; b035: ca          .
+    bne loop_cb032                                                    ; b036: d0 fa       ..
+    jsr sub_cafb5                                                     ; b038: 20 b5 af     ..
+    ldy l00ac                                                         ; b03b: a4 ac       ..
+    jsr gsinit                                                        ; b03d: 20 c2 ff     ..
+    beq cb058                                                         ; b040: f0 16       ..
+    ldx #6                                                            ; b042: a2 06       ..
+    sty l00ac                                                         ; b044: 84 ac       ..
+    ldy #&18                                                          ; b046: a0 18       ..
+    sty l00ad                                                         ; b048: 84 ad       ..
+; &b04a referenced 1 time by &b056
+.loop_cb04a
+    ldy l00ac                                                         ; b04a: a4 ac       ..
+    jsr gsread                                                        ; b04c: 20 c5 ff     ..
+    sty l00ac                                                         ; b04f: 84 ac       ..
+    bcs cb058                                                         ; b051: b0 05       ..
+    jsr sub_cb2f7                                                     ; b053: 20 f7 b2     ..
+    bne loop_cb04a                                                    ; b056: d0 f2       ..
+; &b058 referenced 3 times by &b02a, &b040, &b051
+.cb058
+    jsr sub_cb16d                                                     ; b058: 20 6d b1     m.
+    jsr sub_c983f                                                     ; b05b: 20 3f 98     ?.
+    jsr sub_cb0f6                                                     ; b05e: 20 f6 b0     ..
+    jsr sub_cb0ea                                                     ; b061: 20 ea b0     ..
+    lda #0                                                            ; b064: a9 00       ..
+    tax                                                               ; b066: aa          .
+    ldy #&20 ; ' '                                                    ; b067: a0 20       .
+    sta (l009c),y                                                     ; b069: 91 9c       ..
+; &b06b referenced 1 time by &b097
+.cb06b
+    pla                                                               ; b06b: 68          h
+    beq cb099                                                         ; b06c: f0 2b       .+
+    pha                                                               ; b06e: 48          H
+    tay                                                               ; b06f: a8          .
+    lda (l009e),y                                                     ; b070: b1 9e       ..
+    bpl cb091                                                         ; b072: 10 1d       ..
+    jsr sub_c9a7f                                                     ; b074: 20 7f 9a     ..
+    lda (l009e),y                                                     ; b077: b1 9e       ..
+    sta l00ae                                                         ; b079: 85 ae       ..
+    lda (l00ae,x)                                                     ; b07b: a1 ae       ..
+    beq cb083                                                         ; b07d: f0 04       ..
+    cmp #3                                                            ; b07f: c9 03       ..
+    bne cb091                                                         ; b081: d0 0e       ..
+; &b083 referenced 1 time by &b07d
+.cb083
+    dey                                                               ; b083: 88          .
+    lda (l009e),y                                                     ; b084: b1 9e       ..
+    sta l00b6                                                         ; b086: 85 b6       ..
+    dey                                                               ; b088: 88          .
+    lda (l009e),y                                                     ; b089: b1 9e       ..
+    sta l00b5                                                         ; b08b: 85 b5       ..
+    ldy #&20 ; ' '                                                    ; b08d: a0 20       .
+    sta (l009c),y                                                     ; b08f: 91 9c       ..
+; &b091 referenced 2 times by &b072, &b081
+.cb091
+    pla                                                               ; b091: 68          h
+    tay                                                               ; b092: a8          .
+    lda #&3f ; '?'                                                    ; b093: a9 3f       .?
+    sta (l009e),y                                                     ; b095: 91 9e       ..
+    bne cb06b                                                         ; b097: d0 d2       ..
+; &b099 referenced 1 time by &b06c
+.cb099
+    jsr sub_cb0cf                                                     ; b099: 20 cf b0     ..
+    ldy #&20 ; ' '                                                    ; b09c: a0 20       .
+    lda (l009c),y                                                     ; b09e: b1 9c       ..
+    bne cb0ae                                                         ; b0a0: d0 0c       ..
+    jsr print_inline_top_bit_clear                                    ; b0a2: 20 45 91     E.
+    equs "still "                                                     ; b0a5: 73 74 69... sti
+
+    clv                                                               ; b0ab: b8          .
+    bvc cb0b6                                                         ; b0ac: 50 08       P.
+; &b0ae referenced 1 time by &b0a0
+.cb0ae
+    jsr print_inline_top_bit_clear                                    ; b0ae: 20 45 91     E.
+    equs "now "                                                       ; b0b1: 6e 6f 77... now
+
+    nop                                                               ; b0b5: ea          .
+; &b0b6 referenced 1 time by &b0ac
+.cb0b6
+    jsr sub_ca09e                                                     ; b0b6: 20 9e a0     ..
+; &b0b9 referenced 1 time by &b014
+.cb0b9
+    ldy #2                                                            ; b0b9: a0 02       ..
+    lda l00b5                                                         ; b0bb: a5 b5       ..
+    sta (l009e),y                                                     ; b0bd: 91 9e       ..
+    iny                                                               ; b0bf: c8          .
+    lda l00b6                                                         ; b0c0: a5 b6       ..
+    sta (l009e),y                                                     ; b0c2: 91 9e       ..
+    rts                                                               ; b0c4: 60          `
+
+; &b0c5 referenced 1 time by &a09b
+.sub_cb0c5
+    jsr print_inline_top_bit_clear                                    ; b0c5: 20 45 91     E.
+    equs "File"                                                       ; b0c8: 46 69 6c... Fil
+
+    clv                                                               ; b0cc: b8          .
+    bvc cb0da                                                         ; b0cd: 50 0b       P.
+; &b0cf referenced 2 times by &b099, &b240
+.sub_cb0cf
+    jsr print_inline_top_bit_clear                                    ; b0cf: 20 45 91     E.
+    equs "Printer"                                                    ; b0d2: 50 72 69... Pri
+
+    nop                                                               ; b0d9: ea          .
+; &b0da referenced 1 time by &b0cd
+.cb0da
+    jsr print_inline_top_bit_clear                                    ; b0da: 20 45 91     E.
+    equs " server is "                                                ; b0dd: 20 73 65...  se
+
+    nop                                                               ; b0e8: ea          .
+    rts                                                               ; b0e9: 60          `
+
+; &b0ea referenced 4 times by &b00c, &b061, &b1e3, &b243
+.sub_cb0ea
+    ldy #2                                                            ; b0ea: a0 02       ..
+    lda (l009e),y                                                     ; b0ec: b1 9e       ..
+    sta l00b5                                                         ; b0ee: 85 b5       ..
+    iny                                                               ; b0f0: c8          .
+    lda (l009e),y                                                     ; b0f1: b1 9e       ..
+    sta l00b6                                                         ; b0f3: 85 b6       ..
+    rts                                                               ; b0f5: 60          `
+
+; &b0f6 referenced 2 times by &b05e, &b23d
+.sub_cb0f6
+    pla                                                               ; b0f6: 68          h
+    sta l00aa                                                         ; b0f7: 85 aa       ..
+    pla                                                               ; b0f9: 68          h
+    sta l00ab                                                         ; b0fa: 85 ab       ..
+    lda #0                                                            ; b0fc: a9 00       ..
+    pha                                                               ; b0fe: 48          H
+    lda #&84                                                          ; b0ff: a9 84       ..
+    sta l00ac                                                         ; b101: 85 ac       ..
+    lsr l0d61                                                         ; b103: 4e 61 0d    Na.
+    lda #3                                                            ; b106: a9 03       ..
+; &b108 referenced 1 time by &b11a
+.loop_cb108
+    jsr sub_ca0ce                                                     ; b108: 20 ce a0     ..
+    bcs cb144                                                         ; b10b: b0 37       .7
+    lsr a                                                             ; b10d: 4a          J
+    lsr a                                                             ; b10e: 4a          J
+    tax                                                               ; b10f: aa          .
+    lda (l009e),y                                                     ; b110: b1 9e       ..
+    beq cb144                                                         ; b112: f0 30       .0
+    cmp #&3f ; '?'                                                    ; b114: c9 3f       .?
+    beq cb11c                                                         ; b116: f0 04       ..
+; &b118 referenced 1 time by &b141
+.cb118
+    inx                                                               ; b118: e8          .
+    txa                                                               ; b119: 8a          .
+    bne loop_cb108                                                    ; b11a: d0 ec       ..
+; &b11c referenced 1 time by &b116
+.cb11c
+    tya                                                               ; b11c: 98          .
+    pha                                                               ; b11d: 48          H
+    lda #&7f                                                          ; b11e: a9 7f       ..
+    sta (l009e),y                                                     ; b120: 91 9e       ..
+    iny                                                               ; b122: c8          .
+    lda #&9e                                                          ; b123: a9 9e       ..
+    sta (l009e),y                                                     ; b125: 91 9e       ..
+    lda #0                                                            ; b127: a9 00       ..
+    jsr sub_cb165                                                     ; b129: 20 65 b1     e.
+    lda l00ac                                                         ; b12c: a5 ac       ..
+    sta (l009e),y                                                     ; b12e: 91 9e       ..
+    clc                                                               ; b130: 18          .
+    php                                                               ; b131: 08          .
+    adc #3                                                            ; b132: 69 03       i.
+    plp                                                               ; b134: 28          (
+    sta l00ac                                                         ; b135: 85 ac       ..
+    jsr sub_cb15e                                                     ; b137: 20 5e b1     ^.
+    lda l00ac                                                         ; b13a: a5 ac       ..
+    sta (l009e),y                                                     ; b13c: 91 9e       ..
+.sub_cb13e
+lb13f = sub_cb13e+1
+    jsr sub_cb15e                                                     ; b13e: 20 5e b1     ^.
+; &b13f referenced 1 time by &b2e2
+    jmp cb118                                                         ; b141: 4c 18 b1    L..
+
+; &b144 referenced 2 times by &b10b, &b112
+.cb144
+    asl l0d61                                                         ; b144: 0e 61 0d    .a.
+    lda l00ab                                                         ; b147: a5 ab       ..
+    pha                                                               ; b149: 48          H
+    lda l00aa                                                         ; b14a: a5 aa       ..
+    pha                                                               ; b14c: 48          H
+    lda #&0a                                                          ; b14d: a9 0a       ..
+    tay                                                               ; b14f: a8          .
+    tax                                                               ; b150: aa          .
+    sta l00b4                                                         ; b151: 85 b4       ..
+; &b153 referenced 3 times by &b154, &b157, &b15b
+.cb153
+    dey                                                               ; b153: 88          .
+    bne cb153                                                         ; b154: d0 fd       ..
+    dex                                                               ; b156: ca          .
+    bne cb153                                                         ; b157: d0 fa       ..
+    dec l00b4                                                         ; b159: c6 b4       ..
+    bne cb153                                                         ; b15b: d0 f6       ..
+    rts                                                               ; b15d: 60          `
+
+; &b15e referenced 2 times by &b137, &b13e
+.sub_cb15e
+    iny                                                               ; b15e: c8          .
+    lda l00af                                                         ; b15f: a5 af       ..
+    sta (l009e),y                                                     ; b161: 91 9e       ..
+    lda #&ff                                                          ; b163: a9 ff       ..
+; &b165 referenced 1 time by &b129
+.sub_cb165
+    iny                                                               ; b165: c8          .
+    sta (l009e),y                                                     ; b166: 91 9e       ..
+    iny                                                               ; b168: c8          .
+    sta (l009e),y                                                     ; b169: 91 9e       ..
+    iny                                                               ; b16b: c8          .
+    rts                                                               ; b16c: 60          `
+
+; &b16d referenced 2 times by &b058, &b1ca
+.sub_cb16d
+    ldy #&18                                                          ; b16d: a0 18       ..
+; &b16f referenced 1 time by &b175
+.loop_cb16f
+    lda (l009c),y                                                     ; b16f: b1 9c       ..
+    pha                                                               ; b171: 48          H
+    iny                                                               ; b172: c8          .
+    cpy #&20 ; ' '                                                    ; b173: c0 20       .
+    bne loop_cb16f                                                    ; b175: d0 f8       ..
+    ldy #&17                                                          ; b177: a0 17       ..
+; &b179 referenced 1 time by &b17f
+.loop_cb179
+    pla                                                               ; b179: 68          h
+    sta (l009c),y                                                     ; b17a: 91 9c       ..
+    dey                                                               ; b17c: 88          .
+    cpy #&0f                                                          ; b17d: c0 0f       ..
+    bne loop_cb179                                                    ; b17f: d0 f8       ..
+    lda l009d                                                         ; b181: a5 9d       ..
+    sta l009b                                                         ; b183: 85 9b       ..
+    lda #&0c                                                          ; b185: a9 0c       ..
+    sta l009a                                                         ; b187: 85 9a       ..
+    ldy #3                                                            ; b189: a0 03       ..
+; &b18b referenced 1 time by &b191
+.loop_cb18b
+    lda lb194,y                                                       ; b18b: b9 94 b1    ...
+    sta (l009a),y                                                     ; b18e: 91 9a       ..
+    dey                                                               ; b190: 88          .
+    bpl loop_cb18b                                                    ; b191: 10 f8       ..
+    rts                                                               ; b193: 60          `
+
+; &b194 referenced 1 time by &b18b
+.lb194
+    equb &80, &9f, &ff, &ff                                           ; b194: 80 9f ff... ...
+
+; &b198 referenced 4 times by &a0a1, &b249, &b281, &b2d1
+.sub_cb198
+    php                                                               ; b198: 08          .
+    lda l00b6                                                         ; b199: a5 b6       ..
+    beq cb1a8                                                         ; b19b: f0 0b       ..
+    jsr caf88                                                         ; b19d: 20 88 af     ..
+    lda #&2e ; '.'                                                    ; b1a0: a9 2e       ..
+    jsr osasci                                                        ; b1a2: 20 e3 ff     ..
+    bit l9491                                                         ; b1a5: 2c 91 94    ,..
+; &b1a8 referenced 1 time by &b19b
+.cb1a8
+    bvs cb1b1                                                         ; b1a8: 70 07       p.
+    jsr print_inline_top_bit_clear                                    ; b1aa: 20 45 91     E.
+    equs "    "                                                       ; b1ad: 20 20 20...
+
+; &b1b1 referenced 1 time by &b1a8
+.cb1b1
+    lda l00b5                                                         ; b1b1: a5 b5       ..
+    plp                                                               ; b1b3: 28          (
+    jmp caf88                                                         ; b1b4: 4c 88 af    L..
+
+    equb &80, &9f,   0,   0, &10,   0, &ff, &ff, &18,   0, &ff, &ff   ; b1b7: 80 9f 00... ...
+
+.sub_cb1c3
+    sty l00ac                                                         ; b1c3: 84 ac       ..
+    jsr sub_cafe0                                                     ; b1c5: 20 e0 af     ..
+    sta l00b4                                                         ; b1c8: 85 b4       ..
+    jsr sub_cb16d                                                     ; b1ca: 20 6d b1     m.
+    jsr sub_cb2e0                                                     ; b1cd: 20 e0 b2     ..
+    ldy l00ac                                                         ; b1d0: a4 ac       ..
+    jsr sub_cafd5                                                     ; b1d2: 20 d5 af     ..
+    lda (l00bb),y                                                     ; b1d5: b1 bb       ..
+    cmp #&0d                                                          ; b1d7: c9 0d       ..
+    beq cb205                                                         ; b1d9: f0 2a       .*
+    clv                                                               ; b1db: b8          .
+    jsr sub_c9258                                                     ; b1dc: 20 58 92     X.
+    bcc cb208                                                         ; b1df: 90 27       .'
+    tya                                                               ; b1e1: 98          .
+    pha                                                               ; b1e2: 48          H
+    jsr sub_cb0ea                                                     ; b1e3: 20 ea b0     ..
+    pla                                                               ; b1e6: 68          h
+    tay                                                               ; b1e7: a8          .
+    jsr sub_ca0a7                                                     ; b1e8: 20 a7 a0     ..
+    ldy #&7a ; 'z'                                                    ; b1eb: a0 7a       .z
+    lda l00b5                                                         ; b1ed: a5 b5       ..
+    sta (l00ae),y                                                     ; b1ef: 91 ae       ..
+    iny                                                               ; b1f1: c8          .
+    lda l00b6                                                         ; b1f2: a5 b6       ..
+    sta (l00ae),y                                                     ; b1f4: 91 ae       ..
+    ldy #&10                                                          ; b1f6: a0 10       ..
+    jsr sub_cb019                                                     ; b1f8: 20 19 b0     ..
+    lda l00af                                                         ; b1fb: a5 af       ..
+    sta l009b                                                         ; b1fd: 85 9b       ..
+    lda #&78 ; 'x'                                                    ; b1ff: a9 78       .x
+    sta l009a                                                         ; b201: 85 9a       ..
+    bne cb236                                                         ; b203: d0 31       .1
+; &b205 referenced 1 time by &b1d9
+.cb205
+    bit l9491                                                         ; b205: 2c 91 94    ,..
+; &b208 referenced 1 time by &b1df
+.cb208
+    bvs cb236                                                         ; b208: 70 2c       p,
+    ldx #6                                                            ; b20a: a2 06       ..
+    ldy #&10                                                          ; b20c: a0 10       ..
+    lda #&20 ; ' '                                                    ; b20e: a9 20       .
+; &b210 referenced 1 time by &b214
+.loop_cb210
+    sta (l009c),y                                                     ; b210: 91 9c       ..
+    iny                                                               ; b212: c8          .
+    dex                                                               ; b213: ca          .
+    bne loop_cb210                                                    ; b214: d0 fa       ..
+    jsr sub_cafb5                                                     ; b216: 20 b5 af     ..
+    ldy l00ac                                                         ; b219: a4 ac       ..
+    jsr gsinit                                                        ; b21b: 20 c2 ff     ..
+    beq cb236                                                         ; b21e: f0 16       ..
+    ldx #6                                                            ; b220: a2 06       ..
+    sty l00ac                                                         ; b222: 84 ac       ..
+    ldy #&10                                                          ; b224: a0 10       ..
+    sty l00ad                                                         ; b226: 84 ad       ..
+; &b228 referenced 1 time by &b234
+.loop_cb228
+    ldy l00ac                                                         ; b228: a4 ac       ..
+    jsr gsread                                                        ; b22a: 20 c5 ff     ..
+    sty l00ac                                                         ; b22d: 84 ac       ..
+    bcs cb236                                                         ; b22f: b0 05       ..
+    jsr sub_cb2f7                                                     ; b231: 20 f7 b2     ..
+    bne loop_cb228                                                    ; b234: d0 f2       ..
+; &b236 referenced 4 times by &b203, &b208, &b21e, &b22f
+.cb236
+    lda #&80                                                          ; b236: a9 80       ..
+    sta l0098                                                         ; b238: 85 98       ..
+    jsr sub_c983f                                                     ; b23a: 20 3f 98     ?.
+    jsr sub_cb0f6                                                     ; b23d: 20 f6 b0     ..
+    jsr sub_cb0cf                                                     ; b240: 20 cf b0     ..
+    jsr sub_cb0ea                                                     ; b243: 20 ea b0     ..
+    bit l9491                                                         ; b246: 2c 91 94    ,..
+    jsr sub_cb198                                                     ; b249: 20 98 b1     ..
+    jsr print_inline_top_bit_clear                                    ; b24c: 20 45 91     E.
+    equs " ", '"'                                                     ; b24f: 20 22        "
+
+    ldy #&18                                                          ; b251: a0 18       ..
+; &b253 referenced 1 time by &b25f
+.loop_cb253
+    lda (l009c),y                                                     ; b253: b1 9c       ..
+    cmp #&20 ; ' '                                                    ; b255: c9 20       .
+    beq cb261                                                         ; b257: f0 08       ..
+    jsr osasci                                                        ; b259: 20 e3 ff     ..
+    iny                                                               ; b25c: c8          .
+    cpy #&1e                                                          ; b25d: c0 1e       ..
+    bne loop_cb253                                                    ; b25f: d0 f2       ..
+; &b261 referenced 1 time by &b257
+.cb261
+    jsr print_inline_top_bit_clear                                    ; b261: 20 45 91     E.
+    equs '"', &0d                                                     ; b264: 22 0d       ".
+
+    nop                                                               ; b266: ea          .
+; &b267 referenced 1 time by &b2dd
+.cb267
+    pla                                                               ; b267: 68          h
+    beq cb2df                                                         ; b268: f0 75       .u
+    pha                                                               ; b26a: 48          H
+    tay                                                               ; b26b: a8          .
+    lda (l009e),y                                                     ; b26c: b1 9e       ..
+    bpl cb2d7                                                         ; b26e: 10 67       .g
+    iny                                                               ; b270: c8          .
+    iny                                                               ; b271: c8          .
+    lda (l009e),y                                                     ; b272: b1 9e       ..
+    sta l00b5                                                         ; b274: 85 b5       ..
+    iny                                                               ; b276: c8          .
+    lda (l009e),y                                                     ; b277: b1 9e       ..
+    sta l00b6                                                         ; b279: 85 b6       ..
+    iny                                                               ; b27b: c8          .
+    lda (l009e),y                                                     ; b27c: b1 9e       ..
+    sta l00ae                                                         ; b27e: 85 ae       ..
+    clv                                                               ; b280: b8          .
+    jsr sub_cb198                                                     ; b281: 20 98 b1     ..
+    jsr print_inline_top_bit_clear                                    ; b284: 20 45 91     E.
+    equs " is "                                                       ; b287: 20 69 73...  is
+
+    ldx #0                                                            ; b28b: a2 00       ..
+    lda (l00ae,x)                                                     ; b28d: a1 ae       ..
+    bne cb29c                                                         ; b28f: d0 0b       ..
+    jsr print_inline_top_bit_clear                                    ; b291: 20 45 91     E.
+    equs "ready"                                                      ; b294: 72 65 61... rea
+
+    clv                                                               ; b299: b8          .
+    bvc cb2d4                                                         ; b29a: 50 38       P8
+; &b29c referenced 1 time by &b28f
+.cb29c
+    cmp #2                                                            ; b29c: c9 02       ..
+    bne cb2ac                                                         ; b29e: d0 0c       ..
+; &b2a0 referenced 1 time by &b2ae
+.loop_cb2a0
+    jsr print_inline_top_bit_clear                                    ; b2a0: 20 45 91     E.
+    equs "jammed"                                                     ; b2a3: 6a 61 6d... jam
+
+    clv                                                               ; b2a9: b8          .
+    bvc cb2d4                                                         ; b2aa: 50 28       P(
+; &b2ac referenced 1 time by &b29e
+.cb2ac
+    cmp #1                                                            ; b2ac: c9 01       ..
+    bne loop_cb2a0                                                    ; b2ae: d0 f0       ..
+    jsr print_inline_top_bit_clear                                    ; b2b0: 20 45 91     E.
+    equs "busy"                                                       ; b2b3: 62 75 73... bus
+
+    inc l00ae                                                         ; b2b7: e6 ae       ..
+    lda (l00ae,x)                                                     ; b2b9: a1 ae       ..
+    sta l00b5                                                         ; b2bb: 85 b5       ..
+    beq cb2d4                                                         ; b2bd: f0 15       ..
+    jsr print_inline_top_bit_clear                                    ; b2bf: 20 45 91     E.
+    equs " with "                                                     ; b2c2: 20 77 69...  wi
+
+    inc l00ae                                                         ; b2c8: e6 ae       ..
+    lda (l00ae,x)                                                     ; b2ca: a1 ae       ..
+    sta l00b6                                                         ; b2cc: 85 b6       ..
+    bit l9491                                                         ; b2ce: 2c 91 94    ,..
+    jsr sub_cb198                                                     ; b2d1: 20 98 b1     ..
+; &b2d4 referenced 3 times by &b29a, &b2aa, &b2bd
+.cb2d4
+    jsr osnewl                                                        ; b2d4: 20 e7 ff     ..
+; &b2d7 referenced 1 time by &b26e
+.cb2d7
+    pla                                                               ; b2d7: 68          h
+    tay                                                               ; b2d8: a8          .
+    lda #&3f ; '?'                                                    ; b2d9: a9 3f       .?
+    sta (l009e),y                                                     ; b2db: 91 9e       ..
+    bne cb267                                                         ; b2dd: d0 88       ..
+; &b2df referenced 1 time by &b268
+.cb2df
+    rts                                                               ; b2df: 60          `
+
+; &b2e0 referenced 1 time by &b1cd
+.sub_cb2e0
+    ldy #&78 ; 'x'                                                    ; b2e0: a0 78       .x
+; &b2e2 referenced 1 time by &b2f4
+.loop_cb2e2
+    lda lb13f,y                                                       ; b2e2: b9 3f b1    .?.
+    cpy #&7d ; '}'                                                    ; b2e5: c0 7d       .}
+    beq cb2ed                                                         ; b2e7: f0 04       ..
+    cpy #&81                                                          ; b2e9: c0 81       ..
+    bne cb2ef                                                         ; b2eb: d0 02       ..
+; &b2ed referenced 1 time by &b2e7
+.cb2ed
+    lda l009d                                                         ; b2ed: a5 9d       ..
+; &b2ef referenced 1 time by &b2eb
+.cb2ef
+    sta (l00ae),y                                                     ; b2ef: 91 ae       ..
+    iny                                                               ; b2f1: c8          .
+    cpy #&84                                                          ; b2f2: c0 84       ..
+    bne loop_cb2e2                                                    ; b2f4: d0 ec       ..
+    rts                                                               ; b2f6: 60          `
+
+; &b2f7 referenced 2 times by &b053, &b231
+.sub_cb2f7
+    ldy l00ad                                                         ; b2f7: a4 ad       ..
+    and #&7f                                                          ; b2f9: 29 7f       ).
+    cmp #&61 ; 'a'                                                    ; b2fb: c9 61       .a
+    bcc cb305                                                         ; b2fd: 90 06       ..
+    cmp #&7b ; '{'                                                    ; b2ff: c9 7b       .{
+    bcs cb305                                                         ; b301: b0 02       ..
+    and #&5f ; '_'                                                    ; b303: 29 5f       )_
+; &b305 referenced 2 times by &b2fd, &b301
+.cb305
+    sta (l009c),y                                                     ; b305: 91 9c       ..
+    iny                                                               ; b307: c8          .
+    sty l00ad                                                         ; b308: 84 ad       ..
+    dex                                                               ; b30a: ca          .
+    rts                                                               ; b30b: 60          `
+
+.sub_cb30c
+    lda (l00be),y                                                     ; b30c: b1 be       ..
+    eor #&0d                                                          ; b30e: 49 0d       I.
+    bne cb316                                                         ; b310: d0 04       ..
+    lda #&ff                                                          ; b312: a9 ff       ..
+    bne cb336                                                         ; b314: d0 20       .
+; &b316 referenced 1 time by &b310
+.cb316
+    lda l0d68                                                         ; b316: ad 68 0d    .h.
+    pha                                                               ; b319: 48          H
+; &b31a referenced 1 time by &b32a
+.loop_cb31a
+    ldx #&d3                                                          ; b31a: a2 d3       ..
+    lda (l00be),y                                                     ; b31c: b1 be       ..
+    sta l00a8                                                         ; b31e: 85 a8       ..
+    jsr sub_ca140                                                     ; b320: 20 40 a1     @.
+    bcs cb32c                                                         ; b323: b0 07       ..
+    pla                                                               ; b325: 68          h
+    ora la3f1,x                                                       ; b326: 1d f1 a3    ...
+    pha                                                               ; b329: 48          H
+    bne loop_cb31a                                                    ; b32a: d0 ee       ..
+; &b32c referenced 2 times by &b323, &b350
+.cb32c
+    lda l00a8                                                         ; b32c: a5 a8       ..
+    eor #&0d                                                          ; b32e: 49 0d       I.
+    beq cb335                                                         ; b330: f0 03       ..
+    jmp ca25d                                                         ; b332: 4c 5d a2    L].
+
+; &b335 referenced 1 time by &b330
+.cb335
+    pla                                                               ; b335: 68          h
+; &b336 referenced 2 times by &b314, &b341
+.cb336
+    sta l0d68                                                         ; b336: 8d 68 0d    .h.
+    sta l0d69                                                         ; b339: 8d 69 0d    .i.
+    rts                                                               ; b33c: 60          `
+
+.sub_cb33d
+    lda (l00be),y                                                     ; b33d: b1 be       ..
+    eor #&0d                                                          ; b33f: 49 0d       I.
+    beq cb336                                                         ; b341: f0 f3       ..
+    lda l0d68                                                         ; b343: ad 68 0d    .h.
+    pha                                                               ; b346: 48          H
+; &b347 referenced 1 time by &b357
+.loop_cb347
+    ldx #&d3                                                          ; b347: a2 d3       ..
+    lda (l00be),y                                                     ; b349: b1 be       ..
+    sta l00a8                                                         ; b34b: 85 a8       ..
+    jsr sub_ca140                                                     ; b34d: 20 40 a1     @.
+    bcs cb32c                                                         ; b350: b0 da       ..
+    pla                                                               ; b352: 68          h
+    and la3f2,x                                                       ; b353: 3d f2 a3    =..
+    pha                                                               ; b356: 48          H
+    bcc loop_cb347                                                    ; b357: 90 ee       ..
+.sub_cb359
+    jsr sub_caf32                                                     ; b359: 20 32 af     2.
+    lda #0                                                            ; b35c: a9 00       ..
+    sta l00b5                                                         ; b35e: 85 b5       ..
+    jsr sub_cafb5                                                     ; b360: 20 b5 af     ..
+    jsr sub_cae94                                                     ; b363: 20 94 ae     ..
+    inx                                                               ; b366: e8          .
+    stx l00b6                                                         ; b367: 86 b6       ..
+; &b369 referenced 1 time by &b3a5
+.cb369
+    lda #1                                                            ; b369: a9 01       ..
+    sta l0f05                                                         ; b36b: 8d 05 0f    ...
+    sta l0f07                                                         ; b36e: 8d 07 0f    ...
+    ldx l00b5                                                         ; b371: a6 b5       ..
+    stx l0f06                                                         ; b373: 8e 06 0f    ...
+    ldx #3                                                            ; b376: a2 03       ..
+    jsr sub_caf04                                                     ; b378: 20 04 af     ..
+    ldy #3                                                            ; b37b: a0 03       ..
+    lda #&80                                                          ; b37d: a9 80       ..
+    sta l0098                                                         ; b37f: 85 98       ..
+    jsr c94ad                                                         ; b381: 20 ad 94     ..
+    lda l0f05                                                         ; b384: ad 05 0f    ...
+    bne cb39c                                                         ; b387: d0 13       ..
+    lda #osbyte_flush_buffer_class                                    ; b389: a9 0f       ..
+    ldx #1                                                            ; b38b: a2 01       ..
+    jsr osbyte                                                        ; b38d: 20 f4 ff     ..
+    lda #osbyte_scan_keyboard_from_16                                 ; b390: a9 7a       .z
+    jsr osbyte                                                        ; b392: 20 f4 ff     ..
+    ldy #0                                                            ; b395: a0 00       ..
+    lda #osbyte_write_keys_pressed                                    ; b397: a9 78       .x
+    jmp osbyte                                                        ; b399: 4c f4 ff    L..
+
+; &b39c referenced 1 time by &b387
+.cb39c
+    lda l0f2f                                                         ; b39c: ad 2f 0f    ./.
+; &b39f referenced 1 time by &b3af
+.loop_cb39f
+    cmp #&4c ; 'L'                                                    ; b39f: c9 4c       .L
+    bne cb3a8                                                         ; b3a1: d0 05       ..
+; &b3a3 referenced 1 time by &b420
+.cb3a3
+    inc l00b5                                                         ; b3a3: e6 b5       ..
+    jmp cb369                                                         ; b3a5: 4c 69 b3    Li.
+
+; &b3a8 referenced 1 time by &b3a1
+.cb3a8
+    cmp #&44 ; 'D'                                                    ; b3a8: c9 44       .D
+    bne cb3b1                                                         ; b3aa: d0 05       ..
+    lda l0f30                                                         ; b3ac: ad 30 0f    .0.
+    bne loop_cb39f                                                    ; b3af: d0 ee       ..
+; &b3b1 referenced 1 time by &b3aa
+.cb3b1
+    ldx #1                                                            ; b3b1: a2 01       ..
+    ldy l00b6                                                         ; b3b3: a4 b6       ..
+; &b3b5 referenced 1 time by &b3c2
+.loop_cb3b5
+    lda l0f06,x                                                       ; b3b5: bd 06 0f    ...
+    jsr osasci                                                        ; b3b8: 20 e3 ff     ..
+    sta l0e30,y                                                       ; b3bb: 99 30 0e    .0.
+    iny                                                               ; b3be: c8          .
+    inx                                                               ; b3bf: e8          .
+    cpx #&0c                                                          ; b3c0: e0 0c       ..
+    bne loop_cb3b5                                                    ; b3c2: d0 f1       ..
+    jsr print_inline_top_bit_clear                                    ; b3c4: 20 45 91     E.
+    equs "(?/"                                                        ; b3c7: 28 3f 2f    (?/
+
+    nop                                                               ; b3ca: ea          .
+    jsr sub_cb431                                                     ; b3cb: 20 31 b4     1.
+    cmp #&3f ; '?'                                                    ; b3ce: c9 3f       .?
+    bne cb3ed                                                         ; b3d0: d0 1b       ..
+    lda #&0d                                                          ; b3d2: a9 0d       ..
+    jsr oswrch                                                        ; b3d4: 20 ee ff     ..
+    ldx #2                                                            ; b3d7: a2 02       ..
+; &b3d9 referenced 1 time by &b3e2
+.loop_cb3d9
+    lda l0f05,x                                                       ; b3d9: bd 05 0f    ...
+    jsr osasci                                                        ; b3dc: 20 e3 ff     ..
+    inx                                                               ; b3df: e8          .
+    cpx #&3e ; '>'                                                    ; b3e0: e0 3e       .>
+    bne loop_cb3d9                                                    ; b3e2: d0 f5       ..
+    jsr print_inline_top_bit_clear                                    ; b3e4: 20 45 91     E.
+    equs " ("                                                         ; b3e7: 20 28        (
+
+    nop                                                               ; b3e9: ea          .
+    jsr sub_cb431                                                     ; b3ea: 20 31 b4     1.
+; &b3ed referenced 1 time by &b3d0
+.cb3ed
+    and #&df                                                          ; b3ed: 29 df       ).
+    cmp #&59 ; 'Y'                                                    ; b3ef: c9 59       .Y
+    bne cb41d                                                         ; b3f1: d0 2a       .*
+    jsr osasci                                                        ; b3f3: 20 e3 ff     ..
+    ldx #0                                                            ; b3f6: a2 00       ..
+    lda l0e30,x                                                       ; b3f8: bd 30 0e    .0.
+    cmp #&0d                                                          ; b3fb: c9 0d       ..
+    beq cb423                                                         ; b3fd: f0 24       .$
+; &b3ff referenced 1 time by &b414
+.loop_cb3ff
+    lda l0e30,x                                                       ; b3ff: bd 30 0e    .0.
+    cmp #&0d                                                          ; b402: c9 0d       ..
+    bne cb408                                                         ; b404: d0 02       ..
+    lda #&2e ; '.'                                                    ; b406: a9 2e       ..
+; &b408 referenced 1 time by &b404
+.cb408
+    cmp #&20 ; ' '                                                    ; b408: c9 20       .
+    bne cb40e                                                         ; b40a: d0 02       ..
+; &b40c referenced 1 time by &b42f
+.cb40c
+    lda #&0d                                                          ; b40c: a9 0d       ..
+; &b40e referenced 1 time by &b40a
+.cb40e
+    sta l0f05,x                                                       ; b40e: 9d 05 0f    ...
+    inx                                                               ; b411: e8          .
+    cmp #&0d                                                          ; b412: c9 0d       ..
+    bne loop_cb3ff                                                    ; b414: d0 e9       ..
+    ldy #&14                                                          ; b416: a0 14       ..
+    jsr c94ad                                                         ; b418: 20 ad 94     ..
+    dec l00b5                                                         ; b41b: c6 b5       ..
+; &b41d referenced 1 time by &b3f1
+.cb41d
+    jsr osnewl                                                        ; b41d: 20 e7 ff     ..
+    jmp cb3a3                                                         ; b420: 4c a3 b3    L..
+
+; &b423 referenced 1 time by &b3fd
+.cb423
+    dex                                                               ; b423: ca          .
+; &b424 referenced 1 time by &b42d
+.loop_cb424
+    inx                                                               ; b424: e8          .
+    lda l0e31,x                                                       ; b425: bd 31 0e    .1.
+    sta l0f05,x                                                       ; b428: 9d 05 0f    ...
+    cmp #&20 ; ' '                                                    ; b42b: c9 20       .
+    bne loop_cb424                                                    ; b42d: d0 f5       ..
+    beq cb40c                                                         ; b42f: f0 db       ..
+; &b431 referenced 2 times by &b3cb, &b3ea
+.sub_cb431
+    jsr print_inline_top_bit_clear                                    ; b431: 20 45 91     E.
+    equs "Y/N) "                                                      ; b434: 59 2f 4e... Y/N
+
+    lda #osbyte_flush_buffer_class                                    ; b439: a9 0f       ..
+    ldx #1                                                            ; b43b: a2 01       ..
+    jsr osbyte                                                        ; b43d: 20 f4 ff     ..
+    jsr osrdch                                                        ; b440: 20 e0 ff     ..
+    bcc cb448                                                         ; b443: 90 03       ..
+    jmp c9576                                                         ; b445: 4c 76 95    Lv.
+
+; &b448 referenced 1 time by &b443
+.cb448
+    rts                                                               ; b448: 60          `
+
+; &b449 referenced 1 time by &8b75
+.sub_cb449
+    lda #0                                                            ; b449: a9 00       ..
+    tay                                                               ; b44b: a8          .
+; &b44c referenced 1 time by &b450
+.loop_cb44c
+    sta l1000,y                                                       ; b44c: 99 00 10    ...
+    iny                                                               ; b44f: c8          .
+    bne loop_cb44c                                                    ; b450: d0 fa       ..
+    ldy #&0b                                                          ; b452: a0 0b       ..
+    lda (l009c),y                                                     ; b454: b1 9c       ..
+    sec                                                               ; b456: 38          8
+    sbc #&5a ; 'Z'                                                    ; b457: e9 5a       .Z
+    tay                                                               ; b459: a8          .
+    lda #&40 ; '@'                                                    ; b45a: a9 40       .@
+; &b45c referenced 1 time by &b462
+.loop_cb45c
+    sta l1000,y                                                       ; b45c: 99 00 10    ...
+    dey                                                               ; b45f: 88          .
+    cpy #&b8                                                          ; b460: c0 b8       ..
+    bpl loop_cb45c                                                    ; b462: 10 f8       ..
+    iny                                                               ; b464: c8          .
+    lda #&c0                                                          ; b465: a9 c0       ..
+    sta l1000,y                                                       ; b467: 99 00 10    ...
+    rts                                                               ; b46a: 60          `
+
+; &b46b referenced 1 time by &b73d
+.sub_cb46b
+    php                                                               ; b46b: 08          .
+    sec                                                               ; b46c: 38          8
+    sbc #&20 ; ' '                                                    ; b46d: e9 20       .
+    bmi cb475                                                         ; b46f: 30 04       0.
+    cmp #&10                                                          ; b471: c9 10       ..
+    bcc cb477                                                         ; b473: 90 02       ..
+; &b475 referenced 1 time by &b46f
+.cb475
+    lda #&ff                                                          ; b475: a9 ff       ..
+; &b477 referenced 1 time by &b473
+.cb477
+    plp                                                               ; b477: 28          (
+    tax                                                               ; b478: aa          .
+    rts                                                               ; b479: 60          `
+
+    equb &c9, &20, &90,   4, &c9, &30, &90, &2b, &48                  ; b47a: c9 20 90... . .
+
+; &b483 referenced 1 time by &b4b5
+.cb483
+    lda #&de                                                          ; b483: a9 de       ..
+.sub_cb485
+lb487 = sub_cb485+2
+    jsr generate_error_inline3                                        ; b485: 20 d1 96     ..
+; &b487 referenced 2 times by &b4cd, &b4e1
+    equs "Net channel", 0                                             ; b488: 4e 65 74... Net
+    equs " not on this file server"                                   ; b494: 20 6e 6f...  no
+    equb 0                                                            ; b4ac: 00          .
+
+; &b4ad referenced 1 time by &9ed6
+.sub_cb4ad
+    pha                                                               ; b4ad: 48          H
+    sec                                                               ; b4ae: 38          8
+    sbc #&20 ; ' '                                                    ; b4af: e9 20       .
+    tax                                                               ; b4b1: aa          .
+    lda l1030,x                                                       ; b4b2: bd 30 10    .0.
+    beq cb483                                                         ; b4b5: f0 cc       ..
+    jsr sub_cb586                                                     ; b4b7: 20 86 b5     ..
+    bne cb4c1                                                         ; b4ba: d0 05       ..
+    pla                                                               ; b4bc: 68          h
+    lda l1060,x                                                       ; b4bd: bd 60 10    .`.
+    rts                                                               ; b4c0: 60          `
+
+; &b4c1 referenced 1 time by &b4ba
+.cb4c1
+    lda #&de                                                          ; b4c1: a9 de       ..
+    sta l0101                                                         ; b4c3: 8d 01 01    ...
+    lda #0                                                            ; b4c6: a9 00       ..
+    sta l0100                                                         ; b4c8: 8d 00 01    ...
+    tax                                                               ; b4cb: aa          .
+; &b4cc referenced 1 time by &b4d3
+.loop_cb4cc
+    inx                                                               ; b4cc: e8          .
+    lda lb487,x                                                       ; b4cd: bd 87 b4    ...
+    sta l0101,x                                                       ; b4d0: 9d 01 01    ...
+    bne loop_cb4cc                                                    ; b4d3: d0 f7       ..
+    stx l00b2                                                         ; b4d5: 86 b2       ..
+    stx l00b4                                                         ; b4d7: 86 b4       ..
+    pla                                                               ; b4d9: 68          h
+    jsr sub_c9771                                                     ; b4da: 20 71 97     q.
+    ldy l00b4                                                         ; b4dd: a4 b4       ..
+; &b4df referenced 1 time by &b4e7
+.loop_cb4df
+    iny                                                               ; b4df: c8          .
+    inx                                                               ; b4e0: e8          .
+    lda lb487,y                                                       ; b4e1: b9 87 b4    ...
+    sta l0101,x                                                       ; b4e4: 9d 01 01    ...
+    bne loop_cb4df                                                    ; b4e7: d0 f6       ..
+    jmp l0100                                                         ; b4e9: 4c 00 01    L..
+
+    equb &ad, &c9, &10, &20, &8f, &b9, &20, &7a, &b4, &29,   2, &f0   ; b4ec: ad c9 10... ...
+    equb &0f, &a9, &a8, &20, &d1, &96                                 ; b4f8: 0f a9 a8... ...
+    equs "Is a dir."                                                  ; b4fe: 49 73 20... Is
+    equb   0, &60                                                     ; b507: 00 60       .`
+
+; &b509 referenced 5 times by &a280, &a31f, &a34a, &a381, &b540
+.sub_cb509
+    pha                                                               ; b509: 48          H
+    ldx #&20 ; ' '                                                    ; b50a: a2 20       .
+; &b50c referenced 1 time by &b514
+.loop_cb50c
+    lda l1010,x                                                       ; b50c: bd 10 10    ...
+    beq cb51a                                                         ; b50f: f0 09       ..
+    inx                                                               ; b511: e8          .
+    cpx #&30 ; '0'                                                    ; b512: e0 30       .0
+    bne loop_cb50c                                                    ; b514: d0 f6       ..
+    pla                                                               ; b516: 68          h
+    lda #0                                                            ; b517: a9 00       ..
+    rts                                                               ; b519: 60          `
+
+; &b51a referenced 1 time by &b50f
+.cb51a
+    pla                                                               ; b51a: 68          h
+    sta l1010,x                                                       ; b51b: 9d 10 10    ...
+    lda #0                                                            ; b51e: a9 00       ..
+    sta l0fe0,x                                                       ; b520: 9d e0 0f    ...
+    sta l0ff0,x                                                       ; b523: 9d f0 0f    ...
+    sta l1000,x                                                       ; b526: 9d 00 10    ...
+    lda l0e00                                                         ; b529: ad 00 0e    ...
+    sta l1020,x                                                       ; b52c: 9d 20 10    . .
+    lda l0e01                                                         ; b52f: ad 01 0e    ...
+    sta l1030,x                                                       ; b532: 9d 30 10    .0.
+    txa                                                               ; b535: 8a          .
+    pha                                                               ; b536: 48          H
+    sec                                                               ; b537: 38          8
+    sbc #&20 ; ' '                                                    ; b538: e9 20       .
+    tax                                                               ; b53a: aa          .
+    pla                                                               ; b53b: 68          h
+    rts                                                               ; b53c: 60          `
+
+; &b53d referenced 1 time by &a1ed
+.sub_cb53d
+    pha                                                               ; b53d: 48          H
+    lda #0                                                            ; b53e: a9 00       ..
+    jsr sub_cb509                                                     ; b540: 20 09 b5     ..
+    bne cb557                                                         ; b543: d0 12       ..
+    lda #&c0                                                          ; b545: a9 c0       ..
+    jsr generate_error_inline3                                        ; b547: 20 d1 96     ..
+    equs "No more FCBs", 0                                            ; b54a: 4e 6f 20... No
+
+; &b557 referenced 1 time by &b543
+.cb557
+    pla                                                               ; b557: 68          h
+    rts                                                               ; b558: 60          `
+
+; &b559 referenced 3 times by &94a8, &9533, &a391
+.sub_cb559
+    clc                                                               ; b559: 18          .
+    bit l9491                                                         ; b55a: 2c 91 94    ,..
+    ldx #&10                                                          ; b55d: a2 10       ..
+; &b55f referenced 4 times by &b56b, &b575, &b57a, &b584
+.cb55f
+    dex                                                               ; b55f: ca          .
+    bpl cb563                                                         ; b560: 10 01       ..
+    rts                                                               ; b562: 60          `
+
+; &b563 referenced 1 time by &b560
+.cb563
+    lda l1060,x                                                       ; b563: bd 60 10    .`.
+    tay                                                               ; b566: a8          .
+    and #2                                                            ; b567: 29 02       ).
+    beq cb577                                                         ; b569: f0 0c       ..
+    bvc cb55f                                                         ; b56b: 50 f2       P.
+    bcc cb577                                                         ; b56d: 90 08       ..
+    tya                                                               ; b56f: 98          .
+    and #&df                                                          ; b570: 29 df       ).
+    sta l1060,x                                                       ; b572: 9d 60 10    .`.
+    bvs cb55f                                                         ; b575: 70 e8       p.
+; &b577 referenced 2 times by &b569, &b56d
+.cb577
+    jsr sub_cb586                                                     ; b577: 20 86 b5     ..
+    bne cb55f                                                         ; b57a: d0 e3       ..
+    lda #0                                                            ; b57c: a9 00       ..
+    sta l1060,x                                                       ; b57e: 9d 60 10    .`.
+    sta l1030,x                                                       ; b581: 9d 30 10    .0.
+    beq cb55f                                                         ; b584: f0 d9       ..
+; &b586 referenced 6 times by &a306, &a331, &a368, &ac40, &b4b7, &b577
+.sub_cb586
+    lda l1040,x                                                       ; b586: bd 40 10    .@.
+    eor l0e00                                                         ; b589: 4d 00 0e    M..
+    bne cb594                                                         ; b58c: d0 06       ..
+    lda l1050,x                                                       ; b58e: bd 50 10    .P.
+    eor l0e01                                                         ; b591: 4d 01 0e    M..
+; &b594 referenced 1 time by &b58c
+.cb594
+    rts                                                               ; b594: 60          `
+
+; &b595 referenced 2 times by &b694, &b782
+.sub_cb595
+    ldx l10c8                                                         ; b595: ae c8 10    ...
+    bit l9491                                                         ; b598: 2c 91 94    ,..
+; &b59b referenced 4 times by &b5aa, &b5b0, &b5cd, &b5d4
+.cb59b
+    inx                                                               ; b59b: e8          .
+    cpx #&10                                                          ; b59c: e0 10       ..
+    bne cb5a2                                                         ; b59e: d0 02       ..
+    ldx #0                                                            ; b5a0: a2 00       ..
+; &b5a2 referenced 1 time by &b59e
+.cb5a2
+    cpx l10c8                                                         ; b5a2: ec c8 10    ...
+    bne cb5ac                                                         ; b5a5: d0 05       ..
+    bvc cb5b7                                                         ; b5a7: 50 0e       P.
+    clv                                                               ; b5a9: b8          .
+    bvc cb59b                                                         ; b5aa: 50 ef       P.
+; &b5ac referenced 1 time by &b5a5
+.cb5ac
+    lda l10b8,x                                                       ; b5ac: bd b8 10    ...
+    rol a                                                             ; b5af: 2a          *
+    bpl cb59b                                                         ; b5b0: 10 e9       ..
+    and #4                                                            ; b5b2: 29 04       ).
+    bne cb5cd                                                         ; b5b4: d0 17       ..
+; &b5b6 referenced 1 time by &b5d6
+.cb5b6
+    dex                                                               ; b5b6: ca          .
+; &b5b7 referenced 2 times by &b5a7, &b5c2
+.cb5b7
+    inx                                                               ; b5b7: e8          .
+    cpx #&10                                                          ; b5b8: e0 10       ..
+    bne cb5be                                                         ; b5ba: d0 02       ..
+    ldx #0                                                            ; b5bc: a2 00       ..
+; &b5be referenced 1 time by &b5ba
+.cb5be
+    lda l10b8,x                                                       ; b5be: bd b8 10    ...
+    rol a                                                             ; b5c1: 2a          *
+    bpl cb5b7                                                         ; b5c2: 10 f3       ..
+    sec                                                               ; b5c4: 38          8
+    ror a                                                             ; b5c5: 6a          j
+    sta l10b8,x                                                       ; b5c6: 9d b8 10    ...
+    ldx l10c8                                                         ; b5c9: ae c8 10    ...
+    rts                                                               ; b5cc: 60          `
+
+; &b5cd referenced 1 time by &b5b4
+.cb5cd
+    bvs cb59b                                                         ; b5cd: 70 cc       p.
+    lda l10b8,x                                                       ; b5cf: bd b8 10    ...
+    and #&20 ; ' '                                                    ; b5d2: 29 20       )
+    bne cb59b                                                         ; b5d4: d0 c5       ..
+    beq cb5b6                                                         ; b5d6: f0 de       ..
+; &b5d8 referenced 2 times by &b61b, &b6c6
+.sub_cb5d8
+    ldy #1                                                            ; b5d8: a0 01       ..
+    sty l10d0                                                         ; b5da: 8c d0 10    ...
+    dey                                                               ; b5dd: 88          .
+    sty l10cb                                                         ; b5de: 8c cb 10    ...
+    sty l10cf                                                         ; b5e1: 8c cf 10    ...
+    sty l10d6                                                         ; b5e4: 8c d6 10    ...
+    tya                                                               ; b5e7: 98          .
+    ldx #2                                                            ; b5e8: a2 02       ..
+; &b5ea referenced 1 time by &b5ee
+.loop_cb5ea
+    sta l10d1,x                                                       ; b5ea: 9d d1 10    ...
+    dex                                                               ; b5ed: ca          .
+    bpl loop_cb5ea                                                    ; b5ee: 10 fa       ..
+    stx l10cd                                                         ; b5f0: 8e cd 10    ...
+    stx l10ce                                                         ; b5f3: 8e ce 10    ...
+    ldx #&ca                                                          ; b5f6: a2 ca       ..
+    ldy #&10                                                          ; b5f8: a0 10       ..
+    rts                                                               ; b5fa: 60          `
+
+; &b5fb referenced 2 times by &b68b, &b7b7
+.sub_cb5fb
+    jsr sub_c8fcb                                                     ; b5fb: 20 cb 8f     ..
+    stx l10c8                                                         ; b5fe: 8e c8 10    ...
+    lda l10b8,x                                                       ; b601: bd b8 10    ...
+    ror a                                                             ; b604: 6a          j
+    bcc cb661                                                         ; b605: 90 5a       .Z
+    lda l10d4                                                         ; b607: ad d4 10    ...
+    pha                                                               ; b60a: 48          H
+    lda l10d5                                                         ; b60b: ad d5 10    ...
+    pha                                                               ; b60e: 48          H
+    lda l1078,x                                                       ; b60f: bd 78 10    .x.
+    sta l10d4                                                         ; b612: 8d d4 10    ...
+    lda l1088,x                                                       ; b615: bd 88 10    ...
+    sta l10d5                                                         ; b618: 8d d5 10    ...
+    jsr sub_cb5d8                                                     ; b61b: 20 d8 b5     ..
+    dec l10cf                                                         ; b61e: ce cf 10    ...
+    dec l10d0                                                         ; b621: ce d0 10    ...
+    ldx l10c8                                                         ; b624: ae c8 10    ...
+    txa                                                               ; b627: 8a          .
+    clc                                                               ; b628: 18          .
+    adc #&11                                                          ; b629: 69 11       i.
+    sta l10cc                                                         ; b62b: 8d cc 10    ...
+    lda l10b8,x                                                       ; b62e: bd b8 10    ...
+    and #&20 ; ' '                                                    ; b631: 29 20       )
+    beq cb63b                                                         ; b633: f0 06       ..
+    lda l1098,x                                                       ; b635: bd 98 10    ...
+    sta l10cf                                                         ; b638: 8d cf 10    ...
+; &b63b referenced 1 time by &b633
+.cb63b
+    lda l10a8,x                                                       ; b63b: bd a8 10    ...
+    sta l10ca                                                         ; b63e: 8d ca 10    ...
+    tax                                                               ; b641: aa          .
+    jsr sub_cb98a                                                     ; b642: 20 8a b9     ..
+    pha                                                               ; b645: 48          H
+    txa                                                               ; b646: 8a          .
+    sta (l009c),y                                                     ; b647: 91 9c       ..
+    ldx #&ca                                                          ; b649: a2 ca       ..
+    ldy #&10                                                          ; b64b: a0 10       ..
+    lda #0                                                            ; b64d: a9 00       ..
+    jsr sub_cb984                                                     ; b64f: 20 84 b9     ..
+    ldx l10c8                                                         ; b652: ae c8 10    ...
+    pla                                                               ; b655: 68          h
+    jsr sub_cb98f                                                     ; b656: 20 8f b9     ..
+    pla                                                               ; b659: 68          h
+    sta l10d5                                                         ; b65a: 8d d5 10    ...
+    pla                                                               ; b65d: 68          h
+    sta l10d4                                                         ; b65e: 8d d4 10    ...
+; &b661 referenced 1 time by &b605
+.cb661
+    lda #&dc                                                          ; b661: a9 dc       ..
+    and l10b8,x                                                       ; b663: 3d b8 10    =..
+    sta l10b8,x                                                       ; b666: 9d b8 10    ...
+    rts                                                               ; b669: 60          `
+
+; &b66a referenced 2 times by &b72d, &b8ef
+.sub_cb66a
+    ldx #&0c                                                          ; b66a: a2 0c       ..
+; &b66c referenced 1 time by &b676
+.loop_cb66c
+    lda l0f00,x                                                       ; b66c: bd 00 0f    ...
+    sta l10d9,x                                                       ; b66f: 9d d9 10    ...
+    lda l00b0,x                                                       ; b672: b5 b0       ..
+    pha                                                               ; b674: 48          H
+    dex                                                               ; b675: ca          .
+    bpl loop_cb66c                                                    ; b676: 10 f4       ..
+    cpy #0                                                            ; b678: c0 00       ..
+    bne cb67f                                                         ; b67a: d0 03       ..
+    jmp cb718                                                         ; b67c: 4c 18 b7    L..
+
+; &b67f referenced 1 time by &b67a
+.cb67f
+    php                                                               ; b67f: 08          .
+    ldx #&ff                                                          ; b680: a2 ff       ..
+; &b682 referenced 2 times by &b686, &b689
+.cb682
+    inx                                                               ; b682: e8          .
+    lda l10b8,x                                                       ; b683: bd b8 10    ...
+    bpl cb682                                                         ; b686: 10 fa       ..
+    asl a                                                             ; b688: 0a          .
+    bpl cb682                                                         ; b689: 10 f7       ..
+    jsr sub_cb5fb                                                     ; b68b: 20 fb b5     ..
+    lda #&40 ; '@'                                                    ; b68e: a9 40       .@
+    sta l10b8,x                                                       ; b690: 9d b8 10    ...
+    php                                                               ; b693: 08          .
+    jsr sub_cb595                                                     ; b694: 20 95 b5     ..
+    plp                                                               ; b697: 28          (
+    lda l10c9                                                         ; b698: ad c9 10    ...
+    sta l10ca                                                         ; b69b: 8d ca 10    ...
+    pha                                                               ; b69e: 48          H
+    sec                                                               ; b69f: 38          8
+    sbc #&20 ; ' '                                                    ; b6a0: e9 20       .
+    tay                                                               ; b6a2: a8          .
+    lda l1030,y                                                       ; b6a3: b9 30 10    .0.
+    sta l0f05                                                         ; b6a6: 8d 05 0f    ...
+    pla                                                               ; b6a9: 68          h
+    sta l10a8,x                                                       ; b6aa: 9d a8 10    ...
+    lda l10d4                                                         ; b6ad: ad d4 10    ...
+    sta l1078,x                                                       ; b6b0: 9d 78 10    .x.
+    lda l10d5                                                         ; b6b3: ad d5 10    ...
+    sta l1088,x                                                       ; b6b6: 9d 88 10    ...
+    txa                                                               ; b6b9: 8a          .
+    clc                                                               ; b6ba: 18          .
+    adc #&11                                                          ; b6bb: 69 11       i.
+    sta l10cc                                                         ; b6bd: 8d cc 10    ...
+    plp                                                               ; b6c0: 28          (
+    bvc cb6c6                                                         ; b6c1: 50 03       P.
+    jsr sub_cb8da                                                     ; b6c3: 20 da b8     ..
+; &b6c6 referenced 1 time by &b6c1
+.cb6c6
+    jsr sub_cb5d8                                                     ; b6c6: 20 d8 b5     ..
+    jsr sub_cb98a                                                     ; b6c9: 20 8a b9     ..
+    pha                                                               ; b6cc: 48          H
+    lda l10ca                                                         ; b6cd: ad ca 10    ...
+    sta (l009c),y                                                     ; b6d0: 91 9c       ..
+    ldy #&10                                                          ; b6d2: a0 10       ..
+    lda #2                                                            ; b6d4: a9 02       ..
+    jsr sub_cb984                                                     ; b6d6: 20 84 b9     ..
+    pla                                                               ; b6d9: 68          h
+    jsr sub_cb98f                                                     ; b6da: 20 8f b9     ..
+    ldx l10c8                                                         ; b6dd: ae c8 10    ...
+    lda l10d0                                                         ; b6e0: ad d0 10    ...
+    bne cb6ea                                                         ; b6e3: d0 05       ..
+    lda l10cf                                                         ; b6e5: ad cf 10    ...
+    beq cb70e                                                         ; b6e8: f0 24       .$
+; &b6ea referenced 1 time by &b6e3
+.cb6ea
+    lda l10cf                                                         ; b6ea: ad cf 10    ...
+    eor #&ff                                                          ; b6ed: 49 ff       I.
+    clc                                                               ; b6ef: 18          .
+    adc #1                                                            ; b6f0: 69 01       i.
+    sta l1098,x                                                       ; b6f2: 9d 98 10    ...
+    lda #&20 ; ' '                                                    ; b6f5: a9 20       .
+    ora l10b8,x                                                       ; b6f7: 1d b8 10    ...
+    sta l10b8,x                                                       ; b6fa: 9d b8 10    ...
+    lda l10cc                                                         ; b6fd: ad cc 10    ...
+    sta l00b3                                                         ; b700: 85 b3       ..
+    lda #0                                                            ; b702: a9 00       ..
+    sta l00b2                                                         ; b704: 85 b2       ..
+    ldy l1098,x                                                       ; b706: bc 98 10    ...
+; &b709 referenced 1 time by &b70c
+.loop_cb709
+    sta (l00b2),y                                                     ; b709: 91 b2       ..
+    iny                                                               ; b70b: c8          .
+    bne loop_cb709                                                    ; b70c: d0 fb       ..
+; &b70e referenced 1 time by &b6e8
+.cb70e
+    lda #2                                                            ; b70e: a9 02       ..
+    ora l10b8,x                                                       ; b710: 1d b8 10    ...
+    sta l10b8,x                                                       ; b713: 9d b8 10    ...
+    ldy #0                                                            ; b716: a0 00       ..
+; &b718 referenced 2 times by &b67c, &b71f
+.cb718
+    pla                                                               ; b718: 68          h
+    sta l00b0,y                                                       ; b719: 99 b0 00    ...
+    iny                                                               ; b71c: c8          .
+    cpy #&0d                                                          ; b71d: c0 0d       ..
+    bne cb718                                                         ; b71f: d0 f7       ..
+; &b721 referenced 1 time by &b922
+.sub_cb721
+    ldy #&0c                                                          ; b721: a0 0c       ..
+; &b723 referenced 1 time by &b72a
+.loop_cb723
+    lda l10d9,y                                                       ; b723: b9 d9 10    ...
+    sta l0f00,y                                                       ; b726: 99 00 0f    ...
+    dey                                                               ; b729: 88          .
+    bpl loop_cb723                                                    ; b72a: 10 f7       ..
+    rts                                                               ; b72c: 60          `
+
+; &b72d referenced 1 time by &b74c
+.loop_cb72d
+    jsr sub_cb66a                                                     ; b72d: 20 6a b6     j.
+; &b730 referenced 1 time by &9df8
+.sub_cb730
+    ldx #&ff                                                          ; b730: a2 ff       ..
+; &b732 referenced 2 times by &b76e, &b776
+.cb732
+    ldy l10c9                                                         ; b732: ac c9 10    ...
+; &b735 referenced 2 times by &b754, &b75a
+.cb735
+    inx                                                               ; b735: e8          .
+    cpx #&10                                                          ; b736: e0 10       ..
+    bne cb74f                                                         ; b738: d0 15       ..
+    lda l10c9                                                         ; b73a: ad c9 10    ...
+    jsr sub_cb46b                                                     ; b73d: 20 6b b4     k.
+    lda l1020,x                                                       ; b740: bd 20 10    . .
+    sta l10d5                                                         ; b743: 8d d5 10    ...
+    lda l1010,x                                                       ; b746: bd 10 10    ...
+    sta l10d4                                                         ; b749: 8d d4 10    ...
+    jmp loop_cb72d                                                    ; b74c: 4c 2d b7    L-.
+
+; &b74f referenced 1 time by &b738
+.cb74f
+    lda l10b8,x                                                       ; b74f: bd b8 10    ...
+    and #2                                                            ; b752: 29 02       ).
+    beq cb735                                                         ; b754: f0 df       ..
+    tya                                                               ; b756: 98          .
+    cmp l10a8,x                                                       ; b757: dd a8 10    ...
+    bne cb735                                                         ; b75a: d0 d9       ..
+    stx l10c8                                                         ; b75c: 8e c8 10    ...
+    php                                                               ; b75f: 08          .
+    sec                                                               ; b760: 38          8
+    sbc #&20 ; ' '                                                    ; b761: e9 20       .
+    plp                                                               ; b763: 28          (
+    tay                                                               ; b764: a8          .
+    ldx l10c8                                                         ; b765: ae c8 10    ...
+    lda l1010,y                                                       ; b768: b9 10 10    ...
+    cmp l1078,x                                                       ; b76b: dd 78 10    .x.
+    bne cb732                                                         ; b76e: d0 c2       ..
+    lda l1020,y                                                       ; b770: b9 20 10    . .
+    cmp l1088,x                                                       ; b773: dd 88 10    ...
+    bne cb732                                                         ; b776: d0 ba       ..
+    lda l10b8,x                                                       ; b778: bd b8 10    ...
+    bpl cb788                                                         ; b77b: 10 0b       ..
+    and #&7f                                                          ; b77d: 29 7f       ).
+    sta l10b8,x                                                       ; b77f: 9d b8 10    ...
+    jsr sub_cb595                                                     ; b782: 20 95 b5     ..
+    lda l10b8,x                                                       ; b785: bd b8 10    ...
+; &b788 referenced 1 time by &b77b
+.cb788
+    and #&20 ; ' '                                                    ; b788: 29 20       )
+    rts                                                               ; b78a: 60          `
+
+    equb &fe,   0, &10, &d0,   8, &fe, &10, &10, &d0,   3, &fe, &20   ; b78b: fe 00 10... ...
+    equb &10, &60                                                     ; b797: 10 60       .`
+
+; &b799 referenced 3 times by &8d87, &8fa0, &94a0
+.sub_cb799
+    txa                                                               ; b799: 8a          .
+    pha                                                               ; b79a: 48          H
+    tya                                                               ; b79b: 98          .
+    pha                                                               ; b79c: 48          H
+    ldx #&f7                                                          ; b79d: a2 f7       ..
+; &b79f referenced 1 time by &b7a4
+.loop_cb79f
+    lda lffbd,x                                                       ; b79f: bd bd ff    ...
+    pha                                                               ; b7a2: 48          H
+    inx                                                               ; b7a3: e8          .
+    bmi loop_cb79f                                                    ; b7a4: 30 f9       0.
+    ldx #&0f                                                          ; b7a6: a2 0f       ..
+    stx l10c8                                                         ; b7a8: 8e c8 10    ...
+; &b7ab referenced 1 time by &b7bf
+.loop_cb7ab
+    ldx l10c8                                                         ; b7ab: ae c8 10    ...
+    tya                                                               ; b7ae: 98          .
+    beq cb7b6                                                         ; b7af: f0 05       ..
+    cmp l10a8,x                                                       ; b7b1: dd a8 10    ...
+    bne cb7bc                                                         ; b7b4: d0 06       ..
+; &b7b6 referenced 1 time by &b7af
+.cb7b6
+    pha                                                               ; b7b6: 48          H
+    jsr sub_cb5fb                                                     ; b7b7: 20 fb b5     ..
+    pla                                                               ; b7ba: 68          h
+    tay                                                               ; b7bb: a8          .
+; &b7bc referenced 1 time by &b7b4
+.cb7bc
+    dec l10c8                                                         ; b7bc: ce c8 10    ...
+    bpl loop_cb7ab                                                    ; b7bf: 10 ea       ..
+    ldx #8                                                            ; b7c1: a2 08       ..
+; &b7c3 referenced 1 time by &b7c7
+.loop_cb7c3
+    pla                                                               ; b7c3: 68          h
+    sta l00b4,x                                                       ; b7c4: 95 b4       ..
+    dex                                                               ; b7c6: ca          .
+    bpl loop_cb7c3                                                    ; b7c7: 10 fa       ..
+    pla                                                               ; b7c9: 68          h
+    tay                                                               ; b7ca: a8          .
+    pla                                                               ; b7cb: 68          h
+    tax                                                               ; b7cc: aa          .
+    rts                                                               ; b7cd: 60          `
+
+    equb &8c, &c9, &10, &8a, &48, &20, &ec, &b4, &bd, &60, &10, &29   ; b7ce: 8c c9 10... ...
+    equb &20, &f0, &10, &a9, &d4, &20, &d1, &96                       ; b7da: 20 f0 10...  ..
+    equs "Write only"                                                 ; b7e2: 57 72 69... Wri
+    equb   0, &b8, &20, &30, &b7, &f0, &35, &b9,   0, &10, &dd, &98   ; b7ec: 00 b8 20... ..
+    equb &10, &90, &2d, &b9, &60, &10, &aa, &29, &40, &d0, &14, &8a   ; b7f8: 10 90 2d... ..-
+    equb   9, &40, &99, &60, &10, &a9,   0, &20, &8f, &b9, &68, &aa   ; b804: 09 40 99... .@.
+    equb &a9, &fe, &ac, &c9, &10, &38, &60, &a9, &df, &20, &d1, &96   ; b810: a9 fe ac... ...
+    equs "End of file"                                                ; b81c: 45 6e 64... End
+    equb   0, &b9,   0, &10, &48, &98, &aa, &a9,   0, &20, &8f, &b9   ; b827: 00 b9 00... ...
+    equb &20, &8b, &b7, &68, &a8, &ad, &c8, &10, &18, &69, &11, &85   ; b833: 20 8b b7...  ..
+    equb &b3, &a9,   0, &85, &b2, &68, &aa, &b1, &b2, &ac, &c9, &10   ; b83f: b3 a9 00... ...
+    equb &18, &60, &8c, &c9, &10, &48, &a8, &8a, &48, &98, &48, &8d   ; b84b: 18 60 8c... .`.
+    equb &d7, &10, &20, &ec, &b4, &bd, &60, &10, &30, &19, &a9, &c1   ; b857: d7 10 20... ..
+    equb &20, &d1, &96                                                ; b863: 20 d1 96     ..
+    equs "Not open for update"                                        ; b866: 4e 6f 74... Not
+    equb   0, &29, &20, &f0, &0a, &bc, &30, &10                       ; b879: 00 29 20... .)
+    equs "h +"                                                        ; b881: 68 20 2b    h +
+    equb &b9, &4c, &cb, &b8, &2c, &91, &94, &20, &30, &b7, &b9,   0   ; b884: b9 4c cb... .L.
+    equb &10, &c9, &ff, &d0,   3, &20, &e4, &b8, &dd, &98, &10, &90   ; b890: 10 c9 ff... ...
+    equb &0f, &69,   0, &9d, &98, &10, &d0,   8, &a9, &df, &3d, &b8   ; b89c: 0f 69 00... .i.
+    equb &10, &9d, &b8, &10, &a9,   1, &1d, &b8, &10, &9d, &b8, &10   ; b8a8: 10 9d b8... ...
+    equb &b9,   0, &10, &48, &98, &aa, &68, &a8, &ad, &c8, &10, &18   ; b8b4: b9 00 10... ...
+    equb &69, &11, &85, &b3, &a9,   0, &85, &b2, &68, &91, &b2, &20   ; b8c0: 69 11 85... i..
+    equb &8b, &b7, &a9,   0, &20, &8f, &b9, &68, &aa, &68, &ac, &c9   ; b8cc: 8b b7 a9... ...
+    equb &10, &60                                                     ; b8d8: 10 60       .`
+
+; &b8da referenced 1 time by &b6c3
+.sub_cb8da
+    pha                                                               ; b8da: 48          H
+    txa                                                               ; b8db: 8a          .
+    pha                                                               ; b8dc: 48          H
+    tya                                                               ; b8dd: 98          .
+    pha                                                               ; b8de: 48          H
+    lda l1030,y                                                       ; b8df: b9 30 10    .0.
+    bne cb8f3                                                         ; b8e2: d0 0f       ..
+    pha                                                               ; b8e4: 48          H
+    txa                                                               ; b8e5: 8a          .
+    pha                                                               ; b8e6: 48          H
+    tya                                                               ; b8e7: 98          .
+    pha                                                               ; b8e8: 48          H
+    lda l1030,y                                                       ; b8e9: b9 30 10    .0.
+    pha                                                               ; b8ec: 48          H
+    ldy #0                                                            ; b8ed: a0 00       ..
+    jsr sub_cb66a                                                     ; b8ef: 20 6a b6     j.
+    pla                                                               ; b8f2: 68          h
+; &b8f3 referenced 1 time by &b8e2
+.cb8f3
+    sta l0f05                                                         ; b8f3: 8d 05 0f    ...
+    tax                                                               ; b8f6: aa          .
+    pla                                                               ; b8f7: 68          h
+    tay                                                               ; b8f8: a8          .
+    pha                                                               ; b8f9: 48          H
+    txa                                                               ; b8fa: 8a          .
+    pha                                                               ; b8fb: 48          H
+    ldx #0                                                            ; b8fc: a2 00       ..
+    stx l0f06                                                         ; b8fe: 8e 06 0f    ...
+    lda l1000,y                                                       ; b901: b9 00 10    ...
+    sta l0f07                                                         ; b904: 8d 07 0f    ...
+    lda l1010,y                                                       ; b907: b9 10 10    ...
+    sta l0f08                                                         ; b90a: 8d 08 0f    ...
+    lda l1020,y                                                       ; b90d: b9 20 10    . .
+    sta l0f09                                                         ; b910: 8d 09 0f    ...
+    ldy #&0d                                                          ; b913: a0 0d       ..
+    ldx #5                                                            ; b915: a2 05       ..
+    jsr c94ad                                                         ; b917: 20 ad 94     ..
+    pla                                                               ; b91a: 68          h
+    tay                                                               ; b91b: a8          .
+    lda l10d7                                                         ; b91c: ad d7 10    ...
+    jsr sub_cb92b                                                     ; b91f: 20 2b b9     +.
+    jsr sub_cb721                                                     ; b922: 20 21 b7     !.
+    pla                                                               ; b925: 68          h
+    tay                                                               ; b926: a8          .
+    pla                                                               ; b927: 68          h
+    tax                                                               ; b928: aa          .
+    pla                                                               ; b929: 68          h
+    rts                                                               ; b92a: 60          `
+
+; &b92b referenced 1 time by &b91f
+.sub_cb92b
+    sty l0fde                                                         ; b92b: 8c de 0f    ...
+    sta l0fdf                                                         ; b92e: 8d df 0f    ...
+    tya                                                               ; b931: 98          .
+    pha                                                               ; b932: 48          H
+    txa                                                               ; b933: 8a          .
+    pha                                                               ; b934: 48          H
+    lda #&90                                                          ; b935: a9 90       ..
+    sta l0fdc                                                         ; b937: 8d dc 0f    ...
+    jsr sub_c9473                                                     ; b93a: 20 73 94     s.
+    lda #&dc                                                          ; b93d: a9 dc       ..
+    sta l00c4                                                         ; b93f: 85 c4       ..
+    lda #&e0                                                          ; b941: a9 e0       ..
+    sta l00c8                                                         ; b943: 85 c8       ..
+    lda #9                                                            ; b945: a9 09       ..
+    sta l0fdd                                                         ; b947: 8d dd 0f    ...
+    ldx #&c0                                                          ; b94a: a2 c0       ..
+    ldy #0                                                            ; b94c: a0 00       ..
+    lda l0fde                                                         ; b94e: ad de 0f    ...
+    jsr sub_cac24                                                     ; b951: 20 24 ac     $.
+    lda l0fdd                                                         ; b954: ad dd 0f    ...
+    beq cb974                                                         ; b957: f0 1b       ..
+    sta l0e09                                                         ; b959: 8d 09 0e    ...
+    ldx #0                                                            ; b95c: a2 00       ..
+; &b95e referenced 1 time by &b969
+.loop_cb95e
+    lda l0fdc,x                                                       ; b95e: bd dc 0f    ...
+    sta l0100,x                                                       ; b961: 9d 00 01    ...
+    cmp #&0d                                                          ; b964: c9 0d       ..
+    beq cb96b                                                         ; b966: f0 03       ..
+    inx                                                               ; b968: e8          .
+    bne loop_cb95e                                                    ; b969: d0 f3       ..
+; &b96b referenced 1 time by &b966
+.cb96b
+    lda #0                                                            ; b96b: a9 00       ..
+    sta l0100,x                                                       ; b96d: 9d 00 01    ...
+    dex                                                               ; b970: ca          .
+    jmp c96f0                                                         ; b971: 4c f0 96    L..
+
+; &b974 referenced 1 time by &b957
+.cb974
+    ldx l10c9                                                         ; b974: ae c9 10    ...
+    lda l1040,x                                                       ; b977: bd 40 10    .@.
+    eor #1                                                            ; b97a: 49 01       I.
+    sta l1040,x                                                       ; b97c: 9d 40 10    .@.
+    pla                                                               ; b97f: 68          h
+    tax                                                               ; b980: aa          .
+    pla                                                               ; b981: 68          h
+    tay                                                               ; b982: a8          .
+    rts                                                               ; b983: 60          `
+
+; &b984 referenced 2 times by &b64f, &b6d6
+.sub_cb984
+    jsr sub_c929b                                                     ; b984: 20 9b 92     ..
+    jmp c9edd                                                         ; b987: 4c dd 9e    L..
+
+; &b98a referenced 4 times by &96f0, &9703, &b642, &b6c9
+.sub_cb98a
+    ldy #&0a                                                          ; b98a: a0 0a       ..
+    lda (l009c),y                                                     ; b98c: b1 9c       ..
+    rts                                                               ; b98e: 60          `
+
+; &b98f referenced 4 times by &8b6c, &9ccc, &b656, &b6da
+.sub_cb98f
+    ldy #&0a                                                          ; b98f: a0 0a       ..
+    sta (l009c),y                                                     ; b991: 91 9c       ..
+    rts                                                               ; b993: 60          `
+
+.sub_cb994
+    lda #0                                                            ; b994: a9 00       ..
+    tay                                                               ; b996: a8          .
+    jmp osfind                                                        ; b997: 4c ce ff    L..
+
+.sub_cb99a
+    clv                                                               ; b99a: b8          .
+    bvc cb9a0                                                         ; b99b: 50 03       P.
+.sub_cb99d
+    bit l9491                                                         ; b99d: 2c 91 94    ,..
+; &b9a0 referenced 1 time by &b99b
+.cb9a0
+    jsr sub_cbc44                                                     ; b9a0: 20 44 bc     D.
+    ldy l00a8                                                         ; b9a3: a4 a8       ..
+    lda #0                                                            ; b9a5: a9 00       ..
+    sta l00ad                                                         ; b9a7: 85 ad       ..
+    php                                                               ; b9a9: 08          .
+; &b9aa referenced 3 times by &b9ca, &b9ea, &b9fd
+.cb9aa
+    jsr osbget                                                        ; b9aa: 20 d7 ff     ..
+    bcc cb9b6                                                         ; b9ad: 90 07       ..
+    plp                                                               ; b9af: 28          (
+    jsr cbc3d                                                         ; b9b0: 20 3d bc     =.
+    jmp osnewl                                                        ; b9b3: 4c e7 ff    L..
+
+; &b9b6 referenced 1 time by &b9ad
+.cb9b6
+    jsr sub_cb9ff                                                     ; b9b6: 20 ff b9     ..
+    plp                                                               ; b9b9: 28          (
+    php                                                               ; b9ba: 08          .
+    bvs cb9c5                                                         ; b9bb: 70 08       p.
+    cmp #&0d                                                          ; b9bd: c9 0d       ..
+    beq cb9cd                                                         ; b9bf: f0 0c       ..
+    cmp #&0a                                                          ; b9c1: c9 0a       ..
+    beq cb9cd                                                         ; b9c3: f0 08       ..
+; &b9c5 referenced 1 time by &b9bb
+.cb9c5
+    sta l00ad                                                         ; b9c5: 85 ad       ..
+; &b9c7 referenced 1 time by &b9d8
+.loop_cb9c7
+    jsr oswrch                                                        ; b9c7: 20 ee ff     ..
+    jmp cb9aa                                                         ; b9ca: 4c aa b9    L..
+
+; &b9cd referenced 2 times by &b9bf, &b9c3
+.cb9cd
+    pha                                                               ; b9cd: 48          H
+    ldx l026a                                                         ; b9ce: ae 6a 02    .j.
+    beq cb9da                                                         ; b9d1: f0 07       ..
+    lda #0                                                            ; b9d3: a9 00       ..
+    sta l00ad                                                         ; b9d5: 85 ad       ..
+    pla                                                               ; b9d7: 68          h
+    bne loop_cb9c7                                                    ; b9d8: d0 ed       ..
+; &b9da referenced 1 time by &b9d1
+.cb9da
+    lda l00ad                                                         ; b9da: a5 ad       ..
+    cmp #&0d                                                          ; b9dc: c9 0d       ..
+    beq cb9ed                                                         ; b9de: f0 0d       ..
+    cmp #&0a                                                          ; b9e0: c9 0a       ..
+    beq cb9f4                                                         ; b9e2: f0 10       ..
+    pla                                                               ; b9e4: 68          h
+    sta l00ad                                                         ; b9e5: 85 ad       ..
+; &b9e7 referenced 2 times by &b9f2, &b9f7
+.cb9e7
+    jsr osnewl                                                        ; b9e7: 20 e7 ff     ..
+    jmp cb9aa                                                         ; b9ea: 4c aa b9    L..
+
+; &b9ed referenced 1 time by &b9de
+.cb9ed
+    pla                                                               ; b9ed: 68          h
+    cmp #&0a                                                          ; b9ee: c9 0a       ..
+    beq cb9f9                                                         ; b9f0: f0 07       ..
+    bne cb9e7                                                         ; b9f2: d0 f3       ..
+; &b9f4 referenced 1 time by &b9e2
+.cb9f4
+    pla                                                               ; b9f4: 68          h
+    cmp #&0d                                                          ; b9f5: c9 0d       ..
+    bne cb9e7                                                         ; b9f7: d0 ee       ..
+; &b9f9 referenced 1 time by &b9f0
+.cb9f9
+    lda #0                                                            ; b9f9: a9 00       ..
+    sta l00ad                                                         ; b9fb: 85 ad       ..
+    beq cb9aa                                                         ; b9fd: f0 ab       ..
+; &b9ff referenced 2 times by &b9b6, &ba33
+.sub_cb9ff
+    bit l00ff                                                         ; b9ff: 24 ff       $.
+    bmi cba04                                                         ; ba01: 30 01       0.
+    rts                                                               ; ba03: 60          `
+
+; &ba04 referenced 1 time by &ba01
+.cba04
+    jsr cbc3d                                                         ; ba04: 20 3d bc     =.
+    jsr osnewl                                                        ; ba07: 20 e7 ff     ..
+    lda #osbyte_acknowledge_escape                                    ; ba0a: a9 7e       .~
+    jsr osbyte                                                        ; ba0c: 20 f4 ff     ..
+    lda #&11                                                          ; ba0f: a9 11       ..
+    jsr generate_error_inline2                                        ; ba11: 20 d4 96     ..
+    equs "Escape", 0                                                  ; ba14: 45 73 63... Esc
+
+.sub_cba1b
+    jsr sub_cbc44                                                     ; ba1b: 20 44 bc     D.
+    ldx #&14                                                          ; ba1e: a2 14       ..
+    lda #0                                                            ; ba20: a9 00       ..
+; &ba22 referenced 1 time by &ba24
+.loop_cba22
+    pha                                                               ; ba22: 48          H
+    dex                                                               ; ba23: ca          .
+    bpl loop_cba22                                                    ; ba24: 10 fc       ..
+    tsx                                                               ; ba26: ba          .
+    jsr sub_cbb77                                                     ; ba27: 20 77 bb     w.
+    lda (l00ae),y                                                     ; ba2a: b1 ae       ..
+    and #&f0                                                          ; ba2c: 29 f0       ).
+    beq cba33                                                         ; ba2e: f0 03       ..
+    jsr sub_cbadd                                                     ; ba30: 20 dd ba     ..
+; &ba33 referenced 2 times by &ba2e, &bad5
+.cba33
+    jsr sub_cb9ff                                                     ; ba33: 20 ff b9     ..
+    lda #&ff                                                          ; ba36: a9 ff       ..
+    sta l00aa                                                         ; ba38: 85 aa       ..
+; &ba3a referenced 1 time by &ba49
+.loop_cba3a
+    ldy l00a8                                                         ; ba3a: a4 a8       ..
+    jsr osbget                                                        ; ba3c: 20 d7 ff     ..
+    bcs cba4c                                                         ; ba3f: b0 0b       ..
+    inc l00aa                                                         ; ba41: e6 aa       ..
+    ldy l00aa                                                         ; ba43: a4 aa       ..
+    sta (l00ae),y                                                     ; ba45: 91 ae       ..
+    cpy #&0f                                                          ; ba47: c0 0f       ..
+    bne loop_cba3a                                                    ; ba49: d0 ef       ..
+    clc                                                               ; ba4b: 18          .
+; &ba4c referenced 1 time by &ba3f
+.cba4c
+    php                                                               ; ba4c: 08          .
+    lda l00aa                                                         ; ba4d: a5 aa       ..
+    bpl cba5a                                                         ; ba4f: 10 09       ..
+    ldx #&15                                                          ; ba51: a2 15       ..
+; &ba53 referenced 2 times by &ba55, &bada
+.cba53
+    pla                                                               ; ba53: 68          h
+    dex                                                               ; ba54: ca          .
+    bpl cba53                                                         ; ba55: 10 fc       ..
+    jmp cbc3d                                                         ; ba57: 4c 3d bc    L=.
+
+; &ba5a referenced 1 time by &ba4f
+.cba5a
+    ldy #&10                                                          ; ba5a: a0 10       ..
+    lda (l00ae),y                                                     ; ba5c: b1 ae       ..
+    and #&f0                                                          ; ba5e: 29 f0       ).
+    bne cba65                                                         ; ba60: d0 03       ..
+    jsr sub_cbadd                                                     ; ba62: 20 dd ba     ..
+; &ba65 referenced 1 time by &ba60
+.cba65
+    ldy #&13                                                          ; ba65: a0 13       ..
+; &ba67 referenced 1 time by &ba71
+.loop_cba67
+    lda (l00ae),y                                                     ; ba67: b1 ae       ..
+    pha                                                               ; ba69: 48          H
+    jsr sub_c912f                                                     ; ba6a: 20 2f 91     /.
+    pla                                                               ; ba6d: 68          h
+    dey                                                               ; ba6e: 88          .
+    cpy #&0f                                                          ; ba6f: c0 0f       ..
+    bne loop_cba67                                                    ; ba71: d0 f4       ..
+    iny                                                               ; ba73: c8          .
+    clc                                                               ; ba74: 18          .
+    adc #&10                                                          ; ba75: 69 10       i.
+    php                                                               ; ba77: 08          .
+; &ba78 referenced 1 time by &ba83
+.loop_cba78
+    plp                                                               ; ba78: 28          (
+    sta (l00ae),y                                                     ; ba79: 91 ae       ..
+    iny                                                               ; ba7b: c8          .
+    lda (l00ae),y                                                     ; ba7c: b1 ae       ..
+    adc #0                                                            ; ba7e: 69 00       i.
+    php                                                               ; ba80: 08          .
+    cpy #&14                                                          ; ba81: c0 14       ..
+    bne loop_cba78                                                    ; ba83: d0 f3       ..
+    plp                                                               ; ba85: 28          (
+    jsr print_inline_top_bit_clear                                    ; ba86: 20 45 91     E.
+    equs " : "                                                        ; ba89: 20 3a 20     :
+
+    ldy #0                                                            ; ba8c: a0 00       ..
+    ldx l00aa                                                         ; ba8e: a6 aa       ..
+; &ba90 referenced 1 time by &ba9b
+.loop_cba90
+    lda (l00ae),y                                                     ; ba90: b1 ae       ..
+    jsr sub_cbb03                                                     ; ba92: 20 03 bb     ..
+; &ba95 referenced 1 time by &baa8
+.loop_cba95
+    iny                                                               ; ba95: c8          .
+    cpy #&10                                                          ; ba96: c0 10       ..
+    beq cbaab                                                         ; ba98: f0 11       ..
+    dex                                                               ; ba9a: ca          .
+    bpl loop_cba90                                                    ; ba9b: 10 f3       ..
+    tya                                                               ; ba9d: 98          .
+    pha                                                               ; ba9e: 48          H
+    jsr print_inline_top_bit_clear                                    ; ba9f: 20 45 91     E.
+    equs "   "                                                        ; baa2: 20 20 20
+
+    nop                                                               ; baa5: ea          .
+    pla                                                               ; baa6: 68          h
+    tay                                                               ; baa7: a8          .
+    jmp loop_cba95                                                    ; baa8: 4c 95 ba    L..
+
+; &baab referenced 1 time by &ba98
+.cbaab
+    dex                                                               ; baab: ca          .
+    jsr print_inline_top_bit_clear                                    ; baac: 20 45 91     E.
+    equs ": "                                                         ; baaf: 3a 20       :
+
+    ldy #0                                                            ; bab1: a0 00       ..
+    jsr sub_cbc86                                                     ; bab3: 20 86 bc     ..
+; &bab6 referenced 1 time by &bacd
+.loop_cbab6
+    lda (l00ae),y                                                     ; bab6: b1 ae       ..
+    and #&7f                                                          ; bab8: 29 7f       ).
+    cmp #&20 ; ' '                                                    ; baba: c9 20       .
+    bcs cbac0                                                         ; babc: b0 02       ..
+; &babe referenced 1 time by &bac2
+.loop_cbabe
+    lda #&2e ; '.'                                                    ; babe: a9 2e       ..
+; &bac0 referenced 1 time by &babc
+.cbac0
+    cmp #&7f                                                          ; bac0: c9 7f       ..
+    beq loop_cbabe                                                    ; bac2: f0 fa       ..
+    jsr osasci                                                        ; bac4: 20 e3 ff     ..
+    iny                                                               ; bac7: c8          .
+    cpy #&10                                                          ; bac8: c0 10       ..
+    beq cbacf                                                         ; baca: f0 03       ..
+    dex                                                               ; bacc: ca          .
+    bpl loop_cbab6                                                    ; bacd: 10 e7       ..
+; &bacf referenced 1 time by &baca
+.cbacf
+    jsr osnewl                                                        ; bacf: 20 e7 ff     ..
+    plp                                                               ; bad2: 28          (
+    bcs cbad8                                                         ; bad3: b0 03       ..
+    jmp cba33                                                         ; bad5: 4c 33 ba    L3.
+
+; &bad8 referenced 1 time by &bad3
+.cbad8
+    ldx #&14                                                          ; bad8: a2 14       ..
+    jmp cba53                                                         ; bada: 4c 53 ba    LS.
+
+; &badd referenced 2 times by &ba30, &ba62
+.sub_cbadd
+    lda (l00ae),y                                                     ; badd: b1 ae       ..
+    pha                                                               ; badf: 48          H
+    jsr print_inline_top_bit_clear                                    ; bae0: 20 45 91     E.
+    equs &0d, "Address  : "                                           ; bae3: 0d 41 64... .Ad
+
+    ldx #&0f                                                          ; baef: a2 0f       ..
+    pla                                                               ; baf1: 68          h
+; &baf2 referenced 1 time by &bafb
+.loop_cbaf2
+    jsr sub_cbb03                                                     ; baf2: 20 03 bb     ..
+    sec                                                               ; baf5: 38          8
+    adc #0                                                            ; baf6: 69 00       i.
+    and #&0f                                                          ; baf8: 29 0f       ).
+    dex                                                               ; bafa: ca          .
+    bpl loop_cbaf2                                                    ; bafb: 10 f5       ..
+    jsr osnewl                                                        ; bafd: 20 e7 ff     ..
+    jmp osnewl                                                        ; bb00: 4c e7 ff    L..
+
+; &bb03 referenced 2 times by &ba92, &baf2
+.sub_cbb03
+    pha                                                               ; bb03: 48          H
+    jsr sub_c912f                                                     ; bb04: 20 2f 91     /.
+    lda #&20 ; ' '                                                    ; bb07: a9 20       .
+    jsr osasci                                                        ; bb09: 20 e3 ff     ..
+    pla                                                               ; bb0c: 68          h
+    rts                                                               ; bb0d: 60          `
+
+; &bb0e referenced 2 times by &bb7e, &bc0a
+.sub_cbb0e
+    tya                                                               ; bb0e: 98          .
+    tax                                                               ; bb0f: aa          .
+    lda #0                                                            ; bb10: a9 00       ..
+    tay                                                               ; bb12: a8          .
+; &bb13 referenced 1 time by &bb18
+.loop_cbb13
+    sta (l00ae),y                                                     ; bb13: 91 ae       ..
+    iny                                                               ; bb15: c8          .
+    cpy #4                                                            ; bb16: c0 04       ..
+    bne loop_cbb13                                                    ; bb18: d0 f9       ..
+; &bb1a referenced 1 time by &bb61
+.cbb1a
+    txa                                                               ; bb1a: 8a          .
+    inx                                                               ; bb1b: e8          .
+    tay                                                               ; bb1c: a8          .
+    lda (os_text_ptr),y                                               ; bb1d: b1 f2       ..
+    cmp #&0d                                                          ; bb1f: c9 0d       ..
+    beq cbb6f                                                         ; bb21: f0 4c       .L
+    cmp #&20 ; ' '                                                    ; bb23: c9 20       .
+    beq cbb6f                                                         ; bb25: f0 48       .H
+    cmp #&30 ; '0'                                                    ; bb27: c9 30       .0
+    bcc cbb68                                                         ; bb29: 90 3d       .=
+    cmp #&3a ; ':'                                                    ; bb2b: c9 3a       .:
+    bcc cbb39                                                         ; bb2d: 90 0a       ..
+    and #&5f ; '_'                                                    ; bb2f: 29 5f       )_
+    adc #&b8                                                          ; bb31: 69 b8       i.
+    bcs cbb68                                                         ; bb33: b0 33       .3
+    cmp #&fa                                                          ; bb35: c9 fa       ..
+    bcc cbb68                                                         ; bb37: 90 2f       ./
+; &bb39 referenced 1 time by &bb2d
+.cbb39
+    and #&0f                                                          ; bb39: 29 0f       ).
+    pha                                                               ; bb3b: 48          H
+    txa                                                               ; bb3c: 8a          .
+    pha                                                               ; bb3d: 48          H
+    ldx #4                                                            ; bb3e: a2 04       ..
+; &bb40 referenced 1 time by &bb56
+.loop_cbb40
+    ldy #0                                                            ; bb40: a0 00       ..
+    tya                                                               ; bb42: 98          .
+; &bb43 referenced 1 time by &bb4f
+.loop_cbb43
+    pha                                                               ; bb43: 48          H
+    plp                                                               ; bb44: 28          (
+    lda (l00ae),y                                                     ; bb45: b1 ae       ..
+    rol a                                                             ; bb47: 2a          *
+    sta (l00ae),y                                                     ; bb48: 91 ae       ..
+    php                                                               ; bb4a: 08          .
+    pla                                                               ; bb4b: 68          h
+    iny                                                               ; bb4c: c8          .
+    cpy #4                                                            ; bb4d: c0 04       ..
+    bne loop_cbb43                                                    ; bb4f: d0 f2       ..
+    pha                                                               ; bb51: 48          H
+    plp                                                               ; bb52: 28          (
+    bcs cbb64                                                         ; bb53: b0 0f       ..
+    dex                                                               ; bb55: ca          .
+    bne loop_cbb40                                                    ; bb56: d0 e8       ..
+    pla                                                               ; bb58: 68          h
+    tax                                                               ; bb59: aa          .
+    pla                                                               ; bb5a: 68          h
+    ldy #0                                                            ; bb5b: a0 00       ..
+    ora (l00ae),y                                                     ; bb5d: 11 ae       ..
+    sta (l00ae),y                                                     ; bb5f: 91 ae       ..
+    jmp cbb1a                                                         ; bb61: 4c 1a bb    L..
+
+; &bb64 referenced 1 time by &bb53
+.cbb64
+    pla                                                               ; bb64: 68          h
+    pla                                                               ; bb65: 68          h
+    sec                                                               ; bb66: 38          8
+    rts                                                               ; bb67: 60          `
+
+; &bb68 referenced 3 times by &bb29, &bb33, &bb37
+.cbb68
+    jsr cbc3d                                                         ; bb68: 20 3d bc     =.
+    jmp c9208                                                         ; bb6b: 4c 08 92    L..
+
+; &bb6e referenced 1 time by &bb73
+.loop_cbb6e
+    iny                                                               ; bb6e: c8          .
+; &bb6f referenced 2 times by &bb21, &bb25
+.cbb6f
+    lda (os_text_ptr),y                                               ; bb6f: b1 f2       ..
+    cmp #&20 ; ' '                                                    ; bb71: c9 20       .
+    beq loop_cbb6e                                                    ; bb73: f0 f9       ..
+    clc                                                               ; bb75: 18          .
+    rts                                                               ; bb76: 60          `
+
+; &bb77 referenced 1 time by &ba27
+.sub_cbb77
+    inx                                                               ; bb77: e8          .
+    stx l00ae                                                         ; bb78: 86 ae       ..
+    ldx #1                                                            ; bb7a: a2 01       ..
+    stx l00af                                                         ; bb7c: 86 af       ..
+    jsr sub_cbb0e                                                     ; bb7e: 20 0e bb     ..
+    bcs cbba2                                                         ; bb81: b0 1f       ..
+    tya                                                               ; bb83: 98          .
+    pha                                                               ; bb84: 48          H
+    ldy l00a8                                                         ; bb85: a4 a8       ..
+    ldx #&aa                                                          ; bb87: a2 aa       ..
+    lda #2                                                            ; bb89: a9 02       ..
+    jsr osargs                                                        ; bb8b: 20 da ff     ..
+    ldy #3                                                            ; bb8e: a0 03       ..
+; &bb90 referenced 1 time by &bb98
+.loop_cbb90
+    lda l00aa,y                                                       ; bb90: b9 aa 00    ...
+    cmp (l00ae),y                                                     ; bb93: d1 ae       ..
+    bne cbb9c                                                         ; bb95: d0 05       ..
+    dey                                                               ; bb97: 88          .
+    bpl loop_cbb90                                                    ; bb98: 10 f6       ..
+    bmi cbbbc                                                         ; bb9a: 30 20       0
+; &bb9c referenced 1 time by &bb95
+.cbb9c
+    bcc cbba2                                                         ; bb9c: 90 04       ..
+    ldy #&ff                                                          ; bb9e: a0 ff       ..
+    bne cbbbc                                                         ; bba0: d0 1a       ..
+; &bba2 referenced 2 times by &bb81, &bb9c
+.cbba2
+    jsr cbc3d                                                         ; bba2: 20 3d bc     =.
+    lda #&b7                                                          ; bba5: a9 b7       ..
+    jsr generate_error_inline2                                        ; bba7: 20 d4 96     ..
+    equs "Outside file", 0                                            ; bbaa: 4f 75 74... Out
+
+; &bbb7 referenced 1 time by &bbbf
+.loop_cbbb7
+    lda (l00ae),y                                                     ; bbb7: b1 ae       ..
+    sta l00aa,y                                                       ; bbb9: 99 aa 00    ...
+; &bbbc referenced 2 times by &bb9a, &bba0
+.cbbbc
+    iny                                                               ; bbbc: c8          .
+    cpy #4                                                            ; bbbd: c0 04       ..
+    bne loop_cbbb7                                                    ; bbbf: d0 f6       ..
+    ldx #&aa                                                          ; bbc1: a2 aa       ..
+    ldy l00a8                                                         ; bbc3: a4 a8       ..
+    lda #1                                                            ; bbc5: a9 01       ..
+    jsr osargs                                                        ; bbc7: 20 da ff     ..
+    pla                                                               ; bbca: 68          h
+    tay                                                               ; bbcb: a8          .
+    lda (os_text_ptr),y                                               ; bbcc: b1 f2       ..
+    cmp #&0d                                                          ; bbce: c9 0d       ..
+    bne cbc0a                                                         ; bbd0: d0 38       .8
+    ldy #1                                                            ; bbd2: a0 01       ..
+; &bbd4 referenced 1 time by &bbda
+.loop_cbbd4
+    lda os_text_ptr,y                                                 ; bbd4: b9 f2 00    ...
+    sta (l00ae),y                                                     ; bbd7: 91 ae       ..
+    dey                                                               ; bbd9: 88          .
+    bpl loop_cbbd4                                                    ; bbda: 10 f8       ..
+    lda #osfile_read_catalogue_info                                   ; bbdc: a9 05       ..
+    ldx l00ae                                                         ; bbde: a6 ae       ..
+    ldy l00af                                                         ; bbe0: a4 af       ..
+    jsr osfile                                                        ; bbe2: 20 dd ff     ..
+    ldy #2                                                            ; bbe5: a0 02       ..
+; &bbe7 referenced 1 time by &bbf2
+.loop_cbbe7
+    lda (l00ae),y                                                     ; bbe7: b1 ae       ..
+    dey                                                               ; bbe9: 88          .
+    dey                                                               ; bbea: 88          .
+    sta (l00ae),y                                                     ; bbeb: 91 ae       ..
+    iny                                                               ; bbed: c8          .
+    iny                                                               ; bbee: c8          .
+    iny                                                               ; bbef: c8          .
+    cpy #6                                                            ; bbf0: c0 06       ..
+    bne loop_cbbe7                                                    ; bbf2: d0 f3       ..
+    dey                                                               ; bbf4: 88          .
+    dey                                                               ; bbf5: 88          .
+; &bbf6 referenced 1 time by &bbfd
+.loop_cbbf6
+    lda (l00ae),y                                                     ; bbf6: b1 ae       ..
+    cmp #&ff                                                          ; bbf8: c9 ff       ..
+    bne cbc1f                                                         ; bbfa: d0 23       .#
+    dey                                                               ; bbfc: 88          .
+    bne loop_cbbf6                                                    ; bbfd: d0 f7       ..
+    ldy #3                                                            ; bbff: a0 03       ..
+    lda #0                                                            ; bc01: a9 00       ..
+; &bc03 referenced 1 time by &bc06
+.loop_cbc03
+    sta (l00ae),y                                                     ; bc03: 91 ae       ..
+    dey                                                               ; bc05: 88          .
+    bpl loop_cbc03                                                    ; bc06: 10 fb       ..
+    bmi cbc1f                                                         ; bc08: 30 15       0.
+; &bc0a referenced 1 time by &bbd0
+.cbc0a
+    jsr sub_cbb0e                                                     ; bc0a: 20 0e bb     ..
+    bcc cbc1f                                                         ; bc0d: 90 10       ..
+    jsr cbc3d                                                         ; bc0f: 20 3d bc     =.
+    lda #&fc                                                          ; bc12: a9 fc       ..
+    jsr generate_error_inline                                         ; bc14: 20 b8 96     ..
+    equs "address", 0                                                 ; bc17: 61 64 64... add
+
+; &bc1f referenced 3 times by &bbfa, &bc08, &bc0d
+.cbc1f
+    ldy #0                                                            ; bc1f: a0 00       ..
+    ldx #4                                                            ; bc21: a2 04       ..
+    clc                                                               ; bc23: 18          .
+; &bc24 referenced 1 time by &bc2e
+.loop_cbc24
+    lda (l00ae),y                                                     ; bc24: b1 ae       ..
+    adc l00aa,y                                                       ; bc26: 79 aa 00    y..
+    sta l00aa,y                                                       ; bc29: 99 aa 00    ...
+    iny                                                               ; bc2c: c8          .
+    dex                                                               ; bc2d: ca          .
+    bne loop_cbc24                                                    ; bc2e: d0 f4       ..
+    ldy #&14                                                          ; bc30: a0 14       ..
+    ldx #3                                                            ; bc32: a2 03       ..
+; &bc34 referenced 1 time by &bc3a
+.loop_cbc34
+    dey                                                               ; bc34: 88          .
+    lda l00aa,x                                                       ; bc35: b5 aa       ..
+    sta (l00ae),y                                                     ; bc37: 91 ae       ..
+    dex                                                               ; bc39: ca          .
+    bpl loop_cbc34                                                    ; bc3a: 10 f8       ..
+    rts                                                               ; bc3c: 60          `
+
+; &bc3d referenced 6 times by &b9b0, &ba04, &ba57, &bb68, &bba2, &bc0f
+.cbc3d
+    ldy l00a8                                                         ; bc3d: a4 a8       ..
+    lda #0                                                            ; bc3f: a9 00       ..
+    jmp osfind                                                        ; bc41: 4c ce ff    L..
+
+; &bc44 referenced 2 times by &b9a0, &ba1b
+.sub_cbc44
+    php                                                               ; bc44: 08          .
+    tya                                                               ; bc45: 98          .
+    clc                                                               ; bc46: 18          .
+    adc os_text_ptr                                                   ; bc47: 65 f2       e.
+    pha                                                               ; bc49: 48          H
+    tax                                                               ; bc4a: aa          .
+    lda #0                                                            ; bc4b: a9 00       ..
+    adc l00f3                                                         ; bc4d: 65 f3       e.
+    pha                                                               ; bc4f: 48          H
+    tay                                                               ; bc50: a8          .
+    lda #&40 ; '@'                                                    ; bc51: a9 40       .@
+    jsr osfind                                                        ; bc53: 20 ce ff     ..
+    tay                                                               ; bc56: a8          .
+    sta l00a8                                                         ; bc57: 85 a8       ..
+    bne cbc6a                                                         ; bc59: d0 0f       ..
+    lda #&d6                                                          ; bc5b: a9 d6       ..
+    jsr generate_error_inline2                                        ; bc5d: 20 d4 96     ..
+    equs "Not found", 0                                               ; bc60: 4e 6f 74... Not
+
+; &bc6a referenced 1 time by &bc59
+.cbc6a
+    pla                                                               ; bc6a: 68          h
+    sta l00f3                                                         ; bc6b: 85 f3       ..
+    pla                                                               ; bc6d: 68          h
+    sta os_text_ptr                                                   ; bc6e: 85 f2       ..
+    ldy #0                                                            ; bc70: a0 00       ..
+; &bc72 referenced 1 time by &bc7b
+.loop_cbc72
+    iny                                                               ; bc72: c8          .
+    lda (os_text_ptr),y                                               ; bc73: b1 f2       ..
+    cmp #&0d                                                          ; bc75: c9 0d       ..
+    beq cbc84                                                         ; bc77: f0 0b       ..
+    cmp #&20 ; ' '                                                    ; bc79: c9 20       .
+    bne loop_cbc72                                                    ; bc7b: d0 f5       ..
+; &bc7d referenced 1 time by &bc82
+.loop_cbc7d
+    iny                                                               ; bc7d: c8          .
+    lda (os_text_ptr),y                                               ; bc7e: b1 f2       ..
+    cmp #&20 ; ' '                                                    ; bc80: c9 20       .
+    beq loop_cbc7d                                                    ; bc82: f0 f9       ..
+; &bc84 referenced 1 time by &bc77
+.cbc84
+    plp                                                               ; bc84: 28          (
+    rts                                                               ; bc85: 60          `
+
+; &bc86 referenced 2 times by &a8b0, &bab3
+.sub_cbc86
+    jsr sub_cbc89                                                     ; bc86: 20 89 bc     ..
+; &bc89 referenced 1 time by &bc86
+.sub_cbc89
+    jsr sub_cbc8c                                                     ; bc89: 20 8c bc     ..
+; &bc8c referenced 1 time by &bc89
+.sub_cbc8c
+    inx                                                               ; bc8c: e8          .
+    inx                                                               ; bc8d: e8          .
+    inx                                                               ; bc8e: e8          .
+    inx                                                               ; bc8f: e8          .
+    rts                                                               ; bc90: 60          `
+
+    equb &ff, &ff, &ff                                                ; bc91: ff ff ff    ...
+; &bc94 referenced 1 time by &bea4
+.lbc94
+    equb &37,   5, &96,   5, &f2,   5,   7,   6, &27,   6, &68,   6   ; bc94: 37 05 96... 7..
+    equb &5e,   5, &2d,   5, &20,   5, &42,   5, &a9,   5, &d1,   5   ; bca0: 5e 05 2d... ^.-
+    equb &86, &88, &96, &98, &18, &18, &82, &18, &20, &c5,   6, &a8   ; bcac: 86 88 96... ...
+    equb &20, &c5,   6, &20, &d4, &ff, &4c, &9c,   5, &20, &c5,   6   ; bcb8: 20 c5 06...  ..
+    equb &a8, &20, &d7, &ff, &4c, &3a,   5, &20, &e0, &ff, &6a, &20   ; bcc4: a8 20 d7... . .
+    equb &95,   6, &2a, &4c, &9e,   5, &20, &c5,   6, &f0, &0b, &48   ; bcd0: 95 06 2a... ..*
+    equb &20, &82,   5, &68, &20, &ce, &ff, &4c, &9e,   5, &20, &c5   ; bcdc: 20 82 05...  ..
+    equb   6, &a8, &a9,   0, &20, &ce, &ff, &4c, &9c,   5, &20, &c5   ; bce8: 06 a8 a9... ...
+    equb   6, &a8, &a2,   4, &20, &c5,   6, &95, &ff, &ca, &d0, &f8   ; bcf4: 06 a8 a2... ...
+    equb &20, &c5,   6, &20, &da, &ff, &20, &95,   6, &a2,   3, &b5   ; bd00: 20 c5 06...  ..
+    equb   0, &20, &95,   6, &ca, &10, &f8, &4c, &36,   0, &a2,   0   ; bd0c: 00 20 95... . .
+    equb &a0,   0, &20, &c5,   6, &99,   0,   7, &c8, &f0,   4, &c9   ; bd18: a0 00 20... ..
+    equb &0d, &d0, &f3, &a0,   7, &60, &20, &82,   5, &20, &f7, &ff   ; bd24: 0d d0 f3... ...
+    equb &a9, &7f, &2c, &e2, &fe, &50, &fb, &8d, &e3, &fe, &4c, &36   ; bd30: a9 7f 2c... ..,
+    equb   0, &a2, &10, &20, &c5,   6, &95,   1, &ca, &d0, &f8, &20   ; bd3c: 00 a2 10... ...
+    equb &82,   5, &86,   0, &84,   1, &a0,   0, &20, &c5,   6, &20   ; bd48: 82 05 86... ...
+    equb &dd, &ff, &20, &95,   6, &a2, &10, &b5,   1, &20, &95,   6   ; bd54: dd ff 20... ..
+    equb &ca, &d0, &f8, &f0, &d5, &a2, &0d, &20, &c5,   6, &95, &ff   ; bd60: ca d0 f8... ...
+    equb &ca, &d0, &f8, &20, &c5,   6, &a0,   0, &20, &d1, &ff, &48   ; bd6c: ca d0 f8... ...
+    equb &a2, &0c, &b5,   0, &20, &95,   6, &ca, &10, &f8             ; bd78: a2 0c b5... ...
+    equs "hL:"                                                        ; bd82: 68 4c 3a    hL:
+    equb   5, &20, &c5,   6, &aa, &20, &c5,   6, &20, &f4, &ff, &2c   ; bd85: 05 20 c5... . .
+    equb &e2, &fe, &50                                                ; bd91: e2 fe 50    ..P
+; &bd94 referenced 1 time by &beaa
+.lbd94
+    equb &fb, &8e, &e3, &fe, &4c, &36,   0, &20, &c5,   6, &aa, &20   ; bd94: fb 8e e3... ...
+    equb &c5,   6, &a8, &20, &c5,   6, &20, &f4, &ff, &49, &9d, &f0   ; bda0: c5 06 a8... ...
+    equb &eb, &6a, &20, &95,   6, &2c, &e2, &fe, &50, &fb, &8c, &e3   ; bdac: eb 6a 20... .j
+    equb &fe, &70, &d5, &20, &c5,   6, &a8, &2c, &e2, &fe, &10, &fb   ; bdb8: fe 70 d5... .p.
+    equb &ae, &e3, &fe, &ca, &30, &0f, &2c, &e2, &fe, &10, &fb, &ad   ; bdc4: ae e3 fe... ...
+    equb &e3, &fe, &9d, &28,   1, &ca, &10, &f2, &98, &a2, &28, &a0   ; bdd0: e3 fe 9d... ...
+    equb   1, &20, &f1, &ff, &2c, &e2, &fe, &10, &fb, &ae, &e3, &fe   ; bddc: 01 20 f1... . .
+    equb &ca, &30, &0e, &bc, &28,   1, &2c, &e2, &fe, &50, &fb, &8c   ; bde8: ca 30 0e... .0.
+    equb &e3, &fe, &ca, &10, &f2, &4c, &36,   0, &a2,   4, &20, &c5   ; bdf4: e3 fe ca... ...
+    equb   6, &95,   0, &ca, &10, &f8, &e8, &a0,   0, &8a, &20, &f1   ; be00: 06 95 00... ...
+    equb &ff, &90,   5, &a9, &ff, &4c, &9e,   5, &a2,   0, &a9, &7f   ; be0c: ff 90 05... ...
+    equb &20, &95,   6, &bd,   0,   7, &20, &95,   6, &e8, &c9, &0d   ; be18: 20 95 06...  ..
+    equb &d0, &f5, &4c, &36,   0, &2c, &e2, &fe, &50, &fb, &8d, &e3   ; be24: d0 f5 4c... ..L
+    equb &fe, &60, &2c, &e6, &fe, &50, &fb, &8d, &e7, &fe, &60, &a5   ; be30: fe 60 2c... .`,
+    equb &ff                                                          ; be3c: ff          .
+    equs "8j0"                                                        ; be3d: 38 6a 30    8j0
+    equb &0f, &48, &a9,   0, &20, &bc,   6, &98, &20, &bc,   6, &8a   ; be40: 0f 48 a9... .H.
+    equb &20, &bc,   6, &68, &2c, &e0, &fe, &50, &fb, &8d, &e1, &fe   ; be4c: 20 bc 06...  ..
+    equb &60, &2c, &e2, &fe, &10, &fb, &ad, &e3, &fe, &60             ; be58: 60 2c e2... `,.
+
+; &be62 referenced 1 time by &8a3d
+.service_handler_tube_service_calls
+    cmp #&fe                                                          ; be62: c9 fe       ..
+    bcc cbec2                                                         ; be64: 90 5c       .\
+    bne cbe83                                                         ; be66: d0 1b       ..
+    cpy #0                                                            ; be68: c0 00       ..
+    beq cbec2                                                         ; be6a: f0 56       .V
+    ldx #6                                                            ; be6c: a2 06       ..
+    lda #osbyte_explode_chars                                         ; be6e: a9 14       ..
+    jsr osbyte                                                        ; be70: 20 f4 ff     ..
+; &be73 referenced 2 times by &be76, &be80
+.cbe73
+    bit tube_host_r1_status                                           ; be73: 2c e0 fe    ,..
+    bpl cbe73                                                         ; be76: 10 fb       ..
+    lda tube_host_r1_data                                             ; be78: ad e1 fe    ...
+    beq cbec0                                                         ; be7b: f0 43       .C
+    jsr oswrch                                                        ; be7d: 20 ee ff     ..
+    jmp cbe73                                                         ; be80: 4c 73 be    Ls.
+
+; &be83 referenced 1 time by &be66
+.cbe83
+    lda #&ad                                                          ; be83: a9 ad       ..
+    sta evntv                                                         ; be85: 8d 20 02    . .
+    lda #6                                                            ; be88: a9 06       ..
+    sta evntv+1                                                       ; be8a: 8d 21 02    .!.
+    lda #&16                                                          ; be8d: a9 16       ..
+    sta brkv                                                          ; be8f: 8d 02 02    ...
+    lda #0                                                            ; be92: a9 00       ..
+    sta brkv+1                                                        ; be94: 8d 03 02    ...
+    lda #&8e                                                          ; be97: a9 8e       ..
+    sta tube_host_r1_status                                           ; be99: 8d e0 fe    ...
+    ldy #0                                                            ; be9c: a0 00       ..
+; &be9e referenced 1 time by &beb1
+.loop_cbe9e
+    lda lbf04,y                                                       ; be9e: b9 04 bf    ...
+    sta l0400,y                                                       ; bea1: 99 00 04    ...
+    lda lbc94,y                                                       ; bea4: b9 94 bc    ...
+    sta l0500,y                                                       ; bea7: 99 00 05    ...
+    lda lbd94,y                                                       ; beaa: b9 94 bd    ...
+    sta l0600,y                                                       ; bead: 99 00 06    ...
+    dey                                                               ; beb0: 88          .
+    bne loop_cbe9e                                                    ; beb1: d0 eb       ..
+    jsr sub_c0421                                                     ; beb3: 20 21 04     !.
+    ldx #&41 ; 'A'                                                    ; beb6: a2 41       .A
+; &beb8 referenced 1 time by &bebe
+.loop_cbeb8
+    lda lbec3,x                                                       ; beb8: bd c3 be    ...
+    sta l0016,x                                                       ; bebb: 95 16       ..
+    dex                                                               ; bebd: ca          .
+    bpl loop_cbeb8                                                    ; bebe: 10 f8       ..
+; &bec0 referenced 1 time by &be7b
+.cbec0
+    lda #0                                                            ; bec0: a9 00       ..
+; &bec2 referenced 2 times by &be64, &be6a
+.cbec2
+    rts                                                               ; bec2: 60          `
+
+; &bec3 referenced 1 time by &beb8
+.lbec3
+    equb &a9, &ff, &20, &9e,   6, &ad, &e3, &fe, &a9,   0, &20, &95   ; bec3: a9 ff 20... ..
+    equb   6, &a8, &b1, &fd, &20, &95,   6, &c8, &b1, &fd, &20, &95   ; becf: 06 a8 b1... ...
+    equb   6, &aa, &d0, &f7, &a2, &ff, &9a, &58, &2c, &e0, &fe, &10   ; bedb: 06 aa d0... ...
+    equb   6, &ad, &e1, &fe, &20, &ee, &ff, &2c, &e2, &fe, &10, &f0   ; bee7: 06 ad e1... ...
+    equb &2c, &e0, &fe, &30, &f0, &ae, &e3, &fe, &86, &51, &6c,   0   ; bef3: 2c e0 fe... ,..
+    equb   5,   0, &80,   0,   0                                      ; beff: 05 00 80... ...
+; &bf04 referenced 2 times by &be9e, &bea1
+.lbf04
+; &bf04 referenced 2 times by &be9e, &bea1
+
+    org &0400
+; &bf04 referenced 2 times by &be9e, &bea1
+.l0400
+    equb &4c, &84,   4, &4c, &a7,   6                                 ; bf04: 4c 84 04... L.. :0400[1]
+
+; &bf0a referenced 7 times by &844f, &8933, &893b, &a075, &a2ec, &bf97, &bfcf
+.c0406
+    cmp #&80                                                          ; bf0a: c9 80       ..  :0406[1]
+    bcc c0435                                                         ; bf0c: 90 2b       .+  :0408[1]
+    cmp #&c0                                                          ; bf0e: c9 c0       ..  :040a[1]
+    bcs c0428                                                         ; bf10: b0 1a       ..  :040c[1]
+    ora #&40 ; '@'                                                    ; bf12: 09 40       .@  :040e[1]
+    cmp l0015                                                         ; bf14: c5 15       ..  :0410[1]
+    bne c0434                                                         ; bf16: d0 20       .   :0412[1]
+; &bf18 referenced 1 time by &0471
+.sub_c0414
+    php                                                               ; bf18: 08          .   :0414[1]
+    sei                                                               ; bf19: 78          x   :0415[1]
+    lda #5                                                            ; bf1a: a9 05       ..  :0416[1]
+    jsr l069e                                                         ; bf1c: 20 9e 06     .. :0418[1]
+    lda l0015                                                         ; bf1f: a5 15       ..  :041b[1]
+    jsr l069e                                                         ; bf21: 20 9e 06     .. :041d[1]
+    plp                                                               ; bf24: 28          (   :0420[1]
+; &bf25 referenced 1 time by &beb3
+.sub_c0421
+    lda #&80                                                          ; bf25: a9 80       ..  :0421[1]
+    sta l0015                                                         ; bf27: 85 15       ..  :0423[1]
+    sta l0014                                                         ; bf29: 85 14       ..  :0425[1]
+    rts                                                               ; bf2b: 60          `   :0427[1]
+
+; &bf2c referenced 1 time by &040c
+.c0428
+    asl l0014                                                         ; bf2c: 06 14       ..  :0428[1]
+    bcs c0432                                                         ; bf2e: b0 06       ..  :042a[1]
+    cmp l0015                                                         ; bf30: c5 15       ..  :042c[1]
+    beq c0434                                                         ; bf32: f0 04       ..  :042e[1]
+    clc                                                               ; bf34: 18          .   :0430[1]
+    rts                                                               ; bf35: 60          `   :0431[1]
+
+; &bf36 referenced 1 time by &042a
+.c0432
+    sta l0015                                                         ; bf36: 85 15       ..  :0432[1]
+; &bf38 referenced 2 times by &0412, &042e
+.c0434
+    rts                                                               ; bf38: 60          `   :0434[1]
+
+; &bf39 referenced 1 time by &0408
+.c0435
+    php                                                               ; bf39: 08          .   :0435[1]
+    sei                                                               ; bf3a: 78          x   :0436[1]
+    sty l0013                                                         ; bf3b: 84 13       ..  :0437[1]
+    stx l0012                                                         ; bf3d: 86 12       ..  :0439[1]
+    jsr l069e                                                         ; bf3f: 20 9e 06     .. :043b[1]
+    tax                                                               ; bf42: aa          .   :043e[1]
+    ldy #3                                                            ; bf43: a0 03       ..  :043f[1]
+    lda l0015                                                         ; bf45: a5 15       ..  :0441[1]
+    jsr l069e                                                         ; bf47: 20 9e 06     .. :0443[1]
+; &bf4a referenced 1 time by &044c
+.loop_c0446
+    lda (l0012),y                                                     ; bf4a: b1 12       ..  :0446[1]
+    jsr l069e                                                         ; bf4c: 20 9e 06     .. :0448[1]
+    dey                                                               ; bf4f: 88          .   :044b[1]
+    bpl loop_c0446                                                    ; bf50: 10 f8       ..  :044c[1]
+    ldy #&18                                                          ; bf52: a0 18       ..  :044e[1]
+    sty tube_host_r1_status                                           ; bf54: 8c e0 fe    ... :0450[1]
+    lda l0518,x                                                       ; bf57: bd 18 05    ... :0453[1]
+    sta tube_host_r1_status                                           ; bf5a: 8d e0 fe    ... :0456[1]
+    lsr a                                                             ; bf5d: 4a          J   :0459[1]
+    lsr a                                                             ; bf5e: 4a          J   :045a[1]
+    bcc c0463                                                         ; bf5f: 90 06       ..  :045b[1]
+    bit tube_host_r3_data                                             ; bf61: 2c e5 fe    ,.. :045d[1]
+    bit tube_host_r3_data                                             ; bf64: 2c e5 fe    ,.. :0460[1]
+; &bf67 referenced 1 time by &045b
+.c0463
+    jsr l069e                                                         ; bf67: 20 9e 06     .. :0463[1]
+; &bf6a referenced 1 time by &0469
+.loop_c0466
+    bit tube_host_r4_status                                           ; bf6a: 2c e6 fe    ,.. :0466[1]
+    bvc loop_c0466                                                    ; bf6d: 50 fb       P.  :0469[1]
+    bcs c047a                                                         ; bf6f: b0 0d       ..  :046b[1]
+    cpx #4                                                            ; bf71: e0 04       ..  :046d[1]
+    bne c0482                                                         ; bf73: d0 11       ..  :046f[1]
+    jsr sub_c0414                                                     ; bf75: 20 14 04     .. :0471[1]
+    jsr l0695                                                         ; bf78: 20 95 06     .. :0474[1]
+    jmp l0032                                                         ; bf7b: 4c 32 00    L2. :0477[1]
+
+; &bf7e referenced 1 time by &046b
+.c047a
+    lsr a                                                             ; bf7e: 4a          J   :047a[1]
+    bcc c0482                                                         ; bf7f: 90 05       ..  :047b[1]
+    ldy #&88                                                          ; bf81: a0 88       ..  :047d[1]
+    sty tube_host_r1_status                                           ; bf83: 8c e0 fe    ... :047f[1]
+; &bf86 referenced 2 times by &046f, &047b
+.c0482
+    plp                                                               ; bf86: 28          (   :0482[1]
+    rts                                                               ; bf87: 60          `   :0483[1]
+
+    equb &58, &b0, &0a, &d0,   3, &4c, &9c,   5, &ae, &8d,   2, &f0   ; bf88: 58 b0 0a... X.. :0484[1]
+    equb &e0                                                          ; bf94: e0          .   :0490[1]
+; &bf95 referenced 1 time by &bf9a
+    org lbf04 + (l0491 - l0400)
+    copyblock l0400, l0491, lbf04
+    clear l0400, l0491
+
+; &bf95 referenced 1 time by &bf9a
+.loop_cbf95
+; &bf95 referenced 1 time by &bf9a
+    lda #&ff                                                          ; bf95: a9 ff       ..
+    jsr c0406                                                         ; bf97: 20 06 04     ..
+    bcc loop_cbf95                                                    ; bf9a: 90 f9       ..
+    jsr l04ce                                                         ; bf9c: 20 ce 04     ..
+; &bf9f referenced 1 time by &bfc4
+.cbf9f
+    php                                                               ; bf9f: 08          .
+    sei                                                               ; bfa0: 78          x
+    lda #7                                                            ; bfa1: a9 07       ..
+    jsr l04c7                                                         ; bfa3: 20 c7 04     ..
+    ldy #0                                                            ; bfa6: a0 00       ..
+    sty l0000                                                         ; bfa8: 84 00       ..
+; &bfaa referenced 1 time by &bfb3
+.loop_cbfaa
+    lda (l0000),y                                                     ; bfaa: b1 00       ..
+    sta tube_host_r3_data                                             ; bfac: 8d e5 fe    ...
+    nop                                                               ; bfaf: ea          .
+    nop                                                               ; bfb0: ea          .
+    nop                                                               ; bfb1: ea          .
+    iny                                                               ; bfb2: c8          .
+    bne loop_cbfaa                                                    ; bfb3: d0 f5       ..
+    plp                                                               ; bfb5: 28          (
+    inc l0054                                                         ; bfb6: e6 54       .T
+    bne cbfc0                                                         ; bfb8: d0 06       ..
+    inc l0055                                                         ; bfba: e6 55       .U
+    bne cbfc0                                                         ; bfbc: d0 02       ..
+    inc l0056                                                         ; bfbe: e6 56       .V
+; &bfc0 referenced 2 times by &bfb8, &bfbc
+.cbfc0
+    inc l0001                                                         ; bfc0: e6 01       ..
+    bit l0001                                                         ; bfc2: 24 01       $.
+    bvc cbf9f                                                         ; bfc4: 50 d9       P.
+    jsr l04ce                                                         ; bfc6: 20 ce 04     ..
+    lda #4                                                            ; bfc9: a9 04       ..
+    ldy #0                                                            ; bfcb: a0 00       ..
+    ldx #&53 ; 'S'                                                    ; bfcd: a2 53       .S
+    jmp c0406                                                         ; bfcf: 4c 06 04    L..
+
+    lda #&80                                                          ; bfd2: a9 80       ..
+    sta l0054                                                         ; bfd4: 85 54       .T
+    sta l0001                                                         ; bfd6: 85 01       ..
+    lda #&20 ; ' '                                                    ; bfd8: a9 20       .
+    and rom_type                                                      ; bfda: 2d 06 80    -..
+    tay                                                               ; bfdd: a8          .
+    sty l0053                                                         ; bfde: 84 53       .S
+    beq cbffb                                                         ; bfe0: f0 19       ..
+    ldx copyright_offset                                              ; bfe2: ae 07 80    ...
+; &bfe5 referenced 1 time by &bfe9
+.loop_cbfe5
+    inx                                                               ; bfe5: e8          .
+    lda rom_header,x                                                  ; bfe6: bd 00 80    ...
+    bne loop_cbfe5                                                    ; bfe9: d0 fa       ..
+    lda l8001,x                                                       ; bfeb: bd 01 80    ...
+    sta l0053                                                         ; bfee: 85 53       .S
+    lda l8002,x                                                       ; bff0: bd 02 80    ...
+    sta l0054                                                         ; bff3: 85 54       .T
+    ldy service_entry,x                                               ; bff5: bc 03 80    ...
+    lda l8004,x                                                       ; bff8: bd 04 80    ...
+; &bffb referenced 1 time by &bfe0
+.cbffb
+    sta l0056                                                         ; bffb: 85 56       .V
+    sty l0055                                                         ; bffd: 84 55       .U
+    rts                                                               ; bfff: 60          `
+
+.pydis_end
+
+; Label references by decreasing frequency:
+;     l009e:                                64
+;     l0f05:                                48
+;     l009c:                                42
+;     l00ae:                                38
+;     l009a:                                35
+;     print_inline_top_bit_clear:           35
+;     l00be:                                33
+;     l00bb:                                31
+;     l1071:                                30
+;     l00b2:                                28
+;     l00b4:                                25
+;     osbyte:                               23
+;     osasci:                               22
+;     l00b8:                                21
+;     l00a8:                                20
+;     l00aa:                                20
+;     l00ac:                                20
+;     l0101:                                20
+;     l9491:                                19
+;     l10b8:                                18
+;     osnewl:                               18
+;     l00b0:                                17
+;     l0e30:                                17
+;     l00b5:                                16
+;     os_text_ptr:                          15
+;     c94ad:                                15
+;     l0f06:                                14
+;     l009b:                                13
+;     l00a0:                                13
+;     l00a6:                                13
+;     l0d6c:                                13
+;     l00a9:                                12
+;     l10c8:                                12
+;     la3f0:                                12
+;     l0098:                                11
+;     l00b6:                                11
+;     l0100:                                11
+;     l1030:                                11
+;     generate_error_inline:                11
+;     lfea1:                                11
+;     l00ad:                                10
+;     l0d61:                                10
+;     l0d6a:                                10
+;     l1060:                                10
+;     l00b3:                                 9
+;     l0f03:                                 9
+;     l1000:                                 9
+;     sub_caf04:                             9
+;     sub_caf32:                             9
+;     lfe18:                                 9
+;     l00af:                                 8
+;     l00c8:                                 8
+;     romsel_copy:                           8
+;     l97b9:                                 8
+;     l009d:                                 7
+;     l00bc:                                 7
+;     l00c0:                                 7
+;     l00c4:                                 7
+;     l0d68:                                 7
+;     l0df0:                                 7
+;     l0e01:                                 7
+;     generate_error_inline3:                7
+;     sub_cafb5:                             7
+;     cbf0a:                                 7
+;     lfea0:                                 7
+;     l0015:                                 6
+;     l009f:                                 6
+;     l00cc:                                 6
+;     l00d0:                                 6
+;     l00f3:                                 6
+;     l069e:                                 6
+;     l0d3e:                                 6
+;     l0d60:                                 6
+;     l0e00:                                 6
+;     l0f02:                                 6
+;     l10c9:                                 6
+;     l10d8:                                 6
+;     c9211:                                 6
+;     sta_e09_if_d6c_b7_set:                 6
+;     c9cc7:                                 6
+;     sub_cb586:                             6
+;     cbc3d:                                 6
+;     l00b9:                                 5
+;     l00ba:                                 5
+;     l00bf:                                 5
+;     l0d6b:                                 5
+;     l0e05:                                 5
+;     l0e07:                                 5
+;     l1010:                                 5
+;     l1040:                                 5
+;     l10cf:                                 5
+;     l10d4:                                 5
+;     l10d5:                                 5
+;     jump_table_dispatch_x_plus_y:          5
+;     sub_c916e:                             5
+;     sub_c95dd:                             5
+;     l97ad:                                 5
+;     sub_c983f:                             5
+;     sub_ca140:                             5
+;     caeb7:                                 5
+;     sub_caf02:                             5
+;     sub_cb509:                             5
+;     tube_host_r1_status:                   5
+;     l0099:                                 4
+;     l00b7:                                 4
+;     l00c1:                                 4
+;     l0d62:                                 4
+;     l0d71:                                 4
+;     l0e03:                                 4
+;     l0e09:                                 4
+;     l0f07:                                 4
+;     l0f08:                                 4
+;     l1020:                                 4
+;     l1098:                                 4
+;     l10a8:                                 4
+;     sub_c8cb9:                             4
+;     c8dd2:                                 4
+;     sub_c912f:                             4
+;     c9215:                                 4
+;     sub_c9473:                             4
+;     generate_error_inline2:                4
+;     c96f0:                                 4
+;     sub_cae94:                             4
+;     sub_cb0ea:                             4
+;     sub_cb198:                             4
+;     cb236:                                 4
+;     cb55f:                                 4
+;     cb59b:                                 4
+;     sub_cb98a:                             4
+;     sub_cb98f:                             4
+;     video_ula_control:                     4
+;     gsinit:                                4
+;     gsread:                                4
+;     osfind:                                4
+;     oswrch:                                4
+;     l0001:                                 3
+;     l0054:                                 3
+;     l00a1:                                 3
+;     l00b1:                                 3
+;     l00bd:                                 3
+;     l00f0:                                 3
+;     l0102:                                 3
+;     l0355:                                 3
+;     l0d0c:                                 3
+;     l0d0d:                                 3
+;     l0d3f:                                 3
+;     l0d40:                                 3
+;     l0d63:                                 3
+;     l0d69:                                 3
+;     l0e02:                                 3
+;     l0e04:                                 3
+;     l0e0a:                                 3
+;     l0e31:                                 3
+;     l0f00:                                 3
+;     l0f09:                                 3
+;     l0fc8:                                 3
+;     l1078:                                 3
+;     l1088:                                 3
+;     l10ca:                                 3
+;     l10cc:                                 3
+;     l10d0:                                 3
+;     l10f3:                                 3
+;     c85fb:                                 3
+;     c862f:                                 3
+;     c8a98:                                 3
+;     sub_c8aa0:                             3
+;     sub_c8b02:                             3
+;     c8c70:                                 3
+;     just_rts:                              3
+;     sub_c8e83:                             3
+;     c8f8c:                                 3
+;     c9208:                                 3
+;     sub_c9258:                             3
+;     c92fa:                                 3
+;     c9311:                                 3
+;     c95f4:                                 3
+;     c98c9:                                 3
+;     sub_ca0a7:                             3
+;     ca25d:                                 3
+;     sub_ca32b:                             3
+;     ca38e:                                 3
+;     la3f1:                                 3
+;     la3f2:                                 3
+;     cab36:                                 3
+;     sub_cac24:                             3
+;     cacdd:                                 3
+;     sub_cae82:                             3
+;     sub_cae97:                             3
+;     caeda:                                 3
+;     sub_caf06:                             3
+;     caf88:                                 3
+;     cb058:                                 3
+;     cb153:                                 3
+;     cb2d4:                                 3
+;     sub_cb559:                             3
+;     sub_cb799:                             3
+;     cb9aa:                                 3
+;     cbb68:                                 3
+;     cbc1f:                                 3
+;     tube_host_r3_data:                     3
+;     l0000:                                 2
+;     l0012:                                 2
+;     l0014:                                 2
+;     l0053:                                 2
+;     l0055:                                 2
+;     l0056:                                 2
+;     l00a5:                                 2
+;     l00a7:                                 2
+;     l00ab:                                 2
+;     l00ef:                                 2
+;     osrdsc_ptr:                            2
+;     l00ff:                                 2
+;     evntv:                                 2
+;     l028d:                                 2
+;     l04ce:                                 2
+;     l0d1e:                                 2
+;     l0d20:                                 2
+;     l0d21:                                 2
+;     l0d22:                                 2
+;     l0d24:                                 2
+;     l0d25:                                 2
+;     l0d65:                                 2
+;     l0d6d:                                 2
+;     l0dfe:                                 2
+;     l0e06:                                 2
+;     l0e08:                                 2
+;     l0e2f:                                 2
+;     l0e38:                                 2
+;     l0f04:                                 2
+;     l0f10:                                 2
+;     l0f11:                                 2
+;     l0f12:                                 2
+;     l0fdc:                                 2
+;     l0fdd:                                 2
+;     l0fde:                                 2
+;     l10d9:                                 2
+;     c83fb:                                 2
+;     sub_c858c:                             2
+;     c8641:                                 2
+;     c8945:                                 2
+;     sub_c8969:                             2
+;     c8978:                                 2
+;     c8988:                                 2
+;     c8a38:                                 2
+;     service_handler_common2:               2
+;     c8aba:                                 2
+;     c8b0c:                                 2
+;     c8b98:                                 2
+;     c8bab:                                 2
+;     c8be0:                                 2
+;     sub_c8c33:                             2
+;     c8c4d:                                 2
+;     sub_c8c9f:                             2
+;     sub_c8cc0:                             2
+;     c8d37:                                 2
+;     l8d38:                                 2
+;     c8dbc:                                 2
+;     c8e24:                                 2
+;     l8e54:                                 2
+;     c8eab:                                 2
+;     c8f70:                                 2
+;     sub_c8fcb:                             2
+;     c8fe4:                                 2
+;     c8ff1:                                 2
+;     c91ae:                                 2
+;     c91da:                                 2
+;     c91fb:                                 2
+;     c9229:                                 2
+;     c9235:                                 2
+;     c9266:                                 2
+;     sub_c9269:                             2
+;     sub_c9273:                             2
+;     sub_c9295:                             2
+;     sub_c92a4:                             2
+;     sub_c9309:                             2
+;     c9322:                                 2
+;     sub_c9327:                             2
+;     sub_c9349:                             2
+;     c9363:                                 2
+;     c93bc:                                 2
+;     sub_c949b:                             2
+;     c94ae:                                 2
+;     c94d9:                                 2
+;     sub_c94f0:                             2
+;     c9504:                                 2
+;     c9551:                                 2
+;     sub_c9570:                             2
+;     c9589:                                 2
+;     c964e:                                 2
+;     c9740:                                 2
+;     sub_c974d:                             2
+;     sub_c9771:                             2
+;     sub_c977c:                             2
+;     sub_c978d:                             2
+;     sub_c9837:                             2
+;     c986b:                                 2
+;     c987e:                                 2
+;     l9888:                                 2
+;     c98eb:                                 2
+;     c9926:                                 2
+;     sub_c9998:                             2
+;     sub_c9a62:                             2
+;     c9a64:                                 2
+;     sub_c9a72:                             2
+;     sub_c9a7f:                             2
+;     sub_c9a84:                             2
+;     sub_c9a92:                             2
+;     c9a96:                                 2
+;     sub_c9a9a:                             2
+;     c9b35:                                 2
+;     sub_c9b95:                             2
+;     c9ba8:                                 2
+;     c9cc9:                                 2
+;     c9dbb:                                 2
+;     c9e09:                                 2
+;     ca073:                                 2
+;     sub_ca0cc:                             2
+;     sub_ca0ce:                             2
+;     ca0f7:                                 2
+;     ca133:                                 2
+;     ca159:                                 2
+;     ca1a2:                                 2
+;     ca1b7:                                 2
+;     ca2ef:                                 2
+;     ca303:                                 2
+;     ca32e:                                 2
+;     sub_ca362:                             2
+;     ca365:                                 2
+;     ca38b:                                 2
+;     ca3e3:                                 2
+;     ca522:                                 2
+;     sub_ca865:                             2
+;     ca889:                                 2
+;     ca8c4:                                 2
+;     caaa9:                                 2
+;     caae2:                                 2
+;     sub_cab12:                             2
+;     cac30:                                 2
+;     cac4a:                                 2
+;     cae84:                                 2
+;     caed8:                                 2
+;     caedf:                                 2
+;     caf5a:                                 2
+;     sub_caf96:                             2
+;     sub_cafc1:                             2
+;     cafcd:                                 2
+;     sub_cafd5:                             2
+;     sub_cafe0:                             2
+;     cb091:                                 2
+;     sub_cb0cf:                             2
+;     sub_cb0f6:                             2
+;     cb144:                                 2
+;     sub_cb15e:                             2
+;     sub_cb16d:                             2
+;     sub_cb2f7:                             2
+;     cb305:                                 2
+;     cb32c:                                 2
+;     cb336:                                 2
+;     sub_cb431:                             2
+;     lb487:                                 2
+;     cb577:                                 2
+;     sub_cb595:                             2
+;     cb5b7:                                 2
+;     sub_cb5d8:                             2
+;     sub_cb5fb:                             2
+;     sub_cb66a:                             2
+;     cb682:                                 2
+;     cb718:                                 2
+;     cb732:                                 2
+;     cb735:                                 2
+;     sub_cb984:                             2
+;     cb9cd:                                 2
+;     cb9e7:                                 2
+;     sub_cb9ff:                             2
+;     cba33:                                 2
+;     cba53:                                 2
+;     sub_cbadd:                             2
+;     sub_cbb03:                             2
+;     sub_cbb0e:                             2
+;     cbb6f:                                 2
+;     cbba2:                                 2
+;     cbbbc:                                 2
+;     sub_cbc44:                             2
+;     sub_cbc86:                             2
+;     cbe73:                                 2
+;     cbec2:                                 2
+;     lbf04:                                 2
+;     cbf38:                                 2
+;     cbf86:                                 2
+;     cbfc0:                                 2
+;     romsel:                                2
+;     system_via_acr:                        2
+;     system_via_ifr:                        2
+;     osbget:                                2
+;     osargs:                                2
+;     osrdch:                                2
+;     osword:                                2
+;     l0013:                                 1
+;     l0016:                                 1
+;     l0032:                                 1
+;     l0063:                                 1
+;     l0078:                                 1
+;     l00a2:                                 1
+;     l00a3:                                 1
+;     l00a4:                                 1
+;     l00c2:                                 1
+;     l00c7:                                 1
+;     l00cd:                                 1
+;     l00ed:                                 1
+;     l00f7:                                 1
+;     l00fd:                                 1
+;     l0103:                                 1
+;     l0104:                                 1
+;     brkv:                                  1
+;     brkv+1:                                1
+;     filev:                                 1
+;     fscv:                                  1
+;     evntv+1:                               1
+;     netv:                                  1
+;     l026a:                                 1
+;     l02a0:                                 1
+;     l0350:                                 1
+;     l0351:                                 1
+;     l04c7:                                 1
+;     l0500:                                 1
+;     l0518:                                 1
+;     l0600:                                 1
+;     l0695:                                 1
+;     l0cff:                                 1
+;     l0d07:                                 1
+;     l0d0e:                                 1
+;     l0d11:                                 1
+;     l0d1a:                                 1
+;     l0d23:                                 1
+;     l0d26:                                 1
+;     l0d41:                                 1
+;     l0d64:                                 1
+;     l0d6e:                                 1
+;     l0d6f:                                 1
+;     l0e0b:                                 1
+;     l0e14:                                 1
+;     l0e32:                                 1
+;     l0ef7:                                 1
+;     l0f01:                                 1
+;     l0f0a:                                 1
+;     l0f0b:                                 1
+;     l0f0c:                                 1
+;     l0f0d:                                 1
+;     l0f0e:                                 1
+;     l0f13:                                 1
+;     l0f14:                                 1
+;     l0f2f:                                 1
+;     l0f30:                                 1
+;     l0fdf:                                 1
+;     l0fe0:                                 1
+;     l0ff0:                                 1
+;     l0fff:                                 1
+;     l1050:                                 1
+;     l1070:                                 1
+;     l1072:                                 1
+;     l1073:                                 1
+;     l1074:                                 1
+;     l10cb:                                 1
+;     l10cd:                                 1
+;     l10ce:                                 1
+;     l10d1:                                 1
+;     l10d6:                                 1
+;     l10d7:                                 1
+;     rom_header:                            1
+;     l8001:                                 1
+;     l8002:                                 1
+;     service_entry:                         1
+;     l8004:                                 1
+;     rom_type:                              1
+;     copyright_offset:                      1
+;     c8032:                                 1
+;     sub_c805a:                             1
+;     c805d:                                 1
+;     c806c:                                 1
+;     sub_c8074:                             1
+;     loop_c8096:                            1
+;     c80bd:                                 1
+;     c80be:                                 1
+;     c80d6:                                 1
+;     c80e9:                                 1
+;     c80fd:                                 1
+;     c810a:                                 1
+;     c83f8:                                 1
+;     sub_c8449:                             1
+;     c8452:                                 1
+;     l84bb:                                 1
+;     c8585:                                 1
+;     c85a4:                                 1
+;     loop_c85b8:                            1
+;     c85cf:                                 1
+;     loop_c85d9:                            1
+;     c85e3:                                 1
+;     l8600:                                 1
+;     c8619:                                 1
+;     c8633:                                 1
+;     c863f:                                 1
+;     c864d:                                 1
+;     c8693:                                 1
+;     loop_c869a:                            1
+;     c86ac:                                 1
+;     loop_c86c2:                            1
+;     c86ce:                                 1
+;     c86d5:                                 1
+;     c86d8:                                 1
+;     c86e3:                                 1
+;     l8861:                                 1
+;     l8869:                                 1
+;     sub_c88f2:                             1
+;     c8901:                                 1
+;     loop_c8912:                            1
+;     c8942:                                 1
+;     c89a4:                                 1
+;     l89a6:                                 1
+;     jump_table_low:                        1
+;     jump_table_high:                       1
+;     service_handler:                       1
+;     c8a33:                                 1
+;     service_handler_common1:               1
+;     c8a53:                                 1
+;     c8a62:                                 1
+;     c8a6f:                                 1
+;     c8a71:                                 1
+;     service_handler_not_vectors_changed:   1
+;     c8acb:                                 1
+;     c8ad1:                                 1
+;     sub_c8aea:                             1
+;     loop_c8aee:                            1
+;     c8afb:                                 1
+;     sub_c8b1a:                             1
+;     loop_c8b26:                            1
+;     c8b34:                                 1
+;     loop_c8b39:                            1
+;     loop_c8b4c:                            1
+;     loop_c8b7a:                            1
+;     c8b8d:                                 1
+;     c8ba8:                                 1
+;     c8bae:                                 1
+;     c8bb6:                                 1
+;     loop_c8bc0:                            1
+;     loop_c8bca:                            1
+;     c8bf0:                                 1
+;     c8bf6:                                 1
+;     c8c00:                                 1
+;     loop_c8c06:                            1
+;     c8c12:                                 1
+;     c8c1f:                                 1
+;     c8c24:                                 1
+;     c8c26:                                 1
+;     c8c2f:                                 1
+;     loop_c8c45:                            1
+;     c8c73:                                 1
+;     c8c7d:                                 1
+;     loop_c8c80:                            1
+;     c8c98:                                 1
+;     c8cc9:                                 1
+;     c8cda:                                 1
+;     c8ce0:                                 1
+;     sub_c8cfc:                             1
+;     sub_c8d05:                             1
+;     c8d08:                                 1
+;     c8d0a:                                 1
+;     sub_c8d17:                             1
+;     loop_c8d1b:                            1
+;     c8d26:                                 1
+;     loop_c8d2c:                            1
+;     l8d61:                                 1
+;     c8da7:                                 1
+;     loop_c8dae:                            1
+;     c8dbf:                                 1
+;     loop_c8dc1:                            1
+;     loop_c8de4:                            1
+;     c8deb:                                 1
+;     c8dfa:                                 1
+;     sub_c8e09:                             1
+;     c8e14:                                 1
+;     c8e15:                                 1
+;     c8e20:                                 1
+;     l8e61:                                 1
+;     sub_c8e85:                             1
+;     loop_c8e87:                            1
+;     sub_c8e8c:                             1
+;     clamp_absolute_workspace_and_save:     1
+;     c8eb3:                                 1
+;     loop_c8eee:                            1
+;     loop_c8f18:                            1
+;     loop_c8f2e:                            1
+;     c8f3d:                                 1
+;     c8f40:                                 1
+;     loop_c8f46:                            1
+;     l8f48:                                 1
+;     c8f4c:                                 1
+;     sub_c8f5d:                             1
+;     loop_c8f8e:                            1
+;     sub_c8f99:                             1
+;     loop_c8fb0:                            1
+;     loop_c8fba:                            1
+;     c8fbd:                                 1
+;     c8fca:                                 1
+;     loop_c8fd4:                            1
+;     c901e:                                 1
+;     l9022:                                 1
+;     l9122:                                 1
+;     sub_c9138:                             1
+;     c9140:                                 1
+;     loop_c914d:                            1
+;     c9153:                                 1
+;     c916b:                                 1
+;     c917d:                                 1
+;     c9188:                                 1
+;     c9198:                                 1
+;     c919a:                                 1
+;     c91e3:                                 1
+;     c91f9:                                 1
+;     c9244:                                 1
+;     sub_c9260:                             1
+;     c9267:                                 1
+;     c9277:                                 1
+;     loop_c927b:                            1
+;     c9283:                                 1
+;     l9286:                                 1
+;     sub_c9291:                             1
+;     sub_c929b:                             1
+;     c929f:                                 1
+;     loop_c92a6:                            1
+;     c92af:                                 1
+;     loop_c9329:                            1
+;     loop_c9332:                            1
+;     c933e:                                 1
+;     c9348:                                 1
+;     loop_c934f:                            1
+;     c9358:                                 1
+;     c9371:                                 1
+;     loop_c939b:                            1
+;     c93a2:                                 1
+;     c93ae:                                 1
+;     c93ee:                                 1
+;     loop_c93f0:                            1
+;     c9405:                                 1
+;     c940c:                                 1
+;     c943c:                                 1
+;     c9462:                                 1
+;     sub_c9465:                             1
+;     sub_c9467:                             1
+;     loop_c9476:                            1
+;     c9486:                                 1
+;     l948b:                                 1
+;     sub_c9497:                             1
+;     c94b4:                                 1
+;     c94b5:                                 1
+;     loop_c94bb:                            1
+;     c94d3:                                 1
+;     loop_c94f8:                            1
+;     c9502:                                 1
+;     c9505:                                 1
+;     c950e:                                 1
+;     c951b:                                 1
+;     loop_c9520:                            1
+;     c9547:                                 1
+;     c955b:                                 1
+;     loop_c955d:                            1
+;     c9576:                                 1
+;     c9586:                                 1
+;     c95ee:                                 1
+;     c9607:                                 1
+;     c9619:                                 1
+;     c961a:                                 1
+;     loop_c962a:                            1
+;     c9636:                                 1
+;     c9641:                                 1
+;     c9649:                                 1
+;     c964c:                                 1
+;     c9651:                                 1
+;     loop_c9668:                            1
+;     c9674:                                 1
+;     c9686:                                 1
+;     c9688:                                 1
+;     loop_c968c:                            1
+;     c9698:                                 1
+;     c969a:                                 1
+;     loop_c96a9:                            1
+;     c96af:                                 1
+;     error_template_minus_1:                1
+;     loop_c96c4:                            1
+;     c96dd:                                 1
+;     loop_c96e7:                            1
+;     c96fa:                                 1
+;     c96fd:                                 1
+;     c971e:                                 1
+;     c9722:                                 1
+;     c972c:                                 1
+;     loop_c9734:                            1
+;     c9767:                                 1
+;     loop_c9794:                            1
+;     c97a4:                                 1
+;     c97ac:                                 1
+;     c9846:                                 1
+;     c984f:                                 1
+;     loop_c9865:                            1
+;     c9873:                                 1
+;     c9882:                                 1
+;     sub_c9894:                             1
+;     sub_c989c:                             1
+;     loop_c989e:                            1
+;     c98ab:                                 1
+;     c98b8:                                 1
+;     loop_c98c4:                            1
+;     loop_c98d9:                            1
+;     c98de:                                 1
+;     c98f3:                                 1
+;     loop_c98f8:                            1
+;     c9902:                                 1
+;     sub_c9913:                             1
+;     loop_c991b:                            1
+;     sub_c9951:                             1
+;     c9969:                                 1
+;     c996f:                                 1
+;     loop_c9971:                            1
+;     loop_c998c:                            1
+;     loop_c99a1:                            1
+;     loop_c99a3:                            1
+;     loop_c99b7:                            1
+;     c99c2:                                 1
+;     c99c8:                                 1
+;     loop_c99cd:                            1
+;     loop_c99eb:                            1
+;     c9a0c:                                 1
+;     c9a19:                                 1
+;     c9a1f:                                 1
+;     c9a22:                                 1
+;     loop_c9a2f:                            1
+;     c9a32:                                 1
+;     loop_c9a40:                            1
+;     sub_c9a57:                             1
+;     loop_c9a74:                            1
+;     sub_c9a7e:                             1
+;     c9a83:                                 1
+;     loop_c9a87:                            1
+;     sub_c9a91:                             1
+;     c9aa0:                                 1
+;     loop_c9aab:                            1
+;     loop_c9abd:                            1
+;     c9ac9:                                 1
+;     loop_c9acb:                            1
+;     c9ad2:                                 1
+;     c9afb:                                 1
+;     loop_c9b13:                            1
+;     c9b20:                                 1
+;     loop_c9b2a:                            1
+;     c9b3c:                                 1
+;     c9b41:                                 1
+;     c9b47:                                 1
+;     c9b4c:                                 1
+;     c9b56:                                 1
+;     loop_c9b78:                            1
+;     loop_c9b85:                            1
+;     c9b91:                                 1
+;     c9b92:                                 1
+;     loop_c9b9c:                            1
+;     loop_c9bb3:                            1
+;     c9bb5:                                 1
+;     c9dd2:                                 1
+;     c9dd5:                                 1
+;     c9dda:                                 1
+;     c9ddf:                                 1
+;     c9e0b:                                 1
+;     sub_c9e0f:                             1
+;     sub_c9e16:                             1
+;     sub_c9e17:                             1
+;     loop_c9e19:                            1
+;     c9e25:                                 1
+;     c9e28:                                 1
+;     sub_c9ed2:                             1
+;     c9edd:                                 1
+;     loop_c9ee8:                            1
+;     c9ef3:                                 1
+;     c9efc:                                 1
+;     c9f0a:                                 1
+;     loop_c9f27:                            1
+;     loop_c9f3e:                            1
+;     c9f52:                                 1
+;     c9f55:                                 1
+;     sub_c9f67:                             1
+;     ca09b:                                 1
+;     sub_ca09e:                             1
+;     ca0bd:                                 1
+;     ca0c5:                                 1
+;     ca0c9:                                 1
+;     ca0e3:                                 1
+;     ca0f5:                                 1
+;     ca109:                                 1
+;     ca114:                                 1
+;     ca125:                                 1
+;     ca127:                                 1
+;     ca142:                                 1
+;     loop_ca14a:                            1
+;     loop_ca165:                            1
+;     ca16a:                                 1
+;     loop_ca170:                            1
+;     la17c:                                 1
+;     ca185:                                 1
+;     loop_ca187:                            1
+;     ca18d:                                 1
+;     ca191:                                 1
+;     ca1a3:                                 1
+;     loop_ca1a4:                            1
+;     loop_ca1a8:                            1
+;     ca1a9:                                 1
+;     ca1be:                                 1
+;     ca1c1:                                 1
+;     ca1ca:                                 1
+;     loop_ca1e2:                            1
+;     ca1ea:                                 1
+;     ca206:                                 1
+;     ca209:                                 1
+;     loop_ca21d:                            1
+;     loop_ca225:                            1
+;     loop_ca230:                            1
+;     loop_ca241:                            1
+;     ca243:                                 1
+;     loop_ca245:                            1
+;     ca25a:                                 1
+;     ca26a:                                 1
+;     loop_ca26c:                            1
+;     ca27d:                                 1
+;     la291:                                 1
+;     ca299:                                 1
+;     loop_ca2a2:                            1
+;     loop_ca2a8:                            1
+;     ca2f4:                                 1
+;     sub_ca300:                             1
+;     ca319:                                 1
+;     ca327:                                 1
+;     ca344:                                 1
+;     ca352:                                 1
+;     ca37b:                                 1
+;     ca389:                                 1
+;     ca3b4:                                 1
+;     loop_ca3ce:                            1
+;     la3df:                                 1
+;     ca3e8:                                 1
+;     la477:                                 1
+;     loop_ca4fc:                            1
+;     loop_ca50e:                            1
+;     sub_ca516:                             1
+;     la523:                                 1
+;     la52a:                                 1
+;     la841:                                 1
+;     la84d:                                 1
+;     loop_ca875:                            1
+;     loop_ca89d:                            1
+;     ca8b5:                                 1
+;     sub_ca9be:                             1
+;     sub_caa85:                             1
+;     sub_caa89:                             1
+;     caa8a:                                 1
+;     caa9f:                                 1
+;     caaa1:                                 1
+;     caaa7:                                 1
+;     caaad:                                 1
+;     laab1:                                 1
+;     sub_cab1b:                             1
+;     cab33:                                 1
+;     cab75:                                 1
+;     cab84:                                 1
+;     loop_cab89:                            1
+;     loop_caba8:                            1
+;     cabb5:                                 1
+;     cabb7:                                 1
+;     cabde:                                 1
+;     cabf3:                                 1
+;     cabfe:                                 1
+;     cac10:                                 1
+;     cac3f:                                 1
+;     cac67:                                 1
+;     loop_cac6f:                            1
+;     lac80:                                 1
+;     lac8c:                                 1
+;     loop_cacaf:                            1
+;     sub_cace4:                             1
+;     sub_cacf7:                             1
+;     sub_cacf9:                             1
+;     lad0d:                                 1
+;     cad20:                                 1
+;     loop_cad29:                            1
+;     cad2f:                                 1
+;     lad43:                                 1
+;     cad6f:                                 1
+;     cad89:                                 1
+;     cad96:                                 1
+;     cadb2:                                 1
+;     cade3:                                 1
+;     caded:                                 1
+;     loop_cae1c:                            1
+;     cae27:                                 1
+;     cae4f:                                 1
+;     loop_cae6f:                            1
+;     cae8f:                                 1
+;     sub_cae92:                             1
+;     loop_caebb:                            1
+;     loop_caec9:                            1
+;     caedb:                                 1
+;     caee2:                                 1
+;     caef1:                                 1
+;     laefb:                                 1
+;     laeff:                                 1
+;     loop_caf07:                            1
+;     caf16:                                 1
+;     loop_caf1c:                            1
+;     caf2b:                                 1
+;     loop_caf2d:                            1
+;     caf40:                                 1
+;     sub_caf47:                             1
+;     caf5c:                                 1
+;     caf5f:                                 1
+;     caf72:                                 1
+;     sub_caf85:                             1
+;     loop_caf9d:                            1
+;     cafad:                                 1
+;     cafb4:                                 1
+;     loop_cafc0:                            1
+;     cafd4:                                 1
+;     caff8:                                 1
+;     sub_cb017:                             1
+;     sub_cb019:                             1
+;     loop_cb01b:                            1
+;     cb025:                                 1
+;     cb028:                                 1
+;     loop_cb032:                            1
+;     loop_cb04a:                            1
+;     cb06b:                                 1
+;     cb083:                                 1
+;     cb099:                                 1
+;     cb0ae:                                 1
+;     cb0b6:                                 1
+;     cb0b9:                                 1
+;     sub_cb0c5:                             1
+;     cb0da:                                 1
+;     loop_cb108:                            1
+;     cb118:                                 1
+;     cb11c:                                 1
+;     lb13f:                                 1
+;     sub_cb165:                             1
+;     loop_cb16f:                            1
+;     loop_cb179:                            1
+;     loop_cb18b:                            1
+;     lb194:                                 1
+;     cb1a8:                                 1
+;     cb1b1:                                 1
+;     cb205:                                 1
+;     cb208:                                 1
+;     loop_cb210:                            1
+;     loop_cb228:                            1
+;     loop_cb253:                            1
+;     cb261:                                 1
+;     cb267:                                 1
+;     cb29c:                                 1
+;     loop_cb2a0:                            1
+;     cb2ac:                                 1
+;     cb2d7:                                 1
+;     cb2df:                                 1
+;     sub_cb2e0:                             1
+;     loop_cb2e2:                            1
+;     cb2ed:                                 1
+;     cb2ef:                                 1
+;     cb316:                                 1
+;     loop_cb31a:                            1
+;     cb335:                                 1
+;     loop_cb347:                            1
+;     cb369:                                 1
+;     cb39c:                                 1
+;     loop_cb39f:                            1
+;     cb3a3:                                 1
+;     cb3a8:                                 1
+;     cb3b1:                                 1
+;     loop_cb3b5:                            1
+;     loop_cb3d9:                            1
+;     cb3ed:                                 1
+;     loop_cb3ff:                            1
+;     cb408:                                 1
+;     cb40c:                                 1
+;     cb40e:                                 1
+;     cb41d:                                 1
+;     cb423:                                 1
+;     loop_cb424:                            1
+;     cb448:                                 1
+;     sub_cb449:                             1
+;     loop_cb44c:                            1
+;     loop_cb45c:                            1
+;     sub_cb46b:                             1
+;     cb475:                                 1
+;     cb477:                                 1
+;     cb483:                                 1
+;     sub_cb4ad:                             1
+;     cb4c1:                                 1
+;     loop_cb4cc:                            1
+;     loop_cb4df:                            1
+;     loop_cb50c:                            1
+;     cb51a:                                 1
+;     sub_cb53d:                             1
+;     cb557:                                 1
+;     cb563:                                 1
+;     cb594:                                 1
+;     cb5a2:                                 1
+;     cb5ac:                                 1
+;     cb5b6:                                 1
+;     cb5be:                                 1
+;     cb5cd:                                 1
+;     loop_cb5ea:                            1
+;     cb63b:                                 1
+;     cb661:                                 1
+;     loop_cb66c:                            1
+;     cb67f:                                 1
+;     cb6c6:                                 1
+;     cb6ea:                                 1
+;     loop_cb709:                            1
+;     cb70e:                                 1
+;     sub_cb721:                             1
+;     loop_cb723:                            1
+;     loop_cb72d:                            1
+;     sub_cb730:                             1
+;     cb74f:                                 1
+;     cb788:                                 1
+;     loop_cb79f:                            1
+;     loop_cb7ab:                            1
+;     cb7b6:                                 1
+;     cb7bc:                                 1
+;     loop_cb7c3:                            1
+;     sub_cb8da:                             1
+;     cb8f3:                                 1
+;     sub_cb92b:                             1
+;     loop_cb95e:                            1
+;     cb96b:                                 1
+;     cb974:                                 1
+;     cb9a0:                                 1
+;     cb9b6:                                 1
+;     cb9c5:                                 1
+;     loop_cb9c7:                            1
+;     cb9da:                                 1
+;     cb9ed:                                 1
+;     cb9f4:                                 1
+;     cb9f9:                                 1
+;     cba04:                                 1
+;     loop_cba22:                            1
+;     loop_cba3a:                            1
+;     cba4c:                                 1
+;     cba5a:                                 1
+;     cba65:                                 1
+;     loop_cba67:                            1
+;     loop_cba78:                            1
+;     loop_cba90:                            1
+;     loop_cba95:                            1
+;     cbaab:                                 1
+;     loop_cbab6:                            1
+;     loop_cbabe:                            1
+;     cbac0:                                 1
+;     cbacf:                                 1
+;     cbad8:                                 1
+;     loop_cbaf2:                            1
+;     loop_cbb13:                            1
+;     cbb1a:                                 1
+;     cbb39:                                 1
+;     loop_cbb40:                            1
+;     loop_cbb43:                            1
+;     cbb64:                                 1
+;     loop_cbb6e:                            1
+;     sub_cbb77:                             1
+;     loop_cbb90:                            1
+;     cbb9c:                                 1
+;     loop_cbbb7:                            1
+;     loop_cbbd4:                            1
+;     loop_cbbe7:                            1
+;     loop_cbbf6:                            1
+;     loop_cbc03:                            1
+;     cbc0a:                                 1
+;     loop_cbc24:                            1
+;     loop_cbc34:                            1
+;     cbc6a:                                 1
+;     loop_cbc72:                            1
+;     loop_cbc7d:                            1
+;     cbc84:                                 1
+;     sub_cbc89:                             1
+;     sub_cbc8c:                             1
+;     lbc94:                                 1
+;     lbd94:                                 1
+;     service_handler_tube_service_calls:    1
+;     cbe83:                                 1
+;     loop_cbe9e:                            1
+;     loop_cbeb8:                            1
+;     cbec0:                                 1
+;     lbec3:                                 1
+;     sub_cbf18:                             1
+;     sub_cbf25:                             1
+;     cbf2c:                                 1
+;     cbf36:                                 1
+;     cbf39:                                 1
+;     cbf4a:                                 1
+;     cbf67:                                 1
+;     cbf6a:                                 1
+;     cbf7e:                                 1
+;     loop_cbf95:                            1
+;     cbf9f:                                 1
+;     loop_cbfaa:                            1
+;     loop_cbfe5:                            1
+;     cbffb:                                 1
+;     system_via_sr:                         1
+;     system_via_ier:                        1
+;     lfe87:                                 1
+;     lfea2:                                 1
+;     lfea3:                                 1
+;     tube_host_r1_data:                     1
+;     tube_host_r4_status:                   1
+;     lffb0:                                 1
+;     osrdsc:                                1
+;     lffbd:                                 1
+;     osfile:                                1
+;     oscli:                                 1
+
+; Automatically generated labels:
+;     c0406
+;     c0428
+;     c0432
+;     c0434
+;     c0435
+;     c0463
+;     c047a
+;     c0482
+;     c8032
+;     c805d
+;     c806c
+;     c80bd
+;     c80be
+;     c80d6
+;     c80e9
+;     c80fd
+;     c810a
+;     c83f8
+;     c83fb
+;     c8452
+;     c8585
+;     c85a4
+;     c85cf
+;     c85e3
+;     c85fb
+;     c8619
+;     c862f
+;     c8633
+;     c863f
+;     c8641
+;     c864d
+;     c8693
+;     c86ac
+;     c86ce
+;     c86d5
+;     c86d8
+;     c86e3
+;     c8901
+;     c8942
+;     c8945
+;     c8978
+;     c8988
+;     c89a4
+;     c8a33
+;     c8a38
+;     c8a53
+;     c8a62
+;     c8a6f
+;     c8a71
+;     c8a98
+;     c8aba
+;     c8acb
+;     c8ad1
+;     c8afb
+;     c8b0c
+;     c8b34
+;     c8b8d
+;     c8b98
+;     c8ba8
+;     c8bab
+;     c8bae
+;     c8bb6
+;     c8be0
+;     c8bf0
+;     c8bf6
+;     c8c00
+;     c8c12
+;     c8c1f
+;     c8c24
+;     c8c26
+;     c8c2f
+;     c8c4d
+;     c8c70
+;     c8c73
+;     c8c7d
+;     c8c98
+;     c8cc9
+;     c8cda
+;     c8ce0
+;     c8d08
+;     c8d0a
+;     c8d26
+;     c8d37
+;     c8da7
+;     c8dbc
+;     c8dbf
+;     c8dd2
+;     c8deb
+;     c8dfa
+;     c8e14
+;     c8e15
+;     c8e20
+;     c8e24
+;     c8eab
+;     c8eb3
+;     c8f3d
+;     c8f40
+;     c8f4c
+;     c8f70
+;     c8f8c
+;     c8fbd
+;     c8fca
+;     c8fe4
+;     c8ff1
+;     c901e
+;     c9140
+;     c9153
+;     c916b
+;     c917d
+;     c9188
+;     c9198
+;     c919a
+;     c91ae
+;     c91da
+;     c91e3
+;     c91f9
+;     c91fb
+;     c9208
+;     c9211
+;     c9215
+;     c9229
+;     c9235
+;     c9244
+;     c9266
+;     c9267
+;     c9277
+;     c9283
+;     c929f
+;     c92af
+;     c92fa
+;     c9311
+;     c9322
+;     c933e
+;     c9348
+;     c9358
+;     c9363
+;     c9371
+;     c93a2
+;     c93ae
+;     c93bc
+;     c93ee
+;     c9405
+;     c940c
+;     c943c
+;     c9462
+;     c9486
+;     c94ad
+;     c94ae
+;     c94b4
+;     c94b5
+;     c94d3
+;     c94d9
+;     c9502
+;     c9504
+;     c9505
+;     c950e
+;     c951b
+;     c9547
+;     c9551
+;     c955b
+;     c9576
+;     c9586
+;     c9589
+;     c95ee
+;     c95f4
+;     c9607
+;     c9619
+;     c961a
+;     c9636
+;     c9641
+;     c9649
+;     c964c
+;     c964e
+;     c9651
+;     c9674
+;     c9686
+;     c9688
+;     c9698
+;     c969a
+;     c96af
+;     c96dd
+;     c96f0
+;     c96fa
+;     c96fd
+;     c971e
+;     c9722
+;     c972c
+;     c9740
+;     c9767
+;     c97a4
+;     c97ac
+;     c9846
+;     c984f
+;     c986b
+;     c9873
+;     c987e
+;     c9882
+;     c98ab
+;     c98b8
+;     c98c9
+;     c98de
+;     c98eb
+;     c98f3
+;     c9902
+;     c9926
+;     c9969
+;     c996f
+;     c99c2
+;     c99c8
+;     c9a0c
+;     c9a19
+;     c9a1f
+;     c9a22
+;     c9a32
+;     c9a64
+;     c9a83
+;     c9a96
+;     c9aa0
+;     c9ac9
+;     c9ad2
+;     c9afb
+;     c9b20
+;     c9b35
+;     c9b3c
+;     c9b41
+;     c9b47
+;     c9b4c
+;     c9b56
+;     c9b91
+;     c9b92
+;     c9ba8
+;     c9bb5
+;     c9cc7
+;     c9cc9
+;     c9dbb
+;     c9dd2
+;     c9dd5
+;     c9dda
+;     c9ddf
+;     c9e09
+;     c9e0b
+;     c9e25
+;     c9e28
+;     c9edd
+;     c9ef3
+;     c9efc
+;     c9f0a
+;     c9f52
+;     c9f55
+;     ca073
+;     ca09b
+;     ca0bd
+;     ca0c5
+;     ca0c9
+;     ca0e3
+;     ca0f5
+;     ca0f7
+;     ca109
+;     ca114
+;     ca125
+;     ca127
+;     ca133
+;     ca142
+;     ca159
+;     ca16a
+;     ca185
+;     ca18d
+;     ca191
+;     ca1a2
+;     ca1a3
+;     ca1a9
+;     ca1b7
+;     ca1be
+;     ca1c1
+;     ca1ca
+;     ca1ea
+;     ca206
+;     ca209
+;     ca243
+;     ca25a
+;     ca25d
+;     ca26a
+;     ca27d
+;     ca299
+;     ca2ef
+;     ca2f4
+;     ca303
+;     ca319
+;     ca327
+;     ca32e
+;     ca344
+;     ca352
+;     ca365
+;     ca37b
+;     ca389
+;     ca38b
+;     ca38e
+;     ca3b4
+;     ca3e3
+;     ca3e8
+;     ca522
+;     ca889
+;     ca8b5
+;     ca8c4
+;     caa8a
+;     caa9f
+;     caaa1
+;     caaa7
+;     caaa9
+;     caaad
+;     caae2
+;     cab33
+;     cab36
+;     cab75
+;     cab84
+;     cabb5
+;     cabb7
+;     cabde
+;     cabf3
+;     cabfe
+;     cac10
+;     cac30
+;     cac3f
+;     cac4a
+;     cac67
+;     cacdd
+;     cad20
+;     cad2f
+;     cad6f
+;     cad89
+;     cad96
+;     cadb2
+;     cade3
+;     caded
+;     cae27
+;     cae4f
+;     cae84
+;     cae8f
+;     caeb7
+;     caed8
+;     caeda
+;     caedb
+;     caedf
+;     caee2
+;     caef1
+;     caf16
+;     caf2b
+;     caf40
+;     caf5a
+;     caf5c
+;     caf5f
+;     caf72
+;     caf88
+;     cafad
+;     cafb4
+;     cafcd
+;     cafd4
+;     caff8
+;     cb025
+;     cb028
+;     cb058
+;     cb06b
+;     cb083
+;     cb091
+;     cb099
+;     cb0ae
+;     cb0b6
+;     cb0b9
+;     cb0da
+;     cb118
+;     cb11c
+;     cb144
+;     cb153
+;     cb1a8
+;     cb1b1
+;     cb205
+;     cb208
+;     cb236
+;     cb261
+;     cb267
+;     cb29c
+;     cb2ac
+;     cb2d4
+;     cb2d7
+;     cb2df
+;     cb2ed
+;     cb2ef
+;     cb305
+;     cb316
+;     cb32c
+;     cb335
+;     cb336
+;     cb369
+;     cb39c
+;     cb3a3
+;     cb3a8
+;     cb3b1
+;     cb3ed
+;     cb408
+;     cb40c
+;     cb40e
+;     cb41d
+;     cb423
+;     cb448
+;     cb475
+;     cb477
+;     cb483
+;     cb4c1
+;     cb51a
+;     cb557
+;     cb55f
+;     cb563
+;     cb577
+;     cb594
+;     cb59b
+;     cb5a2
+;     cb5ac
+;     cb5b6
+;     cb5b7
+;     cb5be
+;     cb5cd
+;     cb63b
+;     cb661
+;     cb67f
+;     cb682
+;     cb6c6
+;     cb6ea
+;     cb70e
+;     cb718
+;     cb732
+;     cb735
+;     cb74f
+;     cb788
+;     cb7b6
+;     cb7bc
+;     cb8f3
+;     cb96b
+;     cb974
+;     cb9a0
+;     cb9aa
+;     cb9b6
+;     cb9c5
+;     cb9cd
+;     cb9da
+;     cb9e7
+;     cb9ed
+;     cb9f4
+;     cb9f9
+;     cba04
+;     cba33
+;     cba4c
+;     cba53
+;     cba5a
+;     cba65
+;     cbaab
+;     cbac0
+;     cbacf
+;     cbad8
+;     cbb1a
+;     cbb39
+;     cbb64
+;     cbb68
+;     cbb6f
+;     cbb9c
+;     cbba2
+;     cbbbc
+;     cbc0a
+;     cbc1f
+;     cbc3d
+;     cbc6a
+;     cbc84
+;     cbe73
+;     cbe83
+;     cbec0
+;     cbec2
+;     cbf0a
+;     cbf2c
+;     cbf36
+;     cbf38
+;     cbf39
+;     cbf4a
+;     cbf67
+;     cbf6a
+;     cbf7e
+;     cbf86
+;     cbf9f
+;     cbfc0
+;     cbffb
+;     l0000
+;     l0001
+;     l0012
+;     l0013
+;     l0014
+;     l0015
+;     l0016
+;     l0032
+;     l0053
+;     l0054
+;     l0055
+;     l0056
+;     l0063
+;     l0078
+;     l0098
+;     l0099
+;     l009a
+;     l009b
+;     l009c
+;     l009d
+;     l009e
+;     l009f
+;     l00a0
+;     l00a1
+;     l00a2
+;     l00a3
+;     l00a4
+;     l00a5
+;     l00a6
+;     l00a7
+;     l00a8
+;     l00a9
+;     l00aa
+;     l00ab
+;     l00ac
+;     l00ad
+;     l00ae
+;     l00af
+;     l00b0
+;     l00b1
+;     l00b2
+;     l00b3
+;     l00b4
+;     l00b5
+;     l00b6
+;     l00b7
+;     l00b8
+;     l00b9
+;     l00ba
+;     l00bb
+;     l00bc
+;     l00bd
+;     l00be
+;     l00bf
+;     l00c0
+;     l00c1
+;     l00c2
+;     l00c4
+;     l00c7
+;     l00c8
+;     l00cc
+;     l00cd
+;     l00d0
+;     l00ed
+;     l00ef
+;     l00f0
+;     l00f3
+;     l00f7
+;     l00fd
+;     l00ff
+;     l0100
+;     l0101
+;     l0102
+;     l0103
+;     l0104
+;     l026a
+;     l028d
+;     l02a0
+;     l0350
+;     l0351
+;     l0355
+;     l0400
+;     l0491
+;     l04c7
+;     l04ce
+;     l0500
+;     l0518
+;     l0600
+;     l0601
+;     l0695
+;     l069e
+;     l0a00
+;     l0a81
+;     l0cff
+;     l0d07
+;     l0d0c
+;     l0d0d
+;     l0d0e
+;     l0d11
+;     l0d1a
+;     l0d1e
+;     l0d20
+;     l0d21
+;     l0d22
+;     l0d23
+;     l0d24
+;     l0d25
+;     l0d26
+;     l0d3e
+;     l0d3f
+;     l0d40
+;     l0d41
+;     l0d60
+;     l0d61
+;     l0d62
+;     l0d63
+;     l0d64
+;     l0d65
+;     l0d68
+;     l0d69
+;     l0d6a
+;     l0d6b
+;     l0d6c
+;     l0d6d
+;     l0d6e
+;     l0d6f
+;     l0d71
+;     l0df0
+;     l0dfe
+;     l0e00
+;     l0e01
+;     l0e02
+;     l0e03
+;     l0e04
+;     l0e05
+;     l0e06
+;     l0e07
+;     l0e08
+;     l0e09
+;     l0e0a
+;     l0e0b
+;     l0e14
+;     l0e2f
+;     l0e30
+;     l0e31
+;     l0e32
+;     l0e38
+;     l0e81
+;     l0ef7
+;     l0f00
+;     l0f01
+;     l0f02
+;     l0f03
+;     l0f04
+;     l0f05
+;     l0f06
+;     l0f07
+;     l0f08
+;     l0f09
+;     l0f0a
+;     l0f0b
+;     l0f0c
+;     l0f0d
+;     l0f0e
+;     l0f10
+;     l0f11
+;     l0f12
+;     l0f13
+;     l0f14
+;     l0f2f
+;     l0f30
+;     l0fc8
+;     l0fdc
+;     l0fdd
+;     l0fde
+;     l0fdf
+;     l0fe0
+;     l0ff0
+;     l0fff
+;     l1000
+;     l1010
+;     l1020
+;     l1030
+;     l1040
+;     l1050
+;     l1060
+;     l1070
+;     l1071
+;     l1072
+;     l1073
+;     l1074
+;     l1078
+;     l1088
+;     l1098
+;     l10a8
+;     l10b8
+;     l10c8
+;     l10c9
+;     l10ca
+;     l10cb
+;     l10cc
+;     l10cd
+;     l10ce
+;     l10cf
+;     l10d0
+;     l10d1
+;     l10d4
+;     l10d5
+;     l10d6
+;     l10d7
+;     l10d8
+;     l10d9
+;     l10f3
+;     l8001
+;     l8002
+;     l8004
+;     l84bb
+;     l8600
+;     l8861
+;     l8869
+;     l89a6
+;     l8d38
+;     l8d61
+;     l8e54
+;     l8e61
+;     l8f48
+;     l9022
+;     l9122
+;     l9286
+;     l948b
+;     l9491
+;     l97ad
+;     l97b9
+;     l9888
+;     la17c
+;     la291
+;     la3df
+;     la3f0
+;     la3f1
+;     la3f2
+;     la477
+;     la523
+;     la52a
+;     la841
+;     la84d
+;     laab1
+;     lac80
+;     lac8c
+;     lad0d
+;     lad43
+;     laefb
+;     laeff
+;     lb13f
+;     lb194
+;     lb487
+;     lbc94
+;     lbd94
+;     lbec3
+;     lbf04
+;     lfe18
+;     lfe87
+;     lfea0
+;     lfea1
+;     lfea2
+;     lfea3
+;     lffb0
+;     lffbd
+;     loop_c0446
+;     loop_c0466
+;     loop_c8096
+;     loop_c85b8
+;     loop_c85d9
+;     loop_c869a
+;     loop_c86c2
+;     loop_c8912
+;     loop_c8aee
+;     loop_c8b26
+;     loop_c8b39
+;     loop_c8b4c
+;     loop_c8b7a
+;     loop_c8bc0
+;     loop_c8bca
+;     loop_c8c06
+;     loop_c8c45
+;     loop_c8c80
+;     loop_c8d1b
+;     loop_c8d2c
+;     loop_c8dae
+;     loop_c8dc1
+;     loop_c8de4
+;     loop_c8e87
+;     loop_c8eee
+;     loop_c8f18
+;     loop_c8f2e
+;     loop_c8f46
+;     loop_c8f8e
+;     loop_c8fb0
+;     loop_c8fba
+;     loop_c8fd4
+;     loop_c914d
+;     loop_c927b
+;     loop_c92a6
+;     loop_c9329
+;     loop_c9332
+;     loop_c934f
+;     loop_c939b
+;     loop_c93f0
+;     loop_c9476
+;     loop_c94bb
+;     loop_c94f8
+;     loop_c9520
+;     loop_c955d
+;     loop_c962a
+;     loop_c9668
+;     loop_c968c
+;     loop_c96a9
+;     loop_c96c4
+;     loop_c96e7
+;     loop_c9734
+;     loop_c9794
+;     loop_c9865
+;     loop_c989e
+;     loop_c98c4
+;     loop_c98d9
+;     loop_c98f8
+;     loop_c991b
+;     loop_c9971
+;     loop_c998c
+;     loop_c99a1
+;     loop_c99a3
+;     loop_c99b7
+;     loop_c99cd
+;     loop_c99eb
+;     loop_c9a2f
+;     loop_c9a40
+;     loop_c9a74
+;     loop_c9a87
+;     loop_c9aab
+;     loop_c9abd
+;     loop_c9acb
+;     loop_c9b13
+;     loop_c9b2a
+;     loop_c9b78
+;     loop_c9b85
+;     loop_c9b9c
+;     loop_c9bb3
+;     loop_c9e19
+;     loop_c9ee8
+;     loop_c9f27
+;     loop_c9f3e
+;     loop_ca14a
+;     loop_ca165
+;     loop_ca170
+;     loop_ca187
+;     loop_ca1a4
+;     loop_ca1a8
+;     loop_ca1e2
+;     loop_ca21d
+;     loop_ca225
+;     loop_ca230
+;     loop_ca241
+;     loop_ca245
+;     loop_ca26c
+;     loop_ca2a2
+;     loop_ca2a8
+;     loop_ca3ce
+;     loop_ca4fc
+;     loop_ca50e
+;     loop_ca875
+;     loop_ca89d
+;     loop_cab89
+;     loop_caba8
+;     loop_cac6f
+;     loop_cacaf
+;     loop_cad29
+;     loop_cae1c
+;     loop_cae6f
+;     loop_caebb
+;     loop_caec9
+;     loop_caf07
+;     loop_caf1c
+;     loop_caf2d
+;     loop_caf9d
+;     loop_cafc0
+;     loop_cb01b
+;     loop_cb032
+;     loop_cb04a
+;     loop_cb108
+;     loop_cb16f
+;     loop_cb179
+;     loop_cb18b
+;     loop_cb210
+;     loop_cb228
+;     loop_cb253
+;     loop_cb2a0
+;     loop_cb2e2
+;     loop_cb31a
+;     loop_cb347
+;     loop_cb39f
+;     loop_cb3b5
+;     loop_cb3d9
+;     loop_cb3ff
+;     loop_cb424
+;     loop_cb44c
+;     loop_cb45c
+;     loop_cb4cc
+;     loop_cb4df
+;     loop_cb50c
+;     loop_cb5ea
+;     loop_cb66c
+;     loop_cb709
+;     loop_cb723
+;     loop_cb72d
+;     loop_cb79f
+;     loop_cb7ab
+;     loop_cb7c3
+;     loop_cb95e
+;     loop_cb9c7
+;     loop_cba22
+;     loop_cba3a
+;     loop_cba67
+;     loop_cba78
+;     loop_cba90
+;     loop_cba95
+;     loop_cbab6
+;     loop_cbabe
+;     loop_cbaf2
+;     loop_cbb13
+;     loop_cbb40
+;     loop_cbb43
+;     loop_cbb6e
+;     loop_cbb90
+;     loop_cbbb7
+;     loop_cbbd4
+;     loop_cbbe7
+;     loop_cbbf6
+;     loop_cbc03
+;     loop_cbc24
+;     loop_cbc34
+;     loop_cbc72
+;     loop_cbc7d
+;     loop_cbe9e
+;     loop_cbeb8
+;     loop_cbf95
+;     loop_cbfaa
+;     loop_cbfe5
+;     sub_c0414
+;     sub_c0421
+;     sub_c8028
+;     sub_c805a
+;     sub_c8074
+;     sub_c8090
+;     sub_c8449
+;     sub_c858c
+;     sub_c85ff
+;     sub_c8689
+;     sub_c868d
+;     sub_c8691
+;     sub_c86d3
+;     sub_c88f2
+;     sub_c8969
+;     sub_c8983
+;     sub_c8aa0
+;     sub_c8ad4
+;     sub_c8aea
+;     sub_c8b02
+;     sub_c8b0d
+;     sub_c8b1a
+;     sub_c8b92
+;     sub_c8b96
+;     sub_c8c33
+;     sub_c8c4e
+;     sub_c8c5d
+;     sub_c8c9f
+;     sub_c8cb9
+;     sub_c8cc0
+;     sub_c8cca
+;     sub_c8cfc
+;     sub_c8d05
+;     sub_c8d17
+;     sub_c8d79
+;     sub_c8e09
+;     sub_c8e52
+;     sub_c8e83
+;     sub_c8e85
+;     sub_c8e8c
+;     sub_c8e92
+;     sub_c8f5d
+;     sub_c8f99
+;     sub_c8fcb
+;     sub_c912f
+;     sub_c9138
+;     sub_c916e
+;     sub_c9258
+;     sub_c9260
+;     sub_c9269
+;     sub_c9273
+;     sub_c9291
+;     sub_c9295
+;     sub_c929b
+;     sub_c92a4
+;     sub_c92b0
+;     sub_c92e6
+;     sub_c9309
+;     sub_c9327
+;     sub_c9349
+;     sub_c938b
+;     sub_c93dd
+;     sub_c9465
+;     sub_c9467
+;     sub_c9473
+;     sub_c9497
+;     sub_c949b
+;     sub_c949e
+;     sub_c94f0
+;     sub_c9570
+;     sub_c9580
+;     sub_c95ae
+;     sub_c95be
+;     sub_c95ce
+;     sub_c95dd
+;     sub_c96b3
+;     sub_c974d
+;     sub_c9771
+;     sub_c977c
+;     sub_c978d
+;     sub_c9837
+;     sub_c983f
+;     sub_c9894
+;     sub_c989c
+;     sub_c9913
+;     sub_c9951
+;     sub_c9998
+;     sub_c9a57
+;     sub_c9a62
+;     sub_c9a72
+;     sub_c9a7e
+;     sub_c9a7f
+;     sub_c9a84
+;     sub_c9a91
+;     sub_c9a92
+;     sub_c9a9a
+;     sub_c9b95
+;     sub_c9dc8
+;     sub_c9dee
+;     sub_c9e0f
+;     sub_c9e16
+;     sub_c9e17
+;     sub_c9ed2
+;     sub_c9f67
+;     sub_ca07b
+;     sub_ca09e
+;     sub_ca0a7
+;     sub_ca0cc
+;     sub_ca0ce
+;     sub_ca0e4
+;     sub_ca0ea
+;     sub_ca0fa
+;     sub_ca140
+;     sub_ca2fa
+;     sub_ca300
+;     sub_ca32b
+;     sub_ca356
+;     sub_ca362
+;     sub_ca391
+;     sub_ca39b
+;     sub_ca4ee
+;     sub_ca516
+;     sub_ca865
+;     sub_ca9be
+;     sub_caa85
+;     sub_caa89
+;     sub_cab12
+;     sub_cab1b
+;     sub_cac24
+;     sub_cac98
+;     sub_cace4
+;     sub_cacf7
+;     sub_cacf9
+;     sub_cad10
+;     sub_cad41
+;     sub_cad5f
+;     sub_cad65
+;     sub_cad6b
+;     sub_cad80
+;     sub_cae82
+;     sub_cae92
+;     sub_cae94
+;     sub_cae97
+;     sub_caf02
+;     sub_caf04
+;     sub_caf06
+;     sub_caf32
+;     sub_caf3e
+;     sub_caf47
+;     sub_caf66
+;     sub_caf85
+;     sub_caf96
+;     sub_cafb5
+;     sub_cafc1
+;     sub_cafd5
+;     sub_cafe0
+;     sub_cafee
+;     sub_cb017
+;     sub_cb019
+;     sub_cb0c5
+;     sub_cb0cf
+;     sub_cb0ea
+;     sub_cb0f6
+;     sub_cb13e
+;     sub_cb15e
+;     sub_cb165
+;     sub_cb16d
+;     sub_cb198
+;     sub_cb1c3
+;     sub_cb2e0
+;     sub_cb2f7
+;     sub_cb30c
+;     sub_cb33d
+;     sub_cb359
+;     sub_cb431
+;     sub_cb449
+;     sub_cb46b
+;     sub_cb485
+;     sub_cb4ad
+;     sub_cb509
+;     sub_cb53d
+;     sub_cb559
+;     sub_cb586
+;     sub_cb595
+;     sub_cb5d8
+;     sub_cb5fb
+;     sub_cb66a
+;     sub_cb721
+;     sub_cb730
+;     sub_cb799
+;     sub_cb8da
+;     sub_cb92b
+;     sub_cb984
+;     sub_cb98a
+;     sub_cb98f
+;     sub_cb994
+;     sub_cb99a
+;     sub_cb99d
+;     sub_cb9ff
+;     sub_cba1b
+;     sub_cbadd
+;     sub_cbb03
+;     sub_cbb0e
+;     sub_cbb77
+;     sub_cbc44
+;     sub_cbc86
+;     sub_cbc89
+;     sub_cbc8c
+;     sub_cbf18
+;     sub_cbf25
+    assert <((c86e3)-1) == &e2
+    assert <((c86e3)-1) == &e2
+    assert <((sub_c8689)-1) == &88
+    assert <((sub_c868d)-1) == &8c
+    assert <((sub_c8691)-1) == &90
+    assert <((sub_c86d3)-1) == &d2
+    assert <((sub_c86d3)-1) == &d2
+    assert <((sub_c86d3)-1) == &d2
+    assert <(ca114-1) == &13
+    assert <(ca1c1-1) == &c0
+    assert <(ca1c1-1) == &c0
+    assert <(ca1c1-1) == &c0
+    assert <(ca2f4-1) == &f3
+    assert <(just_rts-1) == &57
+    assert <(just_rts-1) == &57
+    assert <(just_rts-1) == &57
+    assert <(l00b4) == &b4
+    assert <(l0601) == &01
+    assert <(l0601) == &01
+    assert <(l0a00) == &00
+    assert <(l0a00) == &00
+    assert <(l0a00) == &00
+    assert <(l0a81) == &81
+    assert <(l0e00) == &00
+    assert <(l0e81) == &81
+    assert <(service_handler_claim_absolute_workspace-1) == &a4
+    assert <(service_handler_claim_private_workspace-1) == &b7
+    assert <(sub_c8028-1) == &27
+    assert <(sub_c8090-1) == &8f
+    assert <(sub_c8983-1) == &82
+    assert <(sub_c8b0d-1) == &0c
+    assert <(sub_c8c4e-1) == &4d
+    assert <(sub_c8c5d-1) == &5c
+    assert <(sub_c8cca-1) == &c9
+    assert <(sub_c8e92-1) == &91
+    assert <(sub_c8f99-1) == &98
+    assert <(sub_c92b0-1) == &af
+    assert <(sub_c9580-1) == &7f
+    assert <(sub_c95ae-1) == &ad
+    assert <(sub_c95be-1) == &bd
+    assert <(sub_c95ce-1) == &cd
+    assert <(sub_c9dc8-1) == &c7
+    assert <(sub_c9dee-1) == &ed
+    assert <(sub_ca0e4-1) == &e3
+    assert <(sub_ca0ea-1) == &e9
+    assert <(sub_ca0fa-1) == &f9
+    assert <(sub_ca2fa-1) == &f9
+    assert <(sub_ca391-1) == &90
+    assert <(sub_ca39b-1) == &9a
+    assert <(sub_ca4ee-1) == &ed
+    assert <(sub_cac98-1) == &97
+    assert <(sub_cad80-1) == &7f
+    assert <(sub_caf3e-1) == &3d
+    assert >(ca114-1) == &a1
+    assert >(ca1c1-1) == &a1
+    assert >(ca1c1-1) == &a1
+    assert >(ca1c1-1) == &a1
+    assert >(ca2f4-1) == &a2
+    assert >(just_rts-1) == &8e
+    assert >(just_rts-1) == &8e
+    assert >(just_rts-1) == &8e
+    assert >(l00b4) == &00
+    assert >(l0601) == &06
+    assert >(l0601) == &06
+    assert >(l0a00) == &0a
+    assert >(l0a00) == &0a
+    assert >(l0a00) == &0a
+    assert >(l0a81) == &0a
+    assert >(l0e00) == &0e
+    assert >(l0e81) == &0e
+    assert >(service_handler_claim_absolute_workspace-1) == &8e
+    assert >(service_handler_claim_private_workspace-1) == &8e
+    assert >(sub_c8028-1) == &80
+    assert >(sub_c8090-1) == &80
+    assert >(sub_c8983-1) == &89
+    assert >(sub_c8b0d-1) == &8b
+    assert >(sub_c8c4e-1) == &8c
+    assert >(sub_c8c5d-1) == &8c
+    assert >(sub_c8cca-1) == &8c
+    assert >(sub_c8e92-1) == &8e
+    assert >(sub_c8f99-1) == &8f
+    assert >(sub_c92b0-1) == &92
+    assert >(sub_c9580-1) == &95
+    assert >(sub_c95ae-1) == &95
+    assert >(sub_c95be-1) == &95
+    assert >(sub_c95ce-1) == &95
+    assert >(sub_c9dc8-1) == &9d
+    assert >(sub_c9dee-1) == &9d
+    assert >(sub_ca0e4-1) == &a0
+    assert >(sub_ca0ea-1) == &a0
+    assert >(sub_ca0fa-1) == &a0
+    assert >(sub_ca2fa-1) == &a2
+    assert >(sub_ca391-1) == &a3
+    assert >(sub_ca39b-1) == &a3
+    assert >(sub_ca4ee-1) == &a4
+    assert >(sub_cac98-1) == &ac
+    assert >(sub_cad80-1) == &ad
+    assert >(sub_caf3e-1) == &af
+    assert c8dbc-1 == &8dbb
+    assert c8e15-1 == &8e14
+    assert copyright - rom_header == &19
+    assert osbyte_acknowledge_escape == &7e
+    assert osbyte_close_spool_exec == &77
+    assert osbyte_explode_chars == &14
+    assert osbyte_flush_buffer_class == &0f
+    assert osbyte_insert_input_buffer == &99
+    assert osbyte_issue_service_request == &8f
+    assert osbyte_read_os_version == &00
+    assert osbyte_read_write_econet_keyboard_disable == &c9
+    assert osbyte_read_write_econet_os_call_interception == &ce
+    assert osbyte_scan_keyboard == &79
+    assert osbyte_scan_keyboard_from_16 == &7a
+    assert osbyte_vsync == &13
+    assert osbyte_write_keys_pressed == &78
+    assert osfile_read_catalogue_info == &05
+    assert osword_read_palette == &0b
+    assert service_claim_absolute_workspace == &01
+    assert service_vectors_changed == &0f
+    assert sub_c8ad4-1 == &8ad3
+    assert sub_c8b1a-1 == &8b19
+    assert sub_c8b92-1 == &8b91
+    assert sub_c8b96-1 == &8b95
+    assert sub_c8d79-1 == &8d78
+    assert sub_c92e6-1 == &92e5
+    assert sub_c92e6-1 == &92e5
+    assert sub_c92e6-1 == &92e5
+    assert sub_c92e6-1 == &92e5
+    assert sub_c938b-1 == &938a
+    assert sub_c93dd-1 == &93dc
+    assert sub_c949e-1 == &949d
+    assert sub_ca07b-1 == &a07a
+    assert sub_ca356-1 == &a355
+    assert sub_cad10-1 == &ad0f
+    assert sub_cad5f-1 == &ad5e
+    assert sub_cad65-1 == &ad64
+    assert sub_cad6b-1 == &ad6a
+    assert sub_caf66-1 == &af65
+    assert sub_cafee-1 == &afed
+    assert sub_cb1c3-1 == &b1c2
+    assert sub_cb30c-1 == &b30b
+    assert sub_cb33d-1 == &b33c
+    assert sub_cb359-1 == &b358
+    assert sub_cb994-1 == &b993
+    assert sub_cb99a-1 == &b999
+    assert sub_cb99d-1 == &b99c
+    assert sub_cba1b-1 == &ba1a
+
+save pydis_start, pydis_end

--- a/examples/known_good/anfs418_xa.asm
+++ b/examples/known_good/anfs418_xa.asm
@@ -1,0 +1,10534 @@
+// Constants
+osbyte_acknowledge_escape                       = 126
+osbyte_close_spool_exec                         = 119
+osbyte_explode_chars                            = 20
+osbyte_flush_buffer_class                       = 15
+osbyte_insert_input_buffer                      = 153
+osbyte_issue_service_request                    = 143
+osbyte_read_os_version                          = 0
+osbyte_read_write_econet_keyboard_disable       = 201
+osbyte_read_write_econet_os_call_interception   = 206
+osbyte_scan_keyboard                            = 121
+osbyte_scan_keyboard_from_16                    = 122
+osbyte_vsync                                    = 19
+osbyte_write_keys_pressed                       = 120
+osfile_read_catalogue_info                      = 5
+osword_read_palette                             = 11
+service_claim_absolute_workspace                = 1
+service_vectors_changed                         = 15
+
+// Memory locations
+l0000               = $0000
+l0001               = $0001
+l0012               = $0012
+l0013               = $0013
+l0014               = $0014
+l0015               = $0015
+l0016               = $0016
+l0032               = $0032
+l0053               = $0053
+l0054               = $0054
+l0055               = $0055
+l0056               = $0056
+l0063               = $0063
+l0078               = $0078
+l0098               = $0098
+l0099               = $0099
+l009a               = $009a
+l009b               = $009b
+l009c               = $009c
+l009d               = $009d
+l009e               = $009e
+l009f               = $009f
+l00a0               = $00a0
+l00a1               = $00a1
+l00a2               = $00a2
+l00a3               = $00a3
+l00a4               = $00a4
+l00a5               = $00a5
+l00a6               = $00a6
+l00a7               = $00a7
+l00a8               = $00a8
+l00a9               = $00a9
+l00aa               = $00aa
+l00ab               = $00ab
+l00ac               = $00ac
+l00ad               = $00ad
+l00ae               = $00ae
+l00af               = $00af
+l00b0               = $00b0
+l00b1               = $00b1
+l00b2               = $00b2
+l00b3               = $00b3
+l00b4               = $00b4
+l00b5               = $00b5
+l00b6               = $00b6
+l00b7               = $00b7
+l00b8               = $00b8
+l00b9               = $00b9
+l00ba               = $00ba
+l00bb               = $00bb
+l00bc               = $00bc
+l00bd               = $00bd
+l00be               = $00be
+l00bf               = $00bf
+l00c0               = $00c0
+l00c1               = $00c1
+l00c2               = $00c2
+l00c4               = $00c4
+l00c7               = $00c7
+l00c8               = $00c8
+l00cc               = $00cc
+l00cd               = $00cd
+l00d0               = $00d0
+l00ed               = $00ed
+l00ef               = $00ef
+l00f0               = $00f0
+os_text_ptr         = $00f2
+l00f3               = $00f3
+romsel_copy         = $00f4
+osrdsc_ptr          = $00f6
+l00f7               = $00f7
+l00fd               = $00fd
+l00ff               = $00ff
+l0100               = $0100
+l0101               = $0101
+l0102               = $0102
+l0103               = $0103
+l0104               = $0104
+brkv                = $0202
+filev               = $0212
+fscv                = $021e
+evntv               = $0220
+netv                = $0224
+l026a               = $026a
+l028d               = $028d
+l02a0               = $02a0
+l0350               = $0350
+l0351               = $0351
+l0355               = $0355
+l04c7               = $04c7
+l04ce               = $04ce
+l0500               = $0500
+l0518               = $0518
+l0600               = $0600
+l0601               = $0601
+l0695               = $0695
+l069e               = $069e
+l0a00               = $0a00
+l0a81               = $0a81
+l0cff               = $0cff
+l0d07               = $0d07
+l0d0c               = $0d0c
+l0d0d               = $0d0d
+l0d0e               = $0d0e
+l0d11               = $0d11
+l0d1a               = $0d1a
+l0d1e               = $0d1e
+l0d20               = $0d20
+l0d21               = $0d21
+l0d22               = $0d22
+l0d23               = $0d23
+l0d24               = $0d24
+l0d25               = $0d25
+l0d26               = $0d26
+l0d3e               = $0d3e
+l0d3f               = $0d3f
+l0d40               = $0d40
+l0d41               = $0d41
+l0d60               = $0d60
+l0d61               = $0d61
+l0d62               = $0d62
+l0d63               = $0d63
+l0d64               = $0d64
+l0d65               = $0d65
+l0d68               = $0d68
+l0d69               = $0d69
+l0d6a               = $0d6a
+l0d6b               = $0d6b
+l0d6c               = $0d6c
+l0d6d               = $0d6d
+l0d6e               = $0d6e
+l0d6f               = $0d6f
+l0d71               = $0d71
+l0df0               = $0df0
+l0dfe               = $0dfe
+l0e00               = $0e00
+l0e01               = $0e01
+l0e02               = $0e02
+l0e03               = $0e03
+l0e04               = $0e04
+l0e05               = $0e05
+l0e06               = $0e06
+l0e07               = $0e07
+l0e08               = $0e08
+l0e09               = $0e09
+l0e0a               = $0e0a
+l0e0b               = $0e0b
+l0e14               = $0e14
+l0e2f               = $0e2f
+l0e30               = $0e30
+l0e31               = $0e31
+l0e32               = $0e32
+l0e38               = $0e38
+l0e81               = $0e81
+l0ef7               = $0ef7
+l0f00               = $0f00
+l0f01               = $0f01
+l0f02               = $0f02
+l0f03               = $0f03
+l0f04               = $0f04
+l0f05               = $0f05
+l0f06               = $0f06
+l0f07               = $0f07
+l0f08               = $0f08
+l0f09               = $0f09
+l0f0a               = $0f0a
+l0f0b               = $0f0b
+l0f0c               = $0f0c
+l0f0d               = $0f0d
+l0f0e               = $0f0e
+l0f10               = $0f10
+l0f11               = $0f11
+l0f12               = $0f12
+l0f13               = $0f13
+l0f14               = $0f14
+l0f2f               = $0f2f
+l0f30               = $0f30
+l0fc8               = $0fc8
+l0fdc               = $0fdc
+l0fdd               = $0fdd
+l0fde               = $0fde
+l0fdf               = $0fdf
+l0fe0               = $0fe0
+l0ff0               = $0ff0
+l0fff               = $0fff
+l1000               = $1000
+l1010               = $1010
+l1020               = $1020
+l1030               = $1030
+l1040               = $1040
+l1050               = $1050
+l1060               = $1060
+l1070               = $1070
+l1071               = $1071
+l1072               = $1072
+l1073               = $1073
+l1074               = $1074
+l1078               = $1078
+l1088               = $1088
+l1098               = $1098
+l10a8               = $10a8
+l10b8               = $10b8
+l10c8               = $10c8
+l10c9               = $10c9
+l10ca               = $10ca
+l10cb               = $10cb
+l10cc               = $10cc
+l10cd               = $10cd
+l10ce               = $10ce
+l10cf               = $10cf
+l10d0               = $10d0
+l10d1               = $10d1
+l10d4               = $10d4
+l10d5               = $10d5
+l10d6               = $10d6
+l10d7               = $10d7
+l10d8               = $10d8
+l10d9               = $10d9
+l10f3               = $10f3
+lfe18               = $fe18
+video_ula_control   = $fe20
+romsel              = $fe30
+system_via_sr       = $fe4a
+system_via_acr      = $fe4b
+system_via_ifr      = $fe4d
+system_via_ier      = $fe4e
+lfe87               = $fe87
+lfea0               = $fea0
+lfea1               = $fea1
+lfea2               = $fea2
+lfea3               = $fea3
+tube_host_r1_status = $fee0
+tube_host_r1_data   = $fee1
+tube_host_r3_data   = $fee5
+tube_host_r4_status = $fee6
+lffb0               = $ffb0
+osrdsc              = $ffb9
+lffbd               = $ffbd
+gsinit              = $ffc2
+gsread              = $ffc5
+osfind              = $ffce
+osbget              = $ffd7
+osargs              = $ffda
+osfile              = $ffdd
+osrdch              = $ffe0
+osasci              = $ffe3
+osnewl              = $ffe7
+oswrch              = $ffee
+osword              = $fff1
+osbyte              = $fff4
+oscli               = $fff7
+
+    * = $8000
+
+// Sideways ROM header
+// $8000 referenced 1 time by $bfe6
+rom_header
+language_entry
+pydis_start
+l8001 = rom_header+1
+l8002 = rom_header+2
+    .byt   0, $42, $43                                                // 8000: 00 42 43    .BC
+// $8001 referenced 1 time by $bfeb
+// $8002 referenced 1 time by $bff0
+
+// $8003 referenced 1 time by $bff5
+service_entry
+l8004 = service_entry+1
+    jmp service_handler                                               // 8003: 4c 15 8a    L..
+
+// $8004 referenced 1 time by $bff8
+// $8006 referenced 1 time by $bfda
+rom_type
+    .byt $82                                                          // 8006: 82          .
+// $8007 referenced 1 time by $bfe2
+copyright_offset
+    .byt copyright - rom_header                                       // 8007: 19          .
+binary_version
+    .byt 4                                                            // 8008: 04          .
+title
+    .asc "Acorn ANFS 4.18"                                            // 8009: 41 63 6f... Aco
+version
+    .byt 0                                                            // 8018: 00          .
+copyright
+    .byt 0                                                            // 8019: 00          .
+    .asc "(C)1985 Acorn", 0                                           // 801a: 28 43 29... (C)
+
+sub_c8028
+    lda #4                                                            // 8028: a9 04       ..
+    bit system_via_ifr                                                // 802a: 2c 4d fe    ,M.
+    bne c8032                                                         // 802d: d0 03       ..
+    lda #5                                                            // 802f: a9 05       ..
+    rts                                                               // 8031: 60          `
+
+// $8032 referenced 1 time by $802d
+c8032
+    txa                                                               // 8032: 8a          .
+    pha                                                               // 8033: 48          H
+    tya                                                               // 8034: 98          .
+    pha                                                               // 8035: 48          H
+    lda system_via_acr                                                // 8036: ad 4b fe    .K.
+    and #$e3                                                          // 8039: 29 e3       ).
+    ora l0d64                                                         // 803b: 0d 64 0d    .d.
+    sta system_via_acr                                                // 803e: 8d 4b fe    .K.
+    lda system_via_sr                                                 // 8041: ad 4a fe    .J.
+    lda #4                                                            // 8044: a9 04       ..
+    sta system_via_ifr                                                // 8046: 8d 4d fe    .M.
+    sta system_via_ier                                                // 8049: 8d 4e fe    .N.
+    ldy l0d65                                                         // 804c: ac 65 0d    .e.
+    tya                                                               // 804f: 98          .
+    bmi c805d                                                         // 8050: 30 0b       0.
+    lda #$fe                                                          // 8052: a9 fe       ..
+    jsr sub_c805a                                                     // 8054: 20 5a 80     Z.
+    jmp c8585                                                         // 8057: 4c 85 85    L..
+
+// $805a referenced 1 time by $8054
+sub_c805a
+    jmp (evntv)                                                       // 805a: 6c 20 02    l .
+
+// $805d referenced 1 time by $8050
+c805d
+    cpy #$86                                                          // 805d: c0 86       ..
+    bcs c806c                                                         // 805f: b0 0b       ..
+    lda l0d68                                                         // 8061: ad 68 0d    .h.
+    sta l0d69                                                         // 8064: 8d 69 0d    .i.
+    ora #$1c                                                          // 8067: 09 1c       ..
+    sta l0d68                                                         // 8069: 8d 68 0d    .h.
+// $806c referenced 1 time by $805f
+c806c
+    lda #$85                                                          // 806c: a9 85       ..
+    pha                                                               // 806e: 48          H
+    lda l84bb,y                                                       // 806f: b9 bb 84    ...
+    pha                                                               // 8072: 48          H
+    rts                                                               // 8073: 60          `
+
+// $8074 referenced 1 time by $8f5d
+sub_c8074
+    bit lfe18                                                         // 8074: 2c 18 fe    ,..
+    jsr sub_c8969                                                     // 8077: 20 69 89     i.
+    lda #$ea                                                          // 807a: a9 ea       ..
+    ldx #0                                                            // 807c: a2 00       ..
+    stx l0d62                                                         // 807e: 8e 62 0d    .b.
+    jsr sub_c8e83                                                     // 8081: 20 83 8e     ..
+    stx l0d63                                                         // 8084: 8e 63 0d    .c.
+    lda #$8f                                                          // 8087: a9 8f       ..
+    ldx #$0c                                                          // 8089: a2 0c       ..
+    jsr sub_c8e85                                                     // 808b: 20 85 8e     ..
+    ldy #5                                                            // 808e: a0 05       ..
+sub_c8090
+    cpy #5                                                            // 8090: c0 05       ..
+    bne c80bd                                                         // 8092: d0 29       .)
+    ldy #$20 // ' '                                                   // 8094: a0 20       .
+// $8096 referenced 1 time by $809d
+loop_c8096
+    lda l89a6,y                                                       // 8096: b9 a6 89    ...
+    sta l0cff,y                                                       // 8099: 99 ff 0c    ...
+    dey                                                               // 809c: 88          .
+    bne loop_c8096                                                    // 809d: d0 f7       ..
+    lda romsel_copy                                                   // 809f: a5 f4       ..
+    sta l0d07                                                         // 80a1: 8d 07 0d    ...
+    sty l0d23                                                         // 80a4: 8c 23 0d    .#.
+    sty l0099                                                         // 80a7: 84 99       ..
+    sty l0d65                                                         // 80a9: 8c 65 0d    .e.
+    ldy lfe18                                                         // 80ac: ac 18 fe    ...
+    sty l0d22                                                         // 80af: 8c 22 0d    .".
+    lda #$80                                                          // 80b2: a9 80       ..
+    sta l0d60                                                         // 80b4: 8d 60 0d    .`.
+    sta l0d62                                                         // 80b7: 8d 62 0d    .b.
+    bit video_ula_control                                             // 80ba: 2c 20 fe    , .
+// $80bd referenced 1 time by $8092
+c80bd
+    rts                                                               // 80bd: 60          `
+
+// $80be referenced 1 time by $89b2
+c80be
+    lda #1                                                            // 80be: a9 01       ..
+    bit lfea1                                                         // 80c0: 2c a1 fe    ,..
+    beq c80fd                                                         // 80c3: f0 38       .8
+    lda lfea2                                                         // 80c5: ad a2 fe    ...
+    cmp lfe18                                                         // 80c8: cd 18 fe    ...
+    beq c80d6                                                         // 80cb: f0 09       ..
+    cmp #$ff                                                          // 80cd: c9 ff       ..
+    bne c80e9                                                         // 80cf: d0 18       ..
+    lda #$40 // '@'                                                   // 80d1: a9 40       .@
+    sta l0d3e                                                         // 80d3: 8d 3e 0d    .>.
+// $80d6 referenced 1 time by $80cb
+c80d6
+    lda #$db                                                          // 80d6: a9 db       ..
+    jmp l0d11                                                         // 80d8: 4c 11 0d    L..
+
+    .byt $2c, $a1, $fe, $10, $1d, $ad, $a2, $fe, $f0, $0c, $49, $ff   // 80db: 2c a1 fe... ,..
+    .byt $f0, $0b                                                     // 80e7: f0 0b       ..
+
+// $80e9 referenced 1 time by $80cf
+c80e9
+    lda #$a2                                                          // 80e9: a9 a2       ..
+    sta lfea0                                                         // 80eb: 8d a0 fe    ...
+    jmp c83fb                                                         // 80ee: 4c fb 83    L..
+
+    .byt $8d, $3e, $0d, $85, $a2, $a9, $0d, $a0, $81, $4c, $0e, $0d   // 80f1: 8d 3e 0d... .>.
+
+// $80fd referenced 1 time by $80c3
+c80fd
+    lda lfea1                                                         // 80fd: ad a1 fe    ...
+    and #$81                                                          // 8100: 29 81       ).
+    beq c810a                                                         // 8102: f0 06       ..
+    jsr sub_c8969                                                     // 8104: 20 69 89     i.
+    jmp c83fb                                                         // 8107: 4c fb 83    L..
+
+// $810a referenced 1 time by $8102
+c810a
+    jmp c83f8                                                         // 810a: 4c f8 83    L..
+
+    .byt $a4, $a2, $ad, $a1, $fe, $10, $e9, $ad, $a2, $fe, $99, $2e   // 810d: a4 a2 ad... ...
+    .byt $0d, $c8, $ad, $a1, $fe, $30,   2, $d0, $15, $ad, $a2, $fe   // 8119: 0d c8 ad... ...
+    .byt $99, $2e, $0d, $c8, $c0, $0c, $f0, $0a, $84, $a2, $ad, $a1   // 8125: 99 2e 0d... ...
+    .byt $fe, $d0, $de, $4c, $14, $0d, $a9,   0, $8d, $a0, $fe, $a9   // 8131: fe d0 de... ...
+    .byt $84, $8d, $a1, $fe, $a9,   2, $2c, $a1, $fe, $f0, $b5, $10   // 813d: 84 8d a1... ...
+    .byt $b3, $ad, $a2, $fe, $99, $2e, $0d, $a9, $44, $8d, $a0, $fe   // 8149: b3 ad a2... ...
+    .byt $38, $66, $99, $ad, $31, $0d, $d0,   3, $4c, $55, $84, $2c   // 8155: 38 66 99... 8f.
+    .byt $3e, $0d, $50,   5, $a9,   7, $8d, $a1, $fe, $2c, $61, $0d   // 8161: 3e 0d 50... >.P
+    .byt $10, $40, $a9, $c0, $a0,   0, $85, $a6, $84, $a7, $a0,   0   // 816d: 10 40 a9... .@.
+    .byt $b1, $a6, $f0, $2f, $c9, $7f, $d0, $1e, $c8, $b1, $a6, $f0   // 8179: b1 a6 f0... ...
+    .byt   5, $cd, $31, $0d, $d0, $14, $c8, $b1, $a6, $f0, $2a, $cd   // 8185: 05 cd 31... ..1
+    .byt $2e, $0d, $d0, $0a, $c8, $b1, $a6, $f0, $20, $cd, $2f, $0d   // 8191: 2e 0d d0... ...
+    .byt $f0, $1b, $a5, $a7, $f0, $0c, $a5, $a6, $18, $69, $0c, $85   // 819d: f0 1b a5... ...
+    .byt $a6, $90, $cb, $4c, $36, $82, $2c, $61, $0d, $50, $f8, $a9   // 81a9: a6 90 cb... ...
+    .byt   0, $a4, $9f, $d0, $b9, $a9,   3, $8d, $40, $0d, $20, $f2   // 81b5: 00 a4 9f... ...
+    .byt $88, $90                                                     // 81c1: 88 90       ..
+    .asc "r,>"                                                        // 81c3: 72 2c 3e    r,>
+    .byt $0d, $50,   3, $4c, $10, $84, $a9, $44, $8d, $a0, $fe, $a9   // 81c6: 0d 50 03... .P.
+    .byt $a7, $8d, $a1, $fe, $a9, $dd, $a0, $81, $4c,   8, $83, $a9   // 81d2: a7 8d a1... ...
+    .byt $82, $8d, $a0, $fe, $a9, $e7, $4c, $11, $0d, $a9,   1, $2c   // 81de: 82 8d a0... ...
+    .byt $a1, $fe, $f0, $48, $ad, $a2, $fe, $cd, $18, $fe, $d0, $40   // 81ea: a1 fe f0... ...
+    .byt $a9, $fb, $4c, $11, $0d, $2c, $a1, $fe, $10, $36, $ad, $a2   // 81f6: a9 fb 4c... ..L
+    .byt $fe, $d0, $31, $a9, $11, $a0, $82, $2c, $a0, $fe, $30,   3   // 8202: fe d0 31... ..1
+    .byt $4c, $0e, $0d, $2c, $a1, $fe, $10, $20, $ad, $a2, $fe, $ad   // 820e: 4c 0e 0d... L..
+    .byt $a2, $fe, $a9,   2, $2c, $3e, $0d, $d0, $0c, $a9, $44, $a0   // 821a: a2 fe a9... ...
+    .byt $82, $2c, $a0, $fe, $30, $18, $4c, $0e, $0d, $a9, $a1, $a0   // 8226: 82 2c a0... .,.
+    .byt $82, $4c, $0e, $0d, $ad, $3e, $0d, $10,   3, $4c, $d4, $88   // 8232: 82 4c 0e... .L.
+    .byt $20, $69, $89, $4c, $f5, $83, $a4, $a2, $ad, $a1, $fe, $10   // 823e: 20 69 89...  i.
+    .byt $2d, $ad, $a2, $fe, $91, $a4, $c8, $d0,   6, $e6, $a5, $c6   // 824a: 2d ad a2... -..
+    .byt $a3, $f0, $dd, $ad, $a1, $fe, $30,   2, $d0, $18, $ad, $a2   // 8256: a3 f0 dd... ...
+    .byt $fe, $91, $a4, $c8, $84, $a2, $d0,   6, $e6, $a5, $c6, $a3   // 8262: fe 91 a4... ...
+    .byt $f0,   8, $ad, $a1, $fe, $d0, $d4, $4c, $14, $0d, $a9, $84   // 826e: f0 08 ad... ...
+    .byt $8d, $a1, $fe, $a9,   0, $8d, $a0, $fe, $84, $a2, $a9,   2   // 827a: 8d a1 fe... ...
+    .byt $2c, $a1, $fe, $f0, $ab, $10, $11, $a5, $a3, $f0, $a5, $ad   // 8286: 2c a1 fe... ,..
+    .byt $a2, $fe, $a4, $a2, $91, $a4, $e6, $a2, $d0,   2, $e6, $a5   // 8292: a2 fe a4... ...
+    .byt $4c, $ef, $82, $ad, $a1, $fe, $10, $1e, $ad, $a2, $fe, $20   // 829e: 4c ef 82... L..
+    .byt $2f, $85, $f0, $e1, $8d, $e5, $fe, $ad, $a2, $fe, $8d, $e5   // 82aa: 2f 85 f0... /..
+    .byt $fe, $20, $2f, $85, $f0,   8, $ad, $a1, $fe, $d0, $e3, $4c   // 82b6: fe 20 2f... . /
+    .byt $14, $0d, $a9,   0, $8d, $a0, $fe, $a9, $84, $8d, $a1, $fe   // 82c2: 14 0d a9... ...
+    .byt $a9,   2, $2c, $a1, $fe, $f0, $ba, $10, $18, $a5, $a2,   5   // 82ce: a9 02 2c... ..,
+    .byt $a3,   5, $a4,   5, $a5, $f0, $ae, $ad, $a2, $fe, $8d, $42   // 82da: a3 05 a4... ...
+    .byt $0d, $a9, $20, $0d, $3e, $0d, $8d, $3e, $0d, $ad, $3e, $0d   // 82e6: 0d a9 20... ..
+    .byt $10,   6, $20, $4f, $83, $4c, $d0, $88, $a9, $44, $8d, $a0   // 82f2: 10 06 20... ..
+    .byt $fe, $a9, $a7, $8d, $a1, $fe, $a9, $96, $a0, $83, $8d, $43   // 82fe: fe a9 a7... ...
+    .byt $0d, $8c, $44, $0d, $ad, $2e, $0d, $2c, $a0, $fe, $50, $36   // 830a: 0d 8c 44... ..D
+    .byt $8d, $a2, $fe, $ad, $2f, $0d, $8d, $a2, $fe, $a9, $26, $a0   // 8316: 8d a2 fe... ...
+    .byt $83, $4c, $0e, $0d, $ad, $18, $fe, $2c, $a0, $fe, $50, $1e   // 8322: 83 4c 0e... .L.
+    .byt $8d, $a2, $fe, $a9,   0, $8d, $a2, $fe, $ad, $3e, $0d, $30   // 832e: 8d a2 fe... ...
+    .byt $0e, $a9, $3f, $8d, $a1, $fe, $ad, $43, $0d, $ac, $44, $0d   // 833a: 0e a9 3f... ..?
+    .byt $4c, $0e, $0d, $4c, $d1, $87, $4c, $36, $82, $a9,   2, $2c   // 8346: 4c 0e 0d... L..
+    .byt $3e, $0d, $f0, $3f, $18,   8, $a0,   8, $b1, $a6, $28, $79   // 8352: 3e 0d f0... >..
+    .byt $9a,   0, $91, $a6, $c8,   8, $c0, $0c, $90, $f2, $28, $a9   // 835e: 9a 00 91... ...
+    .asc " ,>"                                                        // 836a: 20 2c 3e     ,>
+    .byt $0d, $f0, $23, $8a, $48, $a9,   8, $18, $65, $a6, $aa, $a4   // 836d: 0d f0 23... ..#
+    .byt $a7, $a9,   1, $20,   6,   4, $ad, $42, $0d, $8d, $e5, $fe   // 8379: a7 a9 01... ...
+    .byt $38, $a0,   8, $a9,   0, $71, $a6, $91, $a6, $c8, $b0, $f7   // 8385: 38 a0 08... 8..
+    .byt $68, $aa, $a9, $ff, $60, $ad, $31, $0d, $d0, $0a, $ac, $30   // 8391: 68 aa a9... h..
+    .byt $0d, $c0, $82, $f0,   3, $4c, $f6, $84, $20, $4f, $83, $d0   // 839d: 0d c0 82... ...
+    .byt $12, $a5, $a2, $18, $65, $a4, $90,   2, $e6, $a5, $a0,   8   // 83a9: 12 a5 a2... ...
+    .byt $91, $a6, $c8, $a5, $a5, $91, $a6, $ad, $31, $0d, $f0, $34   // 83b5: 91 a6 c8... ...
+    .byt $ad, $2f, $0d, $a0,   3, $91, $a6, $88, $ad, $2e, $0d, $91   // 83c1: ad 2f 0d... ./.
+    .byt $a6, $88, $ad, $31, $0d, $91, $a6, $88, $ad, $30, $0d,   9   // 83cd: a6 88 ad... ...
+    .byt $80, $91, $a6, $ad, $6c, $0d, $6a, $90, $13, $a5, $a6, $c8   // 83d9: 80 91 a6... ...
+    .byt $e9, $0c, $b0, $fb, $88, $c0,   3, $90,   7, $20,   2, $84   // 83e5: e9 0c b0... ...
+    .byt $98, $4c, $0f, $85, $20,   2, $84                            // 83f1: 98 4c 0f... .L.
+
+// $83f8 referenced 1 time by $810a
+c83f8
+    jsr c8978                                                         // 83f8: 20 78 89     x.
+// $83fb referenced 2 times by $80ee, $8107
+c83fb
+    lda #$be                                                          // 83fb: a9 be       ..
+    ldy #$80                                                          // 83fd: a0 80       ..
+    jmp l0d0e                                                         // 83ff: 4c 0e 0d    L..
+
+    .byt $a9,   2, $2d, $63, $0d, $2c, $3e, $0d, $f0,   3, $20, $49   // 8402: a9 02 2d... ..-
+    .byt $84, $60, $8a, $48, $a2,   4, $a9,   2, $2c, $3e, $0d, $d0   // 840e: 84 60 8a... .`.
+    .byt $1c, $a4, $a2, $bd, $2e, $0d, $91, $a4, $c8, $d0,   6, $e6   // 841a: 1c a4 a2... ...
+    .byt $a5, $c6, $a3, $f0, $52, $e8, $84, $a2, $e0, $0c, $d0, $eb   // 8426: a5 c6 a3... ...
+    .byt $68, $aa, $4c, $a5, $83, $bd, $2e, $0d, $8d, $e5, $fe, $20   // 8432: 68 aa 4c... h.L
+    .byt $2f, $85, $f0, $3d, $e8, $e0, $0c, $d0, $f0, $f0, $e9        // 843e: 2f 85 f0... /..
+
+// $8449 referenced 1 time by $893e
+sub_c8449
+    bit l0099                                                         // 8449: 24 99       $.
+    bmi c8452                                                         // 844b: 30 05       0.
+    lda #$82                                                          // 844d: a9 82       ..
+    jsr c0406                                                         // 844f: 20 06 04     ..
+// $8452 referenced 1 time by $844b
+c8452
+    lsr l0099                                                         // 8452: 46 99       F.
+    rts                                                               // 8454: 60          `
+
+    .byt $ac, $30, $0d, $c0, $81, $90, $29, $c0, $89, $b0, $25, $c0   // 8455: ac 30 0d... .0.
+    .byt $87, $b0, $0e, $98, $38, $e9, $81, $a8, $ad, $68, $0d, $6a   // 8461: 87 b0 0e... ...
+    .byt $88, $10, $fc, $b0, $86, $ac, $30, $0d, $a9, $84, $48, $b9   // 846d: 88 10 fc... ...
+    .byt   7, $84, $48, $60, $e6, $a2, $e0, $0b, $f0, $af, $68, $aa   // 8479: 07 84 48... ..H
+    .byt $4c, $36, $82, $ca, $ad, $8f, $8f, $8f, $e4, $e4, $b8, $a9   // 8485: 4c 36 82... L6.
+    .byt   0, $85, $a4, $a9, $82, $85, $a2, $a9,   1, $85, $a3, $a5   // 8491: 00 85 a4... ...
+    .byt $9d, $85, $a5, $a0,   1, $b9, $32, $0d, $99, $66, $0d, $88   // 849d: 9d 85 a5... ...
+    .byt $10, $f7, $4c, $cc, $81, $a9, $2e, $85, $a6, $a9, $0d, $85   // 84a9: 10 f7 4c... ..L
+    .byt $a7, $4c, $ba, $81, $a9,   1                                 // 84b5: a7 4c ba... .L.
+// $84bb referenced 1 time by $806f
+l84bb
+    .byt $85, $a3, $a9, $fc, $85, $a2, $a9, $cb, $85, $a4, $a9, $88   // 84bb: 85 a3 a9... ...
+    .byt $85, $a5, $d0, $12, $a9, $2e, $85, $a6, $a9, $0d, $85, $a7   // 84c7: 85 a5 d0... ...
+    .byt $a9,   2, $8d, $40, $0d, $20, $f2, $88, $90, $4f, $ad, $3e   // 84d3: a9 02 8d... ...
+    .byt $0d,   9, $80, $8d, $3e, $0d, $a9, $44, $8d, $a0, $fe, $a9   // 84df: 0d 09 80... ...
+    .byt $a7, $8d, $a1, $fe, $a9, $0c, $a0, $85, $4c,   8, $83, $a5   // 84eb: a7 8d a1... ...
+    .byt $a2, $18, $69, $80, $a0, $7f, $91, $9c, $a0, $80, $ad, $2e   // 84f7: a2 18 69... ..i
+    .byt $0d, $91, $9c, $c8, $ad, $2f, $0d, $91, $9c, $ad, $30, $0d   // 8503: 0d 91 9c... ...
+    .byt $8d, $65, $0d, $a9, $84, $8d, $4e, $fe, $ad, $4b, $fe, $29   // 850f: 8d 65 0d... .e.
+    .byt $1c, $8d, $64, $0d, $ad, $4b, $fe, $29, $e3,   9,   8, $8d   // 851b: 1c 8d 64... ..d
+    .byt $4b, $fe, $2c, $4a, $fe, $4c, $f8, $83, $e6, $a2, $d0, $0a   // 8527: 4b fe 2c... K.,
+    .byt $e6, $a3, $d0,   6, $e6, $a4, $d0,   2, $e6, $a5             // 8533: e6 a3 d0... ...
+    .asc "`BKYe|"                                                     // 853d: 60 42 4b... `BK
+    .byt $a9, $85, $48, $a9, $84                                      // 8543: a9 85 48... ..H
+    .asc "Hlf"                                                        // 8548: 48 6c 66    Hlf
+    .byt $0d, $ae, $66, $0d, $ad, $67, $0d, $a0,   8, $20, $bf, $ff   // 854b: 0d ae 66... ..f
+    .byt $4c, $85, $85, $ae, $66, $0d, $ac, $67, $0d, $20, $43, $8e   // 8557: 4c 85 85... L..
+    .byt $4c, $85, $85, $a9,   4, $2c, $61, $0d, $d0, $18, $0d, $61   // 8563: 4c 85 85... L..
+    .byt $0d, $8d, $61, $0d, $a9,   4                                 // 856f: 0d 8d 61... ..a
+    .asc "X,a"                                                        // 8575: 58 2c 61    X,a
+    .byt $0d, $d0, $fb, $f0,   8, $ad, $61, $0d, $29, $fb, $8d, $61   // 8578: 0d d0 fb... ...
+    .byt $0d                                                          // 8584: 0d          .
+
+// $8585 referenced 1 time by $8057
+c8585
+    pla                                                               // 8585: 68          h
+    tay                                                               // 8586: a8          .
+    pla                                                               // 8587: 68          h
+    tax                                                               // 8588: aa          .
+    lda #0                                                            // 8589: a9 00       ..
+    rts                                                               // 858b: 60          `
+
+// $858c referenced 2 times by $98d6, $a89a
+sub_c858c
+    txa                                                               // 858c: 8a          .
+    pha                                                               // 858d: 48          H
+    ldy #2                                                            // 858e: a0 02       ..
+    lda (l00a0),y                                                     // 8590: b1 a0       ..
+    sta l0d20                                                         // 8592: 8d 20 0d    . .
+    iny                                                               // 8595: c8          .
+    lda (l00a0),y                                                     // 8596: b1 a0       ..
+    sta l0d21                                                         // 8598: 8d 21 0d    .!.
+    ldy #0                                                            // 859b: a0 00       ..
+    lda (l00a0),y                                                     // 859d: b1 a0       ..
+    bmi c85a4                                                         // 859f: 30 03       0.
+    jmp c862f                                                         // 85a1: 4c 2f 86    L/.
+
+// $85a4 referenced 1 time by $859f
+c85a4
+    sta l0d24                                                         // 85a4: 8d 24 0d    .$.
+    tax                                                               // 85a7: aa          .
+    iny                                                               // 85a8: c8          .
+    lda (l00a0),y                                                     // 85a9: b1 a0       ..
+    sta l0d25                                                         // 85ab: 8d 25 0d    .%.
+    bne c85e3                                                         // 85ae: d0 33       .3
+    cpx #$83                                                          // 85b0: e0 83       ..
+    bcs c85cf                                                         // 85b2: b0 1b       ..
+    sec                                                               // 85b4: 38          8
+    php                                                               // 85b5: 08          .
+    ldy #8                                                            // 85b6: a0 08       ..
+// $85b8 referenced 1 time by $85cc
+loop_c85b8
+    lda (l00a0),y                                                     // 85b8: b1 a0       ..
+    dey                                                               // 85ba: 88          .
+    dey                                                               // 85bb: 88          .
+    dey                                                               // 85bc: 88          .
+    dey                                                               // 85bd: 88          .
+    plp                                                               // 85be: 28          (
+    sbc (l00a0),y                                                     // 85bf: f1 a0       ..
+    sta l0d26,y                                                       // 85c1: 99 26 0d    .&.
+    iny                                                               // 85c4: c8          .
+    iny                                                               // 85c5: c8          .
+    iny                                                               // 85c6: c8          .
+    iny                                                               // 85c7: c8          .
+    iny                                                               // 85c8: c8          .
+    php                                                               // 85c9: 08          .
+    cpy #$0c                                                          // 85ca: c0 0c       ..
+    bcc loop_c85b8                                                    // 85cc: 90 ea       ..
+    plp                                                               // 85ce: 28          (
+// $85cf referenced 1 time by $85b2
+c85cf
+    cpx #$81                                                          // 85cf: e0 81       ..
+    bcc c862f                                                         // 85d1: 90 5c       .\ 
+    cpx #$89                                                          // 85d3: e0 89       ..
+    bcs c862f                                                         // 85d5: b0 58       .X
+    ldy #$0c                                                          // 85d7: a0 0c       ..
+// $85d9 referenced 1 time by $85e1
+loop_c85d9
+    lda (l00a0),y                                                     // 85d9: b1 a0       ..
+    sta l0d1a,y                                                       // 85db: 99 1a 0d    ...
+    iny                                                               // 85de: c8          .
+    cpy #$10                                                          // 85df: c0 10       ..
+    bcc loop_c85d9                                                    // 85e1: 90 f6       ..
+// $85e3 referenced 1 time by $85ae
+c85e3
+    lda #$20 // ' '                                                   // 85e3: a9 20       .
+    bit lfea1                                                         // 85e5: 2c a1 fe    ,..
+    bne c863f                                                         // 85e8: d0 55       .U
+    lda #$fd                                                          // 85ea: a9 fd       ..
+    pha                                                               // 85ec: 48          H
+    lda #6                                                            // 85ed: a9 06       ..
+    sta l0d3f                                                         // 85ef: 8d 3f 0d    .?.
+    lda #0                                                            // 85f2: a9 00       ..
+    sta l0d41                                                         // 85f4: 8d 41 0d    .A.
+    pha                                                               // 85f7: 48          H
+    pha                                                               // 85f8: 48          H
+    ldy #$e7                                                          // 85f9: a0 e7       ..
+// $85fb referenced 3 times by $8621, $8626, $862b
+c85fb
+    lda #4                                                            // 85fb: a9 04       ..
+    php                                                               // 85fd: 08          .
+    sei                                                               // 85fe: 78          x
+sub_c85ff
+l8600 = sub_c85ff+1
+    bit lfe18                                                         // 85ff: 2c 18 fe    ,..
+// $8600 referenced 1 time by $867c
+    bit lfe18                                                         // 8602: 2c 18 fe    ,..
+    bit lfea1                                                         // 8605: 2c a1 fe    ,..
+    beq c8619                                                         // 8608: f0 0f       ..
+    lda lfea0                                                         // 860a: ad a0 fe    ...
+    lda #$67 // 'g'                                                   // 860d: a9 67       .g
+    sta lfea1                                                         // 860f: 8d a1 fe    ...
+    lda #$10                                                          // 8612: a9 10       ..
+    bit lfea0                                                         // 8614: 2c a0 fe    ,..
+    bne c864d                                                         // 8617: d0 34       .4
+// $8619 referenced 1 time by $8608
+c8619
+    bit video_ula_control                                             // 8619: 2c 20 fe    , .
+    plp                                                               // 861c: 28          (
+    tsx                                                               // 861d: ba          .
+    inc l0101,x                                                       // 861e: fe 01 01    ...
+    bne c85fb                                                         // 8621: d0 d8       ..
+    inc l0102,x                                                       // 8623: fe 02 01    ...
+    bne c85fb                                                         // 8626: d0 d3       ..
+    inc l0103,x                                                       // 8628: fe 03 01    ...
+    bne c85fb                                                         // 862b: d0 ce       ..
+    beq c8633                                                         // 862d: f0 04       ..
+// $862f referenced 3 times by $85a1, $85d1, $85d5
+c862f
+    lda #$44 // 'D'                                                   // 862f: a9 44       .D
+    bne c8641                                                         // 8631: d0 0e       ..
+// $8633 referenced 1 time by $862d
+c8633
+    lda #7                                                            // 8633: a9 07       ..
+    sta lfea1                                                         // 8635: 8d a1 fe    ...
+    pla                                                               // 8638: 68          h
+    pla                                                               // 8639: 68          h
+    pla                                                               // 863a: 68          h
+    lda #$40 // '@'                                                   // 863b: a9 40       .@
+    bne c8641                                                         // 863d: d0 02       ..
+// $863f referenced 1 time by $85e8
+c863f
+    lda #$43 // 'C'                                                   // 863f: a9 43       .C
+// $8641 referenced 2 times by $8631, $863d
+c8641
+    ldy #0                                                            // 8641: a0 00       ..
+    sta (l00a0),y                                                     // 8643: 91 a0       ..
+    lda #$80                                                          // 8645: a9 80       ..
+    sta l0d60                                                         // 8647: 8d 60 0d    .`.
+    pla                                                               // 864a: 68          h
+    tax                                                               // 864b: aa          .
+    rts                                                               // 864c: 60          `
+
+// $864d referenced 1 time by $8617
+c864d
+    sty lfea1                                                         // 864d: 8c a1 fe    ...
+    ldx #$44 // 'D'                                                   // 8650: a2 44       .D
+    stx lfea0                                                         // 8652: 8e a0 fe    ...
+    ldx #$ea                                                          // 8655: a2 ea       ..
+    ldy #$86                                                          // 8657: a0 86       ..
+    stx l0d0c                                                         // 8659: 8e 0c 0d    ...
+    sty l0d0d                                                         // 865c: 8c 0d 0d    ...
+    sec                                                               // 865f: 38          8
+    ror l0099                                                         // 8660: 66 99       f.
+    bit video_ula_control                                             // 8662: 2c 20 fe    , .
+    lda l0d25                                                         // 8665: ad 25 0d    .%.
+    bne c86ac                                                         // 8668: d0 42       .B
+    ldy l0d24                                                         // 866a: ac 24 0d    .$.
+    lda l8869,y                                                       // 866d: b9 69 88    .i.
+    sta l0d3e                                                         // 8670: 8d 3e 0d    .>.
+    lda l8861,y                                                       // 8673: b9 61 88    .a.
+    sta l0d3f                                                         // 8676: 8d 3f 0d    .?.
+    lda #$86                                                          // 8679: a9 86       ..
+    pha                                                               // 867b: 48          H
+    lda l8600,y                                                       // 867c: b9 00 86    ...
+    pha                                                               // 867f: 48          H
+    rts                                                               // 8680: 60          `
+
+    .byt <((sub_c868d)-1), <((sub_c8691)-1), <((sub_c86d3)-1)         // 8681: 8c 90 d2    ...
+    .byt <((sub_c86d3)-1), <((sub_c86d3)-1),     <((c86e3)-1)         // 8684: d2 d2 e2    ...
+    .byt     <((c86e3)-1), <((sub_c8689)-1)                           // 8687: e2 88       ..
+
+sub_c8689
+    lda #3                                                            // 8689: a9 03       ..
+    bne c86d5                                                         // 868b: d0 48       .H
+sub_c868d
+    lda #3                                                            // 868d: a9 03       ..
+    bne c8693                                                         // 868f: d0 02       ..
+sub_c8691
+    lda #2                                                            // 8691: a9 02       ..
+// $8693 referenced 1 time by $868f
+c8693
+    sta l0d40                                                         // 8693: 8d 40 0d    .@.
+    clc                                                               // 8696: 18          .
+    php                                                               // 8697: 08          .
+    ldy #$0c                                                          // 8698: a0 0c       ..
+// $869a referenced 1 time by $86a7
+loop_c869a
+    lda l0d1e,y                                                       // 869a: b9 1e 0d    ...
+    plp                                                               // 869d: 28          (
+    adc (l00a0),y                                                     // 869e: 71 a0       q.
+    sta l0d1e,y                                                       // 86a0: 99 1e 0d    ...
+    iny                                                               // 86a3: c8          .
+    php                                                               // 86a4: 08          .
+    cpy #$10                                                          // 86a5: c0 10       ..
+    bcc loop_c869a                                                    // 86a7: 90 f1       ..
+    plp                                                               // 86a9: 28          (
+    bne c86d8                                                         // 86aa: d0 2c       .,
+// $86ac referenced 1 time by $8668
+c86ac
+    lda l0d20                                                         // 86ac: ad 20 0d    . .
+    and l0d21                                                         // 86af: 2d 21 0d    -!.
+    cmp #$ff                                                          // 86b2: c9 ff       ..
+    bne c86ce                                                         // 86b4: d0 18       ..
+    lda #$0e                                                          // 86b6: a9 0e       ..
+    sta l0d3f                                                         // 86b8: 8d 3f 0d    .?.
+    lda #$40 // '@'                                                   // 86bb: a9 40       .@
+    sta l0d3e                                                         // 86bd: 8d 3e 0d    .>.
+    ldy #4                                                            // 86c0: a0 04       ..
+// $86c2 referenced 1 time by $86ca
+loop_c86c2
+    lda (l00a0),y                                                     // 86c2: b1 a0       ..
+    sta l0d22,y                                                       // 86c4: 99 22 0d    .".
+    iny                                                               // 86c7: c8          .
+    cpy #$0c                                                          // 86c8: c0 0c       ..
+    bcc loop_c86c2                                                    // 86ca: 90 f6       ..
+    bcs c86e3                                                         // 86cc: b0 15       ..
+// $86ce referenced 1 time by $86b4
+c86ce
+    lda #0                                                            // 86ce: a9 00       ..
+    sta l0d3e                                                         // 86d0: 8d 3e 0d    .>.
+sub_c86d3
+    lda #2                                                            // 86d3: a9 02       ..
+// $86d5 referenced 1 time by $868b
+c86d5
+    sta l0d40                                                         // 86d5: 8d 40 0d    .@.
+// $86d8 referenced 1 time by $86aa
+c86d8
+    lda l00a0                                                         // 86d8: a5 a0       ..
+    sta l00a6                                                         // 86da: 85 a6       ..
+    lda l00a1                                                         // 86dc: a5 a1       ..
+    sta l00a7                                                         // 86de: 85 a7       ..
+    jsr sub_c88f2                                                     // 86e0: 20 f2 88     ..
+// $86e3 referenced 1 time by $86cc
+c86e3
+    plp                                                               // 86e3: 28          (
+    pla                                                               // 86e4: 68          h
+    pla                                                               // 86e5: 68          h
+    pla                                                               // 86e6: 68          h
+    pla                                                               // 86e7: 68          h
+    tax                                                               // 86e8: aa          .
+    rts                                                               // 86e9: 60          `
+
+    .byt $ac, $41, $0d, $2c, $a0, $fe, $50, $22, $b9, $20, $0d, $8d   // 86ea: ac 41 0d... .A.
+    .byt $a2, $fe, $c8, $b9, $20, $0d, $c8, $8c, $41, $0d, $8d, $a2   // 86f6: a2 fe c8... ...
+    .byt $fe, $cc, $3f, $0d, $b0, $1e, $2c, $a0, $fe, $30, $e3, $4c   // 8702: fe cc 3f... ..?
+    .byt $14, $0d, $a9, $42, $d0,   7, $a9, $67, $8d, $a1, $fe, $a9   // 870e: 14 0d a9... ...
+    .byt $41, $ac, $18, $fe, $48, $68, $c8, $d0, $fb, $4c, $d6, $88   // 871a: 41 ac 18... A..
+    .byt $a9, $3f, $8d, $a1, $fe, $a9, $32, $a0, $87, $4c, $0e, $0d   // 8726: a9 3f 8d... .?.
+    .byt $a9, $82, $8d, $a0, $fe, $2c, $3e, $0d, $50,   3, $4c, $d0   // 8732: a9 82 8d... ...
+    .byt $88, $a9,   1, $2c, $3e, $0d, $f0,   3, $4c, $78, $88, $a9   // 873e: 88 a9 01... ...
+    .byt $4e, $4c, $11, $0d, $a9,   1, $2c, $a1, $fe, $f0, $bb, $ad   // 874a: 4e 4c 11... NL.
+    .byt $a2, $fe, $cd, $18, $fe, $d0, $19, $a9, $62, $4c, $11, $0d   // 8756: a2 fe cd... ...
+    .byt $2c, $a1, $fe, $10, $0f, $ad, $a2, $fe, $d0, $0a, $a9, $79   // 8762: 2c a1 fe... ,..
+    .byt $2c, $a0, $fe, $30,   6, $4c, $11, $0d, $4c, $d4, $88, $2c   // 876e: 2c a0 fe... ,..
+    .byt $a1, $fe, $10, $f8, $ad, $a2, $fe, $cd, $20, $0d, $d0, $f0   // 877a: a1 fe 10... ...
+    .byt $ad, $a2, $fe, $cd, $21, $0d, $d0, $e8, $a9,   2, $2c, $a1   // 8786: ad a2 fe... ...
+    .byt $fe, $f0, $e1, $a9, $a7, $8d, $a1, $fe, $a9, $44, $8d, $a0   // 8792: fe f0 e1... ...
+    .byt $fe, $a9, $78, $a0, $88, $8d, $43, $0d, $8c, $44, $0d, $ad   // 879e: fe a9 78... ..x
+    .byt $20, $0d, $2c, $a0, $fe, $50, $16, $8d, $a2, $fe, $ad, $21   // 87aa: 20 0d 2c...  .,
+    .byt $0d, $8d, $a2, $fe, $a9, $c1, $a0, $87, $4c, $0e, $0d, $ad   // 87b6: 0d 8d a2... ...
+    .byt $18, $fe, $2c, $a0, $fe, $50, $2c, $8d, $a2, $fe, $a9,   0   // 87c2: 18 fe 2c... ..,
+    .byt $8d, $a2, $fe, $a9,   2, $2c, $3e, $0d, $d0,   7, $a9, $ee   // 87ce: 8d a2 fe... ...
+    .byt $a0, $87, $4c, $0e, $0d, $a9, $37, $a0, $88, $4c, $0e, $0d   // 87da: a0 87 4c... ..L
+    .byt $a4, $a3, $f0, $33, $a4, $a2, $f0,   4, $a4, $a2, $f0, $f4   // 87e6: a4 a3 f0... ...
+    .byt $2c, $a0, $fe, $50, $43, $b1, $a4, $8d, $a2, $fe, $c8, $d0   // 87f2: 2c a0 fe... ,..
+    .byt   6, $c6, $a3, $f0, $1a, $e6, $a5, $b1, $a4, $8d, $a2, $fe   // 87fe: 06 c6 a3... ...
+    .byt $c8, $84, $a2, $d0,   6, $c6, $a3, $f0, $0a, $e6, $a5, $2c   // 880a: c8 84 a2... ...
+    .byt $a0, $fe, $30, $db, $4c, $14, $0d, $a9, $3f, $8d, $a1, $fe   // 8816: a0 fe 30... ..0
+    .byt $ad, $3e, $0d, $10,   7, $a9, $f5, $a0, $83, $4c, $0e, $0d   // 8822: ad 3e 0d... .>.
+    .byt $ad, $43, $0d, $ac, $44, $0d, $4c, $0e, $0d, $2c, $a0, $fe   // 882e: ad 43 0d... .C.
+    .byt $50, $34, $ad, $e5, $fe, $8d, $a2, $fe, $e6, $a2, $d0, $0c   // 883a: 50 34 ad... P4.
+    .byt $e6, $a3, $d0,   8, $e6, $a4, $d0,   4, $e6, $a5, $f0, $cb   // 8846: e6 a3 d0... ...
+    .byt $ad, $e5, $fe, $8d, $a2, $fe, $e6, $a2, $d0, $0c, $e6, $a3   // 8852: ad e5 fe... ...
+    .byt $d0,   8, $e6                                                // 885e: d0 08 e6    ...
+// $8861 referenced 1 time by $8673
+l8861
+    .byt $a4, $d0,   4, $e6, $a5, $f0, $b5, $2c                       // 8861: a4 d0 04... ...
+// $8869 referenced 1 time by $866d
+l8869
+    .byt $a0, $fe, $30, $cd, $4c, $14, $0d, $ad, $3e, $0d, $10, $5f   // 8869: a0 fe 30... ..0
+    .byt $4c, $f5, $83, $a9, $82, $8d, $a0, $fe, $a9, $84, $a0, $88   // 8875: 4c f5 83... L..
+    .byt $4c, $0e, $0d, $a9,   1, $2c, $a1, $fe, $f0, $49, $ad, $a2   // 8881: 4c 0e 0d... L..
+    .byt $fe, $cd, $18, $fe, $d0, $41, $a9, $98, $4c, $11, $0d, $2c   // 888d: fe cd 18... ...
+    .byt $a1, $fe, $10, $37, $ad, $a2, $fe, $d0, $32, $a9, $ac, $2c   // 8899: a1 fe 10... ...
+    .byt $a0, $fe, $30,   3, $4c, $11, $0d, $2c, $a1, $fe, $10, $23   // 88a5: a0 fe 30... ..0
+    .byt $ad, $a2, $fe, $cd, $20, $0d, $d0, $1b, $ad, $a2, $fe, $cd   // 88b1: ad a2 fe... ...
+    .byt $21, $0d, $d0, $13, $ad, $3e, $0d, $10,   3, $4c, $1c, $82   // 88bd: 21 0d d0... !..
+    .byt $a9,   2, $2c, $a1, $fe, $f0,   4, $a9,   0, $f0,   2, $a9   // 88c9: a9 02 2c... ..,
+    .byt $41, $a0,   0, $91, $a0, $a9, $80, $8d, $60, $0d, $4c, $f5   // 88d5: 41 a0 00... A..
+    .byt $83                                                          // 88e1: 83          .
+    .byt >(l0e81)                                                     // 88e2: 0e          .
+    .byt >(l0e00)                                                     // 88e3: 0e          .
+    .byt >(l0a00)                                                     // 88e4: 0a          .
+    .byt >(l0a00)                                                     // 88e5: 0a          .
+    .byt >(l0a00)                                                     // 88e6: 0a          .
+    .byt >(l0601)                                                     // 88e7: 06          .
+    .byt >(l0601)                                                     // 88e8: 06          .
+    .byt >(l0a81)                                                     // 88e9: 0a          .
+    .byt <(l0e81)                                                     // 88ea: 81          .
+    .byt <(l0e00)                                                     // 88eb: 00          .
+    .byt <(l0a00)                                                     // 88ec: 00          .
+    .byt <(l0a00)                                                     // 88ed: 00          .
+    .byt <(l0a00)                                                     // 88ee: 00          .
+    .byt <(l0601)                                                     // 88ef: 01          .
+    .byt <(l0601)                                                     // 88f0: 01          .
+    .byt <(l0a81)                                                     // 88f1: 81          .
+
+// $88f2 referenced 1 time by $86e0
+sub_c88f2
+    ldy #7                                                            // 88f2: a0 07       ..
+    lda (l00a6),y                                                     // 88f4: b1 a6       ..
+    cmp #$ff                                                          // 88f6: c9 ff       ..
+    bne c8901                                                         // 88f8: d0 07       ..
+    dey                                                               // 88fa: 88          .
+    lda (l00a6),y                                                     // 88fb: b1 a6       ..
+    cmp #$fe                                                          // 88fd: c9 fe       ..
+    bcs c8945                                                         // 88ff: b0 44       .D
+// $8901 referenced 1 time by $88f8
+c8901
+    lda l0d63                                                         // 8901: ad 63 0d    .c.
+    beq c8945                                                         // 8904: f0 3f       .?
+    lda l0d3e                                                         // 8906: ad 3e 0d    .>.
+    ora #2                                                            // 8909: 09 02       ..
+    sta l0d3e                                                         // 890b: 8d 3e 0d    .>.
+    sec                                                               // 890e: 38          8
+    php                                                               // 890f: 08          .
+    ldy #4                                                            // 8910: a0 04       ..
+// $8912 referenced 1 time by $8924
+loop_c8912
+    lda (l00a6),y                                                     // 8912: b1 a6       ..
+    iny                                                               // 8914: c8          .
+    iny                                                               // 8915: c8          .
+    iny                                                               // 8916: c8          .
+    iny                                                               // 8917: c8          .
+    plp                                                               // 8918: 28          (
+    sbc (l00a6),y                                                     // 8919: f1 a6       ..
+    sta l009a,y                                                       // 891b: 99 9a 00    ...
+    dey                                                               // 891e: 88          .
+    dey                                                               // 891f: 88          .
+    dey                                                               // 8920: 88          .
+    php                                                               // 8921: 08          .
+    cpy #8                                                            // 8922: c0 08       ..
+    bcc loop_c8912                                                    // 8924: 90 ec       ..
+    plp                                                               // 8926: 28          (
+    txa                                                               // 8927: 8a          .
+    pha                                                               // 8928: 48          H
+    lda #4                                                            // 8929: a9 04       ..
+    clc                                                               // 892b: 18          .
+    adc l00a6                                                         // 892c: 65 a6       e.
+    tax                                                               // 892e: aa          .
+    ldy l00a7                                                         // 892f: a4 a7       ..
+    lda #$c2                                                          // 8931: a9 c2       ..
+    jsr c0406                                                         // 8933: 20 06 04     ..
+    bcc c8942                                                         // 8936: 90 0a       ..
+    lda l0d40                                                         // 8938: ad 40 0d    .@.
+    jsr c0406                                                         // 893b: 20 06 04     ..
+    jsr sub_c8449                                                     // 893e: 20 49 84     I.
+    sec                                                               // 8941: 38          8
+// $8942 referenced 1 time by $8936
+c8942
+    pla                                                               // 8942: 68          h
+    tax                                                               // 8943: aa          .
+    rts                                                               // 8944: 60          `
+
+// $8945 referenced 2 times by $88ff, $8904
+c8945
+    ldy #4                                                            // 8945: a0 04       ..
+    lda (l00a6),y                                                     // 8947: b1 a6       ..
+    ldy #8                                                            // 8949: a0 08       ..
+    sec                                                               // 894b: 38          8
+    sbc (l00a6),y                                                     // 894c: f1 a6       ..
+    sta l00a2                                                         // 894e: 85 a2       ..
+    ldy #5                                                            // 8950: a0 05       ..
+    lda (l00a6),y                                                     // 8952: b1 a6       ..
+    sbc #0                                                            // 8954: e9 00       ..
+    sta l00a5                                                         // 8956: 85 a5       ..
+    ldy #8                                                            // 8958: a0 08       ..
+    lda (l00a6),y                                                     // 895a: b1 a6       ..
+    sta l00a4                                                         // 895c: 85 a4       ..
+    ldy #9                                                            // 895e: a0 09       ..
+    lda (l00a6),y                                                     // 8960: b1 a6       ..
+    sec                                                               // 8962: 38          8
+    sbc l00a5                                                         // 8963: e5 a5       ..
+    sta l00a3                                                         // 8965: 85 a3       ..
+    sec                                                               // 8967: 38          8
+    rts                                                               // 8968: 60          `
+
+// $8969 referenced 2 times by $8077, $8104
+sub_c8969
+    lda #$c1                                                          // 8969: a9 c1       ..
+    sta lfea0                                                         // 896b: 8d a0 fe    ...
+    lda #$1e                                                          // 896e: a9 1e       ..
+    sta lfea3                                                         // 8970: 8d a3 fe    ...
+    lda #0                                                            // 8973: a9 00       ..
+    sta lfea1                                                         // 8975: 8d a1 fe    ...
+// $8978 referenced 2 times by $83f8, $89a4
+c8978
+    lda #$82                                                          // 8978: a9 82       ..
+    sta lfea0                                                         // 897a: 8d a0 fe    ...
+    lda #$67 // 'g'                                                   // 897d: a9 67       .g
+    sta lfea1                                                         // 897f: 8d a1 fe    ...
+    rts                                                               // 8982: 60          `
+
+sub_c8983
+    bit l0d62                                                         // 8983: 2c 62 0d    ,b.
+    bpl c89a4                                                         // 8986: 10 1c       ..
+// $8988 referenced 2 times by $898d, $8994
+c8988
+    lda l0d0c                                                         // 8988: ad 0c 0d    ...
+    cmp #$be                                                          // 898b: c9 be       ..
+    bne c8988                                                         // 898d: d0 f9       ..
+    lda l0d0d                                                         // 898f: ad 0d 0d    ...
+    eor #$80                                                          // 8992: 49 80       I.
+    bne c8988                                                         // 8994: d0 f2       ..
+    bit lfe18                                                         // 8996: 2c 18 fe    ,..
+    bit lfe18                                                         // 8999: 2c 18 fe    ,..
+    sta l0d60                                                         // 899c: 8d 60 0d    .`.
+    sta l0d62                                                         // 899f: 8d 62 0d    .b.
+    ldy #5                                                            // 89a2: a0 05       ..
+// $89a4 referenced 1 time by $8986
+c89a4
+l89a6 = c89a4+2
+    jmp c8978                                                         // 89a4: 4c 78 89    Lx.
+
+// $89a6 referenced 1 time by $8096
+    bit lfe18                                                         // 89a7: 2c 18 fe    ,..
+    pha                                                               // 89aa: 48          H
+    tya                                                               // 89ab: 98          .
+    pha                                                               // 89ac: 48          H
+    lda #0                                                            // 89ad: a9 00       ..
+    sta romsel                                                        // 89af: 8d 30 fe    .0.
+    jmp c80be                                                         // 89b2: 4c be 80    L..
+
+    sty l0d0d                                                         // 89b5: 8c 0d 0d    ...
+    sta l0d0c                                                         // 89b8: 8d 0c 0d    ...
+    lda romsel_copy                                                   // 89bb: a5 f4       ..
+    sta romsel                                                        // 89bd: 8d 30 fe    .0.
+    pla                                                               // 89c0: 68          h
+    tay                                                               // 89c1: a8          .
+    pla                                                               // 89c2: 68          h
+    bit video_ula_control                                             // 89c3: 2c 20 fe    , .
+    rti                                                               // 89c6: 40          @
+
+    .byt   1,   0, $18                                                // 89c7: 01 00 18    ...
+// $89ca referenced 1 time by $8e52
+jump_table_low
+    .byt 4                                                            // 89ca: 04          .
+    .byt <(just_rts-1)                                                // 89cb: 57          W
+    .byt <(service_handler_claim_absolute_workspace-1)                // 89cc: a4          .
+    .byt <(service_handler_claim_private_workspace-1)                 // 89cd: b7          .
+    .byt <(sub_c8cca-1)                                               // 89ce: c9          .
+    .byt <(sub_c8c4e-1)                                               // 89cf: 4d          M
+    .byt <(sub_c8028-1)                                               // 89d0: 27          '
+    .byt <(just_rts-1)                                                // 89d1: 57          W
+    .byt <(sub_c8e92-1)                                               // 89d2: 91          .
+    .byt <(sub_ca4ee-1)                                               // 89d3: ed          .
+    .byt <(sub_c8c5d-1)                                               // 89d4: 5c          \ 
+    .byt <(just_rts-1)                                                // 89d5: 57          W
+    .byt <(sub_c8090-1)                                               // 89d6: 8f          .
+    .byt <(sub_c8983-1)                                               // 89d7: 82          .
+    .byt <(sub_c8b0d-1)                                               // 89d8: 0c          .
+    .byt <(sub_c95ce-1)                                               // 89d9: cd          .
+    .byt <(sub_c9580-1)                                               // 89da: 7f          .
+    .byt <(sub_cac98-1)                                               // 89db: 97          .
+    .byt <(sub_c95ae-1)                                               // 89dc: ad          .
+    .byt <(sub_c95be-1)                                               // 89dd: bd          .
+    .byt <(sub_c9dc8-1)                                               // 89de: c7          .
+    .byt <(sub_c9dee-1)                                               // 89df: ed          .
+    .byt <(ca1c1-1)                                                   // 89e0: c0          .
+    .byt <(ca114-1)                                                   // 89e1: 13          .
+    .byt <(ca1c1-1)                                                   // 89e2: c0          .
+    .byt <(sub_cad80-1)                                               // 89e3: 7f          .
+    .byt <(sub_c8f99-1)                                               // 89e4: 98          .
+    .byt <(sub_c92b0-1)                                               // 89e5: af          .
+    .byt <(sub_caf3e-1)                                               // 89e6: 3d          =
+    .byt <(sub_ca391-1)                                               // 89e7: 90          .
+    .byt <(sub_ca39b-1)                                               // 89e8: 9a          .
+    .byt <(ca2f4-1)                                                   // 89e9: f3          .
+    .byt <(ca1c1-1)                                                   // 89ea: c0          .
+    .byt <(sub_ca2fa-1)                                               // 89eb: f9          .
+    .byt <(sub_ca0e4-1)                                               // 89ec: e3          .
+    .byt <(sub_ca0ea-1)                                               // 89ed: e9          .
+    .byt <(sub_ca0fa-1)                                               // 89ee: f9          .
+// $89ef referenced 1 time by $8e4e
+jump_table_high
+    .byt $d3                                                          // 89ef: d3          .
+    .byt >(just_rts-1)                                                // 89f0: 8e          .
+    .byt >(service_handler_claim_absolute_workspace-1)                // 89f1: 8e          .
+    .byt >(service_handler_claim_private_workspace-1)                 // 89f2: 8e          .
+    .byt >(sub_c8cca-1)                                               // 89f3: 8c          .
+    .byt >(sub_c8c4e-1)                                               // 89f4: 8c          .
+    .byt >(sub_c8028-1)                                               // 89f5: 80          .
+    .byt >(just_rts-1)                                                // 89f6: 8e          .
+    .byt >(sub_c8e92-1)                                               // 89f7: 8e          .
+    .byt >(sub_ca4ee-1)                                               // 89f8: a4          .
+    .byt >(sub_c8c5d-1)                                               // 89f9: 8c          .
+    .byt >(just_rts-1)                                                // 89fa: 8e          .
+    .byt >(sub_c8090-1)                                               // 89fb: 80          .
+    .byt >(sub_c8983-1)                                               // 89fc: 89          .
+    .byt >(sub_c8b0d-1)                                               // 89fd: 8b          .
+    .byt >(sub_c95ce-1)                                               // 89fe: 95          .
+    .byt >(sub_c9580-1)                                               // 89ff: 95          .
+    .byt >(sub_cac98-1)                                               // 8a00: ac          .
+    .byt >(sub_c95ae-1)                                               // 8a01: 95          .
+    .byt >(sub_c95be-1)                                               // 8a02: 95          .
+    .byt >(sub_c9dc8-1)                                               // 8a03: 9d          .
+    .byt >(sub_c9dee-1)                                               // 8a04: 9d          .
+    .byt >(ca1c1-1)                                                   // 8a05: a1          .
+    .byt >(ca114-1)                                                   // 8a06: a1          .
+    .byt >(ca1c1-1)                                                   // 8a07: a1          .
+    .byt >(sub_cad80-1)                                               // 8a08: ad          .
+    .byt >(sub_c8f99-1)                                               // 8a09: 8f          .
+    .byt >(sub_c92b0-1)                                               // 8a0a: 92          .
+    .byt >(sub_caf3e-1)                                               // 8a0b: af          .
+    .byt >(sub_ca391-1)                                               // 8a0c: a3          .
+    .byt >(sub_ca39b-1)                                               // 8a0d: a3          .
+    .byt >(ca2f4-1)                                                   // 8a0e: a2          .
+    .byt >(ca1c1-1)                                                   // 8a0f: a1          .
+    .byt >(sub_ca2fa-1)                                               // 8a10: a2          .
+    .byt >(sub_ca0e4-1)                                               // 8a11: a0          .
+    .byt >(sub_ca0ea-1)                                               // 8a12: a0          .
+    .byt >(sub_ca0fa-1)                                               // 8a13: a0          .
+    .byt $8a                                                          // 8a14: 8a          .
+
+// $8a15 referenced 1 time by $8003
+service_handler
+    pha                                                               // 8a15: 48          H
+    cmp #service_vectors_changed                                      // 8a16: c9 0f       ..
+    bne service_handler_common1                                       // 8a18: d0 22       ."
+// Extra processing for vectors changed service call
+    tya                                                               // 8a1a: 98          .
+    pha                                                               // 8a1b: 48          H
+    lda #osbyte_read_os_version                                       // 8a1c: a9 00       ..
+    ldx #1                                                            // 8a1e: a2 01       ..
+    jsr osbyte                                                        // 8a20: 20 f4 ff     ..
+    cpx #1                                                            // 8a23: e0 01       ..
+    beq c8a38                                                         // 8a25: f0 11       ..
+    cpx #2                                                            // 8a27: e0 02       ..
+    beq c8a38                                                         // 8a29: f0 0d       ..
+    txa                                                               // 8a2b: 8a          .
+    php                                                               // 8a2c: 08          .
+    ldx romsel_copy                                                   // 8a2d: a6 f4       ..
+    plp                                                               // 8a2f: 28          (
+    beq c8a33                                                         // 8a30: f0 01       ..
+    inx                                                               // 8a32: e8          .
+// $8a33 referenced 1 time by $8a30
+c8a33
+    lda #0                                                            // 8a33: a9 00       ..
+    sta l02a0,x                                                       // 8a35: 9d a0 02    ...
+// $8a38 referenced 2 times by $8a25, $8a29
+c8a38
+    ldx romsel_copy                                                   // 8a38: a6 f4       ..
+    pla                                                               // 8a3a: 68          h
+    tay                                                               // 8a3b: a8          .
+// $8a3c referenced 1 time by $8a18
+service_handler_common1
+    pla                                                               // 8a3c: 68          h
+    jsr service_handler_tube_service_calls                            // 8a3d: 20 62 be     b.
+    pha                                                               // 8a40: 48          H
+    cmp #service_claim_absolute_workspace                             // 8a41: c9 01       ..
+    bne service_handler_common2                                       // 8a43: d0 15       ..
+// Extra processing for absolute workspace claim service call
+    lda lfea0                                                         // 8a45: ad a0 fe    ...
+    and #$ed                                                          // 8a48: 29 ed       ).
+    bne c8a53                                                         // 8a4a: d0 07       ..
+    lda lfea1                                                         // 8a4c: ad a1 fe    ...
+    and #$db                                                          // 8a4f: 29 db       ).
+    beq service_handler_common2                                       // 8a51: f0 07       ..
+// $8a53 referenced 1 time by $8a4a
+c8a53
+    rol l0df0,x                                                       // 8a53: 3e f0 0d    >..
+    sec                                                               // 8a56: 38          8
+    ror l0df0,x                                                       // 8a57: 7e f0 0d    ~..
+// $8a5a referenced 2 times by $8a43, $8a51
+service_handler_common2
+    lda l0df0,x                                                       // 8a5a: bd f0 0d    ...
+    asl                                                               // 8a5d: 0a          .
+    pla                                                               // 8a5e: 68          h
+    bcc c8a62                                                         // 8a5f: 90 01       ..
+    rts                                                               // 8a61: 60          `
+
+// $8a62 referenced 1 time by $8a5f
+c8a62
+    cmp #service_vectors_changed                                      // 8a62: c9 0f       ..
+    bne service_handler_not_vectors_changed                           // 8a64: d0 41       .A
+    ldx l0d6a                                                         // 8a66: ae 6a 0d    .j.
+    bne c8a6f                                                         // 8a69: d0 04       ..
+    inx                                                               // 8a6b: e8          .
+    stx l028d                                                         // 8a6c: 8e 8d 02    ...
+// $8a6f referenced 1 time by $8a69
+c8a6f
+    sta l00ac                                                         // 8a6f: 85 ac       ..
+// $8a71 referenced 1 time by $8a9a
+c8a71
+    lda #$80                                                          // 8a71: a9 80       ..
+    sta l00f7                                                         // 8a73: 85 f7       ..
+    lda #$0c                                                          // 8a75: a9 0c       ..
+    sta osrdsc_ptr                                                    // 8a77: 85 f6       ..
+    jsr sub_c8aa0                                                     // 8a79: 20 a0 8a     ..
+    cmp #$4e // 'N'                                                   // 8a7c: c9 4e       .N
+    bne c8a98                                                         // 8a7e: d0 18       ..
+    jsr sub_c8aa0                                                     // 8a80: 20 a0 8a     ..
+    cmp #$45 // 'E'                                                   // 8a83: c9 45       .E
+    bne c8a98                                                         // 8a85: d0 11       ..
+    jsr sub_c8aa0                                                     // 8a87: 20 a0 8a     ..
+    cmp #$54 // 'T'                                                   // 8a8a: c9 54       .T
+    bne c8a98                                                         // 8a8c: d0 0a       ..
+    ldx l00ac                                                         // 8a8e: a6 ac       ..
+    lda l0df0,x                                                       // 8a90: bd f0 0d    ...
+    ora #$80                                                          // 8a93: 09 80       ..
+    sta l0df0,x                                                       // 8a95: 9d f0 0d    ...
+// $8a98 referenced 3 times by $8a7e, $8a85, $8a8c
+c8a98
+    dec l00ac                                                         // 8a98: c6 ac       ..
+    bpl c8a71                                                         // 8a9a: 10 d5       ..
+    lda #$0f                                                          // 8a9c: a9 0f       ..
+    bne c8ad1                                                         // 8a9e: d0 31       .1
+// $8aa0 referenced 3 times by $8a79, $8a80, $8a87
+sub_c8aa0
+    inc osrdsc_ptr                                                    // 8aa0: e6 f6       ..
+    ldy l00ac                                                         // 8aa2: a4 ac       ..
+    jmp osrdsc                                                        // 8aa4: 4c b9 ff    L..
+
+// $8aa7 referenced 1 time by $8a64
+service_handler_not_vectors_changed
+    tax                                                               // 8aa7: aa          .
+    lda l00a9                                                         // 8aa8: a5 a9       ..
+    pha                                                               // 8aaa: 48          H
+    txa                                                               // 8aab: 8a          .
+    sta l00a9                                                         // 8aac: 85 a9       ..
+// Call dispatch table entry X+1 for service calls 1<=X<&D.
+// Call dispatch table entry &D+1 for service call &12.
+// Don't handle any other service call.
+// (+1 because jump_table_dispatch_x_plus_y adds 1 if Y=0.)
+    cmp #$0d                                                          // 8aae: c9 0d       ..
+    bcc c8aba                                                         // 8ab0: 90 08       ..
+    sbc #5                                                            // 8ab2: e9 05       ..
+    cmp #$0d                                                          // 8ab4: c9 0d       ..
+    beq c8aba                                                         // 8ab6: f0 02       ..
+    lda #0                                                            // 8ab8: a9 00       ..
+// $8aba referenced 2 times by $8ab0, $8ab6
+c8aba
+    tax                                                               // 8aba: aa          .
+    beq c8acb                                                         // 8abb: f0 0e       ..
+    lda l00a8                                                         // 8abd: a5 a8       ..
+    pha                                                               // 8abf: 48          H
+    sty l00a8                                                         // 8ac0: 84 a8       ..
+    tya                                                               // 8ac2: 98          .
+    ldy #0                                                            // 8ac3: a0 00       ..
+    jsr jump_table_dispatch_x_plus_y                                  // 8ac5: 20 49 8e     I.
+    pla                                                               // 8ac8: 68          h
+    sta l00a8                                                         // 8ac9: 85 a8       ..
+// $8acb referenced 1 time by $8abb
+c8acb
+    ldx l00a9                                                         // 8acb: a6 a9       ..
+    pla                                                               // 8acd: 68          h
+    sta l00a9                                                         // 8ace: 85 a9       ..
+    txa                                                               // 8ad0: 8a          .
+// $8ad1 referenced 1 time by $8a9e
+c8ad1
+    ldx romsel_copy                                                   // 8ad1: a6 f4       ..
+    rts                                                               // 8ad3: 60          `
+
+sub_c8ad4
+    ldy #0                                                            // 8ad4: a0 00       ..
+    lda (l009c),y                                                     // 8ad6: b1 9c       ..
+    beq c8afb                                                         // 8ad8: f0 21       .!
+    lda #0                                                            // 8ada: a9 00       ..
+    tax                                                               // 8adc: aa          .
+    sta (l009c),y                                                     // 8add: 91 9c       ..
+    tay                                                               // 8adf: a8          .
+    lda #osbyte_read_write_econet_keyboard_disable                    // 8ae0: a9 c9       ..
+    jsr osbyte                                                        // 8ae2: 20 f4 ff     ..
+    lda #$0a                                                          // 8ae5: a9 0a       ..
+    jsr sub_ca9be                                                     // 8ae7: 20 be a9     ..
+// $8aea referenced 1 time by $959f
+sub_c8aea
+    stx l009e                                                         // 8aea: 86 9e       ..
+    lda #osbyte_read_write_econet_os_call_interception                // 8aec: a9 ce       ..
+// $8aee referenced 1 time by $8af9
+loop_c8aee
+    ldx l009e                                                         // 8aee: a6 9e       ..
+    ldy #$7f                                                          // 8af0: a0 7f       ..
+    jsr osbyte                                                        // 8af2: 20 f4 ff     ..
+    adc #1                                                            // 8af5: 69 01       i.
+    cmp #$d0                                                          // 8af7: c9 d0       ..
+    beq loop_c8aee                                                    // 8af9: f0 f3       ..
+// $8afb referenced 1 time by $8ad8
+c8afb
+    lda #0                                                            // 8afb: a9 00       ..
+    sta l00a9                                                         // 8afd: 85 a9       ..
+    sta l009e                                                         // 8aff: 85 9e       ..
+    rts                                                               // 8b01: 60          `
+
+// $8b02 referenced 3 times by $8c52, $8c7d, $a2bf
+sub_c8b02
+    pha                                                               // 8b02: 48          H
+    lda os_text_ptr                                                   // 8b03: a5 f2       ..
+    sta l00be                                                         // 8b05: 85 be       ..
+    lda l00f3                                                         // 8b07: a5 f3       ..
+    sta l00bf                                                         // 8b09: 85 bf       ..
+    pla                                                               // 8b0b: 68          h
+// $8b0c referenced 2 times by $8b0f, $8b18
+c8b0c
+    rts                                                               // 8b0c: 60          `
+
+sub_c8b0d
+    cpy #5                                                            // 8b0d: c0 05       ..
+    bne c8b0c                                                         // 8b0f: d0 fb       ..
+    lda #0                                                            // 8b11: a9 00       ..
+    sta l00a9                                                         // 8b13: 85 a9       ..
+    bit l0d6c                                                         // 8b15: 2c 6c 0d    ,l.
+    bmi c8b0c                                                         // 8b18: 30 f2       0.
+// $8b1a referenced 1 time by $8ce0
+sub_c8b1a
+    jsr sub_c8cb9                                                     // 8b1a: 20 b9 8c     ..
+    sta l00b1                                                         // 8b1d: 85 b1       ..
+    lda #0                                                            // 8b1f: a9 00       ..
+    sta l00b0                                                         // 8b21: 85 b0       ..
+    clc                                                               // 8b23: 18          .
+    ldy #$76 // 'v'                                                   // 8b24: a0 76       .v
+// $8b26 referenced 1 time by $8b29
+loop_c8b26
+    adc (l00b0),y                                                     // 8b26: 71 b0       q.
+    dey                                                               // 8b28: 88          .
+    bpl loop_c8b26                                                    // 8b29: 10 fb       ..
+    ldy #$77 // 'w'                                                   // 8b2b: a0 77       .w
+    eor (l00b0),y                                                     // 8b2d: 51 b0       Q.
+    beq c8b34                                                         // 8b2f: f0 03       ..
+    jmp c8fe4                                                         // 8b31: 4c e4 8f    L..
+
+// $8b34 referenced 1 time by $8b2f
+c8b34
+    jsr sub_c8cfc                                                     // 8b34: 20 fc 8c     ..
+    ldy #9                                                            // 8b37: a0 09       ..
+// $8b39 referenced 1 time by $8b41
+loop_c8b39
+    lda (l009c),y                                                     // 8b39: b1 9c       ..
+    sta l0dfe,y                                                       // 8b3b: 99 fe 0d    ...
+    dey                                                               // 8b3e: 88          .
+    cpy #1                                                            // 8b3f: c0 01       ..
+    bne loop_c8b39                                                    // 8b41: d0 f6       ..
+    rol l0d6c                                                         // 8b43: 2e 6c 0d    .l.
+    clc                                                               // 8b46: 18          .
+    ror l0d6c                                                         // 8b47: 6e 6c 0d    nl.
+    ldy #$0d                                                          // 8b4a: a0 0d       ..
+// $8b4c referenced 1 time by $8b53
+loop_c8b4c
+    lda l8e61,y                                                       // 8b4c: b9 61 8e    .a.
+    sta filev,y                                                       // 8b4f: 99 12 02    ...
+    dey                                                               // 8b52: 88          .
+    bpl loop_c8b4c                                                    // 8b53: 10 f7       ..
+    jsr sub_c8f5d                                                     // 8b55: 20 5d 8f     ].
+    ldy #$1b                                                          // 8b58: a0 1b       ..
+    ldx #7                                                            // 8b5a: a2 07       ..
+    jsr c8f70                                                         // 8b5c: 20 70 8f     p.
+    lda #0                                                            // 8b5f: a9 00       ..
+    sta l0e07                                                         // 8b61: 8d 07 0e    ...
+    sta l10c9                                                         // 8b64: 8d c9 10    ...
+    sta l1071                                                         // 8b67: 8d 71 10    .q.
+    sta l00a9                                                         // 8b6a: 85 a9       ..
+    jsr sub_cb98f                                                     // 8b6c: 20 8f b9     ..
+    sta l0e08                                                         // 8b6f: 8d 08 0e    ...
+    jsr sub_c8cc0                                                     // 8b72: 20 c0 8c     ..
+    jsr sub_cb449                                                     // 8b75: 20 49 b4     I.
+    ldy #$77 // 'w'                                                   // 8b78: a0 77       .w
+// $8b7a referenced 1 time by $8b80
+loop_c8b7a
+    lda (l00cc),y                                                     // 8b7a: b1 cc       ..
+    sta l1000,y                                                       // 8b7c: 99 00 10    ...
+    dey                                                               // 8b7f: 88          .
+    bpl loop_c8b7a                                                    // 8b80: 10 f8       ..
+    lda #$80                                                          // 8b82: a9 80       ..
+    ora l0d6c                                                         // 8b84: 0d 6c 0d    .l.
+    sta l0d6c                                                         // 8b87: 8d 6c 0d    .l.
+    jmp c8d08                                                         // 8b8a: 4c 08 8d    L..
+
+// $8b8d referenced 1 time by $8c7a
+c8b8d
+    ldx #$4a // 'J'                                                   // 8b8d: a2 4a       .J
+    jsr c8b98                                                         // 8b8f: 20 98 8b     ..
+sub_c8b92
+    ldx #0                                                            // 8b92: a2 00       ..
+    beq c8b98                                                         // 8b94: f0 02       ..
+sub_c8b96
+    ldx #$4a // 'J'                                                   // 8b96: a2 4a       .J
+// $8b98 referenced 2 times by $8b8f, $8b94
+c8b98
+    bvc c8ba8                                                         // 8b98: 50 0e       P.
+    txa                                                               // 8b9a: 8a          .
+    pha                                                               // 8b9b: 48          H
+    tya                                                               // 8b9c: 98          .
+    pha                                                               // 8b9d: 48          H
+    jsr sub_c8c9f                                                     // 8b9e: 20 9f 8c     ..
+    pla                                                               // 8ba1: 68          h
+    tay                                                               // 8ba2: a8          .
+    pla                                                               // 8ba3: 68          h
+    tax                                                               // 8ba4: aa          .
+    clv                                                               // 8ba5: b8          .
+    bvc c8bab                                                         // 8ba6: 50 03       P.
+// $8ba8 referenced 1 time by $8b98
+c8ba8
+    jsr osnewl                                                        // 8ba8: 20 e7 ff     ..
+// $8bab referenced 2 times by $8ba6, $8c6d
+c8bab
+    tya                                                               // 8bab: 98          .
+    pha                                                               // 8bac: 48          H
+    php                                                               // 8bad: 08          .
+// $8bae referenced 1 time by $8c2c
+c8bae
+    lda la3f0,x                                                       // 8bae: bd f0 a3    ...
+    bpl c8bb6                                                         // 8bb1: 10 03       ..
+    jmp c8c2f                                                         // 8bb3: 4c 2f 8c    L/.
+
+// $8bb6 referenced 1 time by $8bb1
+c8bb6
+    jsr print_inline_top_bit_clear                                    // 8bb6: 20 45 91     E.
+    .asc "  "                                                         // 8bb9: 20 20
+
+    ldy #9                                                            // 8bbb: a0 09       ..
+    lda la3f0,x                                                       // 8bbd: bd f0 a3    ...
+// $8bc0 referenced 1 time by $8bc8
+loop_c8bc0
+    jsr osasci                                                        // 8bc0: 20 e3 ff     ..
+    inx                                                               // 8bc3: e8          .
+    dey                                                               // 8bc4: 88          .
+    lda la3f0,x                                                       // 8bc5: bd f0 a3    ...
+    bpl loop_c8bc0                                                    // 8bc8: 10 f6       ..
+// $8bca referenced 1 time by $8bd0
+loop_c8bca
+    lda #$20 // ' '                                                   // 8bca: a9 20       .
+    jsr osasci                                                        // 8bcc: 20 e3 ff     ..
+    dey                                                               // 8bcf: 88          .
+    bpl loop_c8bca                                                    // 8bd0: 10 f8       ..
+    lda la3f0,x                                                       // 8bd2: bd f0 a3    ...
+    and #$1f                                                          // 8bd5: 29 1f       ).
+    cmp #$0e                                                          // 8bd7: c9 0e       ..
+    beq c8bf6                                                         // 8bd9: f0 1b       ..
+    tay                                                               // 8bdb: a8          .
+    lda l9122,y                                                       // 8bdc: b9 22 91    .".
+    tay                                                               // 8bdf: a8          .
+// $8be0 referenced 2 times by $8bed, $8bf3
+c8be0
+    iny                                                               // 8be0: c8          .
+    lda l9022,y                                                       // 8be1: b9 22 90    .".
+    beq c8c26                                                         // 8be4: f0 40       .@
+    cmp #$0d                                                          // 8be6: c9 0d       ..
+    bne c8bf0                                                         // 8be8: d0 06       ..
+    jsr sub_c8c33                                                     // 8bea: 20 33 8c     3.
+    jmp c8be0                                                         // 8bed: 4c e0 8b    L..
+
+// $8bf0 referenced 1 time by $8be8
+c8bf0
+    jsr osasci                                                        // 8bf0: 20 e3 ff     ..
+    jmp c8be0                                                         // 8bf3: 4c e0 8b    L..
+
+// $8bf6 referenced 1 time by $8bd9
+c8bf6
+    txa                                                               // 8bf6: 8a          .
+    pha                                                               // 8bf7: 48          H
+    jsr print_inline_top_bit_clear                                    // 8bf8: 20 45 91     E.
+    .asc "("                                                          // 8bfb: 28          (
+
+    ldy #0                                                            // 8bfc: a0 00       ..
+    ldx #$d3                                                          // 8bfe: a2 d3       ..
+// $8c00 referenced 1 time by $8c22
+c8c00
+    lda la3f0,x                                                       // 8c00: bd f0 a3    ...
+    bmi c8c24                                                         // 8c03: 30 1f       0.
+    dex                                                               // 8c05: ca          .
+// $8c06 referenced 1 time by $8c0f
+loop_c8c06
+    inx                                                               // 8c06: e8          .
+    lda la3f0,x                                                       // 8c07: bd f0 a3    ...
+    bmi c8c12                                                         // 8c0a: 30 06       0.
+    jsr osasci                                                        // 8c0c: 20 e3 ff     ..
+    jmp loop_c8c06                                                    // 8c0f: 4c 06 8c    L..
+
+// $8c12 referenced 1 time by $8c0a
+c8c12
+    and #$7f                                                          // 8c12: 29 7f       ).
+    jsr osasci                                                        // 8c14: 20 e3 ff     ..
+    iny                                                               // 8c17: c8          .
+    cpy #4                                                            // 8c18: c0 04       ..
+    bne c8c1f                                                         // 8c1a: d0 03       ..
+    jsr sub_c8c33                                                     // 8c1c: 20 33 8c     3.
+// $8c1f referenced 1 time by $8c1a
+c8c1f
+    inx                                                               // 8c1f: e8          .
+    inx                                                               // 8c20: e8          .
+    inx                                                               // 8c21: e8          .
+    bne c8c00                                                         // 8c22: d0 dc       ..
+// $8c24 referenced 1 time by $8c03
+c8c24
+    pla                                                               // 8c24: 68          h
+    tax                                                               // 8c25: aa          .
+// $8c26 referenced 1 time by $8be4
+c8c26
+    jsr osnewl                                                        // 8c26: 20 e7 ff     ..
+    inx                                                               // 8c29: e8          .
+    inx                                                               // 8c2a: e8          .
+    inx                                                               // 8c2b: e8          .
+    jmp c8bae                                                         // 8c2c: 4c ae 8b    L..
+
+// $8c2f referenced 1 time by $8bb3
+c8c2f
+    plp                                                               // 8c2f: 28          (
+    pla                                                               // 8c30: 68          h
+    tay                                                               // 8c31: a8          .
+    rts                                                               // 8c32: 60          `
+
+// $8c33 referenced 2 times by $8bea, $8c1c
+sub_c8c33
+    lda l0355                                                         // 8c33: ad 55 03    .U.
+    beq c8c4d                                                         // 8c36: f0 15       ..
+    cmp #3                                                            // 8c38: c9 03       ..
+    beq c8c4d                                                         // 8c3a: f0 11       ..
+    tya                                                               // 8c3c: 98          .
+    pha                                                               // 8c3d: 48          H
+    jsr osnewl                                                        // 8c3e: 20 e7 ff     ..
+    ldy #$0b                                                          // 8c41: a0 0b       ..
+    lda #$20 // ' '                                                   // 8c43: a9 20       .
+// $8c45 referenced 1 time by $8c49
+loop_c8c45
+    jsr osasci                                                        // 8c45: 20 e3 ff     ..
+    dey                                                               // 8c48: 88          .
+    bpl loop_c8c45                                                    // 8c49: 10 fa       ..
+    pla                                                               // 8c4b: 68          h
+    tay                                                               // 8c4c: a8          .
+// $8c4d referenced 2 times by $8c36, $8c3a
+c8c4d
+    rts                                                               // 8c4d: 60          `
+
+sub_c8c4e
+    ldx #0                                                            // 8c4e: a2 00       ..
+    ldy l00a8                                                         // 8c50: a4 a8       ..
+    jsr sub_c8b02                                                     // 8c52: 20 02 8b     ..
+    jsr sub_ca140                                                     // 8c55: 20 40 a1     @.
+    bcs c8c70                                                         // 8c58: b0 16       ..
+    jmp ca125                                                         // 8c5a: 4c 25 a1    L%.
+
+sub_c8c5d
+    jsr sub_c8d17                                                     // 8c5d: 20 17 8d     ..
+    ldy l00a8                                                         // 8c60: a4 a8       ..
+    lda (os_text_ptr),y                                               // 8c62: b1 f2       ..
+    cmp #$0d                                                          // 8c64: c9 0d       ..
+    bne c8c73                                                         // 8c66: d0 0b       ..
+    jsr sub_c8c9f                                                     // 8c68: 20 9f 8c     ..
+    ldx #$c4                                                          // 8c6b: a2 c4       ..
+    jsr c8bab                                                         // 8c6d: 20 ab 8b     ..
+// $8c70 referenced 3 times by $8c58, $8c9d, $8cd8
+c8c70
+    ldy l00a8                                                         // 8c70: a4 a8       ..
+    rts                                                               // 8c72: 60          `
+
+// $8c73 referenced 1 time by $8c66
+c8c73
+    bit l9491                                                         // 8c73: 2c 91 94    ,..
+    cmp #$2e // '.'                                                   // 8c76: c9 2e       ..
+    bne c8c7d                                                         // 8c78: d0 03       ..
+    jmp c8b8d                                                         // 8c7a: 4c 8d 8b    L..
+
+// $8c7d referenced 1 time by $8c78
+c8c7d
+    jsr sub_c8b02                                                     // 8c7d: 20 02 8b     ..
+// $8c80 referenced 1 time by $8c9b
+loop_c8c80
+    php                                                               // 8c80: 08          .
+    ldx #$c4                                                          // 8c81: a2 c4       ..
+    jsr sub_ca140                                                     // 8c83: 20 40 a1     @.
+    bcs c8c98                                                         // 8c86: b0 10       ..
+    plp                                                               // 8c88: 28          (
+    lda #$8c                                                          // 8c89: a9 8c       ..
+    pha                                                               // 8c8b: 48          H
+    lda #$7f                                                          // 8c8c: a9 7f       ..
+    pha                                                               // 8c8e: 48          H
+    lda la3f2,x                                                       // 8c8f: bd f2 a3    ...
+    pha                                                               // 8c92: 48          H
+    lda la3f1,x                                                       // 8c93: bd f1 a3    ...
+    pha                                                               // 8c96: 48          H
+    rts                                                               // 8c97: 60          `
+
+// $8c98 referenced 1 time by $8c86
+c8c98
+    plp                                                               // 8c98: 28          (
+    cmp #$0d                                                          // 8c99: c9 0d       ..
+    bne loop_c8c80                                                    // 8c9b: d0 e3       ..
+    beq c8c70                                                         // 8c9d: f0 d1       ..
+// $8c9f referenced 2 times by $8b9e, $8c68
+sub_c8c9f
+    jsr print_inline_top_bit_clear                                    // 8c9f: 20 45 91     E.
+    .asc $0d, "Advanced NFS 4.18", $0d                                // 8ca2: 0d 41 64... .Ad
+
+    nop                                                               // 8cb5: ea          .
+    jmp c8ff1                                                         // 8cb6: 4c f1 8f    L..
+
+// $8cb9 referenced 4 times by $8b1a, $8cc0, $8f87, $afe2
+sub_c8cb9
+    ldy romsel_copy                                                   // 8cb9: a4 f4       ..
+    lda l0df0,y                                                       // 8cbb: b9 f0 0d    ...
+    tay                                                               // 8cbe: a8          .
+    rts                                                               // 8cbf: 60          `
+
+// $8cc0 referenced 2 times by $8b72, $8ee7
+sub_c8cc0
+    jsr sub_c8cb9                                                     // 8cc0: 20 b9 8c     ..
+    sty l00cd                                                         // 8cc3: 84 cd       ..
+    lda #0                                                            // 8cc5: a9 00       ..
+    sta l00cc                                                         // 8cc7: 85 cc       ..
+// $8cc9 referenced 1 time by $8ceb
+c8cc9
+    rts                                                               // 8cc9: 60          `
+
+sub_c8cca
+    lda #osbyte_scan_keyboard_from_16                                 // 8cca: a9 7a       .z
+    jsr osbyte                                                        // 8ccc: 20 f4 ff     ..
+    txa                                                               // 8ccf: 8a          .
+    bmi c8ce0                                                         // 8cd0: 30 0e       0.
+    cmp #$19                                                          // 8cd2: c9 19       ..
+    beq c8cda                                                         // 8cd4: f0 04       ..
+    eor #$55 // 'U'                                                   // 8cd6: 49 55       IU
+    bne c8c70                                                         // 8cd8: d0 96       ..
+// $8cda referenced 1 time by $8cd4
+c8cda
+    tay                                                               // 8cda: a8          .
+    lda #osbyte_write_keys_pressed                                    // 8cdb: a9 78       .x
+    jsr osbyte                                                        // 8cdd: 20 f4 ff     ..
+// $8ce0 referenced 1 time by $8cd0
+c8ce0
+    jsr sub_c8b1a                                                     // 8ce0: 20 1a 8b     ..
+    jsr c8ff1                                                         // 8ce3: 20 f1 8f     ..
+    jsr osnewl                                                        // 8ce6: 20 e7 ff     ..
+    ldx l00a8                                                         // 8ce9: a6 a8       ..
+    bne c8cc9                                                         // 8ceb: d0 dc       ..
+    lda l1071                                                         // 8ced: ad 71 10    .q.
+    ora #4                                                            // 8cf0: 09 04       ..
+    sta l1071                                                         // 8cf2: 8d 71 10    .q.
+    ldx #$0f                                                          // 8cf5: a2 0f       ..
+    ldy #$8d                                                          // 8cf7: a0 8d       ..
+    jmp ca114                                                         // 8cf9: 4c 14 a1    L..
+
+// $8cfc referenced 1 time by $8b34
+sub_c8cfc
+    lda #6                                                            // 8cfc: a9 06       ..
+    jsr sub_c8d05                                                     // 8cfe: 20 05 8d     ..
+    ldx #$0a                                                          // 8d01: a2 0a       ..
+    bne c8d0a                                                         // 8d03: d0 05       ..
+// $8d05 referenced 1 time by $8cfe
+sub_c8d05
+    jmp (fscv)                                                        // 8d05: 6c 1e 02    l..
+
+// $8d08 referenced 1 time by $8b8a
+c8d08
+    ldx #$0f                                                          // 8d08: a2 0f       ..
+// $8d0a referenced 1 time by $8d03
+c8d0a
+    lda #osbyte_issue_service_request                                 // 8d0a: a9 8f       ..
+    jmp osbyte                                                        // 8d0c: 4c f4 ff    L..
+
+    .asc "i .boot"                                                    // 8d0f: 69 20 2e... i .
+    .byt $0d                                                          // 8d16: 0d          .
+
+// $8d17 referenced 1 time by $8c5d
+sub_c8d17
+    ldy l00a8                                                         // 8d17: a4 a8       ..
+    ldx #5                                                            // 8d19: a2 05       ..
+// $8d1b referenced 1 time by $8d24
+loop_c8d1b
+    lda (os_text_ptr),y                                               // 8d1b: b1 f2       ..
+    cmp l8d38,x                                                       // 8d1d: dd 38 8d    .8.
+    bne c8d26                                                         // 8d20: d0 04       ..
+    iny                                                               // 8d22: c8          .
+    inx                                                               // 8d23: e8          .
+    bne loop_c8d1b                                                    // 8d24: d0 f5       ..
+// $8d26 referenced 1 time by $8d20
+c8d26
+    cpx #$0d                                                          // 8d26: e0 0d       ..
+    bne c8d37                                                         // 8d28: d0 0d       ..
+    ldx #0                                                            // 8d2a: a2 00       ..
+// $8d2c referenced 1 time by $8d35
+loop_c8d2c
+    lda l8d38,x                                                       // 8d2c: bd 38 8d    .8.
+    beq c8d37                                                         // 8d2f: f0 06       ..
+    jsr osasci                                                        // 8d31: 20 e3 ff     ..
+    inx                                                               // 8d34: e8          .
+    bne loop_c8d2c                                                    // 8d35: d0 f5       ..
+// $8d37 referenced 2 times by $8d28, $8d2f
+c8d37
+    rts                                                               // 8d37: 60          `
+
+// $8d38 referenced 2 times by $8d1d, $8d2c
+l8d38
+    .byt $0d                                                          // 8d38: 0d          .
+    .asc "The authors of ANFS are;"                                   // 8d39: 54 68 65... The
+    .byt $0d                                                          // 8d51: 0d          .
+    .asc "B Cockburn"                                                 // 8d52: 42 20 43... B C
+    .byt $0d                                                          // 8d5c: 0d          .
+    .asc "J Du"                                                       // 8d5d: 4a 20 44... J D
+// $8d61 referenced 1 time by $b01b
+l8d61
+    .byt $6e, $6e, $0d                                                // 8d61: 6e 6e 0d    nn.
+    .asc "B Robertson"                                                // 8d64: 42 20 52... B R
+    .byt $0d                                                          // 8d6f: 0d          .
+    .asc "J Wills"                                                    // 8d70: 4a 20 57... J W
+    .byt $0d,   0                                                     // 8d77: 0d 00       ..
+
+sub_c8d79
+    tya                                                               // 8d79: 98          .
+    pha                                                               // 8d7a: 48          H
+    lda #osbyte_close_spool_exec                                      // 8d7b: a9 77       .w
+    sta l0e07                                                         // 8d7d: 8d 07 0e    ...
+    jsr osbyte                                                        // 8d80: 20 f4 ff     ..
+    ldy #0                                                            // 8d83: a0 00       ..
+    sty l00b4                                                         // 8d85: 84 b4       ..
+    jsr sub_cb799                                                     // 8d87: 20 99 b7     ..
+    lda #0                                                            // 8d8a: a9 00       ..
+    sta l0e07                                                         // 8d8c: 8d 07 0e    ...
+    pla                                                               // 8d8f: 68          h
+    tay                                                               // 8d90: a8          .
+    lda (l00bb),y                                                     // 8d91: b1 bb       ..
+    jsr sub_c9258                                                     // 8d93: 20 58 92     X.
+    bcc c8dbc                                                         // 8d96: 90 24       .$
+    jsr sub_c916e                                                     // 8d98: 20 6e 91     n.
+    bcs c8da7                                                         // 8d9b: b0 0a       ..
+    sta l0e01                                                         // 8d9d: 8d 01 0e    ...
+    jsr sub_c8e09                                                     // 8da0: 20 09 8e     ..
+    iny                                                               // 8da3: c8          .
+    jsr sub_c916e                                                     // 8da4: 20 6e 91     n.
+// $8da7 referenced 1 time by $8d9b
+c8da7
+    beq c8dbc                                                         // 8da7: f0 13       ..
+    sta l0e00                                                         // 8da9: 8d 00 0e    ...
+    ldx #$ff                                                          // 8dac: a2 ff       ..
+// $8dae referenced 1 time by $8db5
+loop_c8dae
+    inx                                                               // 8dae: e8          .
+    lda la477,x                                                       // 8daf: bd 77 a4    .w.
+    sta l0f05,x                                                       // 8db2: 9d 05 0f    ...
+    bpl loop_c8dae                                                    // 8db5: 10 f7       ..
+    jsr sub_caf06                                                     // 8db7: 20 06 af     ..
+    beq c8dbf                                                         // 8dba: f0 03       ..
+// $8dbc referenced 2 times by $8d96, $8da7
+c8dbc
+    jsr sub_caf02                                                     // 8dbc: 20 02 af     ..
+// $8dbf referenced 1 time by $8dba
+c8dbf
+    ldy #$ff                                                          // 8dbf: a0 ff       ..
+// $8dc1 referenced 1 time by $8dcb
+loop_c8dc1
+    iny                                                               // 8dc1: c8          .
+    lda l0f05,y                                                       // 8dc2: b9 05 0f    ...
+    cmp #$0d                                                          // 8dc5: c9 0d       ..
+    beq c8dfa                                                         // 8dc7: f0 31       .1
+    cmp #$3a // ':'                                                   // 8dc9: c9 3a       .:
+    bne loop_c8dc1                                                    // 8dcb: d0 f4       ..
+    jsr oswrch                                                        // 8dcd: 20 ee ff     ..
+    sty l00b4                                                         // 8dd0: 84 b4       ..
+// $8dd2 referenced 4 times by $8de2, $8de6, $8de9, $8df5
+c8dd2
+    lda #$ff                                                          // 8dd2: a9 ff       ..
+    sta l0098                                                         // 8dd4: 85 98       ..
+    jsr sub_c9570                                                     // 8dd6: 20 70 95     p.
+    jsr osrdch                                                        // 8dd9: 20 e0 ff     ..
+    cmp #$15                                                          // 8ddc: c9 15       ..
+    bne c8deb                                                         // 8dde: d0 0b       ..
+    ldy l00b4                                                         // 8de0: a4 b4       ..
+    bne c8dd2                                                         // 8de2: d0 ee       ..
+// $8de4 referenced 1 time by $8ded
+loop_c8de4
+    cpy l00b4                                                         // 8de4: c4 b4       ..
+    beq c8dd2                                                         // 8de6: f0 ea       ..
+    dey                                                               // 8de8: 88          .
+    bne c8dd2                                                         // 8de9: d0 e7       ..
+// $8deb referenced 1 time by $8dde
+c8deb
+    cmp #$7f                                                          // 8deb: c9 7f       ..
+    beq loop_c8de4                                                    // 8ded: f0 f5       ..
+    sta l0f05,y                                                       // 8def: 99 05 0f    ...
+    iny                                                               // 8df2: c8          .
+    cmp #$0d                                                          // 8df3: c9 0d       ..
+    bne c8dd2                                                         // 8df5: d0 db       ..
+    jsr osnewl                                                        // 8df7: 20 e7 ff     ..
+// $8dfa referenced 1 time by $8dc7
+c8dfa
+    tya                                                               // 8dfa: 98          .
+    pha                                                               // 8dfb: 48          H
+    jsr sub_c9473                                                     // 8dfc: 20 73 94     s.
+    jsr sub_c9894                                                     // 8dff: 20 94 98     ..
+    pla                                                               // 8e02: 68          h
+    tax                                                               // 8e03: aa          .
+    inx                                                               // 8e04: e8          .
+    ldy #0                                                            // 8e05: a0 00       ..
+    beq c8e24                                                         // 8e07: f0 1b       ..
+// $8e09 referenced 1 time by $8da0
+sub_c8e09
+    jsr sub_ca865                                                     // 8e09: 20 65 a8     e.
+    eor l0e01                                                         // 8e0c: 4d 01 0e    M..
+    bne c8e14                                                         // 8e0f: d0 03       ..
+    sta l0e01                                                         // 8e11: 8d 01 0e    ...
+// $8e14 referenced 1 time by $8e0f
+c8e14
+    rts                                                               // 8e14: 60          `
+
+// $8e15 referenced 1 time by $9462
+c8e15
+    ldy #0                                                            // 8e15: a0 00       ..
+    lda (l00be),y                                                     // 8e17: b1 be       ..
+    cmp #$26 // '&'                                                   // 8e19: c9 26       .&
+    bne c8e20                                                         // 8e1b: d0 03       ..
+    jmp ca1c1                                                         // 8e1d: 4c c1 a1    L..
+
+// $8e20 referenced 1 time by $8e1b
+c8e20
+    jsr sub_caf02                                                     // 8e20: 20 02 af     ..
+    tay                                                               // 8e23: a8          .
+// $8e24 referenced 2 times by $8e07, $9324
+c8e24
+    jsr c94ad                                                         // 8e24: 20 ad 94     ..
+    ldx l0f03                                                         // 8e27: ae 03 0f    ...
+    beq just_rts                                                      // 8e2a: f0 2c       .,
+    lda l0f05                                                         // 8e2c: ad 05 0f    ...
+    ldy #$17                                                          // 8e2f: a0 17       ..
+    bne jump_table_dispatch_x_plus_y                                  // 8e31: d0 16       ..
+    jsr sub_c9295                                                     // 8e33: 20 95 92     ..
+    cmp #8                                                            // 8e36: c9 08       ..
+    bcs just_rts                                                      // 8e38: b0 1e       ..
+    tax                                                               // 8e3a: aa          .
+    jsr sub_caf32                                                     // 8e3b: 20 32 af     2.
+    tya                                                               // 8e3e: 98          .
+    ldy #$13                                                          // 8e3f: a0 13       ..
+    bne jump_table_dispatch_x_plus_y                                  // 8e41: d0 06       ..
+    cpx #5                                                            // 8e43: e0 05       ..
+    bcs just_rts                                                      // 8e45: b0 11       ..
+    ldy #$0e                                                          // 8e47: a0 0e       ..
+// Note that if Y=0, this will add 1 instead of 0.
+// $8e49 referenced 5 times by $8ac5, $8e31, $8e41, $8e4b, $8ea2
+jump_table_dispatch_x_plus_y
+    inx                                                               // 8e49: e8          .
+    dey                                                               // 8e4a: 88          .
+    bpl jump_table_dispatch_x_plus_y                                  // 8e4b: 10 fc       ..
+    tay                                                               // 8e4d: a8          .
+    lda jump_table_high,x                                             // 8e4e: bd ef 89    ...
+    pha                                                               // 8e51: 48          H
+sub_c8e52
+l8e54 = sub_c8e52+2
+    lda jump_table_low,x                                              // 8e52: bd ca 89    ...
+// $8e54 referenced 2 times by $8f70, $8f76
+    pha                                                               // 8e55: 48          H
+    ldx l00bb                                                         // 8e56: a6 bb       ..
+// $8e58 referenced 3 times by $8e2a, $8e38, $8e45
+just_rts
+    rts                                                               // 8e58: 60          `
+
+    .asc "PRINT "                                                     // 8e59: 50 52 49... PRI
+    .byt 1, 0                                                         // 8e5f: 01 00       ..
+// $8e61 referenced 1 time by $8b4c
+l8e61
+    .byt $1b, $ff, $1e, $ff, $21, $ff, $24, $ff, $27, $ff, $2a, $ff   // 8e61: 1b ff 1e... ...
+    .byt $2d, $ff, $35, $99, $4a, $be, $9b, $44, $ce, $b7, $57, $4d   // 8e6d: 2d ff 35... -.5
+    .byt $b8, $42, $2f, $9e, $41, $4e, $9d, $52, $33, $8e             // 8e79: b8 42 2f... .B/
+
+// $8e83 referenced 3 times by $8081, $8f62, $970e
+sub_c8e83
+    ldx #0                                                            // 8e83: a2 00       ..
+// $8e85 referenced 1 time by $808b
+sub_c8e85
+    ldy #$ff                                                          // 8e85: a0 ff       ..
+// $8e87 referenced 1 time by $8e90
+loop_c8e87
+    jmp osbyte                                                        // 8e87: 4c f4 ff    L..
+
+    .byt $7a, $a9                                                     // 8e8a: 7a a9       z.
+
+// $8e8c referenced 1 time by $9722
+sub_c8e8c
+    ldx #0                                                            // 8e8c: a2 00       ..
+    ldy #0                                                            // 8e8e: a0 00       ..
+    beq loop_c8e87                                                    // 8e90: f0 f5       ..
+sub_c8e92
+    lda l00ef                                                         // 8e92: a5 ef       ..
+    sbc #$31 // '1'                                                   // 8e94: e9 31       .1
+    cmp #4                                                            // 8e96: c9 04       ..
+    bcs c8eab                                                         // 8e98: b0 11       ..
+    tax                                                               // 8e9a: aa          .
+    lda #0                                                            // 8e9b: a9 00       ..
+    sta l00a9                                                         // 8e9d: 85 a9       ..
+    tya                                                               // 8e9f: 98          .
+    ldy #$21 // '!'                                                   // 8ea0: a0 21       .!
+    jmp jump_table_dispatch_x_plus_y                                  // 8ea2: 4c 49 8e    LI.
+
+service_handler_claim_absolute_workspace
+    cpy #$16                                                          // 8ea5: c0 16       ..
+    bcs c8eab                                                         // 8ea7: b0 02       ..
+    ldy #$16                                                          // 8ea9: a0 16       ..
+// $8eab referenced 2 times by $8e98, $8ea7
+c8eab
+    rts                                                               // 8eab: 60          `
+
+// $8eac referenced 1 time by $8edf
+clamp_absolute_workspace_and_save
+    tya                                                               // 8eac: 98          .
+    cmp #$21 // '!'                                                   // 8ead: c9 21       .!
+    bcc c8eb3                                                         // 8eaf: 90 02       ..
+    lda #$21 // '!'                                                   // 8eb1: a9 21       .!
+// $8eb3 referenced 1 time by $8eaf
+c8eb3
+    ldy #$0b                                                          // 8eb3: a0 0b       ..
+    sta (l009c),y                                                     // 8eb5: 91 9c       ..
+    rts                                                               // 8eb7: 60          `
+
+service_handler_claim_private_workspace
+    sty l009d                                                         // 8eb8: 84 9d       ..
+    iny                                                               // 8eba: c8          .
+    sty l009f                                                         // 8ebb: 84 9f       ..
+    iny                                                               // 8ebd: c8          .
+    tya                                                               // 8ebe: 98          .
+    ldy romsel_copy                                                   // 8ebf: a4 f4       ..
+    sta l0df0,y                                                       // 8ec1: 99 f0 0d    ...
+    ldy lfe87                                                         // 8ec4: ac 87 fe    ...
+    lda #0                                                            // 8ec7: a9 00       ..
+    sta l009c                                                         // 8ec9: 85 9c       ..
+    sta l009e                                                         // 8ecb: 85 9e       ..
+    sta l00a8                                                         // 8ecd: 85 a8       ..
+    sta l0d60                                                         // 8ecf: 8d 60 0d    .`.
+    ldy #0                                                            // 8ed2: a0 00       ..
+    sta (l009c),y                                                     // 8ed4: 91 9c       ..
+    lda #osbyte_issue_service_request                                 // 8ed6: a9 8f       ..
+    ldx #service_claim_absolute_workspace                             // 8ed8: a2 01       ..
+    ldy #$0e                                                          // 8eda: a0 0e       ..
+    jsr osbyte                                                        // 8edc: 20 f4 ff     ..
+    jsr clamp_absolute_workspace_and_save                             // 8edf: 20 ac 8e     ..
+    lda l028d                                                         // 8ee2: ad 8d 02    ...
+    beq c8f40                                                         // 8ee5: f0 59       .Y
+    jsr sub_c8cc0                                                     // 8ee7: 20 c0 8c     ..
+    sta l0d6c                                                         // 8eea: 8d 6c 0d    .l.
+    tay                                                               // 8eed: a8          .
+// $8eee referenced 1 time by $8ef3
+loop_c8eee
+    sta (l00cc),y                                                     // 8eee: 91 cc       ..
+    sta (l009e),y                                                     // 8ef0: 91 9e       ..
+    iny                                                               // 8ef2: c8          .
+    bne loop_c8eee                                                    // 8ef3: d0 f9       ..
+    ldy #8                                                            // 8ef5: a0 08       ..
+    sta (l009c),y                                                     // 8ef7: 91 9c       ..
+    jsr sub_cb017                                                     // 8ef9: 20 17 b0     ..
+    ldy #2                                                            // 8efc: a0 02       ..
+    lda #$fe                                                          // 8efe: a9 fe       ..
+    sta l0e00                                                         // 8f00: 8d 00 0e    ...
+    sta (l009c),y                                                     // 8f03: 91 9c       ..
+    lda #0                                                            // 8f05: a9 00       ..
+    sta l0e01                                                         // 8f07: 8d 01 0e    ...
+    iny                                                               // 8f0a: c8          .
+    sta (l009c),y                                                     // 8f0b: 91 9c       ..
+    ldy #3                                                            // 8f0d: a0 03       ..
+    sta (l009e),y                                                     // 8f0f: 91 9e       ..
+    dey                                                               // 8f11: 88          .
+    lda #$eb                                                          // 8f12: a9 eb       ..
+    sta (l009e),y                                                     // 8f14: 91 9e       ..
+    ldx #3                                                            // 8f16: a2 03       ..
+// $8f18 referenced 1 time by $8f1f
+loop_c8f18
+    lda l8f48,x                                                       // 8f18: bd 48 8f    .H.
+    sta l0d6c,x                                                       // 8f1b: 9d 6c 0d    .l.
+    dex                                                               // 8f1e: ca          .
+    bne loop_c8f18                                                    // 8f1f: d0 f7       ..
+    stx l0d68                                                         // 8f21: 8e 68 0d    .h.
+    stx l0e05                                                         // 8f24: 8e 05 0e    ...
+    jsr caae2                                                         // 8f27: 20 e2 aa     ..
+    dex                                                               // 8f2a: ca          .
+    stx l0d71                                                         // 8f2b: 8e 71 0d    .q.
+// $8f2e referenced 1 time by $8f3b
+loop_c8f2e
+    lda l00a8                                                         // 8f2e: a5 a8       ..
+    jsr sub_ca0ce                                                     // 8f30: 20 ce a0     ..
+    bcs c8f3d                                                         // 8f33: b0 08       ..
+    lda #$3f // '?'                                                   // 8f35: a9 3f       .?
+    sta (l009e),y                                                     // 8f37: 91 9e       ..
+    inc l00a8                                                         // 8f39: e6 a8       ..
+    bne loop_c8f2e                                                    // 8f3b: d0 f1       ..
+// $8f3d referenced 1 time by $8f33
+c8f3d
+    jsr c8f8c                                                         // 8f3d: 20 8c 8f     ..
+// $8f40 referenced 1 time by $8ee5
+c8f40
+    ldy lfe18                                                         // 8f40: ac 18 fe    ...
+    tya                                                               // 8f43: 98          .
+    bne c8f4c                                                         // 8f44: d0 06       ..
+// $8f46 referenced 1 time by $8f4d
+loop_c8f46
+l8f48 = loop_c8f46+2
+    jmp c9215                                                         // 8f46: 4c 15 92    L..
+
+// $8f48 referenced 1 time by $8f18
+    .byt $ff, $28, $0a                                                // 8f49: ff 28 0a    .(.
+
+// $8f4c referenced 1 time by $8f44
+c8f4c
+    iny                                                               // 8f4c: c8          .
+    beq loop_c8f46                                                    // 8f4d: f0 f7       ..
+    ldy #1                                                            // 8f4f: a0 01       ..
+    sta (l009c),y                                                     // 8f51: 91 9c       ..
+    ldx #$40 // '@'                                                   // 8f53: a2 40       .@
+    stx l0d61                                                         // 8f55: 8e 61 0d    .a.
+    lda #3                                                            // 8f58: a9 03       ..
+    jsr sub_cab1b                                                     // 8f5a: 20 1b ab     ..
+// $8f5d referenced 1 time by $8b55
+sub_c8f5d
+    jsr sub_c8074                                                     // 8f5d: 20 74 80     t.
+    lda #$a8                                                          // 8f60: a9 a8       ..
+    jsr sub_c8e83                                                     // 8f62: 20 83 8e     ..
+    stx l00b8                                                         // 8f65: 86 b8       ..
+    sty l00b9                                                         // 8f67: 84 b9       ..
+    ldy #$36 // '6'                                                   // 8f69: a0 36       .6
+    sty netv                                                          // 8f6b: 8c 24 02    .$.
+    ldx #1                                                            // 8f6e: a2 01       ..
+// $8f70 referenced 2 times by $8b5c, $8f82
+c8f70
+    lda l8e54,y                                                       // 8f70: b9 54 8e    .T.
+    sta (l00b8),y                                                     // 8f73: 91 b8       ..
+    iny                                                               // 8f75: c8          .
+    lda l8e54,y                                                       // 8f76: b9 54 8e    .T.
+    sta (l00b8),y                                                     // 8f79: 91 b8       ..
+    iny                                                               // 8f7b: c8          .
+    lda romsel_copy                                                   // 8f7c: a5 f4       ..
+    sta (l00b8),y                                                     // 8f7e: 91 b8       ..
+    iny                                                               // 8f80: c8          .
+    dex                                                               // 8f81: ca          .
+    bne c8f70                                                         // 8f82: d0 ec       ..
+    jsr sub_c8f99                                                     // 8f84: 20 99 8f     ..
+    jsr sub_c8cb9                                                     // 8f87: 20 b9 8c     ..
+    iny                                                               // 8f8a: c8          .
+    rts                                                               // 8f8b: 60          `
+
+// $8f8c referenced 3 times by $8f3d, $8fa8, $a38e
+c8f8c
+    ldy #9                                                            // 8f8c: a0 09       ..
+// $8f8e referenced 1 time by $8f96
+loop_c8f8e
+    lda l0dfe,y                                                       // 8f8e: b9 fe 0d    ...
+    sta (l009c),y                                                     // 8f91: 91 9c       ..
+    dey                                                               // 8f93: 88          .
+    cpy #1                                                            // 8f94: c0 01       ..
+    bne loop_c8f8e                                                    // 8f96: d0 f6       ..
+    rts                                                               // 8f98: 60          `
+
+// $8f99 referenced 1 time by $8f84
+sub_c8f99
+    bit l0d6c                                                         // 8f99: 2c 6c 0d    ,l.
+    bpl c8fca                                                         // 8f9c: 10 2c       .,
+    ldy #0                                                            // 8f9e: a0 00       ..
+    jsr sub_cb799                                                     // 8fa0: 20 99 b7     ..
+    lda #osbyte_close_spool_exec                                      // 8fa3: a9 77       .w
+    jsr osbyte                                                        // 8fa5: 20 f4 ff     ..
+    jsr c8f8c                                                         // 8fa8: 20 8c 8f     ..
+    ldy #$76 // 'v'                                                   // 8fab: a0 76       .v
+    lda #0                                                            // 8fad: a9 00       ..
+    clc                                                               // 8faf: 18          .
+// $8fb0 referenced 1 time by $8fb4
+loop_c8fb0
+    adc l1000,y                                                       // 8fb0: 79 00 10    y..
+    dey                                                               // 8fb3: 88          .
+    bpl loop_c8fb0                                                    // 8fb4: 10 fa       ..
+    ldy #$77 // 'w'                                                   // 8fb6: a0 77       .w
+    bpl c8fbd                                                         // 8fb8: 10 03       ..
+// $8fba referenced 1 time by $8fc0
+loop_c8fba
+    lda l1000,y                                                       // 8fba: b9 00 10    ...
+// $8fbd referenced 1 time by $8fb8
+c8fbd
+    sta (l00cc),y                                                     // 8fbd: 91 cc       ..
+    dey                                                               // 8fbf: 88          .
+    bpl loop_c8fba                                                    // 8fc0: 10 f8       ..
+    lda l0d6c                                                         // 8fc2: ad 6c 0d    .l.
+    and #$7f                                                          // 8fc5: 29 7f       ).
+    sta l0d6c                                                         // 8fc7: 8d 6c 0d    .l.
+// $8fca referenced 1 time by $8f9c
+c8fca
+    rts                                                               // 8fca: 60          `
+
+// $8fcb referenced 2 times by $9dee, $b5fb
+sub_c8fcb
+    php                                                               // 8fcb: 08          .
+    pha                                                               // 8fcc: 48          H
+    tya                                                               // 8fcd: 98          .
+    pha                                                               // 8fce: 48          H
+    ldy #$76 // 'v'                                                   // 8fcf: a0 76       .v
+    lda #0                                                            // 8fd1: a9 00       ..
+    clc                                                               // 8fd3: 18          .
+// $8fd4 referenced 1 time by $8fd7
+loop_c8fd4
+    adc (l00cc),y                                                     // 8fd4: 71 cc       q.
+    dey                                                               // 8fd6: 88          .
+    bpl loop_c8fd4                                                    // 8fd7: 10 fb       ..
+    ldy #$77 // 'w'                                                   // 8fd9: a0 77       .w
+    cmp (l00cc),y                                                     // 8fdb: d1 cc       ..
+    bne c8fe4                                                         // 8fdd: d0 05       ..
+    pla                                                               // 8fdf: 68          h
+    tay                                                               // 8fe0: a8          .
+    pla                                                               // 8fe1: 68          h
+    plp                                                               // 8fe2: 28          (
+    rts                                                               // 8fe3: 60          `
+
+// $8fe4 referenced 2 times by $8b31, $8fdd
+c8fe4
+    lda #$aa                                                          // 8fe4: a9 aa       ..
+    jsr generate_error_inline                                         // 8fe6: 20 b8 96     ..
+    .asc "net sum", 0                                                 // 8fe9: 6e 65 74... net
+
+// $8ff1 referenced 2 times by $8cb6, $8ce3
+c8ff1
+    jsr print_inline_top_bit_clear                                    // 8ff1: 20 45 91     E.
+    .asc "Econet Station "                                            // 8ff4: 45 63 6f... Eco
+
+    ldy #1                                                            // 9003: a0 01       ..
+    lda (l009c),y                                                     // 9005: b1 9c       ..
+    jsr sub_caf85                                                     // 9007: 20 85 af     ..
+    lda #$20 // ' '                                                   // 900a: a9 20       .
+    bit lfea1                                                         // 900c: 2c a1 fe    ,..
+    beq c901e                                                         // 900f: f0 0d       ..
+    jsr print_inline_top_bit_clear                                    // 9011: 20 45 91     E.
+    .asc " No Clock"                                                  // 9014: 20 4e 6f...  No
+
+    nop                                                               // 901d: ea          .
+// $901e referenced 1 time by $900f
+c901e
+    jsr osnewl                                                        // 901e: 20 e7 ff     ..
+    rts                                                               // 9021: 60          `
+
+// $9022 referenced 1 time by $8be1
+l9022
+    .asc "(<dir>)"                                                    // 9022: 28 3c 64... (<d
+    .byt 0                                                            // 9029: 00          .
+    .asc "(<stn. id.>) <user id.> "                                   // 902a: 28 3c 73... (<s
+    .byt $0d                                                          // 9042: 0d          .
+    .asc "((:<CR>)<password>)"                                        // 9043: 28 28 3a... ((:
+    .byt 0                                                            // 9056: 00          .
+    .asc "<object>"                                                   // 9057: 3c 6f 62... <ob
+    .byt 0                                                            // 905f: 00          .
+    .asc "<filename> (<offset> "                                      // 9060: 3c 66 69... <fi
+    .byt $0d                                                          // 9075: 0d          .
+    .asc "(<address>))"                                               // 9076: 28 3c 61... (<a
+    .byt 0                                                            // 9082: 00          .
+    .asc "<dir>"                                                      // 9083: 3c 64 69... <di
+    .byt 0                                                            // 9088: 00          .
+    .asc "<dir> (<number>)"                                           // 9089: 3c 64 69... <di
+    .byt 0                                                            // 9099: 00          .
+    .asc "(:<CR>) <password> "                                        // 909a: 28 3a 3c... (:<
+    .byt $0d                                                          // 90ad: 0d          .
+    .asc "<new password>"                                             // 90ae: 3c 6e 65... <ne
+    .byt 0                                                            // 90bc: 00          .
+    .asc "(<stn. id.>|<ps type>)"                                     // 90bd: 28 3c 73... (<s
+    .byt 0                                                            // 90d3: 00          .
+    .asc "<object> (L)(W)(R)(", $2f, "(W)(R))"                        // 90d4: 3c 6f 62... <ob
+    .byt 0                                                            // 90ef: 00          .
+    .asc "<filename> <new filename>"                                  // 90f0: 3c 66 69... <fi
+    .byt 0                                                            // 9109: 00          .
+    .asc "(<stn. id.>)"                                               // 910a: 28 3c 73... (<s
+    .byt 0                                                            // 9116: 00          .
+    .asc "<filename>"                                                 // 9117: 3c 66 69... <fi
+    .byt 0                                                            // 9121: 00          .
+// $9122 referenced 1 time by $8bdc
+l9122
+    .byt   6, $ff,   7                                                // 9122: 06 ff 07    ...
+    .asc "4=`fw"                                                      // 9125: 34 3d 60... 4=`
+    .byt $9a, $b1, $cd, $e7, $f4                                      // 912a: 9a b1 cd... ...
+
+// $912f referenced 4 times by $9a66, $ae11, $ba6a, $bb04
+sub_c912f
+    pha                                                               // 912f: 48          H
+    lsr                                                               // 9130: 4a          J
+    lsr                                                               // 9131: 4a          J
+    lsr                                                               // 9132: 4a          J
+    lsr                                                               // 9133: 4a          J
+    jsr sub_c9138                                                     // 9134: 20 38 91     8.
+    pla                                                               // 9137: 68          h
+// $9138 referenced 1 time by $9134
+sub_c9138
+    and #$0f                                                          // 9138: 29 0f       ).
+    cmp #$0a                                                          // 913a: c9 0a       ..
+    bcc c9140                                                         // 913c: 90 02       ..
+    adc #6                                                            // 913e: 69 06       i.
+// $9140 referenced 1 time by $913c
+c9140
+    adc #$30 // '0'                                                   // 9140: 69 30       i0
+    jmp osasci                                                        // 9142: 4c e3 ff    L..
+
+// $9145 referenced 35 times by $8bb6, $8bf8, $8c9f, $8ff1, $9011, $953a, $adc0, $adca, $add8, $ade3, $adff, $ae14, $ae27, $ae36, $af53, $b0a2, $b0ae, $b0c5, $b0cf, $b0da, $b1aa, $b24c, $b261, $b284, $b291, $b2a0, $b2b0, $b2bf, $b3c4, $b3e4, $b431, $ba86, $ba9f, $baac, $bae0
+print_inline_top_bit_clear
+    pla                                                               // 9145: 68          h
+    sta l00b8                                                         // 9146: 85 b8       ..
+    pla                                                               // 9148: 68          h
+    sta l00b9                                                         // 9149: 85 b9       ..
+    ldy #0                                                            // 914b: a0 00       ..
+// $914d referenced 1 time by $9168
+loop_c914d
+    inc l00b8                                                         // 914d: e6 b8       ..
+    bne c9153                                                         // 914f: d0 02       ..
+    inc l00b9                                                         // 9151: e6 b9       ..
+// $9153 referenced 1 time by $914f
+c9153
+    lda (l00b8),y                                                     // 9153: b1 b8       ..
+    bmi c916b                                                         // 9155: 30 14       0.
+    lda l00b8                                                         // 9157: a5 b8       ..
+    pha                                                               // 9159: 48          H
+    lda l00b9                                                         // 915a: a5 b9       ..
+    pha                                                               // 915c: 48          H
+    lda (l00b8),y                                                     // 915d: b1 b8       ..
+    jsr osasci                                                        // 915f: 20 e3 ff     ..
+    pla                                                               // 9162: 68          h
+    sta l00b9                                                         // 9163: 85 b9       ..
+    pla                                                               // 9165: 68          h
+    sta l00b8                                                         // 9166: 85 b8       ..
+    jmp loop_c914d                                                    // 9168: 4c 4d 91    LM.
+
+// $916b referenced 1 time by $9155
+c916b
+    jmp (l00b8)                                                       // 916b: 6c b8 00    l..
+
+// $916e referenced 5 times by $8d98, $8da4, $a0ad, $a0c2, $ad24
+sub_c916e
+    lda #0                                                            // 916e: a9 00       ..
+    sta l00b2                                                         // 9170: 85 b2       ..
+    lda (l00be),y                                                     // 9172: b1 be       ..
+    cmp #$26 // '&'                                                   // 9174: c9 26       .&
+    bne c91ae                                                         // 9176: d0 36       .6
+    iny                                                               // 9178: c8          .
+    lda (l00be),y                                                     // 9179: b1 be       ..
+    bcs c9188                                                         // 917b: b0 0b       ..
+// $917d referenced 1 time by $91ac
+c917d
+    iny                                                               // 917d: c8          .
+    lda (l00be),y                                                     // 917e: b1 be       ..
+    cmp #$2e // '.'                                                   // 9180: c9 2e       ..
+    beq c91fb                                                         // 9182: f0 77       .w
+    cmp #$21 // '!'                                                   // 9184: c9 21       .!
+    bcc c91da                                                         // 9186: 90 52       .R
+// $9188 referenced 1 time by $917b
+c9188
+    cmp #$30 // '0'                                                   // 9188: c9 30       .0
+    bcc c9198                                                         // 918a: 90 0c       ..
+    cmp #$3a // ':'                                                   // 918c: c9 3a       .:
+    bcc c919a                                                         // 918e: 90 0a       ..
+    and #$5f // '_'                                                   // 9190: 29 5f       )_
+    adc #$b8                                                          // 9192: 69 b8       i.
+    bcs c9208                                                         // 9194: b0 72       .r
+    cmp #$fa                                                          // 9196: c9 fa       ..
+// $9198 referenced 1 time by $918a
+c9198
+    bcc c9208                                                         // 9198: 90 6e       .n
+// $919a referenced 1 time by $918e
+c919a
+    and #$0f                                                          // 919a: 29 0f       ).
+    sta l00b3                                                         // 919c: 85 b3       ..
+    lda l00b2                                                         // 919e: a5 b2       ..
+    cmp #$10                                                          // 91a0: c9 10       ..
+    bcs c9211                                                         // 91a2: b0 6d       .m
+    asl                                                               // 91a4: 0a          .
+    asl                                                               // 91a5: 0a          .
+    asl                                                               // 91a6: 0a          .
+    asl                                                               // 91a7: 0a          .
+    adc l00b3                                                         // 91a8: 65 b3       e.
+    sta l00b2                                                         // 91aa: 85 b2       ..
+    bcc c917d                                                         // 91ac: 90 cf       ..
+// $91ae referenced 2 times by $9176, $91d8
+c91ae
+    lda (l00be),y                                                     // 91ae: b1 be       ..
+    cmp #$2e // '.'                                                   // 91b0: c9 2e       ..
+    beq c91fb                                                         // 91b2: f0 47       .G
+    cmp #$21 // '!'                                                   // 91b4: c9 21       .!
+    bcc c91da                                                         // 91b6: 90 22       ."
+    jsr sub_c9260                                                     // 91b8: 20 60 92     `.
+    bcc c9229                                                         // 91bb: 90 6c       .l
+    and #$0f                                                          // 91bd: 29 0f       ).
+    sta l00b3                                                         // 91bf: 85 b3       ..
+    asl l00b2                                                         // 91c1: 06 b2       ..
+    bcs c9211                                                         // 91c3: b0 4c       .L
+    lda l00b2                                                         // 91c5: a5 b2       ..
+    asl                                                               // 91c7: 0a          .
+    bcs c9211                                                         // 91c8: b0 47       .G
+    asl                                                               // 91ca: 0a          .
+    bcs c9211                                                         // 91cb: b0 44       .D
+    adc l00b2                                                         // 91cd: 65 b2       e.
+    bcs c9211                                                         // 91cf: b0 40       .@
+    adc l00b3                                                         // 91d1: 65 b3       e.
+    bcs c9211                                                         // 91d3: b0 3c       .<
+    sta l00b2                                                         // 91d5: 85 b2       ..
+    iny                                                               // 91d7: c8          .
+    bne c91ae                                                         // 91d8: d0 d4       ..
+// $91da referenced 2 times by $9186, $91b6
+c91da
+    lda l00b4                                                         // 91da: a5 b4       ..
+    bpl c91e3                                                         // 91dc: 10 05       ..
+    lda l00b2                                                         // 91de: a5 b2       ..
+    beq c9235                                                         // 91e0: f0 53       .S
+    rts                                                               // 91e2: 60          `
+
+// $91e3 referenced 1 time by $91dc
+c91e3
+    lda l00b2                                                         // 91e3: a5 b2       ..
+    cmp #$ff                                                          // 91e5: c9 ff       ..
+    beq c9215                                                         // 91e7: f0 2c       .,
+    lda l00b2                                                         // 91e9: a5 b2       ..
+    bne c91f9                                                         // 91eb: d0 0c       ..
+    lda l00b4                                                         // 91ed: a5 b4       ..
+    beq c9215                                                         // 91ef: f0 24       .$
+    dey                                                               // 91f1: 88          .
+    lda (l00be),y                                                     // 91f2: b1 be       ..
+    iny                                                               // 91f4: c8          .
+    eor #$2e // '.'                                                   // 91f5: 49 2e       I.
+    bne c9215                                                         // 91f7: d0 1c       ..
+// $91f9 referenced 1 time by $91eb
+c91f9
+    sec                                                               // 91f9: 38          8
+    rts                                                               // 91fa: 60          `
+
+// $91fb referenced 2 times by $9182, $91b2
+c91fb
+    lda l00b4                                                         // 91fb: a5 b4       ..
+    bne c9229                                                         // 91fd: d0 2a       .*
+    inc l00b4                                                         // 91ff: e6 b4       ..
+    lda l00b2                                                         // 9201: a5 b2       ..
+    cmp #$ff                                                          // 9203: c9 ff       ..
+    beq c9244                                                         // 9205: f0 3d       .=
+    rts                                                               // 9207: 60          `
+
+// $9208 referenced 3 times by $9194, $9198, $bb6b
+c9208
+    lda #$f1                                                          // 9208: a9 f1       ..
+    jsr generate_error_inline                                         // 920a: 20 b8 96     ..
+    .asc "hex", 0                                                     // 920d: 68 65 78... hex
+
+// $9211 referenced 6 times by $91a2, $91c3, $91c8, $91cb, $91cf, $91d3
+c9211
+    bit l00b4                                                         // 9211: 24 b4       $.
+    bmi c9235                                                         // 9213: 30 20       0
+// $9215 referenced 4 times by $8f46, $91e7, $91ef, $91f7
+c9215
+    lda #$d0                                                          // 9215: a9 d0       ..
+    jsr generate_error_inline                                         // 9217: 20 b8 96     ..
+    .asc "station number", 0                                          // 921a: 73 74 61... sta
+
+// $9229 referenced 2 times by $91bb, $91fd
+c9229
+    lda #$f0                                                          // 9229: a9 f0       ..
+    jsr generate_error_inline                                         // 922b: 20 b8 96     ..
+    .asc "number", 0                                                  // 922e: 6e 75 6d... num
+
+// $9235 referenced 2 times by $91e0, $9213
+c9235
+    lda #$94                                                          // 9235: a9 94       ..
+    jsr generate_error_inline                                         // 9237: 20 b8 96     ..
+    .asc "parameter", 0                                               // 923a: 70 61 72... par
+
+// $9244 referenced 1 time by $9205
+c9244
+    lda #$d1                                                          // 9244: a9 d1       ..
+    jsr generate_error_inline                                         // 9246: 20 b8 96     ..
+    .asc "network number", 0                                          // 9249: 6e 65 74... net
+
+// $9258 referenced 3 times by $8d93, $b005, $b1dc
+sub_c9258
+    cmp #$26 // '&'                                                   // 9258: c9 26       .&
+    beq c9266                                                         // 925a: f0 0a       ..
+    cmp #$2e // '.'                                                   // 925c: c9 2e       ..
+    beq c9266                                                         // 925e: f0 06       ..
+// $9260 referenced 1 time by $91b8
+sub_c9260
+    cmp #$3a // ':'                                                   // 9260: c9 3a       .:
+    bcs c9267                                                         // 9262: b0 03       ..
+    cmp #$30 // '0'                                                   // 9264: c9 30       .0
+// $9266 referenced 2 times by $925a, $925e
+c9266
+    rts                                                               // 9266: 60          `
+
+// $9267 referenced 1 time by $9262
+c9267
+    clc                                                               // 9267: 18          .
+    rts                                                               // 9268: 60          `
+
+// $9269 referenced 2 times by $9b20, $9b4c
+sub_c9269
+    ldy #$0e                                                          // 9269: a0 0e       ..
+    lda (l00bb),y                                                     // 926b: b1 bb       ..
+    and #$3f // '?'                                                   // 926d: 29 3f       )?
+    ldx #4                                                            // 926f: a2 04       ..
+    bne c9277                                                         // 9271: d0 04       ..
+// $9273 referenced 2 times by $9a2a, $9b69
+sub_c9273
+    and #$1f                                                          // 9273: 29 1f       ).
+    ldx #$ff                                                          // 9275: a2 ff       ..
+// $9277 referenced 1 time by $9271
+c9277
+    sta l00b8                                                         // 9277: 85 b8       ..
+    lda #0                                                            // 9279: a9 00       ..
+// $927b referenced 1 time by $9283
+loop_c927b
+    inx                                                               // 927b: e8          .
+    lsr l00b8                                                         // 927c: 46 b8       F.
+    bcc c9283                                                         // 927e: 90 03       ..
+    ora l9286,x                                                       // 9280: 1d 86 92    ...
+// $9283 referenced 1 time by $927e
+c9283
+    bne loop_c927b                                                    // 9283: d0 f6       ..
+    rts                                                               // 9285: 60          `
+
+// $9286 referenced 1 time by $9280
+l9286
+    .byt $50, $20,   5,   2, $88,   4,   8, $80, $10,   1,   2        // 9286: 50 20 05... P .
+
+// $9291 referenced 1 time by $a114
+sub_c9291
+    stx os_text_ptr                                                   // 9291: 86 f2       ..
+    sty l00f3                                                         // 9293: 84 f3       ..
+// $9295 referenced 2 times by $8e33, $ad80
+sub_c9295
+    sta l00bd                                                         // 9295: 85 bd       ..
+    stx l00be                                                         // 9297: 86 be       ..
+    sty l00bf                                                         // 9299: 84 bf       ..
+// $929b referenced 1 time by $b984
+sub_c929b
+    stx l00bb                                                         // 929b: 86 bb       ..
+    sty l00bc                                                         // 929d: 84 bc       ..
+// $929f referenced 1 time by $9885
+c929f
+    php                                                               // 929f: 08          .
+    lsr l0098                                                         // 92a0: 46 98       F.
+    plp                                                               // 92a2: 28          (
+    rts                                                               // 92a3: 60          `
+
+// $92a4 referenced 2 times by $9998, $9a9b
+sub_c92a4
+    ldx #4                                                            // 92a4: a2 04       ..
+// $92a6 referenced 1 time by $92ad
+loop_c92a6
+    lda l00af,x                                                       // 92a6: b5 af       ..
+    eor l00b3,x                                                       // 92a8: 55 b3       U.
+    bne c92af                                                         // 92aa: d0 03       ..
+    dex                                                               // 92ac: ca          .
+    bne loop_c92a6                                                    // 92ad: d0 f7       ..
+// $92af referenced 1 time by $92aa
+c92af
+    rts                                                               // 92af: 60          `
+
+sub_c92b0
+    ldx #$20 // ' '                                                   // 92b0: a2 20       .
+    ldy #$2f // '/'                                                   // 92b2: a0 2f       ./
+    rts                                                               // 92b4: 60          `
+
+    .byt   8, $48, $8a, $48, $ba, $bd,   2,   1, $20, $6b, $b4, $30   // 92b5: 08 48 8a... .H.
+    .byt $1f, $a9, $40, $1d, $60, $10, $9d, $60, $10, $d0, $15,   8   // 92c1: 1f a9 40... ..@
+    .byt $48, $8a, $48, $ba, $bd,   2,   1, $20, $6b, $b4, $30,   8   // 92cd: 48 8a 48... H.H
+    .byt $a9, $bf, $3d, $60, $10, $9d, $60, $10, $68, $aa             // 92d9: a9 bf 3d... ..=
+    .asc "h(`"                                                        // 92e3: 68 28 60    h(`
+
+sub_c92e6
+    jsr sub_c9327                                                     // 92e6: 20 27 93     '.
+    txa                                                               // 92e9: 8a          .
+    pha                                                               // 92ea: 48          H
+    jsr sub_c9349                                                     // 92eb: 20 49 93     I.
+    jsr sub_cae97                                                     // 92ee: 20 97 ae     ..
+    pla                                                               // 92f1: 68          h
+    tax                                                               // 92f2: aa          .
+    jsr sub_c9309                                                     // 92f3: 20 09 93     ..
+    cmp #$0d                                                          // 92f6: c9 0d       ..
+    bne c9311                                                         // 92f8: d0 17       ..
+// $92fa referenced 3 times by $930e, $9409, $aedf
+c92fa
+    lda #$cc                                                          // 92fa: a9 cc       ..
+    jsr generate_error_inline                                         // 92fc: 20 b8 96     ..
+    .asc "file name", 0                                               // 92ff: 66 69 6c... fil
+
+// $9309 referenced 2 times by $92f3, $9311
+sub_c9309
+    lda l0e30                                                         // 9309: ad 30 0e    .0.
+    cmp #$26 // '&'                                                   // 930c: c9 26       .&
+    beq c92fa                                                         // 930e: f0 ea       ..
+    rts                                                               // 9310: 60          `
+
+// $9311 referenced 3 times by $92f8, $931f, $93da
+c9311
+    jsr sub_c9309                                                     // 9311: 20 09 93     ..
+    sta l0f05,x                                                       // 9314: 9d 05 0f    ...
+    inx                                                               // 9317: e8          .
+    cmp #$0d                                                          // 9318: c9 0d       ..
+    beq c9322                                                         // 931a: f0 06       ..
+    jsr caeb7                                                         // 931c: 20 b7 ae     ..
+    jmp c9311                                                         // 931f: 4c 11 93    L..
+
+// $9322 referenced 2 times by $931a, $9402
+c9322
+    ldy #0                                                            // 9322: a0 00       ..
+    jmp c8e24                                                         // 9324: 4c 24 8e    L$.
+
+// $9327 referenced 2 times by $92e6, $938b
+sub_c9327
+    tya                                                               // 9327: 98          .
+    pha                                                               // 9328: 48          H
+// $9329 referenced 1 time by $932d
+loop_c9329
+    dex                                                               // 9329: ca          .
+    lda la3f0,x                                                       // 932a: bd f0 a3    ...
+    bpl loop_c9329                                                    // 932d: 10 fa       ..
+    inx                                                               // 932f: e8          .
+    ldy #0                                                            // 9330: a0 00       ..
+// $9332 referenced 1 time by $933c
+loop_c9332
+    lda la3f0,x                                                       // 9332: bd f0 a3    ...
+    bmi c933e                                                         // 9335: 30 07       0.
+    sta l0f05,y                                                       // 9337: 99 05 0f    ...
+    inx                                                               // 933a: e8          .
+    iny                                                               // 933b: c8          .
+    bne loop_c9332                                                    // 933c: d0 f4       ..
+// $933e referenced 1 time by $9335
+c933e
+    lda #$20 // ' '                                                   // 933e: a9 20       .
+    sta l0f05,y                                                       // 9340: 99 05 0f    ...
+    iny                                                               // 9343: c8          .
+    tya                                                               // 9344: 98          .
+    tax                                                               // 9345: aa          .
+    pla                                                               // 9346: 68          h
+    tay                                                               // 9347: a8          .
+// $9348 referenced 1 time by $937d
+c9348
+    rts                                                               // 9348: 60          `
+
+// $9349 referenced 2 times by $92eb, $9393
+sub_c9349
+    lda #0                                                            // 9349: a9 00       ..
+    tax                                                               // 934b: aa          .
+    sta l10d8                                                         // 934c: 8d d8 10    ...
+// $934f referenced 1 time by $9356
+loop_c934f
+    lda (l00be),y                                                     // 934f: b1 be       ..
+    cmp #$20 // ' '                                                   // 9351: c9 20       .
+    bne c9358                                                         // 9353: d0 03       ..
+    iny                                                               // 9355: c8          .
+    bne loop_c934f                                                    // 9356: d0 f7       ..
+// $9358 referenced 1 time by $9353
+c9358
+    cmp #$22 // '"'                                                   // 9358: c9 22       ."
+    bne c9363                                                         // 935a: d0 07       ..
+    iny                                                               // 935c: c8          .
+    eor l10d8                                                         // 935d: 4d d8 10    M..
+    sta l10d8                                                         // 9360: 8d d8 10    ...
+// $9363 referenced 2 times by $935a, $9378
+c9363
+    lda (l00be),y                                                     // 9363: b1 be       ..
+    cmp #$22 // '"'                                                   // 9365: c9 22       ."
+    bne c9371                                                         // 9367: d0 08       ..
+    eor l10d8                                                         // 9369: 4d d8 10    M..
+    sta l10d8                                                         // 936c: 8d d8 10    ...
+    lda #$20 // ' '                                                   // 936f: a9 20       .
+// $9371 referenced 1 time by $9367
+c9371
+    sta l0e30,x                                                       // 9371: 9d 30 0e    .0.
+    iny                                                               // 9374: c8          .
+    inx                                                               // 9375: e8          .
+    cmp #$0d                                                          // 9376: c9 0d       ..
+    bne c9363                                                         // 9378: d0 e9       ..
+    lda l10d8                                                         // 937a: ad d8 10    ...
+    beq c9348                                                         // 937d: f0 c9       ..
+    lda l00fd                                                         // 937f: a5 fd       ..
+    jsr generate_error_inline                                         // 9381: 20 b8 96     ..
+    .asc "string", 0                                                  // 9384: 73 74 72... str
+
+sub_c938b
+    jsr sub_c9327                                                     // 938b: 20 27 93     '.
+    txa                                                               // 938e: 8a          .
+    pha                                                               // 938f: 48          H
+    jsr sub_caf32                                                     // 9390: 20 32 af     2.
+    jsr sub_c9349                                                     // 9393: 20 49 93     I.
+    jsr sub_cae97                                                     // 9396: 20 97 ae     ..
+    pla                                                               // 9399: 68          h
+    tax                                                               // 939a: aa          .
+// $939b referenced 1 time by $93b9
+loop_c939b
+    lda l0e30                                                         // 939b: ad 30 0e    .0.
+    cmp #$0d                                                          // 939e: c9 0d       ..
+    bne c93ae                                                         // 93a0: d0 0c       ..
+// $93a2 referenced 1 time by $93d8
+c93a2
+    lda #$b0                                                          // 93a2: a9 b0       ..
+    jsr generate_error_inline                                         // 93a4: 20 b8 96     ..
+    .asc "rename", 0                                                  // 93a7: 72 65 6e... ren
+
+// $93ae referenced 1 time by $93a0
+c93ae
+    sta l0f05,x                                                       // 93ae: 9d 05 0f    ...
+    inx                                                               // 93b1: e8          .
+    cmp #$20 // ' '                                                   // 93b2: c9 20       .
+    beq c93bc                                                         // 93b4: f0 06       ..
+    jsr caeb7                                                         // 93b6: 20 b7 ae     ..
+    jmp loop_c939b                                                    // 93b9: 4c 9b 93    L..
+
+// $93bc referenced 2 times by $93b4, $93c4
+c93bc
+    jsr caeb7                                                         // 93bc: 20 b7 ae     ..
+    lda l0e30                                                         // 93bf: ad 30 0e    .0.
+    cmp #$20 // ' '                                                   // 93c2: c9 20       .
+    beq c93bc                                                         // 93c4: f0 f6       ..
+    lda l1071                                                         // 93c6: ad 71 10    .q.
+    pha                                                               // 93c9: 48          H
+    jsr sub_caf32                                                     // 93ca: 20 32 af     2.
+    txa                                                               // 93cd: 8a          .
+    pha                                                               // 93ce: 48          H
+    jsr sub_cae97                                                     // 93cf: 20 97 ae     ..
+    pla                                                               // 93d2: 68          h
+    tax                                                               // 93d3: aa          .
+    pla                                                               // 93d4: 68          h
+    cmp l1071                                                         // 93d5: cd 71 10    .q.
+    bne c93a2                                                         // 93d8: d0 c8       ..
+    jmp c9311                                                         // 93da: 4c 11 93    L..
+
+sub_c93dd
+    lda (l00be),y                                                     // 93dd: b1 be       ..
+    cmp #$26 // '&'                                                   // 93df: c9 26       .&
+    bne c9462                                                         // 93e1: d0 7f       ..
+    iny                                                               // 93e3: c8          .
+    lda (l00be),y                                                     // 93e4: b1 be       ..
+    cmp #$0d                                                          // 93e6: c9 0d       ..
+    beq c93ee                                                         // 93e8: f0 04       ..
+    cmp #$20 // ' '                                                   // 93ea: c9 20       .
+    bne c9405                                                         // 93ec: d0 17       ..
+// $93ee referenced 1 time by $93e8
+c93ee
+    ldy #$ff                                                          // 93ee: a0 ff       ..
+// $93f0 referenced 1 time by $93f8
+loop_c93f0
+    iny                                                               // 93f0: c8          .
+    lda (l00be),y                                                     // 93f1: b1 be       ..
+    sta l0f05,y                                                       // 93f3: 99 05 0f    ...
+    cmp #$26 // '&'                                                   // 93f6: c9 26       .&
+    bne loop_c93f0                                                    // 93f8: d0 f6       ..
+    lda #$0d                                                          // 93fa: a9 0d       ..
+    sta l0f05,y                                                       // 93fc: 99 05 0f    ...
+    iny                                                               // 93ff: c8          .
+    tya                                                               // 9400: 98          .
+    tax                                                               // 9401: aa          .
+    jmp c9322                                                         // 9402: 4c 22 93    L".
+
+// $9405 referenced 1 time by $93ec
+c9405
+    cmp #$2e // '.'                                                   // 9405: c9 2e       ..
+    beq c940c                                                         // 9407: f0 03       ..
+    jmp c92fa                                                         // 9409: 4c fa 92    L..
+
+// $940c referenced 1 time by $9407
+c940c
+    iny                                                               // 940c: c8          .
+    sty l00b0                                                         // 940d: 84 b0       ..
+    lda #4                                                            // 940f: a9 04       ..
+    sta l0f05                                                         // 9411: 8d 05 0f    ...
+    lda l1071                                                         // 9414: ad 71 10    .q.
+    ora #$40 // '@'                                                   // 9417: 09 40       .@
+    sta l1071                                                         // 9419: 8d 71 10    .q.
+    ldx #1                                                            // 941c: a2 01       ..
+    jsr sub_caf06                                                     // 941e: 20 06 af     ..
+    ldy #$12                                                          // 9421: a0 12       ..
+    jsr c94ad                                                         // 9423: 20 ad 94     ..
+    lda l0f05                                                         // 9426: ad 05 0f    ...
+    cmp #2                                                            // 9429: c9 02       ..
+    beq c943c                                                         // 942b: f0 0f       ..
+    lda #$d6                                                          // 942d: a9 d6       ..
+    jsr generate_error_inline3                                        // 942f: 20 d1 96     ..
+    .asc "Not found", 0                                               // 9432: 4e 6f 74... Not
+
+// $943c referenced 1 time by $942b
+c943c
+    lda l0e03                                                         // 943c: ad 03 0e    ...
+    sta l0f05                                                         // 943f: 8d 05 0f    ...
+    ldx #1                                                            // 9442: a2 01       ..
+    ldy #7                                                            // 9444: a0 07       ..
+    jsr c94ad                                                         // 9446: 20 ad 94     ..
+    ldx #1                                                            // 9449: a2 01       ..
+    stx l0f05                                                         // 944b: 8e 05 0f    ...
+    stx l0f06                                                         // 944e: 8e 06 0f    ...
+    inx                                                               // 9451: e8          .
+    ldy l00b0                                                         // 9452: a4 b0       ..
+    jsr sub_caf06                                                     // 9454: 20 06 af     ..
+    ldy #6                                                            // 9457: a0 06       ..
+    jsr c94ad                                                         // 9459: 20 ad 94     ..
+    ldy l0f05                                                         // 945c: ac 05 0f    ...
+    jmp ca2f4                                                         // 945f: 4c f4 a2    L..
+
+// $9462 referenced 1 time by $93e1
+c9462
+    jmp c8e15                                                         // 9462: 4c 15 8e    L..
+
+// $9465 referenced 1 time by $94f1
+sub_c9465
+    lda #$90                                                          // 9465: a9 90       ..
+// $9467 referenced 1 time by $9ae0
+sub_c9467
+    jsr sub_c9473                                                     // 9467: 20 73 94     s.
+    sta l00c1                                                         // 946a: 85 c1       ..
+    lda #3                                                            // 946c: a9 03       ..
+    sta l00c4                                                         // 946e: 85 c4       ..
+    dec l00c0                                                         // 9470: c6 c0       ..
+    rts                                                               // 9472: 60          `
+
+// $9473 referenced 4 times by $8dfc, $9467, $94e0, $b93a
+sub_c9473
+    pha                                                               // 9473: 48          H
+    ldy #$0b                                                          // 9474: a0 0b       ..
+// $9476 referenced 1 time by $9487
+loop_c9476
+    lda l948b,y                                                       // 9476: b9 8b 94    ...
+    sta l00c0,y                                                       // 9479: 99 c0 00    ...
+    cpy #2                                                            // 947c: c0 02       ..
+    bpl c9486                                                         // 947e: 10 06       ..
+    lda l0e00,y                                                       // 9480: b9 00 0e    ...
+    sta l00c2,y                                                       // 9483: 99 c2 00    ...
+// $9486 referenced 1 time by $947e
+c9486
+    dey                                                               // 9486: 88          .
+    bpl loop_c9476                                                    // 9487: 10 ed       ..
+    pla                                                               // 9489: 68          h
+    rts                                                               // 948a: 60          `
+
+// $948b referenced 1 time by $9476
+l948b
+    .byt $80, $99,   0,   0,   0, $0f                                 // 948b: 80 99 00... ...
+// $9491 referenced 19 times by $8c73, $964e, $977d, $9b41, $a09e, $a19d, $a316, $a341, $a378, $af7f, $af85, $b025, $b1a5, $b205, $b246, $b2ce, $b55a, $b598, $b99d
+l9491
+    .byt $ff, $ff, $ff, $0f, $ff, $ff                                 // 9491: ff ff ff... ...
+
+// $9497 referenced 1 time by $9f14
+sub_c9497
+    pha                                                               // 9497: 48          H
+    sec                                                               // 9498: 38          8
+    bcs c94b5                                                         // 9499: b0 1a       ..
+// $949b referenced 2 times by $9958, $9a0c
+sub_c949b
+    clv                                                               // 949b: b8          .
+    bvc c94b4                                                         // 949c: 50 16       P.
+sub_c949e
+    ldy #0                                                            // 949e: a0 00       ..
+    jsr sub_cb799                                                     // 94a0: 20 99 b7     ..
+    lda #osbyte_close_spool_exec                                      // 94a3: a9 77       .w
+    jsr osbyte                                                        // 94a5: 20 f4 ff     ..
+    jsr sub_cb559                                                     // 94a8: 20 59 b5     Y.
+    ldy #$17                                                          // 94ab: a0 17       ..
+// $94ad referenced 15 times by $8e24, $9423, $9446, $9459, $9b5d, $9de4, $a1d6, $a1fe, $ad41, $adb8, $adf6, $ae65, $b381, $b418, $b917
+c94ad
+    clv                                                               // 94ad: b8          .
+// $94ae referenced 2 times by $9b44, $af82
+c94ae
+    lda l0e02                                                         // 94ae: ad 02 0e    ...
+    sta l0f02                                                         // 94b1: 8d 02 0f    ...
+// $94b4 referenced 1 time by $949c
+c94b4
+    clc                                                               // 94b4: 18          .
+// $94b5 referenced 1 time by $9499
+c94b5
+    php                                                               // 94b5: 08          .
+    sty l0f01                                                         // 94b6: 8c 01 0f    ...
+    ldy #1                                                            // 94b9: a0 01       ..
+// $94bb referenced 1 time by $94c2
+loop_c94bb
+    lda l0e03,y                                                       // 94bb: b9 03 0e    ...
+    sta l0f03,y                                                       // 94be: 99 03 0f    ...
+    dey                                                               // 94c1: 88          .
+    bpl loop_c94bb                                                    // 94c2: 10 f7       ..
+    bit l1071                                                         // 94c4: 2c 71 10    ,q.
+    bvs c94d3                                                         // 94c7: 70 0a       p.
+    bpl c94d9                                                         // 94c9: 10 0e       ..
+    lda l0e04                                                         // 94cb: ad 04 0e    ...
+    sta l0f03                                                         // 94ce: 8d 03 0f    ...
+    bvc c94d9                                                         // 94d1: 50 06       P.
+// $94d3 referenced 1 time by $94c7
+c94d3
+    lda l0e02                                                         // 94d3: ad 02 0e    ...
+    sta l0f03                                                         // 94d6: 8d 03 0f    ...
+// $94d9 referenced 2 times by $94c9, $94d1
+c94d9
+    plp                                                               // 94d9: 28          (
+    php                                                               // 94da: 08          .
+    lda #$90                                                          // 94db: a9 90       ..
+    sta l0f00                                                         // 94dd: 8d 00 0f    ...
+    jsr sub_c9473                                                     // 94e0: 20 73 94     s.
+    txa                                                               // 94e3: 8a          .
+    adc #5                                                            // 94e4: 69 05       i.
+    sta l00c8                                                         // 94e6: 85 c8       ..
+    plp                                                               // 94e8: 28          (
+    bcs c9505                                                         // 94e9: b0 1a       ..
+    php                                                               // 94eb: 08          .
+    jsr sub_c9837                                                     // 94ec: 20 37 98     7.
+    plp                                                               // 94ef: 28          (
+// $94f0 referenced 2 times by $9a1f, $9f68
+sub_c94f0
+    php                                                               // 94f0: 08          .
+    jsr sub_c9465                                                     // 94f1: 20 65 94     e.
+    jsr sub_c95dd                                                     // 94f4: 20 dd 95     ..
+    plp                                                               // 94f7: 28          (
+// $94f8 referenced 1 time by $950c
+loop_c94f8
+    iny                                                               // 94f8: c8          .
+    lda (l00c4),y                                                     // 94f9: b1 c4       ..
+    tax                                                               // 94fb: aa          .
+    beq c9504                                                         // 94fc: f0 06       ..
+    bvc c9502                                                         // 94fe: 50 02       P.
+    adc #$2a // '*'                                                   // 9500: 69 2a       i*
+// $9502 referenced 1 time by $94fe
+c9502
+    bne c950e                                                         // 9502: d0 0a       ..
+// $9504 referenced 2 times by $94fc, $9574
+c9504
+    rts                                                               // 9504: 60          `
+
+// $9505 referenced 1 time by $94e9
+c9505
+    pla                                                               // 9505: 68          h
+    ldx #$c0                                                          // 9506: a2 c0       ..
+    iny                                                               // 9508: c8          .
+    jsr sub_cac24                                                     // 9509: 20 24 ac     $.
+    bcc loop_c94f8                                                    // 950c: 90 ea       ..
+// $950e referenced 1 time by $9502
+c950e
+    stx l0e09                                                         // 950e: 8e 09 0e    ...
+    lda l0e07                                                         // 9511: ad 07 0e    ...
+    php                                                               // 9514: 08          .
+    bne c951b                                                         // 9515: d0 04       ..
+    cpx #$bf                                                          // 9517: e0 bf       ..
+    bne c9551                                                         // 9519: d0 36       .6
+// $951b referenced 1 time by $9515
+c951b
+    lda #$40 // '@'                                                   // 951b: a9 40       .@
+    pha                                                               // 951d: 48          H
+    ldx #$f0                                                          // 951e: a2 f0       ..
+// $9520 referenced 1 time by $952e
+loop_c9520
+    pla                                                               // 9520: 68          h
+    ora l0fc8,x                                                       // 9521: 1d c8 0f    ...
+    pha                                                               // 9524: 48          H
+    lda l0fc8,x                                                       // 9525: bd c8 0f    ...
+    and #$c0                                                          // 9528: 29 c0       ).
+    sta l0fc8,x                                                       // 952a: 9d c8 0f    ...
+    inx                                                               // 952d: e8          .
+    bmi loop_c9520                                                    // 952e: 30 f0       0.
+    stx l0e07                                                         // 9530: 8e 07 0e    ...
+    jsr sub_cb559                                                     // 9533: 20 59 b5     Y.
+    pla                                                               // 9536: 68          h
+    ror                                                               // 9537: 6a          j
+    bcc c9547                                                         // 9538: 90 0d       ..
+    jsr print_inline_top_bit_clear                                    // 953a: 20 45 91     E.
+    .asc "Data Lost", $0d                                             // 953d: 44 61 74... Dat
+
+// $9547 referenced 1 time by $9538
+c9547
+    ldx l0e09                                                         // 9547: ae 09 0e    ...
+    plp                                                               // 954a: 28          (
+    beq c9551                                                         // 954b: f0 04       ..
+    pla                                                               // 954d: 68          h
+    pla                                                               // 954e: 68          h
+    pla                                                               // 954f: 68          h
+    rts                                                               // 9550: 60          `
+
+// $9551 referenced 2 times by $9519, $954b
+c9551
+    ldy #1                                                            // 9551: a0 01       ..
+    cpx #$a8                                                          // 9553: e0 a8       ..
+    bcs c955b                                                         // 9555: b0 04       ..
+    lda #$a8                                                          // 9557: a9 a8       ..
+    sta (l00c4),y                                                     // 9559: 91 c4       ..
+// $955b referenced 1 time by $9555
+c955b
+    ldy #$ff                                                          // 955b: a0 ff       ..
+// $955d referenced 1 time by $9565
+loop_c955d
+    iny                                                               // 955d: c8          .
+    lda (l00c4),y                                                     // 955e: b1 c4       ..
+    sta l0100,y                                                       // 9560: 99 00 01    ...
+    eor #$0d                                                          // 9563: 49 0d       I.
+    bne loop_c955d                                                    // 9565: d0 f6       ..
+    sta l0100,y                                                       // 9567: 99 00 01    ...
+    dey                                                               // 956a: 88          .
+    tya                                                               // 956b: 98          .
+    tax                                                               // 956c: aa          .
+    jmp c96f0                                                         // 956d: 4c f0 96    L..
+
+// $9570 referenced 2 times by $8dd6, $985b
+sub_c9570
+    lda l00ff                                                         // 9570: a5 ff       ..
+    and l0098                                                         // 9572: 25 98       %.
+    bpl c9504                                                         // 9574: 10 8e       ..
+// $9576 referenced 1 time by $b445
+c9576
+    lda #osbyte_acknowledge_escape                                    // 9576: a9 7e       .~
+    jsr osbyte                                                        // 9578: 20 f4 ff     ..
+    lda #6                                                            // 957b: a9 06       ..
+    jmp c964e                                                         // 957d: 4c 4e 96    LN.
+
+sub_c9580
+    ldy #0                                                            // 9580: a0 00       ..
+    lda (l009c),y                                                     // 9582: b1 9c       ..
+    beq c9589                                                         // 9584: f0 03       ..
+// $9586 referenced 1 time by $95cc
+c9586
+    jmp cacdd                                                         // 9586: 4c dd ac    L..
+
+// $9589 referenced 2 times by $9584, $95c2
+c9589
+    ora #9                                                            // 9589: 09 09       ..
+    sta (l009c),y                                                     // 958b: 91 9c       ..
+    ldx #$80                                                          // 958d: a2 80       ..
+    ldy #$80                                                          // 958f: a0 80       ..
+    lda (l009c),y                                                     // 9591: b1 9c       ..
+    pha                                                               // 9593: 48          H
+    iny                                                               // 9594: c8          .
+    lda (l009c),y                                                     // 9595: b1 9c       ..
+    ldy #$0f                                                          // 9597: a0 0f       ..
+    sta (l009e),y                                                     // 9599: 91 9e       ..
+    dey                                                               // 959b: 88          .
+    pla                                                               // 959c: 68          h
+    sta (l009e),y                                                     // 959d: 91 9e       ..
+    jsr sub_c8aea                                                     // 959f: 20 ea 8a     ..
+    jsr sub_caa85                                                     // 95a2: 20 85 aa     ..
+    ldx #1                                                            // 95a5: a2 01       ..
+    ldy #0                                                            // 95a7: a0 00       ..
+    lda #osbyte_read_write_econet_keyboard_disable                    // 95a9: a9 c9       ..
+    jsr osbyte                                                        // 95ab: 20 f4 ff     ..
+sub_c95ae
+    jsr cacdd                                                         // 95ae: 20 dd ac     ..
+    lda #0                                                            // 95b1: a9 00       ..
+    jsr generate_error_inline3                                        // 95b3: 20 d1 96     ..
+    .asc "Remoted", 0                                                 // 95b6: 52 65 6d... Rem
+
+sub_c95be
+    ldy #0                                                            // 95be: a0 00       ..
+    lda (l009c),y                                                     // 95c0: b1 9c       ..
+    beq c9589                                                         // 95c2: f0 c5       ..
+    ldy #$80                                                          // 95c4: a0 80       ..
+    lda (l009c),y                                                     // 95c6: b1 9c       ..
+    ldy #$0e                                                          // 95c8: a0 0e       ..
+    cmp (l009e),y                                                     // 95ca: d1 9e       ..
+    bne c9586                                                         // 95cc: d0 b8       ..
+sub_c95ce
+    ldy #$82                                                          // 95ce: a0 82       ..
+    lda (l009c),y                                                     // 95d0: b1 9c       ..
+    tay                                                               // 95d2: a8          .
+    ldx #0                                                            // 95d3: a2 00       ..
+    jsr cacdd                                                         // 95d5: 20 dd ac     ..
+    lda #osbyte_insert_input_buffer                                   // 95d8: a9 99       ..
+    jmp osbyte                                                        // 95da: 4c f4 ff    L..
+
+// $95dd referenced 5 times by $94f4, $99b2, $9aea, $abd1, $ac73
+sub_c95dd
+    lda l0d6e                                                         // 95dd: ad 6e 0d    .n.
+    pha                                                               // 95e0: 48          H
+    lda l0d61                                                         // 95e1: ad 61 0d    .a.
+    pha                                                               // 95e4: 48          H
+    lda l009b                                                         // 95e5: a5 9b       ..
+    bne c95ee                                                         // 95e7: d0 05       ..
+    ora #$80                                                          // 95e9: 09 80       ..
+    sta l0d61                                                         // 95eb: 8d 61 0d    .a.
+// $95ee referenced 1 time by $95e7
+c95ee
+    lda #0                                                            // 95ee: a9 00       ..
+    pha                                                               // 95f0: 48          H
+    pha                                                               // 95f1: 48          H
+    tay                                                               // 95f2: a8          .
+    tsx                                                               // 95f3: ba          .
+// $95f4 referenced 3 times by $95fb, $9600, $9605
+c95f4
+    lda (l009a),y                                                     // 95f4: b1 9a       ..
+    bmi c9607                                                         // 95f6: 30 0f       0.
+    dec l0101,x                                                       // 95f8: de 01 01    ...
+    bne c95f4                                                         // 95fb: d0 f7       ..
+    dec l0102,x                                                       // 95fd: de 02 01    ...
+    bne c95f4                                                         // 9600: d0 f2       ..
+    dec l0104,x                                                       // 9602: de 04 01    ...
+    bne c95f4                                                         // 9605: d0 ed       ..
+// $9607 referenced 1 time by $95f6
+c9607
+    pla                                                               // 9607: 68          h
+    pla                                                               // 9608: 68          h
+    pla                                                               // 9609: 68          h
+    sta l0d61                                                         // 960a: 8d 61 0d    .a.
+    pla                                                               // 960d: 68          h
+    beq c961a                                                         // 960e: f0 0a       ..
+    rts                                                               // 9610: 60          `
+
+// $9611 referenced 6 times by $9627, $9660, $967c, $96a6, $96b8, $96d1
+sta_e09_if_d6c_b7_set
+    bit l0d6c                                                         // 9611: 2c 6c 0d    ,l.
+    bpl c9619                                                         // 9614: 10 03       ..
+    sta l0e09                                                         // 9616: 8d 09 0e    ...
+// $9619 referenced 1 time by $9614
+c9619
+    rts                                                               // 9619: 60          `
+
+// $961a referenced 1 time by $960e
+c961a
+    ldx #8                                                            // 961a: a2 08       ..
+    ldy l97ad,x                                                       // 961c: bc ad 97    ...
+    ldx #0                                                            // 961f: a2 00       ..
+    stx l0100                                                         // 9621: 8e 00 01    ...
+    lda l97b9,y                                                       // 9624: b9 b9 97    ...
+    jsr sta_e09_if_d6c_b7_set                                         // 9627: 20 11 96     ..
+// $962a referenced 1 time by $9634
+loop_c962a
+    lda l97b9,y                                                       // 962a: b9 b9 97    ...
+    sta l0101,x                                                       // 962d: 9d 01 01    ...
+    beq c9636                                                         // 9630: f0 04       ..
+    inx                                                               // 9632: e8          .
+    iny                                                               // 9633: c8          .
+    bne loop_c962a                                                    // 9634: d0 f4       ..
+// $9636 referenced 1 time by $9630
+c9636
+    jsr sub_c974d                                                     // 9636: 20 4d 97     M.
+    lda #0                                                            // 9639: a9 00       ..
+    sta l0101,x                                                       // 963b: 9d 01 01    ...
+    jmp c96f0                                                         // 963e: 4c f0 96    L..
+
+// $9641 referenced 1 time by $98c6
+c9641
+    lda (l009a,x)                                                     // 9641: a1 9a       ..
+    cmp #$41 // 'A'                                                   // 9643: c9 41       .A
+    bne c9649                                                         // 9645: d0 02       ..
+    lda #$42 // 'B'                                                   // 9647: a9 42       .B
+// $9649 referenced 1 time by $9645
+c9649
+    clv                                                               // 9649: b8          .
+    bvc c9651                                                         // 964a: 50 05       P.
+// $964c referenced 1 time by $987f
+c964c
+    lda (l009a,x)                                                     // 964c: a1 9a       ..
+// $964e referenced 2 times by $957d, $9ddc
+c964e
+    bit l9491                                                         // 964e: 2c 91 94    ,..
+// $9651 referenced 1 time by $964a
+c9651
+    and #7                                                            // 9651: 29 07       ).
+    pha                                                               // 9653: 48          H
+    cmp #2                                                            // 9654: c9 02       ..
+    bne c969a                                                         // 9656: d0 42       .B
+    php                                                               // 9658: 08          .
+    tax                                                               // 9659: aa          .
+    ldy l97ad,x                                                       // 965a: bc ad 97    ...
+    lda l97b9,y                                                       // 965d: b9 b9 97    ...
+    jsr sta_e09_if_d6c_b7_set                                         // 9660: 20 11 96     ..
+    ldx #0                                                            // 9663: a2 00       ..
+    stx l0100                                                         // 9665: 8e 00 01    ...
+// $9668 referenced 1 time by $9672
+loop_c9668
+    lda l97b9,y                                                       // 9668: b9 b9 97    ...
+    sta l0101,x                                                       // 966b: 9d 01 01    ...
+    beq c9674                                                         // 966e: f0 04       ..
+    iny                                                               // 9670: c8          .
+    inx                                                               // 9671: e8          .
+    bne loop_c9668                                                    // 9672: d0 f4       ..
+// $9674 referenced 1 time by $966e
+c9674
+    jsr sub_c974d                                                     // 9674: 20 4d 97     M.
+    plp                                                               // 9677: 28          (
+    bvs c9686                                                         // 9678: 70 0c       p.
+    lda #$a4                                                          // 967a: a9 a4       ..
+    jsr sta_e09_if_d6c_b7_set                                         // 967c: 20 11 96     ..
+    sta l0101                                                         // 967f: 8d 01 01    ...
+    ldy #$0b                                                          // 9682: a0 0b       ..
+    bne c9688                                                         // 9684: d0 02       ..
+// $9686 referenced 1 time by $9678
+c9686
+    ldy #9                                                            // 9686: a0 09       ..
+// $9688 referenced 1 time by $9684
+c9688
+    lda l97ad,y                                                       // 9688: b9 ad 97    ...
+    tay                                                               // 968b: a8          .
+// $968c referenced 1 time by $9696
+loop_c968c
+    lda l97b9,y                                                       // 968c: b9 b9 97    ...
+    sta l0101,x                                                       // 968f: 9d 01 01    ...
+    beq c9698                                                         // 9692: f0 04       ..
+    iny                                                               // 9694: c8          .
+    inx                                                               // 9695: e8          .
+    bne loop_c968c                                                    // 9696: d0 f4       ..
+// $9698 referenced 1 time by $9692
+c9698
+    beq c96af                                                         // 9698: f0 15       ..
+// $969a referenced 1 time by $9656
+c969a
+    tax                                                               // 969a: aa          .
+    ldy l97ad,x                                                       // 969b: bc ad 97    ...
+    ldx #0                                                            // 969e: a2 00       ..
+    stx l0100                                                         // 96a0: 8e 00 01    ...
+    lda l97b9,y                                                       // 96a3: b9 b9 97    ...
+    jsr sta_e09_if_d6c_b7_set                                         // 96a6: 20 11 96     ..
+// $96a9 referenced 1 time by $96b3
+loop_c96a9
+    lda l97b9,y                                                       // 96a9: b9 b9 97    ...
+    sta l0101,x                                                       // 96ac: 9d 01 01    ...
+// $96af referenced 1 time by $9698
+c96af
+    beq c96f0                                                         // 96af: f0 3f       .?
+    iny                                                               // 96b1: c8          .
+    inx                                                               // 96b2: e8          .
+sub_c96b3
+error_template_minus_1 = sub_c96b3+1
+    bne loop_c96a9                                                    // 96b3: d0 f4       ..
+// $96b4 referenced 1 time by $96c5
+    .asc "Bad"                                                        // 96b5: 42 61 64    Bad
+
+// $96b8 referenced 11 times by $8fe6, $920a, $9217, $922b, $9237, $9246, $92fc, $9381, $93a4, $a25f, $bc14
+generate_error_inline
+    jsr sta_e09_if_d6c_b7_set                                         // 96b8: 20 11 96     ..
+    tay                                                               // 96bb: a8          .
+    pla                                                               // 96bc: 68          h
+    sta l00b0                                                         // 96bd: 85 b0       ..
+    pla                                                               // 96bf: 68          h
+    sta l00b1                                                         // 96c0: 85 b1       ..
+    ldx #0                                                            // 96c2: a2 00       ..
+// $96c4 referenced 1 time by $96cd
+loop_c96c4
+    inx                                                               // 96c4: e8          .
+    lda error_template_minus_1,x                                      // 96c5: bd b4 96    ...
+    sta l0101,x                                                       // 96c8: 9d 01 01    ...
+    cmp #$20 // ' '                                                   // 96cb: c9 20       .
+    bne loop_c96c4                                                    // 96cd: d0 f5       ..
+    beq c96dd                                                         // 96cf: f0 0c       ..
+// $96d1 referenced 7 times by $942f, $95b3, $a276, $ac00, $ac12, $b485, $b547
+generate_error_inline3
+    jsr sta_e09_if_d6c_b7_set                                         // 96d1: 20 11 96     ..
+// $96d4 referenced 4 times by $a129, $ba11, $bba7, $bc5d
+generate_error_inline2
+    tay                                                               // 96d4: a8          .
+    pla                                                               // 96d5: 68          h
+    sta l00b0                                                         // 96d6: 85 b0       ..
+    pla                                                               // 96d8: 68          h
+    sta l00b1                                                         // 96d9: 85 b1       ..
+    ldx #0                                                            // 96db: a2 00       ..
+// $96dd referenced 1 time by $96cf
+c96dd
+    sty l0101                                                         // 96dd: 8c 01 01    ...
+    tya                                                               // 96e0: 98          .
+    pha                                                               // 96e1: 48          H
+    ldy #0                                                            // 96e2: a0 00       ..
+    sty l0100                                                         // 96e4: 8c 00 01    ...
+// $96e7 referenced 1 time by $96ee
+loop_c96e7
+    inx                                                               // 96e7: e8          .
+    iny                                                               // 96e8: c8          .
+    lda (l00b0),y                                                     // 96e9: b1 b0       ..
+    sta l0101,x                                                       // 96eb: 9d 01 01    ...
+    bne loop_c96e7                                                    // 96ee: d0 f7       ..
+// $96f0 referenced 4 times by $956d, $963e, $96af, $b971
+c96f0
+    jsr sub_cb98a                                                     // 96f0: 20 8a b9     ..
+    bne c96fd                                                         // 96f3: d0 08       ..
+    pla                                                               // 96f5: 68          h
+    cmp #$de                                                          // 96f6: c9 de       ..
+    beq c9740                                                         // 96f8: f0 46       .F
+// $96fa referenced 1 time by $974b
+c96fa
+    jmp l0100                                                         // 96fa: 4c 00 01    L..
+
+// $96fd referenced 1 time by $96f3
+c96fd
+    sta l0e08                                                         // 96fd: 8d 08 0e    ...
+    pha                                                               // 9700: 48          H
+    txa                                                               // 9701: 8a          .
+    pha                                                               // 9702: 48          H
+    jsr sub_cb98a                                                     // 9703: 20 8a b9     ..
+    sta l00b0                                                         // 9706: 85 b0       ..
+    lda #0                                                            // 9708: a9 00       ..
+    sta (l009c),y                                                     // 970a: 91 9c       ..
+    lda #$c6                                                          // 970c: a9 c6       ..
+    jsr sub_c8e83                                                     // 970e: 20 83 8e     ..
+    cpy l00b0                                                         // 9711: c4 b0       ..
+    beq c971e                                                         // 9713: f0 09       ..
+    cpx l00b0                                                         // 9715: e4 b0       ..
+    bne c972c                                                         // 9717: d0 13       ..
+    pha                                                               // 9719: 48          H
+    lda #$c6                                                          // 971a: a9 c6       ..
+    bne c9722                                                         // 971c: d0 04       ..
+// $971e referenced 1 time by $9713
+c971e
+    tya                                                               // 971e: 98          .
+    pha                                                               // 971f: 48          H
+    lda #$c7                                                          // 9720: a9 c7       ..
+// $9722 referenced 1 time by $971c
+c9722
+    jsr sub_c8e8c                                                     // 9722: 20 8c 8e     ..
+    pla                                                               // 9725: 68          h
+    tay                                                               // 9726: a8          .
+    lda #0                                                            // 9727: a9 00       ..
+    jsr osfind                                                        // 9729: 20 ce ff     ..
+// $972c referenced 1 time by $9717
+c972c
+    pla                                                               // 972c: 68          h
+    tax                                                               // 972d: aa          .
+    ldy #$0a                                                          // 972e: a0 0a       ..
+    lda l97ad,y                                                       // 9730: b9 ad 97    ...
+    tay                                                               // 9733: a8          .
+// $9734 referenced 1 time by $973e
+loop_c9734
+    lda l97b9,y                                                       // 9734: b9 b9 97    ...
+    sta l0101,x                                                       // 9737: 9d 01 01    ...
+    beq c9740                                                         // 973a: f0 04       ..
+    inx                                                               // 973c: e8          .
+    iny                                                               // 973d: c8          .
+    bne loop_c9734                                                    // 973e: d0 f4       ..
+// $9740 referenced 2 times by $96f8, $973a
+c9740
+    stx l00b2                                                         // 9740: 86 b2       ..
+    pla                                                               // 9742: 68          h
+    jsr sub_c9771                                                     // 9743: 20 71 97     q.
+    lda #0                                                            // 9746: a9 00       ..
+    sta l0102,x                                                       // 9748: 9d 02 01    ...
+    beq c96fa                                                         // 974b: f0 ad       ..
+// $974d referenced 2 times by $9636, $9674
+sub_c974d
+    lda #$20 // ' '                                                   // 974d: a9 20       .
+    sta l0101,x                                                       // 974f: 9d 01 01    ...
+    inx                                                               // 9752: e8          .
+    stx l00b2                                                         // 9753: 86 b2       ..
+    ldy #3                                                            // 9755: a0 03       ..
+    lda (l009a),y                                                     // 9757: b1 9a       ..
+    beq c9767                                                         // 9759: f0 0c       ..
+    jsr sub_c977c                                                     // 975b: 20 7c 97     |.
+    ldx l00b2                                                         // 975e: a6 b2       ..
+    lda #$2e // '.'                                                   // 9760: a9 2e       ..
+    sta l0101,x                                                       // 9762: 9d 01 01    ...
+    inc l00b2                                                         // 9765: e6 b2       ..
+// $9767 referenced 1 time by $9759
+c9767
+    ldy #2                                                            // 9767: a0 02       ..
+    lda (l009a),y                                                     // 9769: b1 9a       ..
+    jsr sub_c977c                                                     // 976b: 20 7c 97     |.
+    ldx l00b2                                                         // 976e: a6 b2       ..
+    rts                                                               // 9770: 60          `
+
+// $9771 referenced 2 times by $9743, $b4da
+sub_c9771
+    tay                                                               // 9771: a8          .
+    lda #$20 // ' '                                                   // 9772: a9 20       .
+    ldx l00b2                                                         // 9774: a6 b2       ..
+    sta l0101,x                                                       // 9776: 9d 01 01    ...
+    inc l00b2                                                         // 9779: e6 b2       ..
+    tya                                                               // 977b: 98          .
+// $977c referenced 2 times by $975b, $976b
+sub_c977c
+    tay                                                               // 977c: a8          .
+    bit l9491                                                         // 977d: 2c 91 94    ,..
+    lda #$64 // 'd'                                                   // 9780: a9 64       .d
+    jsr sub_c978d                                                     // 9782: 20 8d 97     ..
+    lda #$0a                                                          // 9785: a9 0a       ..
+    jsr sub_c978d                                                     // 9787: 20 8d 97     ..
+    lda #1                                                            // 978a: a9 01       ..
+    clv                                                               // 978c: b8          .
+// $978d referenced 2 times by $9782, $9787
+sub_c978d
+    sta l00b3                                                         // 978d: 85 b3       ..
+    tya                                                               // 978f: 98          .
+    ldx #$2f // '/'                                                   // 9790: a2 2f       ./
+    php                                                               // 9792: 08          .
+    sec                                                               // 9793: 38          8
+// $9794 referenced 1 time by $9797
+loop_c9794
+    inx                                                               // 9794: e8          .
+    sbc l00b3                                                         // 9795: e5 b3       ..
+    bcs loop_c9794                                                    // 9797: b0 fb       ..
+    adc l00b3                                                         // 9799: 65 b3       e.
+    plp                                                               // 979b: 28          (
+    tay                                                               // 979c: a8          .
+    txa                                                               // 979d: 8a          .
+    cmp #$30 // '0'                                                   // 979e: c9 30       .0
+    bne c97a4                                                         // 97a0: d0 02       ..
+    bvs c97ac                                                         // 97a2: 70 08       p.
+// $97a4 referenced 1 time by $97a0
+c97a4
+    clv                                                               // 97a4: b8          .
+    ldx l00b2                                                         // 97a5: a6 b2       ..
+    sta l0101,x                                                       // 97a7: 9d 01 01    ...
+    inc l00b2                                                         // 97aa: e6 b2       ..
+// $97ac referenced 1 time by $97a2
+c97ac
+    rts                                                               // 97ac: 60          `
+
+// $97ad referenced 5 times by $961c, $965a, $9688, $969b, $9730
+l97ad
+    .byt   0, $0d, $18                                                // 97ad: 00 0d 18    ...
+    .asc "!+++3?Veq"                                                  // 97b0: 21 2b 2b... !++
+// $97b9 referenced 8 times by $9624, $962a, $965d, $9668, $968c, $96a3, $96a9, $9734
+l97b9
+    .byt $a0                                                          // 97b9: a0          .
+    .asc "Line jammed"                                                // 97ba: 4c 69 6e... Lin
+    .byt   0, $a1                                                     // 97c5: 00 a1       ..
+    .asc "Net error"                                                  // 97c7: 4e 65 74... Net
+    .byt   0, $a2                                                     // 97d0: 00 a2       ..
+    .asc "Station"                                                    // 97d2: 53 74 61... Sta
+    .byt   0, $a3                                                     // 97d9: 00 a3       ..
+    .asc "No clock"                                                   // 97db: 4e 6f 20... No
+    .byt   0, $11                                                     // 97e3: 00 11       ..
+    .asc "Escape"                                                     // 97e5: 45 73 63... Esc
+    .byt   0, $cb                                                     // 97eb: 00 cb       ..
+    .asc "Bad option"                                                 // 97ed: 42 61 64... Bad
+    .byt   0, $a5                                                     // 97f7: 00 a5       ..
+    .asc "No reply from station"                                      // 97f9: 4e 6f 20... No
+    .byt 0                                                            // 980e: 00          .
+    .asc " not listening"                                             // 980f: 20 6e 6f...  no
+    .byt 0                                                            // 981d: 00          .
+    .asc " on channel"                                                // 981e: 20 6f 6e...  on
+    .byt 0                                                            // 9829: 00          .
+    .asc " not present"                                               // 982a: 20 6e 6f...  no
+    .byt 0                                                            // 9836: 00          .
+
+// $9837 referenced 2 times by $94ec, $9adb
+sub_c9837
+    ldx #$c0                                                          // 9837: a2 c0       ..
+    stx l009a                                                         // 9839: 86 9a       ..
+    ldx #0                                                            // 983b: a2 00       ..
+    stx l009b                                                         // 983d: 86 9b       ..
+// $983f referenced 5 times by $a9d4, $abc6, $ac51, $b05b, $b23a
+sub_c983f
+    lda l0d6d                                                         // 983f: ad 6d 0d    .m.
+    bne c9846                                                         // 9842: d0 02       ..
+    lda #$ff                                                          // 9844: a9 ff       ..
+// $9846 referenced 1 time by $9842
+c9846
+    ldy #$60 // '`'                                                   // 9846: a0 60       .`
+    pha                                                               // 9848: 48          H
+    tya                                                               // 9849: 98          .
+    pha                                                               // 984a: 48          H
+    ldx #0                                                            // 984b: a2 00       ..
+    lda (l009a,x)                                                     // 984d: a1 9a       ..
+// $984f referenced 1 time by $9871
+c984f
+    sta (l009a,x)                                                     // 984f: 81 9a       ..
+    pha                                                               // 9851: 48          H
+    jsr c98c9                                                         // 9852: 20 c9 98     ..
+    asl                                                               // 9855: 0a          .
+    bpl c9882                                                         // 9856: 10 2a       .*
+    asl                                                               // 9858: 0a          .
+    beq c987e                                                         // 9859: f0 23       .#
+    jsr sub_c9570                                                     // 985b: 20 70 95     p.
+    pla                                                               // 985e: 68          h
+    tax                                                               // 985f: aa          .
+    pla                                                               // 9860: 68          h
+    tay                                                               // 9861: a8          .
+    pla                                                               // 9862: 68          h
+    beq c9873                                                         // 9863: f0 0e       ..
+// $9865 referenced 1 time by $987c
+loop_c9865
+    sbc #1                                                            // 9865: e9 01       ..
+    pha                                                               // 9867: 48          H
+    tya                                                               // 9868: 98          .
+    pha                                                               // 9869: 48          H
+    txa                                                               // 986a: 8a          .
+// $986b referenced 2 times by $986c, $986f
+c986b
+    dex                                                               // 986b: ca          .
+    bne c986b                                                         // 986c: d0 fd       ..
+    dey                                                               // 986e: 88          .
+    bne c986b                                                         // 986f: d0 fa       ..
+    beq c984f                                                         // 9871: f0 dc       ..
+// $9873 referenced 1 time by $9863
+c9873
+    cmp l0d6d                                                         // 9873: cd 6d 0d    .m.
+    bne c987e                                                         // 9876: d0 06       ..
+    lda #$80                                                          // 9878: a9 80       ..
+    sta l0098                                                         // 987a: 85 98       ..
+    bne loop_c9865                                                    // 987c: d0 e7       ..
+// $987e referenced 2 times by $9859, $9876
+c987e
+    tax                                                               // 987e: aa          .
+    jmp c964c                                                         // 987f: 4c 4c 96    LL.
+
+// $9882 referenced 1 time by $9856
+c9882
+    pla                                                               // 9882: 68          h
+    pla                                                               // 9883: 68          h
+    pla                                                               // 9884: 68          h
+    jmp c929f                                                         // 9885: 4c 9f 92    L..
+
+// $9888 referenced 2 times by $989e, $98f8
+l9888
+    .byt $88,   0, $fd, $fd, $3a, $0d, $ff, $ff, $3e, $0d, $ff, $ff   // 9888: 88 00 fd... ...
+
+// $9894 referenced 1 time by $8dff
+sub_c9894
+    ldy #$c0                                                          // 9894: a0 c0       ..
+    sty l009a                                                         // 9896: 84 9a       ..
+    ldy #0                                                            // 9898: a0 00       ..
+    sty l009b                                                         // 989a: 84 9b       ..
+// $989c referenced 1 time by $abc3
+sub_c989c
+    ldy #$0b                                                          // 989c: a0 0b       ..
+// $989e referenced 1 time by $98ac
+loop_c989e
+    ldx l9888,y                                                       // 989e: be 88 98    ...
+    cpx #$fd                                                          // 98a1: e0 fd       ..
+    beq c98ab                                                         // 98a3: f0 06       ..
+    lda (l009a),y                                                     // 98a5: b1 9a       ..
+    pha                                                               // 98a7: 48          H
+    txa                                                               // 98a8: 8a          .
+    sta (l009a),y                                                     // 98a9: 91 9a       ..
+// $98ab referenced 1 time by $98a3
+c98ab
+    dey                                                               // 98ab: 88          .
+    bpl loop_c989e                                                    // 98ac: 10 f0       ..
+    lda l0d6f                                                         // 98ae: ad 6f 0d    .o.
+    pha                                                               // 98b1: 48          H
+    tya                                                               // 98b2: 98          .
+    pha                                                               // 98b3: 48          H
+    ldx #0                                                            // 98b4: a2 00       ..
+    lda (l009a,x)                                                     // 98b6: a1 9a       ..
+// $98b8 referenced 1 time by $98f1
+c98b8
+    sta (l009a,x)                                                     // 98b8: 81 9a       ..
+    pha                                                               // 98ba: 48          H
+    jsr c98c9                                                         // 98bb: 20 c9 98     ..
+    asl                                                               // 98be: 0a          .
+    bpl c98f3                                                         // 98bf: 10 32       .2
+    asl                                                               // 98c1: 0a          .
+    bne c98de                                                         // 98c2: d0 1a       ..
+// $98c4 referenced 1 time by $98e3
+loop_c98c4
+    ldx #0                                                            // 98c4: a2 00       ..
+    jmp c9641                                                         // 98c6: 4c 41 96    LA.
+
+// $98c9 referenced 3 times by $9852, $98bb, $98cc
+c98c9
+    asl l0d60                                                         // 98c9: 0e 60 0d    .`.
+    bcc c98c9                                                         // 98cc: 90 fb       ..
+    lda l009a                                                         // 98ce: a5 9a       ..
+    sta l00a0                                                         // 98d0: 85 a0       ..
+    lda l009b                                                         // 98d2: a5 9b       ..
+    sta l00a1                                                         // 98d4: 85 a1       ..
+    jsr sub_c858c                                                     // 98d6: 20 8c 85     ..
+// $98d9 referenced 1 time by $98db
+loop_c98d9
+    lda (l009a,x)                                                     // 98d9: a1 9a       ..
+    bmi loop_c98d9                                                    // 98db: 30 fc       0.
+    rts                                                               // 98dd: 60          `
+
+// $98de referenced 1 time by $98c2
+c98de
+    pla                                                               // 98de: 68          h
+    tax                                                               // 98df: aa          .
+    pla                                                               // 98e0: 68          h
+    tay                                                               // 98e1: a8          .
+    pla                                                               // 98e2: 68          h
+    beq loop_c98c4                                                    // 98e3: f0 df       ..
+    sbc #1                                                            // 98e5: e9 01       ..
+    pha                                                               // 98e7: 48          H
+    tya                                                               // 98e8: 98          .
+    pha                                                               // 98e9: 48          H
+    txa                                                               // 98ea: 8a          .
+// $98eb referenced 2 times by $98ec, $98ef
+c98eb
+    dex                                                               // 98eb: ca          .
+    bne c98eb                                                         // 98ec: d0 fd       ..
+    dey                                                               // 98ee: 88          .
+    bne c98eb                                                         // 98ef: d0 fa       ..
+    beq c98b8                                                         // 98f1: f0 c5       ..
+// $98f3 referenced 1 time by $98bf
+c98f3
+    pla                                                               // 98f3: 68          h
+    pla                                                               // 98f4: 68          h
+    pla                                                               // 98f5: 68          h
+    ldy #0                                                            // 98f6: a0 00       ..
+// $98f8 referenced 1 time by $9905
+loop_c98f8
+    ldx l9888,y                                                       // 98f8: be 88 98    ...
+    cpx #$fd                                                          // 98fb: e0 fd       ..
+    beq c9902                                                         // 98fd: f0 03       ..
+    pla                                                               // 98ff: 68          h
+    sta (l009a),y                                                     // 9900: 91 9a       ..
+// $9902 referenced 1 time by $98fd
+c9902
+    iny                                                               // 9902: c8          .
+    cpy #$0c                                                          // 9903: c0 0c       ..
+    bne loop_c98f8                                                    // 9905: d0 f1       ..
+    rts                                                               // 9907: 60          `
+
+    .byt $a0,   1, $b1, $bb, $99, $f2,   0, $88, $10, $f8, $c8        // 9908: a0 01 b1... ...
+
+// $9913 referenced 1 time by $ae94
+sub_c9913
+    ldx #$ff                                                          // 9913: a2 ff       ..
+    clc                                                               // 9915: 18          .
+    jsr gsinit                                                        // 9916: 20 c2 ff     ..
+    beq c9926                                                         // 9919: f0 0b       ..
+// $991b referenced 1 time by $9924
+loop_c991b
+    jsr gsread                                                        // 991b: 20 c5 ff     ..
+    bcs c9926                                                         // 991e: b0 06       ..
+    inx                                                               // 9920: e8          .
+    sta l0e30,x                                                       // 9921: 9d 30 0e    .0.
+    bcc loop_c991b                                                    // 9924: 90 f5       ..
+// $9926 referenced 2 times by $9919, $991e
+c9926
+    inx                                                               // 9926: e8          .
+    lda #$0d                                                          // 9927: a9 0d       ..
+    sta l0e30,x                                                       // 9929: 9d 30 0e    .0.
+    lda #$30 // '0'                                                   // 992c: a9 30       .0
+    sta l00be                                                         // 992e: 85 be       ..
+    lda #$0e                                                          // 9930: a9 0e       ..
+    sta l00bf                                                         // 9932: 85 bf       ..
+    rts                                                               // 9934: 60          `
+
+    .byt $20, $95, $92, $20,   8, $99, $20, $32, $af, $20, $97, $ae   // 9935: 20 95 92...  ..
+    .byt $a5, $bd, $10, $7e, $c9, $ff, $f0,   3, $4c, $c7, $9c, $20   // 9941: a5 bd 10... ...
+    .byt   2, $af, $a0,   2                                           // 994d: 02 af a0... ...
+
+// $9951 referenced 1 time by $a2d1
+sub_c9951
+    lda #$92                                                          // 9951: a9 92       ..
+    sta l0098                                                         // 9953: 85 98       ..
+    sta l0f02                                                         // 9955: 8d 02 0f    ...
+    jsr sub_c949b                                                     // 9958: 20 9b 94     ..
+    ldy #6                                                            // 995b: a0 06       ..
+    lda (l00bb),y                                                     // 995d: b1 bb       ..
+    bne c9969                                                         // 995f: d0 08       ..
+    jsr sub_c9a72                                                     // 9961: 20 72 9a     r.
+    jsr sub_c9a84                                                     // 9964: 20 84 9a     ..
+    bcc c996f                                                         // 9967: 90 06       ..
+// $9969 referenced 1 time by $995f
+c9969
+    jsr sub_c9a84                                                     // 9969: 20 84 9a     ..
+    jsr sub_c9a72                                                     // 996c: 20 72 9a     r.
+// $996f referenced 1 time by $9967
+c996f
+    ldy #4                                                            // 996f: a0 04       ..
+// $9971 referenced 1 time by $997c
+loop_c9971
+    lda l00b0,x                                                       // 9971: b5 b0       ..
+    sta l00c8,x                                                       // 9973: 95 c8       ..
+    adc l0f0d,x                                                       // 9975: 7d 0d 0f    }..
+    sta l00b4,x                                                       // 9978: 95 b4       ..
+    inx                                                               // 997a: e8          .
+    dey                                                               // 997b: 88          .
+    bne loop_c9971                                                    // 997c: d0 f3       ..
+    sec                                                               // 997e: 38          8
+    sbc l0f10                                                         // 997f: ed 10 0f    ...
+    sta l00b7                                                         // 9982: 85 b7       ..
+    jsr sub_c9b95                                                     // 9984: 20 95 9b     ..
+    jsr sub_c9998                                                     // 9987: 20 98 99     ..
+    ldx #2                                                            // 998a: a2 02       ..
+// $998c referenced 1 time by $9993
+loop_c998c
+    lda l0f10,x                                                       // 998c: bd 10 0f    ...
+    sta l0f05,x                                                       // 998f: 9d 05 0f    ...
+    dex                                                               // 9992: ca          .
+    bpl loop_c998c                                                    // 9993: 10 f7       ..
+    jmp c9a1f                                                         // 9995: 4c 1f 9a    L..
+
+// $9998 referenced 2 times by $9987, $9f52
+sub_c9998
+    jsr sub_c92a4                                                     // 9998: 20 a4 92     ..
+    beq c99c2                                                         // 999b: f0 25       .%
+    lda #$92                                                          // 999d: a9 92       ..
+    sta l00c1                                                         // 999f: 85 c1       ..
+// $99a1 referenced 1 time by $99bd
+loop_c99a1
+    ldx #3                                                            // 99a1: a2 03       ..
+// $99a3 referenced 1 time by $99ac
+loop_c99a3
+    lda l00c8,x                                                       // 99a3: b5 c8       ..
+    sta l00c4,x                                                       // 99a5: 95 c4       ..
+    lda l00b4,x                                                       // 99a7: b5 b4       ..
+    sta l00c8,x                                                       // 99a9: 95 c8       ..
+    dex                                                               // 99ab: ca          .
+    bpl loop_c99a3                                                    // 99ac: 10 f5       ..
+    lda #$7f                                                          // 99ae: a9 7f       ..
+    sta l00c0                                                         // 99b0: 85 c0       ..
+    jsr sub_c95dd                                                     // 99b2: 20 dd 95     ..
+    ldy #3                                                            // 99b5: a0 03       ..
+// $99b7 referenced 1 time by $99c0
+loop_c99b7
+    lda l00c8,y                                                       // 99b7: b9 c8 00    ...
+    eor l00b4,y                                                       // 99ba: 59 b4 00    Y..
+    bne loop_c99a1                                                    // 99bd: d0 e2       ..
+    dey                                                               // 99bf: 88          .
+    bpl loop_c99b7                                                    // 99c0: 10 f5       ..
+// $99c2 referenced 1 time by $999b
+c99c2
+    rts                                                               // 99c2: 60          `
+
+    .byt $f0,   3, $4c, $ef, $9a                                      // 99c3: f0 03 4c... ..L
+
+// $99c8 referenced 1 time by $9af8
+c99c8
+    ldx #4                                                            // 99c8: a2 04       ..
+    ldy #$0e                                                          // 99ca: a0 0e       ..
+    sec                                                               // 99cc: 38          8
+// $99cd referenced 1 time by $99e7
+loop_c99cd
+    lda (l00bb),y                                                     // 99cd: b1 bb       ..
+    sta l00a6,y                                                       // 99cf: 99 a6 00    ...
+    jsr sub_c9a91                                                     // 99d2: 20 91 9a     ..
+    sbc (l00bb),y                                                     // 99d5: f1 bb       ..
+    sta l0f03,y                                                       // 99d7: 99 03 0f    ...
+    pha                                                               // 99da: 48          H
+    lda (l00bb),y                                                     // 99db: b1 bb       ..
+    sta l00a6,y                                                       // 99dd: 99 a6 00    ...
+    pla                                                               // 99e0: 68          h
+    sta (l00bb),y                                                     // 99e1: 91 bb       ..
+    jsr sub_c9a7e                                                     // 99e3: 20 7e 9a     ~.
+    dex                                                               // 99e6: ca          .
+    bne loop_c99cd                                                    // 99e7: d0 e4       ..
+    ldy #9                                                            // 99e9: a0 09       ..
+// $99eb referenced 1 time by $99f1
+loop_c99eb
+    lda (l00bb),y                                                     // 99eb: b1 bb       ..
+    sta l0f03,y                                                       // 99ed: 99 03 0f    ...
+    dey                                                               // 99f0: 88          .
+    bne loop_c99eb                                                    // 99f1: d0 f8       ..
+    lda #$91                                                          // 99f3: a9 91       ..
+    sta l0098                                                         // 99f5: 85 98       ..
+    sta l0f02                                                         // 99f7: 8d 02 0f    ...
+    sta l00b8                                                         // 99fa: 85 b8       ..
+    ldx #$0b                                                          // 99fc: a2 0b       ..
+    jsr sub_caf04                                                     // 99fe: 20 04 af     ..
+    ldy #1                                                            // 9a01: a0 01       ..
+    lda l00bd                                                         // 9a03: a5 bd       ..
+    cmp #7                                                            // 9a05: c9 07       ..
+    php                                                               // 9a07: 08          .
+    bne c9a0c                                                         // 9a08: d0 02       ..
+    ldy #$1d                                                          // 9a0a: a0 1d       ..
+// $9a0c referenced 1 time by $9a08
+c9a0c
+    jsr sub_c949b                                                     // 9a0c: 20 9b 94     ..
+    jsr sub_c9b95                                                     // 9a0f: 20 95 9b     ..
+    plp                                                               // 9a12: 28          (
+    bne c9a19                                                         // 9a13: d0 04       ..
+    ldx #0                                                            // 9a15: a2 00       ..
+    beq c9a22                                                         // 9a17: f0 09       ..
+// $9a19 referenced 1 time by $9a13
+c9a19
+    lda l0f05                                                         // 9a19: ad 05 0f    ...
+    jsr sub_c9a9a                                                     // 9a1c: 20 9a 9a     ..
+// $9a1f referenced 1 time by $9995
+c9a1f
+    jsr sub_c94f0                                                     // 9a1f: 20 f0 94     ..
+// $9a22 referenced 1 time by $9a17
+c9a22
+    stx l0f08                                                         // 9a22: 8e 08 0f    ...
+    ldy #$0e                                                          // 9a25: a0 0e       ..
+    lda l0f05                                                         // 9a27: ad 05 0f    ...
+    jsr sub_c9273                                                     // 9a2a: 20 73 92     s.
+    beq c9a32                                                         // 9a2d: f0 03       ..
+// $9a2f referenced 1 time by $9a37
+loop_c9a2f
+    lda l0ef7,y                                                       // 9a2f: b9 f7 0e    ...
+// $9a32 referenced 1 time by $9a2d
+c9a32
+    sta (l00bb),y                                                     // 9a32: 91 bb       ..
+    iny                                                               // 9a34: c8          .
+    cpy #$12                                                          // 9a35: c0 12       ..
+    bne loop_c9a2f                                                    // 9a37: d0 f6       ..
+    ldy l0e06                                                         // 9a39: ac 06 0e    ...
+    beq c9a83                                                         // 9a3c: f0 45       .E
+    ldy #$f4                                                          // 9a3e: a0 f4       ..
+// $9a40 referenced 1 time by $9a47
+loop_c9a40
+    lda l0fff,y                                                       // 9a40: b9 ff 0f    ...
+    jsr osasci                                                        // 9a43: 20 e3 ff     ..
+    iny                                                               // 9a46: c8          .
+    bne loop_c9a40                                                    // 9a47: d0 f7       ..
+    ldy #5                                                            // 9a49: a0 05       ..
+    jsr sub_c9a62                                                     // 9a4b: 20 62 9a     b.
+    jsr sub_c9a57                                                     // 9a4e: 20 57 9a     W.
+    jsr osnewl                                                        // 9a51: 20 e7 ff     ..
+    jmp c9cc7                                                         // 9a54: 4c c7 9c    L..
+
+// $9a57 referenced 1 time by $9a4e
+sub_c9a57
+    ldy #9                                                            // 9a57: a0 09       ..
+    jsr sub_c9a62                                                     // 9a59: 20 62 9a     b.
+    ldy #$0c                                                          // 9a5c: a0 0c       ..
+    ldx #3                                                            // 9a5e: a2 03       ..
+    bne c9a64                                                         // 9a60: d0 02       ..
+// $9a62 referenced 2 times by $9a4b, $9a59
+sub_c9a62
+    ldx #4                                                            // 9a62: a2 04       ..
+// $9a64 referenced 2 times by $9a60, $9a6b
+c9a64
+    lda (l00bb),y                                                     // 9a64: b1 bb       ..
+    jsr sub_c912f                                                     // 9a66: 20 2f 91     /.
+    dey                                                               // 9a69: 88          .
+    dex                                                               // 9a6a: ca          .
+    bne c9a64                                                         // 9a6b: d0 f7       ..
+    lda #$20 // ' '                                                   // 9a6d: a9 20       .
+    jmp osasci                                                        // 9a6f: 4c e3 ff    L..
+
+// $9a72 referenced 2 times by $9961, $996c
+sub_c9a72
+    ldy #5                                                            // 9a72: a0 05       ..
+// $9a74 referenced 1 time by $9a7c
+loop_c9a74
+    lda (l00bb),y                                                     // 9a74: b1 bb       ..
+    sta l00ae,y                                                       // 9a76: 99 ae 00    ...
+    dey                                                               // 9a79: 88          .
+    cpy #2                                                            // 9a7a: c0 02       ..
+    bcs loop_c9a74                                                    // 9a7c: b0 f6       ..
+// $9a7e referenced 1 time by $99e3
+sub_c9a7e
+    iny                                                               // 9a7e: c8          .
+// $9a7f referenced 2 times by $9f2f, $b074
+sub_c9a7f
+    iny                                                               // 9a7f: c8          .
+    iny                                                               // 9a80: c8          .
+    iny                                                               // 9a81: c8          .
+    iny                                                               // 9a82: c8          .
+// $9a83 referenced 1 time by $9a3c
+c9a83
+    rts                                                               // 9a83: 60          `
+
+// $9a84 referenced 2 times by $9964, $9969
+sub_c9a84
+    ldy #$0d                                                          // 9a84: a0 0d       ..
+    txa                                                               // 9a86: 8a          .
+// $9a87 referenced 1 time by $9a8f
+loop_c9a87
+    sta (l00bb),y                                                     // 9a87: 91 bb       ..
+    lda l0f02,y                                                       // 9a89: b9 02 0f    ...
+    dey                                                               // 9a8c: 88          .
+    cpy #2                                                            // 9a8d: c0 02       ..
+    bcs loop_c9a87                                                    // 9a8f: b0 f6       ..
+// $9a91 referenced 1 time by $99d2
+sub_c9a91
+    dey                                                               // 9a91: 88          .
+// $9a92 referenced 2 times by $9b0e, $9f37
+sub_c9a92
+    dey                                                               // 9a92: 88          .
+    dey                                                               // 9a93: 88          .
+    dey                                                               // 9a94: 88          .
+    rts                                                               // 9a95: 60          `
+
+// $9a96 referenced 2 times by $9a9e, $9ae4
+c9a96
+    pla                                                               // 9a96: 68          h
+    ldy l00bc                                                         // 9a97: a4 bc       ..
+    rts                                                               // 9a99: 60          `
+
+// $9a9a referenced 2 times by $9a1c, $9f4d
+sub_c9a9a
+    pha                                                               // 9a9a: 48          H
+    jsr sub_c92a4                                                     // 9a9b: 20 a4 92     ..
+    beq c9a96                                                         // 9a9e: f0 f6       ..
+// $9aa0 referenced 1 time by $9aed
+c9aa0
+    ldx #0                                                            // 9aa0: a2 00       ..
+    ldy #4                                                            // 9aa2: a0 04       ..
+    stx l0f08                                                         // 9aa4: 8e 08 0f    ...
+    stx l0f09                                                         // 9aa7: 8e 09 0f    ...
+    clc                                                               // 9aaa: 18          .
+// $9aab referenced 1 time by $9ab8
+loop_c9aab
+    lda l00b0,x                                                       // 9aab: b5 b0       ..
+    sta l00c4,x                                                       // 9aad: 95 c4       ..
+    adc l0f06,x                                                       // 9aaf: 7d 06 0f    }..
+    sta l00c8,x                                                       // 9ab2: 95 c8       ..
+    sta l00b0,x                                                       // 9ab4: 95 b0       ..
+    inx                                                               // 9ab6: e8          .
+    dey                                                               // 9ab7: 88          .
+    bne loop_c9aab                                                    // 9ab8: d0 f1       ..
+    bcs c9ac9                                                         // 9aba: b0 0d       ..
+    sec                                                               // 9abc: 38          8
+// $9abd referenced 1 time by $9ac5
+loop_c9abd
+    lda l00b0,y                                                       // 9abd: b9 b0 00    ...
+    sbc l00b4,y                                                       // 9ac0: f9 b4 00    ...
+    iny                                                               // 9ac3: c8          .
+    dex                                                               // 9ac4: ca          .
+    bne loop_c9abd                                                    // 9ac5: d0 f6       ..
+    bcc c9ad2                                                         // 9ac7: 90 09       ..
+// $9ac9 referenced 1 time by $9aba
+c9ac9
+    ldx #3                                                            // 9ac9: a2 03       ..
+// $9acb referenced 1 time by $9ad0
+loop_c9acb
+    lda l00b4,x                                                       // 9acb: b5 b4       ..
+    sta l00c8,x                                                       // 9acd: 95 c8       ..
+    dex                                                               // 9acf: ca          .
+    bpl loop_c9acb                                                    // 9ad0: 10 f9       ..
+// $9ad2 referenced 1 time by $9ac7
+c9ad2
+    pla                                                               // 9ad2: 68          h
+    pha                                                               // 9ad3: 48          H
+    php                                                               // 9ad4: 08          .
+    sta l00c1                                                         // 9ad5: 85 c1       ..
+    lda #$80                                                          // 9ad7: a9 80       ..
+    sta l00c0                                                         // 9ad9: 85 c0       ..
+    jsr sub_c9837                                                     // 9adb: 20 37 98     7.
+    lda l00b8                                                         // 9ade: a5 b8       ..
+    jsr sub_c9467                                                     // 9ae0: 20 67 94     g.
+    plp                                                               // 9ae3: 28          (
+    bcs c9a96                                                         // 9ae4: b0 b0       ..
+    lda #$91                                                          // 9ae6: a9 91       ..
+    sta l00c1                                                         // 9ae8: 85 c1       ..
+    jsr sub_c95dd                                                     // 9aea: 20 dd 95     ..
+    bne c9aa0                                                         // 9aed: d0 b1       ..
+    sta l0f05                                                         // 9aef: 8d 05 0f    ...
+    cmp #7                                                            // 9af2: c9 07       ..
+    bcc c9afb                                                         // 9af4: 90 05       ..
+    bne c9b47                                                         // 9af6: d0 4f       .O
+    jmp c99c8                                                         // 9af8: 4c c8 99    L..
+
+// $9afb referenced 1 time by $9af4
+c9afb
+    cmp #6                                                            // 9afb: c9 06       ..
+    beq c9b3c                                                         // 9afd: f0 3d       .=
+    cmp #5                                                            // 9aff: c9 05       ..
+    beq c9b56                                                         // 9b01: f0 53       .S
+    cmp #4                                                            // 9b03: c9 04       ..
+    beq c9b4c                                                         // 9b05: f0 45       .E
+    cmp #1                                                            // 9b07: c9 01       ..
+    beq c9b20                                                         // 9b09: f0 15       ..
+    asl                                                               // 9b0b: 0a          .
+    asl                                                               // 9b0c: 0a          .
+    tay                                                               // 9b0d: a8          .
+    jsr sub_c9a92                                                     // 9b0e: 20 92 9a     ..
+    ldx #3                                                            // 9b11: a2 03       ..
+// $9b13 referenced 1 time by $9b1a
+loop_c9b13
+    lda (l00bb),y                                                     // 9b13: b1 bb       ..
+    sta l0f06,x                                                       // 9b15: 9d 06 0f    ...
+    dey                                                               // 9b18: 88          .
+    dex                                                               // 9b19: ca          .
+    bpl loop_c9b13                                                    // 9b1a: 10 f7       ..
+    ldx #5                                                            // 9b1c: a2 05       ..
+    bne c9b35                                                         // 9b1e: d0 15       ..
+// $9b20 referenced 1 time by $9b09
+c9b20
+    jsr sub_c9269                                                     // 9b20: 20 69 92     i.
+    sta l0f0e                                                         // 9b23: 8d 0e 0f    ...
+    ldy #9                                                            // 9b26: a0 09       ..
+    ldx #8                                                            // 9b28: a2 08       ..
+// $9b2a referenced 1 time by $9b31
+loop_c9b2a
+    lda (l00bb),y                                                     // 9b2a: b1 bb       ..
+    sta l0f05,x                                                       // 9b2c: 9d 05 0f    ...
+    dey                                                               // 9b2f: 88          .
+    dex                                                               // 9b30: ca          .
+    bne loop_c9b2a                                                    // 9b31: d0 f7       ..
+    ldx #$0a                                                          // 9b33: a2 0a       ..
+// $9b35 referenced 2 times by $9b1e, $9b54
+c9b35
+    jsr sub_caf04                                                     // 9b35: 20 04 af     ..
+    ldy #$13                                                          // 9b38: a0 13       ..
+    bne c9b41                                                         // 9b3a: d0 05       ..
+// $9b3c referenced 1 time by $9afd
+c9b3c
+    jsr sub_caf02                                                     // 9b3c: 20 02 af     ..
+    ldy #$14                                                          // 9b3f: a0 14       ..
+// $9b41 referenced 1 time by $9b3a
+c9b41
+    bit l9491                                                         // 9b41: 2c 91 94    ,..
+    jsr c94ae                                                         // 9b44: 20 ae 94     ..
+// $9b47 referenced 1 time by $9af6
+c9b47
+    bcs c9b92                                                         // 9b47: b0 49       .I
+    jmp c9cc7                                                         // 9b49: 4c c7 9c    L..
+
+// $9b4c referenced 1 time by $9b05
+c9b4c
+    jsr sub_c9269                                                     // 9b4c: 20 69 92     i.
+    sta l0f06                                                         // 9b4f: 8d 06 0f    ...
+    ldx #2                                                            // 9b52: a2 02       ..
+    bne c9b35                                                         // 9b54: d0 df       ..
+// $9b56 referenced 1 time by $9b01
+c9b56
+    ldx #1                                                            // 9b56: a2 01       ..
+    jsr sub_caf04                                                     // 9b58: 20 04 af     ..
+    ldy #$12                                                          // 9b5b: a0 12       ..
+    jsr c94ad                                                         // 9b5d: 20 ad 94     ..
+    lda l0f11                                                         // 9b60: ad 11 0f    ...
+    stx l0f11                                                         // 9b63: 8e 11 0f    ...
+    stx l0f14                                                         // 9b66: 8e 14 0f    ...
+    jsr sub_c9273                                                     // 9b69: 20 73 92     s.
+    ldx l0f05                                                         // 9b6c: ae 05 0f    ...
+    beq c9b91                                                         // 9b6f: f0 20       .
+    ldy #$0e                                                          // 9b71: a0 0e       ..
+    sta (l00bb),y                                                     // 9b73: 91 bb       ..
+    dey                                                               // 9b75: 88          .
+    ldx #$0c                                                          // 9b76: a2 0c       ..
+// $9b78 referenced 1 time by $9b7f
+loop_c9b78
+    lda l0f05,x                                                       // 9b78: bd 05 0f    ...
+    sta (l00bb),y                                                     // 9b7b: 91 bb       ..
+    dey                                                               // 9b7d: 88          .
+    dex                                                               // 9b7e: ca          .
+    bne loop_c9b78                                                    // 9b7f: d0 f7       ..
+    inx                                                               // 9b81: e8          .
+    inx                                                               // 9b82: e8          .
+    ldy #$11                                                          // 9b83: a0 11       ..
+// $9b85 referenced 1 time by $9b8c
+loop_c9b85
+    lda l0f12,x                                                       // 9b85: bd 12 0f    ...
+    sta (l00bb),y                                                     // 9b88: 91 bb       ..
+    dey                                                               // 9b8a: 88          .
+    dex                                                               // 9b8b: ca          .
+    bpl loop_c9b85                                                    // 9b8c: 10 f7       ..
+    ldx l0f05                                                         // 9b8e: ae 05 0f    ...
+// $9b91 referenced 1 time by $9b6f
+c9b91
+    txa                                                               // 9b91: 8a          .
+// $9b92 referenced 1 time by $9b47
+c9b92
+    jmp c9cc9                                                         // 9b92: 4c c9 9c    L..
+
+// $9b95 referenced 2 times by $9984, $9a0f
+sub_c9b95
+    ldy #0                                                            // 9b95: a0 00       ..
+    ldx l0f03                                                         // 9b97: ae 03 0f    ...
+    bne c9bb5                                                         // 9b9a: d0 19       ..
+// $9b9c referenced 1 time by $9ba6
+loop_c9b9c
+    lda (l00be),y                                                     // 9b9c: b1 be       ..
+    cmp #$21 // '!'                                                   // 9b9e: c9 21       .!
+    bcc c9ba8                                                         // 9ba0: 90 06       ..
+    sta l10f3,y                                                       // 9ba2: 99 f3 10    ...
+    iny                                                               // 9ba5: c8          .
+    bne loop_c9b9c                                                    // 9ba6: d0 f4       ..
+// $9ba8 referenced 2 times by $9ba0, $9bb0
+c9ba8
+    lda #$20 // ' '                                                   // 9ba8: a9 20       .
+    sta l10f3,y                                                       // 9baa: 99 f3 10    ...
+    iny                                                               // 9bad: c8          .
+    cpy #$0c                                                          // 9bae: c0 0c       ..
+    bcc c9ba8                                                         // 9bb0: 90 f6       ..
+    rts                                                               // 9bb2: 60          `
+
+// $9bb3 referenced 1 time by $9bbb
+loop_c9bb3
+    inx                                                               // 9bb3: e8          .
+    iny                                                               // 9bb4: c8          .
+// $9bb5 referenced 1 time by $9b9a
+c9bb5
+    lda l0f05,x                                                       // 9bb5: bd 05 0f    ...
+    sta l10f3,y                                                       // 9bb8: 99 f3 10    ...
+    bpl loop_c9bb3                                                    // 9bbb: 10 f6       ..
+    rts                                                               // 9bbd: 60          `
+
+    .byt $20, $cb, $8f, $85, $bd, $20, $9b, $92,   9,   0, $10, $2e   // 9bbe: 20 cb 8f...  ..
+    .byt $0a, $f0,   3, $4c, $c4, $9c, $98, $c9, $20, $b0,   3, $4c   // 9bca: 0a f0 03... ...
+    .byt $82, $b4, $c9, $30, $b0, $f9, $20, $99, $b7, $98, $48, $aa   // 9bd6: 82 b4 c9... ...
+    .byt $a0,   0, $84, $bd, $84, $bc, $bd, $10, $10, $91, $bb, $20   // 9be2: a0 00 84... ...
+    .byt $86, $bc, $c8, $c0,   4, $d0, $f3, $68, $85, $bc, $c9,   5   // 9bee: 86 bc c8... ...
+    .byt $b0, $4f, $c0,   0, $d0,   3, $4c, $d5, $9c, $48, $8a, $48   // 9bfa: b0 4f c0... .O.
+    .byt $98, $48, $20, $f2, $b4, $68, $20, $8f, $b9, $bd, $30, $10   // 9c06: 98 48 20... .H
+    .byt $8d,   5, $0f, $68, $aa, $68, $4a, $f0, $4f,   8, $48, $a6   // 9c12: 8d 05 0f... ...
+    .byt $bb, $a4, $bc, $20, $99, $b7, $b9, $10, $10, $8d,   5, $0f   // 9c1e: bb a4 bc... ...
+    .byt $68, $8d,   6, $0f, $28, $98, $48, $90, $1b, $a0,   3, $b5   // 9c2a: 68 8d 06... h..
+    .byt   3, $99,   7, $0f, $ca, $88, $10, $f7, $a0, $0d, $a2,   5   // 9c36: 03 99 07... ...
+    .byt $20, $ad, $94, $86, $bd, $68, $20, $b5, $92, $4c, $c7, $9c   // 9c42: 20 ad 94...  ..
+    .byt $a0, $0c, $a2,   2, $20, $ad, $94, $85, $bd, $a6, $bb, $a0   // 9c4e: a0 0c a2... ...
+    .byt   2, $95,   3, $b9,   5, $0f, $95,   2, $ca, $88, $10, $f7   // 9c5a: 02 95 03... ...
+    .byt $68, $4c, $c7, $9c, $b0, $20, $a5, $bc, $20, $6b, $b4, $a4   // 9c66: 68 4c c7... hL.
+    .byt $bb, $bd,   0, $10, $99,   0,   0, $bd, $10, $10, $99,   1   // 9c72: bb bd 00... ...
+    .byt   0, $bd, $20, $10, $99,   2,   0, $a9,   0, $99,   3,   0   // 9c7e: 00 bd 20... ..
+    .byt $f0, $3b, $8d,   6, $0f, $8a, $48, $a0,   3, $b5,   3, $99   // 9c8a: f0 3b 8d... .;.
+    .byt   7, $0f, $ca, $88, $10, $f7, $a0, $0d, $a2,   5, $20, $ad   // 9c96: 07 0f ca... ...
+    .byt $94, $86, $bd, $68, $a8, $a5, $bc, $20, $cc, $92, $20, $6b   // 9ca2: 94 86 bd... ...
+    .byt $b4, $b9,   0,   0, $9d,   0, $10, $b9,   1,   0, $9d, $10   // 9cae: b4 b9 00... ...
+    .byt $10, $b9,   2,   0, $9d, $20, $10, $4c, $c7, $9c, $20, $99   // 9cba: 10 b9 02... ...
+    .byt $b7                                                          // 9cc6: b7          .
+
+// $9cc7 referenced 6 times by $9a54, $9b49, $9dbb, $a2f7, $a2fd, $a3b1
+c9cc7
+    lda l00bd                                                         // 9cc7: a5 bd       ..
+// $9cc9 referenced 2 times by $9b92, $a206
+c9cc9
+    pha                                                               // 9cc9: 48          H
+    lda #0                                                            // 9cca: a9 00       ..
+    jsr sub_cb98f                                                     // 9ccc: 20 8f b9     ..
+    pla                                                               // 9ccf: 68          h
+    ldx l00bb                                                         // 9cd0: a6 bb       ..
+    ldy l00bc                                                         // 9cd2: a4 bc       ..
+    rts                                                               // 9cd4: 60          `
+
+    .byt $c9,   2, $b0, $13, $a8, $d0,   4, $a9,   5, $d0, $e9, $b9   // 9cd5: c9 02 b0... ...
+    .byt $0a, $0e, $91, $bb, $88, $10, $f8, $94,   2, $94,   3, $f0   // 9ce1: 0a 0e 91... ...
+    .byt   2, $a9,   0, $4a, $10, $d6, $29, $3f, $d0, $f7, $8a, $20   // 9ced: 02 a9 00... ...
+    .byt $3d, $b5, $49, $80, $0a, $8d,   5, $0f, $2a, $8d,   6, $0f   // 9cf9: 3d b5 49... =.I
+    .byt $20, $92, $ae, $a2,   2, $20,   4, $af, $a0,   6, $2c, $91   // 9d05: 20 92 ae...  ..
+    .byt $94, $38, $66, $98, $20, $ae, $94, $b0, $6d, $a9, $ff, $20   // 9d11: 94 38 66... .8f
+    .byt $8f, $b9, $ad,   5, $0f, $48, $a9,   4, $8d,   5, $0f, $a2   // 9d1d: 8f b9 ad... ...
+    .byt   1, $bd,   6, $0f, $9d,   5, $0f, $e8, $c9, $0d, $d0, $f5   // 9d29: 01 bd 06... ...
+    .byt $a0, $12, $20, $ad, $94, $a5, $bd, $29, $bf, $0d,   5, $0f   // 9d35: a0 12 20... ..
+    .byt   9,   1, $a8, $29,   2, $f0                                 // 9d41: 09 01 a8... ...
+    .asc "#h "                                                        // 9d47: 23 68 20    #h
+    .byt   9, $b5, $d0, $33, $20, $cb, $8f, $20, $95, $92, $aa, $20   // 9d4a: 09 b5 d0... ...
+    .byt $32, $af, $8a, $f0, $2f, $20, $b5, $af, $ac, $70, $10, $f0   // 9d56: 32 af 8a... 2..
+    .byt $90, $98, $a2,   0, $8e, $70, $10, $f0, $1c, $ad,   6, $0f   // 9d62: 90 98 a2... ...
+    .byt $6a, $b0, $0c, $6a, $90,   9, $2c,   7, $0f, $10,   4, $98   // 9d6e: 6a b0 0c... j..
+    .byt   9, $20, $a8, $68, $20,   9, $b5, $aa, $98, $9d, $40, $10   // 9d7a: 09 20 a8... . .
+    .byt $8a, $4c, $c9, $9c, $20, $99, $b7, $98, $d0, $13, $a5, $bb   // 9d86: 8a 4c c9... .L.
+    .byt $48, $a9, $77, $20, $f4, $ff, $68, $85, $bb, $a9,   0, $85   // 9d92: 48 a9 77... H.w
+    .byt $bd, $85, $bc, $f0,   6, $20, $7a, $b4, $bd, $30, $10, $8d   // 9d9e: bd 85 bc... ...
+    .byt   5, $0f, $a2,   1, $a0,   7, $20, $ad, $94, $a4, $bc, $d0   // 9daa: 05 0f a2... ...
+    .byt   7, $b8, $20, $5d, $b5                                      // 9db6: 07 b8 20... ..
+
+// $9dbb referenced 2 times by $9dd8, $9dec
+c9dbb
+    jmp c9cc7                                                         // 9dbb: 4c c7 9c    L..
+
+    .byt $a9,   0, $99, $10, $10, $99, $40, $10, $f0, $f3             // 9dbe: a9 00 99... ...
+
+sub_c9dc8
+    beq c9dd5                                                         // 9dc8: f0 0b       ..
+    cpx #4                                                            // 9dca: e0 04       ..
+    bne c9dd2                                                         // 9dcc: d0 04       ..
+    cpy #4                                                            // 9dce: c0 04       ..
+    bcc c9ddf                                                         // 9dd0: 90 0d       ..
+// $9dd2 referenced 1 time by $9dcc
+c9dd2
+    dex                                                               // 9dd2: ca          .
+    bne c9dda                                                         // 9dd3: d0 05       ..
+// $9dd5 referenced 1 time by $9dc8
+c9dd5
+    sty l0e06                                                         // 9dd5: 8c 06 0e    ...
+    bcc c9dbb                                                         // 9dd8: 90 e1       ..
+// $9dda referenced 1 time by $9dd3
+c9dda
+    lda #7                                                            // 9dda: a9 07       ..
+    jmp c964e                                                         // 9ddc: 4c 4e 96    LN.
+
+// $9ddf referenced 1 time by $9dd0
+c9ddf
+    sty l0f05                                                         // 9ddf: 8c 05 0f    ...
+    ldy #$16                                                          // 9de2: a0 16       ..
+    jsr c94ad                                                         // 9de4: 20 ad 94     ..
+    ldy l00bc                                                         // 9de7: a4 bc       ..
+    sty l0e05                                                         // 9de9: 8c 05 0e    ...
+    bpl c9dbb                                                         // 9dec: 10 cd       ..
+sub_c9dee
+    jsr sub_c8fcb                                                     // 9dee: 20 cb 8f     ..
+    pha                                                               // 9df1: 48          H
+    lda l00bc                                                         // 9df2: a5 bc       ..
+    pha                                                               // 9df4: 48          H
+    stx l10c9                                                         // 9df5: 8e c9 10    ...
+    jsr sub_cb730                                                     // 9df8: 20 30 b7     0.
+    beq c9e09                                                         // 9dfb: f0 0c       ..
+    lda l1000,y                                                       // 9dfd: b9 00 10    ...
+    cmp l1098,x                                                       // 9e00: dd 98 10    ...
+    bcc c9e09                                                         // 9e03: 90 04       ..
+    ldx #$ff                                                          // 9e05: a2 ff       ..
+    bmi c9e0b                                                         // 9e07: 30 02       0.
+// $9e09 referenced 2 times by $9dfb, $9e03
+c9e09
+    ldx #0                                                            // 9e09: a2 00       ..
+// $9e0b referenced 1 time by $9e07
+c9e0b
+    pla                                                               // 9e0b: 68          h
+    tay                                                               // 9e0c: a8          .
+    pla                                                               // 9e0d: 68          h
+    rts                                                               // 9e0e: 60          `
+
+// $9e0f referenced 1 time by $9f5a
+sub_c9e0f
+    ldy #9                                                            // 9e0f: a0 09       ..
+    jsr sub_c9e16                                                     // 9e11: 20 16 9e     ..
+    ldy #1                                                            // 9e14: a0 01       ..
+// $9e16 referenced 1 time by $9e11
+sub_c9e16
+    clc                                                               // 9e16: 18          .
+// $9e17 referenced 1 time by $9f60
+sub_c9e17
+    ldx #$fc                                                          // 9e17: a2 fc       ..
+// $9e19 referenced 1 time by $9e2c
+loop_c9e19
+    lda (l00bb),y                                                     // 9e19: b1 bb       ..
+    bit l00b2                                                         // 9e1b: 24 b2       $.
+    bmi c9e25                                                         // 9e1d: 30 06       0.
+    adc l0e0a,x                                                       // 9e1f: 7d 0a 0e    }..
+    jmp c9e28                                                         // 9e22: 4c 28 9e    L(.
+
+// $9e25 referenced 1 time by $9e1d
+c9e25
+    sbc l0e0a,x                                                       // 9e25: fd 0a 0e    ...
+// $9e28 referenced 1 time by $9e22
+c9e28
+    sta (l00bb),y                                                     // 9e28: 91 bb       ..
+    iny                                                               // 9e2a: c8          .
+    inx                                                               // 9e2b: e8          .
+    bne loop_c9e19                                                    // 9e2c: d0 eb       ..
+    rts                                                               // 9e2e: 60          `
+
+    .byt $20, $cb, $8f, $20, $95, $92                                 // 9e2f: 20 cb 8f...  ..
+    .asc "H 2"                                                        // 9e35: 48 20 32    H 2
+    .byt $af, $68, $aa, $f0,   5, $ca, $e0,   8, $90,   3, $4c, $c7   // 9e38: af 68 aa... .h.
+    .byt $9c, $8a, $a0,   0, $48, $c9,   4, $90,   3, $4c, $82, $9f   // 9e44: 9c 8a a0... ...
+    .byt $b1, $bb, $48, $20, $f2, $b4, $68, $a8, $20, $99, $b7, $bd   // 9e50: b1 bb 48... ..H
+    .byt $30, $10, $8d,   5, $0f, $a9,   0, $8d,   6, $0f, $bd,   0   // 9e5c: 30 10 8d... 0..
+    .byt $10, $8d,   7, $0f, $bd, $10, $10, $8d,   8, $0f, $bd, $20   // 9e68: 10 8d 07... ...
+    .byt $10, $8d,   9, $0f, $a0, $0d, $a2,   5, $20, $ad, $94, $68   // 9e74: 10 8d 09... ...
+    .byt $20, $dd, $9e,   8, $a0,   0, $b1, $bb, $b0,   5, $20, $cc   // 9e80: 20 dd 9e...  ..
+    .byt $92, $10,   3, $20, $b5, $92, $8c,   6, $0f, $20, $d6, $9e   // 9e8c: 92 10 03... ...
+    .byt $8d,   5, $0f, $a0, $0c, $a2,   2, $20, $ad, $94, $20, $d2   // 9e98: 8d 05 0f... ...
+    .byt $9e, $a0,   9, $ad,   5, $0f, $9d,   0, $10, $91, $bb, $c8   // 9ea4: 9e a0 09... ...
+    .byt $ad,   6, $0f, $9d, $10, $10, $91, $bb, $c8, $ad,   7, $0f   // 9eb0: ad 06 0f... ...
+    .byt $9d, $20, $10, $91, $bb, $a9,   0, $c8, $91, $bb, $28, $90   // 9ebc: 9d 20 10... . .
+    .byt   4, $a5, $bd, $c9,   3, $a9,   0, $4c, $c9, $9c             // 9ec8: 04 a5 bd... ...
+
+// $9ed2 referenced 1 time by $9ede
+sub_c9ed2
+    ldy #0                                                            // 9ed2: a0 00       ..
+    lda (l00bb),y                                                     // 9ed4: b1 bb       ..
+    jsr sub_cb4ad                                                     // 9ed6: 20 ad b4     ..
+    lda l1030,x                                                       // 9ed9: bd 30 10    .0.
+    rts                                                               // 9edc: 60          `
+
+// $9edd referenced 1 time by $b987
+c9edd
+    pha                                                               // 9edd: 48          H
+    jsr sub_c9ed2                                                     // 9ede: 20 d2 9e     ..
+    sta l0f05                                                         // 9ee1: 8d 05 0f    ...
+    ldy #$0b                                                          // 9ee4: a0 0b       ..
+    ldx #6                                                            // 9ee6: a2 06       ..
+// $9ee8 referenced 1 time by $9ef4
+loop_c9ee8
+    lda (l00bb),y                                                     // 9ee8: b1 bb       ..
+    sta l0f06,x                                                       // 9eea: 9d 06 0f    ...
+    dey                                                               // 9eed: 88          .
+    cpy #8                                                            // 9eee: c0 08       ..
+    bne c9ef3                                                         // 9ef0: d0 01       ..
+    dey                                                               // 9ef2: 88          .
+// $9ef3 referenced 1 time by $9ef0
+c9ef3
+    dex                                                               // 9ef3: ca          .
+    bne loop_c9ee8                                                    // 9ef4: d0 f2       ..
+    pla                                                               // 9ef6: 68          h
+    lsr                                                               // 9ef7: 4a          J
+    pha                                                               // 9ef8: 48          H
+    bcc c9efc                                                         // 9ef9: 90 01       ..
+    inx                                                               // 9efb: e8          .
+// $9efc referenced 1 time by $9ef9
+c9efc
+    stx l0f06                                                         // 9efc: 8e 06 0f    ...
+    ldy #$0b                                                          // 9eff: a0 0b       ..
+    ldx #$91                                                          // 9f01: a2 91       ..
+    pla                                                               // 9f03: 68          h
+    pha                                                               // 9f04: 48          H
+    beq c9f0a                                                         // 9f05: f0 03       ..
+    ldx #$92                                                          // 9f07: a2 92       ..
+    dey                                                               // 9f09: 88          .
+// $9f0a referenced 1 time by $9f05
+c9f0a
+    stx l0f02                                                         // 9f0a: 8e 02 0f    ...
+    stx l00b8                                                         // 9f0d: 86 b8       ..
+    ldx #8                                                            // 9f0f: a2 08       ..
+    lda l0f05                                                         // 9f11: ad 05 0f    ...
+    jsr sub_c9497                                                     // 9f14: 20 97 94     ..
+    ldx #0                                                            // 9f17: a2 00       ..
+    lda (l00bb,x)                                                     // 9f19: a1 bb       ..
+    tax                                                               // 9f1b: aa          .
+    lda l1040,x                                                       // 9f1c: bd 40 10    .@.
+    eor #1                                                            // 9f1f: 49 01       I.
+    sta l1040,x                                                       // 9f21: 9d 40 10    .@.
+    clc                                                               // 9f24: 18          .
+    ldx #4                                                            // 9f25: a2 04       ..
+// $9f27 referenced 1 time by $9f3b
+loop_c9f27
+    lda (l00bb),y                                                     // 9f27: b1 bb       ..
+    sta l00af,y                                                       // 9f29: 99 af 00    ...
+    sta l00c7,y                                                       // 9f2c: 99 c7 00    ...
+    jsr sub_c9a7f                                                     // 9f2f: 20 7f 9a     ..
+    adc (l00bb),y                                                     // 9f32: 71 bb       q.
+    sta l00af,y                                                       // 9f34: 99 af 00    ...
+    jsr sub_c9a92                                                     // 9f37: 20 92 9a     ..
+    dex                                                               // 9f3a: ca          .
+    bne loop_c9f27                                                    // 9f3b: d0 ea       ..
+    inx                                                               // 9f3d: e8          .
+// $9f3e referenced 1 time by $9f45
+loop_c9f3e
+    lda l0f03,x                                                       // 9f3e: bd 03 0f    ...
+    sta l0f06,x                                                       // 9f41: 9d 06 0f    ...
+    dex                                                               // 9f44: ca          .
+    bpl loop_c9f3e                                                    // 9f45: 10 f7       ..
+    pla                                                               // 9f47: 68          h
+    bne c9f52                                                         // 9f48: d0 08       ..
+    lda l0f02                                                         // 9f4a: ad 02 0f    ...
+    jsr sub_c9a9a                                                     // 9f4d: 20 9a 9a     ..
+    bcs c9f55                                                         // 9f50: b0 03       ..
+// $9f52 referenced 1 time by $9f48
+c9f52
+    jsr sub_c9998                                                     // 9f52: 20 98 99     ..
+// $9f55 referenced 1 time by $9f50
+c9f55
+    jsr sub_c9f67                                                     // 9f55: 20 67 9f     g.
+    stx l00b2                                                         // 9f58: 86 b2       ..
+    jsr sub_c9e0f                                                     // 9f5a: 20 0f 9e     ..
+    dec l00b2                                                         // 9f5d: c6 b2       ..
+    sec                                                               // 9f5f: 38          8
+    jsr sub_c9e17                                                     // 9f60: 20 17 9e     ..
+    asl l0f05                                                         // 9f63: 0e 05 0f    ...
+    rts                                                               // 9f66: 60          `
+
+// $9f67 referenced 1 time by $9f55
+sub_c9f67
+    php                                                               // 9f67: 08          .
+    jsr sub_c94f0                                                     // 9f68: 20 f0 94     ..
+    plp                                                               // 9f6b: 28          (
+    rts                                                               // 9f6c: 60          `
+
+    .byt $a0, $15, $20, $ad, $94, $ad,   5, $0e, $8d, $16, $0f, $86   // 9f6d: a0 15 20... ..
+    .byt $b0, $86, $b1, $a9, $12, $85, $b2, $d0, $4e, $a0,   4, $ad   // 9f79: b0 86 b1... ...
+    .byt $63, $0d, $f0,   7, $d1, $bb, $d0,   3, $88, $f1, $bb, $85   // 9f85: 63 0d f0... c..
+    .byt $a9, $b1, $bb, $99, $bd,   0, $88, $d0, $f8, $68, $29,   3   // 9f91: a9 b1 bb... ...
+    .byt $f0, $ce, $4a, $f0,   2, $b0, $6b, $a8, $b9,   3, $0e, $8d   // 9f9d: f0 ce 4a... ..J
+    .byt   3, $0f, $ad,   4, $0e, $8d,   4, $0f, $ad,   2, $0e, $8d   // 9fa9: 03 0f ad... ...
+    .byt   2, $0f, $a2, $12, $8e,   1, $0f, $a9, $0d, $8d,   6, $0f   // 9fb5: 02 0f a2... ...
+    .byt $85, $b2, $4a, $8d,   5, $0f, $18, $20, $da, $94, $86, $b1   // 9fc1: 85 b2 4a... ..J
+    .byt $e8, $86, $b0, $a5, $a9, $d0, $11, $a6, $b0, $a4, $b1, $bd   // 9fcd: e8 86 b0... ...
+    .byt   5, $0f, $91, $be, $e8, $c8, $c6, $b2, $d0, $f5, $f0        // 9fd9: 05 0f 91... ...
+    .asc "' s"                                                        // 9fe4: 27 20 73    ' s
+    .byt $a0, $a9,   1, $a6, $bb, $a4, $bc, $e8, $d0,   1, $c8, $20   // 9fe7: a0 a9 01... ...
+    .byt   6,   4, $a6, $b0, $bd,   5, $0f, $8d, $e5, $fe, $e8, $a0   // 9ff3: 06 04 a6... ...
+    .byt   6, $88, $d0, $fd, $c6, $b2, $d0, $f0, $a9, $83, $20,   6   // 9fff: 06 88 d0... ...
+    .byt   4, $4c, $ee, $9c, $a0,   9, $b1, $bb, $8d,   6, $0f, $a0   // a00b: 04 4c ee... .L.
+    .byt   5, $b1, $bb, $8d,   7, $0f, $a2, $0d, $8e,   8, $0f, $a0   // a017: 05 b1 bb... ...
+    .byt   2, $84, $b0, $8c,   5, $0f, $c8, $20, $ad, $94, $86, $b1   // a023: 02 84 b0... ...
+    .byt $ad,   6, $0f, $81, $bb, $ad,   5, $0f, $a0,   9, $71, $bb   // a02f: ad 06 0f... ...
+    .byt $91, $bb, $a5, $c8, $e9,   7, $8d,   6, $0f, $85, $b2, $f0   // a03b: 91 bb a5... ...
+    .byt   3, $20, $d0, $9f, $a2,   2, $9d,   7, $0f, $ca, $10, $fa   // a047: 03 20 d0... . .
+    .byt $20, $14, $9e, $38, $c6, $b2, $ad,   5, $0f, $8d,   6, $0f   // a053: 20 14 9e...  ..
+    .byt $20, $17, $9e, $a2,   3, $a0,   5, $38, $b1, $bb, $d0,   5   // a05f: 20 17 9e...  ..
+    .byt $c8, $ca, $10, $f8, $18, $4c, $0c, $a0                       // a06b: c8 ca 10... ...
+
+// $a073 referenced 2 times by $a078, $a2e3
+ca073
+    lda #$c3                                                          // a073: a9 c3       ..
+    jsr c0406                                                         // a075: 20 06 04     ..
+    bcc ca073                                                         // a078: 90 f9       ..
+    rts                                                               // a07a: 60          `
+
+sub_ca07b
+    lda l0e00                                                         // a07b: ad 00 0e    ...
+    sta l00b5                                                         // a07e: 85 b5       ..
+    lda l0e01                                                         // a080: ad 01 0e    ...
+    sta l00b6                                                         // a083: 85 b6       ..
+    lda (l00be),y                                                     // a085: b1 be       ..
+    cmp #$0d                                                          // a087: c9 0d       ..
+    beq ca09b                                                         // a089: f0 10       ..
+    jsr sub_ca0a7                                                     // a08b: 20 a7 a0     ..
+    lda #1                                                            // a08e: a9 01       ..
+    sta l00b4                                                         // a090: 85 b4       ..
+    lda #$13                                                          // a092: a9 13       ..
+    ldx #<(l00b4)                                                     // a094: a2 b4       ..
+    ldy #>(l00b4)                                                     // a096: a0 00       ..
+    jmp osword                                                        // a098: 4c f1 ff    L..
+
+// $a09b referenced 1 time by $a089
+ca09b
+    jsr sub_cb0c5                                                     // a09b: 20 c5 b0     ..
+// $a09e referenced 1 time by $b0b6
+sub_ca09e
+    bit l9491                                                         // a09e: 2c 91 94    ,..
+    jsr sub_cb198                                                     // a0a1: 20 98 b1     ..
+    jmp osnewl                                                        // a0a4: 4c e7 ff    L..
+
+// $a0a7 referenced 3 times by $a08b, $b011, $b1e8
+sub_ca0a7
+    txa                                                               // a0a7: 8a          .
+    pha                                                               // a0a8: 48          H
+    lda #0                                                            // a0a9: a9 00       ..
+    sta l00b4                                                         // a0ab: 85 b4       ..
+    jsr sub_c916e                                                     // a0ad: 20 6e 91     n.
+    bcs ca0c5                                                         // a0b0: b0 13       ..
+    tya                                                               // a0b2: 98          .
+    pha                                                               // a0b3: 48          H
+    jsr sub_ca865                                                     // a0b4: 20 65 a8     e.
+    eor l00b2                                                         // a0b7: 45 b2       E.
+    beq ca0bd                                                         // a0b9: f0 02       ..
+    lda l00b2                                                         // a0bb: a5 b2       ..
+// $a0bd referenced 1 time by $a0b9
+ca0bd
+    sta l00b6                                                         // a0bd: 85 b6       ..
+    pla                                                               // a0bf: 68          h
+    tay                                                               // a0c0: a8          .
+    iny                                                               // a0c1: c8          .
+    jsr sub_c916e                                                     // a0c2: 20 6e 91     n.
+// $a0c5 referenced 1 time by $a0b0
+ca0c5
+    beq ca0c9                                                         // a0c5: f0 02       ..
+    sta l00b5                                                         // a0c7: 85 b5       ..
+// $a0c9 referenced 1 time by $a0c5
+ca0c9
+    pla                                                               // a0c9: 68          h
+    tax                                                               // a0ca: aa          .
+    rts                                                               // a0cb: 60          `
+
+// $a0cc referenced 2 times by $a0ea, $a0fa
+sub_ca0cc
+    lda l00f0                                                         // a0cc: a5 f0       ..
+// $a0ce referenced 2 times by $8f30, $b108
+sub_ca0ce
+    asl                                                               // a0ce: 0a          .
+    asl                                                               // a0cf: 0a          .
+    pha                                                               // a0d0: 48          H
+    asl                                                               // a0d1: 0a          .
+    tsx                                                               // a0d2: ba          .
+    php                                                               // a0d3: 08          .
+    adc l0101,x                                                       // a0d4: 7d 01 01    }..
+    ror                                                               // a0d7: 6a          j
+    plp                                                               // a0d8: 28          (
+    asl                                                               // a0d9: 0a          .
+    tay                                                               // a0da: a8          .
+    pla                                                               // a0db: 68          h
+    cmp #$48 // 'H'                                                   // a0dc: c9 48       .H
+    bcc ca0e3                                                         // a0de: 90 03       ..
+    ldy #0                                                            // a0e0: a0 00       ..
+    tya                                                               // a0e2: 98          .
+// $a0e3 referenced 1 time by $a0de
+ca0e3
+    rts                                                               // a0e3: 60          `
+
+sub_ca0e4
+    ldy #$6f // 'o'                                                   // a0e4: a0 6f       .o
+    lda (l009c),y                                                     // a0e6: b1 9c       ..
+    bcc ca0f7                                                         // a0e8: 90 0d       ..
+sub_ca0ea
+    jsr sub_ca0cc                                                     // a0ea: 20 cc a0     ..
+    bcs ca0f5                                                         // a0ed: b0 06       ..
+    lda (l009e),y                                                     // a0ef: b1 9e       ..
+    cmp #$3f // '?'                                                   // a0f1: c9 3f       .?
+    bne ca0f7                                                         // a0f3: d0 02       ..
+// $a0f5 referenced 1 time by $a0ed
+ca0f5
+    lda #0                                                            // a0f5: a9 00       ..
+// $a0f7 referenced 2 times by $a0e8, $a0f3
+ca0f7
+    sta l00f0                                                         // a0f7: 85 f0       ..
+    rts                                                               // a0f9: 60          `
+
+sub_ca0fa
+    jsr sub_ca0cc                                                     // a0fa: 20 cc a0     ..
+    bcc ca109                                                         // a0fd: 90 0a       ..
+    ror l0d6c                                                         // a0ff: 6e 6c 0d    nl.
+    lda l00f0                                                         // a102: a5 f0       ..
+    rol                                                               // a104: 2a          *
+    rol l0d6c                                                         // a105: 2e 6c 0d    .l.
+    rts                                                               // a108: 60          `
+
+// $a109 referenced 1 time by $a0fd
+ca109
+    ror l0d61                                                         // a109: 6e 61 0d    na.
+    lda #$3f // '?'                                                   // a10c: a9 3f       .?
+    sta (l009e),y                                                     // a10e: 91 9e       ..
+    rol l0d61                                                         // a110: 2e 61 0d    .a.
+    rts                                                               // a113: 60          `
+
+// $a114 referenced 1 time by $8cf9
+ca114
+    jsr sub_c9291                                                     // a114: 20 91 92     ..
+    ldy #$ff                                                          // a117: a0 ff       ..
+    sty l00ba                                                         // a119: 84 ba       ..
+    sty l0098                                                         // a11b: 84 98       ..
+    iny                                                               // a11d: c8          .
+    ldx #$4a // 'J'                                                   // a11e: a2 4a       .J
+    jsr sub_ca140                                                     // a120: 20 40 a1     @.
+    bcs ca133                                                         // a123: b0 0e       ..
+// $a125 referenced 1 time by $8c5a
+ca125
+    bvc ca133                                                         // a125: 50 0c       P.
+// $a127 referenced 1 time by $af6f
+ca127
+    lda #$dc                                                          // a127: a9 dc       ..
+    jsr generate_error_inline2                                        // a129: 20 d4 96     ..
+    .asc "Syntax", 0                                                  // a12c: 53 79 6e... Syn
+
+// $a133 referenced 2 times by $a123, $a125
+ca133
+    lda #0                                                            // a133: a9 00       ..
+    sta l00a9                                                         // a135: 85 a9       ..
+    lda la3f2,x                                                       // a137: bd f2 a3    ...
+    pha                                                               // a13a: 48          H
+    lda la3f1,x                                                       // a13b: bd f1 a3    ...
+    pha                                                               // a13e: 48          H
+    rts                                                               // a13f: 60          `
+
+// $a140 referenced 5 times by $8c55, $8c83, $a120, $b320, $b34d
+sub_ca140
+    tya                                                               // a140: 98          .
+    pha                                                               // a141: 48          H
+// $a142 referenced 1 time by $a168
+ca142
+    pla                                                               // a142: 68          h
+    pha                                                               // a143: 48          H
+    tay                                                               // a144: a8          .
+    lda la3f0,x                                                       // a145: bd f0 a3    ...
+    bmi ca1a9                                                         // a148: 30 5f       0_
+// $a14a referenced 1 time by $a157
+loop_ca14a
+    lda la3f0,x                                                       // a14a: bd f0 a3    ...
+    bmi ca16a                                                         // a14d: 30 1b       0.
+    eor (l00be),y                                                     // a14f: 51 be       Q.
+    and #$df                                                          // a151: 29 df       ).
+    bne ca159                                                         // a153: d0 04       ..
+    iny                                                               // a155: c8          .
+    inx                                                               // a156: e8          .
+    bne loop_ca14a                                                    // a157: d0 f1       ..
+// $a159 referenced 2 times by $a153, $a15d
+ca159
+    inx                                                               // a159: e8          .
+    lda la3f0,x                                                       // a15a: bd f0 a3    ...
+    bpl ca159                                                         // a15d: 10 fa       ..
+    lda (l00be),y                                                     // a15f: b1 be       ..
+    cmp #$2e // '.'                                                   // a161: c9 2e       ..
+    beq ca18d                                                         // a163: f0 28       .(
+// $a165 referenced 1 time by $a17a
+loop_ca165
+    inx                                                               // a165: e8          .
+    inx                                                               // a166: e8          .
+    inx                                                               // a167: e8          .
+    bne ca142                                                         // a168: d0 d8       ..
+// $a16a referenced 1 time by $a14d
+ca16a
+    tya                                                               // a16a: 98          .
+    pha                                                               // a16b: 48          H
+    lda (l00be),y                                                     // a16c: b1 be       ..
+    ldy #9                                                            // a16e: a0 09       ..
+// $a170 referenced 1 time by $a176
+loop_ca170
+    cmp la17c,y                                                       // a170: d9 7c a1    .|.
+    beq ca185                                                         // a173: f0 10       ..
+    dey                                                               // a175: 88          .
+    bpl loop_ca170                                                    // a176: 10 f8       ..
+    pla                                                               // a178: 68          h
+    tay                                                               // a179: a8          .
+    bne loop_ca165                                                    // a17a: d0 e9       ..
+// $a17c referenced 1 time by $a170
+la17c
+    .asc " ", 34, "#$&*:@"                                            // a17c: 20 22 23...  "#
+    .byt $0d                                                          // a184: 0d          .
+
+// $a185 referenced 1 time by $a173
+ca185
+    pla                                                               // a185: 68          h
+    tay                                                               // a186: a8          .
+// $a187 referenced 1 time by $a18e
+loop_ca187
+    lda (l00be),y                                                     // a187: b1 be       ..
+    cmp #$20 // ' '                                                   // a189: c9 20       .
+    bne ca191                                                         // a18b: d0 04       ..
+// $a18d referenced 1 time by $a163
+ca18d
+    iny                                                               // a18d: c8          .
+    jmp loop_ca187                                                    // a18e: 4c 87 a1    L..
+
+// $a191 referenced 1 time by $a18b
+ca191
+    lda la3f0,x                                                       // a191: bd f0 a3    ...
+    asl                                                               // a194: 0a          .
+    bpl ca1a2                                                         // a195: 10 0b       ..
+    lda (l00be),y                                                     // a197: b1 be       ..
+    cmp #$0d                                                          // a199: c9 0d       ..
+    bne ca1a2                                                         // a19b: d0 05       ..
+    bit l9491                                                         // a19d: 2c 91 94    ,..
+    bvs ca1a3                                                         // a1a0: 70 01       p.
+// $a1a2 referenced 2 times by $a195, $a19b
+ca1a2
+    clv                                                               // a1a2: b8          .
+// $a1a3 referenced 1 time by $a1a0
+ca1a3
+    clc                                                               // a1a3: 18          .
+// $a1a4 referenced 1 time by $a1bf
+loop_ca1a4
+    pla                                                               // a1a4: 68          h
+    lda (l00be),y                                                     // a1a5: b1 be       ..
+    rts                                                               // a1a7: 60          `
+
+// $a1a8 referenced 1 time by $a1b5
+loop_ca1a8
+    iny                                                               // a1a8: c8          .
+// $a1a9 referenced 1 time by $a148
+ca1a9
+    lda (l00be),y                                                     // a1a9: b1 be       ..
+    cmp #$0d                                                          // a1ab: c9 0d       ..
+    beq ca1be                                                         // a1ad: f0 0f       ..
+    cmp #$2e // '.'                                                   // a1af: c9 2e       ..
+    beq ca1b7                                                         // a1b1: f0 04       ..
+    cmp #$20 // ' '                                                   // a1b3: c9 20       .
+    bne loop_ca1a8                                                    // a1b5: d0 f1       ..
+// $a1b7 referenced 2 times by $a1b1, $a1bc
+ca1b7
+    iny                                                               // a1b7: c8          .
+    lda (l00be),y                                                     // a1b8: b1 be       ..
+    cmp #$20 // ' '                                                   // a1ba: c9 20       .
+    beq ca1b7                                                         // a1bc: f0 f9       ..
+// $a1be referenced 1 time by $a1ad
+ca1be
+    sec                                                               // a1be: 38          8
+    bcs loop_ca1a4                                                    // a1bf: b0 e3       ..
+// $a1c1 referenced 1 time by $8e1d
+ca1c1
+    jsr sub_cafb5                                                     // a1c1: 20 b5 af     ..
+    jsr sub_caf32                                                     // a1c4: 20 32 af     2.
+    jsr sub_cae92                                                     // a1c7: 20 92 ae     ..
+// $a1ca referenced 1 time by $a241
+ca1ca
+    ldx #1                                                            // a1ca: a2 01       ..
+    jsr sub_caf04                                                     // a1cc: 20 04 af     ..
+    lda #2                                                            // a1cf: a9 02       ..
+    sta l0f05                                                         // a1d1: 8d 05 0f    ...
+    ldy #$12                                                          // a1d4: a0 12       ..
+    jsr c94ad                                                         // a1d6: 20 ad 94     ..
+    lda l0f05                                                         // a1d9: ad 05 0f    ...
+    cmp #1                                                            // a1dc: c9 01       ..
+    bne ca209                                                         // a1de: d0 29       .)
+    ldx #3                                                            // a1e0: a2 03       ..
+// $a1e2 referenced 1 time by $a1eb
+loop_ca1e2
+    inc l0f0a,x                                                       // a1e2: fe 0a 0f    ...
+    beq ca1ea                                                         // a1e5: f0 03       ..
+    jmp ca26a                                                         // a1e7: 4c 6a a2    Lj.
+
+// $a1ea referenced 1 time by $a1e5
+ca1ea
+    dex                                                               // a1ea: ca          .
+    bpl loop_ca1e2                                                    // a1eb: 10 f5       ..
+    jsr sub_cb53d                                                     // a1ed: 20 3d b5     =.
+    ldx #1                                                            // a1f0: a2 01       ..
+    stx l0f05                                                         // a1f2: 8e 05 0f    ...
+    stx l0f06                                                         // a1f5: 8e 06 0f    ...
+    inx                                                               // a1f8: e8          .
+    jsr sub_caf04                                                     // a1f9: 20 04 af     ..
+    ldy #6                                                            // a1fc: a0 06       ..
+    jsr c94ad                                                         // a1fe: 20 ad 94     ..
+    bcs ca206                                                         // a201: b0 03       ..
+    jmp ca27d                                                         // a203: 4c 7d a2    L}.
+
+// $a206 referenced 1 time by $a201
+ca206
+    jmp c9cc9                                                         // a206: 4c c9 9c    L..
+
+// $a209 referenced 1 time by $a1de
+ca209
+    lda l0e30                                                         // a209: ad 30 0e    .0.
+    cmp #$24 // '$'                                                   // a20c: c9 24       .$
+    beq ca25d                                                         // a20e: f0 4d       .M
+    lda l1071                                                         // a210: ad 71 10    .q.
+    bmi ca25a                                                         // a213: 30 45       0E
+    rol                                                               // a215: 2a          *
+    rol                                                               // a216: 2a          *
+    bmi ca243                                                         // a217: 30 2a       0*
+    bcs ca25d                                                         // a219: b0 42       .B
+    ldx #$ff                                                          // a21b: a2 ff       ..
+// $a21d referenced 1 time by $a223
+loop_ca21d
+    inx                                                               // a21d: e8          .
+    lda l0e30,x                                                       // a21e: bd 30 0e    .0.
+    cmp #$0d                                                          // a221: c9 0d       ..
+    bne loop_ca21d                                                    // a223: d0 f8       ..
+// $a225 referenced 1 time by $a22c
+loop_ca225
+    lda l0e30,x                                                       // a225: bd 30 0e    .0.
+    sta l0e38,x                                                       // a228: 9d 38 0e    .8.
+    dex                                                               // a22b: ca          .
+    bpl loop_ca225                                                    // a22c: 10 f7       ..
+    ldx #7                                                            // a22e: a2 07       ..
+// $a230 referenced 1 time by $a237
+loop_ca230
+    lda la291,x                                                       // a230: bd 91 a2    ...
+    sta l0e30,x                                                       // a233: 9d 30 0e    .0.
+    dex                                                               // a236: ca          .
+    bpl loop_ca230                                                    // a237: 10 f7       ..
+    lda l1071                                                         // a239: ad 71 10    .q.
+    ora #$60 // '`'                                                   // a23c: 09 60       .`
+    sta l1071                                                         // a23e: 8d 71 10    .q.
+// $a241 referenced 1 time by $a258
+loop_ca241
+    bne ca1ca                                                         // a241: d0 87       ..
+// $a243 referenced 1 time by $a217
+ca243
+    ldx #$ff                                                          // a243: a2 ff       ..
+// $a245 referenced 1 time by $a24e
+loop_ca245
+    inx                                                               // a245: e8          .
+    lda l0e38,x                                                       // a246: bd 38 0e    .8.
+    sta l0e30,x                                                       // a249: 9d 30 0e    .0.
+    eor #$0d                                                          // a24c: 49 0d       I.
+    bne loop_ca245                                                    // a24e: d0 f5       ..
+    jsr sub_caf32                                                     // a250: 20 32 af     2.
+    ora #$80                                                          // a253: 09 80       ..
+    sta l1071                                                         // a255: 8d 71 10    .q.
+    bne loop_ca241                                                    // a258: d0 e7       ..
+// $a25a referenced 1 time by $a213
+ca25a
+    jsr sub_caf32                                                     // a25a: 20 32 af     2.
+// $a25d referenced 3 times by $a20e, $a219, $b332
+ca25d
+    lda #$fe                                                          // a25d: a9 fe       ..
+    jsr generate_error_inline                                         // a25f: 20 b8 96     ..
+    .asc "command", 0                                                 // a262: 63 6f 6d... com
+
+// $a26a referenced 1 time by $a1e7
+ca26a
+    ldx #3                                                            // a26a: a2 03       ..
+// $a26c referenced 1 time by $a272
+loop_ca26c
+    inc l0f06,x                                                       // a26c: fe 06 0f    ...
+    bne ca299                                                         // a26f: d0 28       .(
+    dex                                                               // a271: ca          .
+    bne loop_ca26c                                                    // a272: d0 f8       ..
+    lda #$93                                                          // a274: a9 93       ..
+    jsr generate_error_inline3                                        // a276: 20 d1 96     ..
+    .asc "No!", 0                                                     // a279: 4e 6f 21... No!
+
+// $a27d referenced 1 time by $a203
+ca27d
+    lda l0f05                                                         // a27d: ad 05 0f    ...
+    jsr sub_cb509                                                     // a280: 20 09 b5     ..
+    tay                                                               // a283: a8          .
+    lda #0                                                            // a284: a9 00       ..
+    sta l1060,x                                                       // a286: 9d 60 10    .`.
+    sty l1070                                                         // a289: 8c 70 10    .p.
+    ldy #3                                                            // a28c: a0 03       ..
+    jmp ca3e8                                                         // a28e: 4c e8 a3    L..
+
+// $a291 referenced 1 time by $a230
+la291
+    .asc "Library."                                                   // a291: 4c 69 62... Lib
+
+// $a299 referenced 1 time by $a26f
+ca299
+    jsr sub_caf02                                                     // a299: 20 02 af     ..
+    ldy #0                                                            // a29c: a0 00       ..
+    clc                                                               // a29e: 18          .
+    jsr gsinit                                                        // a29f: 20 c2 ff     ..
+// $a2a2 referenced 1 time by $a2a5
+loop_ca2a2
+    jsr gsread                                                        // a2a2: 20 c5 ff     ..
+    bcc loop_ca2a2                                                    // a2a5: 90 fb       ..
+    dey                                                               // a2a7: 88          .
+// $a2a8 referenced 1 time by $a2ad
+loop_ca2a8
+    iny                                                               // a2a8: c8          .
+    lda (os_text_ptr),y                                               // a2a9: b1 f2       ..
+    cmp #$20 // ' '                                                   // a2ab: c9 20       .
+    beq loop_ca2a8                                                    // a2ad: f0 f9       ..
+    eor #$0d                                                          // a2af: 49 0d       I.
+    clc                                                               // a2b1: 18          .
+    tya                                                               // a2b2: 98          .
+    adc os_text_ptr                                                   // a2b3: 65 f2       e.
+    sta l0e0a                                                         // a2b5: 8d 0a 0e    ...
+    lda l00f3                                                         // a2b8: a5 f3       ..
+    adc #0                                                            // a2ba: 69 00       i.
+    sta l0e0b                                                         // a2bc: 8d 0b 0e    ...
+    jsr sub_c8b02                                                     // a2bf: 20 02 8b     ..
+    ldx #$0e                                                          // a2c2: a2 0e       ..
+    stx l00bc                                                         // a2c4: 86 bc       ..
+    lda #$0e                                                          // a2c6: a9 0e       ..
+    sta l00bb                                                         // a2c8: 85 bb       ..
+    sta l0e14                                                         // a2ca: 8d 14 0e    ...
+    ldx #$4a // 'J'                                                   // a2cd: a2 4a       .J
+    ldy #5                                                            // a2cf: a0 05       ..
+    jsr sub_c9951                                                     // a2d1: 20 51 99     Q.
+    lda l0d63                                                         // a2d4: ad 63 0d    .c.
+    beq ca2ef                                                         // a2d7: f0 16       ..
+    and l0f0b                                                         // a2d9: 2d 0b 0f    -..
+    and l0f0c                                                         // a2dc: 2d 0c 0f    -..
+    cmp #$ff                                                          // a2df: c9 ff       ..
+    beq ca2ef                                                         // a2e1: f0 0c       ..
+    jsr ca073                                                         // a2e3: 20 73 a0     s.
+    ldx #9                                                            // a2e6: a2 09       ..
+    ldy #$0f                                                          // a2e8: a0 0f       ..
+    lda #4                                                            // a2ea: a9 04       ..
+    jmp c0406                                                         // a2ec: 4c 06 04    L..
+
+// $a2ef referenced 2 times by $a2d7, $a2e1
+ca2ef
+    lda #1                                                            // a2ef: a9 01       ..
+    jmp (l0f09)                                                       // a2f1: 6c 09 0f    l..
+
+// $a2f4 referenced 1 time by $945f
+ca2f4
+    jsr sub_ca32b                                                     // a2f4: 20 2b a3     +.
+    jmp c9cc7                                                         // a2f7: 4c c7 9c    L..
+
+sub_ca2fa
+    jsr sub_ca362                                                     // a2fa: 20 62 a3     b.
+    jmp c9cc7                                                         // a2fd: 4c c7 9c    L..
+
+// $a300 referenced 1 time by $a39f
+sub_ca300
+    ldx #$10                                                          // a300: a2 10       ..
+    clv                                                               // a302: b8          .
+// $a303 referenced 2 times by $a309, $a310
+ca303
+    dex                                                               // a303: ca          .
+    bmi ca319                                                         // a304: 30 13       0.
+    jsr sub_cb586                                                     // a306: 20 86 b5     ..
+    bne ca303                                                         // a309: d0 f8       ..
+    lda l1060,x                                                       // a30b: bd 60 10    .`.
+    and #4                                                            // a30e: 29 04       ).
+    beq ca303                                                         // a310: f0 f1       ..
+    tya                                                               // a312: 98          .
+    sta l1030,x                                                       // a313: 9d 30 10    .0.
+    bit l9491                                                         // a316: 2c 91 94    ,..
+// $a319 referenced 1 time by $a304
+ca319
+    sty l0e02                                                         // a319: 8c 02 0e    ...
+    bvs ca327                                                         // a31c: 70 09       p.
+    tya                                                               // a31e: 98          .
+    jsr sub_cb509                                                     // a31f: 20 09 b5     ..
+    sta l1072                                                         // a322: 8d 72 10    .r.
+    beq ca38e                                                         // a325: f0 67       .g
+// $a327 referenced 1 time by $a31c
+ca327
+    lda #$26 // '&'                                                   // a327: a9 26       .&
+    bne ca38b                                                         // a329: d0 60       .`
+// $a32b referenced 3 times by $a2f4, $a35d, $a3a5
+sub_ca32b
+    ldx #$10                                                          // a32b: a2 10       ..
+    clv                                                               // a32d: b8          .
+// $a32e referenced 2 times by $a334, $a33b
+ca32e
+    dex                                                               // a32e: ca          .
+    bmi ca344                                                         // a32f: 30 13       0.
+    jsr sub_cb586                                                     // a331: 20 86 b5     ..
+    bne ca32e                                                         // a334: d0 f8       ..
+    lda l1060,x                                                       // a336: bd 60 10    .`.
+    and #8                                                            // a339: 29 08       ).
+    beq ca32e                                                         // a33b: f0 f1       ..
+    tya                                                               // a33d: 98          .
+    sta l1030,x                                                       // a33e: 9d 30 10    .0.
+    bit l9491                                                         // a341: 2c 91 94    ,..
+// $a344 referenced 1 time by $a32f
+ca344
+    sty l0e03                                                         // a344: 8c 03 0e    ...
+    bvs ca352                                                         // a347: 70 09       p.
+    tya                                                               // a349: 98          .
+    jsr sub_cb509                                                     // a34a: 20 09 b5     ..
+    sta l1073                                                         // a34d: 8d 73 10    .s.
+    beq ca38e                                                         // a350: f0 3c       .<
+// $a352 referenced 1 time by $a347
+ca352
+    lda #$2a // '*'                                                   // a352: a9 2a       .*
+    bne ca38b                                                         // a354: d0 35       .5
+sub_ca356
+    lda l0e03                                                         // a356: ad 03 0e    ...
+    pha                                                               // a359: 48          H
+    ldy l0e04                                                         // a35a: ac 04 0e    ...
+    jsr sub_ca32b                                                     // a35d: 20 2b a3     +.
+    pla                                                               // a360: 68          h
+    tay                                                               // a361: a8          .
+// $a362 referenced 2 times by $a2fa, $a3ab
+sub_ca362
+    ldx #$10                                                          // a362: a2 10       ..
+    clv                                                               // a364: b8          .
+// $a365 referenced 2 times by $a36b, $a372
+ca365
+    dex                                                               // a365: ca          .
+    bmi ca37b                                                         // a366: 30 13       0.
+    jsr sub_cb586                                                     // a368: 20 86 b5     ..
+    bne ca365                                                         // a36b: d0 f8       ..
+    lda l1060,x                                                       // a36d: bd 60 10    .`.
+    and #$10                                                          // a370: 29 10       ).
+    beq ca365                                                         // a372: f0 f1       ..
+    tya                                                               // a374: 98          .
+    sta l1030,x                                                       // a375: 9d 30 10    .0.
+    bit l9491                                                         // a378: 2c 91 94    ,..
+// $a37b referenced 1 time by $a366
+ca37b
+    sty l0e04                                                         // a37b: 8c 04 0e    ...
+    bvs ca389                                                         // a37e: 70 09       p.
+    tya                                                               // a380: 98          .
+    jsr sub_cb509                                                     // a381: 20 09 b5     ..
+    sta l1074                                                         // a384: 8d 74 10    .t.
+    beq ca38e                                                         // a387: f0 05       ..
+// $a389 referenced 1 time by $a37e
+ca389
+    lda #$32 // '2'                                                   // a389: a9 32       .2
+// $a38b referenced 2 times by $a329, $a354
+ca38b
+    sta l1060,x                                                       // a38b: 9d 60 10    .`.
+// $a38e referenced 3 times by $a325, $a350, $a387
+ca38e
+    jmp c8f8c                                                         // a38e: 4c 8c 8f    L..
+
+sub_ca391
+    jsr sub_cb559                                                     // a391: 20 59 b5     Y.
+    sec                                                               // a394: 38          8
+    lda l0f08                                                         // a395: ad 08 0f    ...
+    sta l0e05                                                         // a398: 8d 05 0e    ...
+sub_ca39b
+    php                                                               // a39b: 08          .
+    ldy l0f05                                                         // a39c: ac 05 0f    ...
+    jsr sub_ca300                                                     // a39f: 20 00 a3     ..
+    ldy l0f06                                                         // a3a2: ac 06 0f    ...
+    jsr sub_ca32b                                                     // a3a5: 20 2b a3     +.
+    ldy l0f07                                                         // a3a8: ac 07 0f    ...
+    jsr sub_ca362                                                     // a3ab: 20 62 a3     b.
+    plp                                                               // a3ae: 28          (
+    bcs ca3b4                                                         // a3af: b0 03       ..
+    jmp c9cc7                                                         // a3b1: 4c c7 9c    L..
+
+// $a3b4 referenced 1 time by $a3af
+ca3b4
+    lda l1071                                                         // a3b4: ad 71 10    .q.
+    tax                                                               // a3b7: aa          .
+    and #4                                                            // a3b8: 29 04       ).
+    php                                                               // a3ba: 08          .
+    txa                                                               // a3bb: 8a          .
+    and #$fb                                                          // a3bc: 29 fb       ).
+    sta l1071                                                         // a3be: 8d 71 10    .q.
+    plp                                                               // a3c1: 28          (
+    bne ca3e3                                                         // a3c2: d0 1f       ..
+    lda #osbyte_scan_keyboard                                         // a3c4: a9 79       .y
+    ldx #$81                                                          // a3c6: a2 81       ..
+    jsr osbyte                                                        // a3c8: 20 f4 ff     ..
+    txa                                                               // a3cb: 8a          .
+    bpl ca3e3                                                         // a3cc: 10 15       ..
+// $a3ce referenced 1 time by $a3e6
+loop_ca3ce
+    rts                                                               // a3ce: 60          `
+
+    .asc "L.!BOOT"                                                    // a3cf: 4c 2e 21... L.!
+    .byt $0d                                                          // a3d6: 0d          .
+    .asc "E.!BOOT"                                                    // a3d7: 45 2e 21... E.!
+    .byt $0d                                                          // a3de: 0d          .
+// $a3df referenced 1 time by $a3e8
+la3df
+    .byt $de, $cf, $d1, $d7                                           // a3df: de cf d1... ...
+
+// $a3e3 referenced 2 times by $a3c2, $a3cc
+ca3e3
+    ldy l0e05                                                         // a3e3: ac 05 0e    ...
+    beq loop_ca3ce                                                    // a3e6: f0 e6       ..
+// $a3e8 referenced 1 time by $a28e
+ca3e8
+    ldx la3df,y                                                       // a3e8: be df a3    ...
+    ldy #$a3                                                          // a3eb: a0 a3       ..
+    jmp oscli                                                         // a3ed: 4c f7 ff    L..
+
+// $a3f0 referenced 12 times by $8bae, $8bbd, $8bc5, $8bd2, $8c00, $8c07, $932a, $9332, $a145, $a14a, $a15a, $a191
+la3f0
+la3f1 = la3f0+1
+la3f2 = la3f0+2
+    .asc "Close"                                                      // a3f0: 43 6c 6f... Clo
+// $a3f1 referenced 3 times by $8c93, $a13b, $b326
+// $a3f2 referenced 3 times by $8c8f, $a137, $b353
+    .byt $80                                                          // a3f5: 80          .
+    .word sub_cb994-1                                                 // a3f6: 93 b9       ..
+    .asc "Dump"                                                       // a3f8: 44 75 6d... Dum
+    .byt $c4                                                          // a3fc: c4          .
+    .word sub_cba1b-1                                                 // a3fd: 1a ba       ..
+    .asc "Net"                                                        // a3ff: 4e 65 74    Net
+    .byt $80                                                          // a402: 80          .
+    .word sub_c8b1a-1                                                 // a403: 19 8b       ..
+    .asc "Pollps"                                                     // a405: 50 6f 6c... Pol
+    .byt $88                                                          // a40b: 88          .
+    .word sub_cb1c3-1                                                 // a40c: c2 b1       ..
+    .asc "Print"                                                      // a40e: 50 72 69... Pri
+    .byt $cc                                                          // a413: cc          .
+    .word sub_cb99d-1                                                 // a414: 9c b9       ..
+    .asc "Prot"                                                       // a416: 50 72 6f... Pro
+    .byt $8e                                                          // a41a: 8e          .
+    .word sub_cb30c-1                                                 // a41b: 0b b3       ..
+    .asc "PS"                                                         // a41d: 50 53       PS
+    .byt $88                                                          // a41f: 88          .
+    .word sub_cafee-1                                                 // a420: ed af       ..
+    .asc "Roff"                                                       // a422: 52 6f 66... Rof
+    .byt $80                                                          // a426: 80          .
+    .word sub_c8ad4-1                                                 // a427: d3 8a       ..
+    .asc "Type"                                                       // a429: 54 79 70... Typ
+    .byt $cc                                                          // a42d: cc          .
+    .word sub_cb99a-1                                                 // a42e: 99 b9       ..
+    .asc "Unprot"                                                     // a430: 55 6e 70... Unp
+    .byt $8e                                                          // a436: 8e          .
+    .word sub_cb33d-1                                                 // a437: 3c b3       <.
+    .byt $80                                                          // a439: 80          .
+    .asc "Access"                                                     // a43a: 41 63 63... Acc
+    .byt $c9                                                          // a440: c9          .
+    .word sub_c92e6-1                                                 // a441: e5 92       ..
+    .asc "Bye"                                                        // a443: 42 79 65    Bye
+    .byt $80                                                          // a446: 80          .
+    .word sub_c949e-1                                                 // a447: 9d 94       ..
+    .asc "Cdir"                                                       // a449: 43 64 69... Cdi
+    .byt $c6                                                          // a44d: c6          .
+    .word sub_cad10-1                                                 // a44e: 0f ad       ..
+    .asc "Delete"                                                     // a450: 44 65 6c... Del
+    .byt $c3                                                          // a456: c3          .
+    .word sub_c92e6-1                                                 // a457: e5 92       ..
+    .asc "Dir"                                                        // a459: 44 69 72    Dir
+    .byt $81                                                          // a45c: 81          .
+    .word sub_c93dd-1                                                 // a45d: dc 93       ..
+    .asc "Ex"                                                         // a45f: 45 78       Ex
+    .byt $81                                                          // a461: 81          .
+    .word sub_cad6b-1                                                 // a462: 6a ad       j.
+    .asc "Flip"                                                       // a464: 46 6c 69... Fli
+    .byt $80                                                          // a468: 80          .
+    .word sub_ca356-1                                                 // a469: 55 a3       U.
+    .asc "FS"                                                         // a46b: 46 53       FS
+    .byt $8b                                                          // a46d: 8b          .
+    .word sub_ca07b-1                                                 // a46e: 7a a0       z.
+    .asc "Info"                                                       // a470: 49 6e 66... Inf
+    .byt $c3                                                          // a474: c3          .
+    .word sub_c92e6-1                                                 // a475: e5 92       ..
+// $a477 referenced 1 time by $8daf
+la477
+    .asc "I am"                                                       // a477: 49 20 61... I a
+    .byt $c2                                                          // a47b: c2          .
+    .word sub_c8d79-1                                                 // a47c: 78 8d       x.
+    .asc "Lcat"                                                       // a47e: 4c 63 61... Lca
+    .byt $81                                                          // a482: 81          .
+    .word sub_cad5f-1                                                 // a483: 5e ad       ^.
+    .asc "Lex"                                                        // a485: 4c 65 78    Lex
+    .byt $81                                                          // a488: 81          .
+    .word sub_cad65-1                                                 // a489: 64 ad       d.
+    .asc "Lib"                                                        // a48b: 4c 69 62    Lib
+    .byt $c5                                                          // a48e: c5          .
+    .word sub_c92e6-1                                                 // a48f: e5 92       ..
+    .asc "Pass"                                                       // a491: 50 61 73... Pas
+    .byt $c7                                                          // a495: c7          .
+    .word c8dbc-1                                                     // a496: bb 8d       ..
+    .asc "Remove"                                                     // a498: 52 65 6d... Rem
+    .byt $c3                                                          // a49e: c3          .
+    .word sub_caf66-1                                                 // a49f: 65 af       e.
+    .asc "Rename"                                                     // a4a1: 52 65 6e... Ren
+    .byt $ca                                                          // a4a7: ca          .
+    .word sub_c938b-1                                                 // a4a8: 8a 93       ..
+    .asc "Wipe"                                                       // a4aa: 57 69 70... Wip
+    .byt $81                                                          // a4ae: 81          .
+    .word sub_cb359-1                                                 // a4af: 58 b3       X.
+    .byt $80                                                          // a4b1: 80          .
+    .word c8e15-1                                                     // a4b2: 14 8e       ..
+    .asc "Net"                                                        // a4b4: 4e 65 74    Net
+    .byt $80                                                          // a4b7: 80          .
+    .word sub_c8b96-1                                                 // a4b8: 95 8b       ..
+    .asc "Utils"                                                      // a4ba: 55 74 69... Uti
+    .byt $80                                                          // a4bf: 80          .
+    .word sub_c8b92-1                                                 // a4c0: 91 8b       ..
+    .byt $80                                                          // a4c2: 80          .
+    .asc "Halt"                                                       // a4c3: 48 61 6c... Hal
+    .byt $fc, $20, $df                                                // a4c7: fc 20 df    . .
+    .asc "JSR"                                                        // a4ca: 4a 53 52    JSR
+    .byt $fc,   4, $fb                                                // a4cd: fc 04 fb    ...
+    .asc "Peek"                                                       // a4d0: 50 65 65... Pee
+    .byt $fc,   1, $fe                                                // a4d4: fc 01 fe    ...
+    .asc "Poke"                                                       // a4d7: 50 6f 6b... Pok
+    .byt $fc,   2, $fd                                                // a4db: fc 02 fd    ...
+    .asc "Proc"                                                       // a4de: 50 72 6f... Pro
+    .byt $fc,   8, $f7                                                // a4e2: fc 08 f7    ...
+    .asc "Utils"                                                      // a4e5: 55 74 69... Uti
+    .byt $a9, $10, $ef, $80                                           // a4ea: a9 10 ef... ...
+
+sub_ca4ee
+    clc                                                               // a4ee: 18          .
+    lda l00ef                                                         // a4ef: a5 ef       ..
+    sbc #$0d                                                          // a4f1: e9 0d       ..
+    bmi ca522                                                         // a4f3: 30 2d       0-
+    cmp #7                                                            // a4f5: c9 07       ..
+    bcs ca522                                                         // a4f7: b0 29       .)
+    tax                                                               // a4f9: aa          .
+    ldy #6                                                            // a4fa: a0 06       ..
+// $a4fc referenced 1 time by $a507
+loop_ca4fc
+    lda l00a9,y                                                       // a4fc: b9 a9 00    ...
+    pha                                                               // a4ff: 48          H
+    lda l00ed,y                                                       // a500: b9 ed 00    ...
+    sta l00a9,y                                                       // a503: 99 a9 00    ...
+    dey                                                               // a506: 88          .
+    bne loop_ca4fc                                                    // a507: d0 f3       ..
+    jsr sub_ca516                                                     // a509: 20 16 a5     ..
+    ldy #$fa                                                          // a50c: a0 fa       ..
+// $a50e referenced 1 time by $a513
+loop_ca50e
+    pla                                                               // a50e: 68          h
+    sta lffb0,y                                                       // a50f: 99 b0 ff    ...
+    iny                                                               // a512: c8          .
+    bne loop_ca50e                                                    // a513: d0 f9       ..
+    rts                                                               // a515: 60          `
+
+// $a516 referenced 1 time by $a509
+sub_ca516
+    lda la52a,x                                                       // a516: bd 2a a5    .*.
+    pha                                                               // a519: 48          H
+    lda la523,x                                                       // a51a: bd 23 a5    .#.
+    pha                                                               // a51d: 48          H
+    lda (l00ac),y                                                     // a51e: b1 ac       ..
+    sty l00a9                                                         // a520: 84 a9       ..
+// $a522 referenced 2 times by $a4f3, $a4f7
+ca522
+    rts                                                               // a522: 60          `
+
+// $a523 referenced 1 time by $a51a
+la523
+    .byt $30, $21, $a3, $c0, $18, $2d, $c4                            // a523: 30 21 a3... 0!.
+// $a52a referenced 1 time by $a516
+la52a
+    .byt $a5, $a5, $a5, $a5, $a6, $a6, $a8, $2c, $6c, $0d, $10,   8   // a52a: a5 a5 a5... ...
+    .byt $c9,   4, $f0,   5, $a9,   8, $85, $a9, $60, $a2,   0, $a0   // a536: c9 04 f0... ...
+    .byt $10, $20, $ad, $94, $ad,   9, $0f, $20, $95, $a5, $8d, $0b   // a542: 10 20 ad... . .
+    .byt $0f, $ad,   8, $0f, $20, $95, $a5, $8d, $0a, $0f, $ad,   7   // a54e: 0f ad 08... ...
+    .byt $0f, $20, $95, $a5, $8d,   9, $0f, $a9,   0, $8d,   8, $0f   // a55a: 0f 20 95... . .
+    .byt $ad,   6, $0f, $48, $ad,   5, $0f, $20, $95, $a5, $8d,   7   // a566: ad 06 0f... ...
+    .byt $0f                                                          // a572: 0f          .
+    .asc "hH)"                                                        // a573: 68 48 29    hH)
+    .byt $0f, $20, $95, $a5, $8d,   6, $0f                            // a576: 0f 20 95... . .
+    .asc "hJJJJiQ "                                                   // a57d: 68 4a 4a... hJJ
+    .byt $95, $a5, $8d,   5, $0f, $a0,   6, $b9,   5, $0f, $91, $ac   // a585: 95 a5 8d... ...
+    .byt $88, $10, $f8, $60,   8, $aa, $f0,   9, $f8, $a9,   0, $18   // a591: 88 10 f8... ...
+    .byt $69,   1, $ca, $d0, $fa, $28, $60, $0e, $60, $0d, $98, $b0   // a59d: 69 01 ca... i..
+    .byt   3, $91, $ac, $60, $a5, $9d, $85, $ab, $85, $a1, $a9, $6f   // a5a9: 03 91 ac... ...
+    .byt $85, $aa, $85, $a0, $a2, $0f, $20, $f8, $a6, $4c, $8c, $85   // a5b5: 85 aa 85... ...
+    .byt $a6, $9f, $86, $ab, $84, $aa, $6e, $61, $0d, $a8, $85, $ae   // a5c1: a6 9f 86... ...
+    .byt $d0, $1b, $a9,   3, $20, $ce, $a0, $b0                       // a5cd: d0 1b a9... ...
+    .asc "=JJ"                                                        // a5d5: 3d 4a 4a    =JJ
+    .byt $aa, $b1, $aa, $f0, $36, $c9, $3f, $f0,   4, $e8, $8a, $d0   // a5d8: aa b1 aa... ...
+    .byt $ec, $8a, $a2,   0, $81, $ac, $20, $ce, $a0, $b0, $24, $88   // a5e4: ec 8a a2... ...
+    .byt $84, $aa, $a9, $c0, $a0,   1, $a2, $0b, $c4, $ae, $71, $aa   // a5f0: 84 aa a9... ...
+    .byt $f0,   3, $30, $0e, $18, $20, $f8, $a6, $b0, $0f, $a9, $3f   // a5fc: f0 03 30... ..0
+    .byt $a0,   1, $91, $aa, $d0,   7, $69,   1, $d0, $ee, $88, $91   // a608: a0 01 91... ...
+    .byt $ac, $2e, $61, $0d, $60, $a5, $9d, $85, $ab, $a0, $7f, $b1   // a614: ac 2e 61... ..a
+    .byt $9c, $c8, $84, $aa, $aa, $ca, $a0,   0, $20, $f8, $a6, $4c   // a620: 9c c8 84... ...
+    .byt $dd, $ac, $aa, $c9, $13, $b0,   8, $bd, $4e, $a6, $48, $bd   // a62c: dd ac aa... ...
+    .byt $3c, $a6                                                     // a638: 3c a6       <.
+    .asc "H`_r"                                                       // a63a: 48 60 5f... H`_
+    .byt   6, $12                                                     // a63e: 06 12       ..
+    .asc "'-3C"                                                       // a640: 27 2d 33... '-3
+    .byt $e3, $ec, $fa,   1, $e7, $ea,   6, $0e, $19, $24, $a6, $a6   // a644: e3 ec fa... ...
+    .byt $a7, $a7, $a7, $a7, $a7, $a7, $a7, $a7, $a7, $a8, $a6, $a6   // a650: a7 a7 a7... ...
+    .byt $a8, $a8, $a8, $a8, $2c, $6c, $0d, $30,   3, $4c, $49, $a7   // a65c: a8 a8 a8... ...
+    .byt $a0,   2, $b9, $ff, $0d, $91, $f0, $88, $d0, $f8             // a668: a0 02 b9... ...
+    .asc "`,l"                                                        // a672: 60 2c 6c    `,l
+    .byt $0d, $10, $ed, $a0,   0, $20, $99, $b7, $a0,   2, $b1, $f0   // a675: 0d 10 ed... ...
+    .byt $99, $ff, $0d, $88, $d0, $f8, $20,   9, $8e, $a2, $0f, $bd   // a681: 99 ff 0d... ...
+    .byt $60, $10, $a8, $29,   2, $f0, $50, $98, $29, $df, $9d, $60   // a68d: 60 10 a8... `..
+    .byt $10, $a8, $20, $86, $b5, $d0, $44, $18, $98, $29,   4, $f0   // a699: 10 a8 20... ..
+    .byt $10, $98,   9, $20, $a8, $bd, $30, $10, $8d,   2, $0e, $8a   // a6a5: 10 98 09... ...
+    .byt $69, $20, $8d, $72, $10, $98, $29,   8, $f0, $10, $98,   9   // a6b1: 69 20 8d... i .
+    .byt $20, $a8, $bd, $30, $10, $8d,   3, $0e, $8a, $69, $20, $8d   // a6bd: 20 a8 bd...  ..
+    .byt $73, $10, $98, $29, $10, $f0, $10, $98,   9, $20, $a8, $bd   // a6c9: 73 10 98... s..
+    .byt $30, $10, $8d,   4, $0e, $8a, $69, $20, $8d, $74, $10, $98   // a6d5: 30 10 8d... 0..
+    .byt $9d, $60, $10, $ca, $10, $a5, $60, $18, $90,   1, $38, $a9   // a6e1: 9d 60 10... .`.
+    .byt $17, $85, $aa, $a5, $9d, $85, $ab, $a0,   1, $a2,   5, $90   // a6ed: 17 85 aa... ...
+    .byt   4, $b1, $ac, $91, $aa, $b1, $aa, $91, $ac, $c8, $ca, $10   // a6f9: 04 b1 ac... ...
+    .byt $f2, $60, $a5, $9f, $85, $ab, $c8, $98, $85, $aa, $aa, $18   // a705: f2 60 a5... .`.
+    .byt $90, $e5, $c8, $b1, $ac, $c8, $91, $9e, $b1, $ac, $c8, $91   // a711: 90 e5 c8... ...
+    .byt $9e, $20, $65, $a8, $51, $9e, $d0,   2, $91, $9e, $60, $ad   // a71d: 9e 20 65... . e
+    .byt $68, $0d, $4c, $fe, $a7, $c8, $b1, $ac, $4c, $36, $b3, $2c   // a729: 68 0d 4c... h.L
+    .byt $6c, $0d, $10, $10, $a0,   3, $b9, $71, $10, $91, $ac, $88   // a735: 6c 0d 10... l..
+    .byt $d0, $f8                                                     // a741: d0 f8       ..
+    .asc "`,l"                                                        // a743: 60 2c 6c    `,l
+    .byt $0d, $30,   6, $a9,   0, $a8, $91, $ac, $60, $a0,   1, $b1   // a746: 0d 30 06... .0.
+    .byt $ac, $c9, $20, $90, $0a, $c9, $30, $b0,   6, $aa, $bd, $10   // a752: ac c9 20... ..
+    .byt $10, $d0,   7, $a9,   0, $aa, $81, $ac, $f0, $26, $bd, $40   // a75e: 10 d0 07... ...
+    .byt $10, $29,   2, $f0, $f2, $8a, $99, $71, $10, $bd, $10, $10   // a76a: 10 29 02... .).
+    .byt $99,   1, $0e, $c0,   1, $d0, $18, $98, $48, $a0,   4, $20   // a776: 99 01 0e... ...
+    .byt $bf, $a7, $68, $a8, $bd, $40, $10,   9, $24, $9d, $40, $10   // a782: bf a7 68... ..h
+    .byt $c8, $c0,   4, $d0, $be, $88, $60, $c0,   2, $d0, $13, $98   // a78e: c8 c0 04... ...
+    .byt $48, $a0,   8, $20, $bf, $a7, $68, $a8, $bd, $40, $10,   9   // a79a: 48 a0 08... H..
+    .byt $28, $9d, $40, $10, $d0, $e2, $98, $48, $a0, $10, $20, $bf   // a7a6: 28 9d 40... (.@
+    .byt $a7, $68, $a8, $bd, $40, $10,   9, $30, $9d, $40, $10, $d0   // a7b2: a7 68 a8... .h.
+    .byt $cf, $8a, $48, $a2, $0f, $bd, $60, $10, $2a, $2a, $10, $14   // a7be: cf 8a 48... ..H
+    .byt $98, $3d, $60, $10, $f0,   5, $98,   9, $20, $d0,   1, $98   // a7ca: 98 3d 60... .=`
+    .byt $49, $ff, $3d, $60, $10, $9d, $60, $10, $ca, $10, $e2, $68   // a7d6: 49 ff 3d... I.=
+    .byt $aa, $60, $a0,   1, $b1, $9c, $a0,   0, $4c, $fe, $a7, $a0   // a7e2: aa 60 a0... .`.
+    .byt $7f, $b1, $9c, $a0,   1, $91, $ac, $c8, $a9, $80, $91, $ac   // a7ee: 7f b1 9c... ...
+    .byt $60, $ad,   9, $0e, $c8, $91, $ac, $60, $ad,   8, $0e, $10   // a7fa: 60 ad 09... `..
+    .byt $f7, $a9, $6f, $38, $ed, $6b, $0d, $b0, $ef, $c8, $b9, $6c   // a806: f7 a9 6f... ..o
+    .byt $0d, $91, $ac, $c0,   3, $d0, $f6, $60, $c8, $b1, $ac, $99   // a812: 0d 91 ac... ...
+    .byt $6c, $0d, $c0,   3, $d0, $f6                                 // a81e: 6c 0d c0... l..
+    .asc "` e"                                                        // a824: 60 20 65    ` e
+    .byt $a8, $a0,   0, $ad, $71, $0d, $c9, $ff, $d0,   6, $98, $91   // a827: a8 a0 00... ...
+    .byt $ac, $c8, $d0, $13, $c8, $91, $ac, $c8, $c8, $b1, $ac, $f0   // a833: ac c8 d0... ...
+    .byt   7, $4d                                                     // a83f: 07 4d       .M
+// $a841 referenced 1 time by $a875
+la841
+    .byt $71, $0d, $d0,   7, $f0,   3, $ad,   1, $0e, $91, $ac, $60   // a841: 71 0d d0... q..
+// $a84d referenced 1 time by $a87a
+la84d
+    .byt $82, $9c, $ff, $ff                                           // a84d: 82 9c ff... ...
+    .asc "BRIDGE"                                                     // a851: 42 52 49... BRI
+    .byt $9c,   0, $7f, $9c,   0,   0, $71, $0d, $ff, $ff, $73, $0d   // a857: 9c 00 7f... ...
+    .byt $ff, $ff                                                     // a863: ff ff       ..
+
+// $a865 referenced 2 times by $8e09, $a0b4
+sub_ca865
+    lda l0d71                                                         // a865: ad 71 0d    .q.
+    cmp #$ff                                                          // a868: c9 ff       ..
+    bne ca8c4                                                         // a86a: d0 58       .X
+    tya                                                               // a86c: 98          .
+    pha                                                               // a86d: 48          H
+    ldy #$18                                                          // a86e: a0 18       ..
+    ldx #$0b                                                          // a870: a2 0b       ..
+    ror l0d61                                                         // a872: 6e 61 0d    na.
+// $a875 referenced 1 time by $a881
+loop_ca875
+    lda la841,y                                                       // a875: b9 41 a8    .A.
+    sta (l009e),y                                                     // a878: 91 9e       ..
+    lda la84d,x                                                       // a87a: bd 4d a8    .M.
+    sta l00c0,x                                                       // a87d: 95 c0       ..
+    iny                                                               // a87f: c8          .
+    dex                                                               // a880: ca          .
+    bpl loop_ca875                                                    // a881: 10 f2       ..
+    stx l0d71                                                         // a883: 8e 71 0d    .q.
+    rol l0d61                                                         // a886: 2e 61 0d    .a.
+// $a889 referenced 2 times by $a88c, $a8b3
+ca889
+    asl l0d60                                                         // a889: 0e 60 0d    .`.
+    bcc ca889                                                         // a88c: 90 fb       ..
+    lda #$82                                                          // a88e: a9 82       ..
+    sta l00c0                                                         // a890: 85 c0       ..
+    lda #$c0                                                          // a892: a9 c0       ..
+    sta l00a0                                                         // a894: 85 a0       ..
+    lda #0                                                            // a896: a9 00       ..
+    sta l00a1                                                         // a898: 85 a1       ..
+    jsr sub_c858c                                                     // a89a: 20 8c 85     ..
+// $a89d referenced 1 time by $a89f
+loop_ca89d
+    bit l00c0                                                         // a89d: 24 c0       $.
+    bmi loop_ca89d                                                    // a89f: 30 fc       0.
+    txa                                                               // a8a1: 8a          .
+    pha                                                               // a8a2: 48          H
+    lda #osbyte_vsync                                                 // a8a3: a9 13       ..
+    jsr osbyte                                                        // a8a5: 20 f4 ff     ..
+    pla                                                               // a8a8: 68          h
+    tax                                                               // a8a9: aa          .
+    ldy #$18                                                          // a8aa: a0 18       ..
+    lda (l009e),y                                                     // a8ac: b1 9e       ..
+    bmi ca8b5                                                         // a8ae: 30 05       0.
+    jsr sub_cbc86                                                     // a8b0: 20 86 bc     ..
+    bpl ca889                                                         // a8b3: 10 d4       ..
+// $a8b5 referenced 1 time by $a8ae
+ca8b5
+    lda #$3f // '?'                                                   // a8b5: a9 3f       .?
+    sta (l009e),y                                                     // a8b7: 91 9e       ..
+    pla                                                               // a8b9: 68          h
+    tay                                                               // a8ba: a8          .
+    lda l0d71                                                         // a8bb: ad 71 0d    .q.
+    tax                                                               // a8be: aa          .
+    eor #$ff                                                          // a8bf: 49 ff       I.
+    beq ca8c4                                                         // a8c1: f0 01       ..
+    txa                                                               // a8c3: 8a          .
+// $a8c4 referenced 2 times by $a86a, $a8c1
+ca8c4
+    rts                                                               // a8c4: 60          `
+
+    .byt $c9,   1, $b0                                                // a8c5: c9 01 b0    ...
+    .asc "l,l"                                                        // a8c8: 6c 2c 6c    l,l
+    .byt $0d, $10, $f6, $a0                                           // a8cb: 0d 10 f6... ...
+    .asc "# 2"                                                        // a8cf: 23 20 32    # 2
+    .byt $af, $b9, $73, $94, $d0,   3, $b9, $e6, $0d, $91, $9e, $88   // a8d2: af b9 73... ..s
+    .byt $c0, $17, $d0, $f1, $c8, $84, $9a, $a0, $1c, $a5, $ac, $69   // a8de: c0 17 d0... ...
+    .byt   1, $20, $2b, $a9, $a0,   1, $b1, $ac, $a0, $20, $65, $ac   // a8ea: 01 20 2b... . +
+    .byt $20, $2b, $a9, $a0,   2, $a9, $90, $85, $98, $91, $ac, $c8   // a8f6: 20 2b a9...  +.
+    .byt $c8, $b9, $fe, $0d, $91, $ac, $c8, $c0,   7, $d0, $f6, $a5   // a902: c8 b9 fe... ...
+    .byt $9f, $85, $9b, $20, $76, $a9, $a0, $20, $a9, $ff, $91, $9e   // a90e: 9f 85 9b... ...
+    .byt $c8, $91, $9e, $a0, $19, $a9, $90, $91, $9e, $88, $a9, $7f   // a91a: c8 91 9e... ...
+    .byt $91, $9e, $4c, $dd, $95, $91, $9e, $c8, $a5, $ad, $69,   0   // a926: 91 9e 4c... ..L
+    .byt $91, $9e, $60,   8, $a0,   1, $b1, $ac, $aa, $c8, $b1, $ac   // a932: 91 9e 60... ..`
+    .byt $c8, $84, $aa, $a0, $72, $91, $9c, $88, $8a, $91, $9c, $28   // a93e: c8 84 aa... ...
+    .byt $d0, $1f, $a4, $aa, $e6, $aa, $b1, $ac, $f0, $16, $a0, $7d   // a94a: d0 1f a4... ...
+    .byt $91, $9c                                                     // a956: 91 9c       ..
+    .asc "H |"                                                        // a958: 48 20 7c    H |
+    .byt $aa, $38, $66, $98, $20, $76, $a9, $ca, $d0, $fd, $68, $49   // a95b: aa 38 66... .8f
+    .byt $0d, $d0, $e2                                                // a967: 0d d0 e2    ...
+    .asc "` |"                                                        // a96a: 60 20 7c    ` |
+    .byt $aa, $a0, $7b, $b1, $9c, $69,   3, $91, $9c                  // a96d: aa a0 7b... ..{
+    .asc "XL?"                                                        // a976: 58 4c 3f    XL?
+    .byt $98,   8, $48, $8a, $48, $98, $48, $ba, $bd,   3,   1, $c9   // a979: 98 08 48... ..H
+    .byt   9, $b0,   4, $aa, $20, $93, $a9, $68, $a8, $68, $aa        // a985: 09 b0 04... ...
+    .asc "h(`"                                                        // a990: 68 28 60    h(`
+    .byt $bd, $a7, $a9, $48, $bd, $9e, $a9, $48, $a5, $ef, $60, $57   // a993: bd a7 a9... ...
+    .byt $ec, $ec, $ec, $af, $d7, $57, $e1, $50, $8e, $aa, $aa, $aa   // a99f: ec ec ec... ...
+    .byt $a9, $aa, $8e, $a9, $aa, $ba, $7e,   6,   1, $1e,   6,   1   // a9ab: a9 aa 8e... ...
+    .byt $98, $a0, $da, $91, $9e, $a9,   0                            // a9b7: 98 a0 da... ...
+
+// $a9be referenced 1 time by $8ae7
+sub_ca9be
+    ldy #$d9                                                          // a9be: a0 d9       ..
+    sta (l009e),y                                                     // a9c0: 91 9e       ..
+    lda #$80                                                          // a9c2: a9 80       ..
+    ldy #$0c                                                          // a9c4: a0 0c       ..
+    sta (l009e),y                                                     // a9c6: 91 9e       ..
+    lda l009a                                                         // a9c8: a5 9a       ..
+    pha                                                               // a9ca: 48          H
+    lda l009b                                                         // a9cb: a5 9b       ..
+    pha                                                               // a9cd: 48          H
+    sty l009a                                                         // a9ce: 84 9a       ..
+    ldx l009f                                                         // a9d0: a6 9f       ..
+    stx l009b                                                         // a9d2: 86 9b       ..
+    jsr sub_c983f                                                     // a9d4: 20 3f 98     ?.
+    lda #$3f // '?'                                                   // a9d7: a9 3f       .?
+    sta (l009a,x)                                                     // a9d9: 81 9a       ..
+    pla                                                               // a9db: 68          h
+    sta l009b                                                         // a9dc: 85 9b       ..
+    pla                                                               // a9de: 68          h
+    sta l009a                                                         // a9df: 85 9a       ..
+    rts                                                               // a9e1: 60          `
+
+    .byt $a4, $f1, $c9, $81, $f0, $13, $a0,   1, $a2, $0a, $20, $36   // a9e2: a4 f1 c9... ...
+    .byt $aa, $f0, $0a, $88, $88, $a2, $11, $20, $36, $aa, $f0,   1   // a9ee: aa f0 0a... ...
+    .byt $c8, $a2,   2, $98, $f0, $35,   8, $10,   1, $e8, $a0, $dc   // a9fa: c8 a2 02... ...
+    .byt $b9, $15,   0, $91, $9e, $88, $c0, $da, $10, $f6, $8a, $20   // aa06: b9 15 00... ...
+    .byt $be, $a9, $28, $10, $1e, $a9, $7f, $a0, $0c, $91, $9e, $b1   // aa12: be a9 28... ..(
+    .byt $9e, $10, $fc, $ba, $a0, $dd, $b1, $9e,   9, $44, $d0,   4   // aa1e: 9e 10 fc... ...
+    .byt $88, $ca, $b1, $9e, $9d,   6,   1, $c0, $da, $d0, $f5, $60   // aa2a: 88 ca b1... ...
+    .byt $dd, $3f, $aa, $f0,   3, $ca, $10, $f8, $60,   4,   9, $0a   // aa36: dd 3f aa... .?.
+    .byt $14, $15, $9a, $9b, $e1, $e2, $e3, $e4, $0b, $0c, $0f, $79   // aa42: 14 15 9a... ...
+    .byt $7a, $86, $87, $a0, $0e, $c9,   7, $f0,   4, $c9,   8, $d0   // aa4e: 7a 86 87... z..
+    .byt $e3, $a2, $db, $86, $9e, $b1, $f0, $91, $9e, $88, $10, $f9   // aa5a: e3 a2 db... ...
+    .byt $c8, $c6, $9e, $a5, $ef, $91, $9e, $84, $9e, $a0, $14, $a9   // aa66: c8 c6 9e... ...
+    .byt $e9, $91, $9e, $a9,   1, $20, $be, $a9, $86, $9e, $a2, $0d   // aa72: e9 91 9e... ...
+    .byt $a0, $7c, $2c, $91, $94, $70,   5                            // aa7e: a0 7c 2c... .|,
+
+// $aa85 referenced 1 time by $95a2
+sub_caa85
+    ldy #$17                                                          // aa85: a0 17       ..
+    ldx #$1a                                                          // aa87: a2 1a       ..
+// $aa89 referenced 1 time by $ab4a
+sub_caa89
+    clv                                                               // aa89: b8          .
+// $aa8a referenced 1 time by $aaab
+caa8a
+    lda laab1,x                                                       // aa8a: bd b1 aa    ...
+    cmp #$fe                                                          // aa8d: c9 fe       ..
+    beq caaad                                                         // aa8f: f0 1c       ..
+    cmp #$fd                                                          // aa91: c9 fd       ..
+    beq caaa9                                                         // aa93: f0 14       ..
+    cmp #$fc                                                          // aa95: c9 fc       ..
+    bne caaa1                                                         // aa97: d0 08       ..
+    lda l009d                                                         // aa99: a5 9d       ..
+    bvs caa9f                                                         // aa9b: 70 02       p.
+    lda l009f                                                         // aa9d: a5 9f       ..
+// $aa9f referenced 1 time by $aa9b
+caa9f
+    sta l009b                                                         // aa9f: 85 9b       ..
+// $aaa1 referenced 1 time by $aa97
+caaa1
+    bvs caaa7                                                         // aaa1: 70 04       p.
+    sta (l009e),y                                                     // aaa3: 91 9e       ..
+    bvc caaa9                                                         // aaa5: 50 02       P.
+// $aaa7 referenced 1 time by $aaa1
+caaa7
+    sta (l009c),y                                                     // aaa7: 91 9c       ..
+// $aaa9 referenced 2 times by $aa93, $aaa5
+caaa9
+    dey                                                               // aaa9: 88          .
+    dex                                                               // aaaa: ca          .
+    bpl caa8a                                                         // aaab: 10 dd       ..
+// $aaad referenced 1 time by $aa8f
+caaad
+    iny                                                               // aaad: c8          .
+    sty l009a                                                         // aaae: 84 9a       ..
+    rts                                                               // aab0: 60          `
+
+// $aab1 referenced 1 time by $aa8a
+laab1
+    .byt $85,   0, $fd, $fd, $7d, $fc, $ff, $ff, $7e, $fc, $ff, $ff   // aab1: 85 00 fd... ...
+    .byt   0,   0, $fe, $80, $93, $fd, $fd, $d9, $fc, $ff, $ff, $de   // aabd: 00 00 fe... ...
+    .byt $fc, $ff, $ff, $fe, $d1, $fd, $fd, $21, $fd, $ff, $ff, $fd   // aac9: fc ff ff... ...
+    .byt $fd, $ff, $ff, $ca, $e4, $f0, $d0, $0f, $a5, $d0, $6a, $b0   // aad5: fd ff ff... ...
+    .byt $0a                                                          // aae1: 0a          .
+
+// $aae2 referenced 2 times by $8f27, $ab33
+caae2
+    lda #$21 // '!'                                                   // aae2: a9 21       .!
+    sta l0d6b                                                         // aae4: 8d 6b 0d    .k.
+    lda #$41 // 'A'                                                   // aae7: a9 41       .A
+    sta l0d6a                                                         // aae9: 8d 6a 0d    .j.
+    rts                                                               // aaec: 60          `
+
+    .byt $c0,   4, $d0, $fb, $8a, $ca, $d0, $26, $ba, $1d,   6,   1   // aaed: c0 04 d0... ...
+    .byt $9d,   6,   1, $a9, $91, $a2,   3, $20, $f4, $ff, $b0, $e7   // aaf9: 9d 06 01... ...
+    .byt $98, $20, $12, $ab, $c0, $6e, $90, $ef, $20, $36, $ab, $90   // ab05: 98 20 12... . .
+    .byt $ea                                                          // ab11: ea          .
+
+// $ab12 referenced 2 times by $ab2d, $abe4
+sub_cab12
+    ldy l0d6b                                                         // ab12: ac 6b 0d    .k.
+    sta (l009c),y                                                     // ab15: 91 9c       ..
+    inc l0d6b                                                         // ab17: ee 6b 0d    .k.
+    rts                                                               // ab1a: 60          `
+
+// $ab1b referenced 1 time by $8f5a
+sub_cab1b
+    ror                                                               // ab1b: 6a          j
+    bcc cab75                                                         // ab1c: 90 57       .W
+    lda l0d6a                                                         // ab1e: ad 6a 0d    .j.
+    pha                                                               // ab21: 48          H
+    ror                                                               // ab22: 6a          j
+    pla                                                               // ab23: 68          h
+    bcs cab33                                                         // ab24: b0 0d       ..
+    ora #3                                                            // ab26: 09 03       ..
+    sta l0d6a                                                         // ab28: 8d 6a 0d    .j.
+    lda #3                                                            // ab2b: a9 03       ..
+    jsr sub_cab12                                                     // ab2d: 20 12 ab     ..
+    jsr cab36                                                         // ab30: 20 36 ab     6.
+// $ab33 referenced 1 time by $ab24
+cab33
+    jmp caae2                                                         // ab33: 4c e2 aa    L..
+
+// $ab36 referenced 3 times by $ab30, $ab79, $abe7
+cab36
+    ldy #8                                                            // ab36: a0 08       ..
+    lda l0d6b                                                         // ab38: ad 6b 0d    .k.
+    sta (l009e),y                                                     // ab3b: 91 9e       ..
+    lda l009d                                                         // ab3d: a5 9d       ..
+    iny                                                               // ab3f: c8          .
+    sta (l009e),y                                                     // ab40: 91 9e       ..
+    ldy #5                                                            // ab42: a0 05       ..
+    sta (l009e),y                                                     // ab44: 91 9e       ..
+    ldy #$0b                                                          // ab46: a0 0b       ..
+    ldx #$26 // '&'                                                   // ab48: a2 26       .&
+    jsr sub_caa89                                                     // ab4a: 20 89 aa     ..
+    dey                                                               // ab4d: 88          .
+    lda l0d6a                                                         // ab4e: ad 6a 0d    .j.
+    pha                                                               // ab51: 48          H
+    rol                                                               // ab52: 2a          *
+    pla                                                               // ab53: 68          h
+    eor #$80                                                          // ab54: 49 80       I.
+    sta l0d6a                                                         // ab56: 8d 6a 0d    .j.
+    rol                                                               // ab59: 2a          *
+    sta (l009e),y                                                     // ab5a: 91 9e       ..
+    lda l00d0                                                         // ab5c: a5 d0       ..
+    pha                                                               // ab5e: 48          H
+    and #$fe                                                          // ab5f: 29 fe       ).
+    sta l00d0                                                         // ab61: 85 d0       ..
+    ldy #$21 // '!'                                                   // ab63: a0 21       .!
+    sty l0d6b                                                         // ab65: 8c 6b 0d    .k.
+    lda #0                                                            // ab68: a9 00       ..
+    tax                                                               // ab6a: aa          .
+    ldy l009f                                                         // ab6b: a4 9f       ..
+    cli                                                               // ab6d: 58          X
+    jsr sub_cac24                                                     // ab6e: 20 24 ac     $.
+    pla                                                               // ab71: 68          h
+    sta l00d0                                                         // ab72: 85 d0       ..
+    rts                                                               // ab74: 60          `
+
+// $ab75 referenced 1 time by $ab1c
+cab75
+    lda l0d6a                                                         // ab75: ad 6a 0d    .j.
+    ror                                                               // ab78: 6a          j
+    bcc cab36                                                         // ab79: 90 bb       ..
+    lda l00d0                                                         // ab7b: a5 d0       ..
+    pha                                                               // ab7d: 48          H
+    and #$fe                                                          // ab7e: 29 fe       ).
+    sta l00d0                                                         // ab80: 85 d0       ..
+    lda #$14                                                          // ab82: a9 14       ..
+// $ab84 referenced 1 time by $abf8
+cab84
+    pha                                                               // ab84: 48          H
+    ldx #$0b                                                          // ab85: a2 0b       ..
+    ldy #$2c // ','                                                   // ab87: a0 2c       .,
+// $ab89 referenced 1 time by $ab90
+loop_cab89
+    lda lac80,x                                                       // ab89: bd 80 ac    ...
+    sta (l009c),y                                                     // ab8c: 91 9c       ..
+    dey                                                               // ab8e: 88          .
+    dex                                                               // ab8f: ca          .
+    bpl loop_cab89                                                    // ab90: 10 f7       ..
+    stx l0098                                                         // ab92: 86 98       ..
+    ldy #2                                                            // ab94: a0 02       ..
+    lda (l009e),y                                                     // ab96: b1 9e       ..
+    pha                                                               // ab98: 48          H
+    iny                                                               // ab99: c8          .
+    lda (l009e),y                                                     // ab9a: b1 9e       ..
+    ldy #$24 // '$'                                                   // ab9c: a0 24       .$
+    sta (l009c),y                                                     // ab9e: 91 9c       ..
+    dey                                                               // aba0: 88          .
+    pla                                                               // aba1: 68          h
+    sta (l009c),y                                                     // aba2: 91 9c       ..
+    ldx #$0b                                                          // aba4: a2 0b       ..
+    ldy #$0b                                                          // aba6: a0 0b       ..
+// $aba8 referenced 1 time by $abb9
+loop_caba8
+    lda lac8c,x                                                       // aba8: bd 8c ac    ...
+    cmp #$fd                                                          // abab: c9 fd       ..
+    beq cabb7                                                         // abad: f0 08       ..
+    cmp #$fc                                                          // abaf: c9 fc       ..
+    bne cabb5                                                         // abb1: d0 02       ..
+    lda l009d                                                         // abb3: a5 9d       ..
+// $abb5 referenced 1 time by $abb1
+cabb5
+    sta (l009e),y                                                     // abb5: 91 9e       ..
+// $abb7 referenced 1 time by $abad
+cabb7
+    dey                                                               // abb7: 88          .
+    dex                                                               // abb8: ca          .
+    bpl loop_caba8                                                    // abb9: 10 ed       ..
+    lda #$21 // '!'                                                   // abbb: a9 21       .!
+    sta l009a                                                         // abbd: 85 9a       ..
+    lda l009d                                                         // abbf: a5 9d       ..
+    sta l009b                                                         // abc1: 85 9b       ..
+    jsr sub_c989c                                                     // abc3: 20 9c 98     ..
+    jsr sub_c983f                                                     // abc6: 20 3f 98     ?.
+    lda #0                                                            // abc9: a9 00       ..
+    sta l009a                                                         // abcb: 85 9a       ..
+    lda l009f                                                         // abcd: a5 9f       ..
+    sta l009b                                                         // abcf: 85 9b       ..
+    jsr sub_c95dd                                                     // abd1: 20 dd 95     ..
+    ldy #$2d // '-'                                                   // abd4: a0 2d       .-
+    lda (l009c),y                                                     // abd6: b1 9c       ..
+    beq cabde                                                         // abd8: f0 04       ..
+    cmp #3                                                            // abda: c9 03       ..
+    bne cabf3                                                         // abdc: d0 15       ..
+// $abde referenced 1 time by $abd8
+cabde
+    pla                                                               // abde: 68          h
+    pla                                                               // abdf: 68          h
+    sta l00d0                                                         // abe0: 85 d0       ..
+    lda #0                                                            // abe2: a9 00       ..
+    jsr sub_cab12                                                     // abe4: 20 12 ab     ..
+    jsr cab36                                                         // abe7: 20 36 ab     6.
+    lda l0d6a                                                         // abea: ad 6a 0d    .j.
+    and #$f0                                                          // abed: 29 f0       ).
+    sta l0d6a                                                         // abef: 8d 6a 0d    .j.
+    rts                                                               // abf2: 60          `
+
+// $abf3 referenced 1 time by $abdc
+cabf3
+    tax                                                               // abf3: aa          .
+    pla                                                               // abf4: 68          h
+    sec                                                               // abf5: 38          8
+    sbc #1                                                            // abf6: e9 01       ..
+    bne cab84                                                         // abf8: d0 8a       ..
+    cpx #1                                                            // abfa: e0 01       ..
+    bne cac10                                                         // abfc: d0 12       ..
+// $abfe referenced 1 time by $aff5
+cabfe
+    lda #$a6                                                          // abfe: a9 a6       ..
+    jsr generate_error_inline3                                        // ac00: 20 d1 96     ..
+    .asc "Printer busy", 0                                            // ac03: 50 72 69... Pri
+
+// $ac10 referenced 1 time by $abfc
+cac10
+    lda #$a7                                                          // ac10: a9 a7       ..
+    jsr generate_error_inline3                                        // ac12: 20 d1 96     ..
+    .asc "Printer jammed", 0                                          // ac15: 50 72 69... Pri
+
+// $ac24 referenced 3 times by $9509, $ab6e, $b951
+sub_cac24
+    stx l009a                                                         // ac24: 86 9a       ..
+    sty l009b                                                         // ac26: 84 9b       ..
+    pha                                                               // ac28: 48          H
+    ora #0                                                            // ac29: 09 00       ..
+    beq cac4a                                                         // ac2b: f0 1d       ..
+    ldx #$ff                                                          // ac2d: a2 ff       ..
+    tay                                                               // ac2f: a8          .
+// $ac30 referenced 2 times by $ac39, $ac43
+cac30
+    tya                                                               // ac30: 98          .
+    inx                                                               // ac31: e8          .
+    cmp l1030,x                                                       // ac32: dd 30 10    .0.
+    beq cac3f                                                         // ac35: f0 08       ..
+    cpx #$0f                                                          // ac37: e0 0f       ..
+    bne cac30                                                         // ac39: d0 f5       ..
+    lda #0                                                            // ac3b: a9 00       ..
+    beq cac4a                                                         // ac3d: f0 0b       ..
+// $ac3f referenced 1 time by $ac35
+cac3f
+    tay                                                               // ac3f: a8          .
+    jsr sub_cb586                                                     // ac40: 20 86 b5     ..
+    bne cac30                                                         // ac43: d0 eb       ..
+    lda l1060,x                                                       // ac45: bd 60 10    .`.
+    and #1                                                            // ac48: 29 01       ).
+// $ac4a referenced 2 times by $ac2b, $ac3d
+cac4a
+    ldy #0                                                            // ac4a: a0 00       ..
+    ora (l009a),y                                                     // ac4c: 11 9a       ..
+    pha                                                               // ac4e: 48          H
+    sta (l009a),y                                                     // ac4f: 91 9a       ..
+    jsr sub_c983f                                                     // ac51: 20 3f 98     ?.
+    lda #$ff                                                          // ac54: a9 ff       ..
+    ldy #8                                                            // ac56: a0 08       ..
+    sta (l009a),y                                                     // ac58: 91 9a       ..
+    iny                                                               // ac5a: c8          .
+    sta (l009a),y                                                     // ac5b: 91 9a       ..
+    pla                                                               // ac5d: 68          h
+    tax                                                               // ac5e: aa          .
+    ldy #$d1                                                          // ac5f: a0 d1       ..
+    pla                                                               // ac61: 68          h
+    pha                                                               // ac62: 48          H
+    beq cac67                                                         // ac63: f0 02       ..
+    ldy #$90                                                          // ac65: a0 90       ..
+// $ac67 referenced 1 time by $ac63
+cac67
+    tya                                                               // ac67: 98          .
+    ldy #1                                                            // ac68: a0 01       ..
+    sta (l009a),y                                                     // ac6a: 91 9a       ..
+    txa                                                               // ac6c: 8a          .
+    dey                                                               // ac6d: 88          .
+    pha                                                               // ac6e: 48          H
+// $ac6f referenced 1 time by $ac7b
+loop_cac6f
+    lda #$7f                                                          // ac6f: a9 7f       ..
+    sta (l009a),y                                                     // ac71: 91 9a       ..
+    jsr sub_c95dd                                                     // ac73: 20 dd 95     ..
+    pla                                                               // ac76: 68          h
+    pha                                                               // ac77: 48          H
+    eor (l009a),y                                                     // ac78: 51 9a       Q.
+    ror                                                               // ac7a: 6a          j
+    bcs loop_cac6f                                                    // ac7b: b0 f2       ..
+    pla                                                               // ac7d: 68          h
+    pla                                                               // ac7e: 68          h
+    rts                                                               // ac7f: 60          `
+
+// $ac80 referenced 1 time by $ab89
+lac80
+    .byt $80, $9f,   0,   0, $59, $8e, $ff, $ff, $61, $8e, $ff, $ff   // ac80: 80 9f 00... ...
+// $ac8c referenced 1 time by $aba8
+lac8c
+    .byt $7f, $9e, $fd, $fd, $2d, $fc, $ff, $ff, $30, $fc, $ff, $ff   // ac8c: 7f 9e fd... ...
+
+sub_cac98
+    lda l00aa                                                         // ac98: a5 aa       ..
+    pha                                                               // ac9a: 48          H
+    lda #$e9                                                          // ac9b: a9 e9       ..
+    sta l009e                                                         // ac9d: 85 9e       ..
+    ldy #0                                                            // ac9f: a0 00       ..
+    sty l00aa                                                         // aca1: 84 aa       ..
+    lda l0350                                                         // aca3: ad 50 03    .P.
+    sta (l009e),y                                                     // aca6: 91 9e       ..
+    inc l009e                                                         // aca8: e6 9e       ..
+    lda l0351                                                         // acaa: ad 51 03    .Q.
+    pha                                                               // acad: 48          H
+    tya                                                               // acae: 98          .
+// $acaf referenced 1 time by $acce
+loop_cacaf
+    sta (l009e),y                                                     // acaf: 91 9e       ..
+    ldx l009e                                                         // acb1: a6 9e       ..
+    ldy l009f                                                         // acb3: a4 9f       ..
+    lda #osword_read_palette                                          // acb5: a9 0b       ..
+    jsr osword                                                        // acb7: 20 f1 ff     ..
+    pla                                                               // acba: 68          h
+    ldy #0                                                            // acbb: a0 00       ..
+    sta (l009e),y                                                     // acbd: 91 9e       ..
+    iny                                                               // acbf: c8          .
+    lda (l009e),y                                                     // acc0: b1 9e       ..
+    pha                                                               // acc2: 48          H
+    ldx l009e                                                         // acc3: a6 9e       ..
+    inc l009e                                                         // acc5: e6 9e       ..
+    inc l00aa                                                         // acc7: e6 aa       ..
+    dey                                                               // acc9: 88          .
+    lda l00aa                                                         // acca: a5 aa       ..
+    cpx #$f9                                                          // accc: e0 f9       ..
+    bne loop_cacaf                                                    // acce: d0 df       ..
+    pla                                                               // acd0: 68          h
+    sty l00aa                                                         // acd1: 84 aa       ..
+    inc l009e                                                         // acd3: e6 9e       ..
+    jsr sub_cace4                                                     // acd5: 20 e4 ac     ..
+    inc l009e                                                         // acd8: e6 9e       ..
+    pla                                                               // acda: 68          h
+    sta l00aa                                                         // acdb: 85 aa       ..
+// $acdd referenced 3 times by $9586, $95ae, $95d5
+cacdd
+    lda l0d69                                                         // acdd: ad 69 0d    .i.
+    sta l0d68                                                         // ace0: 8d 68 0d    .h.
+    rts                                                               // ace3: 60          `
+
+// $ace4 referenced 1 time by $acd5
+sub_cace4
+    lda l0355                                                         // ace4: ad 55 03    .U.
+    sta (l009e),y                                                     // ace7: 91 9e       ..
+    ldx l0355                                                         // ace9: ae 55 03    .U.
+    jsr sub_cacf9                                                     // acec: 20 f9 ac     ..
+    inc l009e                                                         // acef: e6 9e       ..
+    tya                                                               // acf1: 98          .
+    sta (l009e,x)                                                     // acf2: 81 9e       ..
+    jsr sub_cacf7                                                     // acf4: 20 f7 ac     ..
+// $acf7 referenced 1 time by $acf4
+sub_cacf7
+    ldx #0                                                            // acf7: a2 00       ..
+// $acf9 referenced 1 time by $acec
+sub_cacf9
+    ldy l00aa                                                         // acf9: a4 aa       ..
+    inc l00aa                                                         // acfb: e6 aa       ..
+    inc l009e                                                         // acfd: e6 9e       ..
+    lda lad0d,y                                                       // acff: b9 0d ad    ...
+    ldy #$ff                                                          // ad02: a0 ff       ..
+    jsr osbyte                                                        // ad04: 20 f4 ff     ..
+    txa                                                               // ad07: 8a          .
+    ldx #0                                                            // ad08: a2 00       ..
+    sta (l009e,x)                                                     // ad0a: 81 9e       ..
+    rts                                                               // ad0c: 60          `
+
+// $ad0d referenced 1 time by $acff
+lad0d
+    .byt $84, $c2, $c3                                                // ad0d: 84 c2 c3    ...
+
+sub_cad10
+    tya                                                               // ad10: 98          .
+    pha                                                               // ad11: 48          H
+    jsr sub_caf32                                                     // ad12: 20 32 af     2.
+    jsr sub_cafc1                                                     // ad15: 20 c1 af     ..
+    cmp #$0d                                                          // ad18: c9 0d       ..
+    bne cad20                                                         // ad1a: d0 04       ..
+    ldx #2                                                            // ad1c: a2 02       ..
+    bne cad2f                                                         // ad1e: d0 0f       ..
+// $ad20 referenced 1 time by $ad1a
+cad20
+    lda #$ff                                                          // ad20: a9 ff       ..
+    sta l00b4                                                         // ad22: 85 b4       ..
+    jsr sub_c916e                                                     // ad24: 20 6e 91     n.
+    ldx #$1b                                                          // ad27: a2 1b       ..
+// $ad29 referenced 1 time by $ad2d
+loop_cad29
+    dex                                                               // ad29: ca          .
+    cmp lad43,x                                                       // ad2a: dd 43 ad    .C.
+    bcc loop_cad29                                                    // ad2d: 90 fa       ..
+// $ad2f referenced 1 time by $ad1e
+cad2f
+    stx l0f05                                                         // ad2f: 8e 05 0f    ...
+    pla                                                               // ad32: 68          h
+    tay                                                               // ad33: a8          .
+    jsr sub_cafb5                                                     // ad34: 20 b5 af     ..
+    jsr sub_cae94                                                     // ad37: 20 94 ae     ..
+    ldx #1                                                            // ad3a: a2 01       ..
+    jsr sub_caf04                                                     // ad3c: 20 04 af     ..
+    ldy #$1b                                                          // ad3f: a0 1b       ..
+sub_cad41
+lad43 = sub_cad41+2
+    jmp c94ad                                                         // ad41: 4c ad 94    L..
+
+// $ad43 referenced 1 time by $ad2a
+    .byt   0, $0a, $14, $1d                                           // ad44: 00 0a 14... ...
+    .asc "'1;EOXblv"                                                  // ad48: 27 31 3b... '1;
+    .byt $80, $8a, $94, $9d, $a7, $b1, $bb, $c5, $cf, $d8, $e2, $ec   // ad51: 80 8a 94... ...
+    .byt $f6, $ff                                                     // ad5d: f6 ff       ..
+
+sub_cad5f
+    ror l1071                                                         // ad5f: 6e 71 10    nq.
+    sec                                                               // ad62: 38          8
+    bcs cad89                                                         // ad63: b0 24       .$
+sub_cad65
+    ror l1071                                                         // ad65: 6e 71 10    nq.
+    sec                                                               // ad68: 38          8
+    bcs cad6f                                                         // ad69: b0 04       ..
+sub_cad6b
+    ror l1071                                                         // ad6b: 6e 71 10    nq.
+    clc                                                               // ad6e: 18          .
+// $ad6f referenced 1 time by $ad69
+cad6f
+    rol l1071                                                         // ad6f: 2e 71 10    .q.
+    lda #$ff                                                          // ad72: a9 ff       ..
+    sta l00ba                                                         // ad74: 85 ba       ..
+    lda #1                                                            // ad76: a9 01       ..
+    sta l00b7                                                         // ad78: 85 b7       ..
+    lda #3                                                            // ad7a: a9 03       ..
+    sta l00b5                                                         // ad7c: 85 b5       ..
+    bne cad96                                                         // ad7e: d0 16       ..
+sub_cad80
+    jsr sub_c9295                                                     // ad80: 20 95 92     ..
+    ldy #0                                                            // ad83: a0 00       ..
+    ror l1071                                                         // ad85: 6e 71 10    nq.
+    clc                                                               // ad88: 18          .
+// $ad89 referenced 1 time by $ad63
+cad89
+    rol l1071                                                         // ad89: 2e 71 10    .q.
+    lda #3                                                            // ad8c: a9 03       ..
+    sta l00ba                                                         // ad8e: 85 ba       ..
+    sta l00b7                                                         // ad90: 85 b7       ..
+    lda #$0b                                                          // ad92: a9 0b       ..
+    sta l00b5                                                         // ad94: 85 b5       ..
+// $ad96 referenced 1 time by $ad7e
+cad96
+    jsr sub_cafb5                                                     // ad96: 20 b5 af     ..
+    lda #$ff                                                          // ad99: a9 ff       ..
+    sta l0098                                                         // ad9b: 85 98       ..
+    lda #6                                                            // ad9d: a9 06       ..
+    sta l0f05                                                         // ad9f: 8d 05 0f    ...
+    jsr sub_cae94                                                     // ada2: 20 94 ae     ..
+    ldx #1                                                            // ada5: a2 01       ..
+    jsr sub_caf04                                                     // ada7: 20 04 af     ..
+    lda l1071                                                         // adaa: ad 71 10    .q.
+    lsr                                                               // adad: 4a          J
+    bcc cadb2                                                         // adae: 90 02       ..
+    ora #$40 // '@'                                                   // adb0: 09 40       .@
+// $adb2 referenced 1 time by $adae
+cadb2
+    rol                                                               // adb2: 2a          *
+    sta l1071                                                         // adb3: 8d 71 10    .q.
+    ldy #$12                                                          // adb6: a0 12       ..
+    jsr c94ad                                                         // adb8: 20 ad 94     ..
+    ldx #3                                                            // adbb: a2 03       ..
+    jsr sub_cae82                                                     // adbd: 20 82 ae     ..
+    jsr print_inline_top_bit_clear                                    // adc0: 20 45 91     E.
+    .asc "("                                                          // adc3: 28          (
+
+    lda l0f13                                                         // adc4: ad 13 0f    ...
+    jsr caf88                                                         // adc7: 20 88 af     ..
+    jsr print_inline_top_bit_clear                                    // adca: 20 45 91     E.
+    .asc ")     "                                                     // adcd: 29 20 20... )
+
+    ldy l0f12                                                         // add3: ac 12 0f    ...
+    bne cade3                                                         // add6: d0 0b       ..
+    jsr print_inline_top_bit_clear                                    // add8: 20 45 91     E.
+    .asc "Owner", $0d                                                 // addb: 4f 77 6e... Own
+
+    bne caded                                                         // ade1: d0 0a       ..
+// $ade3 referenced 1 time by $add6
+cade3
+    jsr print_inline_top_bit_clear                                    // ade3: 20 45 91     E.
+    .asc "Public", $0d                                                // ade6: 50 75 62... Pub
+
+// $aded referenced 1 time by $ade1
+caded
+    lda l1071                                                         // aded: ad 71 10    .q.
+    pha                                                               // adf0: 48          H
+    jsr sub_caf32                                                     // adf1: 20 32 af     2.
+    ldy #$15                                                          // adf4: a0 15       ..
+    jsr c94ad                                                         // adf6: 20 ad 94     ..
+    inx                                                               // adf9: e8          .
+    ldy #$10                                                          // adfa: a0 10       ..
+    jsr cae84                                                         // adfc: 20 84 ae     ..
+    jsr print_inline_top_bit_clear                                    // adff: 20 45 91     E.
+    .asc "    Option "                                                // ae02: 20 20 20...
+
+    lda l0e05                                                         // ae0d: ad 05 0e    ...
+    tax                                                               // ae10: aa          .
+    jsr sub_c912f                                                     // ae11: 20 2f 91     /.
+    jsr print_inline_top_bit_clear                                    // ae14: 20 45 91     E.
+    .asc " ("                                                         // ae17: 20 28        (
+
+    ldy laefb,x                                                       // ae19: bc fb ae    ...
+// $ae1c referenced 1 time by $ae25
+loop_cae1c
+    lda laeff,y                                                       // ae1c: b9 ff ae    ...
+    bmi cae27                                                         // ae1f: 30 06       0.
+    jsr osasci                                                        // ae21: 20 e3 ff     ..
+    iny                                                               // ae24: c8          .
+    bne loop_cae1c                                                    // ae25: d0 f5       ..
+// $ae27 referenced 1 time by $ae1f
+cae27
+    jsr print_inline_top_bit_clear                                    // ae27: 20 45 91     E.
+    .asc ")", $0d, "Dir. "                                            // ae2a: 29 0d 44... ).D
+
+    ldx #$11                                                          // ae31: a2 11       ..
+    jsr sub_cae82                                                     // ae33: 20 82 ae     ..
+    jsr print_inline_top_bit_clear                                    // ae36: 20 45 91     E.
+    .asc "     Lib. "                                                 // ae39: 20 20 20...
+
+    ldx #$1b                                                          // ae43: a2 1b       ..
+    jsr sub_cae82                                                     // ae45: 20 82 ae     ..
+    jsr osnewl                                                        // ae48: 20 e7 ff     ..
+    pla                                                               // ae4b: 68          h
+    sta l1071                                                         // ae4c: 8d 71 10    .q.
+// $ae4f referenced 1 time by $ae80
+cae4f
+    sty l0f06                                                         // ae4f: 8c 06 0f    ...
+    sty l00b4                                                         // ae52: 84 b4       ..
+    ldx l00b5                                                         // ae54: a6 b5       ..
+    stx l0f07                                                         // ae56: 8e 07 0f    ...
+    ldx l00b7                                                         // ae59: a6 b7       ..
+    stx l0f05                                                         // ae5b: 8e 05 0f    ...
+    ldx #3                                                            // ae5e: a2 03       ..
+    jsr sub_caf04                                                     // ae60: 20 04 af     ..
+    ldy #3                                                            // ae63: a0 03       ..
+    jsr c94ad                                                         // ae65: 20 ad 94     ..
+    inx                                                               // ae68: e8          .
+    lda l0f05                                                         // ae69: ad 05 0f    ...
+    beq cae8f                                                         // ae6c: f0 21       .!
+    pha                                                               // ae6e: 48          H
+// $ae6f referenced 1 time by $ae73
+loop_cae6f
+    iny                                                               // ae6f: c8          .
+    lda l0f05,y                                                       // ae70: b9 05 0f    ...
+    bpl loop_cae6f                                                    // ae73: 10 fa       ..
+    sta l0f04,y                                                       // ae75: 99 04 0f    ...
+    jsr sub_caf47                                                     // ae78: 20 47 af     G.
+    pla                                                               // ae7b: 68          h
+    clc                                                               // ae7c: 18          .
+    adc l00b4                                                         // ae7d: 65 b4       e.
+    tay                                                               // ae7f: a8          .
+    bne cae4f                                                         // ae80: d0 cd       ..
+// $ae82 referenced 3 times by $adbd, $ae33, $ae45
+sub_cae82
+    ldy #$0a                                                          // ae82: a0 0a       ..
+// $ae84 referenced 2 times by $adfc, $ae8c
+cae84
+    lda l0f05,x                                                       // ae84: bd 05 0f    ...
+    jsr osasci                                                        // ae87: 20 e3 ff     ..
+    inx                                                               // ae8a: e8          .
+    dey                                                               // ae8b: 88          .
+    bne cae84                                                         // ae8c: d0 f6       ..
+    rts                                                               // ae8e: 60          `
+
+// $ae8f referenced 1 time by $ae6c
+cae8f
+    jmp osnewl                                                        // ae8f: 4c e7 ff    L..
+
+// $ae92 referenced 1 time by $a1c7
+sub_cae92
+    ldy #0                                                            // ae92: a0 00       ..
+// $ae94 referenced 4 times by $ad37, $ada2, $af77, $b363
+sub_cae94
+    jsr sub_c9913                                                     // ae94: 20 13 99     ..
+// $ae97 referenced 3 times by $92ee, $9396, $93cf
+sub_cae97
+    lda l0e30                                                         // ae97: ad 30 0e    .0.
+    eor #$26 // '&'                                                   // ae9a: 49 26       I&
+    bne caee2                                                         // ae9c: d0 44       .D
+    lda l1071                                                         // ae9e: ad 71 10    .q.
+    ora #$40 // '@'                                                   // aea1: 09 40       .@
+    sta l1071                                                         // aea3: 8d 71 10    .q.
+    jsr caeb7                                                         // aea6: 20 b7 ae     ..
+    lda l0e30                                                         // aea9: ad 30 0e    .0.
+    eor #$2e // '.'                                                   // aeac: 49 2e       I.
+    bne caedb                                                         // aeae: d0 2b       .+
+    lda l0e31                                                         // aeb0: ad 31 0e    .1.
+    eor #$0d                                                          // aeb3: 49 0d       I.
+    beq caedf                                                         // aeb5: f0 28       .(
+// $aeb7 referenced 5 times by $931c, $93b6, $93bc, $aea6, $aef9
+caeb7
+    txa                                                               // aeb7: 8a          .
+    pha                                                               // aeb8: 48          H
+    ldx #$ff                                                          // aeb9: a2 ff       ..
+// $aebb referenced 1 time by $aec4
+loop_caebb
+    inx                                                               // aebb: e8          .
+    lda l0e31,x                                                       // aebc: bd 31 0e    .1.
+    sta l0e30,x                                                       // aebf: 9d 30 0e    .0.
+    eor #$0d                                                          // aec2: 49 0d       I.
+    bne loop_caebb                                                    // aec4: d0 f5       ..
+    txa                                                               // aec6: 8a          .
+    beq caed8                                                         // aec7: f0 0f       ..
+// $aec9 referenced 1 time by $aed6
+loop_caec9
+    lda l0e2f,x                                                       // aec9: bd 2f 0e    ./.
+    eor #$20 // ' '                                                   // aecc: 49 20       I
+    bne caed8                                                         // aece: d0 08       ..
+    lda #$0d                                                          // aed0: a9 0d       ..
+    sta l0e2f,x                                                       // aed2: 9d 2f 0e    ./.
+    dex                                                               // aed5: ca          .
+    bne loop_caec9                                                    // aed6: d0 f1       ..
+// $aed8 referenced 2 times by $aec7, $aece
+caed8
+    pla                                                               // aed8: 68          h
+    tax                                                               // aed9: aa          .
+// $aeda referenced 3 times by $aedd, $aee4, $aeef
+caeda
+    rts                                                               // aeda: 60          `
+
+// $aedb referenced 1 time by $aeae
+caedb
+    eor #$23 // '#'                                                   // aedb: 49 23       I#
+    beq caeda                                                         // aedd: f0 fb       ..
+// $aedf referenced 2 times by $aeb5, $af12
+caedf
+    jmp c92fa                                                         // aedf: 4c fa 92    L..
+
+// $aee2 referenced 1 time by $ae9c
+caee2
+    eor #$1c                                                          // aee2: 49 1c       I.
+    bne caeda                                                         // aee4: d0 f4       ..
+    lda l0e32                                                         // aee6: ad 32 0e    .2.
+    eor #$2e // '.'                                                   // aee9: 49 2e       I.
+    beq caef1                                                         // aeeb: f0 04       ..
+    eor #$23 // '#'                                                   // aeed: 49 23       I#
+    bne caeda                                                         // aeef: d0 e9       ..
+// $aef1 referenced 1 time by $aeeb
+caef1
+    lda l1071                                                         // aef1: ad 71 10    .q.
+    ora #$40 // '@'                                                   // aef4: 09 40       .@
+    sta l1071                                                         // aef6: 8d 71 10    .q.
+    bne caeb7                                                         // aef9: d0 bc       ..
+// $aefb referenced 1 time by $ae19
+laefb
+    .byt 0                                                            // aefb: 00          .
+    .asc $2f, "<c"                                                    // aefc: 2f 3c 63    /<c
+// $aeff referenced 1 time by $ae1c
+laeff
+    .asc "Off"                                                        // aeff: 4f 66 66    Off
+
+// $af02 referenced 5 times by $8dbc, $8e20, $9b3c, $a299, $af7a
+sub_caf02
+    ldx #0                                                            // af02: a2 00       ..
+// $af04 referenced 9 times by $99fe, $9b35, $9b58, $a1cc, $a1f9, $ad3c, $ada7, $ae60, $b378
+sub_caf04
+    ldy #0                                                            // af04: a0 00       ..
+// $af06 referenced 3 times by $8db7, $941e, $9454
+sub_caf06
+    sec                                                               // af06: 38          8
+// $af07 referenced 1 time by $af1a
+loop_caf07
+    lda (l00be),y                                                     // af07: b1 be       ..
+    sta l0f05,x                                                       // af09: 9d 05 0f    ...
+    bcc caf16                                                         // af0c: 90 08       ..
+    cmp #$21 // '!'                                                   // af0e: c9 21       .!
+    eor #$26 // '&'                                                   // af10: 49 26       I&
+    beq caedf                                                         // af12: f0 cb       ..
+    eor #$26 // '&'                                                   // af14: 49 26       I&
+// $af16 referenced 1 time by $af0c
+caf16
+    inx                                                               // af16: e8          .
+    iny                                                               // af17: c8          .
+    eor #$0d                                                          // af18: 49 0d       I.
+    bne loop_caf07                                                    // af1a: d0 eb       ..
+// $af1c referenced 1 time by $af29
+loop_caf1c
+    lda l0f03,x                                                       // af1c: bd 03 0f    ...
+    eor #$20 // ' '                                                   // af1f: 49 20       I
+    bne caf2b                                                         // af21: d0 08       ..
+    dex                                                               // af23: ca          .
+    lda #$0d                                                          // af24: a9 0d       ..
+    sta l0f04,x                                                       // af26: 9d 04 0f    ...
+    bne loop_caf1c                                                    // af29: d0 f1       ..
+// $af2b referenced 1 time by $af21
+caf2b
+    lda #0                                                            // af2b: a9 00       ..
+// $af2d referenced 1 time by $af43
+loop_caf2d
+    rts                                                               // af2d: 60          `
+
+    .asc "Load"                                                       // af2e: 4c 6f 61... Loa
+
+// $af32 referenced 9 times by $8e3b, $9390, $93ca, $a1c4, $a250, $a25a, $ad12, $adf1, $b359
+sub_caf32
+    lda l1071                                                         // af32: ad 71 10    .q.
+    and #$1f                                                          // af35: 29 1f       ).
+    sta l1071                                                         // af37: 8d 71 10    .q.
+    rts                                                               // af3a: 60          `
+
+    .asc "Run"                                                        // af3b: 52 75 6e    Run
+
+sub_caf3e
+    ldx #0                                                            // af3e: a2 00       ..
+// $af40 referenced 1 time by $af60
+caf40
+    lda l0f05,x                                                       // af40: bd 05 0f    ...
+    bmi loop_caf2d                                                    // af43: 30 e8       0.
+    bne caf5c                                                         // af45: d0 15       ..
+// $af47 referenced 1 time by $ae78
+sub_caf47
+    ldy l00ba                                                         // af47: a4 ba       ..
+    bmi caf5a                                                         // af49: 30 0f       0.
+    iny                                                               // af4b: c8          .
+    tya                                                               // af4c: 98          .
+    and #3                                                            // af4d: 29 03       ).
+    sta l00ba                                                         // af4f: 85 ba       ..
+    beq caf5a                                                         // af51: f0 07       ..
+    jsr print_inline_top_bit_clear                                    // af53: 20 45 91     E.
+    .asc "  "                                                         // af56: 20 20
+
+    bne caf5f                                                         // af58: d0 05       ..
+// $af5a referenced 2 times by $af49, $af51
+caf5a
+    lda #$0d                                                          // af5a: a9 0d       ..
+// $af5c referenced 1 time by $af45
+caf5c
+    jsr osasci                                                        // af5c: 20 e3 ff     ..
+// $af5f referenced 1 time by $af58
+caf5f
+    inx                                                               // af5f: e8          .
+    bne caf40                                                         // af60: d0 de       ..
+    eor l0078                                                         // af62: 45 78       Ex
+    adc l0063                                                         // af64: 65 63       ec
+sub_caf66
+    tya                                                               // af66: 98          .
+    pha                                                               // af67: 48          H
+    jsr sub_cafc1                                                     // af68: 20 c1 af     ..
+    cmp #$0d                                                          // af6b: c9 0d       ..
+    beq caf72                                                         // af6d: f0 03       ..
+    jmp ca127                                                         // af6f: 4c 27 a1    L'.
+
+// $af72 referenced 1 time by $af6d
+caf72
+    pla                                                               // af72: 68          h
+    tay                                                               // af73: a8          .
+    jsr sub_cafb5                                                     // af74: 20 b5 af     ..
+    jsr sub_cae94                                                     // af77: 20 94 ae     ..
+    jsr sub_caf02                                                     // af7a: 20 02 af     ..
+    ldy #$14                                                          // af7d: a0 14       ..
+    bit l9491                                                         // af7f: 2c 91 94    ,..
+    jmp c94ae                                                         // af82: 4c ae 94    L..
+
+// $af85 referenced 1 time by $9007
+sub_caf85
+    bit l9491                                                         // af85: 2c 91 94    ,..
+// $af88 referenced 3 times by $adc7, $b19d, $b1b4
+caf88
+    tay                                                               // af88: a8          .
+    lda #$64 // 'd'                                                   // af89: a9 64       .d
+    jsr sub_caf96                                                     // af8b: 20 96 af     ..
+    lda #$0a                                                          // af8e: a9 0a       ..
+    jsr sub_caf96                                                     // af90: 20 96 af     ..
+    clv                                                               // af93: b8          .
+    lda #1                                                            // af94: a9 01       ..
+// $af96 referenced 2 times by $af8b, $af90
+sub_caf96
+    sta l00b8                                                         // af96: 85 b8       ..
+    tya                                                               // af98: 98          .
+    ldx #$2f // '/'                                                   // af99: a2 2f       ./
+    sec                                                               // af9b: 38          8
+    php                                                               // af9c: 08          .
+// $af9d referenced 1 time by $afa0
+loop_caf9d
+    inx                                                               // af9d: e8          .
+    sbc l00b8                                                         // af9e: e5 b8       ..
+    bcs loop_caf9d                                                    // afa0: b0 fb       ..
+    adc l00b8                                                         // afa2: 65 b8       e.
+    tay                                                               // afa4: a8          .
+    txa                                                               // afa5: 8a          .
+    plp                                                               // afa6: 28          (
+    bvc cafad                                                         // afa7: 50 04       P.
+    cmp #$30 // '0'                                                   // afa9: c9 30       .0
+    beq cafb4                                                         // afab: f0 07       ..
+// $afad referenced 1 time by $afa7
+cafad
+    ldx l00b8                                                         // afad: a6 b8       ..
+    jsr osasci                                                        // afaf: 20 e3 ff     ..
+    stx l00b8                                                         // afb2: 86 b8       ..
+// $afb4 referenced 1 time by $afab
+cafb4
+    rts                                                               // afb4: 60          `
+
+// $afb5 referenced 7 times by $a1c1, $ad34, $ad96, $af74, $b038, $b216, $b360
+sub_cafb5
+    pha                                                               // afb5: 48          H
+    lda l00be                                                         // afb6: a5 be       ..
+    sta os_text_ptr                                                   // afb8: 85 f2       ..
+    lda l00bf                                                         // afba: a5 bf       ..
+    sta l00f3                                                         // afbc: 85 f3       ..
+    pla                                                               // afbe: 68          h
+    rts                                                               // afbf: 60          `
+
+// $afc0 referenced 1 time by $afcb
+loop_cafc0
+    iny                                                               // afc0: c8          .
+// $afc1 referenced 2 times by $ad15, $af68
+sub_cafc1
+    lda (l00be),y                                                     // afc1: b1 be       ..
+    cmp #$20 // ' '                                                   // afc3: c9 20       .
+    beq cafcd                                                         // afc5: f0 06       ..
+    cmp #$0d                                                          // afc7: c9 0d       ..
+    beq cafd4                                                         // afc9: f0 09       ..
+    bne loop_cafc0                                                    // afcb: d0 f3       ..
+// $afcd referenced 2 times by $afc5, $afd2
+cafcd
+    iny                                                               // afcd: c8          .
+    lda (l00be),y                                                     // afce: b1 be       ..
+    cmp #$20 // ' '                                                   // afd0: c9 20       .
+    beq cafcd                                                         // afd2: f0 f9       ..
+// $afd4 referenced 1 time by $afc9
+cafd4
+    rts                                                               // afd4: 60          `
+
+// $afd5 referenced 2 times by $affb, $b1d2
+sub_cafd5
+    pha                                                               // afd5: 48          H
+    lda l00be                                                         // afd6: a5 be       ..
+    sta l00bb                                                         // afd8: 85 bb       ..
+    lda l00bf                                                         // afda: a5 bf       ..
+    sta l00bc                                                         // afdc: 85 bc       ..
+    pla                                                               // afde: 68          h
+    rts                                                               // afdf: 60          `
+
+// $afe0 referenced 2 times by $aff8, $b1c5
+sub_cafe0
+    tya                                                               // afe0: 98          .
+    pha                                                               // afe1: 48          H
+    jsr sub_c8cb9                                                     // afe2: 20 b9 8c     ..
+    sta l00af                                                         // afe5: 85 af       ..
+    pla                                                               // afe7: 68          h
+    tay                                                               // afe8: a8          .
+    lda #0                                                            // afe9: a9 00       ..
+    sta l00ae                                                         // afeb: 85 ae       ..
+    rts                                                               // afed: 60          `
+
+sub_cafee
+    lda #1                                                            // afee: a9 01       ..
+    bit l0d6a                                                         // aff0: 2c 6a 0d    ,j.
+    bne caff8                                                         // aff3: d0 03       ..
+    jmp cabfe                                                         // aff5: 4c fe ab    L..
+
+// $aff8 referenced 1 time by $aff3
+caff8
+    jsr sub_cafe0                                                     // aff8: 20 e0 af     ..
+    jsr sub_cafd5                                                     // affb: 20 d5 af     ..
+    lda (l00bb),y                                                     // affe: b1 bb       ..
+    cmp #$0d                                                          // b000: c9 0d       ..
+    beq cb025                                                         // b002: f0 21       .!
+    clv                                                               // b004: b8          .
+    jsr sub_c9258                                                     // b005: 20 58 92     X.
+    bcc cb028                                                         // b008: 90 1e       ..
+    tya                                                               // b00a: 98          .
+    pha                                                               // b00b: 48          H
+    jsr sub_cb0ea                                                     // b00c: 20 ea b0     ..
+    pla                                                               // b00f: 68          h
+    tay                                                               // b010: a8          .
+    jsr sub_ca0a7                                                     // b011: 20 a7 a0     ..
+    jmp cb0b9                                                         // b014: 4c b9 b0    L..
+
+// $b017 referenced 1 time by $8ef9
+sub_cb017
+    ldy #$18                                                          // b017: a0 18       ..
+// $b019 referenced 1 time by $b1f8
+sub_cb019
+    ldx #$f8                                                          // b019: a2 f8       ..
+// $b01b referenced 1 time by $b022
+loop_cb01b
+    lda l8d61,x                                                       // b01b: bd 61 8d    .a.
+    sta (l009c),y                                                     // b01e: 91 9c       ..
+    iny                                                               // b020: c8          .
+    inx                                                               // b021: e8          .
+    bne loop_cb01b                                                    // b022: d0 f7       ..
+    rts                                                               // b024: 60          `
+
+// $b025 referenced 1 time by $b002
+cb025
+    bit l9491                                                         // b025: 2c 91 94    ,..
+// $b028 referenced 1 time by $b008
+cb028
+    sty l00ac                                                         // b028: 84 ac       ..
+    bvs cb058                                                         // b02a: 70 2c       p,
+    ldx #6                                                            // b02c: a2 06       ..
+    ldy #$18                                                          // b02e: a0 18       ..
+    lda #$20 // ' '                                                   // b030: a9 20       .
+// $b032 referenced 1 time by $b036
+loop_cb032
+    sta (l009c),y                                                     // b032: 91 9c       ..
+    iny                                                               // b034: c8          .
+    dex                                                               // b035: ca          .
+    bne loop_cb032                                                    // b036: d0 fa       ..
+    jsr sub_cafb5                                                     // b038: 20 b5 af     ..
+    ldy l00ac                                                         // b03b: a4 ac       ..
+    jsr gsinit                                                        // b03d: 20 c2 ff     ..
+    beq cb058                                                         // b040: f0 16       ..
+    ldx #6                                                            // b042: a2 06       ..
+    sty l00ac                                                         // b044: 84 ac       ..
+    ldy #$18                                                          // b046: a0 18       ..
+    sty l00ad                                                         // b048: 84 ad       ..
+// $b04a referenced 1 time by $b056
+loop_cb04a
+    ldy l00ac                                                         // b04a: a4 ac       ..
+    jsr gsread                                                        // b04c: 20 c5 ff     ..
+    sty l00ac                                                         // b04f: 84 ac       ..
+    bcs cb058                                                         // b051: b0 05       ..
+    jsr sub_cb2f7                                                     // b053: 20 f7 b2     ..
+    bne loop_cb04a                                                    // b056: d0 f2       ..
+// $b058 referenced 3 times by $b02a, $b040, $b051
+cb058
+    jsr sub_cb16d                                                     // b058: 20 6d b1     m.
+    jsr sub_c983f                                                     // b05b: 20 3f 98     ?.
+    jsr sub_cb0f6                                                     // b05e: 20 f6 b0     ..
+    jsr sub_cb0ea                                                     // b061: 20 ea b0     ..
+    lda #0                                                            // b064: a9 00       ..
+    tax                                                               // b066: aa          .
+    ldy #$20 // ' '                                                   // b067: a0 20       .
+    sta (l009c),y                                                     // b069: 91 9c       ..
+// $b06b referenced 1 time by $b097
+cb06b
+    pla                                                               // b06b: 68          h
+    beq cb099                                                         // b06c: f0 2b       .+
+    pha                                                               // b06e: 48          H
+    tay                                                               // b06f: a8          .
+    lda (l009e),y                                                     // b070: b1 9e       ..
+    bpl cb091                                                         // b072: 10 1d       ..
+    jsr sub_c9a7f                                                     // b074: 20 7f 9a     ..
+    lda (l009e),y                                                     // b077: b1 9e       ..
+    sta l00ae                                                         // b079: 85 ae       ..
+    lda (l00ae,x)                                                     // b07b: a1 ae       ..
+    beq cb083                                                         // b07d: f0 04       ..
+    cmp #3                                                            // b07f: c9 03       ..
+    bne cb091                                                         // b081: d0 0e       ..
+// $b083 referenced 1 time by $b07d
+cb083
+    dey                                                               // b083: 88          .
+    lda (l009e),y                                                     // b084: b1 9e       ..
+    sta l00b6                                                         // b086: 85 b6       ..
+    dey                                                               // b088: 88          .
+    lda (l009e),y                                                     // b089: b1 9e       ..
+    sta l00b5                                                         // b08b: 85 b5       ..
+    ldy #$20 // ' '                                                   // b08d: a0 20       .
+    sta (l009c),y                                                     // b08f: 91 9c       ..
+// $b091 referenced 2 times by $b072, $b081
+cb091
+    pla                                                               // b091: 68          h
+    tay                                                               // b092: a8          .
+    lda #$3f // '?'                                                   // b093: a9 3f       .?
+    sta (l009e),y                                                     // b095: 91 9e       ..
+    bne cb06b                                                         // b097: d0 d2       ..
+// $b099 referenced 1 time by $b06c
+cb099
+    jsr sub_cb0cf                                                     // b099: 20 cf b0     ..
+    ldy #$20 // ' '                                                   // b09c: a0 20       .
+    lda (l009c),y                                                     // b09e: b1 9c       ..
+    bne cb0ae                                                         // b0a0: d0 0c       ..
+    jsr print_inline_top_bit_clear                                    // b0a2: 20 45 91     E.
+    .asc "still "                                                     // b0a5: 73 74 69... sti
+
+    clv                                                               // b0ab: b8          .
+    bvc cb0b6                                                         // b0ac: 50 08       P.
+// $b0ae referenced 1 time by $b0a0
+cb0ae
+    jsr print_inline_top_bit_clear                                    // b0ae: 20 45 91     E.
+    .asc "now "                                                       // b0b1: 6e 6f 77... now
+
+    nop                                                               // b0b5: ea          .
+// $b0b6 referenced 1 time by $b0ac
+cb0b6
+    jsr sub_ca09e                                                     // b0b6: 20 9e a0     ..
+// $b0b9 referenced 1 time by $b014
+cb0b9
+    ldy #2                                                            // b0b9: a0 02       ..
+    lda l00b5                                                         // b0bb: a5 b5       ..
+    sta (l009e),y                                                     // b0bd: 91 9e       ..
+    iny                                                               // b0bf: c8          .
+    lda l00b6                                                         // b0c0: a5 b6       ..
+    sta (l009e),y                                                     // b0c2: 91 9e       ..
+    rts                                                               // b0c4: 60          `
+
+// $b0c5 referenced 1 time by $a09b
+sub_cb0c5
+    jsr print_inline_top_bit_clear                                    // b0c5: 20 45 91     E.
+    .asc "File"                                                       // b0c8: 46 69 6c... Fil
+
+    clv                                                               // b0cc: b8          .
+    bvc cb0da                                                         // b0cd: 50 0b       P.
+// $b0cf referenced 2 times by $b099, $b240
+sub_cb0cf
+    jsr print_inline_top_bit_clear                                    // b0cf: 20 45 91     E.
+    .asc "Printer"                                                    // b0d2: 50 72 69... Pri
+
+    nop                                                               // b0d9: ea          .
+// $b0da referenced 1 time by $b0cd
+cb0da
+    jsr print_inline_top_bit_clear                                    // b0da: 20 45 91     E.
+    .asc " server is "                                                // b0dd: 20 73 65...  se
+
+    nop                                                               // b0e8: ea          .
+    rts                                                               // b0e9: 60          `
+
+// $b0ea referenced 4 times by $b00c, $b061, $b1e3, $b243
+sub_cb0ea
+    ldy #2                                                            // b0ea: a0 02       ..
+    lda (l009e),y                                                     // b0ec: b1 9e       ..
+    sta l00b5                                                         // b0ee: 85 b5       ..
+    iny                                                               // b0f0: c8          .
+    lda (l009e),y                                                     // b0f1: b1 9e       ..
+    sta l00b6                                                         // b0f3: 85 b6       ..
+    rts                                                               // b0f5: 60          `
+
+// $b0f6 referenced 2 times by $b05e, $b23d
+sub_cb0f6
+    pla                                                               // b0f6: 68          h
+    sta l00aa                                                         // b0f7: 85 aa       ..
+    pla                                                               // b0f9: 68          h
+    sta l00ab                                                         // b0fa: 85 ab       ..
+    lda #0                                                            // b0fc: a9 00       ..
+    pha                                                               // b0fe: 48          H
+    lda #$84                                                          // b0ff: a9 84       ..
+    sta l00ac                                                         // b101: 85 ac       ..
+    lsr l0d61                                                         // b103: 4e 61 0d    Na.
+    lda #3                                                            // b106: a9 03       ..
+// $b108 referenced 1 time by $b11a
+loop_cb108
+    jsr sub_ca0ce                                                     // b108: 20 ce a0     ..
+    bcs cb144                                                         // b10b: b0 37       .7
+    lsr                                                               // b10d: 4a          J
+    lsr                                                               // b10e: 4a          J
+    tax                                                               // b10f: aa          .
+    lda (l009e),y                                                     // b110: b1 9e       ..
+    beq cb144                                                         // b112: f0 30       .0
+    cmp #$3f // '?'                                                   // b114: c9 3f       .?
+    beq cb11c                                                         // b116: f0 04       ..
+// $b118 referenced 1 time by $b141
+cb118
+    inx                                                               // b118: e8          .
+    txa                                                               // b119: 8a          .
+    bne loop_cb108                                                    // b11a: d0 ec       ..
+// $b11c referenced 1 time by $b116
+cb11c
+    tya                                                               // b11c: 98          .
+    pha                                                               // b11d: 48          H
+    lda #$7f                                                          // b11e: a9 7f       ..
+    sta (l009e),y                                                     // b120: 91 9e       ..
+    iny                                                               // b122: c8          .
+    lda #$9e                                                          // b123: a9 9e       ..
+    sta (l009e),y                                                     // b125: 91 9e       ..
+    lda #0                                                            // b127: a9 00       ..
+    jsr sub_cb165                                                     // b129: 20 65 b1     e.
+    lda l00ac                                                         // b12c: a5 ac       ..
+    sta (l009e),y                                                     // b12e: 91 9e       ..
+    clc                                                               // b130: 18          .
+    php                                                               // b131: 08          .
+    adc #3                                                            // b132: 69 03       i.
+    plp                                                               // b134: 28          (
+    sta l00ac                                                         // b135: 85 ac       ..
+    jsr sub_cb15e                                                     // b137: 20 5e b1     ^.
+    lda l00ac                                                         // b13a: a5 ac       ..
+    sta (l009e),y                                                     // b13c: 91 9e       ..
+sub_cb13e
+lb13f = sub_cb13e+1
+    jsr sub_cb15e                                                     // b13e: 20 5e b1     ^.
+// $b13f referenced 1 time by $b2e2
+    jmp cb118                                                         // b141: 4c 18 b1    L..
+
+// $b144 referenced 2 times by $b10b, $b112
+cb144
+    asl l0d61                                                         // b144: 0e 61 0d    .a.
+    lda l00ab                                                         // b147: a5 ab       ..
+    pha                                                               // b149: 48          H
+    lda l00aa                                                         // b14a: a5 aa       ..
+    pha                                                               // b14c: 48          H
+    lda #$0a                                                          // b14d: a9 0a       ..
+    tay                                                               // b14f: a8          .
+    tax                                                               // b150: aa          .
+    sta l00b4                                                         // b151: 85 b4       ..
+// $b153 referenced 3 times by $b154, $b157, $b15b
+cb153
+    dey                                                               // b153: 88          .
+    bne cb153                                                         // b154: d0 fd       ..
+    dex                                                               // b156: ca          .
+    bne cb153                                                         // b157: d0 fa       ..
+    dec l00b4                                                         // b159: c6 b4       ..
+    bne cb153                                                         // b15b: d0 f6       ..
+    rts                                                               // b15d: 60          `
+
+// $b15e referenced 2 times by $b137, $b13e
+sub_cb15e
+    iny                                                               // b15e: c8          .
+    lda l00af                                                         // b15f: a5 af       ..
+    sta (l009e),y                                                     // b161: 91 9e       ..
+    lda #$ff                                                          // b163: a9 ff       ..
+// $b165 referenced 1 time by $b129
+sub_cb165
+    iny                                                               // b165: c8          .
+    sta (l009e),y                                                     // b166: 91 9e       ..
+    iny                                                               // b168: c8          .
+    sta (l009e),y                                                     // b169: 91 9e       ..
+    iny                                                               // b16b: c8          .
+    rts                                                               // b16c: 60          `
+
+// $b16d referenced 2 times by $b058, $b1ca
+sub_cb16d
+    ldy #$18                                                          // b16d: a0 18       ..
+// $b16f referenced 1 time by $b175
+loop_cb16f
+    lda (l009c),y                                                     // b16f: b1 9c       ..
+    pha                                                               // b171: 48          H
+    iny                                                               // b172: c8          .
+    cpy #$20 // ' '                                                   // b173: c0 20       .
+    bne loop_cb16f                                                    // b175: d0 f8       ..
+    ldy #$17                                                          // b177: a0 17       ..
+// $b179 referenced 1 time by $b17f
+loop_cb179
+    pla                                                               // b179: 68          h
+    sta (l009c),y                                                     // b17a: 91 9c       ..
+    dey                                                               // b17c: 88          .
+    cpy #$0f                                                          // b17d: c0 0f       ..
+    bne loop_cb179                                                    // b17f: d0 f8       ..
+    lda l009d                                                         // b181: a5 9d       ..
+    sta l009b                                                         // b183: 85 9b       ..
+    lda #$0c                                                          // b185: a9 0c       ..
+    sta l009a                                                         // b187: 85 9a       ..
+    ldy #3                                                            // b189: a0 03       ..
+// $b18b referenced 1 time by $b191
+loop_cb18b
+    lda lb194,y                                                       // b18b: b9 94 b1    ...
+    sta (l009a),y                                                     // b18e: 91 9a       ..
+    dey                                                               // b190: 88          .
+    bpl loop_cb18b                                                    // b191: 10 f8       ..
+    rts                                                               // b193: 60          `
+
+// $b194 referenced 1 time by $b18b
+lb194
+    .byt $80, $9f, $ff, $ff                                           // b194: 80 9f ff... ...
+
+// $b198 referenced 4 times by $a0a1, $b249, $b281, $b2d1
+sub_cb198
+    php                                                               // b198: 08          .
+    lda l00b6                                                         // b199: a5 b6       ..
+    beq cb1a8                                                         // b19b: f0 0b       ..
+    jsr caf88                                                         // b19d: 20 88 af     ..
+    lda #$2e // '.'                                                   // b1a0: a9 2e       ..
+    jsr osasci                                                        // b1a2: 20 e3 ff     ..
+    bit l9491                                                         // b1a5: 2c 91 94    ,..
+// $b1a8 referenced 1 time by $b19b
+cb1a8
+    bvs cb1b1                                                         // b1a8: 70 07       p.
+    jsr print_inline_top_bit_clear                                    // b1aa: 20 45 91     E.
+    .asc "    "                                                       // b1ad: 20 20 20...
+
+// $b1b1 referenced 1 time by $b1a8
+cb1b1
+    lda l00b5                                                         // b1b1: a5 b5       ..
+    plp                                                               // b1b3: 28          (
+    jmp caf88                                                         // b1b4: 4c 88 af    L..
+
+    .byt $80, $9f,   0,   0, $10,   0, $ff, $ff, $18,   0, $ff, $ff   // b1b7: 80 9f 00... ...
+
+sub_cb1c3
+    sty l00ac                                                         // b1c3: 84 ac       ..
+    jsr sub_cafe0                                                     // b1c5: 20 e0 af     ..
+    sta l00b4                                                         // b1c8: 85 b4       ..
+    jsr sub_cb16d                                                     // b1ca: 20 6d b1     m.
+    jsr sub_cb2e0                                                     // b1cd: 20 e0 b2     ..
+    ldy l00ac                                                         // b1d0: a4 ac       ..
+    jsr sub_cafd5                                                     // b1d2: 20 d5 af     ..
+    lda (l00bb),y                                                     // b1d5: b1 bb       ..
+    cmp #$0d                                                          // b1d7: c9 0d       ..
+    beq cb205                                                         // b1d9: f0 2a       .*
+    clv                                                               // b1db: b8          .
+    jsr sub_c9258                                                     // b1dc: 20 58 92     X.
+    bcc cb208                                                         // b1df: 90 27       .'
+    tya                                                               // b1e1: 98          .
+    pha                                                               // b1e2: 48          H
+    jsr sub_cb0ea                                                     // b1e3: 20 ea b0     ..
+    pla                                                               // b1e6: 68          h
+    tay                                                               // b1e7: a8          .
+    jsr sub_ca0a7                                                     // b1e8: 20 a7 a0     ..
+    ldy #$7a // 'z'                                                   // b1eb: a0 7a       .z
+    lda l00b5                                                         // b1ed: a5 b5       ..
+    sta (l00ae),y                                                     // b1ef: 91 ae       ..
+    iny                                                               // b1f1: c8          .
+    lda l00b6                                                         // b1f2: a5 b6       ..
+    sta (l00ae),y                                                     // b1f4: 91 ae       ..
+    ldy #$10                                                          // b1f6: a0 10       ..
+    jsr sub_cb019                                                     // b1f8: 20 19 b0     ..
+    lda l00af                                                         // b1fb: a5 af       ..
+    sta l009b                                                         // b1fd: 85 9b       ..
+    lda #$78 // 'x'                                                   // b1ff: a9 78       .x
+    sta l009a                                                         // b201: 85 9a       ..
+    bne cb236                                                         // b203: d0 31       .1
+// $b205 referenced 1 time by $b1d9
+cb205
+    bit l9491                                                         // b205: 2c 91 94    ,..
+// $b208 referenced 1 time by $b1df
+cb208
+    bvs cb236                                                         // b208: 70 2c       p,
+    ldx #6                                                            // b20a: a2 06       ..
+    ldy #$10                                                          // b20c: a0 10       ..
+    lda #$20 // ' '                                                   // b20e: a9 20       .
+// $b210 referenced 1 time by $b214
+loop_cb210
+    sta (l009c),y                                                     // b210: 91 9c       ..
+    iny                                                               // b212: c8          .
+    dex                                                               // b213: ca          .
+    bne loop_cb210                                                    // b214: d0 fa       ..
+    jsr sub_cafb5                                                     // b216: 20 b5 af     ..
+    ldy l00ac                                                         // b219: a4 ac       ..
+    jsr gsinit                                                        // b21b: 20 c2 ff     ..
+    beq cb236                                                         // b21e: f0 16       ..
+    ldx #6                                                            // b220: a2 06       ..
+    sty l00ac                                                         // b222: 84 ac       ..
+    ldy #$10                                                          // b224: a0 10       ..
+    sty l00ad                                                         // b226: 84 ad       ..
+// $b228 referenced 1 time by $b234
+loop_cb228
+    ldy l00ac                                                         // b228: a4 ac       ..
+    jsr gsread                                                        // b22a: 20 c5 ff     ..
+    sty l00ac                                                         // b22d: 84 ac       ..
+    bcs cb236                                                         // b22f: b0 05       ..
+    jsr sub_cb2f7                                                     // b231: 20 f7 b2     ..
+    bne loop_cb228                                                    // b234: d0 f2       ..
+// $b236 referenced 4 times by $b203, $b208, $b21e, $b22f
+cb236
+    lda #$80                                                          // b236: a9 80       ..
+    sta l0098                                                         // b238: 85 98       ..
+    jsr sub_c983f                                                     // b23a: 20 3f 98     ?.
+    jsr sub_cb0f6                                                     // b23d: 20 f6 b0     ..
+    jsr sub_cb0cf                                                     // b240: 20 cf b0     ..
+    jsr sub_cb0ea                                                     // b243: 20 ea b0     ..
+    bit l9491                                                         // b246: 2c 91 94    ,..
+    jsr sub_cb198                                                     // b249: 20 98 b1     ..
+    jsr print_inline_top_bit_clear                                    // b24c: 20 45 91     E.
+    .asc " ", 34, ""                                                  // b24f: 20 22        "
+
+    ldy #$18                                                          // b251: a0 18       ..
+// $b253 referenced 1 time by $b25f
+loop_cb253
+    lda (l009c),y                                                     // b253: b1 9c       ..
+    cmp #$20 // ' '                                                   // b255: c9 20       .
+    beq cb261                                                         // b257: f0 08       ..
+    jsr osasci                                                        // b259: 20 e3 ff     ..
+    iny                                                               // b25c: c8          .
+    cpy #$1e                                                          // b25d: c0 1e       ..
+    bne loop_cb253                                                    // b25f: d0 f2       ..
+// $b261 referenced 1 time by $b257
+cb261
+    jsr print_inline_top_bit_clear                                    // b261: 20 45 91     E.
+    .asc "", 34, "", $0d                                              // b264: 22 0d       ".
+
+    nop                                                               // b266: ea          .
+// $b267 referenced 1 time by $b2dd
+cb267
+    pla                                                               // b267: 68          h
+    beq cb2df                                                         // b268: f0 75       .u
+    pha                                                               // b26a: 48          H
+    tay                                                               // b26b: a8          .
+    lda (l009e),y                                                     // b26c: b1 9e       ..
+    bpl cb2d7                                                         // b26e: 10 67       .g
+    iny                                                               // b270: c8          .
+    iny                                                               // b271: c8          .
+    lda (l009e),y                                                     // b272: b1 9e       ..
+    sta l00b5                                                         // b274: 85 b5       ..
+    iny                                                               // b276: c8          .
+    lda (l009e),y                                                     // b277: b1 9e       ..
+    sta l00b6                                                         // b279: 85 b6       ..
+    iny                                                               // b27b: c8          .
+    lda (l009e),y                                                     // b27c: b1 9e       ..
+    sta l00ae                                                         // b27e: 85 ae       ..
+    clv                                                               // b280: b8          .
+    jsr sub_cb198                                                     // b281: 20 98 b1     ..
+    jsr print_inline_top_bit_clear                                    // b284: 20 45 91     E.
+    .asc " is "                                                       // b287: 20 69 73...  is
+
+    ldx #0                                                            // b28b: a2 00       ..
+    lda (l00ae,x)                                                     // b28d: a1 ae       ..
+    bne cb29c                                                         // b28f: d0 0b       ..
+    jsr print_inline_top_bit_clear                                    // b291: 20 45 91     E.
+    .asc "ready"                                                      // b294: 72 65 61... rea
+
+    clv                                                               // b299: b8          .
+    bvc cb2d4                                                         // b29a: 50 38       P8
+// $b29c referenced 1 time by $b28f
+cb29c
+    cmp #2                                                            // b29c: c9 02       ..
+    bne cb2ac                                                         // b29e: d0 0c       ..
+// $b2a0 referenced 1 time by $b2ae
+loop_cb2a0
+    jsr print_inline_top_bit_clear                                    // b2a0: 20 45 91     E.
+    .asc "jammed"                                                     // b2a3: 6a 61 6d... jam
+
+    clv                                                               // b2a9: b8          .
+    bvc cb2d4                                                         // b2aa: 50 28       P(
+// $b2ac referenced 1 time by $b29e
+cb2ac
+    cmp #1                                                            // b2ac: c9 01       ..
+    bne loop_cb2a0                                                    // b2ae: d0 f0       ..
+    jsr print_inline_top_bit_clear                                    // b2b0: 20 45 91     E.
+    .asc "busy"                                                       // b2b3: 62 75 73... bus
+
+    inc l00ae                                                         // b2b7: e6 ae       ..
+    lda (l00ae,x)                                                     // b2b9: a1 ae       ..
+    sta l00b5                                                         // b2bb: 85 b5       ..
+    beq cb2d4                                                         // b2bd: f0 15       ..
+    jsr print_inline_top_bit_clear                                    // b2bf: 20 45 91     E.
+    .asc " with "                                                     // b2c2: 20 77 69...  wi
+
+    inc l00ae                                                         // b2c8: e6 ae       ..
+    lda (l00ae,x)                                                     // b2ca: a1 ae       ..
+    sta l00b6                                                         // b2cc: 85 b6       ..
+    bit l9491                                                         // b2ce: 2c 91 94    ,..
+    jsr sub_cb198                                                     // b2d1: 20 98 b1     ..
+// $b2d4 referenced 3 times by $b29a, $b2aa, $b2bd
+cb2d4
+    jsr osnewl                                                        // b2d4: 20 e7 ff     ..
+// $b2d7 referenced 1 time by $b26e
+cb2d7
+    pla                                                               // b2d7: 68          h
+    tay                                                               // b2d8: a8          .
+    lda #$3f // '?'                                                   // b2d9: a9 3f       .?
+    sta (l009e),y                                                     // b2db: 91 9e       ..
+    bne cb267                                                         // b2dd: d0 88       ..
+// $b2df referenced 1 time by $b268
+cb2df
+    rts                                                               // b2df: 60          `
+
+// $b2e0 referenced 1 time by $b1cd
+sub_cb2e0
+    ldy #$78 // 'x'                                                   // b2e0: a0 78       .x
+// $b2e2 referenced 1 time by $b2f4
+loop_cb2e2
+    lda lb13f,y                                                       // b2e2: b9 3f b1    .?.
+    cpy #$7d // '}'                                                   // b2e5: c0 7d       .}
+    beq cb2ed                                                         // b2e7: f0 04       ..
+    cpy #$81                                                          // b2e9: c0 81       ..
+    bne cb2ef                                                         // b2eb: d0 02       ..
+// $b2ed referenced 1 time by $b2e7
+cb2ed
+    lda l009d                                                         // b2ed: a5 9d       ..
+// $b2ef referenced 1 time by $b2eb
+cb2ef
+    sta (l00ae),y                                                     // b2ef: 91 ae       ..
+    iny                                                               // b2f1: c8          .
+    cpy #$84                                                          // b2f2: c0 84       ..
+    bne loop_cb2e2                                                    // b2f4: d0 ec       ..
+    rts                                                               // b2f6: 60          `
+
+// $b2f7 referenced 2 times by $b053, $b231
+sub_cb2f7
+    ldy l00ad                                                         // b2f7: a4 ad       ..
+    and #$7f                                                          // b2f9: 29 7f       ).
+    cmp #$61 // 'a'                                                   // b2fb: c9 61       .a
+    bcc cb305                                                         // b2fd: 90 06       ..
+    cmp #$7b // '{'                                                   // b2ff: c9 7b       .{
+    bcs cb305                                                         // b301: b0 02       ..
+    and #$5f // '_'                                                   // b303: 29 5f       )_
+// $b305 referenced 2 times by $b2fd, $b301
+cb305
+    sta (l009c),y                                                     // b305: 91 9c       ..
+    iny                                                               // b307: c8          .
+    sty l00ad                                                         // b308: 84 ad       ..
+    dex                                                               // b30a: ca          .
+    rts                                                               // b30b: 60          `
+
+sub_cb30c
+    lda (l00be),y                                                     // b30c: b1 be       ..
+    eor #$0d                                                          // b30e: 49 0d       I.
+    bne cb316                                                         // b310: d0 04       ..
+    lda #$ff                                                          // b312: a9 ff       ..
+    bne cb336                                                         // b314: d0 20       .
+// $b316 referenced 1 time by $b310
+cb316
+    lda l0d68                                                         // b316: ad 68 0d    .h.
+    pha                                                               // b319: 48          H
+// $b31a referenced 1 time by $b32a
+loop_cb31a
+    ldx #$d3                                                          // b31a: a2 d3       ..
+    lda (l00be),y                                                     // b31c: b1 be       ..
+    sta l00a8                                                         // b31e: 85 a8       ..
+    jsr sub_ca140                                                     // b320: 20 40 a1     @.
+    bcs cb32c                                                         // b323: b0 07       ..
+    pla                                                               // b325: 68          h
+    ora la3f1,x                                                       // b326: 1d f1 a3    ...
+    pha                                                               // b329: 48          H
+    bne loop_cb31a                                                    // b32a: d0 ee       ..
+// $b32c referenced 2 times by $b323, $b350
+cb32c
+    lda l00a8                                                         // b32c: a5 a8       ..
+    eor #$0d                                                          // b32e: 49 0d       I.
+    beq cb335                                                         // b330: f0 03       ..
+    jmp ca25d                                                         // b332: 4c 5d a2    L].
+
+// $b335 referenced 1 time by $b330
+cb335
+    pla                                                               // b335: 68          h
+// $b336 referenced 2 times by $b314, $b341
+cb336
+    sta l0d68                                                         // b336: 8d 68 0d    .h.
+    sta l0d69                                                         // b339: 8d 69 0d    .i.
+    rts                                                               // b33c: 60          `
+
+sub_cb33d
+    lda (l00be),y                                                     // b33d: b1 be       ..
+    eor #$0d                                                          // b33f: 49 0d       I.
+    beq cb336                                                         // b341: f0 f3       ..
+    lda l0d68                                                         // b343: ad 68 0d    .h.
+    pha                                                               // b346: 48          H
+// $b347 referenced 1 time by $b357
+loop_cb347
+    ldx #$d3                                                          // b347: a2 d3       ..
+    lda (l00be),y                                                     // b349: b1 be       ..
+    sta l00a8                                                         // b34b: 85 a8       ..
+    jsr sub_ca140                                                     // b34d: 20 40 a1     @.
+    bcs cb32c                                                         // b350: b0 da       ..
+    pla                                                               // b352: 68          h
+    and la3f2,x                                                       // b353: 3d f2 a3    =..
+    pha                                                               // b356: 48          H
+    bcc loop_cb347                                                    // b357: 90 ee       ..
+sub_cb359
+    jsr sub_caf32                                                     // b359: 20 32 af     2.
+    lda #0                                                            // b35c: a9 00       ..
+    sta l00b5                                                         // b35e: 85 b5       ..
+    jsr sub_cafb5                                                     // b360: 20 b5 af     ..
+    jsr sub_cae94                                                     // b363: 20 94 ae     ..
+    inx                                                               // b366: e8          .
+    stx l00b6                                                         // b367: 86 b6       ..
+// $b369 referenced 1 time by $b3a5
+cb369
+    lda #1                                                            // b369: a9 01       ..
+    sta l0f05                                                         // b36b: 8d 05 0f    ...
+    sta l0f07                                                         // b36e: 8d 07 0f    ...
+    ldx l00b5                                                         // b371: a6 b5       ..
+    stx l0f06                                                         // b373: 8e 06 0f    ...
+    ldx #3                                                            // b376: a2 03       ..
+    jsr sub_caf04                                                     // b378: 20 04 af     ..
+    ldy #3                                                            // b37b: a0 03       ..
+    lda #$80                                                          // b37d: a9 80       ..
+    sta l0098                                                         // b37f: 85 98       ..
+    jsr c94ad                                                         // b381: 20 ad 94     ..
+    lda l0f05                                                         // b384: ad 05 0f    ...
+    bne cb39c                                                         // b387: d0 13       ..
+    lda #osbyte_flush_buffer_class                                    // b389: a9 0f       ..
+    ldx #1                                                            // b38b: a2 01       ..
+    jsr osbyte                                                        // b38d: 20 f4 ff     ..
+    lda #osbyte_scan_keyboard_from_16                                 // b390: a9 7a       .z
+    jsr osbyte                                                        // b392: 20 f4 ff     ..
+    ldy #0                                                            // b395: a0 00       ..
+    lda #osbyte_write_keys_pressed                                    // b397: a9 78       .x
+    jmp osbyte                                                        // b399: 4c f4 ff    L..
+
+// $b39c referenced 1 time by $b387
+cb39c
+    lda l0f2f                                                         // b39c: ad 2f 0f    ./.
+// $b39f referenced 1 time by $b3af
+loop_cb39f
+    cmp #$4c // 'L'                                                   // b39f: c9 4c       .L
+    bne cb3a8                                                         // b3a1: d0 05       ..
+// $b3a3 referenced 1 time by $b420
+cb3a3
+    inc l00b5                                                         // b3a3: e6 b5       ..
+    jmp cb369                                                         // b3a5: 4c 69 b3    Li.
+
+// $b3a8 referenced 1 time by $b3a1
+cb3a8
+    cmp #$44 // 'D'                                                   // b3a8: c9 44       .D
+    bne cb3b1                                                         // b3aa: d0 05       ..
+    lda l0f30                                                         // b3ac: ad 30 0f    .0.
+    bne loop_cb39f                                                    // b3af: d0 ee       ..
+// $b3b1 referenced 1 time by $b3aa
+cb3b1
+    ldx #1                                                            // b3b1: a2 01       ..
+    ldy l00b6                                                         // b3b3: a4 b6       ..
+// $b3b5 referenced 1 time by $b3c2
+loop_cb3b5
+    lda l0f06,x                                                       // b3b5: bd 06 0f    ...
+    jsr osasci                                                        // b3b8: 20 e3 ff     ..
+    sta l0e30,y                                                       // b3bb: 99 30 0e    .0.
+    iny                                                               // b3be: c8          .
+    inx                                                               // b3bf: e8          .
+    cpx #$0c                                                          // b3c0: e0 0c       ..
+    bne loop_cb3b5                                                    // b3c2: d0 f1       ..
+    jsr print_inline_top_bit_clear                                    // b3c4: 20 45 91     E.
+    .asc "(?", $2f                                                    // b3c7: 28 3f 2f    (?/
+
+    nop                                                               // b3ca: ea          .
+    jsr sub_cb431                                                     // b3cb: 20 31 b4     1.
+    cmp #$3f // '?'                                                   // b3ce: c9 3f       .?
+    bne cb3ed                                                         // b3d0: d0 1b       ..
+    lda #$0d                                                          // b3d2: a9 0d       ..
+    jsr oswrch                                                        // b3d4: 20 ee ff     ..
+    ldx #2                                                            // b3d7: a2 02       ..
+// $b3d9 referenced 1 time by $b3e2
+loop_cb3d9
+    lda l0f05,x                                                       // b3d9: bd 05 0f    ...
+    jsr osasci                                                        // b3dc: 20 e3 ff     ..
+    inx                                                               // b3df: e8          .
+    cpx #$3e // '>'                                                   // b3e0: e0 3e       .>
+    bne loop_cb3d9                                                    // b3e2: d0 f5       ..
+    jsr print_inline_top_bit_clear                                    // b3e4: 20 45 91     E.
+    .asc " ("                                                         // b3e7: 20 28        (
+
+    nop                                                               // b3e9: ea          .
+    jsr sub_cb431                                                     // b3ea: 20 31 b4     1.
+// $b3ed referenced 1 time by $b3d0
+cb3ed
+    and #$df                                                          // b3ed: 29 df       ).
+    cmp #$59 // 'Y'                                                   // b3ef: c9 59       .Y
+    bne cb41d                                                         // b3f1: d0 2a       .*
+    jsr osasci                                                        // b3f3: 20 e3 ff     ..
+    ldx #0                                                            // b3f6: a2 00       ..
+    lda l0e30,x                                                       // b3f8: bd 30 0e    .0.
+    cmp #$0d                                                          // b3fb: c9 0d       ..
+    beq cb423                                                         // b3fd: f0 24       .$
+// $b3ff referenced 1 time by $b414
+loop_cb3ff
+    lda l0e30,x                                                       // b3ff: bd 30 0e    .0.
+    cmp #$0d                                                          // b402: c9 0d       ..
+    bne cb408                                                         // b404: d0 02       ..
+    lda #$2e // '.'                                                   // b406: a9 2e       ..
+// $b408 referenced 1 time by $b404
+cb408
+    cmp #$20 // ' '                                                   // b408: c9 20       .
+    bne cb40e                                                         // b40a: d0 02       ..
+// $b40c referenced 1 time by $b42f
+cb40c
+    lda #$0d                                                          // b40c: a9 0d       ..
+// $b40e referenced 1 time by $b40a
+cb40e
+    sta l0f05,x                                                       // b40e: 9d 05 0f    ...
+    inx                                                               // b411: e8          .
+    cmp #$0d                                                          // b412: c9 0d       ..
+    bne loop_cb3ff                                                    // b414: d0 e9       ..
+    ldy #$14                                                          // b416: a0 14       ..
+    jsr c94ad                                                         // b418: 20 ad 94     ..
+    dec l00b5                                                         // b41b: c6 b5       ..
+// $b41d referenced 1 time by $b3f1
+cb41d
+    jsr osnewl                                                        // b41d: 20 e7 ff     ..
+    jmp cb3a3                                                         // b420: 4c a3 b3    L..
+
+// $b423 referenced 1 time by $b3fd
+cb423
+    dex                                                               // b423: ca          .
+// $b424 referenced 1 time by $b42d
+loop_cb424
+    inx                                                               // b424: e8          .
+    lda l0e31,x                                                       // b425: bd 31 0e    .1.
+    sta l0f05,x                                                       // b428: 9d 05 0f    ...
+    cmp #$20 // ' '                                                   // b42b: c9 20       .
+    bne loop_cb424                                                    // b42d: d0 f5       ..
+    beq cb40c                                                         // b42f: f0 db       ..
+// $b431 referenced 2 times by $b3cb, $b3ea
+sub_cb431
+    jsr print_inline_top_bit_clear                                    // b431: 20 45 91     E.
+    .asc "Y", $2f, "N) "                                              // b434: 59 2f 4e... Y/N
+
+    lda #osbyte_flush_buffer_class                                    // b439: a9 0f       ..
+    ldx #1                                                            // b43b: a2 01       ..
+    jsr osbyte                                                        // b43d: 20 f4 ff     ..
+    jsr osrdch                                                        // b440: 20 e0 ff     ..
+    bcc cb448                                                         // b443: 90 03       ..
+    jmp c9576                                                         // b445: 4c 76 95    Lv.
+
+// $b448 referenced 1 time by $b443
+cb448
+    rts                                                               // b448: 60          `
+
+// $b449 referenced 1 time by $8b75
+sub_cb449
+    lda #0                                                            // b449: a9 00       ..
+    tay                                                               // b44b: a8          .
+// $b44c referenced 1 time by $b450
+loop_cb44c
+    sta l1000,y                                                       // b44c: 99 00 10    ...
+    iny                                                               // b44f: c8          .
+    bne loop_cb44c                                                    // b450: d0 fa       ..
+    ldy #$0b                                                          // b452: a0 0b       ..
+    lda (l009c),y                                                     // b454: b1 9c       ..
+    sec                                                               // b456: 38          8
+    sbc #$5a // 'Z'                                                   // b457: e9 5a       .Z
+    tay                                                               // b459: a8          .
+    lda #$40 // '@'                                                   // b45a: a9 40       .@
+// $b45c referenced 1 time by $b462
+loop_cb45c
+    sta l1000,y                                                       // b45c: 99 00 10    ...
+    dey                                                               // b45f: 88          .
+    cpy #$b8                                                          // b460: c0 b8       ..
+    bpl loop_cb45c                                                    // b462: 10 f8       ..
+    iny                                                               // b464: c8          .
+    lda #$c0                                                          // b465: a9 c0       ..
+    sta l1000,y                                                       // b467: 99 00 10    ...
+    rts                                                               // b46a: 60          `
+
+// $b46b referenced 1 time by $b73d
+sub_cb46b
+    php                                                               // b46b: 08          .
+    sec                                                               // b46c: 38          8
+    sbc #$20 // ' '                                                   // b46d: e9 20       .
+    bmi cb475                                                         // b46f: 30 04       0.
+    cmp #$10                                                          // b471: c9 10       ..
+    bcc cb477                                                         // b473: 90 02       ..
+// $b475 referenced 1 time by $b46f
+cb475
+    lda #$ff                                                          // b475: a9 ff       ..
+// $b477 referenced 1 time by $b473
+cb477
+    plp                                                               // b477: 28          (
+    tax                                                               // b478: aa          .
+    rts                                                               // b479: 60          `
+
+    .byt $c9, $20, $90,   4, $c9, $30, $90, $2b, $48                  // b47a: c9 20 90... . .
+
+// $b483 referenced 1 time by $b4b5
+cb483
+    lda #$de                                                          // b483: a9 de       ..
+sub_cb485
+lb487 = sub_cb485+2
+    jsr generate_error_inline3                                        // b485: 20 d1 96     ..
+// $b487 referenced 2 times by $b4cd, $b4e1
+    .asc "Net channel", 0                                             // b488: 4e 65 74... Net
+    .asc " not on this file server"                                   // b494: 20 6e 6f...  no
+    .byt 0                                                            // b4ac: 00          .
+
+// $b4ad referenced 1 time by $9ed6
+sub_cb4ad
+    pha                                                               // b4ad: 48          H
+    sec                                                               // b4ae: 38          8
+    sbc #$20 // ' '                                                   // b4af: e9 20       .
+    tax                                                               // b4b1: aa          .
+    lda l1030,x                                                       // b4b2: bd 30 10    .0.
+    beq cb483                                                         // b4b5: f0 cc       ..
+    jsr sub_cb586                                                     // b4b7: 20 86 b5     ..
+    bne cb4c1                                                         // b4ba: d0 05       ..
+    pla                                                               // b4bc: 68          h
+    lda l1060,x                                                       // b4bd: bd 60 10    .`.
+    rts                                                               // b4c0: 60          `
+
+// $b4c1 referenced 1 time by $b4ba
+cb4c1
+    lda #$de                                                          // b4c1: a9 de       ..
+    sta l0101                                                         // b4c3: 8d 01 01    ...
+    lda #0                                                            // b4c6: a9 00       ..
+    sta l0100                                                         // b4c8: 8d 00 01    ...
+    tax                                                               // b4cb: aa          .
+// $b4cc referenced 1 time by $b4d3
+loop_cb4cc
+    inx                                                               // b4cc: e8          .
+    lda lb487,x                                                       // b4cd: bd 87 b4    ...
+    sta l0101,x                                                       // b4d0: 9d 01 01    ...
+    bne loop_cb4cc                                                    // b4d3: d0 f7       ..
+    stx l00b2                                                         // b4d5: 86 b2       ..
+    stx l00b4                                                         // b4d7: 86 b4       ..
+    pla                                                               // b4d9: 68          h
+    jsr sub_c9771                                                     // b4da: 20 71 97     q.
+    ldy l00b4                                                         // b4dd: a4 b4       ..
+// $b4df referenced 1 time by $b4e7
+loop_cb4df
+    iny                                                               // b4df: c8          .
+    inx                                                               // b4e0: e8          .
+    lda lb487,y                                                       // b4e1: b9 87 b4    ...
+    sta l0101,x                                                       // b4e4: 9d 01 01    ...
+    bne loop_cb4df                                                    // b4e7: d0 f6       ..
+    jmp l0100                                                         // b4e9: 4c 00 01    L..
+
+    .byt $ad, $c9, $10, $20, $8f, $b9, $20, $7a, $b4, $29,   2, $f0   // b4ec: ad c9 10... ...
+    .byt $0f, $a9, $a8, $20, $d1, $96                                 // b4f8: 0f a9 a8... ...
+    .asc "Is a dir."                                                  // b4fe: 49 73 20... Is
+    .byt   0, $60                                                     // b507: 00 60       .`
+
+// $b509 referenced 5 times by $a280, $a31f, $a34a, $a381, $b540
+sub_cb509
+    pha                                                               // b509: 48          H
+    ldx #$20 // ' '                                                   // b50a: a2 20       .
+// $b50c referenced 1 time by $b514
+loop_cb50c
+    lda l1010,x                                                       // b50c: bd 10 10    ...
+    beq cb51a                                                         // b50f: f0 09       ..
+    inx                                                               // b511: e8          .
+    cpx #$30 // '0'                                                   // b512: e0 30       .0
+    bne loop_cb50c                                                    // b514: d0 f6       ..
+    pla                                                               // b516: 68          h
+    lda #0                                                            // b517: a9 00       ..
+    rts                                                               // b519: 60          `
+
+// $b51a referenced 1 time by $b50f
+cb51a
+    pla                                                               // b51a: 68          h
+    sta l1010,x                                                       // b51b: 9d 10 10    ...
+    lda #0                                                            // b51e: a9 00       ..
+    sta l0fe0,x                                                       // b520: 9d e0 0f    ...
+    sta l0ff0,x                                                       // b523: 9d f0 0f    ...
+    sta l1000,x                                                       // b526: 9d 00 10    ...
+    lda l0e00                                                         // b529: ad 00 0e    ...
+    sta l1020,x                                                       // b52c: 9d 20 10    . .
+    lda l0e01                                                         // b52f: ad 01 0e    ...
+    sta l1030,x                                                       // b532: 9d 30 10    .0.
+    txa                                                               // b535: 8a          .
+    pha                                                               // b536: 48          H
+    sec                                                               // b537: 38          8
+    sbc #$20 // ' '                                                   // b538: e9 20       .
+    tax                                                               // b53a: aa          .
+    pla                                                               // b53b: 68          h
+    rts                                                               // b53c: 60          `
+
+// $b53d referenced 1 time by $a1ed
+sub_cb53d
+    pha                                                               // b53d: 48          H
+    lda #0                                                            // b53e: a9 00       ..
+    jsr sub_cb509                                                     // b540: 20 09 b5     ..
+    bne cb557                                                         // b543: d0 12       ..
+    lda #$c0                                                          // b545: a9 c0       ..
+    jsr generate_error_inline3                                        // b547: 20 d1 96     ..
+    .asc "No more FCBs", 0                                            // b54a: 4e 6f 20... No
+
+// $b557 referenced 1 time by $b543
+cb557
+    pla                                                               // b557: 68          h
+    rts                                                               // b558: 60          `
+
+// $b559 referenced 3 times by $94a8, $9533, $a391
+sub_cb559
+    clc                                                               // b559: 18          .
+    bit l9491                                                         // b55a: 2c 91 94    ,..
+    ldx #$10                                                          // b55d: a2 10       ..
+// $b55f referenced 4 times by $b56b, $b575, $b57a, $b584
+cb55f
+    dex                                                               // b55f: ca          .
+    bpl cb563                                                         // b560: 10 01       ..
+    rts                                                               // b562: 60          `
+
+// $b563 referenced 1 time by $b560
+cb563
+    lda l1060,x                                                       // b563: bd 60 10    .`.
+    tay                                                               // b566: a8          .
+    and #2                                                            // b567: 29 02       ).
+    beq cb577                                                         // b569: f0 0c       ..
+    bvc cb55f                                                         // b56b: 50 f2       P.
+    bcc cb577                                                         // b56d: 90 08       ..
+    tya                                                               // b56f: 98          .
+    and #$df                                                          // b570: 29 df       ).
+    sta l1060,x                                                       // b572: 9d 60 10    .`.
+    bvs cb55f                                                         // b575: 70 e8       p.
+// $b577 referenced 2 times by $b569, $b56d
+cb577
+    jsr sub_cb586                                                     // b577: 20 86 b5     ..
+    bne cb55f                                                         // b57a: d0 e3       ..
+    lda #0                                                            // b57c: a9 00       ..
+    sta l1060,x                                                       // b57e: 9d 60 10    .`.
+    sta l1030,x                                                       // b581: 9d 30 10    .0.
+    beq cb55f                                                         // b584: f0 d9       ..
+// $b586 referenced 6 times by $a306, $a331, $a368, $ac40, $b4b7, $b577
+sub_cb586
+    lda l1040,x                                                       // b586: bd 40 10    .@.
+    eor l0e00                                                         // b589: 4d 00 0e    M..
+    bne cb594                                                         // b58c: d0 06       ..
+    lda l1050,x                                                       // b58e: bd 50 10    .P.
+    eor l0e01                                                         // b591: 4d 01 0e    M..
+// $b594 referenced 1 time by $b58c
+cb594
+    rts                                                               // b594: 60          `
+
+// $b595 referenced 2 times by $b694, $b782
+sub_cb595
+    ldx l10c8                                                         // b595: ae c8 10    ...
+    bit l9491                                                         // b598: 2c 91 94    ,..
+// $b59b referenced 4 times by $b5aa, $b5b0, $b5cd, $b5d4
+cb59b
+    inx                                                               // b59b: e8          .
+    cpx #$10                                                          // b59c: e0 10       ..
+    bne cb5a2                                                         // b59e: d0 02       ..
+    ldx #0                                                            // b5a0: a2 00       ..
+// $b5a2 referenced 1 time by $b59e
+cb5a2
+    cpx l10c8                                                         // b5a2: ec c8 10    ...
+    bne cb5ac                                                         // b5a5: d0 05       ..
+    bvc cb5b7                                                         // b5a7: 50 0e       P.
+    clv                                                               // b5a9: b8          .
+    bvc cb59b                                                         // b5aa: 50 ef       P.
+// $b5ac referenced 1 time by $b5a5
+cb5ac
+    lda l10b8,x                                                       // b5ac: bd b8 10    ...
+    rol                                                               // b5af: 2a          *
+    bpl cb59b                                                         // b5b0: 10 e9       ..
+    and #4                                                            // b5b2: 29 04       ).
+    bne cb5cd                                                         // b5b4: d0 17       ..
+// $b5b6 referenced 1 time by $b5d6
+cb5b6
+    dex                                                               // b5b6: ca          .
+// $b5b7 referenced 2 times by $b5a7, $b5c2
+cb5b7
+    inx                                                               // b5b7: e8          .
+    cpx #$10                                                          // b5b8: e0 10       ..
+    bne cb5be                                                         // b5ba: d0 02       ..
+    ldx #0                                                            // b5bc: a2 00       ..
+// $b5be referenced 1 time by $b5ba
+cb5be
+    lda l10b8,x                                                       // b5be: bd b8 10    ...
+    rol                                                               // b5c1: 2a          *
+    bpl cb5b7                                                         // b5c2: 10 f3       ..
+    sec                                                               // b5c4: 38          8
+    ror                                                               // b5c5: 6a          j
+    sta l10b8,x                                                       // b5c6: 9d b8 10    ...
+    ldx l10c8                                                         // b5c9: ae c8 10    ...
+    rts                                                               // b5cc: 60          `
+
+// $b5cd referenced 1 time by $b5b4
+cb5cd
+    bvs cb59b                                                         // b5cd: 70 cc       p.
+    lda l10b8,x                                                       // b5cf: bd b8 10    ...
+    and #$20 // ' '                                                   // b5d2: 29 20       )
+    bne cb59b                                                         // b5d4: d0 c5       ..
+    beq cb5b6                                                         // b5d6: f0 de       ..
+// $b5d8 referenced 2 times by $b61b, $b6c6
+sub_cb5d8
+    ldy #1                                                            // b5d8: a0 01       ..
+    sty l10d0                                                         // b5da: 8c d0 10    ...
+    dey                                                               // b5dd: 88          .
+    sty l10cb                                                         // b5de: 8c cb 10    ...
+    sty l10cf                                                         // b5e1: 8c cf 10    ...
+    sty l10d6                                                         // b5e4: 8c d6 10    ...
+    tya                                                               // b5e7: 98          .
+    ldx #2                                                            // b5e8: a2 02       ..
+// $b5ea referenced 1 time by $b5ee
+loop_cb5ea
+    sta l10d1,x                                                       // b5ea: 9d d1 10    ...
+    dex                                                               // b5ed: ca          .
+    bpl loop_cb5ea                                                    // b5ee: 10 fa       ..
+    stx l10cd                                                         // b5f0: 8e cd 10    ...
+    stx l10ce                                                         // b5f3: 8e ce 10    ...
+    ldx #$ca                                                          // b5f6: a2 ca       ..
+    ldy #$10                                                          // b5f8: a0 10       ..
+    rts                                                               // b5fa: 60          `
+
+// $b5fb referenced 2 times by $b68b, $b7b7
+sub_cb5fb
+    jsr sub_c8fcb                                                     // b5fb: 20 cb 8f     ..
+    stx l10c8                                                         // b5fe: 8e c8 10    ...
+    lda l10b8,x                                                       // b601: bd b8 10    ...
+    ror                                                               // b604: 6a          j
+    bcc cb661                                                         // b605: 90 5a       .Z
+    lda l10d4                                                         // b607: ad d4 10    ...
+    pha                                                               // b60a: 48          H
+    lda l10d5                                                         // b60b: ad d5 10    ...
+    pha                                                               // b60e: 48          H
+    lda l1078,x                                                       // b60f: bd 78 10    .x.
+    sta l10d4                                                         // b612: 8d d4 10    ...
+    lda l1088,x                                                       // b615: bd 88 10    ...
+    sta l10d5                                                         // b618: 8d d5 10    ...
+    jsr sub_cb5d8                                                     // b61b: 20 d8 b5     ..
+    dec l10cf                                                         // b61e: ce cf 10    ...
+    dec l10d0                                                         // b621: ce d0 10    ...
+    ldx l10c8                                                         // b624: ae c8 10    ...
+    txa                                                               // b627: 8a          .
+    clc                                                               // b628: 18          .
+    adc #$11                                                          // b629: 69 11       i.
+    sta l10cc                                                         // b62b: 8d cc 10    ...
+    lda l10b8,x                                                       // b62e: bd b8 10    ...
+    and #$20 // ' '                                                   // b631: 29 20       )
+    beq cb63b                                                         // b633: f0 06       ..
+    lda l1098,x                                                       // b635: bd 98 10    ...
+    sta l10cf                                                         // b638: 8d cf 10    ...
+// $b63b referenced 1 time by $b633
+cb63b
+    lda l10a8,x                                                       // b63b: bd a8 10    ...
+    sta l10ca                                                         // b63e: 8d ca 10    ...
+    tax                                                               // b641: aa          .
+    jsr sub_cb98a                                                     // b642: 20 8a b9     ..
+    pha                                                               // b645: 48          H
+    txa                                                               // b646: 8a          .
+    sta (l009c),y                                                     // b647: 91 9c       ..
+    ldx #$ca                                                          // b649: a2 ca       ..
+    ldy #$10                                                          // b64b: a0 10       ..
+    lda #0                                                            // b64d: a9 00       ..
+    jsr sub_cb984                                                     // b64f: 20 84 b9     ..
+    ldx l10c8                                                         // b652: ae c8 10    ...
+    pla                                                               // b655: 68          h
+    jsr sub_cb98f                                                     // b656: 20 8f b9     ..
+    pla                                                               // b659: 68          h
+    sta l10d5                                                         // b65a: 8d d5 10    ...
+    pla                                                               // b65d: 68          h
+    sta l10d4                                                         // b65e: 8d d4 10    ...
+// $b661 referenced 1 time by $b605
+cb661
+    lda #$dc                                                          // b661: a9 dc       ..
+    and l10b8,x                                                       // b663: 3d b8 10    =..
+    sta l10b8,x                                                       // b666: 9d b8 10    ...
+    rts                                                               // b669: 60          `
+
+// $b66a referenced 2 times by $b72d, $b8ef
+sub_cb66a
+    ldx #$0c                                                          // b66a: a2 0c       ..
+// $b66c referenced 1 time by $b676
+loop_cb66c
+    lda l0f00,x                                                       // b66c: bd 00 0f    ...
+    sta l10d9,x                                                       // b66f: 9d d9 10    ...
+    lda l00b0,x                                                       // b672: b5 b0       ..
+    pha                                                               // b674: 48          H
+    dex                                                               // b675: ca          .
+    bpl loop_cb66c                                                    // b676: 10 f4       ..
+    cpy #0                                                            // b678: c0 00       ..
+    bne cb67f                                                         // b67a: d0 03       ..
+    jmp cb718                                                         // b67c: 4c 18 b7    L..
+
+// $b67f referenced 1 time by $b67a
+cb67f
+    php                                                               // b67f: 08          .
+    ldx #$ff                                                          // b680: a2 ff       ..
+// $b682 referenced 2 times by $b686, $b689
+cb682
+    inx                                                               // b682: e8          .
+    lda l10b8,x                                                       // b683: bd b8 10    ...
+    bpl cb682                                                         // b686: 10 fa       ..
+    asl                                                               // b688: 0a          .
+    bpl cb682                                                         // b689: 10 f7       ..
+    jsr sub_cb5fb                                                     // b68b: 20 fb b5     ..
+    lda #$40 // '@'                                                   // b68e: a9 40       .@
+    sta l10b8,x                                                       // b690: 9d b8 10    ...
+    php                                                               // b693: 08          .
+    jsr sub_cb595                                                     // b694: 20 95 b5     ..
+    plp                                                               // b697: 28          (
+    lda l10c9                                                         // b698: ad c9 10    ...
+    sta l10ca                                                         // b69b: 8d ca 10    ...
+    pha                                                               // b69e: 48          H
+    sec                                                               // b69f: 38          8
+    sbc #$20 // ' '                                                   // b6a0: e9 20       .
+    tay                                                               // b6a2: a8          .
+    lda l1030,y                                                       // b6a3: b9 30 10    .0.
+    sta l0f05                                                         // b6a6: 8d 05 0f    ...
+    pla                                                               // b6a9: 68          h
+    sta l10a8,x                                                       // b6aa: 9d a8 10    ...
+    lda l10d4                                                         // b6ad: ad d4 10    ...
+    sta l1078,x                                                       // b6b0: 9d 78 10    .x.
+    lda l10d5                                                         // b6b3: ad d5 10    ...
+    sta l1088,x                                                       // b6b6: 9d 88 10    ...
+    txa                                                               // b6b9: 8a          .
+    clc                                                               // b6ba: 18          .
+    adc #$11                                                          // b6bb: 69 11       i.
+    sta l10cc                                                         // b6bd: 8d cc 10    ...
+    plp                                                               // b6c0: 28          (
+    bvc cb6c6                                                         // b6c1: 50 03       P.
+    jsr sub_cb8da                                                     // b6c3: 20 da b8     ..
+// $b6c6 referenced 1 time by $b6c1
+cb6c6
+    jsr sub_cb5d8                                                     // b6c6: 20 d8 b5     ..
+    jsr sub_cb98a                                                     // b6c9: 20 8a b9     ..
+    pha                                                               // b6cc: 48          H
+    lda l10ca                                                         // b6cd: ad ca 10    ...
+    sta (l009c),y                                                     // b6d0: 91 9c       ..
+    ldy #$10                                                          // b6d2: a0 10       ..
+    lda #2                                                            // b6d4: a9 02       ..
+    jsr sub_cb984                                                     // b6d6: 20 84 b9     ..
+    pla                                                               // b6d9: 68          h
+    jsr sub_cb98f                                                     // b6da: 20 8f b9     ..
+    ldx l10c8                                                         // b6dd: ae c8 10    ...
+    lda l10d0                                                         // b6e0: ad d0 10    ...
+    bne cb6ea                                                         // b6e3: d0 05       ..
+    lda l10cf                                                         // b6e5: ad cf 10    ...
+    beq cb70e                                                         // b6e8: f0 24       .$
+// $b6ea referenced 1 time by $b6e3
+cb6ea
+    lda l10cf                                                         // b6ea: ad cf 10    ...
+    eor #$ff                                                          // b6ed: 49 ff       I.
+    clc                                                               // b6ef: 18          .
+    adc #1                                                            // b6f0: 69 01       i.
+    sta l1098,x                                                       // b6f2: 9d 98 10    ...
+    lda #$20 // ' '                                                   // b6f5: a9 20       .
+    ora l10b8,x                                                       // b6f7: 1d b8 10    ...
+    sta l10b8,x                                                       // b6fa: 9d b8 10    ...
+    lda l10cc                                                         // b6fd: ad cc 10    ...
+    sta l00b3                                                         // b700: 85 b3       ..
+    lda #0                                                            // b702: a9 00       ..
+    sta l00b2                                                         // b704: 85 b2       ..
+    ldy l1098,x                                                       // b706: bc 98 10    ...
+// $b709 referenced 1 time by $b70c
+loop_cb709
+    sta (l00b2),y                                                     // b709: 91 b2       ..
+    iny                                                               // b70b: c8          .
+    bne loop_cb709                                                    // b70c: d0 fb       ..
+// $b70e referenced 1 time by $b6e8
+cb70e
+    lda #2                                                            // b70e: a9 02       ..
+    ora l10b8,x                                                       // b710: 1d b8 10    ...
+    sta l10b8,x                                                       // b713: 9d b8 10    ...
+    ldy #0                                                            // b716: a0 00       ..
+// $b718 referenced 2 times by $b67c, $b71f
+cb718
+    pla                                                               // b718: 68          h
+    sta l00b0,y                                                       // b719: 99 b0 00    ...
+    iny                                                               // b71c: c8          .
+    cpy #$0d                                                          // b71d: c0 0d       ..
+    bne cb718                                                         // b71f: d0 f7       ..
+// $b721 referenced 1 time by $b922
+sub_cb721
+    ldy #$0c                                                          // b721: a0 0c       ..
+// $b723 referenced 1 time by $b72a
+loop_cb723
+    lda l10d9,y                                                       // b723: b9 d9 10    ...
+    sta l0f00,y                                                       // b726: 99 00 0f    ...
+    dey                                                               // b729: 88          .
+    bpl loop_cb723                                                    // b72a: 10 f7       ..
+    rts                                                               // b72c: 60          `
+
+// $b72d referenced 1 time by $b74c
+loop_cb72d
+    jsr sub_cb66a                                                     // b72d: 20 6a b6     j.
+// $b730 referenced 1 time by $9df8
+sub_cb730
+    ldx #$ff                                                          // b730: a2 ff       ..
+// $b732 referenced 2 times by $b76e, $b776
+cb732
+    ldy l10c9                                                         // b732: ac c9 10    ...
+// $b735 referenced 2 times by $b754, $b75a
+cb735
+    inx                                                               // b735: e8          .
+    cpx #$10                                                          // b736: e0 10       ..
+    bne cb74f                                                         // b738: d0 15       ..
+    lda l10c9                                                         // b73a: ad c9 10    ...
+    jsr sub_cb46b                                                     // b73d: 20 6b b4     k.
+    lda l1020,x                                                       // b740: bd 20 10    . .
+    sta l10d5                                                         // b743: 8d d5 10    ...
+    lda l1010,x                                                       // b746: bd 10 10    ...
+    sta l10d4                                                         // b749: 8d d4 10    ...
+    jmp loop_cb72d                                                    // b74c: 4c 2d b7    L-.
+
+// $b74f referenced 1 time by $b738
+cb74f
+    lda l10b8,x                                                       // b74f: bd b8 10    ...
+    and #2                                                            // b752: 29 02       ).
+    beq cb735                                                         // b754: f0 df       ..
+    tya                                                               // b756: 98          .
+    cmp l10a8,x                                                       // b757: dd a8 10    ...
+    bne cb735                                                         // b75a: d0 d9       ..
+    stx l10c8                                                         // b75c: 8e c8 10    ...
+    php                                                               // b75f: 08          .
+    sec                                                               // b760: 38          8
+    sbc #$20 // ' '                                                   // b761: e9 20       .
+    plp                                                               // b763: 28          (
+    tay                                                               // b764: a8          .
+    ldx l10c8                                                         // b765: ae c8 10    ...
+    lda l1010,y                                                       // b768: b9 10 10    ...
+    cmp l1078,x                                                       // b76b: dd 78 10    .x.
+    bne cb732                                                         // b76e: d0 c2       ..
+    lda l1020,y                                                       // b770: b9 20 10    . .
+    cmp l1088,x                                                       // b773: dd 88 10    ...
+    bne cb732                                                         // b776: d0 ba       ..
+    lda l10b8,x                                                       // b778: bd b8 10    ...
+    bpl cb788                                                         // b77b: 10 0b       ..
+    and #$7f                                                          // b77d: 29 7f       ).
+    sta l10b8,x                                                       // b77f: 9d b8 10    ...
+    jsr sub_cb595                                                     // b782: 20 95 b5     ..
+    lda l10b8,x                                                       // b785: bd b8 10    ...
+// $b788 referenced 1 time by $b77b
+cb788
+    and #$20 // ' '                                                   // b788: 29 20       )
+    rts                                                               // b78a: 60          `
+
+    .byt $fe,   0, $10, $d0,   8, $fe, $10, $10, $d0,   3, $fe, $20   // b78b: fe 00 10... ...
+    .byt $10, $60                                                     // b797: 10 60       .`
+
+// $b799 referenced 3 times by $8d87, $8fa0, $94a0
+sub_cb799
+    txa                                                               // b799: 8a          .
+    pha                                                               // b79a: 48          H
+    tya                                                               // b79b: 98          .
+    pha                                                               // b79c: 48          H
+    ldx #$f7                                                          // b79d: a2 f7       ..
+// $b79f referenced 1 time by $b7a4
+loop_cb79f
+    lda lffbd,x                                                       // b79f: bd bd ff    ...
+    pha                                                               // b7a2: 48          H
+    inx                                                               // b7a3: e8          .
+    bmi loop_cb79f                                                    // b7a4: 30 f9       0.
+    ldx #$0f                                                          // b7a6: a2 0f       ..
+    stx l10c8                                                         // b7a8: 8e c8 10    ...
+// $b7ab referenced 1 time by $b7bf
+loop_cb7ab
+    ldx l10c8                                                         // b7ab: ae c8 10    ...
+    tya                                                               // b7ae: 98          .
+    beq cb7b6                                                         // b7af: f0 05       ..
+    cmp l10a8,x                                                       // b7b1: dd a8 10    ...
+    bne cb7bc                                                         // b7b4: d0 06       ..
+// $b7b6 referenced 1 time by $b7af
+cb7b6
+    pha                                                               // b7b6: 48          H
+    jsr sub_cb5fb                                                     // b7b7: 20 fb b5     ..
+    pla                                                               // b7ba: 68          h
+    tay                                                               // b7bb: a8          .
+// $b7bc referenced 1 time by $b7b4
+cb7bc
+    dec l10c8                                                         // b7bc: ce c8 10    ...
+    bpl loop_cb7ab                                                    // b7bf: 10 ea       ..
+    ldx #8                                                            // b7c1: a2 08       ..
+// $b7c3 referenced 1 time by $b7c7
+loop_cb7c3
+    pla                                                               // b7c3: 68          h
+    sta l00b4,x                                                       // b7c4: 95 b4       ..
+    dex                                                               // b7c6: ca          .
+    bpl loop_cb7c3                                                    // b7c7: 10 fa       ..
+    pla                                                               // b7c9: 68          h
+    tay                                                               // b7ca: a8          .
+    pla                                                               // b7cb: 68          h
+    tax                                                               // b7cc: aa          .
+    rts                                                               // b7cd: 60          `
+
+    .byt $8c, $c9, $10, $8a, $48, $20, $ec, $b4, $bd, $60, $10, $29   // b7ce: 8c c9 10... ...
+    .byt $20, $f0, $10, $a9, $d4, $20, $d1, $96                       // b7da: 20 f0 10...  ..
+    .asc "Write only"                                                 // b7e2: 57 72 69... Wri
+    .byt   0, $b8, $20, $30, $b7, $f0, $35, $b9,   0, $10, $dd, $98   // b7ec: 00 b8 20... ..
+    .byt $10, $90, $2d, $b9, $60, $10, $aa, $29, $40, $d0, $14, $8a   // b7f8: 10 90 2d... ..-
+    .byt   9, $40, $99, $60, $10, $a9,   0, $20, $8f, $b9, $68, $aa   // b804: 09 40 99... .@.
+    .byt $a9, $fe, $ac, $c9, $10, $38, $60, $a9, $df, $20, $d1, $96   // b810: a9 fe ac... ...
+    .asc "End of file"                                                // b81c: 45 6e 64... End
+    .byt   0, $b9,   0, $10, $48, $98, $aa, $a9,   0, $20, $8f, $b9   // b827: 00 b9 00... ...
+    .byt $20, $8b, $b7, $68, $a8, $ad, $c8, $10, $18, $69, $11, $85   // b833: 20 8b b7...  ..
+    .byt $b3, $a9,   0, $85, $b2, $68, $aa, $b1, $b2, $ac, $c9, $10   // b83f: b3 a9 00... ...
+    .byt $18, $60, $8c, $c9, $10, $48, $a8, $8a, $48, $98, $48, $8d   // b84b: 18 60 8c... .`.
+    .byt $d7, $10, $20, $ec, $b4, $bd, $60, $10, $30, $19, $a9, $c1   // b857: d7 10 20... ..
+    .byt $20, $d1, $96                                                // b863: 20 d1 96     ..
+    .asc "Not open for update"                                        // b866: 4e 6f 74... Not
+    .byt   0, $29, $20, $f0, $0a, $bc, $30, $10                       // b879: 00 29 20... .)
+    .asc "h +"                                                        // b881: 68 20 2b    h +
+    .byt $b9, $4c, $cb, $b8, $2c, $91, $94, $20, $30, $b7, $b9,   0   // b884: b9 4c cb... .L.
+    .byt $10, $c9, $ff, $d0,   3, $20, $e4, $b8, $dd, $98, $10, $90   // b890: 10 c9 ff... ...
+    .byt $0f, $69,   0, $9d, $98, $10, $d0,   8, $a9, $df, $3d, $b8   // b89c: 0f 69 00... .i.
+    .byt $10, $9d, $b8, $10, $a9,   1, $1d, $b8, $10, $9d, $b8, $10   // b8a8: 10 9d b8... ...
+    .byt $b9,   0, $10, $48, $98, $aa, $68, $a8, $ad, $c8, $10, $18   // b8b4: b9 00 10... ...
+    .byt $69, $11, $85, $b3, $a9,   0, $85, $b2, $68, $91, $b2, $20   // b8c0: 69 11 85... i..
+    .byt $8b, $b7, $a9,   0, $20, $8f, $b9, $68, $aa, $68, $ac, $c9   // b8cc: 8b b7 a9... ...
+    .byt $10, $60                                                     // b8d8: 10 60       .`
+
+// $b8da referenced 1 time by $b6c3
+sub_cb8da
+    pha                                                               // b8da: 48          H
+    txa                                                               // b8db: 8a          .
+    pha                                                               // b8dc: 48          H
+    tya                                                               // b8dd: 98          .
+    pha                                                               // b8de: 48          H
+    lda l1030,y                                                       // b8df: b9 30 10    .0.
+    bne cb8f3                                                         // b8e2: d0 0f       ..
+    pha                                                               // b8e4: 48          H
+    txa                                                               // b8e5: 8a          .
+    pha                                                               // b8e6: 48          H
+    tya                                                               // b8e7: 98          .
+    pha                                                               // b8e8: 48          H
+    lda l1030,y                                                       // b8e9: b9 30 10    .0.
+    pha                                                               // b8ec: 48          H
+    ldy #0                                                            // b8ed: a0 00       ..
+    jsr sub_cb66a                                                     // b8ef: 20 6a b6     j.
+    pla                                                               // b8f2: 68          h
+// $b8f3 referenced 1 time by $b8e2
+cb8f3
+    sta l0f05                                                         // b8f3: 8d 05 0f    ...
+    tax                                                               // b8f6: aa          .
+    pla                                                               // b8f7: 68          h
+    tay                                                               // b8f8: a8          .
+    pha                                                               // b8f9: 48          H
+    txa                                                               // b8fa: 8a          .
+    pha                                                               // b8fb: 48          H
+    ldx #0                                                            // b8fc: a2 00       ..
+    stx l0f06                                                         // b8fe: 8e 06 0f    ...
+    lda l1000,y                                                       // b901: b9 00 10    ...
+    sta l0f07                                                         // b904: 8d 07 0f    ...
+    lda l1010,y                                                       // b907: b9 10 10    ...
+    sta l0f08                                                         // b90a: 8d 08 0f    ...
+    lda l1020,y                                                       // b90d: b9 20 10    . .
+    sta l0f09                                                         // b910: 8d 09 0f    ...
+    ldy #$0d                                                          // b913: a0 0d       ..
+    ldx #5                                                            // b915: a2 05       ..
+    jsr c94ad                                                         // b917: 20 ad 94     ..
+    pla                                                               // b91a: 68          h
+    tay                                                               // b91b: a8          .
+    lda l10d7                                                         // b91c: ad d7 10    ...
+    jsr sub_cb92b                                                     // b91f: 20 2b b9     +.
+    jsr sub_cb721                                                     // b922: 20 21 b7     !.
+    pla                                                               // b925: 68          h
+    tay                                                               // b926: a8          .
+    pla                                                               // b927: 68          h
+    tax                                                               // b928: aa          .
+    pla                                                               // b929: 68          h
+    rts                                                               // b92a: 60          `
+
+// $b92b referenced 1 time by $b91f
+sub_cb92b
+    sty l0fde                                                         // b92b: 8c de 0f    ...
+    sta l0fdf                                                         // b92e: 8d df 0f    ...
+    tya                                                               // b931: 98          .
+    pha                                                               // b932: 48          H
+    txa                                                               // b933: 8a          .
+    pha                                                               // b934: 48          H
+    lda #$90                                                          // b935: a9 90       ..
+    sta l0fdc                                                         // b937: 8d dc 0f    ...
+    jsr sub_c9473                                                     // b93a: 20 73 94     s.
+    lda #$dc                                                          // b93d: a9 dc       ..
+    sta l00c4                                                         // b93f: 85 c4       ..
+    lda #$e0                                                          // b941: a9 e0       ..
+    sta l00c8                                                         // b943: 85 c8       ..
+    lda #9                                                            // b945: a9 09       ..
+    sta l0fdd                                                         // b947: 8d dd 0f    ...
+    ldx #$c0                                                          // b94a: a2 c0       ..
+    ldy #0                                                            // b94c: a0 00       ..
+    lda l0fde                                                         // b94e: ad de 0f    ...
+    jsr sub_cac24                                                     // b951: 20 24 ac     $.
+    lda l0fdd                                                         // b954: ad dd 0f    ...
+    beq cb974                                                         // b957: f0 1b       ..
+    sta l0e09                                                         // b959: 8d 09 0e    ...
+    ldx #0                                                            // b95c: a2 00       ..
+// $b95e referenced 1 time by $b969
+loop_cb95e
+    lda l0fdc,x                                                       // b95e: bd dc 0f    ...
+    sta l0100,x                                                       // b961: 9d 00 01    ...
+    cmp #$0d                                                          // b964: c9 0d       ..
+    beq cb96b                                                         // b966: f0 03       ..
+    inx                                                               // b968: e8          .
+    bne loop_cb95e                                                    // b969: d0 f3       ..
+// $b96b referenced 1 time by $b966
+cb96b
+    lda #0                                                            // b96b: a9 00       ..
+    sta l0100,x                                                       // b96d: 9d 00 01    ...
+    dex                                                               // b970: ca          .
+    jmp c96f0                                                         // b971: 4c f0 96    L..
+
+// $b974 referenced 1 time by $b957
+cb974
+    ldx l10c9                                                         // b974: ae c9 10    ...
+    lda l1040,x                                                       // b977: bd 40 10    .@.
+    eor #1                                                            // b97a: 49 01       I.
+    sta l1040,x                                                       // b97c: 9d 40 10    .@.
+    pla                                                               // b97f: 68          h
+    tax                                                               // b980: aa          .
+    pla                                                               // b981: 68          h
+    tay                                                               // b982: a8          .
+    rts                                                               // b983: 60          `
+
+// $b984 referenced 2 times by $b64f, $b6d6
+sub_cb984
+    jsr sub_c929b                                                     // b984: 20 9b 92     ..
+    jmp c9edd                                                         // b987: 4c dd 9e    L..
+
+// $b98a referenced 4 times by $96f0, $9703, $b642, $b6c9
+sub_cb98a
+    ldy #$0a                                                          // b98a: a0 0a       ..
+    lda (l009c),y                                                     // b98c: b1 9c       ..
+    rts                                                               // b98e: 60          `
+
+// $b98f referenced 4 times by $8b6c, $9ccc, $b656, $b6da
+sub_cb98f
+    ldy #$0a                                                          // b98f: a0 0a       ..
+    sta (l009c),y                                                     // b991: 91 9c       ..
+    rts                                                               // b993: 60          `
+
+sub_cb994
+    lda #0                                                            // b994: a9 00       ..
+    tay                                                               // b996: a8          .
+    jmp osfind                                                        // b997: 4c ce ff    L..
+
+sub_cb99a
+    clv                                                               // b99a: b8          .
+    bvc cb9a0                                                         // b99b: 50 03       P.
+sub_cb99d
+    bit l9491                                                         // b99d: 2c 91 94    ,..
+// $b9a0 referenced 1 time by $b99b
+cb9a0
+    jsr sub_cbc44                                                     // b9a0: 20 44 bc     D.
+    ldy l00a8                                                         // b9a3: a4 a8       ..
+    lda #0                                                            // b9a5: a9 00       ..
+    sta l00ad                                                         // b9a7: 85 ad       ..
+    php                                                               // b9a9: 08          .
+// $b9aa referenced 3 times by $b9ca, $b9ea, $b9fd
+cb9aa
+    jsr osbget                                                        // b9aa: 20 d7 ff     ..
+    bcc cb9b6                                                         // b9ad: 90 07       ..
+    plp                                                               // b9af: 28          (
+    jsr cbc3d                                                         // b9b0: 20 3d bc     =.
+    jmp osnewl                                                        // b9b3: 4c e7 ff    L..
+
+// $b9b6 referenced 1 time by $b9ad
+cb9b6
+    jsr sub_cb9ff                                                     // b9b6: 20 ff b9     ..
+    plp                                                               // b9b9: 28          (
+    php                                                               // b9ba: 08          .
+    bvs cb9c5                                                         // b9bb: 70 08       p.
+    cmp #$0d                                                          // b9bd: c9 0d       ..
+    beq cb9cd                                                         // b9bf: f0 0c       ..
+    cmp #$0a                                                          // b9c1: c9 0a       ..
+    beq cb9cd                                                         // b9c3: f0 08       ..
+// $b9c5 referenced 1 time by $b9bb
+cb9c5
+    sta l00ad                                                         // b9c5: 85 ad       ..
+// $b9c7 referenced 1 time by $b9d8
+loop_cb9c7
+    jsr oswrch                                                        // b9c7: 20 ee ff     ..
+    jmp cb9aa                                                         // b9ca: 4c aa b9    L..
+
+// $b9cd referenced 2 times by $b9bf, $b9c3
+cb9cd
+    pha                                                               // b9cd: 48          H
+    ldx l026a                                                         // b9ce: ae 6a 02    .j.
+    beq cb9da                                                         // b9d1: f0 07       ..
+    lda #0                                                            // b9d3: a9 00       ..
+    sta l00ad                                                         // b9d5: 85 ad       ..
+    pla                                                               // b9d7: 68          h
+    bne loop_cb9c7                                                    // b9d8: d0 ed       ..
+// $b9da referenced 1 time by $b9d1
+cb9da
+    lda l00ad                                                         // b9da: a5 ad       ..
+    cmp #$0d                                                          // b9dc: c9 0d       ..
+    beq cb9ed                                                         // b9de: f0 0d       ..
+    cmp #$0a                                                          // b9e0: c9 0a       ..
+    beq cb9f4                                                         // b9e2: f0 10       ..
+    pla                                                               // b9e4: 68          h
+    sta l00ad                                                         // b9e5: 85 ad       ..
+// $b9e7 referenced 2 times by $b9f2, $b9f7
+cb9e7
+    jsr osnewl                                                        // b9e7: 20 e7 ff     ..
+    jmp cb9aa                                                         // b9ea: 4c aa b9    L..
+
+// $b9ed referenced 1 time by $b9de
+cb9ed
+    pla                                                               // b9ed: 68          h
+    cmp #$0a                                                          // b9ee: c9 0a       ..
+    beq cb9f9                                                         // b9f0: f0 07       ..
+    bne cb9e7                                                         // b9f2: d0 f3       ..
+// $b9f4 referenced 1 time by $b9e2
+cb9f4
+    pla                                                               // b9f4: 68          h
+    cmp #$0d                                                          // b9f5: c9 0d       ..
+    bne cb9e7                                                         // b9f7: d0 ee       ..
+// $b9f9 referenced 1 time by $b9f0
+cb9f9
+    lda #0                                                            // b9f9: a9 00       ..
+    sta l00ad                                                         // b9fb: 85 ad       ..
+    beq cb9aa                                                         // b9fd: f0 ab       ..
+// $b9ff referenced 2 times by $b9b6, $ba33
+sub_cb9ff
+    bit l00ff                                                         // b9ff: 24 ff       $.
+    bmi cba04                                                         // ba01: 30 01       0.
+    rts                                                               // ba03: 60          `
+
+// $ba04 referenced 1 time by $ba01
+cba04
+    jsr cbc3d                                                         // ba04: 20 3d bc     =.
+    jsr osnewl                                                        // ba07: 20 e7 ff     ..
+    lda #osbyte_acknowledge_escape                                    // ba0a: a9 7e       .~
+    jsr osbyte                                                        // ba0c: 20 f4 ff     ..
+    lda #$11                                                          // ba0f: a9 11       ..
+    jsr generate_error_inline2                                        // ba11: 20 d4 96     ..
+    .asc "Escape", 0                                                  // ba14: 45 73 63... Esc
+
+sub_cba1b
+    jsr sub_cbc44                                                     // ba1b: 20 44 bc     D.
+    ldx #$14                                                          // ba1e: a2 14       ..
+    lda #0                                                            // ba20: a9 00       ..
+// $ba22 referenced 1 time by $ba24
+loop_cba22
+    pha                                                               // ba22: 48          H
+    dex                                                               // ba23: ca          .
+    bpl loop_cba22                                                    // ba24: 10 fc       ..
+    tsx                                                               // ba26: ba          .
+    jsr sub_cbb77                                                     // ba27: 20 77 bb     w.
+    lda (l00ae),y                                                     // ba2a: b1 ae       ..
+    and #$f0                                                          // ba2c: 29 f0       ).
+    beq cba33                                                         // ba2e: f0 03       ..
+    jsr sub_cbadd                                                     // ba30: 20 dd ba     ..
+// $ba33 referenced 2 times by $ba2e, $bad5
+cba33
+    jsr sub_cb9ff                                                     // ba33: 20 ff b9     ..
+    lda #$ff                                                          // ba36: a9 ff       ..
+    sta l00aa                                                         // ba38: 85 aa       ..
+// $ba3a referenced 1 time by $ba49
+loop_cba3a
+    ldy l00a8                                                         // ba3a: a4 a8       ..
+    jsr osbget                                                        // ba3c: 20 d7 ff     ..
+    bcs cba4c                                                         // ba3f: b0 0b       ..
+    inc l00aa                                                         // ba41: e6 aa       ..
+    ldy l00aa                                                         // ba43: a4 aa       ..
+    sta (l00ae),y                                                     // ba45: 91 ae       ..
+    cpy #$0f                                                          // ba47: c0 0f       ..
+    bne loop_cba3a                                                    // ba49: d0 ef       ..
+    clc                                                               // ba4b: 18          .
+// $ba4c referenced 1 time by $ba3f
+cba4c
+    php                                                               // ba4c: 08          .
+    lda l00aa                                                         // ba4d: a5 aa       ..
+    bpl cba5a                                                         // ba4f: 10 09       ..
+    ldx #$15                                                          // ba51: a2 15       ..
+// $ba53 referenced 2 times by $ba55, $bada
+cba53
+    pla                                                               // ba53: 68          h
+    dex                                                               // ba54: ca          .
+    bpl cba53                                                         // ba55: 10 fc       ..
+    jmp cbc3d                                                         // ba57: 4c 3d bc    L=.
+
+// $ba5a referenced 1 time by $ba4f
+cba5a
+    ldy #$10                                                          // ba5a: a0 10       ..
+    lda (l00ae),y                                                     // ba5c: b1 ae       ..
+    and #$f0                                                          // ba5e: 29 f0       ).
+    bne cba65                                                         // ba60: d0 03       ..
+    jsr sub_cbadd                                                     // ba62: 20 dd ba     ..
+// $ba65 referenced 1 time by $ba60
+cba65
+    ldy #$13                                                          // ba65: a0 13       ..
+// $ba67 referenced 1 time by $ba71
+loop_cba67
+    lda (l00ae),y                                                     // ba67: b1 ae       ..
+    pha                                                               // ba69: 48          H
+    jsr sub_c912f                                                     // ba6a: 20 2f 91     /.
+    pla                                                               // ba6d: 68          h
+    dey                                                               // ba6e: 88          .
+    cpy #$0f                                                          // ba6f: c0 0f       ..
+    bne loop_cba67                                                    // ba71: d0 f4       ..
+    iny                                                               // ba73: c8          .
+    clc                                                               // ba74: 18          .
+    adc #$10                                                          // ba75: 69 10       i.
+    php                                                               // ba77: 08          .
+// $ba78 referenced 1 time by $ba83
+loop_cba78
+    plp                                                               // ba78: 28          (
+    sta (l00ae),y                                                     // ba79: 91 ae       ..
+    iny                                                               // ba7b: c8          .
+    lda (l00ae),y                                                     // ba7c: b1 ae       ..
+    adc #0                                                            // ba7e: 69 00       i.
+    php                                                               // ba80: 08          .
+    cpy #$14                                                          // ba81: c0 14       ..
+    bne loop_cba78                                                    // ba83: d0 f3       ..
+    plp                                                               // ba85: 28          (
+    jsr print_inline_top_bit_clear                                    // ba86: 20 45 91     E.
+    .asc " : "                                                        // ba89: 20 3a 20     :
+
+    ldy #0                                                            // ba8c: a0 00       ..
+    ldx l00aa                                                         // ba8e: a6 aa       ..
+// $ba90 referenced 1 time by $ba9b
+loop_cba90
+    lda (l00ae),y                                                     // ba90: b1 ae       ..
+    jsr sub_cbb03                                                     // ba92: 20 03 bb     ..
+// $ba95 referenced 1 time by $baa8
+loop_cba95
+    iny                                                               // ba95: c8          .
+    cpy #$10                                                          // ba96: c0 10       ..
+    beq cbaab                                                         // ba98: f0 11       ..
+    dex                                                               // ba9a: ca          .
+    bpl loop_cba90                                                    // ba9b: 10 f3       ..
+    tya                                                               // ba9d: 98          .
+    pha                                                               // ba9e: 48          H
+    jsr print_inline_top_bit_clear                                    // ba9f: 20 45 91     E.
+    .asc "   "                                                        // baa2: 20 20 20
+
+    nop                                                               // baa5: ea          .
+    pla                                                               // baa6: 68          h
+    tay                                                               // baa7: a8          .
+    jmp loop_cba95                                                    // baa8: 4c 95 ba    L..
+
+// $baab referenced 1 time by $ba98
+cbaab
+    dex                                                               // baab: ca          .
+    jsr print_inline_top_bit_clear                                    // baac: 20 45 91     E.
+    .asc ": "                                                         // baaf: 3a 20       :
+
+    ldy #0                                                            // bab1: a0 00       ..
+    jsr sub_cbc86                                                     // bab3: 20 86 bc     ..
+// $bab6 referenced 1 time by $bacd
+loop_cbab6
+    lda (l00ae),y                                                     // bab6: b1 ae       ..
+    and #$7f                                                          // bab8: 29 7f       ).
+    cmp #$20 // ' '                                                   // baba: c9 20       .
+    bcs cbac0                                                         // babc: b0 02       ..
+// $babe referenced 1 time by $bac2
+loop_cbabe
+    lda #$2e // '.'                                                   // babe: a9 2e       ..
+// $bac0 referenced 1 time by $babc
+cbac0
+    cmp #$7f                                                          // bac0: c9 7f       ..
+    beq loop_cbabe                                                    // bac2: f0 fa       ..
+    jsr osasci                                                        // bac4: 20 e3 ff     ..
+    iny                                                               // bac7: c8          .
+    cpy #$10                                                          // bac8: c0 10       ..
+    beq cbacf                                                         // baca: f0 03       ..
+    dex                                                               // bacc: ca          .
+    bpl loop_cbab6                                                    // bacd: 10 e7       ..
+// $bacf referenced 1 time by $baca
+cbacf
+    jsr osnewl                                                        // bacf: 20 e7 ff     ..
+    plp                                                               // bad2: 28          (
+    bcs cbad8                                                         // bad3: b0 03       ..
+    jmp cba33                                                         // bad5: 4c 33 ba    L3.
+
+// $bad8 referenced 1 time by $bad3
+cbad8
+    ldx #$14                                                          // bad8: a2 14       ..
+    jmp cba53                                                         // bada: 4c 53 ba    LS.
+
+// $badd referenced 2 times by $ba30, $ba62
+sub_cbadd
+    lda (l00ae),y                                                     // badd: b1 ae       ..
+    pha                                                               // badf: 48          H
+    jsr print_inline_top_bit_clear                                    // bae0: 20 45 91     E.
+    .asc $0d, "Address  : "                                           // bae3: 0d 41 64... .Ad
+
+    ldx #$0f                                                          // baef: a2 0f       ..
+    pla                                                               // baf1: 68          h
+// $baf2 referenced 1 time by $bafb
+loop_cbaf2
+    jsr sub_cbb03                                                     // baf2: 20 03 bb     ..
+    sec                                                               // baf5: 38          8
+    adc #0                                                            // baf6: 69 00       i.
+    and #$0f                                                          // baf8: 29 0f       ).
+    dex                                                               // bafa: ca          .
+    bpl loop_cbaf2                                                    // bafb: 10 f5       ..
+    jsr osnewl                                                        // bafd: 20 e7 ff     ..
+    jmp osnewl                                                        // bb00: 4c e7 ff    L..
+
+// $bb03 referenced 2 times by $ba92, $baf2
+sub_cbb03
+    pha                                                               // bb03: 48          H
+    jsr sub_c912f                                                     // bb04: 20 2f 91     /.
+    lda #$20 // ' '                                                   // bb07: a9 20       .
+    jsr osasci                                                        // bb09: 20 e3 ff     ..
+    pla                                                               // bb0c: 68          h
+    rts                                                               // bb0d: 60          `
+
+// $bb0e referenced 2 times by $bb7e, $bc0a
+sub_cbb0e
+    tya                                                               // bb0e: 98          .
+    tax                                                               // bb0f: aa          .
+    lda #0                                                            // bb10: a9 00       ..
+    tay                                                               // bb12: a8          .
+// $bb13 referenced 1 time by $bb18
+loop_cbb13
+    sta (l00ae),y                                                     // bb13: 91 ae       ..
+    iny                                                               // bb15: c8          .
+    cpy #4                                                            // bb16: c0 04       ..
+    bne loop_cbb13                                                    // bb18: d0 f9       ..
+// $bb1a referenced 1 time by $bb61
+cbb1a
+    txa                                                               // bb1a: 8a          .
+    inx                                                               // bb1b: e8          .
+    tay                                                               // bb1c: a8          .
+    lda (os_text_ptr),y                                               // bb1d: b1 f2       ..
+    cmp #$0d                                                          // bb1f: c9 0d       ..
+    beq cbb6f                                                         // bb21: f0 4c       .L
+    cmp #$20 // ' '                                                   // bb23: c9 20       .
+    beq cbb6f                                                         // bb25: f0 48       .H
+    cmp #$30 // '0'                                                   // bb27: c9 30       .0
+    bcc cbb68                                                         // bb29: 90 3d       .=
+    cmp #$3a // ':'                                                   // bb2b: c9 3a       .:
+    bcc cbb39                                                         // bb2d: 90 0a       ..
+    and #$5f // '_'                                                   // bb2f: 29 5f       )_
+    adc #$b8                                                          // bb31: 69 b8       i.
+    bcs cbb68                                                         // bb33: b0 33       .3
+    cmp #$fa                                                          // bb35: c9 fa       ..
+    bcc cbb68                                                         // bb37: 90 2f       ./
+// $bb39 referenced 1 time by $bb2d
+cbb39
+    and #$0f                                                          // bb39: 29 0f       ).
+    pha                                                               // bb3b: 48          H
+    txa                                                               // bb3c: 8a          .
+    pha                                                               // bb3d: 48          H
+    ldx #4                                                            // bb3e: a2 04       ..
+// $bb40 referenced 1 time by $bb56
+loop_cbb40
+    ldy #0                                                            // bb40: a0 00       ..
+    tya                                                               // bb42: 98          .
+// $bb43 referenced 1 time by $bb4f
+loop_cbb43
+    pha                                                               // bb43: 48          H
+    plp                                                               // bb44: 28          (
+    lda (l00ae),y                                                     // bb45: b1 ae       ..
+    rol                                                               // bb47: 2a          *
+    sta (l00ae),y                                                     // bb48: 91 ae       ..
+    php                                                               // bb4a: 08          .
+    pla                                                               // bb4b: 68          h
+    iny                                                               // bb4c: c8          .
+    cpy #4                                                            // bb4d: c0 04       ..
+    bne loop_cbb43                                                    // bb4f: d0 f2       ..
+    pha                                                               // bb51: 48          H
+    plp                                                               // bb52: 28          (
+    bcs cbb64                                                         // bb53: b0 0f       ..
+    dex                                                               // bb55: ca          .
+    bne loop_cbb40                                                    // bb56: d0 e8       ..
+    pla                                                               // bb58: 68          h
+    tax                                                               // bb59: aa          .
+    pla                                                               // bb5a: 68          h
+    ldy #0                                                            // bb5b: a0 00       ..
+    ora (l00ae),y                                                     // bb5d: 11 ae       ..
+    sta (l00ae),y                                                     // bb5f: 91 ae       ..
+    jmp cbb1a                                                         // bb61: 4c 1a bb    L..
+
+// $bb64 referenced 1 time by $bb53
+cbb64
+    pla                                                               // bb64: 68          h
+    pla                                                               // bb65: 68          h
+    sec                                                               // bb66: 38          8
+    rts                                                               // bb67: 60          `
+
+// $bb68 referenced 3 times by $bb29, $bb33, $bb37
+cbb68
+    jsr cbc3d                                                         // bb68: 20 3d bc     =.
+    jmp c9208                                                         // bb6b: 4c 08 92    L..
+
+// $bb6e referenced 1 time by $bb73
+loop_cbb6e
+    iny                                                               // bb6e: c8          .
+// $bb6f referenced 2 times by $bb21, $bb25
+cbb6f
+    lda (os_text_ptr),y                                               // bb6f: b1 f2       ..
+    cmp #$20 // ' '                                                   // bb71: c9 20       .
+    beq loop_cbb6e                                                    // bb73: f0 f9       ..
+    clc                                                               // bb75: 18          .
+    rts                                                               // bb76: 60          `
+
+// $bb77 referenced 1 time by $ba27
+sub_cbb77
+    inx                                                               // bb77: e8          .
+    stx l00ae                                                         // bb78: 86 ae       ..
+    ldx #1                                                            // bb7a: a2 01       ..
+    stx l00af                                                         // bb7c: 86 af       ..
+    jsr sub_cbb0e                                                     // bb7e: 20 0e bb     ..
+    bcs cbba2                                                         // bb81: b0 1f       ..
+    tya                                                               // bb83: 98          .
+    pha                                                               // bb84: 48          H
+    ldy l00a8                                                         // bb85: a4 a8       ..
+    ldx #$aa                                                          // bb87: a2 aa       ..
+    lda #2                                                            // bb89: a9 02       ..
+    jsr osargs                                                        // bb8b: 20 da ff     ..
+    ldy #3                                                            // bb8e: a0 03       ..
+// $bb90 referenced 1 time by $bb98
+loop_cbb90
+    lda l00aa,y                                                       // bb90: b9 aa 00    ...
+    cmp (l00ae),y                                                     // bb93: d1 ae       ..
+    bne cbb9c                                                         // bb95: d0 05       ..
+    dey                                                               // bb97: 88          .
+    bpl loop_cbb90                                                    // bb98: 10 f6       ..
+    bmi cbbbc                                                         // bb9a: 30 20       0
+// $bb9c referenced 1 time by $bb95
+cbb9c
+    bcc cbba2                                                         // bb9c: 90 04       ..
+    ldy #$ff                                                          // bb9e: a0 ff       ..
+    bne cbbbc                                                         // bba0: d0 1a       ..
+// $bba2 referenced 2 times by $bb81, $bb9c
+cbba2
+    jsr cbc3d                                                         // bba2: 20 3d bc     =.
+    lda #$b7                                                          // bba5: a9 b7       ..
+    jsr generate_error_inline2                                        // bba7: 20 d4 96     ..
+    .asc "Outside file", 0                                            // bbaa: 4f 75 74... Out
+
+// $bbb7 referenced 1 time by $bbbf
+loop_cbbb7
+    lda (l00ae),y                                                     // bbb7: b1 ae       ..
+    sta l00aa,y                                                       // bbb9: 99 aa 00    ...
+// $bbbc referenced 2 times by $bb9a, $bba0
+cbbbc
+    iny                                                               // bbbc: c8          .
+    cpy #4                                                            // bbbd: c0 04       ..
+    bne loop_cbbb7                                                    // bbbf: d0 f6       ..
+    ldx #$aa                                                          // bbc1: a2 aa       ..
+    ldy l00a8                                                         // bbc3: a4 a8       ..
+    lda #1                                                            // bbc5: a9 01       ..
+    jsr osargs                                                        // bbc7: 20 da ff     ..
+    pla                                                               // bbca: 68          h
+    tay                                                               // bbcb: a8          .
+    lda (os_text_ptr),y                                               // bbcc: b1 f2       ..
+    cmp #$0d                                                          // bbce: c9 0d       ..
+    bne cbc0a                                                         // bbd0: d0 38       .8
+    ldy #1                                                            // bbd2: a0 01       ..
+// $bbd4 referenced 1 time by $bbda
+loop_cbbd4
+    lda os_text_ptr,y                                                 // bbd4: b9 f2 00    ...
+    sta (l00ae),y                                                     // bbd7: 91 ae       ..
+    dey                                                               // bbd9: 88          .
+    bpl loop_cbbd4                                                    // bbda: 10 f8       ..
+    lda #osfile_read_catalogue_info                                   // bbdc: a9 05       ..
+    ldx l00ae                                                         // bbde: a6 ae       ..
+    ldy l00af                                                         // bbe0: a4 af       ..
+    jsr osfile                                                        // bbe2: 20 dd ff     ..
+    ldy #2                                                            // bbe5: a0 02       ..
+// $bbe7 referenced 1 time by $bbf2
+loop_cbbe7
+    lda (l00ae),y                                                     // bbe7: b1 ae       ..
+    dey                                                               // bbe9: 88          .
+    dey                                                               // bbea: 88          .
+    sta (l00ae),y                                                     // bbeb: 91 ae       ..
+    iny                                                               // bbed: c8          .
+    iny                                                               // bbee: c8          .
+    iny                                                               // bbef: c8          .
+    cpy #6                                                            // bbf0: c0 06       ..
+    bne loop_cbbe7                                                    // bbf2: d0 f3       ..
+    dey                                                               // bbf4: 88          .
+    dey                                                               // bbf5: 88          .
+// $bbf6 referenced 1 time by $bbfd
+loop_cbbf6
+    lda (l00ae),y                                                     // bbf6: b1 ae       ..
+    cmp #$ff                                                          // bbf8: c9 ff       ..
+    bne cbc1f                                                         // bbfa: d0 23       .#
+    dey                                                               // bbfc: 88          .
+    bne loop_cbbf6                                                    // bbfd: d0 f7       ..
+    ldy #3                                                            // bbff: a0 03       ..
+    lda #0                                                            // bc01: a9 00       ..
+// $bc03 referenced 1 time by $bc06
+loop_cbc03
+    sta (l00ae),y                                                     // bc03: 91 ae       ..
+    dey                                                               // bc05: 88          .
+    bpl loop_cbc03                                                    // bc06: 10 fb       ..
+    bmi cbc1f                                                         // bc08: 30 15       0.
+// $bc0a referenced 1 time by $bbd0
+cbc0a
+    jsr sub_cbb0e                                                     // bc0a: 20 0e bb     ..
+    bcc cbc1f                                                         // bc0d: 90 10       ..
+    jsr cbc3d                                                         // bc0f: 20 3d bc     =.
+    lda #$fc                                                          // bc12: a9 fc       ..
+    jsr generate_error_inline                                         // bc14: 20 b8 96     ..
+    .asc "address", 0                                                 // bc17: 61 64 64... add
+
+// $bc1f referenced 3 times by $bbfa, $bc08, $bc0d
+cbc1f
+    ldy #0                                                            // bc1f: a0 00       ..
+    ldx #4                                                            // bc21: a2 04       ..
+    clc                                                               // bc23: 18          .
+// $bc24 referenced 1 time by $bc2e
+loop_cbc24
+    lda (l00ae),y                                                     // bc24: b1 ae       ..
+    adc l00aa,y                                                       // bc26: 79 aa 00    y..
+    sta l00aa,y                                                       // bc29: 99 aa 00    ...
+    iny                                                               // bc2c: c8          .
+    dex                                                               // bc2d: ca          .
+    bne loop_cbc24                                                    // bc2e: d0 f4       ..
+    ldy #$14                                                          // bc30: a0 14       ..
+    ldx #3                                                            // bc32: a2 03       ..
+// $bc34 referenced 1 time by $bc3a
+loop_cbc34
+    dey                                                               // bc34: 88          .
+    lda l00aa,x                                                       // bc35: b5 aa       ..
+    sta (l00ae),y                                                     // bc37: 91 ae       ..
+    dex                                                               // bc39: ca          .
+    bpl loop_cbc34                                                    // bc3a: 10 f8       ..
+    rts                                                               // bc3c: 60          `
+
+// $bc3d referenced 6 times by $b9b0, $ba04, $ba57, $bb68, $bba2, $bc0f
+cbc3d
+    ldy l00a8                                                         // bc3d: a4 a8       ..
+    lda #0                                                            // bc3f: a9 00       ..
+    jmp osfind                                                        // bc41: 4c ce ff    L..
+
+// $bc44 referenced 2 times by $b9a0, $ba1b
+sub_cbc44
+    php                                                               // bc44: 08          .
+    tya                                                               // bc45: 98          .
+    clc                                                               // bc46: 18          .
+    adc os_text_ptr                                                   // bc47: 65 f2       e.
+    pha                                                               // bc49: 48          H
+    tax                                                               // bc4a: aa          .
+    lda #0                                                            // bc4b: a9 00       ..
+    adc l00f3                                                         // bc4d: 65 f3       e.
+    pha                                                               // bc4f: 48          H
+    tay                                                               // bc50: a8          .
+    lda #$40 // '@'                                                   // bc51: a9 40       .@
+    jsr osfind                                                        // bc53: 20 ce ff     ..
+    tay                                                               // bc56: a8          .
+    sta l00a8                                                         // bc57: 85 a8       ..
+    bne cbc6a                                                         // bc59: d0 0f       ..
+    lda #$d6                                                          // bc5b: a9 d6       ..
+    jsr generate_error_inline2                                        // bc5d: 20 d4 96     ..
+    .asc "Not found", 0                                               // bc60: 4e 6f 74... Not
+
+// $bc6a referenced 1 time by $bc59
+cbc6a
+    pla                                                               // bc6a: 68          h
+    sta l00f3                                                         // bc6b: 85 f3       ..
+    pla                                                               // bc6d: 68          h
+    sta os_text_ptr                                                   // bc6e: 85 f2       ..
+    ldy #0                                                            // bc70: a0 00       ..
+// $bc72 referenced 1 time by $bc7b
+loop_cbc72
+    iny                                                               // bc72: c8          .
+    lda (os_text_ptr),y                                               // bc73: b1 f2       ..
+    cmp #$0d                                                          // bc75: c9 0d       ..
+    beq cbc84                                                         // bc77: f0 0b       ..
+    cmp #$20 // ' '                                                   // bc79: c9 20       .
+    bne loop_cbc72                                                    // bc7b: d0 f5       ..
+// $bc7d referenced 1 time by $bc82
+loop_cbc7d
+    iny                                                               // bc7d: c8          .
+    lda (os_text_ptr),y                                               // bc7e: b1 f2       ..
+    cmp #$20 // ' '                                                   // bc80: c9 20       .
+    beq loop_cbc7d                                                    // bc82: f0 f9       ..
+// $bc84 referenced 1 time by $bc77
+cbc84
+    plp                                                               // bc84: 28          (
+    rts                                                               // bc85: 60          `
+
+// $bc86 referenced 2 times by $a8b0, $bab3
+sub_cbc86
+    jsr sub_cbc89                                                     // bc86: 20 89 bc     ..
+// $bc89 referenced 1 time by $bc86
+sub_cbc89
+    jsr sub_cbc8c                                                     // bc89: 20 8c bc     ..
+// $bc8c referenced 1 time by $bc89
+sub_cbc8c
+    inx                                                               // bc8c: e8          .
+    inx                                                               // bc8d: e8          .
+    inx                                                               // bc8e: e8          .
+    inx                                                               // bc8f: e8          .
+    rts                                                               // bc90: 60          `
+
+    .byt $ff, $ff, $ff                                                // bc91: ff ff ff    ...
+// $bc94 referenced 1 time by $bea4
+lbc94
+    .byt $37,   5, $96,   5, $f2,   5,   7,   6, $27,   6, $68,   6   // bc94: 37 05 96... 7..
+    .byt $5e,   5, $2d,   5, $20,   5, $42,   5, $a9,   5, $d1,   5   // bca0: 5e 05 2d... ^.-
+    .byt $86, $88, $96, $98, $18, $18, $82, $18, $20, $c5,   6, $a8   // bcac: 86 88 96... ...
+    .byt $20, $c5,   6, $20, $d4, $ff, $4c, $9c,   5, $20, $c5,   6   // bcb8: 20 c5 06...  ..
+    .byt $a8, $20, $d7, $ff, $4c, $3a,   5, $20, $e0, $ff, $6a, $20   // bcc4: a8 20 d7... . .
+    .byt $95,   6, $2a, $4c, $9e,   5, $20, $c5,   6, $f0, $0b, $48   // bcd0: 95 06 2a... ..*
+    .byt $20, $82,   5, $68, $20, $ce, $ff, $4c, $9e,   5, $20, $c5   // bcdc: 20 82 05...  ..
+    .byt   6, $a8, $a9,   0, $20, $ce, $ff, $4c, $9c,   5, $20, $c5   // bce8: 06 a8 a9... ...
+    .byt   6, $a8, $a2,   4, $20, $c5,   6, $95, $ff, $ca, $d0, $f8   // bcf4: 06 a8 a2... ...
+    .byt $20, $c5,   6, $20, $da, $ff, $20, $95,   6, $a2,   3, $b5   // bd00: 20 c5 06...  ..
+    .byt   0, $20, $95,   6, $ca, $10, $f8, $4c, $36,   0, $a2,   0   // bd0c: 00 20 95... . .
+    .byt $a0,   0, $20, $c5,   6, $99,   0,   7, $c8, $f0,   4, $c9   // bd18: a0 00 20... ..
+    .byt $0d, $d0, $f3, $a0,   7, $60, $20, $82,   5, $20, $f7, $ff   // bd24: 0d d0 f3... ...
+    .byt $a9, $7f, $2c, $e2, $fe, $50, $fb, $8d, $e3, $fe, $4c, $36   // bd30: a9 7f 2c... ..,
+    .byt   0, $a2, $10, $20, $c5,   6, $95,   1, $ca, $d0, $f8, $20   // bd3c: 00 a2 10... ...
+    .byt $82,   5, $86,   0, $84,   1, $a0,   0, $20, $c5,   6, $20   // bd48: 82 05 86... ...
+    .byt $dd, $ff, $20, $95,   6, $a2, $10, $b5,   1, $20, $95,   6   // bd54: dd ff 20... ..
+    .byt $ca, $d0, $f8, $f0, $d5, $a2, $0d, $20, $c5,   6, $95, $ff   // bd60: ca d0 f8... ...
+    .byt $ca, $d0, $f8, $20, $c5,   6, $a0,   0, $20, $d1, $ff, $48   // bd6c: ca d0 f8... ...
+    .byt $a2, $0c, $b5,   0, $20, $95,   6, $ca, $10, $f8             // bd78: a2 0c b5... ...
+    .asc "hL:"                                                        // bd82: 68 4c 3a    hL:
+    .byt   5, $20, $c5,   6, $aa, $20, $c5,   6, $20, $f4, $ff, $2c   // bd85: 05 20 c5... . .
+    .byt $e2, $fe, $50                                                // bd91: e2 fe 50    ..P
+// $bd94 referenced 1 time by $beaa
+lbd94
+    .byt $fb, $8e, $e3, $fe, $4c, $36,   0, $20, $c5,   6, $aa, $20   // bd94: fb 8e e3... ...
+    .byt $c5,   6, $a8, $20, $c5,   6, $20, $f4, $ff, $49, $9d, $f0   // bda0: c5 06 a8... ...
+    .byt $eb, $6a, $20, $95,   6, $2c, $e2, $fe, $50, $fb, $8c, $e3   // bdac: eb 6a 20... .j
+    .byt $fe, $70, $d5, $20, $c5,   6, $a8, $2c, $e2, $fe, $10, $fb   // bdb8: fe 70 d5... .p.
+    .byt $ae, $e3, $fe, $ca, $30, $0f, $2c, $e2, $fe, $10, $fb, $ad   // bdc4: ae e3 fe... ...
+    .byt $e3, $fe, $9d, $28,   1, $ca, $10, $f2, $98, $a2, $28, $a0   // bdd0: e3 fe 9d... ...
+    .byt   1, $20, $f1, $ff, $2c, $e2, $fe, $10, $fb, $ae, $e3, $fe   // bddc: 01 20 f1... . .
+    .byt $ca, $30, $0e, $bc, $28,   1, $2c, $e2, $fe, $50, $fb, $8c   // bde8: ca 30 0e... .0.
+    .byt $e3, $fe, $ca, $10, $f2, $4c, $36,   0, $a2,   4, $20, $c5   // bdf4: e3 fe ca... ...
+    .byt   6, $95,   0, $ca, $10, $f8, $e8, $a0,   0, $8a, $20, $f1   // be00: 06 95 00... ...
+    .byt $ff, $90,   5, $a9, $ff, $4c, $9e,   5, $a2,   0, $a9, $7f   // be0c: ff 90 05... ...
+    .byt $20, $95,   6, $bd,   0,   7, $20, $95,   6, $e8, $c9, $0d   // be18: 20 95 06...  ..
+    .byt $d0, $f5, $4c, $36,   0, $2c, $e2, $fe, $50, $fb, $8d, $e3   // be24: d0 f5 4c... ..L
+    .byt $fe, $60, $2c, $e6, $fe, $50, $fb, $8d, $e7, $fe, $60, $a5   // be30: fe 60 2c... .`,
+    .byt $ff                                                          // be3c: ff          .
+    .asc "8j0"                                                        // be3d: 38 6a 30    8j0
+    .byt $0f, $48, $a9,   0, $20, $bc,   6, $98, $20, $bc,   6, $8a   // be40: 0f 48 a9... .H.
+    .byt $20, $bc,   6, $68, $2c, $e0, $fe, $50, $fb, $8d, $e1, $fe   // be4c: 20 bc 06...  ..
+    .byt $60, $2c, $e2, $fe, $10, $fb, $ad, $e3, $fe, $60             // be58: 60 2c e2... `,.
+
+// $be62 referenced 1 time by $8a3d
+service_handler_tube_service_calls
+    cmp #$fe                                                          // be62: c9 fe       ..
+    bcc cbec2                                                         // be64: 90 5c       .\ 
+    bne cbe83                                                         // be66: d0 1b       ..
+    cpy #0                                                            // be68: c0 00       ..
+    beq cbec2                                                         // be6a: f0 56       .V
+    ldx #6                                                            // be6c: a2 06       ..
+    lda #osbyte_explode_chars                                         // be6e: a9 14       ..
+    jsr osbyte                                                        // be70: 20 f4 ff     ..
+// $be73 referenced 2 times by $be76, $be80
+cbe73
+    bit tube_host_r1_status                                           // be73: 2c e0 fe    ,..
+    bpl cbe73                                                         // be76: 10 fb       ..
+    lda tube_host_r1_data                                             // be78: ad e1 fe    ...
+    beq cbec0                                                         // be7b: f0 43       .C
+    jsr oswrch                                                        // be7d: 20 ee ff     ..
+    jmp cbe73                                                         // be80: 4c 73 be    Ls.
+
+// $be83 referenced 1 time by $be66
+cbe83
+    lda #$ad                                                          // be83: a9 ad       ..
+    sta evntv                                                         // be85: 8d 20 02    . .
+    lda #6                                                            // be88: a9 06       ..
+    sta evntv+1                                                       // be8a: 8d 21 02    .!.
+    lda #$16                                                          // be8d: a9 16       ..
+    sta brkv                                                          // be8f: 8d 02 02    ...
+    lda #0                                                            // be92: a9 00       ..
+    sta brkv+1                                                        // be94: 8d 03 02    ...
+    lda #$8e                                                          // be97: a9 8e       ..
+    sta tube_host_r1_status                                           // be99: 8d e0 fe    ...
+    ldy #0                                                            // be9c: a0 00       ..
+// $be9e referenced 1 time by $beb1
+loop_cbe9e
+    lda lbf04,y                                                       // be9e: b9 04 bf    ...
+    sta l0400,y                                                       // bea1: 99 00 04    ...
+    lda lbc94,y                                                       // bea4: b9 94 bc    ...
+    sta l0500,y                                                       // bea7: 99 00 05    ...
+    lda lbd94,y                                                       // beaa: b9 94 bd    ...
+    sta l0600,y                                                       // bead: 99 00 06    ...
+    dey                                                               // beb0: 88          .
+    bne loop_cbe9e                                                    // beb1: d0 eb       ..
+    jsr sub_c0421                                                     // beb3: 20 21 04     !.
+    ldx #$41 // 'A'                                                   // beb6: a2 41       .A
+// $beb8 referenced 1 time by $bebe
+loop_cbeb8
+    lda lbec3,x                                                       // beb8: bd c3 be    ...
+    sta l0016,x                                                       // bebb: 95 16       ..
+    dex                                                               // bebd: ca          .
+    bpl loop_cbeb8                                                    // bebe: 10 f8       ..
+// $bec0 referenced 1 time by $be7b
+cbec0
+    lda #0                                                            // bec0: a9 00       ..
+// $bec2 referenced 2 times by $be64, $be6a
+cbec2
+    rts                                                               // bec2: 60          `
+
+// $bec3 referenced 1 time by $beb8
+lbec3
+    .byt $a9, $ff, $20, $9e,   6, $ad, $e3, $fe, $a9,   0, $20, $95   // bec3: a9 ff 20... ..
+    .byt   6, $a8, $b1, $fd, $20, $95,   6, $c8, $b1, $fd, $20, $95   // becf: 06 a8 b1... ...
+    .byt   6, $aa, $d0, $f7, $a2, $ff, $9a, $58, $2c, $e0, $fe, $10   // bedb: 06 aa d0... ...
+    .byt   6, $ad, $e1, $fe, $20, $ee, $ff, $2c, $e2, $fe, $10, $f0   // bee7: 06 ad e1... ...
+    .byt $2c, $e0, $fe, $30, $f0, $ae, $e3, $fe, $86, $51, $6c,   0   // bef3: 2c e0 fe... ,..
+    .byt   5,   0, $80,   0,   0                                      // beff: 05 00 80... ...
+// $bf04 referenced 2 times by $be9e, $bea1
+lbf04
+// $bf04 referenced 2 times by $be9e, $bea1
+* = $0400
+// $bf04 referenced 2 times by $be9e, $bea1
+l0400
+    .byt $4c, $84,   4, $4c, $a7,   6                                 // bf04: 4c 84 04... L.. :0400[1]
+
+// $bf0a referenced 7 times by $844f, $8933, $893b, $a075, $a2ec, $bf97, $bfcf
+c0406
+    cmp #$80                                                          // bf0a: c9 80       ..  :0406[1]
+    bcc c0435                                                         // bf0c: 90 2b       .+  :0408[1]
+    cmp #$c0                                                          // bf0e: c9 c0       ..  :040a[1]
+    bcs c0428                                                         // bf10: b0 1a       ..  :040c[1]
+    ora #$40 // '@'                                                   // bf12: 09 40       .@  :040e[1]
+    cmp l0015                                                         // bf14: c5 15       ..  :0410[1]
+    bne c0434                                                         // bf16: d0 20       .   :0412[1]
+// $bf18 referenced 1 time by $0471
+sub_c0414
+    php                                                               // bf18: 08          .   :0414[1]
+    sei                                                               // bf19: 78          x   :0415[1]
+    lda #5                                                            // bf1a: a9 05       ..  :0416[1]
+    jsr l069e                                                         // bf1c: 20 9e 06     .. :0418[1]
+    lda l0015                                                         // bf1f: a5 15       ..  :041b[1]
+    jsr l069e                                                         // bf21: 20 9e 06     .. :041d[1]
+    plp                                                               // bf24: 28          (   :0420[1]
+// $bf25 referenced 1 time by $beb3
+sub_c0421
+    lda #$80                                                          // bf25: a9 80       ..  :0421[1]
+    sta l0015                                                         // bf27: 85 15       ..  :0423[1]
+    sta l0014                                                         // bf29: 85 14       ..  :0425[1]
+    rts                                                               // bf2b: 60          `   :0427[1]
+
+// $bf2c referenced 1 time by $040c
+c0428
+    asl l0014                                                         // bf2c: 06 14       ..  :0428[1]
+    bcs c0432                                                         // bf2e: b0 06       ..  :042a[1]
+    cmp l0015                                                         // bf30: c5 15       ..  :042c[1]
+    beq c0434                                                         // bf32: f0 04       ..  :042e[1]
+    clc                                                               // bf34: 18          .   :0430[1]
+    rts                                                               // bf35: 60          `   :0431[1]
+
+// $bf36 referenced 1 time by $042a
+c0432
+    sta l0015                                                         // bf36: 85 15       ..  :0432[1]
+// $bf38 referenced 2 times by $0412, $042e
+c0434
+    rts                                                               // bf38: 60          `   :0434[1]
+
+// $bf39 referenced 1 time by $0408
+c0435
+    php                                                               // bf39: 08          .   :0435[1]
+    sei                                                               // bf3a: 78          x   :0436[1]
+    sty l0013                                                         // bf3b: 84 13       ..  :0437[1]
+    stx l0012                                                         // bf3d: 86 12       ..  :0439[1]
+    jsr l069e                                                         // bf3f: 20 9e 06     .. :043b[1]
+    tax                                                               // bf42: aa          .   :043e[1]
+    ldy #3                                                            // bf43: a0 03       ..  :043f[1]
+    lda l0015                                                         // bf45: a5 15       ..  :0441[1]
+    jsr l069e                                                         // bf47: 20 9e 06     .. :0443[1]
+// $bf4a referenced 1 time by $044c
+loop_c0446
+    lda (l0012),y                                                     // bf4a: b1 12       ..  :0446[1]
+    jsr l069e                                                         // bf4c: 20 9e 06     .. :0448[1]
+    dey                                                               // bf4f: 88          .   :044b[1]
+    bpl loop_c0446                                                    // bf50: 10 f8       ..  :044c[1]
+    ldy #$18                                                          // bf52: a0 18       ..  :044e[1]
+    sty tube_host_r1_status                                           // bf54: 8c e0 fe    ... :0450[1]
+    lda l0518,x                                                       // bf57: bd 18 05    ... :0453[1]
+    sta tube_host_r1_status                                           // bf5a: 8d e0 fe    ... :0456[1]
+    lsr                                                               // bf5d: 4a          J   :0459[1]
+    lsr                                                               // bf5e: 4a          J   :045a[1]
+    bcc c0463                                                         // bf5f: 90 06       ..  :045b[1]
+    bit tube_host_r3_data                                             // bf61: 2c e5 fe    ,.. :045d[1]
+    bit tube_host_r3_data                                             // bf64: 2c e5 fe    ,.. :0460[1]
+// $bf67 referenced 1 time by $045b
+c0463
+    jsr l069e                                                         // bf67: 20 9e 06     .. :0463[1]
+// $bf6a referenced 1 time by $0469
+loop_c0466
+    bit tube_host_r4_status                                           // bf6a: 2c e6 fe    ,.. :0466[1]
+    bvc loop_c0466                                                    // bf6d: 50 fb       P.  :0469[1]
+    bcs c047a                                                         // bf6f: b0 0d       ..  :046b[1]
+    cpx #4                                                            // bf71: e0 04       ..  :046d[1]
+    bne c0482                                                         // bf73: d0 11       ..  :046f[1]
+    jsr sub_c0414                                                     // bf75: 20 14 04     .. :0471[1]
+    jsr l0695                                                         // bf78: 20 95 06     .. :0474[1]
+    jmp l0032                                                         // bf7b: 4c 32 00    L2. :0477[1]
+
+// $bf7e referenced 1 time by $046b
+c047a
+    lsr                                                               // bf7e: 4a          J   :047a[1]
+    bcc c0482                                                         // bf7f: 90 05       ..  :047b[1]
+    ldy #$88                                                          // bf81: a0 88       ..  :047d[1]
+    sty tube_host_r1_status                                           // bf83: 8c e0 fe    ... :047f[1]
+// $bf86 referenced 2 times by $046f, $047b
+c0482
+    plp                                                               // bf86: 28          (   :0482[1]
+    rts                                                               // bf87: 60          `   :0483[1]
+
+    .byt $58, $b0, $0a, $d0,   3, $4c, $9c,   5, $ae, $8d,   2, $f0   // bf88: 58 b0 0a... X.. :0484[1]
+    .byt $e0                                                          // bf94: e0          .   :0490[1]
+// $bf95 referenced 1 time by $bf9a
+* = $bf95
+// $bf95 referenced 1 time by $bf9a
+loop_cbf95
+// $bf95 referenced 1 time by $bf9a
+    lda #$ff                                                          // bf95: a9 ff       ..
+    jsr c0406                                                         // bf97: 20 06 04     ..
+    bcc loop_cbf95                                                    // bf9a: 90 f9       ..
+    jsr l04ce                                                         // bf9c: 20 ce 04     ..
+// $bf9f referenced 1 time by $bfc4
+cbf9f
+    php                                                               // bf9f: 08          .
+    sei                                                               // bfa0: 78          x
+    lda #7                                                            // bfa1: a9 07       ..
+    jsr l04c7                                                         // bfa3: 20 c7 04     ..
+    ldy #0                                                            // bfa6: a0 00       ..
+    sty l0000                                                         // bfa8: 84 00       ..
+// $bfaa referenced 1 time by $bfb3
+loop_cbfaa
+    lda (l0000),y                                                     // bfaa: b1 00       ..
+    sta tube_host_r3_data                                             // bfac: 8d e5 fe    ...
+    nop                                                               // bfaf: ea          .
+    nop                                                               // bfb0: ea          .
+    nop                                                               // bfb1: ea          .
+    iny                                                               // bfb2: c8          .
+    bne loop_cbfaa                                                    // bfb3: d0 f5       ..
+    plp                                                               // bfb5: 28          (
+    inc l0054                                                         // bfb6: e6 54       .T
+    bne cbfc0                                                         // bfb8: d0 06       ..
+    inc l0055                                                         // bfba: e6 55       .U
+    bne cbfc0                                                         // bfbc: d0 02       ..
+    inc l0056                                                         // bfbe: e6 56       .V
+// $bfc0 referenced 2 times by $bfb8, $bfbc
+cbfc0
+    inc l0001                                                         // bfc0: e6 01       ..
+    bit l0001                                                         // bfc2: 24 01       $.
+    bvc cbf9f                                                         // bfc4: 50 d9       P.
+    jsr l04ce                                                         // bfc6: 20 ce 04     ..
+    lda #4                                                            // bfc9: a9 04       ..
+    ldy #0                                                            // bfcb: a0 00       ..
+    ldx #$53 // 'S'                                                   // bfcd: a2 53       .S
+    jmp c0406                                                         // bfcf: 4c 06 04    L..
+
+    lda #$80                                                          // bfd2: a9 80       ..
+    sta l0054                                                         // bfd4: 85 54       .T
+    sta l0001                                                         // bfd6: 85 01       ..
+    lda #$20 // ' '                                                   // bfd8: a9 20       .
+    and rom_type                                                      // bfda: 2d 06 80    -..
+    tay                                                               // bfdd: a8          .
+    sty l0053                                                         // bfde: 84 53       .S
+    beq cbffb                                                         // bfe0: f0 19       ..
+    ldx copyright_offset                                              // bfe2: ae 07 80    ...
+// $bfe5 referenced 1 time by $bfe9
+loop_cbfe5
+    inx                                                               // bfe5: e8          .
+    lda rom_header,x                                                  // bfe6: bd 00 80    ...
+    bne loop_cbfe5                                                    // bfe9: d0 fa       ..
+    lda l8001,x                                                       // bfeb: bd 01 80    ...
+    sta l0053                                                         // bfee: 85 53       .S
+    lda l8002,x                                                       // bff0: bd 02 80    ...
+    sta l0054                                                         // bff3: 85 54       .T
+    ldy service_entry,x                                               // bff5: bc 03 80    ...
+    lda l8004,x                                                       // bff8: bd 04 80    ...
+// $bffb referenced 1 time by $bfe0
+cbffb
+    sta l0056                                                         // bffb: 85 56       .V
+    sty l0055                                                         // bffd: 84 55       .U
+    rts                                                               // bfff: 60          `
+
+pydis_end
+
+// Label references by decreasing frequency:
+//     l009e:                                64
+//     l0f05:                                48
+//     l009c:                                42
+//     l00ae:                                38
+//     l009a:                                35
+//     print_inline_top_bit_clear:           35
+//     l00be:                                33
+//     l00bb:                                31
+//     l1071:                                30
+//     l00b2:                                28
+//     l00b4:                                25
+//     osbyte:                               23
+//     osasci:                               22
+//     l00b8:                                21
+//     l00a8:                                20
+//     l00aa:                                20
+//     l00ac:                                20
+//     l0101:                                20
+//     l9491:                                19
+//     l10b8:                                18
+//     osnewl:                               18
+//     l00b0:                                17
+//     l0e30:                                17
+//     l00b5:                                16
+//     os_text_ptr:                          15
+//     c94ad:                                15
+//     l0f06:                                14
+//     l009b:                                13
+//     l00a0:                                13
+//     l00a6:                                13
+//     l0d6c:                                13
+//     l00a9:                                12
+//     l10c8:                                12
+//     la3f0:                                12
+//     l0098:                                11
+//     l00b6:                                11
+//     l0100:                                11
+//     l1030:                                11
+//     generate_error_inline:                11
+//     lfea1:                                11
+//     l00ad:                                10
+//     l0d61:                                10
+//     l0d6a:                                10
+//     l1060:                                10
+//     l00b3:                                 9
+//     l0f03:                                 9
+//     l1000:                                 9
+//     sub_caf04:                             9
+//     sub_caf32:                             9
+//     lfe18:                                 9
+//     l00af:                                 8
+//     l00c8:                                 8
+//     romsel_copy:                           8
+//     l97b9:                                 8
+//     l009d:                                 7
+//     l00bc:                                 7
+//     l00c0:                                 7
+//     l00c4:                                 7
+//     l0d68:                                 7
+//     l0df0:                                 7
+//     l0e01:                                 7
+//     generate_error_inline3:                7
+//     sub_cafb5:                             7
+//     cbf0a:                                 7
+//     lfea0:                                 7
+//     l0015:                                 6
+//     l009f:                                 6
+//     l00cc:                                 6
+//     l00d0:                                 6
+//     l00f3:                                 6
+//     l069e:                                 6
+//     l0d3e:                                 6
+//     l0d60:                                 6
+//     l0e00:                                 6
+//     l0f02:                                 6
+//     l10c9:                                 6
+//     l10d8:                                 6
+//     c9211:                                 6
+//     sta_e09_if_d6c_b7_set:                 6
+//     c9cc7:                                 6
+//     sub_cb586:                             6
+//     cbc3d:                                 6
+//     l00b9:                                 5
+//     l00ba:                                 5
+//     l00bf:                                 5
+//     l0d6b:                                 5
+//     l0e05:                                 5
+//     l0e07:                                 5
+//     l1010:                                 5
+//     l1040:                                 5
+//     l10cf:                                 5
+//     l10d4:                                 5
+//     l10d5:                                 5
+//     jump_table_dispatch_x_plus_y:          5
+//     sub_c916e:                             5
+//     sub_c95dd:                             5
+//     l97ad:                                 5
+//     sub_c983f:                             5
+//     sub_ca140:                             5
+//     caeb7:                                 5
+//     sub_caf02:                             5
+//     sub_cb509:                             5
+//     tube_host_r1_status:                   5
+//     l0099:                                 4
+//     l00b7:                                 4
+//     l00c1:                                 4
+//     l0d62:                                 4
+//     l0d71:                                 4
+//     l0e03:                                 4
+//     l0e09:                                 4
+//     l0f07:                                 4
+//     l0f08:                                 4
+//     l1020:                                 4
+//     l1098:                                 4
+//     l10a8:                                 4
+//     sub_c8cb9:                             4
+//     c8dd2:                                 4
+//     sub_c912f:                             4
+//     c9215:                                 4
+//     sub_c9473:                             4
+//     generate_error_inline2:                4
+//     c96f0:                                 4
+//     sub_cae94:                             4
+//     sub_cb0ea:                             4
+//     sub_cb198:                             4
+//     cb236:                                 4
+//     cb55f:                                 4
+//     cb59b:                                 4
+//     sub_cb98a:                             4
+//     sub_cb98f:                             4
+//     video_ula_control:                     4
+//     gsinit:                                4
+//     gsread:                                4
+//     osfind:                                4
+//     oswrch:                                4
+//     l0001:                                 3
+//     l0054:                                 3
+//     l00a1:                                 3
+//     l00b1:                                 3
+//     l00bd:                                 3
+//     l00f0:                                 3
+//     l0102:                                 3
+//     l0355:                                 3
+//     l0d0c:                                 3
+//     l0d0d:                                 3
+//     l0d3f:                                 3
+//     l0d40:                                 3
+//     l0d63:                                 3
+//     l0d69:                                 3
+//     l0e02:                                 3
+//     l0e04:                                 3
+//     l0e0a:                                 3
+//     l0e31:                                 3
+//     l0f00:                                 3
+//     l0f09:                                 3
+//     l0fc8:                                 3
+//     l1078:                                 3
+//     l1088:                                 3
+//     l10ca:                                 3
+//     l10cc:                                 3
+//     l10d0:                                 3
+//     l10f3:                                 3
+//     c85fb:                                 3
+//     c862f:                                 3
+//     c8a98:                                 3
+//     sub_c8aa0:                             3
+//     sub_c8b02:                             3
+//     c8c70:                                 3
+//     just_rts:                              3
+//     sub_c8e83:                             3
+//     c8f8c:                                 3
+//     c9208:                                 3
+//     sub_c9258:                             3
+//     c92fa:                                 3
+//     c9311:                                 3
+//     c95f4:                                 3
+//     c98c9:                                 3
+//     sub_ca0a7:                             3
+//     ca25d:                                 3
+//     sub_ca32b:                             3
+//     ca38e:                                 3
+//     la3f1:                                 3
+//     la3f2:                                 3
+//     cab36:                                 3
+//     sub_cac24:                             3
+//     cacdd:                                 3
+//     sub_cae82:                             3
+//     sub_cae97:                             3
+//     caeda:                                 3
+//     sub_caf06:                             3
+//     caf88:                                 3
+//     cb058:                                 3
+//     cb153:                                 3
+//     cb2d4:                                 3
+//     sub_cb559:                             3
+//     sub_cb799:                             3
+//     cb9aa:                                 3
+//     cbb68:                                 3
+//     cbc1f:                                 3
+//     tube_host_r3_data:                     3
+//     l0000:                                 2
+//     l0012:                                 2
+//     l0014:                                 2
+//     l0053:                                 2
+//     l0055:                                 2
+//     l0056:                                 2
+//     l00a5:                                 2
+//     l00a7:                                 2
+//     l00ab:                                 2
+//     l00ef:                                 2
+//     osrdsc_ptr:                            2
+//     l00ff:                                 2
+//     evntv:                                 2
+//     l028d:                                 2
+//     l04ce:                                 2
+//     l0d1e:                                 2
+//     l0d20:                                 2
+//     l0d21:                                 2
+//     l0d22:                                 2
+//     l0d24:                                 2
+//     l0d25:                                 2
+//     l0d65:                                 2
+//     l0d6d:                                 2
+//     l0dfe:                                 2
+//     l0e06:                                 2
+//     l0e08:                                 2
+//     l0e2f:                                 2
+//     l0e38:                                 2
+//     l0f04:                                 2
+//     l0f10:                                 2
+//     l0f11:                                 2
+//     l0f12:                                 2
+//     l0fdc:                                 2
+//     l0fdd:                                 2
+//     l0fde:                                 2
+//     l10d9:                                 2
+//     c83fb:                                 2
+//     sub_c858c:                             2
+//     c8641:                                 2
+//     c8945:                                 2
+//     sub_c8969:                             2
+//     c8978:                                 2
+//     c8988:                                 2
+//     c8a38:                                 2
+//     service_handler_common2:               2
+//     c8aba:                                 2
+//     c8b0c:                                 2
+//     c8b98:                                 2
+//     c8bab:                                 2
+//     c8be0:                                 2
+//     sub_c8c33:                             2
+//     c8c4d:                                 2
+//     sub_c8c9f:                             2
+//     sub_c8cc0:                             2
+//     c8d37:                                 2
+//     l8d38:                                 2
+//     c8dbc:                                 2
+//     c8e24:                                 2
+//     l8e54:                                 2
+//     c8eab:                                 2
+//     c8f70:                                 2
+//     sub_c8fcb:                             2
+//     c8fe4:                                 2
+//     c8ff1:                                 2
+//     c91ae:                                 2
+//     c91da:                                 2
+//     c91fb:                                 2
+//     c9229:                                 2
+//     c9235:                                 2
+//     c9266:                                 2
+//     sub_c9269:                             2
+//     sub_c9273:                             2
+//     sub_c9295:                             2
+//     sub_c92a4:                             2
+//     sub_c9309:                             2
+//     c9322:                                 2
+//     sub_c9327:                             2
+//     sub_c9349:                             2
+//     c9363:                                 2
+//     c93bc:                                 2
+//     sub_c949b:                             2
+//     c94ae:                                 2
+//     c94d9:                                 2
+//     sub_c94f0:                             2
+//     c9504:                                 2
+//     c9551:                                 2
+//     sub_c9570:                             2
+//     c9589:                                 2
+//     c964e:                                 2
+//     c9740:                                 2
+//     sub_c974d:                             2
+//     sub_c9771:                             2
+//     sub_c977c:                             2
+//     sub_c978d:                             2
+//     sub_c9837:                             2
+//     c986b:                                 2
+//     c987e:                                 2
+//     l9888:                                 2
+//     c98eb:                                 2
+//     c9926:                                 2
+//     sub_c9998:                             2
+//     sub_c9a62:                             2
+//     c9a64:                                 2
+//     sub_c9a72:                             2
+//     sub_c9a7f:                             2
+//     sub_c9a84:                             2
+//     sub_c9a92:                             2
+//     c9a96:                                 2
+//     sub_c9a9a:                             2
+//     c9b35:                                 2
+//     sub_c9b95:                             2
+//     c9ba8:                                 2
+//     c9cc9:                                 2
+//     c9dbb:                                 2
+//     c9e09:                                 2
+//     ca073:                                 2
+//     sub_ca0cc:                             2
+//     sub_ca0ce:                             2
+//     ca0f7:                                 2
+//     ca133:                                 2
+//     ca159:                                 2
+//     ca1a2:                                 2
+//     ca1b7:                                 2
+//     ca2ef:                                 2
+//     ca303:                                 2
+//     ca32e:                                 2
+//     sub_ca362:                             2
+//     ca365:                                 2
+//     ca38b:                                 2
+//     ca3e3:                                 2
+//     ca522:                                 2
+//     sub_ca865:                             2
+//     ca889:                                 2
+//     ca8c4:                                 2
+//     caaa9:                                 2
+//     caae2:                                 2
+//     sub_cab12:                             2
+//     cac30:                                 2
+//     cac4a:                                 2
+//     cae84:                                 2
+//     caed8:                                 2
+//     caedf:                                 2
+//     caf5a:                                 2
+//     sub_caf96:                             2
+//     sub_cafc1:                             2
+//     cafcd:                                 2
+//     sub_cafd5:                             2
+//     sub_cafe0:                             2
+//     cb091:                                 2
+//     sub_cb0cf:                             2
+//     sub_cb0f6:                             2
+//     cb144:                                 2
+//     sub_cb15e:                             2
+//     sub_cb16d:                             2
+//     sub_cb2f7:                             2
+//     cb305:                                 2
+//     cb32c:                                 2
+//     cb336:                                 2
+//     sub_cb431:                             2
+//     lb487:                                 2
+//     cb577:                                 2
+//     sub_cb595:                             2
+//     cb5b7:                                 2
+//     sub_cb5d8:                             2
+//     sub_cb5fb:                             2
+//     sub_cb66a:                             2
+//     cb682:                                 2
+//     cb718:                                 2
+//     cb732:                                 2
+//     cb735:                                 2
+//     sub_cb984:                             2
+//     cb9cd:                                 2
+//     cb9e7:                                 2
+//     sub_cb9ff:                             2
+//     cba33:                                 2
+//     cba53:                                 2
+//     sub_cbadd:                             2
+//     sub_cbb03:                             2
+//     sub_cbb0e:                             2
+//     cbb6f:                                 2
+//     cbba2:                                 2
+//     cbbbc:                                 2
+//     sub_cbc44:                             2
+//     sub_cbc86:                             2
+//     cbe73:                                 2
+//     cbec2:                                 2
+//     lbf04:                                 2
+//     cbf38:                                 2
+//     cbf86:                                 2
+//     cbfc0:                                 2
+//     romsel:                                2
+//     system_via_acr:                        2
+//     system_via_ifr:                        2
+//     osbget:                                2
+//     osargs:                                2
+//     osrdch:                                2
+//     osword:                                2
+//     l0013:                                 1
+//     l0016:                                 1
+//     l0032:                                 1
+//     l0063:                                 1
+//     l0078:                                 1
+//     l00a2:                                 1
+//     l00a3:                                 1
+//     l00a4:                                 1
+//     l00c2:                                 1
+//     l00c7:                                 1
+//     l00cd:                                 1
+//     l00ed:                                 1
+//     l00f7:                                 1
+//     l00fd:                                 1
+//     l0103:                                 1
+//     l0104:                                 1
+//     brkv:                                  1
+//     brkv+1:                                1
+//     filev:                                 1
+//     fscv:                                  1
+//     evntv+1:                               1
+//     netv:                                  1
+//     l026a:                                 1
+//     l02a0:                                 1
+//     l0350:                                 1
+//     l0351:                                 1
+//     l04c7:                                 1
+//     l0500:                                 1
+//     l0518:                                 1
+//     l0600:                                 1
+//     l0695:                                 1
+//     l0cff:                                 1
+//     l0d07:                                 1
+//     l0d0e:                                 1
+//     l0d11:                                 1
+//     l0d1a:                                 1
+//     l0d23:                                 1
+//     l0d26:                                 1
+//     l0d41:                                 1
+//     l0d64:                                 1
+//     l0d6e:                                 1
+//     l0d6f:                                 1
+//     l0e0b:                                 1
+//     l0e14:                                 1
+//     l0e32:                                 1
+//     l0ef7:                                 1
+//     l0f01:                                 1
+//     l0f0a:                                 1
+//     l0f0b:                                 1
+//     l0f0c:                                 1
+//     l0f0d:                                 1
+//     l0f0e:                                 1
+//     l0f13:                                 1
+//     l0f14:                                 1
+//     l0f2f:                                 1
+//     l0f30:                                 1
+//     l0fdf:                                 1
+//     l0fe0:                                 1
+//     l0ff0:                                 1
+//     l0fff:                                 1
+//     l1050:                                 1
+//     l1070:                                 1
+//     l1072:                                 1
+//     l1073:                                 1
+//     l1074:                                 1
+//     l10cb:                                 1
+//     l10cd:                                 1
+//     l10ce:                                 1
+//     l10d1:                                 1
+//     l10d6:                                 1
+//     l10d7:                                 1
+//     rom_header:                            1
+//     l8001:                                 1
+//     l8002:                                 1
+//     service_entry:                         1
+//     l8004:                                 1
+//     rom_type:                              1
+//     copyright_offset:                      1
+//     c8032:                                 1
+//     sub_c805a:                             1
+//     c805d:                                 1
+//     c806c:                                 1
+//     sub_c8074:                             1
+//     loop_c8096:                            1
+//     c80bd:                                 1
+//     c80be:                                 1
+//     c80d6:                                 1
+//     c80e9:                                 1
+//     c80fd:                                 1
+//     c810a:                                 1
+//     c83f8:                                 1
+//     sub_c8449:                             1
+//     c8452:                                 1
+//     l84bb:                                 1
+//     c8585:                                 1
+//     c85a4:                                 1
+//     loop_c85b8:                            1
+//     c85cf:                                 1
+//     loop_c85d9:                            1
+//     c85e3:                                 1
+//     l8600:                                 1
+//     c8619:                                 1
+//     c8633:                                 1
+//     c863f:                                 1
+//     c864d:                                 1
+//     c8693:                                 1
+//     loop_c869a:                            1
+//     c86ac:                                 1
+//     loop_c86c2:                            1
+//     c86ce:                                 1
+//     c86d5:                                 1
+//     c86d8:                                 1
+//     c86e3:                                 1
+//     l8861:                                 1
+//     l8869:                                 1
+//     sub_c88f2:                             1
+//     c8901:                                 1
+//     loop_c8912:                            1
+//     c8942:                                 1
+//     c89a4:                                 1
+//     l89a6:                                 1
+//     jump_table_low:                        1
+//     jump_table_high:                       1
+//     service_handler:                       1
+//     c8a33:                                 1
+//     service_handler_common1:               1
+//     c8a53:                                 1
+//     c8a62:                                 1
+//     c8a6f:                                 1
+//     c8a71:                                 1
+//     service_handler_not_vectors_changed:   1
+//     c8acb:                                 1
+//     c8ad1:                                 1
+//     sub_c8aea:                             1
+//     loop_c8aee:                            1
+//     c8afb:                                 1
+//     sub_c8b1a:                             1
+//     loop_c8b26:                            1
+//     c8b34:                                 1
+//     loop_c8b39:                            1
+//     loop_c8b4c:                            1
+//     loop_c8b7a:                            1
+//     c8b8d:                                 1
+//     c8ba8:                                 1
+//     c8bae:                                 1
+//     c8bb6:                                 1
+//     loop_c8bc0:                            1
+//     loop_c8bca:                            1
+//     c8bf0:                                 1
+//     c8bf6:                                 1
+//     c8c00:                                 1
+//     loop_c8c06:                            1
+//     c8c12:                                 1
+//     c8c1f:                                 1
+//     c8c24:                                 1
+//     c8c26:                                 1
+//     c8c2f:                                 1
+//     loop_c8c45:                            1
+//     c8c73:                                 1
+//     c8c7d:                                 1
+//     loop_c8c80:                            1
+//     c8c98:                                 1
+//     c8cc9:                                 1
+//     c8cda:                                 1
+//     c8ce0:                                 1
+//     sub_c8cfc:                             1
+//     sub_c8d05:                             1
+//     c8d08:                                 1
+//     c8d0a:                                 1
+//     sub_c8d17:                             1
+//     loop_c8d1b:                            1
+//     c8d26:                                 1
+//     loop_c8d2c:                            1
+//     l8d61:                                 1
+//     c8da7:                                 1
+//     loop_c8dae:                            1
+//     c8dbf:                                 1
+//     loop_c8dc1:                            1
+//     loop_c8de4:                            1
+//     c8deb:                                 1
+//     c8dfa:                                 1
+//     sub_c8e09:                             1
+//     c8e14:                                 1
+//     c8e15:                                 1
+//     c8e20:                                 1
+//     l8e61:                                 1
+//     sub_c8e85:                             1
+//     loop_c8e87:                            1
+//     sub_c8e8c:                             1
+//     clamp_absolute_workspace_and_save:     1
+//     c8eb3:                                 1
+//     loop_c8eee:                            1
+//     loop_c8f18:                            1
+//     loop_c8f2e:                            1
+//     c8f3d:                                 1
+//     c8f40:                                 1
+//     loop_c8f46:                            1
+//     l8f48:                                 1
+//     c8f4c:                                 1
+//     sub_c8f5d:                             1
+//     loop_c8f8e:                            1
+//     sub_c8f99:                             1
+//     loop_c8fb0:                            1
+//     loop_c8fba:                            1
+//     c8fbd:                                 1
+//     c8fca:                                 1
+//     loop_c8fd4:                            1
+//     c901e:                                 1
+//     l9022:                                 1
+//     l9122:                                 1
+//     sub_c9138:                             1
+//     c9140:                                 1
+//     loop_c914d:                            1
+//     c9153:                                 1
+//     c916b:                                 1
+//     c917d:                                 1
+//     c9188:                                 1
+//     c9198:                                 1
+//     c919a:                                 1
+//     c91e3:                                 1
+//     c91f9:                                 1
+//     c9244:                                 1
+//     sub_c9260:                             1
+//     c9267:                                 1
+//     c9277:                                 1
+//     loop_c927b:                            1
+//     c9283:                                 1
+//     l9286:                                 1
+//     sub_c9291:                             1
+//     sub_c929b:                             1
+//     c929f:                                 1
+//     loop_c92a6:                            1
+//     c92af:                                 1
+//     loop_c9329:                            1
+//     loop_c9332:                            1
+//     c933e:                                 1
+//     c9348:                                 1
+//     loop_c934f:                            1
+//     c9358:                                 1
+//     c9371:                                 1
+//     loop_c939b:                            1
+//     c93a2:                                 1
+//     c93ae:                                 1
+//     c93ee:                                 1
+//     loop_c93f0:                            1
+//     c9405:                                 1
+//     c940c:                                 1
+//     c943c:                                 1
+//     c9462:                                 1
+//     sub_c9465:                             1
+//     sub_c9467:                             1
+//     loop_c9476:                            1
+//     c9486:                                 1
+//     l948b:                                 1
+//     sub_c9497:                             1
+//     c94b4:                                 1
+//     c94b5:                                 1
+//     loop_c94bb:                            1
+//     c94d3:                                 1
+//     loop_c94f8:                            1
+//     c9502:                                 1
+//     c9505:                                 1
+//     c950e:                                 1
+//     c951b:                                 1
+//     loop_c9520:                            1
+//     c9547:                                 1
+//     c955b:                                 1
+//     loop_c955d:                            1
+//     c9576:                                 1
+//     c9586:                                 1
+//     c95ee:                                 1
+//     c9607:                                 1
+//     c9619:                                 1
+//     c961a:                                 1
+//     loop_c962a:                            1
+//     c9636:                                 1
+//     c9641:                                 1
+//     c9649:                                 1
+//     c964c:                                 1
+//     c9651:                                 1
+//     loop_c9668:                            1
+//     c9674:                                 1
+//     c9686:                                 1
+//     c9688:                                 1
+//     loop_c968c:                            1
+//     c9698:                                 1
+//     c969a:                                 1
+//     loop_c96a9:                            1
+//     c96af:                                 1
+//     error_template_minus_1:                1
+//     loop_c96c4:                            1
+//     c96dd:                                 1
+//     loop_c96e7:                            1
+//     c96fa:                                 1
+//     c96fd:                                 1
+//     c971e:                                 1
+//     c9722:                                 1
+//     c972c:                                 1
+//     loop_c9734:                            1
+//     c9767:                                 1
+//     loop_c9794:                            1
+//     c97a4:                                 1
+//     c97ac:                                 1
+//     c9846:                                 1
+//     c984f:                                 1
+//     loop_c9865:                            1
+//     c9873:                                 1
+//     c9882:                                 1
+//     sub_c9894:                             1
+//     sub_c989c:                             1
+//     loop_c989e:                            1
+//     c98ab:                                 1
+//     c98b8:                                 1
+//     loop_c98c4:                            1
+//     loop_c98d9:                            1
+//     c98de:                                 1
+//     c98f3:                                 1
+//     loop_c98f8:                            1
+//     c9902:                                 1
+//     sub_c9913:                             1
+//     loop_c991b:                            1
+//     sub_c9951:                             1
+//     c9969:                                 1
+//     c996f:                                 1
+//     loop_c9971:                            1
+//     loop_c998c:                            1
+//     loop_c99a1:                            1
+//     loop_c99a3:                            1
+//     loop_c99b7:                            1
+//     c99c2:                                 1
+//     c99c8:                                 1
+//     loop_c99cd:                            1
+//     loop_c99eb:                            1
+//     c9a0c:                                 1
+//     c9a19:                                 1
+//     c9a1f:                                 1
+//     c9a22:                                 1
+//     loop_c9a2f:                            1
+//     c9a32:                                 1
+//     loop_c9a40:                            1
+//     sub_c9a57:                             1
+//     loop_c9a74:                            1
+//     sub_c9a7e:                             1
+//     c9a83:                                 1
+//     loop_c9a87:                            1
+//     sub_c9a91:                             1
+//     c9aa0:                                 1
+//     loop_c9aab:                            1
+//     loop_c9abd:                            1
+//     c9ac9:                                 1
+//     loop_c9acb:                            1
+//     c9ad2:                                 1
+//     c9afb:                                 1
+//     loop_c9b13:                            1
+//     c9b20:                                 1
+//     loop_c9b2a:                            1
+//     c9b3c:                                 1
+//     c9b41:                                 1
+//     c9b47:                                 1
+//     c9b4c:                                 1
+//     c9b56:                                 1
+//     loop_c9b78:                            1
+//     loop_c9b85:                            1
+//     c9b91:                                 1
+//     c9b92:                                 1
+//     loop_c9b9c:                            1
+//     loop_c9bb3:                            1
+//     c9bb5:                                 1
+//     c9dd2:                                 1
+//     c9dd5:                                 1
+//     c9dda:                                 1
+//     c9ddf:                                 1
+//     c9e0b:                                 1
+//     sub_c9e0f:                             1
+//     sub_c9e16:                             1
+//     sub_c9e17:                             1
+//     loop_c9e19:                            1
+//     c9e25:                                 1
+//     c9e28:                                 1
+//     sub_c9ed2:                             1
+//     c9edd:                                 1
+//     loop_c9ee8:                            1
+//     c9ef3:                                 1
+//     c9efc:                                 1
+//     c9f0a:                                 1
+//     loop_c9f27:                            1
+//     loop_c9f3e:                            1
+//     c9f52:                                 1
+//     c9f55:                                 1
+//     sub_c9f67:                             1
+//     ca09b:                                 1
+//     sub_ca09e:                             1
+//     ca0bd:                                 1
+//     ca0c5:                                 1
+//     ca0c9:                                 1
+//     ca0e3:                                 1
+//     ca0f5:                                 1
+//     ca109:                                 1
+//     ca114:                                 1
+//     ca125:                                 1
+//     ca127:                                 1
+//     ca142:                                 1
+//     loop_ca14a:                            1
+//     loop_ca165:                            1
+//     ca16a:                                 1
+//     loop_ca170:                            1
+//     la17c:                                 1
+//     ca185:                                 1
+//     loop_ca187:                            1
+//     ca18d:                                 1
+//     ca191:                                 1
+//     ca1a3:                                 1
+//     loop_ca1a4:                            1
+//     loop_ca1a8:                            1
+//     ca1a9:                                 1
+//     ca1be:                                 1
+//     ca1c1:                                 1
+//     ca1ca:                                 1
+//     loop_ca1e2:                            1
+//     ca1ea:                                 1
+//     ca206:                                 1
+//     ca209:                                 1
+//     loop_ca21d:                            1
+//     loop_ca225:                            1
+//     loop_ca230:                            1
+//     loop_ca241:                            1
+//     ca243:                                 1
+//     loop_ca245:                            1
+//     ca25a:                                 1
+//     ca26a:                                 1
+//     loop_ca26c:                            1
+//     ca27d:                                 1
+//     la291:                                 1
+//     ca299:                                 1
+//     loop_ca2a2:                            1
+//     loop_ca2a8:                            1
+//     ca2f4:                                 1
+//     sub_ca300:                             1
+//     ca319:                                 1
+//     ca327:                                 1
+//     ca344:                                 1
+//     ca352:                                 1
+//     ca37b:                                 1
+//     ca389:                                 1
+//     ca3b4:                                 1
+//     loop_ca3ce:                            1
+//     la3df:                                 1
+//     ca3e8:                                 1
+//     la477:                                 1
+//     loop_ca4fc:                            1
+//     loop_ca50e:                            1
+//     sub_ca516:                             1
+//     la523:                                 1
+//     la52a:                                 1
+//     la841:                                 1
+//     la84d:                                 1
+//     loop_ca875:                            1
+//     loop_ca89d:                            1
+//     ca8b5:                                 1
+//     sub_ca9be:                             1
+//     sub_caa85:                             1
+//     sub_caa89:                             1
+//     caa8a:                                 1
+//     caa9f:                                 1
+//     caaa1:                                 1
+//     caaa7:                                 1
+//     caaad:                                 1
+//     laab1:                                 1
+//     sub_cab1b:                             1
+//     cab33:                                 1
+//     cab75:                                 1
+//     cab84:                                 1
+//     loop_cab89:                            1
+//     loop_caba8:                            1
+//     cabb5:                                 1
+//     cabb7:                                 1
+//     cabde:                                 1
+//     cabf3:                                 1
+//     cabfe:                                 1
+//     cac10:                                 1
+//     cac3f:                                 1
+//     cac67:                                 1
+//     loop_cac6f:                            1
+//     lac80:                                 1
+//     lac8c:                                 1
+//     loop_cacaf:                            1
+//     sub_cace4:                             1
+//     sub_cacf7:                             1
+//     sub_cacf9:                             1
+//     lad0d:                                 1
+//     cad20:                                 1
+//     loop_cad29:                            1
+//     cad2f:                                 1
+//     lad43:                                 1
+//     cad6f:                                 1
+//     cad89:                                 1
+//     cad96:                                 1
+//     cadb2:                                 1
+//     cade3:                                 1
+//     caded:                                 1
+//     loop_cae1c:                            1
+//     cae27:                                 1
+//     cae4f:                                 1
+//     loop_cae6f:                            1
+//     cae8f:                                 1
+//     sub_cae92:                             1
+//     loop_caebb:                            1
+//     loop_caec9:                            1
+//     caedb:                                 1
+//     caee2:                                 1
+//     caef1:                                 1
+//     laefb:                                 1
+//     laeff:                                 1
+//     loop_caf07:                            1
+//     caf16:                                 1
+//     loop_caf1c:                            1
+//     caf2b:                                 1
+//     loop_caf2d:                            1
+//     caf40:                                 1
+//     sub_caf47:                             1
+//     caf5c:                                 1
+//     caf5f:                                 1
+//     caf72:                                 1
+//     sub_caf85:                             1
+//     loop_caf9d:                            1
+//     cafad:                                 1
+//     cafb4:                                 1
+//     loop_cafc0:                            1
+//     cafd4:                                 1
+//     caff8:                                 1
+//     sub_cb017:                             1
+//     sub_cb019:                             1
+//     loop_cb01b:                            1
+//     cb025:                                 1
+//     cb028:                                 1
+//     loop_cb032:                            1
+//     loop_cb04a:                            1
+//     cb06b:                                 1
+//     cb083:                                 1
+//     cb099:                                 1
+//     cb0ae:                                 1
+//     cb0b6:                                 1
+//     cb0b9:                                 1
+//     sub_cb0c5:                             1
+//     cb0da:                                 1
+//     loop_cb108:                            1
+//     cb118:                                 1
+//     cb11c:                                 1
+//     lb13f:                                 1
+//     sub_cb165:                             1
+//     loop_cb16f:                            1
+//     loop_cb179:                            1
+//     loop_cb18b:                            1
+//     lb194:                                 1
+//     cb1a8:                                 1
+//     cb1b1:                                 1
+//     cb205:                                 1
+//     cb208:                                 1
+//     loop_cb210:                            1
+//     loop_cb228:                            1
+//     loop_cb253:                            1
+//     cb261:                                 1
+//     cb267:                                 1
+//     cb29c:                                 1
+//     loop_cb2a0:                            1
+//     cb2ac:                                 1
+//     cb2d7:                                 1
+//     cb2df:                                 1
+//     sub_cb2e0:                             1
+//     loop_cb2e2:                            1
+//     cb2ed:                                 1
+//     cb2ef:                                 1
+//     cb316:                                 1
+//     loop_cb31a:                            1
+//     cb335:                                 1
+//     loop_cb347:                            1
+//     cb369:                                 1
+//     cb39c:                                 1
+//     loop_cb39f:                            1
+//     cb3a3:                                 1
+//     cb3a8:                                 1
+//     cb3b1:                                 1
+//     loop_cb3b5:                            1
+//     loop_cb3d9:                            1
+//     cb3ed:                                 1
+//     loop_cb3ff:                            1
+//     cb408:                                 1
+//     cb40c:                                 1
+//     cb40e:                                 1
+//     cb41d:                                 1
+//     cb423:                                 1
+//     loop_cb424:                            1
+//     cb448:                                 1
+//     sub_cb449:                             1
+//     loop_cb44c:                            1
+//     loop_cb45c:                            1
+//     sub_cb46b:                             1
+//     cb475:                                 1
+//     cb477:                                 1
+//     cb483:                                 1
+//     sub_cb4ad:                             1
+//     cb4c1:                                 1
+//     loop_cb4cc:                            1
+//     loop_cb4df:                            1
+//     loop_cb50c:                            1
+//     cb51a:                                 1
+//     sub_cb53d:                             1
+//     cb557:                                 1
+//     cb563:                                 1
+//     cb594:                                 1
+//     cb5a2:                                 1
+//     cb5ac:                                 1
+//     cb5b6:                                 1
+//     cb5be:                                 1
+//     cb5cd:                                 1
+//     loop_cb5ea:                            1
+//     cb63b:                                 1
+//     cb661:                                 1
+//     loop_cb66c:                            1
+//     cb67f:                                 1
+//     cb6c6:                                 1
+//     cb6ea:                                 1
+//     loop_cb709:                            1
+//     cb70e:                                 1
+//     sub_cb721:                             1
+//     loop_cb723:                            1
+//     loop_cb72d:                            1
+//     sub_cb730:                             1
+//     cb74f:                                 1
+//     cb788:                                 1
+//     loop_cb79f:                            1
+//     loop_cb7ab:                            1
+//     cb7b6:                                 1
+//     cb7bc:                                 1
+//     loop_cb7c3:                            1
+//     sub_cb8da:                             1
+//     cb8f3:                                 1
+//     sub_cb92b:                             1
+//     loop_cb95e:                            1
+//     cb96b:                                 1
+//     cb974:                                 1
+//     cb9a0:                                 1
+//     cb9b6:                                 1
+//     cb9c5:                                 1
+//     loop_cb9c7:                            1
+//     cb9da:                                 1
+//     cb9ed:                                 1
+//     cb9f4:                                 1
+//     cb9f9:                                 1
+//     cba04:                                 1
+//     loop_cba22:                            1
+//     loop_cba3a:                            1
+//     cba4c:                                 1
+//     cba5a:                                 1
+//     cba65:                                 1
+//     loop_cba67:                            1
+//     loop_cba78:                            1
+//     loop_cba90:                            1
+//     loop_cba95:                            1
+//     cbaab:                                 1
+//     loop_cbab6:                            1
+//     loop_cbabe:                            1
+//     cbac0:                                 1
+//     cbacf:                                 1
+//     cbad8:                                 1
+//     loop_cbaf2:                            1
+//     loop_cbb13:                            1
+//     cbb1a:                                 1
+//     cbb39:                                 1
+//     loop_cbb40:                            1
+//     loop_cbb43:                            1
+//     cbb64:                                 1
+//     loop_cbb6e:                            1
+//     sub_cbb77:                             1
+//     loop_cbb90:                            1
+//     cbb9c:                                 1
+//     loop_cbbb7:                            1
+//     loop_cbbd4:                            1
+//     loop_cbbe7:                            1
+//     loop_cbbf6:                            1
+//     loop_cbc03:                            1
+//     cbc0a:                                 1
+//     loop_cbc24:                            1
+//     loop_cbc34:                            1
+//     cbc6a:                                 1
+//     loop_cbc72:                            1
+//     loop_cbc7d:                            1
+//     cbc84:                                 1
+//     sub_cbc89:                             1
+//     sub_cbc8c:                             1
+//     lbc94:                                 1
+//     lbd94:                                 1
+//     service_handler_tube_service_calls:    1
+//     cbe83:                                 1
+//     loop_cbe9e:                            1
+//     loop_cbeb8:                            1
+//     cbec0:                                 1
+//     lbec3:                                 1
+//     sub_cbf18:                             1
+//     sub_cbf25:                             1
+//     cbf2c:                                 1
+//     cbf36:                                 1
+//     cbf39:                                 1
+//     cbf4a:                                 1
+//     cbf67:                                 1
+//     cbf6a:                                 1
+//     cbf7e:                                 1
+//     loop_cbf95:                            1
+//     cbf9f:                                 1
+//     loop_cbfaa:                            1
+//     loop_cbfe5:                            1
+//     cbffb:                                 1
+//     system_via_sr:                         1
+//     system_via_ier:                        1
+//     lfe87:                                 1
+//     lfea2:                                 1
+//     lfea3:                                 1
+//     tube_host_r1_data:                     1
+//     tube_host_r4_status:                   1
+//     lffb0:                                 1
+//     osrdsc:                                1
+//     lffbd:                                 1
+//     osfile:                                1
+//     oscli:                                 1
+
+// Automatically generated labels:
+//     c0406
+//     c0428
+//     c0432
+//     c0434
+//     c0435
+//     c0463
+//     c047a
+//     c0482
+//     c8032
+//     c805d
+//     c806c
+//     c80bd
+//     c80be
+//     c80d6
+//     c80e9
+//     c80fd
+//     c810a
+//     c83f8
+//     c83fb
+//     c8452
+//     c8585
+//     c85a4
+//     c85cf
+//     c85e3
+//     c85fb
+//     c8619
+//     c862f
+//     c8633
+//     c863f
+//     c8641
+//     c864d
+//     c8693
+//     c86ac
+//     c86ce
+//     c86d5
+//     c86d8
+//     c86e3
+//     c8901
+//     c8942
+//     c8945
+//     c8978
+//     c8988
+//     c89a4
+//     c8a33
+//     c8a38
+//     c8a53
+//     c8a62
+//     c8a6f
+//     c8a71
+//     c8a98
+//     c8aba
+//     c8acb
+//     c8ad1
+//     c8afb
+//     c8b0c
+//     c8b34
+//     c8b8d
+//     c8b98
+//     c8ba8
+//     c8bab
+//     c8bae
+//     c8bb6
+//     c8be0
+//     c8bf0
+//     c8bf6
+//     c8c00
+//     c8c12
+//     c8c1f
+//     c8c24
+//     c8c26
+//     c8c2f
+//     c8c4d
+//     c8c70
+//     c8c73
+//     c8c7d
+//     c8c98
+//     c8cc9
+//     c8cda
+//     c8ce0
+//     c8d08
+//     c8d0a
+//     c8d26
+//     c8d37
+//     c8da7
+//     c8dbc
+//     c8dbf
+//     c8dd2
+//     c8deb
+//     c8dfa
+//     c8e14
+//     c8e15
+//     c8e20
+//     c8e24
+//     c8eab
+//     c8eb3
+//     c8f3d
+//     c8f40
+//     c8f4c
+//     c8f70
+//     c8f8c
+//     c8fbd
+//     c8fca
+//     c8fe4
+//     c8ff1
+//     c901e
+//     c9140
+//     c9153
+//     c916b
+//     c917d
+//     c9188
+//     c9198
+//     c919a
+//     c91ae
+//     c91da
+//     c91e3
+//     c91f9
+//     c91fb
+//     c9208
+//     c9211
+//     c9215
+//     c9229
+//     c9235
+//     c9244
+//     c9266
+//     c9267
+//     c9277
+//     c9283
+//     c929f
+//     c92af
+//     c92fa
+//     c9311
+//     c9322
+//     c933e
+//     c9348
+//     c9358
+//     c9363
+//     c9371
+//     c93a2
+//     c93ae
+//     c93bc
+//     c93ee
+//     c9405
+//     c940c
+//     c943c
+//     c9462
+//     c9486
+//     c94ad
+//     c94ae
+//     c94b4
+//     c94b5
+//     c94d3
+//     c94d9
+//     c9502
+//     c9504
+//     c9505
+//     c950e
+//     c951b
+//     c9547
+//     c9551
+//     c955b
+//     c9576
+//     c9586
+//     c9589
+//     c95ee
+//     c95f4
+//     c9607
+//     c9619
+//     c961a
+//     c9636
+//     c9641
+//     c9649
+//     c964c
+//     c964e
+//     c9651
+//     c9674
+//     c9686
+//     c9688
+//     c9698
+//     c969a
+//     c96af
+//     c96dd
+//     c96f0
+//     c96fa
+//     c96fd
+//     c971e
+//     c9722
+//     c972c
+//     c9740
+//     c9767
+//     c97a4
+//     c97ac
+//     c9846
+//     c984f
+//     c986b
+//     c9873
+//     c987e
+//     c9882
+//     c98ab
+//     c98b8
+//     c98c9
+//     c98de
+//     c98eb
+//     c98f3
+//     c9902
+//     c9926
+//     c9969
+//     c996f
+//     c99c2
+//     c99c8
+//     c9a0c
+//     c9a19
+//     c9a1f
+//     c9a22
+//     c9a32
+//     c9a64
+//     c9a83
+//     c9a96
+//     c9aa0
+//     c9ac9
+//     c9ad2
+//     c9afb
+//     c9b20
+//     c9b35
+//     c9b3c
+//     c9b41
+//     c9b47
+//     c9b4c
+//     c9b56
+//     c9b91
+//     c9b92
+//     c9ba8
+//     c9bb5
+//     c9cc7
+//     c9cc9
+//     c9dbb
+//     c9dd2
+//     c9dd5
+//     c9dda
+//     c9ddf
+//     c9e09
+//     c9e0b
+//     c9e25
+//     c9e28
+//     c9edd
+//     c9ef3
+//     c9efc
+//     c9f0a
+//     c9f52
+//     c9f55
+//     ca073
+//     ca09b
+//     ca0bd
+//     ca0c5
+//     ca0c9
+//     ca0e3
+//     ca0f5
+//     ca0f7
+//     ca109
+//     ca114
+//     ca125
+//     ca127
+//     ca133
+//     ca142
+//     ca159
+//     ca16a
+//     ca185
+//     ca18d
+//     ca191
+//     ca1a2
+//     ca1a3
+//     ca1a9
+//     ca1b7
+//     ca1be
+//     ca1c1
+//     ca1ca
+//     ca1ea
+//     ca206
+//     ca209
+//     ca243
+//     ca25a
+//     ca25d
+//     ca26a
+//     ca27d
+//     ca299
+//     ca2ef
+//     ca2f4
+//     ca303
+//     ca319
+//     ca327
+//     ca32e
+//     ca344
+//     ca352
+//     ca365
+//     ca37b
+//     ca389
+//     ca38b
+//     ca38e
+//     ca3b4
+//     ca3e3
+//     ca3e8
+//     ca522
+//     ca889
+//     ca8b5
+//     ca8c4
+//     caa8a
+//     caa9f
+//     caaa1
+//     caaa7
+//     caaa9
+//     caaad
+//     caae2
+//     cab33
+//     cab36
+//     cab75
+//     cab84
+//     cabb5
+//     cabb7
+//     cabde
+//     cabf3
+//     cabfe
+//     cac10
+//     cac30
+//     cac3f
+//     cac4a
+//     cac67
+//     cacdd
+//     cad20
+//     cad2f
+//     cad6f
+//     cad89
+//     cad96
+//     cadb2
+//     cade3
+//     caded
+//     cae27
+//     cae4f
+//     cae84
+//     cae8f
+//     caeb7
+//     caed8
+//     caeda
+//     caedb
+//     caedf
+//     caee2
+//     caef1
+//     caf16
+//     caf2b
+//     caf40
+//     caf5a
+//     caf5c
+//     caf5f
+//     caf72
+//     caf88
+//     cafad
+//     cafb4
+//     cafcd
+//     cafd4
+//     caff8
+//     cb025
+//     cb028
+//     cb058
+//     cb06b
+//     cb083
+//     cb091
+//     cb099
+//     cb0ae
+//     cb0b6
+//     cb0b9
+//     cb0da
+//     cb118
+//     cb11c
+//     cb144
+//     cb153
+//     cb1a8
+//     cb1b1
+//     cb205
+//     cb208
+//     cb236
+//     cb261
+//     cb267
+//     cb29c
+//     cb2ac
+//     cb2d4
+//     cb2d7
+//     cb2df
+//     cb2ed
+//     cb2ef
+//     cb305
+//     cb316
+//     cb32c
+//     cb335
+//     cb336
+//     cb369
+//     cb39c
+//     cb3a3
+//     cb3a8
+//     cb3b1
+//     cb3ed
+//     cb408
+//     cb40c
+//     cb40e
+//     cb41d
+//     cb423
+//     cb448
+//     cb475
+//     cb477
+//     cb483
+//     cb4c1
+//     cb51a
+//     cb557
+//     cb55f
+//     cb563
+//     cb577
+//     cb594
+//     cb59b
+//     cb5a2
+//     cb5ac
+//     cb5b6
+//     cb5b7
+//     cb5be
+//     cb5cd
+//     cb63b
+//     cb661
+//     cb67f
+//     cb682
+//     cb6c6
+//     cb6ea
+//     cb70e
+//     cb718
+//     cb732
+//     cb735
+//     cb74f
+//     cb788
+//     cb7b6
+//     cb7bc
+//     cb8f3
+//     cb96b
+//     cb974
+//     cb9a0
+//     cb9aa
+//     cb9b6
+//     cb9c5
+//     cb9cd
+//     cb9da
+//     cb9e7
+//     cb9ed
+//     cb9f4
+//     cb9f9
+//     cba04
+//     cba33
+//     cba4c
+//     cba53
+//     cba5a
+//     cba65
+//     cbaab
+//     cbac0
+//     cbacf
+//     cbad8
+//     cbb1a
+//     cbb39
+//     cbb64
+//     cbb68
+//     cbb6f
+//     cbb9c
+//     cbba2
+//     cbbbc
+//     cbc0a
+//     cbc1f
+//     cbc3d
+//     cbc6a
+//     cbc84
+//     cbe73
+//     cbe83
+//     cbec0
+//     cbec2
+//     cbf0a
+//     cbf2c
+//     cbf36
+//     cbf38
+//     cbf39
+//     cbf4a
+//     cbf67
+//     cbf6a
+//     cbf7e
+//     cbf86
+//     cbf9f
+//     cbfc0
+//     cbffb
+//     l0000
+//     l0001
+//     l0012
+//     l0013
+//     l0014
+//     l0015
+//     l0016
+//     l0032
+//     l0053
+//     l0054
+//     l0055
+//     l0056
+//     l0063
+//     l0078
+//     l0098
+//     l0099
+//     l009a
+//     l009b
+//     l009c
+//     l009d
+//     l009e
+//     l009f
+//     l00a0
+//     l00a1
+//     l00a2
+//     l00a3
+//     l00a4
+//     l00a5
+//     l00a6
+//     l00a7
+//     l00a8
+//     l00a9
+//     l00aa
+//     l00ab
+//     l00ac
+//     l00ad
+//     l00ae
+//     l00af
+//     l00b0
+//     l00b1
+//     l00b2
+//     l00b3
+//     l00b4
+//     l00b5
+//     l00b6
+//     l00b7
+//     l00b8
+//     l00b9
+//     l00ba
+//     l00bb
+//     l00bc
+//     l00bd
+//     l00be
+//     l00bf
+//     l00c0
+//     l00c1
+//     l00c2
+//     l00c4
+//     l00c7
+//     l00c8
+//     l00cc
+//     l00cd
+//     l00d0
+//     l00ed
+//     l00ef
+//     l00f0
+//     l00f3
+//     l00f7
+//     l00fd
+//     l00ff
+//     l0100
+//     l0101
+//     l0102
+//     l0103
+//     l0104
+//     l026a
+//     l028d
+//     l02a0
+//     l0350
+//     l0351
+//     l0355
+//     l0400
+//     l04c7
+//     l04ce
+//     l0500
+//     l0518
+//     l0600
+//     l0601
+//     l0695
+//     l069e
+//     l0a00
+//     l0a81
+//     l0cff
+//     l0d07
+//     l0d0c
+//     l0d0d
+//     l0d0e
+//     l0d11
+//     l0d1a
+//     l0d1e
+//     l0d20
+//     l0d21
+//     l0d22
+//     l0d23
+//     l0d24
+//     l0d25
+//     l0d26
+//     l0d3e
+//     l0d3f
+//     l0d40
+//     l0d41
+//     l0d60
+//     l0d61
+//     l0d62
+//     l0d63
+//     l0d64
+//     l0d65
+//     l0d68
+//     l0d69
+//     l0d6a
+//     l0d6b
+//     l0d6c
+//     l0d6d
+//     l0d6e
+//     l0d6f
+//     l0d71
+//     l0df0
+//     l0dfe
+//     l0e00
+//     l0e01
+//     l0e02
+//     l0e03
+//     l0e04
+//     l0e05
+//     l0e06
+//     l0e07
+//     l0e08
+//     l0e09
+//     l0e0a
+//     l0e0b
+//     l0e14
+//     l0e2f
+//     l0e30
+//     l0e31
+//     l0e32
+//     l0e38
+//     l0e81
+//     l0ef7
+//     l0f00
+//     l0f01
+//     l0f02
+//     l0f03
+//     l0f04
+//     l0f05
+//     l0f06
+//     l0f07
+//     l0f08
+//     l0f09
+//     l0f0a
+//     l0f0b
+//     l0f0c
+//     l0f0d
+//     l0f0e
+//     l0f10
+//     l0f11
+//     l0f12
+//     l0f13
+//     l0f14
+//     l0f2f
+//     l0f30
+//     l0fc8
+//     l0fdc
+//     l0fdd
+//     l0fde
+//     l0fdf
+//     l0fe0
+//     l0ff0
+//     l0fff
+//     l1000
+//     l1010
+//     l1020
+//     l1030
+//     l1040
+//     l1050
+//     l1060
+//     l1070
+//     l1071
+//     l1072
+//     l1073
+//     l1074
+//     l1078
+//     l1088
+//     l1098
+//     l10a8
+//     l10b8
+//     l10c8
+//     l10c9
+//     l10ca
+//     l10cb
+//     l10cc
+//     l10cd
+//     l10ce
+//     l10cf
+//     l10d0
+//     l10d1
+//     l10d4
+//     l10d5
+//     l10d6
+//     l10d7
+//     l10d8
+//     l10d9
+//     l10f3
+//     l8001
+//     l8002
+//     l8004
+//     l84bb
+//     l8600
+//     l8861
+//     l8869
+//     l89a6
+//     l8d38
+//     l8d61
+//     l8e54
+//     l8e61
+//     l8f48
+//     l9022
+//     l9122
+//     l9286
+//     l948b
+//     l9491
+//     l97ad
+//     l97b9
+//     l9888
+//     la17c
+//     la291
+//     la3df
+//     la3f0
+//     la3f1
+//     la3f2
+//     la477
+//     la523
+//     la52a
+//     la841
+//     la84d
+//     laab1
+//     lac80
+//     lac8c
+//     lad0d
+//     lad43
+//     laefb
+//     laeff
+//     lb13f
+//     lb194
+//     lb487
+//     lbc94
+//     lbd94
+//     lbec3
+//     lbf04
+//     lfe18
+//     lfe87
+//     lfea0
+//     lfea1
+//     lfea2
+//     lfea3
+//     lffb0
+//     lffbd
+//     loop_c0446
+//     loop_c0466
+//     loop_c8096
+//     loop_c85b8
+//     loop_c85d9
+//     loop_c869a
+//     loop_c86c2
+//     loop_c8912
+//     loop_c8aee
+//     loop_c8b26
+//     loop_c8b39
+//     loop_c8b4c
+//     loop_c8b7a
+//     loop_c8bc0
+//     loop_c8bca
+//     loop_c8c06
+//     loop_c8c45
+//     loop_c8c80
+//     loop_c8d1b
+//     loop_c8d2c
+//     loop_c8dae
+//     loop_c8dc1
+//     loop_c8de4
+//     loop_c8e87
+//     loop_c8eee
+//     loop_c8f18
+//     loop_c8f2e
+//     loop_c8f46
+//     loop_c8f8e
+//     loop_c8fb0
+//     loop_c8fba
+//     loop_c8fd4
+//     loop_c914d
+//     loop_c927b
+//     loop_c92a6
+//     loop_c9329
+//     loop_c9332
+//     loop_c934f
+//     loop_c939b
+//     loop_c93f0
+//     loop_c9476
+//     loop_c94bb
+//     loop_c94f8
+//     loop_c9520
+//     loop_c955d
+//     loop_c962a
+//     loop_c9668
+//     loop_c968c
+//     loop_c96a9
+//     loop_c96c4
+//     loop_c96e7
+//     loop_c9734
+//     loop_c9794
+//     loop_c9865
+//     loop_c989e
+//     loop_c98c4
+//     loop_c98d9
+//     loop_c98f8
+//     loop_c991b
+//     loop_c9971
+//     loop_c998c
+//     loop_c99a1
+//     loop_c99a3
+//     loop_c99b7
+//     loop_c99cd
+//     loop_c99eb
+//     loop_c9a2f
+//     loop_c9a40
+//     loop_c9a74
+//     loop_c9a87
+//     loop_c9aab
+//     loop_c9abd
+//     loop_c9acb
+//     loop_c9b13
+//     loop_c9b2a
+//     loop_c9b78
+//     loop_c9b85
+//     loop_c9b9c
+//     loop_c9bb3
+//     loop_c9e19
+//     loop_c9ee8
+//     loop_c9f27
+//     loop_c9f3e
+//     loop_ca14a
+//     loop_ca165
+//     loop_ca170
+//     loop_ca187
+//     loop_ca1a4
+//     loop_ca1a8
+//     loop_ca1e2
+//     loop_ca21d
+//     loop_ca225
+//     loop_ca230
+//     loop_ca241
+//     loop_ca245
+//     loop_ca26c
+//     loop_ca2a2
+//     loop_ca2a8
+//     loop_ca3ce
+//     loop_ca4fc
+//     loop_ca50e
+//     loop_ca875
+//     loop_ca89d
+//     loop_cab89
+//     loop_caba8
+//     loop_cac6f
+//     loop_cacaf
+//     loop_cad29
+//     loop_cae1c
+//     loop_cae6f
+//     loop_caebb
+//     loop_caec9
+//     loop_caf07
+//     loop_caf1c
+//     loop_caf2d
+//     loop_caf9d
+//     loop_cafc0
+//     loop_cb01b
+//     loop_cb032
+//     loop_cb04a
+//     loop_cb108
+//     loop_cb16f
+//     loop_cb179
+//     loop_cb18b
+//     loop_cb210
+//     loop_cb228
+//     loop_cb253
+//     loop_cb2a0
+//     loop_cb2e2
+//     loop_cb31a
+//     loop_cb347
+//     loop_cb39f
+//     loop_cb3b5
+//     loop_cb3d9
+//     loop_cb3ff
+//     loop_cb424
+//     loop_cb44c
+//     loop_cb45c
+//     loop_cb4cc
+//     loop_cb4df
+//     loop_cb50c
+//     loop_cb5ea
+//     loop_cb66c
+//     loop_cb709
+//     loop_cb723
+//     loop_cb72d
+//     loop_cb79f
+//     loop_cb7ab
+//     loop_cb7c3
+//     loop_cb95e
+//     loop_cb9c7
+//     loop_cba22
+//     loop_cba3a
+//     loop_cba67
+//     loop_cba78
+//     loop_cba90
+//     loop_cba95
+//     loop_cbab6
+//     loop_cbabe
+//     loop_cbaf2
+//     loop_cbb13
+//     loop_cbb40
+//     loop_cbb43
+//     loop_cbb6e
+//     loop_cbb90
+//     loop_cbbb7
+//     loop_cbbd4
+//     loop_cbbe7
+//     loop_cbbf6
+//     loop_cbc03
+//     loop_cbc24
+//     loop_cbc34
+//     loop_cbc72
+//     loop_cbc7d
+//     loop_cbe9e
+//     loop_cbeb8
+//     loop_cbf95
+//     loop_cbfaa
+//     loop_cbfe5
+//     sub_c0414
+//     sub_c0421
+//     sub_c8028
+//     sub_c805a
+//     sub_c8074
+//     sub_c8090
+//     sub_c8449
+//     sub_c858c
+//     sub_c85ff
+//     sub_c8689
+//     sub_c868d
+//     sub_c8691
+//     sub_c86d3
+//     sub_c88f2
+//     sub_c8969
+//     sub_c8983
+//     sub_c8aa0
+//     sub_c8ad4
+//     sub_c8aea
+//     sub_c8b02
+//     sub_c8b0d
+//     sub_c8b1a
+//     sub_c8b92
+//     sub_c8b96
+//     sub_c8c33
+//     sub_c8c4e
+//     sub_c8c5d
+//     sub_c8c9f
+//     sub_c8cb9
+//     sub_c8cc0
+//     sub_c8cca
+//     sub_c8cfc
+//     sub_c8d05
+//     sub_c8d17
+//     sub_c8d79
+//     sub_c8e09
+//     sub_c8e52
+//     sub_c8e83
+//     sub_c8e85
+//     sub_c8e8c
+//     sub_c8e92
+//     sub_c8f5d
+//     sub_c8f99
+//     sub_c8fcb
+//     sub_c912f
+//     sub_c9138
+//     sub_c916e
+//     sub_c9258
+//     sub_c9260
+//     sub_c9269
+//     sub_c9273
+//     sub_c9291
+//     sub_c9295
+//     sub_c929b
+//     sub_c92a4
+//     sub_c92b0
+//     sub_c92e6
+//     sub_c9309
+//     sub_c9327
+//     sub_c9349
+//     sub_c938b
+//     sub_c93dd
+//     sub_c9465
+//     sub_c9467
+//     sub_c9473
+//     sub_c9497
+//     sub_c949b
+//     sub_c949e
+//     sub_c94f0
+//     sub_c9570
+//     sub_c9580
+//     sub_c95ae
+//     sub_c95be
+//     sub_c95ce
+//     sub_c95dd
+//     sub_c96b3
+//     sub_c974d
+//     sub_c9771
+//     sub_c977c
+//     sub_c978d
+//     sub_c9837
+//     sub_c983f
+//     sub_c9894
+//     sub_c989c
+//     sub_c9913
+//     sub_c9951
+//     sub_c9998
+//     sub_c9a57
+//     sub_c9a62
+//     sub_c9a72
+//     sub_c9a7e
+//     sub_c9a7f
+//     sub_c9a84
+//     sub_c9a91
+//     sub_c9a92
+//     sub_c9a9a
+//     sub_c9b95
+//     sub_c9dc8
+//     sub_c9dee
+//     sub_c9e0f
+//     sub_c9e16
+//     sub_c9e17
+//     sub_c9ed2
+//     sub_c9f67
+//     sub_ca07b
+//     sub_ca09e
+//     sub_ca0a7
+//     sub_ca0cc
+//     sub_ca0ce
+//     sub_ca0e4
+//     sub_ca0ea
+//     sub_ca0fa
+//     sub_ca140
+//     sub_ca2fa
+//     sub_ca300
+//     sub_ca32b
+//     sub_ca356
+//     sub_ca362
+//     sub_ca391
+//     sub_ca39b
+//     sub_ca4ee
+//     sub_ca516
+//     sub_ca865
+//     sub_ca9be
+//     sub_caa85
+//     sub_caa89
+//     sub_cab12
+//     sub_cab1b
+//     sub_cac24
+//     sub_cac98
+//     sub_cace4
+//     sub_cacf7
+//     sub_cacf9
+//     sub_cad10
+//     sub_cad41
+//     sub_cad5f
+//     sub_cad65
+//     sub_cad6b
+//     sub_cad80
+//     sub_cae82
+//     sub_cae92
+//     sub_cae94
+//     sub_cae97
+//     sub_caf02
+//     sub_caf04
+//     sub_caf06
+//     sub_caf32
+//     sub_caf3e
+//     sub_caf47
+//     sub_caf66
+//     sub_caf85
+//     sub_caf96
+//     sub_cafb5
+//     sub_cafc1
+//     sub_cafd5
+//     sub_cafe0
+//     sub_cafee
+//     sub_cb017
+//     sub_cb019
+//     sub_cb0c5
+//     sub_cb0cf
+//     sub_cb0ea
+//     sub_cb0f6
+//     sub_cb13e
+//     sub_cb15e
+//     sub_cb165
+//     sub_cb16d
+//     sub_cb198
+//     sub_cb1c3
+//     sub_cb2e0
+//     sub_cb2f7
+//     sub_cb30c
+//     sub_cb33d
+//     sub_cb359
+//     sub_cb431
+//     sub_cb449
+//     sub_cb46b
+//     sub_cb485
+//     sub_cb4ad
+//     sub_cb509
+//     sub_cb53d
+//     sub_cb559
+//     sub_cb586
+//     sub_cb595
+//     sub_cb5d8
+//     sub_cb5fb
+//     sub_cb66a
+//     sub_cb721
+//     sub_cb730
+//     sub_cb799
+//     sub_cb8da
+//     sub_cb92b
+//     sub_cb984
+//     sub_cb98a
+//     sub_cb98f
+//     sub_cb994
+//     sub_cb99a
+//     sub_cb99d
+//     sub_cb9ff
+//     sub_cba1b
+//     sub_cbadd
+//     sub_cbb03
+//     sub_cbb0e
+//     sub_cbb77
+//     sub_cbc44
+//     sub_cbc86
+//     sub_cbc89
+//     sub_cbc8c
+//     sub_cbf18
+//     sub_cbf25

--- a/examples/known_good/basic4_acme.asm
+++ b/examples/known_good/basic4_acme.asm
@@ -1,0 +1,14349 @@
+!cpu 65c02
+
+; Constants
+osbyte_check_eof                       = 127
+osbyte_enter_language                  = 142
+osbyte_inkey                           = 129
+osbyte_read_adc_or_get_buffer_status   = 128
+osbyte_read_high_order_address         = 130
+osbyte_read_himem                      = 132
+osbyte_read_himem_for_mode             = 133
+osbyte_read_text_cursor_pos            = 134
+osbyte_read_tube_presence              = 234
+osbyte_read_write_basic_rom_bank       = 187
+osfile_load                            = 255
+osfile_save                            = 0
+osword_read_clock                      = 1
+osword_read_cmos_clock                 = 14
+osword_read_io_memory                  = 5
+osword_read_pixel                      = 9
+
+; Memory locations
+l0000       = $00
+l0001       = $01
+l0002       = $02
+l0003       = $03
+l0004       = $04
+l0005       = $05
+l0006       = $06
+l0007       = $07
+l0008       = $08
+l0009       = $09
+l000a       = $0a
+l000b       = $0b
+l000c       = $0c
+l000d       = $0d
+l000e       = $0e
+l000f       = $0f
+l0010       = $10
+l0011       = $11
+l0012       = $12
+l0013       = $13
+l0014       = $14
+l0015       = $15
+l0016       = $16
+l0017       = $17
+l0018       = $18
+l0019       = $19
+l001a       = $1a
+l001b       = $1b
+l001c       = $1c
+l001d       = $1d
+l001e       = $1e
+l001f       = $1f
+l0020       = $20
+l0021       = $21
+l0022       = $22
+l0023       = $23
+l0024       = $24
+l0025       = $25
+l0026       = $26
+l0027       = $27
+l0028       = $28
+l0029       = $29
+l002a       = $2a
+l002b       = $2b
+l002c       = $2c
+l002d       = $2d
+l002e       = $2e
+l002f       = $2f
+l0030       = $30
+l0031       = $31
+l0032       = $32
+l0033       = $33
+l0034       = $34
+l0035       = $35
+l0036       = $36
+l0037       = $37
+l0038       = $38
+l0039       = $39
+l003a       = $3a
+l003b       = $3b
+l003c       = $3c
+l003d       = $3d
+l003e       = $3e
+l003f       = $3f
+l0040       = $40
+l0041       = $41
+l0042       = $42
+l0043       = $43
+l0044       = $44
+l0045       = $45
+l0046       = $46
+l0047       = $47
+l0048       = $48
+l0049       = $49
+l004a       = $4a
+l004b       = $4b
+l004c       = $4c
+l004d       = $4d
+l004e       = $4e
+l0061       = $61
+l0064       = $64
+l0066       = $66
+l00c1       = $c1
+l00e1       = $e1
+l00e6       = $e6
+os_text_ptr = $f2
+romsel_copy = $f4
+l00fd       = $fd
+l00fe       = $fe
+l00ff       = $ff
+l0100       = $0100
+l0106       = $0106
+l01ff       = $01ff
+brkv        = $0202
+wrchv       = $020e
+l0400       = $0400
+l0401       = $0401
+l0402       = $0402
+l0403       = $0403
+l0404       = $0404
+l040c       = $040c
+l043c       = $043c
+l043d       = $043d
+l0440       = $0440
+l0441       = $0441
+l0460       = $0460
+l0464       = $0464
+l0469       = $0469
+l046c       = $046c
+l047f       = $047f
+l04ff       = $04ff
+l0500       = $0500
+l0513       = $0513
+l0514       = $0514
+l0519       = $0519
+l051a       = $051a
+l051b       = $051b
+l051c       = $051c
+l051d       = $051d
+l051e       = $051e
+l051f       = $051f
+l0521       = $0521
+l0522       = $0522
+l0523       = $0523
+l0524       = $0524
+l0526       = $0526
+l0527       = $0527
+l0528       = $0528
+l0529       = $0529
+l052a       = $052a
+l05cb       = $05cb
+l05cc       = $05cc
+l05e5       = $05e5
+l05e6       = $05e6
+l05ff       = $05ff
+l0600       = $0600
+l0700       = $0700
+l07ef       = $07ef
+l0bb1       = $0bb1
+l0e4e       = $0e4e
+l4e4e       = $4e4e
+l5252       = $5252
+l6142       = $6142
+l7461       = $7461
+l7f0e       = $7f0e
+l7f13       = $7f13
+le09c       = $e09c
+osfind      = $ffce
+osbput      = $ffd4
+osbget      = $ffd7
+osargs      = $ffda
+osfile      = $ffdd
+osrdch      = $ffe0
+osasci      = $ffe3
+osnewl      = $ffe7
+oswrch      = $ffee
+osword      = $fff1
+osbyte      = $fff4
+oscli       = $fff7
+
+    * = $8000
+
+; Sideways ROM header
+rom_header
+language_entry
+pydis_start
+    jmp language_handler                                              ; 8000: 4c e7 80    L..
+
+service_entry
+    jmp service_handler                                               ; 8003: 4c 2c 80    L,.
+
+rom_type
+    !byte $e2                                                         ; 8006: e2          .
+copyright_offset
+    !byte copyright - rom_header                                      ; 8007: 13          .
+binary_version
+    !byte 7                                                           ; 8008: 07          .
+title
+    !text "BASIC"                                                     ; 8009: 42 41 53... BAS
+version
+    !byte 0                                                           ; 800e: 00          .
+    !text "4r32"                                                      ; 800f: 34 72 33... 4r3
+copyright
+    !byte 0                                                           ; 8013: 00          .
+    !text "(C)1988 Acorn", $0a, $0d, 0                                ; 8014: 28 43 29... (C)
+    !byte   0, $b8, $28, $80,   0, $c0, $82,   0                      ; 8024: 00 b8 28... ..(
+
+; $802c referenced 1 time by $8003
+service_handler
+    pha                                                               ; 802c: 48          H
+    tax                                                               ; 802d: aa          .
+    tya                                                               ; 802e: 98          .
+    pha                                                               ; 802f: 48          H
+    cpx #9                                                            ; 8030: e0 09       ..
+    beq c804c                                                         ; 8032: f0 18       ..
+    cpx #4                                                            ; 8034: e0 04       ..
+    beq c8070                                                         ; 8036: f0 38       .8
+    cpx #2                                                            ; 8038: e0 02       ..
+    beq c8040                                                         ; 803a: f0 04       ..
+    cpx #$27 ; '''                                                    ; 803c: e0 27       .'
+    bne c806a                                                         ; 803e: d0 2a       .*
+; $8040 referenced 1 time by $803a
+c8040
+    lda #osbyte_read_write_basic_rom_bank                             ; 8040: a9 bb       ..
+    ldx romsel_copy                                                   ; 8042: a6 f4       ..
+    ldy #0                                                            ; 8044: a0 00       ..
+    jsr osbyte                                                        ; 8046: 20 f4 ff     ..
+    jmp c806a                                                         ; 8049: 4c 6a 80    Lj.
+
+; $804c referenced 1 time by $8032
+c804c
+    lda (os_text_ptr),y                                               ; 804c: b1 f2       ..
+    cmp #$0d                                                          ; 804e: c9 0d       ..
+    bne c806a                                                         ; 8050: d0 18       ..
+    jsr osnewl                                                        ; 8052: 20 e7 ff     ..
+    ldx #$f6                                                          ; 8055: a2 f6       ..
+; $8057 referenced 1 time by $8062
+loop_c8057
+    lda l7f13,x                                                       ; 8057: bd 13 7f    ...
+    bne c805e                                                         ; 805a: d0 02       ..
+    lda #$20 ; ' '                                                    ; 805c: a9 20       .
+; $805e referenced 1 time by $805a
+c805e
+    jsr osasci                                                        ; 805e: 20 e3 ff     ..
+    inx                                                               ; 8061: e8          .
+    bne loop_c8057                                                    ; 8062: d0 f3       ..
+    jsr osnewl                                                        ; 8064: 20 e7 ff     ..
+; $8067 referenced 2 times by $809c, $80a6
+c8067
+    jsr sub_c80d8                                                     ; 8067: 20 d8 80     ..
+; $806a referenced 3 times by $803e, $8049, $8050
+c806a
+    pla                                                               ; 806a: 68          h
+    tay                                                               ; 806b: a8          .
+    ldx romsel_copy                                                   ; 806c: a6 f4       ..
+    pla                                                               ; 806e: 68          h
+    rts                                                               ; 806f: 60          `
+
+; $8070 referenced 1 time by $8036
+c8070
+    lda (os_text_ptr),y                                               ; 8070: b1 f2       ..
+    and #$df                                                          ; 8072: 29 df       ).
+    cmp #$48 ; 'H'                                                    ; 8074: c9 48       .H
+    bne c808f                                                         ; 8076: d0 17       ..
+    iny                                                               ; 8078: c8          .
+    lda #$40 ; '@'                                                    ; 8079: a9 40       .@
+    tsb romsel_copy                                                   ; 807b: 04 f4       ..
+    lda (os_text_ptr),y                                               ; 807d: b1 f2       ..
+    iny                                                               ; 807f: c8          .
+    cmp #$2e ; '.'                                                    ; 8080: c9 2e       ..
+    beq c80a8                                                         ; 8082: f0 24       .$
+    and #$df                                                          ; 8084: 29 df       ).
+    cmp #$49 ; 'I'                                                    ; 8086: c9 49       .I
+    beq c808f                                                         ; 8088: f0 05       ..
+    jsr sub_c80d8                                                     ; 808a: 20 d8 80     ..
+    dey                                                               ; 808d: 88          .
+    dey                                                               ; 808e: 88          .
+; $808f referenced 2 times by $8076, $8088
+c808f
+    ldx #$fb                                                          ; 808f: a2 fb       ..
+; $8091 referenced 1 time by $80a0
+loop_c8091
+    lda (os_text_ptr),y                                               ; 8091: b1 f2       ..
+    cmp #$2e ; '.'                                                    ; 8093: c9 2e       ..
+    beq c80a8                                                         ; 8095: f0 11       ..
+    and #$df                                                          ; 8097: 29 df       ).
+    cmp l7f0e,x                                                       ; 8099: dd 0e 7f    ...
+    bne c8067                                                         ; 809c: d0 c9       ..
+    iny                                                               ; 809e: c8          .
+    inx                                                               ; 809f: e8          .
+    bne loop_c8091                                                    ; 80a0: d0 ef       ..
+    lda (os_text_ptr),y                                               ; 80a2: b1 f2       ..
+    cmp #$21 ; '!'                                                    ; 80a4: c9 21       .!
+    bcs c8067                                                         ; 80a6: b0 bf       ..
+; $80a8 referenced 2 times by $8082, $8095
+c80a8
+    bit romsel_copy                                                   ; 80a8: 24 f4       $.
+    bvc c80cc                                                         ; 80aa: 50 20       P
+    jsr sub_cbf66                                                     ; 80ac: 20 66 bf     f.
+    bne c80cc                                                         ; 80af: d0 1b       ..
+    jsr sub_c80d8                                                     ; 80b1: 20 d8 80     ..
+    ldx #$0a                                                          ; 80b4: a2 0a       ..
+; $80b6 referenced 1 time by $80bd
+copy_to_stack_loop
+    lda l80c2,x                                                       ; 80b6: bd c2 80    ...
+    sta l0100,x                                                       ; 80b9: 9d 00 01    ...
+    dex                                                               ; 80bc: ca          .
+    bpl copy_to_stack_loop                                            ; 80bd: 10 f7       ..
+    jmp l0100                                                         ; 80bf: 4c 00 01    L..
+
+; $80c2 referenced 1 time by $80b6
+l80c2
+    !byte 0, 0                                                        ; 80c2: 00 00       ..
+    !text "No TUBE"                                                   ; 80c4: 4e 6f 20... No
+    !byte 0                                                           ; 80cb: 00          .
+
+; $80cc referenced 2 times by $80aa, $80af
+c80cc
+    lda romsel_copy                                                   ; 80cc: a5 f4       ..
+    eor #$40 ; '@'                                                    ; 80ce: 49 40       I@
+    tax                                                               ; 80d0: aa          .
+    lda #osbyte_enter_language                                        ; 80d1: a9 8e       ..
+    ldy #0                                                            ; 80d3: a0 00       ..
+    jmp osbyte                                                        ; 80d5: 4c f4 ff    L..
+
+; $80d8 referenced 3 times by $8067, $808a, $80b1
+sub_c80d8
+    lda #$40 ; '@'                                                    ; 80d8: a9 40       .@
+    trb romsel_copy                                                   ; 80da: 14 f4       ..
+    rts                                                               ; 80dc: 60          `
+
+; $80dd referenced 1 time by $a0fd
+l80dd
+    !byte   0,   0,   0,   3, $27                                     ; 80dd: 00 00 00... ...
+; $80e2 referenced 1 time by $a0f7
+l80e2
+    !byte   1, $0a, $64, $e8, $10                                     ; 80e2: 01 0a 64... ..d
+
+; $80e7 referenced 1 time by $8000
+language_handler
+    and l0011                                                         ; 80e7: 25 11       %.
+    ora l000d                                                         ; 80e9: 05 0d       ..
+    ora l000e                                                         ; 80eb: 05 0e       ..
+    ora l000f                                                         ; 80ed: 05 0f       ..
+    ora l0010                                                         ; 80ef: 05 10       ..
+    bne c80ff                                                         ; 80f1: d0 0c       ..
+    lda #$41 ; 'A'                                                    ; 80f3: a9 41       .A
+    sta l000d                                                         ; 80f5: 85 0d       ..
+    eor #$13                                                          ; 80f7: 49 13       I.
+    sta l000e                                                         ; 80f9: 85 0e       ..
+    eor #5                                                            ; 80fb: 49 05       I.
+    sta l000f                                                         ; 80fd: 85 0f       ..
+; $80ff referenced 1 time by $80f1
+c80ff
+    lda #osbyte_read_himem                                            ; 80ff: a9 84       ..
+    jsr osbyte                                                        ; 8101: 20 f4 ff     ..
+    stx l0006                                                         ; 8104: 86 06       ..
+    sty l0007                                                         ; 8106: 84 07       ..
+    dec                                                               ; 8108: 3a          :
+    jsr osbyte                                                        ; 8109: 20 f4 ff     ..
+    sty l0018                                                         ; 810c: 84 18       ..
+    ldx #$13                                                          ; 810e: a2 13       ..
+    stx l00fd                                                         ; 8110: 86 fd       ..
+    ldx #$80                                                          ; 8112: a2 80       ..
+    stx l00fe                                                         ; 8114: 86 fe       ..
+    stz l001f                                                         ; 8116: 64 1f       d.
+    stz l0402                                                         ; 8118: 9c 02 04    ...
+    stz l0403                                                         ; 811b: 9c 03 04    ...
+    ldx #$ff                                                          ; 811e: a2 ff       ..
+    stx l0023                                                         ; 8120: 86 23       .#
+    ldx #$0a                                                          ; 8122: a2 0a       ..
+    stx l0400                                                         ; 8124: 8e 00 04    ...
+    dex                                                               ; 8127: ca          .
+    stx l0401                                                         ; 8128: 8e 01 04    ...
+    lda #$b2                                                          ; 812b: a9 b2       ..
+    sta brkv                                                          ; 812d: 8d 02 02    ...
+    lda #$b2                                                          ; 8130: a9 b2       ..
+    sta brkv+1                                                        ; 8132: 8d 03 02    ...
+    cli                                                               ; 8135: 58          X
+    jmp c8ff2                                                         ; 8136: 4c f2 8f    L..
+
+; $8139 referenced 1 time by $b09e
+sub_c8139
+    sty l0039                                                         ; 8139: 84 39       .9
+    ldy #1                                                            ; 813b: a0 01       ..
+    lda (l0037),y                                                     ; 813d: b1 37       .7
+    ldy #$f6                                                          ; 813f: a0 f6       ..
+    cmp #$f2                                                          ; 8141: c9 f2       ..
+    beq c8151                                                         ; 8143: f0 0c       ..
+    ldy #$f8                                                          ; 8145: a0 f8       ..
+    bra c8151                                                         ; 8147: 80 08       ..
+; $8149 referenced 4 times by $9638, $9a5c, $9aaf, $9acb
+sub_c8149
+    sty l0039                                                         ; 8149: 84 39       .9
+    ldy #1                                                            ; 814b: a0 01       ..
+    lda (l0037),y                                                     ; 814d: b1 37       .7
+    asl                                                               ; 814f: 0a          .
+    tay                                                               ; 8150: a8          .
+; $8151 referenced 2 times by $8143, $8147
+c8151
+    lda l0401,y                                                       ; 8151: b9 01 04    ...
+    beq c8190                                                         ; 8154: f0 3a       .:
+    sta l002b                                                         ; 8156: 85 2b       .+
+    lda l0400,y                                                       ; 8158: b9 00 04    ...
+    bra c8168                                                         ; 815b: 80 0b       ..
+; $815d referenced 4 times by $8172, $8178, $817c, $8185
+c815d
+    ldy #1                                                            ; 815d: a0 01       ..
+    lda (l002a),y                                                     ; 815f: b1 2a       .*
+    beq c8190                                                         ; 8161: f0 2d       .-
+    tay                                                               ; 8163: a8          .
+    lda (l002a)                                                       ; 8164: b2 2a       .*
+    sty l002b                                                         ; 8166: 84 2b       .+
+; $8168 referenced 1 time by $815b
+c8168
+    sta l002a                                                         ; 8168: 85 2a       .*
+    ldy #2                                                            ; 816a: a0 02       ..
+    lda (l002a),y                                                     ; 816c: b1 2a       .*
+    bne c817a                                                         ; 816e: d0 0a       ..
+    cpy l0039                                                         ; 8170: c4 39       .9
+    bne c815d                                                         ; 8172: d0 e9       ..
+    bra c8187                                                         ; 8174: 80 11       ..
+; $8176 referenced 1 time by $8181
+loop_c8176
+    lda (l002a),y                                                     ; 8176: b1 2a       .*
+    beq c815d                                                         ; 8178: f0 e3       ..
+; $817a referenced 1 time by $816e
+c817a
+    cmp (l0037),y                                                     ; 817a: d1 37       .7
+    bne c815d                                                         ; 817c: d0 df       ..
+    iny                                                               ; 817e: c8          .
+    cpy l0039                                                         ; 817f: c4 39       .9
+    bne loop_c8176                                                    ; 8181: d0 f3       ..
+    lda (l002a),y                                                     ; 8183: b1 2a       .*
+    bne c815d                                                         ; 8185: d0 d6       ..
+; $8187 referenced 1 time by $8174
+c8187
+    tya                                                               ; 8187: 98          .
+    adc l002a                                                         ; 8188: 65 2a       e*
+    sta l002a                                                         ; 818a: 85 2a       .*
+    bcc c8190                                                         ; 818c: 90 02       ..
+    inc l002b                                                         ; 818e: e6 2b       .+
+; $8190 referenced 3 times by $8154, $8161, $818c
+c8190
+    rts                                                               ; 8190: 60          `
+
+; $8191 referenced 3 times by $b435, $b866, $bac8
+sub_c8191
+    stz l003d                                                         ; 8191: 64 3d       d=
+    lda l0018                                                         ; 8193: a5 18       ..
+    sta l003e                                                         ; 8195: 85 3e       .>
+; $8197 referenced 2 times by $81a7, $81ab
+c8197
+    ldy #1                                                            ; 8197: a0 01       ..
+    lda (l003d),y                                                     ; 8199: b1 3d       .=
+    cmp l002b                                                         ; 819b: c5 2b       .+
+    bcs c81ad                                                         ; 819d: b0 0e       ..
+; $819f referenced 1 time by $81b4
+loop_c819f
+    ldy #3                                                            ; 819f: a0 03       ..
+    lda (l003d),y                                                     ; 81a1: b1 3d       .=
+    adc l003d                                                         ; 81a3: 65 3d       e=
+    sta l003d                                                         ; 81a5: 85 3d       .=
+    bcc c8197                                                         ; 81a7: 90 ee       ..
+    inc l003e                                                         ; 81a9: e6 3e       .>
+    bra c8197                                                         ; 81ab: 80 ea       ..
+; $81ad referenced 1 time by $819d
+c81ad
+    bne c81b9                                                         ; 81ad: d0 0a       ..
+    iny                                                               ; 81af: c8          .
+    lda (l003d),y                                                     ; 81b0: b1 3d       .=
+    cmp l002a                                                         ; 81b2: c5 2a       .*
+    bcc loop_c819f                                                    ; 81b4: 90 e9       ..
+    bne c81b9                                                         ; 81b6: d0 01       ..
+    rts                                                               ; 81b8: 60          `
+
+; $81b9 referenced 2 times by $81ad, $81b6
+c81b9
+    ldy #2                                                            ; 81b9: a0 02       ..
+    clc                                                               ; 81bb: 18          .
+    rts                                                               ; 81bc: 60          `
+
+; $81bd referenced 2 times by $a04a, $a05f
+sub_c81bd
+    jsr sub_c9783                                                     ; 81bd: 20 83 97     ..
+    lda l002d                                                         ; 81c0: a5 2d       .-
+    pha                                                               ; 81c2: 48          H
+    bpl c81c8                                                         ; 81c3: 10 03       ..
+    jsr cad20                                                         ; 81c5: 20 20 ad      .
+; $81c8 referenced 1 time by $81c3
+c81c8
+    jsr sub_ca069                                                     ; 81c8: 20 69 a0     i.
+    stx l0027                                                         ; 81cb: 86 27       .'
+    jsr sub_c9783                                                     ; 81cd: 20 83 97     ..
+    pla                                                               ; 81d0: 68          h
+    sta l0038                                                         ; 81d1: 85 38       .8
+    eor l002d                                                         ; 81d3: 45 2d       E-
+    sta l0037                                                         ; 81d5: 85 37       .7
+    jsr sub_cad07                                                     ; 81d7: 20 07 ad     ..
+    ldx #$39 ; '9'                                                    ; 81da: a2 39       .9
+    jsr sub_cbd48                                                     ; 81dc: 20 48 bd     H.
+    ldx #3                                                            ; 81df: a2 03       ..
+; $81e1 referenced 1 time by $81e8
+loop_c81e1
+    stz l003d,x                                                       ; 81e1: 74 3d       t=
+    lda l002a,x                                                       ; 81e3: b5 2a       .*
+    bne c81fd                                                         ; 81e5: d0 16       ..
+    dex                                                               ; 81e7: ca          .
+    bpl loop_c81e1                                                    ; 81e8: 10 f7       ..
+; $81ea referenced 1 time by $a62c
+c81ea
+    brk                                                               ; 81ea: 00          .
+
+    !byte $12                                                         ; 81eb: 12          .
+    !text "Division by zero"                                          ; 81ec: 44 69 76... Div
+    !byte 0                                                           ; 81fc: 00          .
+
+; $81fd referenced 1 time by $81e5
+c81fd
+    rol                                                               ; 81fd: 2a          *
+    txa                                                               ; 81fe: 8a          .
+    tay                                                               ; 81ff: a8          .
+    adc #0                                                            ; 8200: 69 00       i.
+    sta l0042                                                         ; 8202: 85 42       .B
+    ldx #3                                                            ; 8204: a2 03       ..
+; $8206 referenced 1 time by $820d
+loop_c8206
+    lda l0039,x                                                       ; 8206: b5 39       .9
+    stz l003d,x                                                       ; 8208: 74 3d       t=
+    bne c8230                                                         ; 820a: d0 24       .$
+    dex                                                               ; 820c: ca          .
+    bpl loop_c8206                                                    ; 820d: 10 f7       ..
+; $820f referenced 4 times by $8211, $8225, $822a, $822e
+c820f
+    rts                                                               ; 820f: 60          `
+
+; $8210 referenced 1 time by $823d
+c8210
+    tya                                                               ; 8210: 98          .
+    beq c820f                                                         ; 8211: f0 fc       ..
+    lda l003d,y                                                       ; 8213: b9 3d 00    .=.
+    sta l003d                                                         ; 8216: 85 3d       .=
+    lda l003e,y                                                       ; 8218: b9 3e 00    .>.
+    sta l003e                                                         ; 821b: 85 3e       .>
+    lda l003f,y                                                       ; 821d: b9 3f 00    .?.
+    sta l003f                                                         ; 8220: 85 3f       .?
+    stz l0040                                                         ; 8222: 64 40       d@
+    dey                                                               ; 8224: 88          .
+    beq c820f                                                         ; 8225: f0 e8       ..
+    stz l003f                                                         ; 8227: 64 3f       d?
+    dey                                                               ; 8229: 88          .
+    beq c820f                                                         ; 822a: f0 e3       ..
+    stz l003e                                                         ; 822c: 64 3e       d>
+    bra c820f                                                         ; 822e: 80 df       ..
+; $8230 referenced 1 time by $820a
+c8230
+    cmp l002a,y                                                       ; 8230: d9 2a 00    .*.
+    bcs c823f                                                         ; 8233: b0 0a       ..
+; $8235 referenced 1 time by $8240
+loop_c8235
+    lda l0039,x                                                       ; 8235: b5 39       .9
+    sta l003d,y                                                       ; 8237: 99 3d 00    .=.
+    stz l0039,x                                                       ; 823a: 74 39       t9
+    dex                                                               ; 823c: ca          .
+    bmi c8210                                                         ; 823d: 30 d1       0.
+; $823f referenced 1 time by $8233
+c823f
+    dey                                                               ; 823f: 88          .
+    bpl loop_c8235                                                    ; 8240: 10 f3       ..
+; $8242 referenced 1 time by $8284
+c8242
+    ldy #8                                                            ; 8242: a0 08       ..
+    stx l0041                                                         ; 8244: 86 41       .A
+; $8246 referenced 1 time by $827f
+c8246
+    rol l0039,x                                                       ; 8246: 36 39       69
+    rol l003d                                                         ; 8248: 26 3d       &=
+    rol l003e                                                         ; 824a: 26 3e       &>
+    rol l003f                                                         ; 824c: 26 3f       &?
+    rol l0040                                                         ; 824e: 26 40       &@
+    ldx l0042                                                         ; 8250: a6 42       .B
+; $8252 referenced 1 time by $8259
+loop_c8252
+    lda l003d,x                                                       ; 8252: b5 3d       .=
+    cmp l002a,x                                                       ; 8254: d5 2a       .*
+    bne c825b                                                         ; 8256: d0 03       ..
+    dex                                                               ; 8258: ca          .
+    bpl loop_c8252                                                    ; 8259: 10 f7       ..
+; $825b referenced 1 time by $8256
+c825b
+    bcc c827c                                                         ; 825b: 90 1f       ..
+    lda l003d                                                         ; 825d: a5 3d       .=
+    sbc l002a                                                         ; 825f: e5 2a       .*
+    sta l003d                                                         ; 8261: 85 3d       .=
+    ldx l0042                                                         ; 8263: a6 42       .B
+    beq c827c                                                         ; 8265: f0 15       ..
+    lda l003e                                                         ; 8267: a5 3e       .>
+    sbc l002b                                                         ; 8269: e5 2b       .+
+    sta l003e                                                         ; 826b: 85 3e       .>
+    dex                                                               ; 826d: ca          .
+    beq c827c                                                         ; 826e: f0 0c       ..
+    lda l003f                                                         ; 8270: a5 3f       .?
+    sbc l002c                                                         ; 8272: e5 2c       .,
+    sta l003f                                                         ; 8274: 85 3f       .?
+    lda l0040                                                         ; 8276: a5 40       .@
+    sbc l002d                                                         ; 8278: e5 2d       .-
+    sta l0040                                                         ; 827a: 85 40       .@
+; $827c referenced 3 times by $825b, $8265, $826e
+c827c
+    ldx l0041                                                         ; 827c: a6 41       .A
+    dey                                                               ; 827e: 88          .
+    bne c8246                                                         ; 827f: d0 c5       ..
+    rol l0039,x                                                       ; 8281: 36 39       69
+    dex                                                               ; 8283: ca          .
+    bpl c8242                                                         ; 8284: 10 bc       ..
+    rts                                                               ; 8286: 60          `
+
+; $8287 referenced 2 times by $9f66, $9f9d
+sub_c8287
+    jsr sub_cbd26                                                     ; 8287: 20 26 bd     &.
+; $828a referenced 2 times by $9d4e, $aab3
+sub_c828a
+    jsr sub_ca3ed                                                     ; 828a: 20 ed a3     ..
+; $828d referenced 8 times by $97a6, $9f9a, $9fa7, $a09c, $a1ac, $a37e, $a99d, $b39b
+c828d
+    stz l0035                                                         ; 828d: 64 35       d5
+    lda l002d                                                         ; 828f: a5 2d       .-
+    sta l002e                                                         ; 8291: 85 2e       ..
+    bpl c829a                                                         ; 8293: 10 05       ..
+    jsr cad20                                                         ; 8295: 20 20 ad      .
+    lda l002d                                                         ; 8298: a5 2d       .-
+; $829a referenced 1 time by $8293
+c829a
+    bne c82c8                                                         ; 829a: d0 2c       .,
+    stz l0034                                                         ; 829c: 64 34       d4
+    ldy l002a                                                         ; 829e: a4 2a       .*
+    lda l002c                                                         ; 82a0: a5 2c       .,
+    bne c82be                                                         ; 82a2: d0 1a       ..
+    stz l0033                                                         ; 82a4: 64 33       d3
+    lda l002b                                                         ; 82a6: a5 2b       .+
+    beq c82d8                                                         ; 82a8: f0 2e       ..
+    sty l0032                                                         ; 82aa: 84 32       .2
+    ldy #$90                                                          ; 82ac: a0 90       ..
+; $82ae referenced 2 times by $82c6, $82d6
+c82ae
+    ora #0                                                            ; 82ae: 09 00       ..
+    bmi c82fb                                                         ; 82b0: 30 49       0I
+; $82b2 referenced 1 time by $82ba
+loop_c82b2
+    dey                                                               ; 82b2: 88          .
+    asl l0034                                                         ; 82b3: 06 34       .4
+    rol l0033                                                         ; 82b5: 26 33       &3
+    rol l0032                                                         ; 82b7: 26 32       &2
+    rol                                                               ; 82b9: 2a          *
+    bpl loop_c82b2                                                    ; 82ba: 10 f6       ..
+    bra c82fb                                                         ; 82bc: 80 3d       .=
+; $82be referenced 1 time by $82a2
+c82be
+    sty l0033                                                         ; 82be: 84 33       .3
+    ldy l002b                                                         ; 82c0: a4 2b       .+
+    sty l0032                                                         ; 82c2: 84 32       .2
+    ldy #$98                                                          ; 82c4: a0 98       ..
+    bra c82ae                                                         ; 82c6: 80 e6       ..
+; $82c8 referenced 1 time by $829a
+c82c8
+    ldy l002c                                                         ; 82c8: a4 2c       .,
+    sty l0032                                                         ; 82ca: 84 32       .2
+    ldy l002b                                                         ; 82cc: a4 2b       .+
+    sty l0033                                                         ; 82ce: 84 33       .3
+    ldy l002a                                                         ; 82d0: a4 2a       .*
+    sty l0034                                                         ; 82d2: 84 34       .4
+    ldy #$a0                                                          ; 82d4: a0 a0       ..
+    bra c82ae                                                         ; 82d6: 80 d6       ..
+; $82d8 referenced 1 time by $82a8
+c82d8
+    stz l0032                                                         ; 82d8: 64 32       d2
+    tya                                                               ; 82da: 98          .
+    bne c82f4                                                         ; 82db: d0 17       ..
+; $82dd referenced 3 times by $82ed, $8310, $a2d9
+c82dd
+    stz l0031                                                         ; 82dd: 64 31       d1
+    stz l002e                                                         ; 82df: 64 2e       d.
+    stz l0030                                                         ; 82e1: 64 30       d0
+    stz l002f                                                         ; 82e3: 64 2f       d/
+    rts                                                               ; 82e5: 60          `
+
+; $82e6 referenced 1 time by $a7f7
+sub_c82e6
+    sta l002e                                                         ; 82e6: 85 2e       ..
+    jsr sub_ca731                                                     ; 82e8: 20 31 a7     1.
+    lda l002e                                                         ; 82eb: a5 2e       ..
+    beq c82dd                                                         ; 82ed: f0 ee       ..
+    bpl c82f4                                                         ; 82ef: 10 03       ..
+    eor #$ff                                                          ; 82f1: 49 ff       I.
+    inc                                                               ; 82f3: 1a          .
+; $82f4 referenced 2 times by $82db, $82ef
+c82f4
+    ldy #$89                                                          ; 82f4: a0 89       ..
+    lsr                                                               ; 82f6: 4a          J
+; $82f7 referenced 1 time by $82f9
+loop_c82f7
+    dey                                                               ; 82f7: 88          .
+    rol                                                               ; 82f8: 2a          *
+    bpl loop_c82f7                                                    ; 82f9: 10 fc       ..
+; $82fb referenced 2 times by $82b0, $82bc
+c82fb
+    sty l0030                                                         ; 82fb: 84 30       .0
+    stz l002f                                                         ; 82fd: 64 2f       d/
+    sta l0031                                                         ; 82ff: 85 31       .1
+    rts                                                               ; 8301: 60          `
+
+    !byte $a5, $31                                                    ; 8302: a5 31       .1
+
+; $8304 referenced 3 times by $84f1, $8510, $a390
+c8304
+    bmi c8346                                                         ; 8304: 30 40       0@
+; $8306 referenced 2 times by $a6c6, $a7a9
+c8306
+    bne c832f                                                         ; 8306: d0 27       .'
+    ora l0032                                                         ; 8308: 05 32       .2
+    ora l0033                                                         ; 830a: 05 33       .3
+    ora l0034                                                         ; 830c: 05 34       .4
+    ora l0035                                                         ; 830e: 05 35       .5
+    beq c82dd                                                         ; 8310: f0 cb       ..
+    ldy l0030                                                         ; 8312: a4 30       .0
+; $8314 referenced 1 time by $832b
+loop_c8314
+    lda l0032                                                         ; 8314: a5 32       .2
+    pha                                                               ; 8316: 48          H
+    lda l0033                                                         ; 8317: a5 33       .3
+    sta l0032                                                         ; 8319: 85 32       .2
+    lda l0034                                                         ; 831b: a5 34       .4
+    sta l0033                                                         ; 831d: 85 33       .3
+    lda l0035                                                         ; 831f: a5 35       .5
+    sta l0034                                                         ; 8321: 85 34       .4
+    stz l0035                                                         ; 8323: 64 35       d5
+    tya                                                               ; 8325: 98          .
+    sec                                                               ; 8326: 38          8
+    sbc #8                                                            ; 8327: e9 08       ..
+    tay                                                               ; 8329: a8          .
+    pla                                                               ; 832a: 68          h
+    beq loop_c8314                                                    ; 832b: f0 e7       ..
+    bra c833b                                                         ; 832d: 80 0c       ..
+; $832f referenced 1 time by $8306
+c832f
+    ldy l0030                                                         ; 832f: a4 30       .0
+; $8331 referenced 1 time by $833b
+loop_c8331
+    dey                                                               ; 8331: 88          .
+    asl l0035                                                         ; 8332: 06 35       .5
+    rol l0034                                                         ; 8334: 26 34       &4
+    rol l0033                                                         ; 8336: 26 33       &3
+    rol l0032                                                         ; 8338: 26 32       &2
+    rol                                                               ; 833a: 2a          *
+; $833b referenced 1 time by $832d
+c833b
+    bpl loop_c8331                                                    ; 833b: 10 f4       ..
+    cpy l0030                                                         ; 833d: c4 30       .0
+    sty l0030                                                         ; 833f: 84 30       .0
+    bcc c8345                                                         ; 8341: 90 02       ..
+    dec l002f                                                         ; 8343: c6 2f       ./
+; $8345 referenced 1 time by $8341
+c8345
+    tay                                                               ; 8345: a8          .
+; $8346 referenced 1 time by $8304
+c8346
+    sta l0031                                                         ; 8346: 85 31       .1
+    rts                                                               ; 8348: 60          `
+
+; $8349 referenced 1 time by $abed
+sub_c8349
+    stz l003d                                                         ; 8349: 64 3d       d=
+sub_c834b
+    ldy l0031                                                         ; 834b: a4 31       .1
+    bra c8353                                                         ; 834d: 80 04       ..
+; $834f referenced 1 time by $9788
+sub_c834f
+    ldy l0031                                                         ; 834f: a4 31       .1
+    sty l003d                                                         ; 8351: 84 3d       .=
+; $8353 referenced 1 time by $834d
+c8353
+    lda l0030                                                         ; 8353: a5 30       .0
+    cmp #$81                                                          ; 8355: c9 81       ..
+    bcs c835e                                                         ; 8357: b0 05       ..
+    sty l003d                                                         ; 8359: 84 3d       .=
+    jmp ca72b                                                         ; 835b: 4c 2b a7    L+.
+
+; $835e referenced 1 time by $8357
+c835e
+    cmp #$a0                                                          ; 835e: c9 a0       ..
+    bcc c8372                                                         ; 8360: 90 10       ..
+; $8362 referenced 1 time by $83d0
+c8362
+    jmp ca6f2                                                         ; 8362: 4c f2 a6    L..
+
+; $8365 referenced 1 time by $8374
+loop_c8365
+    lsr l0031                                                         ; 8365: 46 31       F1
+    ror l0032                                                         ; 8367: 66 32       f2
+    ror l0033                                                         ; 8369: 66 33       f3
+    ror l0034                                                         ; 836b: 66 34       f4
+    bcc c8371                                                         ; 836d: 90 02       ..
+    sta l003d                                                         ; 836f: 85 3d       .=
+; $8371 referenced 1 time by $836d
+c8371
+    inc                                                               ; 8371: 1a          .
+; $8372 referenced 1 time by $8360
+c8372
+    bit #7                                                            ; 8372: 89 07       ..
+    bne loop_c8365                                                    ; 8374: d0 ef       ..
+    and #$18                                                          ; 8376: 29 18       ).
+    beq c83a6                                                         ; 8378: f0 2c       .,
+    lsr                                                               ; 837a: 4a          J
+    lsr                                                               ; 837b: 4a          J
+    lsr                                                               ; 837c: 4a          J
+    tay                                                               ; 837d: a8          .
+    phx                                                               ; 837e: da          .
+    eor #3                                                            ; 837f: 49 03       I.
+    tax                                                               ; 8381: aa          .
+    lda l003d                                                         ; 8382: a5 3d       .=
+    bne c8392                                                         ; 8384: d0 0c       ..
+    stz l0035                                                         ; 8386: 64 35       d5
+    lda l0034                                                         ; 8388: a5 34       .4
+    ora l0031,y                                                       ; 838a: 19 31 00    .1.
+    ora l0032,y                                                       ; 838d: 19 32 00    .2.
+    sta l003d                                                         ; 8390: 85 3d       .=
+; $8392 referenced 1 time by $8384
+c8392
+    lda l0033                                                         ; 8392: a5 33       .3
+    sta l0034                                                         ; 8394: 85 34       .4
+    lda l0032                                                         ; 8396: a5 32       .2
+    sta l0033,x                                                       ; 8398: 95 33       .3
+    lda l0031                                                         ; 839a: a5 31       .1
+    sta l0032,x                                                       ; 839c: 95 32       .2
+; $839e referenced 1 time by $83a1
+loop_c839e
+    stz l0031,x                                                       ; 839e: 74 31       t1
+    dex                                                               ; 83a0: ca          .
+    bpl loop_c839e                                                    ; 83a1: 10 fb       ..
+    plx                                                               ; 83a3: fa          .
+    stz l0035                                                         ; 83a4: 64 35       d5
+; $83a6 referenced 1 time by $8378
+c83a6
+    lda l002e                                                         ; 83a6: a5 2e       ..
+    bpl c83c1                                                         ; 83a8: 10 17       ..
+; $83aa referenced 1 time by $abfa
+sub_c83aa
+    sec                                                               ; 83aa: 38          8
+    ldy #0                                                            ; 83ab: a0 00       ..
+    tya                                                               ; 83ad: 98          .
+    sbc l0034                                                         ; 83ae: e5 34       .4
+    sta l0034                                                         ; 83b0: 85 34       .4
+    tya                                                               ; 83b2: 98          .
+    sbc l0033                                                         ; 83b3: e5 33       .3
+    sta l0033                                                         ; 83b5: 85 33       .3
+    tya                                                               ; 83b7: 98          .
+    sbc l0032                                                         ; 83b8: e5 32       .2
+    sta l0032                                                         ; 83ba: 85 32       .2
+    tya                                                               ; 83bc: 98          .
+    sbc l0031                                                         ; 83bd: e5 31       .1
+    sta l0031                                                         ; 83bf: 85 31       .1
+; $83c1 referenced 1 time by $83a8
+c83c1
+    rts                                                               ; 83c1: 60          `
+
+; $83c2 referenced 1 time by $abf7
+sub_c83c2
+    inc l0034                                                         ; 83c2: e6 34       .4
+    bne c83d2                                                         ; 83c4: d0 0c       ..
+    inc l0033                                                         ; 83c6: e6 33       .3
+    bne c83d2                                                         ; 83c8: d0 08       ..
+    inc l0032                                                         ; 83ca: e6 32       .2
+    bne c83d2                                                         ; 83cc: d0 04       ..
+    inc l0031                                                         ; 83ce: e6 31       .1
+    beq c8362                                                         ; 83d0: f0 90       ..
+; $83d2 referenced 3 times by $83c4, $83c8, $83cc
+c83d2
+    rts                                                               ; 83d2: 60          `
+
+; $83d3 referenced 2 times by $aa7a, $aad3
+sub_c83d3
+    ldy #2                                                            ; 83d3: a0 02       ..
+; $83d5 referenced 1 time by $8407
+c83d5
+    ror l0011                                                         ; 83d5: 66 11       f.
+    ror l0010                                                         ; 83d7: 66 10       f.
+    lda l000f                                                         ; 83d9: a5 0f       ..
+    sta l0011                                                         ; 83db: 85 11       ..
+    ror                                                               ; 83dd: 6a          j
+    pha                                                               ; 83de: 48          H
+    lda l000e                                                         ; 83df: a5 0e       ..
+    ldx l000d                                                         ; 83e1: a6 0d       ..
+    lsr l000f                                                         ; 83e3: 46 0f       F.
+    ror                                                               ; 83e5: 6a          j
+    ror l000d                                                         ; 83e6: 66 0d       f.
+    lsr l000f                                                         ; 83e8: 46 0f       F.
+    ror                                                               ; 83ea: 6a          j
+    ror l000d                                                         ; 83eb: 66 0d       f.
+    lsr l000f                                                         ; 83ed: 46 0f       F.
+    ror                                                               ; 83ef: 6a          j
+    ror l000d                                                         ; 83f0: 66 0d       f.
+    lsr l000f                                                         ; 83f2: 46 0f       F.
+    ror                                                               ; 83f4: 6a          j
+    ror l000d                                                         ; 83f5: 66 0d       f.
+    eor l0010                                                         ; 83f7: 45 10       E.
+    stx l000f                                                         ; 83f9: 86 0f       ..
+    ldx l000e                                                         ; 83fb: a6 0e       ..
+    stx l0010                                                         ; 83fd: 86 10       ..
+    sta l000e                                                         ; 83ff: 85 0e       ..
+    pla                                                               ; 8401: 68          h
+    eor l000d                                                         ; 8402: 45 0d       E.
+    sta l000d                                                         ; 8404: 85 0d       ..
+    dey                                                               ; 8406: 88          .
+    bne c83d5                                                         ; 8407: d0 cc       ..
+    rts                                                               ; 8409: 60          `
+
+; $840a referenced 2 times by $842b, $846f
+c840a
+    lda l003b                                                         ; 840a: a5 3b       .;
+    sta l002e                                                         ; 840c: 85 2e       ..
+    stz l002f                                                         ; 840e: 64 2f       d/
+    lda l003c                                                         ; 8410: a5 3c       .<
+    sta l0030                                                         ; 8412: 85 30       .0
+    lda l003d                                                         ; 8414: a5 3d       .=
+    sta l0031                                                         ; 8416: 85 31       .1
+    lda l003e                                                         ; 8418: a5 3e       .>
+    sta l0032                                                         ; 841a: 85 32       .2
+    lda l003f                                                         ; 841c: a5 3f       .?
+    sta l0033                                                         ; 841e: 85 33       .3
+    lda l0040                                                         ; 8420: a5 40       .@
+    sta l0034                                                         ; 8422: 85 34       .4
+    lda l0041                                                         ; 8424: a5 41       .A
+    sta l0035                                                         ; 8426: 85 35       .5
+; $8428 referenced 1 time by $8438
+loop_c8428
+    rts                                                               ; 8428: 60          `
+
+; $8429 referenced 2 times by $a204, $a70f
+sub_c8429
+    lda l0031                                                         ; 8429: a5 31       .1
+    beq c840a                                                         ; 842b: f0 dd       ..
+    sec                                                               ; 842d: 38          8
+    lda l0030                                                         ; 842e: a5 30       .0
+    sbc l003c                                                         ; 8430: e5 3c       .<
+    beq c84a3                                                         ; 8432: f0 6f       .o
+    bcc c846a                                                         ; 8434: 90 34       .4
+    cmp #$25 ; '%'                                                    ; 8436: c9 25       .%
+    bcs loop_c8428                                                    ; 8438: b0 ee       ..
+    tay                                                               ; 843a: a8          .
+    and #$38 ; '8'                                                    ; 843b: 29 38       )8
+    beq c8456                                                         ; 843d: f0 17       ..
+    sec                                                               ; 843f: 38          8
+; $8440 referenced 1 time by $8454
+loop_c8440
+    ldx l0040                                                         ; 8440: a6 40       .@
+    stx l0041                                                         ; 8442: 86 41       .A
+    ldx l003f                                                         ; 8444: a6 3f       .?
+    stx l0040                                                         ; 8446: 86 40       .@
+    ldx l003e                                                         ; 8448: a6 3e       .>
+    stx l003f                                                         ; 844a: 86 3f       .?
+    ldx l003d                                                         ; 844c: a6 3d       .=
+    stx l003e                                                         ; 844e: 86 3e       .>
+    stz l003d                                                         ; 8450: 64 3d       d=
+    sbc #8                                                            ; 8452: e9 08       ..
+    bne loop_c8440                                                    ; 8454: d0 ea       ..
+; $8456 referenced 1 time by $843d
+c8456
+    tya                                                               ; 8456: 98          .
+    and #7                                                            ; 8457: 29 07       ).
+    beq c84a3                                                         ; 8459: f0 48       .H
+; $845b referenced 1 time by $8466
+loop_c845b
+    lsr l003d                                                         ; 845b: 46 3d       F=
+    ror l003e                                                         ; 845d: 66 3e       f>
+    ror l003f                                                         ; 845f: 66 3f       f?
+    ror l0040                                                         ; 8461: 66 40       f@
+    ror l0041                                                         ; 8463: 66 41       fA
+    dec                                                               ; 8465: 3a          :
+    bne loop_c845b                                                    ; 8466: d0 f3       ..
+    bra c84a3                                                         ; 8468: 80 39       .9
+; $846a referenced 1 time by $8434
+c846a
+    eor #$ff                                                          ; 846a: 49 ff       I.
+    inc                                                               ; 846c: 1a          .
+    cmp #$25 ; '%'                                                    ; 846d: c9 25       .%
+    bcs c840a                                                         ; 846f: b0 99       ..
+    ldy l003c                                                         ; 8471: a4 3c       .<
+    sty l0030                                                         ; 8473: 84 30       .0
+    tay                                                               ; 8475: a8          .
+    and #$38 ; '8'                                                    ; 8476: 29 38       )8
+    beq c8491                                                         ; 8478: f0 17       ..
+    sec                                                               ; 847a: 38          8
+; $847b referenced 1 time by $848f
+loop_c847b
+    ldx l0034                                                         ; 847b: a6 34       .4
+    stx l0035                                                         ; 847d: 86 35       .5
+    ldx l0033                                                         ; 847f: a6 33       .3
+    stx l0034                                                         ; 8481: 86 34       .4
+    ldx l0032                                                         ; 8483: a6 32       .2
+    stx l0033                                                         ; 8485: 86 33       .3
+    ldx l0031                                                         ; 8487: a6 31       .1
+    stx l0032                                                         ; 8489: 86 32       .2
+    stz l0031                                                         ; 848b: 64 31       d1
+    sbc #8                                                            ; 848d: e9 08       ..
+    bne loop_c847b                                                    ; 848f: d0 ea       ..
+; $8491 referenced 1 time by $8478
+c8491
+    tya                                                               ; 8491: 98          .
+    and #7                                                            ; 8492: 29 07       ).
+    beq c84a3                                                         ; 8494: f0 0d       ..
+; $8496 referenced 1 time by $84a1
+loop_c8496
+    lsr l0031                                                         ; 8496: 46 31       F1
+    ror l0032                                                         ; 8498: 66 32       f2
+    ror l0033                                                         ; 849a: 66 33       f3
+    ror l0034                                                         ; 849c: 66 34       f4
+    ror l0035                                                         ; 849e: 66 35       f5
+    dec                                                               ; 84a0: 3a          :
+    bne loop_c8496                                                    ; 84a1: d0 f3       ..
+; $84a3 referenced 4 times by $8432, $8459, $8468, $8494
+c84a3
+    lda l002e                                                         ; 84a3: a5 2e       ..
+    eor l003b                                                         ; 84a5: 45 3b       E;
+    bmi c84ad                                                         ; 84a7: 30 04       0.
+    clc                                                               ; 84a9: 18          .
+    jmp ca489                                                         ; 84aa: 4c 89 a4    L..
+
+; $84ad referenced 1 time by $84a7
+c84ad
+    lda l0031                                                         ; 84ad: a5 31       .1
+    cmp l003d                                                         ; 84af: c5 3d       .=
+    bne c84ce                                                         ; 84b1: d0 1b       ..
+    lda l0032                                                         ; 84b3: a5 32       .2
+    cmp l003e                                                         ; 84b5: c5 3e       .>
+    bne c84ce                                                         ; 84b7: d0 15       ..
+    lda l0033                                                         ; 84b9: a5 33       .3
+    cmp l003f                                                         ; 84bb: c5 3f       .?
+    bne c84ce                                                         ; 84bd: d0 0f       ..
+    lda l0034                                                         ; 84bf: a5 34       .4
+    cmp l0040                                                         ; 84c1: c5 40       .@
+    bne c84ce                                                         ; 84c3: d0 09       ..
+    lda l0035                                                         ; 84c5: a5 35       .5
+    cmp l0041                                                         ; 84c7: c5 41       .A
+    bne c84ce                                                         ; 84c9: d0 03       ..
+    jmp ca72b                                                         ; 84cb: 4c 2b a7    L+.
+
+; $84ce referenced 5 times by $84b1, $84b7, $84bd, $84c3, $84c9
+c84ce
+    bcs c84f4                                                         ; 84ce: b0 24       .$
+    lda l003b                                                         ; 84d0: a5 3b       .;
+    sta l002e                                                         ; 84d2: 85 2e       ..
+    sec                                                               ; 84d4: 38          8
+    lda l0041                                                         ; 84d5: a5 41       .A
+    sbc l0035                                                         ; 84d7: e5 35       .5
+    sta l0035                                                         ; 84d9: 85 35       .5
+    lda l0040                                                         ; 84db: a5 40       .@
+    sbc l0034                                                         ; 84dd: e5 34       .4
+    sta l0034                                                         ; 84df: 85 34       .4
+    lda l003f                                                         ; 84e1: a5 3f       .?
+    sbc l0033                                                         ; 84e3: e5 33       .3
+    sta l0033                                                         ; 84e5: 85 33       .3
+    lda l003e                                                         ; 84e7: a5 3e       .>
+    sbc l0032                                                         ; 84e9: e5 32       .2
+    sta l0032                                                         ; 84eb: 85 32       .2
+    lda l003d                                                         ; 84ed: a5 3d       .=
+    sbc l0031                                                         ; 84ef: e5 31       .1
+    jmp c8304                                                         ; 84f1: 4c 04 83    L..
+
+; $84f4 referenced 1 time by $84ce
+c84f4
+    lda l0035                                                         ; 84f4: a5 35       .5
+    sbc l0041                                                         ; 84f6: e5 41       .A
+    sta l0035                                                         ; 84f8: 85 35       .5
+    lda l0034                                                         ; 84fa: a5 34       .4
+    sbc l0040                                                         ; 84fc: e5 40       .@
+    sta l0034                                                         ; 84fe: 85 34       .4
+    lda l0033                                                         ; 8500: a5 33       .3
+    sbc l003f                                                         ; 8502: e5 3f       .?
+    sta l0033                                                         ; 8504: 85 33       .3
+    lda l0032                                                         ; 8506: a5 32       .2
+    sbc l003e                                                         ; 8508: e5 3e       .>
+    sta l0032                                                         ; 850a: 85 32       .2
+    lda l0031                                                         ; 850c: a5 31       .1
+    sbc l003d                                                         ; 850e: e5 3d       .=
+    jmp c8304                                                         ; 8510: 4c 04 83    L..
+
+    !text "AND"                                                       ; 8513: 41 4e 44    AND
+    !byte $80,   0                                                    ; 8516: 80 00       ..
+    !text "ABS"                                                       ; 8518: 41 42 53    ABS
+    !byte $94,   0                                                    ; 851b: 94 00       ..
+    !text "ACS"                                                       ; 851d: 41 43 53    ACS
+    !byte $95,   0                                                    ; 8520: 95 00       ..
+    !text "ADVAL"                                                     ; 8522: 41 44 56... ADV
+    !byte $96,   0                                                    ; 8527: 96 00       ..
+    !text "ASC"                                                       ; 8529: 41 53 43    ASC
+    !byte $97,   0                                                    ; 852c: 97 00       ..
+    !text "ASN"                                                       ; 852e: 41 53 4e    ASN
+    !byte $98,   0                                                    ; 8531: 98 00       ..
+    !text "ATN"                                                       ; 8533: 41 54 4e    ATN
+    !byte $99,   0                                                    ; 8536: 99 00       ..
+    !text "AUTO"                                                      ; 8538: 41 55 54... AUT
+    !byte $c6, $10                                                    ; 853c: c6 10       ..
+    !text "BGET"                                                      ; 853e: 42 47 45... BGE
+    !byte $9a,   1                                                    ; 8542: 9a 01       ..
+    !text "BPUT"                                                      ; 8544: 42 50 55... BPU
+    !byte $d5,   3                                                    ; 8548: d5 03       ..
+    !text "COLOUR"                                                    ; 854a: 43 4f 4c... COL
+    !byte $fb,   2                                                    ; 8550: fb 02       ..
+    !text "CALL"                                                      ; 8552: 43 41 4c... CAL
+    !byte $d6,   2                                                    ; 8556: d6 02       ..
+    !text "CHAIN"                                                     ; 8558: 43 48 41... CHA
+    !byte $d7,   2                                                    ; 855d: d7 02       ..
+    !text "CHR$"                                                      ; 855f: 43 48 52... CHR
+    !byte $bd,   0                                                    ; 8563: bd 00       ..
+    !text "CLEAR"                                                     ; 8565: 43 4c 45... CLE
+    !byte $d8,   1                                                    ; 856a: d8 01       ..
+    !text "CLOSE"                                                     ; 856c: 43 4c 4f... CLO
+    !byte $d9,   3                                                    ; 8571: d9 03       ..
+    !text "CLG"                                                       ; 8573: 43 4c 47    CLG
+    !byte $da,   1                                                    ; 8576: da 01       ..
+    !text "CLS"                                                       ; 8578: 43 4c 53    CLS
+    !byte $db,   1                                                    ; 857b: db 01       ..
+    !text "COS"                                                       ; 857d: 43 4f 53    COS
+    !byte $9b,   0                                                    ; 8580: 9b 00       ..
+    !text "COUNT"                                                     ; 8582: 43 4f 55... COU
+    !byte $9c,   1                                                    ; 8587: 9c 01       ..
+    !text "COLOR"                                                     ; 8589: 43 4f 4c... COL
+    !byte $fb,   2                                                    ; 858e: fb 02       ..
+    !text "DATA"                                                      ; 8590: 44 41 54... DAT
+    !byte $dc                                                         ; 8594: dc          .
+    !text " DEG"                                                      ; 8595: 20 44 45...  DE
+    !byte $9d,   0                                                    ; 8599: 9d 00       ..
+    !text "DEF"                                                       ; 859b: 44 45 46    DEF
+    !byte $dd,   0                                                    ; 859e: dd 00       ..
+    !text "DELETE"                                                    ; 85a0: 44 45 4c... DEL
+    !byte $c7, $10                                                    ; 85a6: c7 10       ..
+    !text "DIV"                                                       ; 85a8: 44 49 56    DIV
+    !byte $81,   0                                                    ; 85ab: 81 00       ..
+    !text "DIM"                                                       ; 85ad: 44 49 4d    DIM
+    !byte $de,   2                                                    ; 85b0: de 02       ..
+    !text "DRAW"                                                      ; 85b2: 44 52 41... DRA
+    !byte $df,   2                                                    ; 85b6: df 02       ..
+    !text "ENDPROC"                                                   ; 85b8: 45 4e 44... END
+    !byte $e1,   1                                                    ; 85bf: e1 01       ..
+    !text "END"                                                       ; 85c1: 45 4e 44    END
+    !byte $e0,   1                                                    ; 85c4: e0 01       ..
+    !text "ENVELOPE"                                                  ; 85c6: 45 4e 56... ENV
+    !byte $e2,   2                                                    ; 85ce: e2 02       ..
+    !text "ELSE"                                                      ; 85d0: 45 4c 53... ELS
+    !byte $8b, $14                                                    ; 85d4: 8b 14       ..
+    !text "EVAL"                                                      ; 85d6: 45 56 41... EVA
+    !byte $a0,   0                                                    ; 85da: a0 00       ..
+    !text "ERL"                                                       ; 85dc: 45 52 4c    ERL
+    !byte $9e,   1                                                    ; 85df: 9e 01       ..
+    !text "ERROR"                                                     ; 85e1: 45 52 52... ERR
+    !byte $85,   4                                                    ; 85e6: 85 04       ..
+    !text "EOF"                                                       ; 85e8: 45 4f 46    EOF
+    !byte $c5,   1                                                    ; 85eb: c5 01       ..
+    !text "EOR"                                                       ; 85ed: 45 4f 52    EOR
+    !byte $82,   0                                                    ; 85f0: 82 00       ..
+    !text "ERR"                                                       ; 85f2: 45 52 52    ERR
+    !byte $9f,   1                                                    ; 85f5: 9f 01       ..
+    !text "EXP"                                                       ; 85f7: 45 58 50    EXP
+    !byte $a1,   0                                                    ; 85fa: a1 00       ..
+    !text "EXT"                                                       ; 85fc: 45 58 54    EXT
+    !byte $a2,   1                                                    ; 85ff: a2 01       ..
+    !text "EDIT"                                                      ; 8601: 45 44 49... EDI
+    !byte $ce, $10                                                    ; 8605: ce 10       ..
+    !text "FOR"                                                       ; 8607: 46 4f 52    FOR
+    !byte $e3,   2                                                    ; 860a: e3 02       ..
+    !text "FALSE"                                                     ; 860c: 46 41 4c... FAL
+    !byte $a3,   1, $46, $4e, $a4,   8                                ; 8611: a3 01 46... ..F
+    !text "GOTO"                                                      ; 8617: 47 4f 54... GOT
+    !byte $e5, $12                                                    ; 861b: e5 12       ..
+    !text "GET$"                                                      ; 861d: 47 45 54... GET
+    !byte $be,   0                                                    ; 8621: be 00       ..
+    !text "GET"                                                       ; 8623: 47 45 54    GET
+    !byte $a5,   0                                                    ; 8626: a5 00       ..
+    !text "GOSUB"                                                     ; 8628: 47 4f 53... GOS
+    !byte $e4, $12                                                    ; 862d: e4 12       ..
+    !text "GCOL"                                                      ; 862f: 47 43 4f... GCO
+    !byte $e6,   2                                                    ; 8633: e6 02       ..
+    !text "HIMEM"                                                     ; 8635: 48 49 4d... HIM
+    !byte $93                                                         ; 863a: 93          .
+    !text "CINPUT"                                                    ; 863b: 43 49 4e... CIN
+    !byte $e8,   2, $49, $46, $e7,   2                                ; 8641: e8 02 49... ..I
+    !text "INKEY$"                                                    ; 8647: 49 4e 4b... INK
+    !byte $bf,   0                                                    ; 864d: bf 00       ..
+    !text "INKEY"                                                     ; 864f: 49 4e 4b... INK
+    !byte $a6,   0                                                    ; 8654: a6 00       ..
+    !text "INT"                                                       ; 8656: 49 4e 54    INT
+    !byte $a8,   0                                                    ; 8659: a8 00       ..
+    !text "INSTR("                                                    ; 865b: 49 4e 53... INS
+    !byte $a7,   0                                                    ; 8661: a7 00       ..
+    !text "LIST"                                                      ; 8663: 4c 49 53... LIS
+    !byte $c9, $10                                                    ; 8667: c9 10       ..
+    !text "LINE"                                                      ; 8669: 4c 49 4e... LIN
+    !byte $86,   0                                                    ; 866d: 86 00       ..
+    !text "LOAD"                                                      ; 866f: 4c 4f 41... LOA
+    !byte $c8,   2                                                    ; 8673: c8 02       ..
+    !text "LOMEM"                                                     ; 8675: 4c 4f 4d... LOM
+    !byte $92                                                         ; 867a: 92          .
+    !text "CLOCAL"                                                    ; 867b: 43 4c 4f... CLO
+    !byte $ea,   2                                                    ; 8681: ea 02       ..
+    !text "LEFT$("                                                    ; 8683: 4c 45 46... LEF
+    !byte $c0,   0                                                    ; 8689: c0 00       ..
+    !text "LEN"                                                       ; 868b: 4c 45 4e    LEN
+    !byte $a9,   0                                                    ; 868e: a9 00       ..
+    !text "LET"                                                       ; 8690: 4c 45 54    LET
+    !byte $e9,   4                                                    ; 8693: e9 04       ..
+    !text "LOG"                                                       ; 8695: 4c 4f 47    LOG
+    !byte $ab,   0, $4c, $4e, $aa,   0                                ; 8698: ab 00 4c... ..L
+    !text "MID$("                                                     ; 869e: 4d 49 44... MID
+    !byte $c1,   0                                                    ; 86a3: c1 00       ..
+    !text "MODE"                                                      ; 86a5: 4d 4f 44... MOD
+    !byte $eb,   2                                                    ; 86a9: eb 02       ..
+    !text "MOD"                                                       ; 86ab: 4d 4f 44    MOD
+    !byte $83,   0                                                    ; 86ae: 83 00       ..
+    !text "MOVE"                                                      ; 86b0: 4d 4f 56... MOV
+    !byte $ec,   2                                                    ; 86b4: ec 02       ..
+    !text "NEXT"                                                      ; 86b6: 4e 45 58... NEX
+    !byte $ed,   2                                                    ; 86ba: ed 02       ..
+    !text "NEW"                                                       ; 86bc: 4e 45 57    NEW
+    !byte $ca,   1                                                    ; 86bf: ca 01       ..
+    !text "NOT"                                                       ; 86c1: 4e 4f 54    NOT
+    !byte $ac,   0                                                    ; 86c4: ac 00       ..
+    !text "OLD"                                                       ; 86c6: 4f 4c 44    OLD
+    !byte $cb,   1, $4f, $4e, $ee,   2                                ; 86c9: cb 01 4f... ..O
+    !text "OFF"                                                       ; 86cf: 4f 46 46    OFF
+    !byte $87,   0, $4f, $52, $84,   0                                ; 86d2: 87 00 4f... ..O
+    !text "OPENIN"                                                    ; 86d8: 4f 50 45... OPE
+    !byte $8e,   0                                                    ; 86de: 8e 00       ..
+    !text "OPENOUT"                                                   ; 86e0: 4f 50 45... OPE
+    !byte $ae,   0                                                    ; 86e7: ae 00       ..
+    !text "OPENUP"                                                    ; 86e9: 4f 50 45... OPE
+    !byte $ad,   0                                                    ; 86ef: ad 00       ..
+    !text "OSCLI"                                                     ; 86f1: 4f 53 43... OSC
+    !byte $ff,   2                                                    ; 86f6: ff 02       ..
+    !text "PRINT"                                                     ; 86f8: 50 52 49... PRI
+    !byte $f1,   2                                                    ; 86fd: f1 02       ..
+    !text "PAGE"                                                      ; 86ff: 50 41 47... PAG
+    !byte $90                                                         ; 8703: 90          .
+    !text "CPTR"                                                      ; 8704: 43 50 54... CPT
+    !byte $8f                                                         ; 8708: 8f          .
+    !text "CPI"                                                       ; 8709: 43 50 49    CPI
+    !byte $af,   1                                                    ; 870c: af 01       ..
+    !text "PLOT"                                                      ; 870e: 50 4c 4f... PLO
+    !byte $f0,   2                                                    ; 8712: f0 02       ..
+    !text "POINT("                                                    ; 8714: 50 4f 49... POI
+    !byte $b0,   0                                                    ; 871a: b0 00       ..
+    !text "PROC"                                                      ; 871c: 50 52 4f... PRO
+    !byte $f2, $0a                                                    ; 8720: f2 0a       ..
+    !text "POS"                                                       ; 8722: 50 4f 53    POS
+    !byte $b1,   1                                                    ; 8725: b1 01       ..
+    !text "RETURN"                                                    ; 8727: 52 45 54... RET
+    !byte $f8,   1                                                    ; 872d: f8 01       ..
+    !text "REPEAT"                                                    ; 872f: 52 45 50... REP
+    !byte $f5,   0                                                    ; 8735: f5 00       ..
+    !text "REPORT"                                                    ; 8737: 52 45 50... REP
+    !byte $f6,   1                                                    ; 873d: f6 01       ..
+    !text "READ"                                                      ; 873f: 52 45 41... REA
+    !byte $f3,   2                                                    ; 8743: f3 02       ..
+    !text "REM"                                                       ; 8745: 52 45 4d    REM
+    !byte $f4                                                         ; 8748: f4          .
+    !text " RUN"                                                      ; 8749: 20 52 55...  RU
+    !byte $f9,   1                                                    ; 874d: f9 01       ..
+    !text "RAD"                                                       ; 874f: 52 41 44    RAD
+    !byte $b2,   0                                                    ; 8752: b2 00       ..
+    !text "RESTORE"                                                   ; 8754: 52 45 53... RES
+    !byte $f7, $12                                                    ; 875b: f7 12       ..
+    !text "RIGHT$("                                                   ; 875d: 52 49 47... RIG
+    !byte $c2,   0                                                    ; 8764: c2 00       ..
+    !text "RND"                                                       ; 8766: 52 4e 44    RND
+    !byte $b3,   1                                                    ; 8769: b3 01       ..
+    !text "RENUMBER"                                                  ; 876b: 52 45 4e... REN
+    !byte $cc, $10                                                    ; 8773: cc 10       ..
+    !text "STEP"                                                      ; 8775: 53 54 45... STE
+    !byte $88,   0                                                    ; 8779: 88 00       ..
+    !text "SAVE"                                                      ; 877b: 53 41 56... SAV
+    !byte $cd,   2                                                    ; 877f: cd 02       ..
+    !text "SGN"                                                       ; 8781: 53 47 4e    SGN
+    !byte $b4,   0                                                    ; 8784: b4 00       ..
+    !text "SIN"                                                       ; 8786: 53 49 4e    SIN
+    !byte $b5,   0                                                    ; 8789: b5 00       ..
+    !text "SQR"                                                       ; 878b: 53 51 52    SQR
+    !byte $b6,   0                                                    ; 878e: b6 00       ..
+    !text "SPC"                                                       ; 8790: 53 50 43    SPC
+    !byte $89,   0                                                    ; 8793: 89 00       ..
+    !text "STR$"                                                      ; 8795: 53 54 52... STR
+    !byte $c3,   0                                                    ; 8799: c3 00       ..
+    !text "STRING$("                                                  ; 879b: 53 54 52... STR
+    !byte $c4,   0                                                    ; 87a3: c4 00       ..
+    !text "SOUND"                                                     ; 87a5: 53 4f 55... SOU
+    !byte $d4,   2                                                    ; 87aa: d4 02       ..
+    !text "STOP"                                                      ; 87ac: 53 54 4f... STO
+    !byte $fa,   1                                                    ; 87b0: fa 01       ..
+    !text "TAN"                                                       ; 87b2: 54 41 4e    TAN
+    !byte $b7,   0                                                    ; 87b5: b7 00       ..
+    !text "THEN"                                                      ; 87b7: 54 48 45... THE
+    !byte $8c, $14, $54, $4f, $b8,   0                                ; 87bb: 8c 14 54... ..T
+    !text "TAB("                                                      ; 87c1: 54 41 42... TAB
+    !byte $8a,   0                                                    ; 87c5: 8a 00       ..
+    !text "TRACE"                                                     ; 87c7: 54 52 41... TRA
+    !byte $fc, $12                                                    ; 87cc: fc 12       ..
+    !text "TIME"                                                      ; 87ce: 54 49 4d... TIM
+    !byte $91                                                         ; 87d2: 91          .
+    !text "CTRUE"                                                     ; 87d3: 43 54 52... CTR
+    !byte $b9,   1                                                    ; 87d8: b9 01       ..
+    !text "UNTIL"                                                     ; 87da: 55 4e 54... UNT
+    !byte $fd,   2                                                    ; 87df: fd 02       ..
+    !text "USR"                                                       ; 87e1: 55 53 52    USR
+    !byte $ba,   0                                                    ; 87e4: ba 00       ..
+    !text "VDU"                                                       ; 87e6: 56 44 55    VDU
+    !byte $ef,   2                                                    ; 87e9: ef 02       ..
+    !text "VAL"                                                       ; 87eb: 56 41 4c    VAL
+    !byte $bb,   0                                                    ; 87ee: bb 00       ..
+    !text "VPOS"                                                      ; 87f0: 56 50 4f... VPO
+    !byte $bc,   1                                                    ; 87f4: bc 01       ..
+    !text "WIDTH"                                                     ; 87f6: 57 49 44... WID
+    !byte $fe,   2                                                    ; 87fb: fe 02       ..
+    !text "PAGE"                                                      ; 87fd: 50 41 47... PAG
+    !byte $d0,   0                                                    ; 8801: d0 00       ..
+    !text "PTR"                                                       ; 8803: 50 54 52    PTR
+    !byte $cf,   0, $54, $49                                          ; 8806: cf 00 54... ..T
+; $880a referenced 1 time by $90e0
+l880a
+    !byte $4d, $45, $d1,   0                                          ; 880a: 4d 45 d1... ME.
+    !text "LOMEM"                                                     ; 880e: 4c 4f 4d... LOM
+    !byte $d2,   0                                                    ; 8813: d2 00       ..
+    !text "HIMEM"                                                     ; 8815: 48 49 4d... HIM
+    !byte $d3,   0                                                    ; 881a: d3 00       ..
+    !text "Missing "                                                  ; 881c: 4d 69 73... Mis
+    !byte $8d,   0                                                    ; 8824: 8d 00       ..
+l8826
+l8909 = l8826+227
+    !word sub_cab37, sub_cab21, sub_cae50, sub_cae8c, sub_cae71       ; 8826: 37 ab 21... 7.!
+    !word sub_cae77, sub_cad00, sub_ca6fc, sub_cae34, sub_cac03       ; 8830: 77 ae 00... w..
+    !word sub_ca901, sub_ca919, sub_cab2f, sub_ca954, sub_cae6d       ; 883a: 01 a9 19... ...
+    !word sub_ca9ca, sub_cae7d, sub_cae83, sub_cab5c, sub_caa17       ; 8844: ca a9 7d... ..}
+    !word sub_cab1d,     cac38, sub_cb055, sub_cae87, sub_cac12       ; 884e: 1d ab 38... ..8
+    !word sub_cac7f, sub_cabe1, sub_cae59, sub_ca7ac, sub_ca9bc       ; 8858: 7f ac e1... ...
+    !word sub_caaeb, sub_cab3f, sub_cab3b, sub_cab54, sub_cac5d       ; 8862: eb aa 3f... ..?
+    !word sub_caafb, sub_ca9b5, sub_caacb, sub_cac46, sub_ca94f       ; 886c: fb aa b5... ...
+    !word sub_ca808, sub_ca96b, sub_cae41,     cac2b, sub_cab01       ; 8876: 08 a8 6b... ..k
+    !word sub_caba0, sub_cab14, sub_cb269, sub_caeb1, sub_caefb       ; 8880: a0 ab 14... ...
+    !word sub_caebb, sub_caf0a, sub_caebc, sub_caf61, sub_caf8b       ; 888a: bb ae 0a... ...
+    !word sub_cac1f, sub_c954c, sub_c93da, sub_c8fe5, sub_cb412       ; 8894: 1f ac 4c... ..L
+    !word sub_c9042, sub_c8fc5, sub_c9447, sub_cbe95, sub_cb3c8       ; 889e: 42 90 c5... B..
+    !word sub_cbed7, sub_c96f9, sub_c973e, sub_c96e5, sub_c96d4       ; 88a8: d7 be f9... ...
+    !word sub_cb302, sub_cbefd, sub_c9381, sub_c8fc0, sub_c9703       ; 88b2: 02 b3 fd... ...
+    !word sub_cbeee, sub_c98af, sub_c98b6,     c9073,     c9073       ; 88bc: ee be af... ...
+    !word     c95f9, sub_c9875, sub_c8fea, sub_c9c5e, sub_cb326       ; 88c6: f9 95 75... ..u
+    !word sub_cb649, sub_cb709, sub_cb74d, sub_c9810, sub_c9ccc       ; 88d0: 49 b6 09... I..
+    !word sub_cb8e6, sub_c910d,     c97d2, sub_c982e, sub_c9871       ; 88da: e6 b8 0d... ...
+    !word     cb522, sub_cb78b,     c98dc, sub_c9880, sub_c9250       ; 88e4: 22 b5 8b... "..
+    !word sub_c97a9,     cb9ad,     c9073, sub_cba88, sub_c98c3       ; 88ee: a9 97 ad... ...
+    !word sub_cb97d, sub_cb737, sub_c8fd7, sub_c9149, sub_c9824       ; 88f8: 7d b9 37... }.7
+    !word sub_c970b, sub_cba47, sub_cb351, sub_cbec7, sub_c834b       ; 8902: 0b 97 47... ..G
+    !word sub_c8984, sub_cb896                                        ; 890c: 84 89 96... ...
+; $8909 referenced 1 time by $8ae3
+    !byte $b9, $d8, $d9, $f0,   1, $10, $81, $90, $89, $93, $a3, $a4  ; 8910: b9 d8 d9... ...
+    !byte $a9                                                         ; 891c: a9          .
+    !text "89x"                                                       ; 891d: 38 39 78    89x
+    !byte   1, $13, $21, $a1, $c1, $19, $18, $99, $98, $63, $73, $b1  ; 8920: 01 13 21... ..!
+    !byte $a9, $c5, $0c, $c3, $d3, $41, $c4, $f2, $41, $83, $b0, $81  ; 892c: a9 c5 0c... ...
+    !text "Clr"                                                       ; 8938: 43 6c 72    Clr
+    !byte $ec, $f2, $a3, $c3, $92, $9a, $18, $19                      ; 893b: ec f2 a3... ...
+    !text "bB4"                                                       ; 8943: 62 42 34    bB4
+    !byte $b0, $72, $98, $99, $81, $98, $99, $14                      ; 8946: b0 72 98... .r.
+; $894e referenced 1 time by $8ae8
+l894e
+    !byte $35, $0a, $0d, $0d, $0d, $0d, $10, $10                      ; 894e: 35 0a 0d... 5..
+    !text "%%9AAAAJJLLLPPRSSS"                                        ; 8956: 25 25 39... %%9
+    !byte $10                                                         ; 8968: 10          .
+    !text "%AAAA"                                                     ; 8969: 25 41 41... %AA
+    !byte   8,   8,   8,   9,   9, $0a, $0a, $0a, $0a,   5, $15, $3e  ; 896e: 08 08 08... ...
+    !byte   4, $0d, $30, $4c,   6                                     ; 897a: 04 0d 30... ..0
+    !text "2II"                                                       ; 897f: 32 49 49    2II
+    !byte $10, $25                                                    ; 8982: 10 25       .%
+
+sub_c8984
+    ora l0e4e                                                         ; 8984: 0d 4e 0e    .N.
+    asl l5252                                                         ; 8987: 0e 52 52    .RR
+    ora #$29 ; ')'                                                    ; 898a: 09 29       .)
+    rol                                                               ; 898c: 2a          *
+    bmi c89bf                                                         ; 898d: 30 30       00
+    lsr l4e4e                                                         ; 898f: 4e 4e 4e    NNN
+sub_c8992
+l8993 = sub_c8992+1
+    rol+2 l0016,x                                                     ; 8992: 3e 16 00    >..
+; $8993 referenced 1 time by $8b10
+    clc                                                               ; 8995: 18          .
+    cld                                                               ; 8996: d8          .
+    cli                                                               ; 8997: 58          X
+    clv                                                               ; 8998: b8          .
+    dex                                                               ; 8999: ca          .
+    dey                                                               ; 899a: 88          .
+    inx                                                               ; 899b: e8          .
+    iny                                                               ; 899c: c8          .
+    nop                                                               ; 899d: ea          .
+    pha                                                               ; 899e: 48          H
+    php                                                               ; 899f: 08          .
+    pla                                                               ; 89a0: 68          h
+    plp                                                               ; 89a1: 28          (
+    rti                                                               ; 89a2: 40          @
+
+    !byte $60, $38, $f8, $78, $aa, $a8, $ba, $8a, $9a, $98, $3a, $1a  ; 89a3: 60 38 f8... `8.
+    !byte $5a, $da, $7a, $fa, $90, $b0, $f0, $30, $d0, $10, $50, $70  ; 89af: 5a da 7a... Z.z
+    !byte $80, $21, $41,   1                                          ; 89bb: 80 21 41... .!A
+
+; $89bf referenced 1 time by $898d
+c89bf
+    adc (l00c1,x)                                                     ; 89bf: 61 c1       a.
+    lda (l00e1,x)                                                     ; 89c1: a1 e1       ..
+    asl l0046                                                         ; 89c3: 06 46       .F
+    rol l0066                                                         ; 89c5: 26 66       &f
+    dec l00e6                                                         ; 89c7: c6 e6       ..
+    stz le09c                                                         ; 89c9: 9c 9c e0    ...
+    cpy #0                                                            ; 89cc: c0 00       ..
+    bpl c89f4                                                         ; 89ce: 10 24       .$
+    jmp ca220                                                         ; 89d0: 4c 20 a2    L .
+
+    !byte $a0, $81, $86, $84                                          ; 89d3: a0 81 86... ...
+
+; $89d7 referenced 1 time by $89e2
+loop_c89d7
+    dec                                                               ; 89d7: 3a          :
+    sta l0028                                                         ; 89d8: 85 28       .(
+    jmp c90d0                                                         ; 89da: 4c d0 90    L..
+
+; $89dd referenced 2 times by $8a8e, $90aa
+c89dd
+    jsr c8f9d                                                         ; 89dd: 20 9d 8f     ..
+    eor #$5d ; ']'                                                    ; 89e0: 49 5d       I]
+    beq loop_c89d7                                                    ; 89e2: f0 f3       ..
+    jsr c9c80                                                         ; 89e4: 20 80 9c     ..
+    dec l000a                                                         ; 89e7: c6 0a       ..
+    jsr sub_c8aa8                                                     ; 89e9: 20 a8 8a     ..
+    dec l000a                                                         ; 89ec: c6 0a       ..
+    lda l0028                                                         ; 89ee: a5 28       .(
+    lsr                                                               ; 89f0: 4a          J
+    bcc c8a6b                                                         ; 89f1: 90 78       .x
+; overlapping: lda l001e                                              ; 89f3: a5 1e       ..
+    !byte $a5                                                         ; 89f3: a5          .
+
+; $89f4 referenced 1 time by $89ce
+c89f4
+    asl l0469,x                                                       ; 89f4: 1e 69 04    .i.
+; overlapping: adc #4                                                 ; 89f5: 69 04       i.
+    sta l003f                                                         ; 89f7: 85 3f       .?
+    lda l0038                                                         ; 89f9: a5 38       .8
+    jsr sub_cbdac                                                     ; 89fb: 20 ac bd     ..
+    lda l0037                                                         ; 89fe: a5 37       .7
+    jsr sub_cbdcf                                                     ; 8a00: 20 cf bd     ..
+    ldx #$fc                                                          ; 8a03: a2 fc       ..
+    ldy l0039                                                         ; 8a05: a4 39       .9
+    bpl c8a0b                                                         ; 8a07: 10 02       ..
+    ldy l0036                                                         ; 8a09: a4 36       .6
+; $8a0b referenced 1 time by $8a07
+c8a0b
+    sty l0038                                                         ; 8a0b: 84 38       .8
+    beq c8a28                                                         ; 8a0d: f0 19       ..
+    ldy #0                                                            ; 8a0f: a0 00       ..
+; $8a11 referenced 1 time by $8a26
+loop_c8a11
+    inx                                                               ; 8a11: e8          .
+    bne c8a1e                                                         ; 8a12: d0 0a       ..
+    jsr sub_cbac2                                                     ; 8a14: 20 c2 ba     ..
+    ldx l003f                                                         ; 8a17: a6 3f       .?
+    jsr cbdff                                                         ; 8a19: 20 ff bd     ..
+    ldx #$fd                                                          ; 8a1c: a2 fd       ..
+; $8a1e referenced 1 time by $8a12
+c8a1e
+    lda (l003a),y                                                     ; 8a1e: b1 3a       .:
+    jsr sub_cbdcf                                                     ; 8a20: 20 cf bd     ..
+    iny                                                               ; 8a23: c8          .
+    dec l0038                                                         ; 8a24: c6 38       .8
+    bne loop_c8a11                                                    ; 8a26: d0 e9       ..
+; $8a28 referenced 1 time by $8a0d
+c8a28
+    txa                                                               ; 8a28: 8a          .
+    tay                                                               ; 8a29: a8          .
+; $8a2a referenced 1 time by $8a32
+loop_c8a2a
+    iny                                                               ; 8a2a: c8          .
+    beq c8a34                                                         ; 8a2b: f0 07       ..
+    ldx #3                                                            ; 8a2d: a2 03       ..
+    jsr cbdff                                                         ; 8a2f: 20 ff bd     ..
+    bra loop_c8a2a                                                    ; 8a32: 80 f6       ..
+; $8a34 referenced 1 time by $8a2b
+c8a34
+    ldx #$0a                                                          ; 8a34: a2 0a       ..
+    lda (l000b)                                                       ; 8a36: b2 0b       ..
+    cmp #$2e ; '.'                                                    ; 8a38: c9 2e       ..
+    bne c8a4b                                                         ; 8a3a: d0 0f       ..
+; $8a3c referenced 1 time by $8a49
+loop_c8a3c
+    jsr sub_cbd77                                                     ; 8a3c: 20 77 bd     w.
+    dex                                                               ; 8a3f: ca          .
+    bne c8a44                                                         ; 8a40: d0 02       ..
+    ldx #1                                                            ; 8a42: a2 01       ..
+; $8a44 referenced 1 time by $8a40
+c8a44
+    iny                                                               ; 8a44: c8          .
+    lda (l000b),y                                                     ; 8a45: b1 0b       ..
+    cpy l004e                                                         ; 8a47: c4 4e       .N
+    bne loop_c8a3c                                                    ; 8a49: d0 f1       ..
+; $8a4b referenced 1 time by $8a3a
+c8a4b
+    jsr cbdff                                                         ; 8a4b: 20 ff bd     ..
+    dey                                                               ; 8a4e: 88          .
+; $8a4f referenced 1 time by $8a52
+loop_c8a4f
+    iny                                                               ; 8a4f: c8          .
+    cmp (l000b),y                                                     ; 8a50: d1 0b       ..
+    beq loop_c8a4f                                                    ; 8a52: f0 fb       ..
+; $8a54 referenced 1 time by $8a62
+loop_c8a54
+    lda (l000b),y                                                     ; 8a54: b1 0b       ..
+    cmp #$3a ; ':'                                                    ; 8a56: c9 3a       .:
+    beq c8a64                                                         ; 8a58: f0 0a       ..
+    cmp #$0d                                                          ; 8a5a: c9 0d       ..
+    beq c8a68                                                         ; 8a5c: f0 0a       ..
+; $8a5e referenced 1 time by $8a66
+loop_c8a5e
+    jsr sub_cbd77                                                     ; 8a5e: 20 77 bd     w.
+    iny                                                               ; 8a61: c8          .
+    bra loop_c8a54                                                    ; 8a62: 80 f0       ..
+; $8a64 referenced 1 time by $8a58
+c8a64
+    cpy l000a                                                         ; 8a64: c4 0a       ..
+    bcc loop_c8a5e                                                    ; 8a66: 90 f6       ..
+; $8a68 referenced 1 time by $8a5c
+c8a68
+    jsr sub_cbac2                                                     ; 8a68: 20 c2 ba     ..
+; $8a6b referenced 1 time by $89f1
+c8a6b
+    ldy l000a                                                         ; 8a6b: a4 0a       ..
+    dey                                                               ; 8a6d: 88          .
+; $8a6e referenced 1 time by $8a77
+loop_c8a6e
+    iny                                                               ; 8a6e: c8          .
+    lda (l000b),y                                                     ; 8a6f: b1 0b       ..
+    cmp #$3a ; ':'                                                    ; 8a71: c9 3a       .:
+    beq c8a79                                                         ; 8a73: f0 04       ..
+    cmp #$0d                                                          ; 8a75: c9 0d       ..
+    bne loop_c8a6e                                                    ; 8a77: d0 f5       ..
+; $8a79 referenced 1 time by $8a73
+c8a79
+    jsr c9c6c                                                         ; 8a79: 20 6c 9c     l.
+    lda (l000b)                                                       ; 8a7c: b2 0b       ..
+    cmp #$3a ; ':'                                                    ; 8a7e: c9 3a       .:
+    beq c8a8e                                                         ; 8a80: f0 0c       ..
+    lda l000c                                                         ; 8a82: a5 0c       ..
+    cmp #7                                                            ; 8a84: c9 07       ..
+    bne c8a8b                                                         ; 8a86: d0 03       ..
+    jmp c904b                                                         ; 8a88: 4c 4b 90    LK.
+
+; $8a8b referenced 1 time by $8a86
+c8a8b
+    jsr sub_c9ca2                                                     ; 8a8b: 20 a2 9c     ..
+; $8a8e referenced 1 time by $8a80
+c8a8e
+    jmp c89dd                                                         ; 8a8e: 4c dd 89    L..
+
+; $8a91 referenced 1 time by $8abd
+c8a91
+    jsr sub_c997d                                                     ; 8a91: 20 7d 99     }.
+    beq c8af2                                                         ; 8a94: f0 5c       .\
+    bcs c8af2                                                         ; 8a96: b0 5a       .Z
+    jsr sub_cbc83                                                     ; 8a98: 20 83 bc     ..
+    jsr sub_cadc6                                                     ; 8a9b: 20 c6 ad     ..
+    sta l0027                                                         ; 8a9e: 85 27       .'
+    jsr sub_cb365                                                     ; 8aa0: 20 65 b3     e.
+    jsr c9338                                                         ; 8aa3: 20 38 93     8.
+    sty l004e                                                         ; 8aa6: 84 4e       .N
+; $8aa8 referenced 1 time by $89e9
+sub_c8aa8
+    jsr c8f9d                                                         ; 8aa8: 20 9d 8f     ..
+    ldy #0                                                            ; 8aab: a0 00       ..
+    stz l003d                                                         ; 8aad: 64 3d       d=
+    cmp #$3a ; ':'                                                    ; 8aaf: c9 3a       .:
+    beq c8b1b                                                         ; 8ab1: f0 68       .h
+    cmp #$0d                                                          ; 8ab3: c9 0d       ..
+    beq c8b1b                                                         ; 8ab5: f0 64       .d
+    cmp #$5c ; '\'                                                    ; 8ab7: c9 5c       .\
+    beq c8b1b                                                         ; 8ab9: f0 60       .`
+    cmp #$2e ; '.'                                                    ; 8abb: c9 2e       ..
+    beq c8a91                                                         ; 8abd: f0 d2       ..
+    dec l000a                                                         ; 8abf: c6 0a       ..
+    ldx #3                                                            ; 8ac1: a2 03       ..
+; $8ac3 referenced 1 time by $8add
+loop_c8ac3
+    ldy l000a                                                         ; 8ac3: a4 0a       ..
+    inc l000a                                                         ; 8ac5: e6 0a       ..
+    lda (l000b),y                                                     ; 8ac7: b1 0b       ..
+    bmi c8af5                                                         ; 8ac9: 30 2a       0*
+    cmp #$20 ; ' '                                                    ; 8acb: c9 20       .
+    beq c8adf                                                         ; 8acd: f0 10       ..
+    ldy #5                                                            ; 8acf: a0 05       ..
+    asl                                                               ; 8ad1: 0a          .
+    asl                                                               ; 8ad2: 0a          .
+    asl                                                               ; 8ad3: 0a          .
+; $8ad4 referenced 1 time by $8ada
+loop_c8ad4
+    asl                                                               ; 8ad4: 0a          .
+    rol l003d                                                         ; 8ad5: 26 3d       &=
+    rol l003e                                                         ; 8ad7: 26 3e       &>
+    dey                                                               ; 8ad9: 88          .
+    bne loop_c8ad4                                                    ; 8ada: d0 f8       ..
+    dex                                                               ; 8adc: ca          .
+    bne loop_c8ac3                                                    ; 8add: d0 e4       ..
+; $8adf referenced 1 time by $8acd
+c8adf
+    ldx #$45 ; 'E'                                                    ; 8adf: a2 45       .E
+    lda l003d                                                         ; 8ae1: a5 3d       .=
+; $8ae3 referenced 1 time by $8af0
+loop_c8ae3
+    cmp l8909,x                                                       ; 8ae3: dd 09 89    ...
+    bne c8aef                                                         ; 8ae6: d0 07       ..
+    ldy l894e,x                                                       ; 8ae8: bc 4e 89    .N.
+    cpy l003e                                                         ; 8aeb: c4 3e       .>
+    beq c8b10                                                         ; 8aed: f0 21       .!
+; $8aef referenced 1 time by $8ae6
+c8aef
+    dex                                                               ; 8aef: ca          .
+    bne loop_c8ae3                                                    ; 8af0: d0 f1       ..
+; $8af2 referenced 4 times by $8a94, $8a96, $8b03, $8b0e
+c8af2
+    jmp c9c2d                                                         ; 8af2: 4c 2d 9c    L-.
+
+; $8af5 referenced 1 time by $8ac9
+c8af5
+    ldx #$29 ; ')'                                                    ; 8af5: a2 29       .)
+    cmp #$80                                                          ; 8af7: c9 80       ..
+    beq c8b10                                                         ; 8af9: f0 15       ..
+    inx                                                               ; 8afb: e8          .
+    cmp #$82                                                          ; 8afc: c9 82       ..
+    beq c8b10                                                         ; 8afe: f0 10       ..
+    inx                                                               ; 8b00: e8          .
+    cmp #$84                                                          ; 8b01: c9 84       ..
+    bne c8af2                                                         ; 8b03: d0 ed       ..
+    inc l000a                                                         ; 8b05: e6 0a       ..
+    iny                                                               ; 8b07: c8          .
+    lda (l000b),y                                                     ; 8b08: b1 0b       ..
+    and #$df                                                          ; 8b0a: 29 df       ).
+    cmp #$41 ; 'A'                                                    ; 8b0c: c9 41       .A
+    bne c8af2                                                         ; 8b0e: d0 e2       ..
+; $8b10 referenced 3 times by $8aed, $8af9, $8afe
+c8b10
+    lda l8993,x                                                       ; 8b10: bd 93 89    ...
+    sta l0029                                                         ; 8b13: 85 29       .)
+    ldy #1                                                            ; 8b15: a0 01       ..
+    cpx #$20 ; ' '                                                    ; 8b17: e0 20       .
+    bcs c8b63                                                         ; 8b19: b0 48       .H
+; $8b1b referenced 6 times by $8ab1, $8ab5, $8ab9, $8ba0, $8cbd, $8d6e
+c8b1b
+    lda l0440                                                         ; 8b1b: ad 40 04    .@.
+    sta l0037                                                         ; 8b1e: 85 37       .7
+    sty l0039                                                         ; 8b20: 84 39       .9
+    ldx l0028                                                         ; 8b22: a6 28       .(
+    cpx #4                                                            ; 8b24: e0 04       ..
+    ldx l0441                                                         ; 8b26: ae 41 04    .A.
+    stx l0038                                                         ; 8b29: 86 38       .8
+    bcc c8b33                                                         ; 8b2b: 90 06       ..
+    lda l043c                                                         ; 8b2d: ad 3c 04    .<.
+    ldx l043d                                                         ; 8b30: ae 3d 04    .=.
+; $8b33 referenced 1 time by $8b2b
+c8b33
+    sta l003a                                                         ; 8b33: 85 3a       .:
+    stx l003b                                                         ; 8b35: 86 3b       .;
+    tya                                                               ; 8b37: 98          .
+    beq c8b62                                                         ; 8b38: f0 28       .(
+    bpl c8b40                                                         ; 8b3a: 10 04       ..
+    ldy l0036                                                         ; 8b3c: a4 36       .6
+    beq c8b62                                                         ; 8b3e: f0 22       ."
+; $8b40 referenced 2 times by $8b3a, $8b60
+c8b40
+    dey                                                               ; 8b40: 88          .
+    lda l0029,y                                                       ; 8b41: b9 29 00    .).
+    bit l0039                                                         ; 8b44: 24 39       $9
+    bpl c8b4b                                                         ; 8b46: 10 03       ..
+    lda l0600,y                                                       ; 8b48: b9 00 06    ...
+; $8b4b referenced 1 time by $8b46
+c8b4b
+    sta (l003a),y                                                     ; 8b4b: 91 3a       .:
+    inc l0440                                                         ; 8b4d: ee 40 04    .@.
+    bne c8b55                                                         ; 8b50: d0 03       ..
+    inc l0441                                                         ; 8b52: ee 41 04    .A.
+; $8b55 referenced 1 time by $8b50
+c8b55
+    bcc c8b5f                                                         ; 8b55: 90 08       ..
+    inc l043c                                                         ; 8b57: ee 3c 04    .<.
+    bne c8b5f                                                         ; 8b5a: d0 03       ..
+    inc l043d                                                         ; 8b5c: ee 3d 04    .=.
+; $8b5f referenced 2 times by $8b55, $8b5a
+c8b5f
+    tya                                                               ; 8b5f: 98          .
+    bne c8b40                                                         ; 8b60: d0 de       ..
+; $8b62 referenced 2 times by $8b38, $8b3e
+c8b62
+    rts                                                               ; 8b62: 60          `
+
+; $8b63 referenced 1 time by $8b19
+c8b63
+    cpx #$29 ; ')'                                                    ; 8b63: e0 29       .)
+    bcs c8ba3                                                         ; 8b65: b0 3c       .<
+    jsr sub_c9332                                                     ; 8b67: 20 32 93     2.
+    clc                                                               ; 8b6a: 18          .
+    lda l002a                                                         ; 8b6b: a5 2a       .*
+    sbc l0440                                                         ; 8b6d: ed 40 04    .@.
+    tay                                                               ; 8b70: a8          .
+    lda l002b                                                         ; 8b71: a5 2b       .+
+    sbc l0441                                                         ; 8b73: ed 41 04    .A.
+    cpy #1                                                            ; 8b76: c0 01       ..
+    dey                                                               ; 8b78: 88          .
+    sbc #0                                                            ; 8b79: e9 00       ..
+    beq c8b98                                                         ; 8b7b: f0 1b       ..
+    inc                                                               ; 8b7d: 1a          .
+    bne c8b83                                                         ; 8b7e: d0 03       ..
+    tya                                                               ; 8b80: 98          .
+    bmi c8b9c                                                         ; 8b81: 30 19       0.
+; $8b83 referenced 2 times by $8b7e, $8b99
+c8b83
+    lda l0028                                                         ; 8b83: a5 28       .(
+    and #2                                                            ; 8b85: 29 02       ).
+    beq c8b9b                                                         ; 8b87: f0 12       ..
+    brk                                                               ; 8b89: 00          .
+
+    !byte 1                                                           ; 8b8a: 01          .
+    !text "Out of range"                                              ; 8b8b: 4f 75 74... Out
+    !byte 0                                                           ; 8b97: 00          .
+
+; $8b98 referenced 1 time by $8b7b
+c8b98
+    tya                                                               ; 8b98: 98          .
+    bmi c8b83                                                         ; 8b99: 30 e8       0.
+; $8b9b referenced 1 time by $8b87
+c8b9b
+    tay                                                               ; 8b9b: a8          .
+; $8b9c referenced 1 time by $8b81
+c8b9c
+    sty l002a                                                         ; 8b9c: 84 2a       .*
+; $8b9e referenced 1 time by $8bb4
+loop_c8b9e
+    ldy #2                                                            ; 8b9e: a0 02       ..
+    jmp c8b1b                                                         ; 8ba0: 4c 1b 8b    L..
+
+; $8ba3 referenced 1 time by $8b65
+c8ba3
+    cpx #$30 ; '0'                                                    ; 8ba3: e0 30       .0
+    bcs c8bbd                                                         ; 8ba5: b0 16       ..
+    jsr sub_c8d9c                                                     ; 8ba7: 20 9c 8d     ..
+    bne c8bc4                                                         ; 8baa: d0 18       ..
+    jsr sub_c8d89                                                     ; 8bac: 20 89 8d     ..
+; $8baf referenced 1 time by $8ca4
+c8baf
+    jsr sub_c9332                                                     ; 8baf: 20 32 93     2.
+; $8bb2 referenced 3 times by $8bdc, $8be5, $8bf7
+c8bb2
+    lda l002b                                                         ; 8bb2: a5 2b       .+
+; $8bb4 referenced 1 time by $8c22
+c8bb4
+    beq loop_c8b9e                                                    ; 8bb4: f0 e8       ..
+; $8bb6 referenced 1 time by $8d31
+c8bb6
+    brk                                                               ; 8bb6: 00          .
+
+    !byte 2                                                           ; 8bb7: 02          .
+    !text "Byte"                                                      ; 8bb8: 42 79 74... Byt
+    !byte 0                                                           ; 8bbc: 00          .
+
+; $8bbd referenced 1 time by $8ba5
+c8bbd
+    cpx #$41 ; 'A'                                                    ; 8bbd: e0 41       .A
+    bne c8c24                                                         ; 8bbf: d0 63       .c
+    jsr c8f9d                                                         ; 8bc1: 20 9d 8f     ..
+; $8bc4 referenced 1 time by $8baa
+c8bc4
+    cmp #$28 ; '('                                                    ; 8bc4: c9 28       .(
+    bne c8c01                                                         ; 8bc6: d0 39       .9
+    jsr sub_c9332                                                     ; 8bc8: 20 32 93     2.
+    jsr c8f9d                                                         ; 8bcb: 20 9d 8f     ..
+    cmp #$29 ; ')'                                                    ; 8bce: c9 29       .)
+    bne c8be9                                                         ; 8bd0: d0 17       ..
+    jsr sub_c8d86                                                     ; 8bd2: 20 86 8d     ..
+    jsr sub_c8da2                                                     ; 8bd5: 20 a2 8d     ..
+    beq c8bde                                                         ; 8bd8: f0 04       ..
+    inc l0029                                                         ; 8bda: e6 29       .)
+    bra c8bb2                                                         ; 8bdc: 80 d4       ..
+; $8bde referenced 1 time by $8bd8
+c8bde
+    jsr c8f9d                                                         ; 8bde: 20 9d 8f     ..
+    and #$df                                                          ; 8be1: 29 df       ).
+    cmp #$59 ; 'Y'                                                    ; 8be3: c9 59       .Y
+    beq c8bb2                                                         ; 8be5: f0 cb       ..
+    bra c8bf9                                                         ; 8be7: 80 10       ..
+; $8be9 referenced 1 time by $8bd0
+c8be9
+    cmp #$2c ; ','                                                    ; 8be9: c9 2c       .,
+    bne c8bf9                                                         ; 8beb: d0 0c       ..
+    jsr sub_c8d94                                                     ; 8bed: 20 94 8d     ..
+    bne c8bf9                                                         ; 8bf0: d0 07       ..
+    jsr c8f9d                                                         ; 8bf2: 20 9d 8f     ..
+    cmp #$29 ; ')'                                                    ; 8bf5: c9 29       .)
+    beq c8bb2                                                         ; 8bf7: f0 b9       ..
+; $8bf9 referenced 6 times by $8be7, $8beb, $8bf0, $8c13, $8c41, $8ce3
+c8bf9
+    brk                                                               ; 8bf9: 00          .
+
+    !byte 3                                                           ; 8bfa: 03          .
+    !text "Index"                                                     ; 8bfb: 49 6e 64... Ind
+    !byte 0                                                           ; 8c00: 00          .
+
+; $8c01 referenced 1 time by $8bc6
+c8c01
+    jsr sub_c9330                                                     ; 8c01: 20 30 93     0.
+    jsr sub_c8da2                                                     ; 8c04: 20 a2 8d     ..
+    bne c8c1b                                                         ; 8c07: d0 12       ..
+    jsr sub_c8d86                                                     ; 8c09: 20 86 8d     ..
+    jsr sub_c8d94                                                     ; 8c0c: 20 94 8d     ..
+    beq c8c1b                                                         ; 8c0f: f0 0a       ..
+    cmp #$59 ; 'Y'                                                    ; 8c11: c9 59       .Y
+    bne c8bf9                                                         ; 8c13: d0 e4       ..
+; $8c15 referenced 1 time by $8c20
+loop_c8c15
+    jsr sub_c8d89                                                     ; 8c15: 20 89 8d     ..
+    jmp c8cbb                                                         ; 8c18: 4c bb 8c    L..
+
+; $8c1b referenced 3 times by $8c07, $8c0f, $8c99
+c8c1b
+    jsr sub_c8d8c                                                     ; 8c1b: 20 8c 8d     ..
+; $8c1e referenced 3 times by $8c37, $8c3f, $8d34
+c8c1e
+    lda l002b                                                         ; 8c1e: a5 2b       .+
+    bne loop_c8c15                                                    ; 8c20: d0 f3       ..
+    bra c8bb4                                                         ; 8c22: 80 90       ..
+; $8c24 referenced 1 time by $8bbf
+c8c24
+    cpx #$36 ; '6'                                                    ; 8c24: e0 36       .6
+    bcs c8c5e                                                         ; 8c26: b0 36       .6
+    jsr c8f9d                                                         ; 8c28: 20 9d 8f     ..
+    and #$df                                                          ; 8c2b: 29 df       ).
+    cmp #$41 ; 'A'                                                    ; 8c2d: c9 41       .A
+    beq c8c43                                                         ; 8c2f: f0 12       ..
+; $8c31 referenced 2 times by $8c49, $8c9e
+c8c31
+    jsr sub_c9330                                                     ; 8c31: 20 30 93     0.
+    jsr sub_c8da2                                                     ; 8c34: 20 a2 8d     ..
+    bne c8c1e                                                         ; 8c37: d0 e5       ..
+    jsr sub_c8d86                                                     ; 8c39: 20 86 8d     ..
+    jsr sub_c8d94                                                     ; 8c3c: 20 94 8d     ..
+    beq c8c1e                                                         ; 8c3f: f0 dd       ..
+; $8c41 referenced 1 time by $8c7d
+c8c41
+    bra c8bf9                                                         ; 8c41: 80 b6       ..
+; $8c43 referenced 1 time by $8c2f
+c8c43
+    iny                                                               ; 8c43: c8          .
+    lda (l000b),y                                                     ; 8c44: b1 0b       ..
+    jsr sub_c8e41                                                     ; 8c46: 20 41 8e     A.
+    bcs c8c31                                                         ; 8c49: b0 e6       ..
+    ldy #$16                                                          ; 8c4b: a0 16       ..
+    cpx #$34 ; '4'                                                    ; 8c4d: e0 34       .4
+    bcc c8c57                                                         ; 8c4f: 90 06       ..
+    bne c8c55                                                         ; 8c51: d0 02       ..
+    ldy #$36 ; '6'                                                    ; 8c53: a0 36       .6
+; $8c55 referenced 1 time by $8c51
+c8c55
+    sty l0029                                                         ; 8c55: 84 29       .)
+; $8c57 referenced 1 time by $8c4f
+c8c57
+    jsr sub_c8d8c                                                     ; 8c57: 20 8c 8d     ..
+    ldy #1                                                            ; 8c5a: a0 01       ..
+    bra c8cbd                                                         ; 8c5c: 80 5f       ._
+; $8c5e referenced 1 time by $8c26
+c8c5e
+    cpx #$38 ; '8'                                                    ; 8c5e: e0 38       .8
+    bcs c8c87                                                         ; 8c60: b0 25       .%
+    jsr sub_c9332                                                     ; 8c62: 20 32 93     2.
+    ldy #3                                                            ; 8c65: a0 03       ..
+    ldx #1                                                            ; 8c67: a2 01       ..
+    lda l002b                                                         ; 8c69: a5 2b       .+
+    bne c8c74                                                         ; 8c6b: d0 07       ..
+    ldx #$0f                                                          ; 8c6d: a2 0f       ..
+    lda #$64 ; 'd'                                                    ; 8c6f: a9 64       .d
+    sta l0029                                                         ; 8c71: 85 29       .)
+    dey                                                               ; 8c73: 88          .
+; $8c74 referenced 1 time by $8c6b
+c8c74
+    phy                                                               ; 8c74: 5a          Z
+    jsr sub_c8da2                                                     ; 8c75: 20 a2 8d     ..
+    bne c8c84                                                         ; 8c78: d0 0a       ..
+    jsr sub_c8d94                                                     ; 8c7a: 20 94 8d     ..
+    bne c8c41                                                         ; 8c7d: d0 c2       ..
+    txa                                                               ; 8c7f: 8a          .
+    adc l0029                                                         ; 8c80: 65 29       e)
+    sta l0029                                                         ; 8c82: 85 29       .)
+; $8c84 referenced 1 time by $8c78
+c8c84
+    ply                                                               ; 8c84: 7a          z
+    bra c8cbd                                                         ; 8c85: 80 36       .6
+; $8c87 referenced 1 time by $8c60
+c8c87
+    cpx #$3c ; '<'                                                    ; 8c87: e0 3c       .<
+    bcs c8ca7                                                         ; 8c89: b0 1c       ..
+    cpx #$3a ; ':'                                                    ; 8c8b: e0 3a       .:
+    bcs c8c96                                                         ; 8c8d: b0 07       ..
+    jsr sub_c8d9c                                                     ; 8c8f: 20 9c 8d     ..
+    beq c8ca4                                                         ; 8c92: f0 10       ..
+    dec l000a                                                         ; 8c94: c6 0a       ..
+; $8c96 referenced 1 time by $8c8d
+c8c96
+    jsr sub_c9332                                                     ; 8c96: 20 32 93     2.
+; $8c99 referenced 2 times by $8d06, $8d14
+c8c99
+    bra c8c1b                                                         ; 8c99: 80 80       ..
+; $8c9b referenced 1 time by $8ca7
+loop_c8c9b
+    jsr sub_c8d9c                                                     ; 8c9b: 20 9c 8d     ..
+    bne c8c31                                                         ; 8c9e: d0 91       ..
+    ldy #$89                                                          ; 8ca0: a0 89       ..
+    sty l0029                                                         ; 8ca2: 84 29       .)
+; $8ca4 referenced 2 times by $8c92, $8cfb
+c8ca4
+    jmp c8baf                                                         ; 8ca4: 4c af 8b    L..
+
+; $8ca7 referenced 1 time by $8c89
+c8ca7
+    beq loop_c8c9b                                                    ; 8ca7: f0 f2       ..
+    cpx #$3e ; '>'                                                    ; 8ca9: e0 3e       .>
+    beq c8cb8                                                         ; 8cab: f0 0b       ..
+    bcs c8ce6                                                         ; 8cad: b0 37       .7
+    jsr c8f9d                                                         ; 8caf: 20 9d 8f     ..
+    cmp #$28 ; '('                                                    ; 8cb2: c9 28       .(
+    beq c8cc0                                                         ; 8cb4: f0 0a       ..
+    dec l000a                                                         ; 8cb6: c6 0a       ..
+; $8cb8 referenced 1 time by $8cab
+c8cb8
+    jsr sub_c9332                                                     ; 8cb8: 20 32 93     2.
+; $8cbb referenced 3 times by $8c18, $8cce, $8ce1
+c8cbb
+    ldy #3                                                            ; 8cbb: a0 03       ..
+; $8cbd referenced 2 times by $8c5c, $8c85
+c8cbd
+    jmp c8b1b                                                         ; 8cbd: 4c 1b 8b    L..
+
+; $8cc0 referenced 1 time by $8cb4
+c8cc0
+    jsr sub_c8d86                                                     ; 8cc0: 20 86 8d     ..
+    jsr sub_c8d86                                                     ; 8cc3: 20 86 8d     ..
+    jsr sub_c9332                                                     ; 8cc6: 20 32 93     2.
+    jsr c8f9d                                                         ; 8cc9: 20 9d 8f     ..
+    cmp #$29 ; ')'                                                    ; 8ccc: c9 29       .)
+    beq c8cbb                                                         ; 8cce: f0 eb       ..
+    cmp #$2c ; ','                                                    ; 8cd0: c9 2c       .,
+    bne c8ce3                                                         ; 8cd2: d0 0f       ..
+    jsr sub_c8d86                                                     ; 8cd4: 20 86 8d     ..
+    jsr sub_c8d94                                                     ; 8cd7: 20 94 8d     ..
+    bne c8ce3                                                         ; 8cda: d0 07       ..
+    jsr c8f9d                                                         ; 8cdc: 20 9d 8f     ..
+    cmp #$29 ; ')'                                                    ; 8cdf: c9 29       .)
+    beq c8cbb                                                         ; 8ce1: f0 d8       ..
+; $8ce3 referenced 4 times by $8cd2, $8cda, $8d0f, $8d28
+c8ce3
+    jmp c8bf9                                                         ; 8ce3: 4c f9 8b    L..
+
+; $8ce6 referenced 1 time by $8cad
+c8ce6
+    cpx #$44 ; 'D'                                                    ; 8ce6: e0 44       .D
+    bcs c8d37                                                         ; 8ce8: b0 4d       .M
+    lda l003d                                                         ; 8cea: a5 3d       .=
+    eor #1                                                            ; 8cec: 49 01       I.
+    and #$1f                                                          ; 8cee: 29 1f       ).
+    pha                                                               ; 8cf0: 48          H
+    cpx #$41 ; 'A'                                                    ; 8cf1: e0 41       .A
+    bcs c8d16                                                         ; 8cf3: b0 21       .!
+    jsr sub_c8d9c                                                     ; 8cf5: 20 9c 8d     ..
+    bne c8cfd                                                         ; 8cf8: d0 03       ..
+    pla                                                               ; 8cfa: 68          h
+    bra c8ca4                                                         ; 8cfb: 80 a7       ..
+; $8cfd referenced 1 time by $8cf8
+c8cfd
+    jsr sub_c9330                                                     ; 8cfd: 20 30 93     0.
+    pla                                                               ; 8d00: 68          h
+    sta l0037                                                         ; 8d01: 85 37       .7
+    jsr sub_c8da2                                                     ; 8d03: 20 a2 8d     ..
+    bne c8c99                                                         ; 8d06: d0 91       ..
+    jsr c8f9d                                                         ; 8d08: 20 9d 8f     ..
+    and #$1f                                                          ; 8d0b: 29 1f       ).
+    cmp l0037                                                         ; 8d0d: c5 37       .7
+    bne c8ce3                                                         ; 8d0f: d0 d2       ..
+    jsr sub_c8d86                                                     ; 8d11: 20 86 8d     ..
+    bra c8c99                                                         ; 8d14: 80 83       ..
+; $8d16 referenced 1 time by $8cf3
+c8d16
+    jsr sub_c9332                                                     ; 8d16: 20 32 93     2.
+    pla                                                               ; 8d19: 68          h
+    sta l0037                                                         ; 8d1a: 85 37       .7
+    jsr sub_c8da2                                                     ; 8d1c: 20 a2 8d     ..
+    bne c8d34                                                         ; 8d1f: d0 13       ..
+    jsr c8f9d                                                         ; 8d21: 20 9d 8f     ..
+    and #$1f                                                          ; 8d24: 29 1f       ).
+    cmp l0037                                                         ; 8d26: c5 37       .7
+    bne c8ce3                                                         ; 8d28: d0 b9       ..
+    jsr sub_c8d86                                                     ; 8d2a: 20 86 8d     ..
+    lda l002b                                                         ; 8d2d: a5 2b       .+
+    beq c8d34                                                         ; 8d2f: f0 03       ..
+    jmp c8bb6                                                         ; 8d31: 4c b6 8b    L..
+
+; $8d34 referenced 2 times by $8d1f, $8d2f
+c8d34
+    jmp c8c1e                                                         ; 8d34: 4c 1e 8c    L..
+
+; $8d37 referenced 1 time by $8ce8
+c8d37
+    bne c8d44                                                         ; 8d37: d0 0b       ..
+    jsr sub_c9332                                                     ; 8d39: 20 32 93     2.
+    lda l002a                                                         ; 8d3c: a5 2a       .*
+    sta l0028                                                         ; 8d3e: 85 28       .(
+    ldy #0                                                            ; 8d40: a0 00       ..
+    bra c8d6e                                                         ; 8d42: 80 2a       .*
+; $8d44 referenced 1 time by $8d37
+c8d44
+    ldx #1                                                            ; 8d44: a2 01       ..
+    ldy l000a                                                         ; 8d46: a4 0a       ..
+    inc l000a                                                         ; 8d48: e6 0a       ..
+    lda (l000b),y                                                     ; 8d4a: b1 0b       ..
+    and #$df                                                          ; 8d4c: 29 df       ).
+    cmp #$42 ; 'B'                                                    ; 8d4e: c9 42       .B
+    beq c8d64                                                         ; 8d50: f0 12       ..
+    inx                                                               ; 8d52: e8          .
+    cmp #$57 ; 'W'                                                    ; 8d53: c9 57       .W
+    beq c8d64                                                         ; 8d55: f0 0d       ..
+    ldx #4                                                            ; 8d57: a2 04       ..
+    cmp #$44 ; 'D'                                                    ; 8d59: c9 44       .D
+    beq c8d64                                                         ; 8d5b: f0 07       ..
+    cmp #$53 ; 'S'                                                    ; 8d5d: c9 53       .S
+    beq c8d74                                                         ; 8d5f: f0 13       ..
+    jmp c9c2d                                                         ; 8d61: 4c 2d 9c    L-.
+
+; $8d64 referenced 3 times by $8d50, $8d55, $8d5b
+c8d64
+    phx                                                               ; 8d64: da          .
+    jsr sub_c9332                                                     ; 8d65: 20 32 93     2.
+    ldx #$29 ; ')'                                                    ; 8d68: a2 29       .)
+    jsr sub_cbe06                                                     ; 8d6a: 20 06 be     ..
+    ply                                                               ; 8d6d: 7a          z
+; $8d6e referenced 2 times by $8d42, $8d84
+c8d6e
+    jmp c8b1b                                                         ; 8d6e: 4c 1b 8b    L..
+
+; $8d71 referenced 1 time by $8d7a
+loop_c8d71
+    jmp c9155                                                         ; 8d71: 4c 55 91    LU.
+
+; $8d74 referenced 1 time by $8d5f
+c8d74
+    lda l0028                                                         ; 8d74: a5 28       .(
+    pha                                                               ; 8d76: 48          H
+    jsr sub_c9df3                                                     ; 8d77: 20 f3 9d     ..
+    bne loop_c8d71                                                    ; 8d7a: d0 f5       ..
+    pla                                                               ; 8d7c: 68          h
+    sta l0028                                                         ; 8d7d: 85 28       .(
+    jsr c9338                                                         ; 8d7f: 20 38 93     8.
+    ldy #$ff                                                          ; 8d82: a0 ff       ..
+    bra c8d6e                                                         ; 8d84: 80 e8       ..
+; $8d86 referenced 8 times by $8bd2, $8c09, $8c39, $8cc0, $8cc3, $8cd4, $8d11, $8d2a
+sub_c8d86
+    jsr sub_c8d89                                                     ; 8d86: 20 89 8d     ..
+; $8d89 referenced 3 times by $8bac, $8c15, $8d86
+sub_c8d89
+    jsr sub_c8d8c                                                     ; 8d89: 20 8c 8d     ..
+; $8d8c referenced 3 times by $8c1b, $8c57, $8d89
+sub_c8d8c
+    lda l0029                                                         ; 8d8c: a5 29       .)
+    clc                                                               ; 8d8e: 18          .
+    adc #4                                                            ; 8d8f: 69 04       i.
+    sta l0029                                                         ; 8d91: 85 29       .)
+    rts                                                               ; 8d93: 60          `
+
+; $8d94 referenced 5 times by $8bed, $8c0c, $8c3c, $8c7a, $8cd7
+sub_c8d94
+    jsr c8f9d                                                         ; 8d94: 20 9d 8f     ..
+    and #$df                                                          ; 8d97: 29 df       ).
+    cmp #$58 ; 'X'                                                    ; 8d99: c9 58       .X
+    rts                                                               ; 8d9b: 60          `
+
+; $8d9c referenced 6 times by $8ba7, $8c8f, $8c9b, $8cf5, $9250, $b8e6
+sub_c8d9c
+    jsr c8f9d                                                         ; 8d9c: 20 9d 8f     ..
+    cmp #$23 ; '#'                                                    ; 8d9f: c9 23       .#
+    rts                                                               ; 8da1: 60          `
+
+; $8da2 referenced 18 times by $8bd5, $8c04, $8c34, $8c75, $8d03, $8d1c, $93e2, $9420, $95be, $9670, $97f6, $98f3, $b133, $b3e5, $b3f4, $b5e9, $b87f, $b9a5
+sub_c8da2
+    jsr c8f9d                                                         ; 8da2: 20 9d 8f     ..
+    cmp #$2c ; ','                                                    ; 8da5: c9 2c       .,
+    rts                                                               ; 8da7: 60          `
+
+; $8da8 referenced 2 times by $8e02, $8f5e
+sub_c8da8
+    sta (l0037)                                                       ; 8da8: 92 37       .7
+    clc                                                               ; 8daa: 18          .
+    tya                                                               ; 8dab: 98          .
+    adc l0037                                                         ; 8dac: 65 37       e7
+    sta l0039                                                         ; 8dae: 85 39       .9
+    ldy #0                                                            ; 8db0: a0 00       ..
+    tya                                                               ; 8db2: 98          .
+    adc l0038                                                         ; 8db3: 65 38       e8
+    sta l003a                                                         ; 8db5: 85 3a       .:
+; $8db7 referenced 1 time by $8dbe
+loop_c8db7
+    iny                                                               ; 8db7: c8          .
+    lda (l0039),y                                                     ; 8db8: b1 39       .9
+    sta (l0037),y                                                     ; 8dba: 91 37       .7
+    cmp #$0d                                                          ; 8dbc: c9 0d       ..
+    bne loop_c8db7                                                    ; 8dbe: d0 f7       ..
+    rts                                                               ; 8dc0: 60          `
+
+; $8dc1 referenced 1 time by $8ecb
+sub_c8dc1
+    and #$0f                                                          ; 8dc1: 29 0f       ).
+    sta l003d                                                         ; 8dc3: 85 3d       .=
+    ldx #0                                                            ; 8dc5: a2 00       ..
+    ldy #0                                                            ; 8dc7: a0 00       ..
+; $8dc9 referenced 2 times by $8df6, $8df9
+c8dc9
+    iny                                                               ; 8dc9: c8          .
+    lda (l0037),y                                                     ; 8dca: b1 37       .7
+    jsr c8e51                                                         ; 8dcc: 20 51 8e     Q.
+    bcc c8dff                                                         ; 8dcf: 90 2e       ..
+    and #$0f                                                          ; 8dd1: 29 0f       ).
+    pha                                                               ; 8dd3: 48          H
+    stx l003e                                                         ; 8dd4: 86 3e       .>
+    lda l003d                                                         ; 8dd6: a5 3d       .=
+    asl                                                               ; 8dd8: 0a          .
+    rol l003e                                                         ; 8dd9: 26 3e       &>
+    bmi c8dfc                                                         ; 8ddb: 30 1f       0.
+    asl                                                               ; 8ddd: 0a          .
+    rol l003e                                                         ; 8dde: 26 3e       &>
+    bmi c8dfc                                                         ; 8de0: 30 1a       0.
+    adc l003d                                                         ; 8de2: 65 3d       e=
+    sta l003d                                                         ; 8de4: 85 3d       .=
+    txa                                                               ; 8de6: 8a          .
+    adc l003e                                                         ; 8de7: 65 3e       e>
+    asl l003d                                                         ; 8de9: 06 3d       .=
+    rol                                                               ; 8deb: 2a          *
+    bmi c8dfc                                                         ; 8dec: 30 0e       0.
+    bcs c8dfc                                                         ; 8dee: b0 0c       ..
+    tax                                                               ; 8df0: aa          .
+    pla                                                               ; 8df1: 68          h
+    adc l003d                                                         ; 8df2: 65 3d       e=
+    sta l003d                                                         ; 8df4: 85 3d       .=
+    bcc c8dc9                                                         ; 8df6: 90 d1       ..
+    inx                                                               ; 8df8: e8          .
+    bpl c8dc9                                                         ; 8df9: 10 ce       ..
+    pha                                                               ; 8dfb: 48          H
+; $8dfc referenced 4 times by $8ddb, $8de0, $8dec, $8dee
+c8dfc
+    pla                                                               ; 8dfc: 68          h
+    sec                                                               ; 8dfd: 38          8
+    rts                                                               ; 8dfe: 60          `
+
+; $8dff referenced 1 time by $8dcf
+c8dff
+    dey                                                               ; 8dff: 88          .
+    lda #$8d                                                          ; 8e00: a9 8d       ..
+    jsr sub_c8da8                                                     ; 8e02: 20 a8 8d     ..
+    lda l0037                                                         ; 8e05: a5 37       .7
+    sta l0039                                                         ; 8e07: 85 39       .9
+    lda l0038                                                         ; 8e09: a5 38       .8
+    sta l003a                                                         ; 8e0b: 85 3a       .:
+    jsr sub_c8e5f                                                     ; 8e0d: 20 5f 8e     _.
+    jsr sub_c8e5f                                                     ; 8e10: 20 5f 8e     _.
+    jsr sub_c8e5f                                                     ; 8e13: 20 5f 8e     _.
+; $8e16 referenced 1 time by $8e1b
+loop_c8e16
+    lda (l0039),y                                                     ; 8e16: b1 39       .9
+    sta (l0037),y                                                     ; 8e18: 91 37       .7
+    dey                                                               ; 8e1a: 88          .
+    bne loop_c8e16                                                    ; 8e1b: d0 f9       ..
+    ldy #3                                                            ; 8e1d: a0 03       ..
+; $8e1f referenced 1 time by $9506
+sub_c8e1f
+    txa                                                               ; 8e1f: 8a          .
+    ora #$40 ; '@'                                                    ; 8e20: 09 40       .@
+    sta (l0039),y                                                     ; 8e22: 91 39       .9
+    dey                                                               ; 8e24: 88          .
+    lda l003d                                                         ; 8e25: a5 3d       .=
+    and #$3f ; '?'                                                    ; 8e27: 29 3f       )?
+    ora #$40 ; '@'                                                    ; 8e29: 09 40       .@
+    sta (l0039),y                                                     ; 8e2b: 91 39       .9
+    dey                                                               ; 8e2d: 88          .
+    lda #$3f ; '?'                                                    ; 8e2e: a9 3f       .?
+    trb l003d                                                         ; 8e30: 14 3d       .=
+    txa                                                               ; 8e32: 8a          .
+    and #$c0                                                          ; 8e33: 29 c0       ).
+    lsr                                                               ; 8e35: 4a          J
+    lsr                                                               ; 8e36: 4a          J
+    ora l003d                                                         ; 8e37: 05 3d       .=
+    lsr                                                               ; 8e39: 4a          J
+    lsr                                                               ; 8e3a: 4a          J
+    eor #$54 ; 'T'                                                    ; 8e3b: 49 54       IT
+    sta (l0039),y                                                     ; 8e3d: 91 39       .9
+; $8e3f referenced 3 times by $8e43, $8e4b, $8e53
+c8e3f
+    clc                                                               ; 8e3f: 18          .
+    rts                                                               ; 8e40: 60          `
+
+; $8e41 referenced 6 times by $8c46, $8ee2, $8ee9, $8f4d, $8f7c, $b027
+sub_c8e41
+    cmp #$7b ; '{'                                                    ; 8e41: c9 7b       .{
+    bcs c8e3f                                                         ; 8e43: b0 fa       ..
+    cmp #$5f ; '_'                                                    ; 8e45: c9 5f       ._
+    bcs c8e57                                                         ; 8e47: b0 0e       ..
+    cmp #$5b ; '['                                                    ; 8e49: c9 5b       .[
+    bcs c8e3f                                                         ; 8e4b: b0 f2       ..
+    cmp #$41 ; 'A'                                                    ; 8e4d: c9 41       .A
+    bcs c8e57                                                         ; 8e4f: b0 06       ..
+; $8e51 referenced 4 times by $8dcc, $8e5a, $8e80, $8ec2
+c8e51
+    cmp #$3a ; ':'                                                    ; 8e51: c9 3a       .:
+    bcs c8e3f                                                         ; 8e53: b0 ea       ..
+    cmp #$30 ; '0'                                                    ; 8e55: c9 30       .0
+; $8e57 referenced 2 times by $8e47, $8e4f
+c8e57
+    rts                                                               ; 8e57: 60          `
+
+; $8e58 referenced 1 time by $8ed2
+sub_c8e58
+    cmp #$2e ; '.'                                                    ; 8e58: c9 2e       ..
+    bne c8e51                                                         ; 8e5a: d0 f5       ..
+    rts                                                               ; 8e5c: 60          `
+
+    !byte $b2, $37                                                    ; 8e5d: b2 37       .7
+
+; $8e5f referenced 9 times by $8e0d, $8e10, $8e13, $8e66, $8e6c, $8ea1, $8ed7, $8eee, $8f81
+sub_c8e5f
+    inc l0037                                                         ; 8e5f: e6 37       .7
+    bne c8e9c                                                         ; 8e61: d0 39       .9
+    inc l0038                                                         ; 8e63: e6 38       .8
+    rts                                                               ; 8e65: 60          `
+
+; $8e66 referenced 3 times by $8e7d, $8e91, $bf1a
+sub_c8e66
+    jsr sub_c8e5f                                                     ; 8e66: 20 5f 8e     _.
+    lda (l0037)                                                       ; 8e69: b2 37       .7
+    rts                                                               ; 8e6b: 60          `
+
+; $8e6c referenced 6 times by $8e77, $8e96, $8eac, $8ebc, $8ece, $8f8f
+c8e6c
+    jsr sub_c8e5f                                                     ; 8e6c: 20 5f 8e     _.
+; $8e6f referenced 3 times by $8e87, $8ea8, $bb30
+c8e6f
+    lda (l0037)                                                       ; 8e6f: b2 37       .7
+    cmp #$0d                                                          ; 8e71: c9 0d       ..
+    beq c8e9c                                                         ; 8e73: f0 27       .'
+    cmp #$20 ; ' '                                                    ; 8e75: c9 20       .
+    beq c8e6c                                                         ; 8e77: f0 f3       ..
+    cmp #$26 ; '&'                                                    ; 8e79: c9 26       .&
+    bne c8e8d                                                         ; 8e7b: d0 10       ..
+; $8e7d referenced 2 times by $8e83, $8e8b
+c8e7d
+    jsr sub_c8e66                                                     ; 8e7d: 20 66 8e     f.
+    jsr c8e51                                                         ; 8e80: 20 51 8e     Q.
+    bcs c8e7d                                                         ; 8e83: b0 f8       ..
+    cmp #$41 ; 'A'                                                    ; 8e85: c9 41       .A
+    bcc c8e6f                                                         ; 8e87: 90 e6       ..
+    cmp #$47 ; 'G'                                                    ; 8e89: c9 47       .G
+    bcc c8e7d                                                         ; 8e8b: 90 f0       ..
+; $8e8d referenced 1 time by $8e7b
+c8e8d
+    cmp #$22 ; '"'                                                    ; 8e8d: c9 22       ."
+    bne c8e9d                                                         ; 8e8f: d0 0c       ..
+; $8e91 referenced 1 time by $8e9a
+loop_c8e91
+    jsr sub_c8e66                                                     ; 8e91: 20 66 8e     f.
+    cmp #$22 ; '"'                                                    ; 8e94: c9 22       ."
+    beq c8e6c                                                         ; 8e96: f0 d4       ..
+    cmp #$0d                                                          ; 8e98: c9 0d       ..
+    bne loop_c8e91                                                    ; 8e9a: d0 f5       ..
+; $8e9c referenced 3 times by $8e61, $8e73, $8eb4
+c8e9c
+    rts                                                               ; 8e9c: 60          `
+
+; $8e9d referenced 1 time by $8e8f
+c8e9d
+    cmp #$3a ; ':'                                                    ; 8e9d: c9 3a       .:
+    bne c8eaa                                                         ; 8e9f: d0 09       ..
+    jsr sub_c8e5f                                                     ; 8ea1: 20 5f 8e     _.
+; $8ea4 referenced 1 time by $9561
+sub_c8ea4
+    stz l003b                                                         ; 8ea4: 64 3b       d;
+; $8ea6 referenced 1 time by $8ee0
+c8ea6
+    stz l003c                                                         ; 8ea6: 64 3c       d<
+    bra c8e6f                                                         ; 8ea8: 80 c5       ..
+; $8eaa referenced 1 time by $8e9f
+c8eaa
+    cmp #$2c ; ','                                                    ; 8eaa: c9 2c       .,
+    beq c8e6c                                                         ; 8eac: f0 be       ..
+    cmp #$2a ; '*'                                                    ; 8eae: c9 2a       .*
+    bne c8ebe                                                         ; 8eb0: d0 0c       ..
+    lda l003b                                                         ; 8eb2: a5 3b       .;
+    beq c8e9c                                                         ; 8eb4: f0 e6       ..
+; $8eb6 referenced 2 times by $8ee5, $8ef5
+c8eb6
+    ldx #$ff                                                          ; 8eb6: a2 ff       ..
+    stx l003b                                                         ; 8eb8: 86 3b       .;
+    stz l003c                                                         ; 8eba: 64 3c       d<
+    bra c8e6c                                                         ; 8ebc: 80 ae       ..
+; $8ebe referenced 1 time by $8eb0
+c8ebe
+    cmp #$2e ; '.'                                                    ; 8ebe: c9 2e       ..
+    beq c8ed0                                                         ; 8ec0: f0 0e       ..
+    jsr c8e51                                                         ; 8ec2: 20 51 8e     Q.
+    bcc c8ef3                                                         ; 8ec5: 90 2c       .,
+    ldx l003c                                                         ; 8ec7: a6 3c       .<
+    beq c8ed0                                                         ; 8ec9: f0 05       ..
+    jsr sub_c8dc1                                                     ; 8ecb: 20 c1 8d     ..
+    bcc c8e6c                                                         ; 8ece: 90 9c       ..
+; $8ed0 referenced 3 times by $8ec0, $8ec9, $8eda
+c8ed0
+    lda (l0037)                                                       ; 8ed0: b2 37       .7
+    jsr sub_c8e58                                                     ; 8ed2: 20 58 8e     X.
+    bcc c8edc                                                         ; 8ed5: 90 05       ..
+    jsr sub_c8e5f                                                     ; 8ed7: 20 5f 8e     _.
+    bra c8ed0                                                         ; 8eda: 80 f4       ..
+; $8edc referenced 3 times by $8ed5, $8eec, $ab86
+c8edc
+    ldx #$ff                                                          ; 8edc: a2 ff       ..
+    stx l003b                                                         ; 8ede: 86 3b       .;
+    bra c8ea6                                                         ; 8ee0: 80 c4       ..
+; $8ee2 referenced 1 time by $8ef9
+loop_c8ee2
+    jsr sub_c8e41                                                     ; 8ee2: 20 41 8e     A.
+    bcc c8eb6                                                         ; 8ee5: 90 cf       ..
+; $8ee7 referenced 4 times by $8ef1, $8f07, $8f23, $8f50
+c8ee7
+    lda (l0037)                                                       ; 8ee7: b2 37       .7
+    jsr sub_c8e41                                                     ; 8ee9: 20 41 8e     A.
+    bcc c8edc                                                         ; 8eec: 90 ee       ..
+    jsr sub_c8e5f                                                     ; 8eee: 20 5f 8e     _.
+    bra c8ee7                                                         ; 8ef1: 80 f4       ..
+; $8ef3 referenced 1 time by $8ec5
+c8ef3
+    cmp #$41 ; 'A'                                                    ; 8ef3: c9 41       .A
+    bcc c8eb6                                                         ; 8ef5: 90 bf       ..
+    cmp #$58 ; 'X'                                                    ; 8ef7: c9 58       .X
+    bcs loop_c8ee2                                                    ; 8ef9: b0 e7       ..
+    ldx #$13                                                          ; 8efb: a2 13       ..
+    stx l0039                                                         ; 8efd: 86 39       .9
+    ldx #$85                                                          ; 8eff: a2 85       ..
+    stx l003a                                                         ; 8f01: 86 3a       .:
+; $8f03 referenced 1 time by $8f3f
+c8f03
+    ldy #0                                                            ; 8f03: a0 00       ..
+    cmp (l0039)                                                       ; 8f05: d2 39       .9
+    bcc c8ee7                                                         ; 8f07: 90 de       ..
+    bne c8f1a                                                         ; 8f09: d0 0f       ..
+; $8f0b referenced 1 time by $8f12
+loop_c8f0b
+    iny                                                               ; 8f0b: c8          .
+    lda (l0039),y                                                     ; 8f0c: b1 39       .9
+    bmi c8f41                                                         ; 8f0e: 30 31       01
+    cmp (l0037),y                                                     ; 8f10: d1 37       .7
+    beq loop_c8f0b                                                    ; 8f12: f0 f7       ..
+    lda (l0037),y                                                     ; 8f14: b1 37       .7
+    cmp #$2e ; '.'                                                    ; 8f16: c9 2e       ..
+    beq c8f25                                                         ; 8f18: f0 0b       ..
+; $8f1a referenced 2 times by $8f09, $8f1d
+c8f1a
+    iny                                                               ; 8f1a: c8          .
+    lda (l0039),y                                                     ; 8f1b: b1 39       .9
+    bpl c8f1a                                                         ; 8f1d: 10 fb       ..
+    cmp #$fe                                                          ; 8f1f: c9 fe       ..
+    bne c8f32                                                         ; 8f21: d0 0f       ..
+    bcs c8ee7                                                         ; 8f23: b0 c2       ..
+; $8f25 referenced 1 time by $8f18
+c8f25
+    iny                                                               ; 8f25: c8          .
+; $8f26 referenced 2 times by $8f2c, $8f30
+c8f26
+    lda (l0039),y                                                     ; 8f26: b1 39       .9
+    bmi c8f41                                                         ; 8f28: 30 17       0.
+    inc l0039                                                         ; 8f2a: e6 39       .9
+    bne c8f26                                                         ; 8f2c: d0 f8       ..
+    inc l003a                                                         ; 8f2e: e6 3a       .:
+    bra c8f26                                                         ; 8f30: 80 f4       ..
+; $8f32 referenced 1 time by $8f21
+c8f32
+    sec                                                               ; 8f32: 38          8
+    iny                                                               ; 8f33: c8          .
+    tya                                                               ; 8f34: 98          .
+    adc l0039                                                         ; 8f35: 65 39       e9
+    sta l0039                                                         ; 8f37: 85 39       .9
+    bcc c8f3d                                                         ; 8f39: 90 02       ..
+    inc l003a                                                         ; 8f3b: e6 3a       .:
+; $8f3d referenced 1 time by $8f39
+c8f3d
+    lda (l0037)                                                       ; 8f3d: b2 37       .7
+    bra c8f03                                                         ; 8f3f: 80 c2       ..
+; $8f41 referenced 2 times by $8f0e, $8f28
+c8f41
+    tax                                                               ; 8f41: aa          .
+    iny                                                               ; 8f42: c8          .
+    lda (l0039),y                                                     ; 8f43: b1 39       .9
+    sta l003d                                                         ; 8f45: 85 3d       .=
+    dey                                                               ; 8f47: 88          .
+    lsr                                                               ; 8f48: 4a          J
+    bcc c8f52                                                         ; 8f49: 90 07       ..
+    lda (l0037),y                                                     ; 8f4b: b1 37       .7
+    jsr sub_c8e41                                                     ; 8f4d: 20 41 8e     A.
+    bcs c8ee7                                                         ; 8f50: b0 95       ..
+; $8f52 referenced 1 time by $8f49
+c8f52
+    txa                                                               ; 8f52: 8a          .
+    bit l003d                                                         ; 8f53: 24 3d       $=
+    bvc c8f5d                                                         ; 8f55: 50 06       P.
+    ldx l003b                                                         ; 8f57: a6 3b       .;
+    bne c8f5d                                                         ; 8f59: d0 02       ..
+    adc #$40 ; '@'                                                    ; 8f5b: 69 40       i@
+; $8f5d referenced 2 times by $8f55, $8f59
+c8f5d
+    dey                                                               ; 8f5d: 88          .
+    jsr sub_c8da8                                                     ; 8f5e: 20 a8 8d     ..
+    ldx #$ff                                                          ; 8f61: a2 ff       ..
+    lda l003d                                                         ; 8f63: a5 3d       .=
+    lsr                                                               ; 8f65: 4a          J
+    lsr                                                               ; 8f66: 4a          J
+    bcc c8f6d                                                         ; 8f67: 90 04       ..
+    stx l003b                                                         ; 8f69: 86 3b       .;
+    stz l003c                                                         ; 8f6b: 64 3c       d<
+; $8f6d referenced 1 time by $8f67
+c8f6d
+    lsr                                                               ; 8f6d: 4a          J
+    bcc c8f74                                                         ; 8f6e: 90 04       ..
+    stz l003b                                                         ; 8f70: 64 3b       d;
+    stz l003c                                                         ; 8f72: 64 3c       d<
+; $8f74 referenced 1 time by $8f6e
+c8f74
+    lsr                                                               ; 8f74: 4a          J
+    bcc c8f87                                                         ; 8f75: 90 10       ..
+    pha                                                               ; 8f77: 48          H
+    ldy #1                                                            ; 8f78: a0 01       ..
+; $8f7a referenced 1 time by $8f84
+loop_c8f7a
+    lda (l0037),y                                                     ; 8f7a: b1 37       .7
+    jsr sub_c8e41                                                     ; 8f7c: 20 41 8e     A.
+    bcc c8f86                                                         ; 8f7f: 90 05       ..
+    jsr sub_c8e5f                                                     ; 8f81: 20 5f 8e     _.
+    bra loop_c8f7a                                                    ; 8f84: 80 f4       ..
+; $8f86 referenced 1 time by $8f7f
+c8f86
+    pla                                                               ; 8f86: 68          h
+; $8f87 referenced 1 time by $8f75
+c8f87
+    lsr                                                               ; 8f87: 4a          J
+    bcc c8f8c                                                         ; 8f88: 90 02       ..
+    stx l003c                                                         ; 8f8a: 86 3c       .<
+; $8f8c referenced 1 time by $8f88
+c8f8c
+    lsr                                                               ; 8f8c: 4a          J
+    bcs c8f9c                                                         ; 8f8d: b0 0d       ..
+    jmp c8e6c                                                         ; 8f8f: 4c 6c 8e    Ll.
+
+; $8f92 referenced 16 times by $8f9a, $8fa8, $8fb4, $9c4a, $abbb, $abc6, $abd0, $ad3a, $ad8e, $af61, $b13f, $b659, $b69b, $b6e8, $b835, $ba7a
+c8f92
+    ldy l001b                                                         ; 8f92: a4 1b       ..
+    inc l001b                                                         ; 8f94: e6 1b       ..
+    lda (l0019),y                                                     ; 8f96: b1 19       ..
+    cmp #$20 ; ' '                                                    ; 8f98: c9 20       .
+    beq c8f92                                                         ; 8f9a: f0 f6       ..
+; $8f9c referenced 1 time by $8f8d
+c8f9c
+    rts                                                               ; 8f9c: 60          `
+
+; $8f9d referenced 29 times by $89dd, $8aa8, $8bc1, $8bcb, $8bde, $8bf2, $8c28, $8caf, $8cc9, $8cdc, $8d08, $8d21, $8d94, $8d9c, $8da2, $8fa5, $90e3, $9276, $928f, $935c, $95f9, $98dc, $b000, $b0b5, $b403, $b40a, $b771, $b78b, $b983
+c8f9d
+    ldy l000a                                                         ; 8f9d: a4 0a       ..
+    inc l000a                                                         ; 8f9f: e6 0a       ..
+    lda (l000b),y                                                     ; 8fa1: b1 0b       ..
+    cmp #$20 ; ' '                                                    ; 8fa3: c9 20       .
+    beq c8f9d                                                         ; 8fa5: f0 f6       ..
+; $8fa7 referenced 1 time by $8fb9
+loop_c8fa7
+    rts                                                               ; 8fa7: 60          `
+
+; $8fa8 referenced 7 times by $9208, $9307, $9390, $b156, $b95a, $b9e9, $b9f6
+sub_c8fa8
+    jsr c8f92                                                         ; 8fa8: 20 92 8f     ..
+    cmp #$2c ; ','                                                    ; 8fab: c9 2c       .,
+    rts                                                               ; 8fad: 60          `
+
+; $8fae referenced 2 times by $ac5d, $af8b
+sub_c8fae
+    jsr sub_c9774                                                     ; 8fae: 20 74 97     t.
+    jsr cbc66                                                         ; 8fb1: 20 66 bc     f.
+; $8fb4 referenced 1 time by $9771
+sub_c8fb4
+    jsr c8f92                                                         ; 8fb4: 20 92 8f     ..
+    cmp #$2c ; ','                                                    ; 8fb7: c9 2c       .,
+    beq loop_c8fa7                                                    ; 8fb9: f0 ec       ..
+; $8fbb referenced 3 times by $92ed, $aca0, $af07
+c8fbb
+    brk                                                               ; 8fbb: 00          .
+
+    !byte   5, $8d, $2c,   0                                          ; 8fbc: 05 8d 2c... ..,
+
+sub_c8fc0
+    jsr sub_cbe17                                                     ; 8fc0: 20 17 be     ..
+    bra c8fda                                                         ; 8fc3: 80 15       ..
+sub_c8fc5
+    jsr c9c6a                                                         ; 8fc5: 20 6a 9c     j.
+    lda l0018                                                         ; 8fc8: a5 18       ..
+    sta l0038                                                         ; 8fca: 85 38       .8
+    stz l0037                                                         ; 8fcc: 64 37       d7
+    lda #0                                                            ; 8fce: a9 00       ..
+    sta (l0037),y                                                     ; 8fd0: 91 37       .7
+    jsr sub_cbe25                                                     ; 8fd2: 20 25 be     %.
+    bra c9048                                                         ; 8fd5: 80 71       .q
+sub_c8fd7
+    jsr c9c6a                                                         ; 8fd7: 20 6a 9c     j.
+; $8fda referenced 1 time by $8fc3
+c8fda
+    jsr sub_cbbdc                                                     ; 8fda: 20 dc bb     ..
+    lda l0018                                                         ; 8fdd: a5 18       ..
+    sta l000c                                                         ; 8fdf: 85 0c       ..
+    stz l000b                                                         ; 8fe1: 64 0b       d.
+    bra c905c                                                         ; 8fe3: 80 77       .w
+sub_c8fe5
+    jsr sub_cbe17                                                     ; 8fe5: 20 17 be     ..
+    bra c9048                                                         ; 8fe8: 80 5e       .^
+sub_c8fea
+    jsr c9c6a                                                         ; 8fea: 20 6a 9c     j.
+    jsr sub_cbe25                                                     ; 8fed: 20 25 be     %.
+    bra c904b                                                         ; 8ff0: 80 59       .Y
+; $8ff2 referenced 1 time by $8136
+c8ff2
+    lda #$f2                                                          ; 8ff2: a9 f2       ..
+    jsr cae60                                                         ; 8ff4: 20 60 ae     `.
+    jsr sub_cbf22                                                     ; 8ff7: 20 22 bf     ".
+    tax                                                               ; 8ffa: aa          .
+    jsr sub_cbf22                                                     ; 8ffb: 20 22 bf     ".
+    sta l002b                                                         ; 8ffe: 85 2b       .+
+    stx l002a                                                         ; 9000: 86 2a       .*
+    ldx #$14                                                          ; 9002: a2 14       ..
+; $9004 referenced 1 time by $9010
+loop_c9004
+    dex                                                               ; 9004: ca          .
+    beq c9045                                                         ; 9005: f0 3e       .>
+    jsr sub_cbf22                                                     ; 9007: 20 22 bf     ".
+    cmp #$0d                                                          ; 900a: c9 0d       ..
+    beq c9045                                                         ; 900c: f0 37       .7
+    cmp #$40 ; '@'                                                    ; 900e: c9 40       .@
+    bne loop_c9004                                                    ; 9010: d0 f2       ..
+    jsr sub_cbf22                                                     ; 9012: 20 22 bf     ".
+    cmp #$0d                                                          ; 9015: c9 0d       ..
+    bne c9045                                                         ; 9017: d0 2c       .,
+    jsr sub_cbf3e                                                     ; 9019: 20 3e bf     >.
+; $901c referenced 1 time by $9040
+c901c
+    ldy #0                                                            ; 901c: a0 00       ..
+    stz l000b                                                         ; 901e: 64 0b       d.
+    lda #7                                                            ; 9020: a9 07       ..
+    sta l000c                                                         ; 9022: 85 0c       ..
+; $9024 referenced 1 time by $9035
+loop_c9024
+    lda (l0000)                                                       ; 9024: b2 00       ..
+    beq c9048                                                         ; 9026: f0 20       .
+    sta (l000b),y                                                     ; 9028: 91 0b       ..
+    iny                                                               ; 902a: c8          .
+    beq c9045                                                         ; 902b: f0 18       ..
+    inc l0000                                                         ; 902d: e6 00       ..
+    bne c9033                                                         ; 902f: d0 02       ..
+    inc l0001                                                         ; 9031: e6 01       ..
+; $9033 referenced 1 time by $902f
+c9033
+    cmp #$0d                                                          ; 9033: c9 0d       ..
+    bne loop_c9024                                                    ; 9035: d0 ed       ..
+    lda l0001                                                         ; 9037: a5 01       ..
+    cmp l0007                                                         ; 9039: c5 07       ..
+    bcs c9048                                                         ; 903b: b0 0b       ..
+    jsr sub_cbb1b                                                     ; 903d: 20 1b bb     ..
+    bra c901c                                                         ; 9040: 80 da       ..
+sub_c9042
+    jsr c9c6a                                                         ; 9042: 20 6a 9c     j.
+; $9045 referenced 4 times by $9005, $900c, $9017, $902b
+c9045
+    jsr sub_cbf3e                                                     ; 9045: 20 3e bf     >.
+; $9048 referenced 7 times by $8fd5, $8fe8, $9026, $903b, $9065, $940d, $9579
+c9048
+    jsr sub_cbbdc                                                     ; 9048: 20 dc bb     ..
+; $904b referenced 6 times by $8a88, $8ff0, $908a, $9090, $9cc6, $b425
+c904b
+    ldy #7                                                            ; 904b: a0 07       ..
+    sty l000c                                                         ; 904d: 84 0c       ..
+    stz l000b                                                         ; 904f: 64 0b       d.
+    jsr sub_cb2e0                                                     ; 9051: 20 e0 b2     ..
+    lda #$3e ; '>'                                                    ; 9054: a9 3e       .>
+    jsr oswrch                                                        ; 9056: 20 ee ff     ..
+    jsr sub_cbaa4                                                     ; 9059: 20 a4 ba     ..
+; $905c referenced 1 time by $8fe3
+c905c
+    ldx #$ff                                                          ; 905c: a2 ff       ..
+    txs                                                               ; 905e: 9a          .
+    jsr sub_cb2e0                                                     ; 905f: 20 e0 b2     ..
+    jsr sub_cbb1b                                                     ; 9062: 20 1b bb     ..
+    bcs c9048                                                         ; 9065: b0 e1       ..
+    bra c90e3                                                         ; 9067: 80 7a       .z
+; $9069 referenced 1 time by $90b7
+c9069
+    jsr c9c80                                                         ; 9069: 20 80 9c     ..
+    ldx l000b                                                         ; 906c: a6 0b       ..
+    ldy l000c                                                         ; 906e: a4 0c       ..
+    jsr oscli                                                         ; 9070: 20 f7 ff     ..
+; $9073 referenced 2 times by $9084, $b788
+c9073
+    lda #$0d                                                          ; 9073: a9 0d       ..
+    ldy l000a                                                         ; 9075: a4 0a       ..
+    dey                                                               ; 9077: 88          .
+; $9078 referenced 1 time by $907b
+loop_c9078
+    iny                                                               ; 9078: c8          .
+    cmp (l000b),y                                                     ; 9079: d1 0b       ..
+    bne loop_c9078                                                    ; 907b: d0 fb       ..
+; $907d referenced 1 time by $9d0c
+c907d
+    jsr c9c80                                                         ; 907d: 20 80 9c     ..
+    bra c9086                                                         ; 9080: 80 04       ..
+; $9082 referenced 1 time by $90ce
+c9082
+    cmp #$0d                                                          ; 9082: c9 0d       ..
+    bne c9073                                                         ; 9084: d0 ed       ..
+; $9086 referenced 1 time by $9080
+c9086
+    lda l000c                                                         ; 9086: a5 0c       ..
+    cmp #7                                                            ; 9088: c9 07       ..
+    beq c904b                                                         ; 908a: f0 bf       ..
+    ldy #1                                                            ; 908c: a0 01       ..
+    lda (l000b),y                                                     ; 908e: b1 0b       ..
+    bmi c904b                                                         ; 9090: 30 b9       0.
+    ldx l0020                                                         ; 9092: a6 20       .
+    beq c90a0                                                         ; 9094: f0 0a       ..
+    sta l002b                                                         ; 9096: 85 2b       .+
+    iny                                                               ; 9098: c8          .
+    lda (l000b),y                                                     ; 9099: b1 0b       ..
+    sta l002a                                                         ; 909b: 85 2a       .*
+    jsr sub_c9d0f                                                     ; 909d: 20 0f 9d     ..
+; $90a0 referenced 1 time by $9094
+c90a0
+    ldy #4                                                            ; 90a0: a0 04       ..
+    sty l000a                                                         ; 90a2: 84 0a       ..
+    bra c90d2                                                         ; 90a4: 80 2c       .,
+; $90a6 referenced 1 time by $90bb
+loop_c90a6
+    lda #3                                                            ; 90a6: a9 03       ..
+    sta l0028                                                         ; 90a8: 85 28       .(
+    jmp c89dd                                                         ; 90aa: 4c dd 89    L..
+
+; $90ad referenced 1 time by $90bf
+loop_c90ad
+    jmp cbed3                                                         ; 90ad: 4c d3 be    L..
+
+; $90b0 referenced 1 time by $90f7
+c90b0
+    ldy l000a                                                         ; 90b0: a4 0a       ..
+    dey                                                               ; 90b2: 88          .
+    lda (l000b),y                                                     ; 90b3: b1 0b       ..
+    cmp #$2a ; '*'                                                    ; 90b5: c9 2a       .*
+    beq c9069                                                         ; 90b7: f0 b0       ..
+    cmp #$5b ; '['                                                    ; 90b9: c9 5b       .[
+    beq loop_c90a6                                                    ; 90bb: f0 e9       ..
+    cmp #$a2                                                          ; 90bd: c9 a2       ..
+    beq loop_c90ad                                                    ; 90bf: f0 ec       ..
+    cmp #$3d ; '='                                                    ; 90c1: c9 3d       .=
+    beq c9123                                                         ; 90c3: f0 5e       .^
+; $90c5 referenced 6 times by $9288, $95c3, $97fb, $990c, $b626, $b9aa
+c90c5
+    dec l000a                                                         ; 90c5: c6 0a       ..
+; $90c7 referenced 4 times by $924d, $97fe, $b844, $b874
+c90c7
+    jsr c9c6a                                                         ; 90c7: 20 6a 9c     j.
+; $90ca referenced 11 times by $9121, $9144, $93c1, $9700, $97bd, $98c0, $b35c, $b74a, $b9a2, $ba60, $beeb
+c90ca
+    lda (l000b)                                                       ; 90ca: b2 0b       ..
+    cmp #$3a ; ':'                                                    ; 90cc: c9 3a       .:
+    bne c9082                                                         ; 90ce: d0 b2       ..
+; $90d0 referenced 8 times by $89da, $90d8, $9ce8, $b0c7, $b5dc, $b6ce, $b766, $ba9d
+c90d0
+    ldy l000a                                                         ; 90d0: a4 0a       ..
+; $90d2 referenced 1 time by $90a4
+c90d2
+    inc l000a                                                         ; 90d2: e6 0a       ..
+    lda (l000b),y                                                     ; 90d4: b1 0b       ..
+    cmp #$20 ; ' '                                                    ; 90d6: c9 20       .
+    beq c90d0                                                         ; 90d8: f0 f6       ..
+    cmp #$cf                                                          ; 90da: c9 cf       ..
+    bcc c90ea                                                         ; 90dc: 90 0c       ..
+; $90de referenced 2 times by $90e8, $ad99
+c90de
+    asl                                                               ; 90de: 0a          .
+    tax                                                               ; 90df: aa          .
+    jmp (l880a,x)                                                     ; 90e0: 7c 0a 88    |..
+
+; $90e3 referenced 1 time by $9067
+c90e3
+    jsr c8f9d                                                         ; 90e3: 20 9d 8f     ..
+    cmp #$c6                                                          ; 90e6: c9 c6       ..
+    bcs c90de                                                         ; 90e8: b0 f4       ..
+; $90ea referenced 1 time by $90dc
+c90ea
+    ldx l000b                                                         ; 90ea: a6 0b       ..
+    stx l0019                                                         ; 90ec: 86 19       ..
+    ldx l000c                                                         ; 90ee: a6 0c       ..
+    stx l001a                                                         ; 90f0: 86 1a       ..
+    jsr sub_c99d6                                                     ; 90f2: 20 d6 99     ..
+    bne c9112                                                         ; 90f5: d0 1b       ..
+    bcs c90b0                                                         ; 90f7: b0 b7       ..
+    stx l001b                                                         ; 90f9: 86 1b       ..
+    jsr sub_c9c4a                                                     ; 90fb: 20 4a 9c     J.
+    jsr sub_c9923                                                     ; 90fe: 20 23 99     #.
+    ldx #5                                                            ; 9101: a2 05       ..
+    cpx l002c                                                         ; 9103: e4 2c       .,
+    bne c9108                                                         ; 9105: d0 01       ..
+    inx                                                               ; 9107: e8          .
+; $9108 referenced 1 time by $9105
+c9108
+    jsr sub_c9952                                                     ; 9108: 20 52 99     R.
+    dec l000a                                                         ; 910b: c6 0a       ..
+sub_c910d
+    jsr sub_c997d                                                     ; 910d: 20 7d 99     }.
+    beq c9146                                                         ; 9110: f0 34       .4
+; $9112 referenced 1 time by $90f5
+c9112
+    bcc c9135                                                         ; 9112: 90 21       .!
+    jsr cbc66                                                         ; 9114: 20 66 bc     f.
+    jsr c9c16                                                         ; 9117: 20 16 9c     ..
+    lda l0027                                                         ; 911a: a5 27       .'
+    bne c9155                                                         ; 911c: d0 37       .7
+    jsr sub_c916e                                                     ; 911e: 20 6e 91     n.
+    bra c90ca                                                         ; 9121: 80 a7       ..
+; $9123 referenced 1 time by $90c3
+c9123
+    tsx                                                               ; 9123: ba          .
+    cpx #$fc                                                          ; 9124: e0 fc       ..
+    bcs c914f                                                         ; 9126: b0 27       .'
+    lda l01ff                                                         ; 9128: ad ff 01    ...
+    cmp #$a4                                                          ; 912b: c9 a4       ..
+    bne c914f                                                         ; 912d: d0 20       .
+    jsr sub_c9df3                                                     ; 912f: 20 f3 9d     ..
+    jmp c9c55                                                         ; 9132: 4c 55 9c    LU.
+
+; $9135 referenced 1 time by $9112
+c9135
+    lda l002a                                                         ; 9135: a5 2a       .*
+    pha                                                               ; 9137: 48          H
+    lda l002b                                                         ; 9138: a5 2b       .+
+    pha                                                               ; 913a: 48          H
+    lda l002c                                                         ; 913b: a5 2c       .,
+    pha                                                               ; 913d: 48          H
+    jsr c9c16                                                         ; 913e: 20 16 9c     ..
+    jsr sub_cb365                                                     ; 9141: 20 65 b3     e.
+    bra c90ca                                                         ; 9144: 80 84       ..
+; $9146 referenced 1 time by $9110
+c9146
+    jmp c9c2d                                                         ; 9146: 4c 2d 9c    L-.
+
+sub_c9149
+    jsr c9c6a                                                         ; 9149: 20 6a 9c     j.
+    brk                                                               ; 914c: 00          .
+
+    !byte   0, $fa                                                    ; 914d: 00 fa       ..
+
+; $914f referenced 2 times by $9126, $912d
+c914f
+    brk                                                               ; 914f: 00          .
+
+    !byte 7                                                           ; 9150: 07          .
+    !text "No "                                                       ; 9151: 4e 6f 20    No
+    !byte $a4                                                         ; 9154: a4          .
+
+; $9155 referenced 14 times by $8d71, $911c, $979c, $9cc9, $9d7c, $9f4c, $ab9d, $ac1c, $acfd, $ae56, $af88, $b35f, $b86c, $be73
+c9155
+    brk                                                               ; 9155: 00          .
+
+    !byte 6                                                           ; 9156: 06          .
+    !text "Type mismatch"                                             ; 9157: 54 79 70... Typ
+
+; $9164 referenced 3 times by $91bb, $9974, $bd74
+c9164
+    brk                                                               ; 9164: 00          .
+
+    !byte 0                                                           ; 9165: 00          .
+    !text "No room"                                                   ; 9166: 4e 6f 20... No
+    !byte 0                                                           ; 916d: 00          .
+
+; $916e referenced 3 times by $911e, $b8b5, $b9ca
+sub_c916e
+    jsr sub_cbd26                                                     ; 916e: 20 26 bd     &.
+; $9171 referenced 2 times by $b1b2, $b978
+sub_c9171
+    lda l002c                                                         ; 9171: a5 2c       .,
+    cmp #$80                                                          ; 9173: c9 80       ..
+    beq c91ef                                                         ; 9175: f0 78       .x
+    ldy #2                                                            ; 9177: a0 02       ..
+    lda (l002a),y                                                     ; 9179: b1 2a       .*
+    cmp l0036                                                         ; 917b: c5 36       .6
+    bcs c91d1                                                         ; 917d: b0 52       .R
+    lda l0002                                                         ; 917f: a5 02       ..
+    sta l002c                                                         ; 9181: 85 2c       .,
+    lda l0003                                                         ; 9183: a5 03       ..
+    sta l002d                                                         ; 9185: 85 2d       .-
+    lda l0036                                                         ; 9187: a5 36       .6
+    cmp #8                                                            ; 9189: c9 08       ..
+    bcc c9193                                                         ; 918b: 90 06       ..
+    adc #7                                                            ; 918d: 69 07       i.
+    bcc c9193                                                         ; 918f: 90 02       ..
+    lda #$ff                                                          ; 9191: a9 ff       ..
+; $9193 referenced 2 times by $918b, $918f
+c9193
+    clc                                                               ; 9193: 18          .
+    pha                                                               ; 9194: 48          H
+    tax                                                               ; 9195: aa          .
+    lda (l002a),y                                                     ; 9196: b1 2a       .*
+    adc (l002a)                                                       ; 9198: 72 2a       r*
+    eor l0002                                                         ; 919a: 45 02       E.
+    bne c91ad                                                         ; 919c: d0 0f       ..
+    dey                                                               ; 919e: 88          .
+    adc (l002a),y                                                     ; 919f: 71 2a       q*
+    eor l0003                                                         ; 91a1: 45 03       E.
+    bne c91ad                                                         ; 91a3: d0 08       ..
+    sta l002d                                                         ; 91a5: 85 2d       .-
+    txa                                                               ; 91a7: 8a          .
+    iny                                                               ; 91a8: c8          .
+    sec                                                               ; 91a9: 38          8
+    sbc (l002a),y                                                     ; 91aa: f1 2a       .*
+    tax                                                               ; 91ac: aa          .
+; $91ad referenced 2 times by $919c, $91a3
+c91ad
+    txa                                                               ; 91ad: 8a          .
+    clc                                                               ; 91ae: 18          .
+    adc l0002                                                         ; 91af: 65 02       e.
+    tay                                                               ; 91b1: a8          .
+    lda l0003                                                         ; 91b2: a5 03       ..
+    adc #0                                                            ; 91b4: 69 00       i.
+    tax                                                               ; 91b6: aa          .
+    cpy l0004                                                         ; 91b7: c4 04       ..
+    sbc l0005                                                         ; 91b9: e5 05       ..
+    bcs c9164                                                         ; 91bb: b0 a7       ..
+    sty l0002                                                         ; 91bd: 84 02       ..
+    stx l0003                                                         ; 91bf: 86 03       ..
+    pla                                                               ; 91c1: 68          h
+    ldy #2                                                            ; 91c2: a0 02       ..
+    sta (l002a),y                                                     ; 91c4: 91 2a       .*
+    dey                                                               ; 91c6: 88          .
+    lda l002d                                                         ; 91c7: a5 2d       .-
+    beq c91d1                                                         ; 91c9: f0 06       ..
+    sta (l002a),y                                                     ; 91cb: 91 2a       .*
+    lda l002c                                                         ; 91cd: a5 2c       .,
+    sta (l002a)                                                       ; 91cf: 92 2a       .*
+; $91d1 referenced 2 times by $917d, $91c9
+c91d1
+    ldy #3                                                            ; 91d1: a0 03       ..
+    lda l0036                                                         ; 91d3: a5 36       .6
+    sta (l002a),y                                                     ; 91d5: 91 2a       .*
+    beq c91ee                                                         ; 91d7: f0 15       ..
+    ldy #1                                                            ; 91d9: a0 01       ..
+    lda (l002a),y                                                     ; 91db: b1 2a       .*
+    sta l002d                                                         ; 91dd: 85 2d       .-
+    lda (l002a)                                                       ; 91df: b2 2a       .*
+    sta l002c                                                         ; 91e1: 85 2c       .,
+    dey                                                               ; 91e3: 88          .
+; $91e4 referenced 1 time by $91ec
+loop_c91e4
+    lda l0600,y                                                       ; 91e4: b9 00 06    ...
+    sta (l002c),y                                                     ; 91e7: 91 2c       .,
+    iny                                                               ; 91e9: c8          .
+    cpy l0036                                                         ; 91ea: c4 36       .6
+    bne loop_c91e4                                                    ; 91ec: d0 f6       ..
+; $91ee referenced 1 time by $91d7
+c91ee
+    rts                                                               ; 91ee: 60          `
+
+; $91ef referenced 1 time by $9175
+c91ef
+    jsr sub_cbe6b                                                     ; 91ef: 20 6b be     k.
+    cpy #0                                                            ; 91f2: c0 00       ..
+    beq c9201                                                         ; 91f4: f0 0b       ..
+; $91f6 referenced 1 time by $91fc
+loop_c91f6
+    lda l0600,y                                                       ; 91f6: b9 00 06    ...
+    sta (l002a),y                                                     ; 91f9: 91 2a       .*
+    dey                                                               ; 91fb: 88          .
+    bne loop_c91f6                                                    ; 91fc: d0 f8       ..
+    lda l0600                                                         ; 91fe: ad 00 06    ...
+; $9201 referenced 1 time by $91f4
+c9201
+    sta (l002a)                                                       ; 9201: 92 2a       .*
+    rts                                                               ; 9203: 60          `
+
+; $9204 referenced 1 time by $9253
+c9204
+    jsr sub_cba6c                                                     ; 9204: 20 6c ba     l.
+; $9207 referenced 4 times by $9228, $9235, $923d, $9248
+c9207
+    phy                                                               ; 9207: 5a          Z
+    jsr sub_c8fa8                                                     ; 9208: 20 a8 8f     ..
+    bne c924a                                                         ; 920b: d0 3d       .=
+    jsr sub_c9dff                                                     ; 920d: 20 ff 9d     ..
+    jsr sub_ca545                                                     ; 9210: 20 45 a5     E.
+    ply                                                               ; 9213: 7a          z
+    lda l0027                                                         ; 9214: a5 27       .'
+    jsr osbput                                                        ; 9216: 20 d4 ff     ..
+    tax                                                               ; 9219: aa          .
+    beq c9237                                                         ; 921a: f0 1b       ..
+    bmi c922a                                                         ; 921c: 30 0c       0.
+    ldx #3                                                            ; 921e: a2 03       ..
+; $9220 referenced 1 time by $9226
+loop_c9220
+    lda l002a,x                                                       ; 9220: b5 2a       .*
+    jsr osbput                                                        ; 9222: 20 d4 ff     ..
+    dex                                                               ; 9225: ca          .
+    bpl loop_c9220                                                    ; 9226: 10 f8       ..
+    bra c9207                                                         ; 9228: 80 dd       ..
+; $922a referenced 1 time by $921c
+c922a
+    ldx #4                                                            ; 922a: a2 04       ..
+; $922c referenced 1 time by $9233
+loop_c922c
+    lda l046c,x                                                       ; 922c: bd 6c 04    .l.
+    jsr osbput                                                        ; 922f: 20 d4 ff     ..
+    dex                                                               ; 9232: ca          .
+    bpl loop_c922c                                                    ; 9233: 10 f7       ..
+    bra c9207                                                         ; 9235: 80 d0       ..
+; $9237 referenced 1 time by $921a
+c9237
+    lda l0036                                                         ; 9237: a5 36       .6
+    jsr osbput                                                        ; 9239: 20 d4 ff     ..
+    tax                                                               ; 923c: aa          .
+    beq c9207                                                         ; 923d: f0 c8       ..
+; $923f referenced 1 time by $9246
+loop_c923f
+    lda l05ff,x                                                       ; 923f: bd ff 05    ...
+    jsr osbput                                                        ; 9242: 20 d4 ff     ..
+    dex                                                               ; 9245: ca          .
+    bne loop_c923f                                                    ; 9246: d0 f7       ..
+    bra c9207                                                         ; 9248: 80 bd       ..
+; $924a referenced 1 time by $920b
+c924a
+    pla                                                               ; 924a: 68          h
+    sty l000a                                                         ; 924b: 84 0a       ..
+    jmp c90c7                                                         ; 924d: 4c c7 90    L..
+
+sub_c9250
+    jsr sub_c8d9c                                                     ; 9250: 20 9c 8d     ..
+    beq c9204                                                         ; 9253: f0 af       ..
+    dec l000a                                                         ; 9255: c6 0a       ..
+    bra c926e                                                         ; 9257: 80 15       ..
+; $9259 referenced 1 time by $92a4
+c9259
+    lda l0400                                                         ; 9259: ad 00 04    ...
+    beq c926e                                                         ; 925c: f0 10       ..
+    lda l001e                                                         ; 925e: a5 1e       ..
+; $9260 referenced 1 time by $9265
+loop_c9260
+    beq c926e                                                         ; 9260: f0 0c       ..
+    sbc l0400                                                         ; 9262: ed 00 04    ...
+    bcs loop_c9260                                                    ; 9265: b0 f9       ..
+    tay                                                               ; 9267: a8          .
+; $9268 referenced 1 time by $926c
+loop_c9268
+    jsr cbdd2                                                         ; 9268: 20 d2 bd     ..
+    iny                                                               ; 926b: c8          .
+    bne loop_c9268                                                    ; 926c: d0 fa       ..
+; $926e referenced 3 times by $9257, $925c, $9260
+c926e
+    clc                                                               ; 926e: 18          .
+    lda l0400                                                         ; 926f: ad 00 04    ...
+    sta l0014                                                         ; 9272: 85 14       ..
+; $9274 referenced 1 time by $92a0
+c9274
+    ror l0015                                                         ; 9274: 66 15       f.
+; $9276 referenced 3 times by $92ad, $92dc, $92eb
+c9276
+    jsr c8f9d                                                         ; 9276: 20 9d 8f     ..
+    cmp #$3a ; ':'                                                    ; 9279: c9 3a       .:
+    beq c9285                                                         ; 927b: f0 08       ..
+    cmp #$0d                                                          ; 927d: c9 0d       ..
+    beq c9285                                                         ; 927f: f0 04       ..
+    cmp #$8b                                                          ; 9281: c9 8b       ..
+    bne c929e                                                         ; 9283: d0 19       ..
+; $9285 referenced 2 times by $927b, $927f
+c9285
+    jsr sub_cbac2                                                     ; 9285: 20 c2 ba     ..
+; $9288 referenced 3 times by $9294, $9298, $929c
+c9288
+    jmp c90c5                                                         ; 9288: 4c c5 90    L..
+
+; $928b referenced 1 time by $92a8
+loop_c928b
+    stz l0014                                                         ; 928b: 64 14       d.
+    stz l0015                                                         ; 928d: 64 15       d.
+    jsr c8f9d                                                         ; 928f: 20 9d 8f     ..
+    cmp #$3a ; ':'                                                    ; 9292: c9 3a       .:
+    beq c9288                                                         ; 9294: f0 f2       ..
+    cmp #$0d                                                          ; 9296: c9 0d       ..
+    beq c9288                                                         ; 9298: f0 ee       ..
+    cmp #$8b                                                          ; 929a: c9 8b       ..
+    beq c9288                                                         ; 929c: f0 ea       ..
+; $929e referenced 1 time by $9283
+c929e
+    cmp #$7e ; '~'                                                    ; 929e: c9 7e       .~
+    beq c9274                                                         ; 92a0: f0 d2       ..
+    cmp #$2c ; ','                                                    ; 92a2: c9 2c       .,
+    beq c9259                                                         ; 92a4: f0 b3       ..
+    cmp #$3b ; ';'                                                    ; 92a6: c9 3b       .;
+    beq loop_c928b                                                    ; 92a8: f0 e1       ..
+    jsr sub_c933d                                                     ; 92aa: 20 3d 93     =.
+    bcc c9276                                                         ; 92ad: 90 c7       ..
+    lda l0014                                                         ; 92af: a5 14       ..
+    pha                                                               ; 92b1: 48          H
+    lda l0015                                                         ; 92b2: a5 15       ..
+    pha                                                               ; 92b4: 48          H
+    dec l001b                                                         ; 92b5: c6 1b       ..
+    jsr sub_c9dff                                                     ; 92b7: 20 ff 9d     ..
+    pla                                                               ; 92ba: 68          h
+    sta l0015                                                         ; 92bb: 85 15       ..
+    pla                                                               ; 92bd: 68          h
+    sta l0014                                                         ; 92be: 85 14       ..
+    lda l001b                                                         ; 92c0: a5 1b       ..
+    sta l000a                                                         ; 92c2: 85 0a       ..
+    tya                                                               ; 92c4: 98          .
+    beq c92da                                                         ; 92c5: f0 13       ..
+    jsr sub_ca181                                                     ; 92c7: 20 81 a1     ..
+    lda l0014                                                         ; 92ca: a5 14       ..
+    sec                                                               ; 92cc: 38          8
+    sbc l0036                                                         ; 92cd: e5 36       .6
+    bcc c92da                                                         ; 92cf: 90 09       ..
+    beq c92da                                                         ; 92d1: f0 07       ..
+    tay                                                               ; 92d3: a8          .
+; $92d4 referenced 1 time by $92d8
+loop_c92d4
+    jsr cbdd2                                                         ; 92d4: 20 d2 bd     ..
+    dey                                                               ; 92d7: 88          .
+    bne loop_c92d4                                                    ; 92d8: d0 fa       ..
+; $92da referenced 3 times by $92c5, $92cf, $92d1
+c92da
+    lda l0036                                                         ; 92da: a5 36       .6
+    beq c9276                                                         ; 92dc: f0 98       ..
+    ldy #0                                                            ; 92de: a0 00       ..
+; $92e0 referenced 1 time by $92e9
+loop_c92e0
+    lda l0600,y                                                       ; 92e0: b9 00 06    ...
+    jsr sub_cbdd8                                                     ; 92e3: 20 d8 bd     ..
+    iny                                                               ; 92e6: c8          .
+    cpy l0036                                                         ; 92e7: c4 36       .6
+    bne loop_c92e0                                                    ; 92e9: d0 f5       ..
+    bra c9276                                                         ; 92eb: 80 89       ..
+; $92ed referenced 1 time by $930e
+c92ed
+    jmp c8fbb                                                         ; 92ed: 4c bb 8f    L..
+
+; $92f0 referenced 1 time by $930a
+loop_c92f0
+    lda l002a                                                         ; 92f0: a5 2a       .*
+    pha                                                               ; 92f2: 48          H
+    jsr sub_c976c                                                     ; 92f3: 20 6c 97     l.
+    lda #$1f                                                          ; 92f6: a9 1f       ..
+    jsr oswrch                                                        ; 92f8: 20 ee ff     ..
+    pla                                                               ; 92fb: 68          h
+    jsr oswrch                                                        ; 92fc: 20 ee ff     ..
+    jsr sub_c990f                                                     ; 92ff: 20 0f 99     ..
+    bra c932d                                                         ; 9302: 80 29       .)
+; $9304 referenced 1 time by $934f
+c9304
+    jsr sub_c9774                                                     ; 9304: 20 74 97     t.
+    jsr sub_c8fa8                                                     ; 9307: 20 a8 8f     ..
+    beq loop_c92f0                                                    ; 930a: f0 e4       ..
+    cmp #$29 ; ')'                                                    ; 930c: c9 29       .)
+    bne c92ed                                                         ; 930e: d0 dd       ..
+    lda l002a                                                         ; 9310: a5 2a       .*
+    sbc l001e                                                         ; 9312: e5 1e       ..
+    beq c932d                                                         ; 9314: f0 17       ..
+    tax                                                               ; 9316: aa          .
+    bcs c9325                                                         ; 9317: b0 0c       ..
+    jsr sub_cbac2                                                     ; 9319: 20 c2 ba     ..
+    bra c9321                                                         ; 931c: 80 03       ..
+; $931e referenced 1 time by $9353
+c931e
+    jsr sub_c9779                                                     ; 931e: 20 79 97     y.
+; $9321 referenced 1 time by $931c
+c9321
+    ldx l002a                                                         ; 9321: a6 2a       .*
+    beq c932d                                                         ; 9323: f0 08       ..
+; $9325 referenced 1 time by $9317
+c9325
+    jsr cbdff                                                         ; 9325: 20 ff bd     ..
+    bra c932d                                                         ; 9328: 80 03       ..
+; $932a referenced 1 time by $934b
+c932a
+    jsr sub_cbac2                                                     ; 932a: 20 c2 ba     ..
+; $932d referenced 5 times by $9302, $9314, $9323, $9328, $937a
+c932d
+    clc                                                               ; 932d: 18          .
+    bra c9338                                                         ; 932e: 80 08       ..
+; $9330 referenced 3 times by $8c01, $8c31, $8cfd
+sub_c9330
+    dec l000a                                                         ; 9330: c6 0a       ..
+; $9332 referenced 23 times by $8b67, $8baf, $8bc8, $8c62, $8c96, $8cb8, $8cc6, $8d16, $8d39, $8d65, $9651, $9718, $9810, $9824, $982e, $9880, $98ed, $b302, $b326, $b351, $b41b, $b794, $b85f
+sub_c9332
+    jsr sub_c9df3                                                     ; 9332: 20 f3 9d     ..
+    jsr c9784                                                         ; 9335: 20 84 97     ..
+; $9338 referenced 8 times by $8aa3, $8d7f, $932e, $95bb, $b87c, $b88c, $b92a, $b9dc
+c9338
+    ldy l001b                                                         ; 9338: a4 1b       ..
+    sty l000a                                                         ; 933a: 84 0a       ..
+    rts                                                               ; 933c: 60          `
+
+; $933d referenced 2 times by $92aa, $935f
+sub_c933d
+    ldx l000b                                                         ; 933d: a6 0b       ..
+    stx l0019                                                         ; 933f: 86 19       ..
+    ldx l000c                                                         ; 9341: a6 0c       ..
+    stx l001a                                                         ; 9343: 86 1a       ..
+    ldx l000a                                                         ; 9345: a6 0a       ..
+    stx l001b                                                         ; 9347: 86 1b       ..
+    cmp #$27 ; '''                                                    ; 9349: c9 27       .'
+    beq c932a                                                         ; 934b: f0 dd       ..
+    cmp #$8a                                                          ; 934d: c9 8a       ..
+    beq c9304                                                         ; 934f: f0 b3       ..
+    cmp #$89                                                          ; 9351: c9 89       ..
+    beq c931e                                                         ; 9353: f0 c9       ..
+; $9355 referenced 1 time by $9366
+loop_c9355
+    sec                                                               ; 9355: 38          8
+; $9356 referenced 1 time by $9362
+loop_c9356
+    rts                                                               ; 9356: 60          `
+
+; $9357 referenced 2 times by $936d, $ad75
+c9357
+    brk                                                               ; 9357: 00          .
+
+    !byte   9, $8d, $22,   0                                          ; 9358: 09 8d 22... .."
+
+; $935c referenced 2 times by $b8fa, $b8ff
+sub_c935c
+    jsr c8f9d                                                         ; 935c: 20 9d 8f     ..
+    jsr sub_c933d                                                     ; 935f: 20 3d 93     =.
+    bcc loop_c9356                                                    ; 9362: 90 f2       ..
+    cmp #$22 ; '"'                                                    ; 9364: c9 22       ."
+    bne loop_c9355                                                    ; 9366: d0 ed       ..
+; $9368 referenced 1 time by $937f
+loop_c9368
+    iny                                                               ; 9368: c8          .
+    lda (l0019),y                                                     ; 9369: b1 19       ..
+    cmp #$0d                                                          ; 936b: c9 0d       ..
+    beq c9357                                                         ; 936d: f0 e8       ..
+    cmp #$22 ; '"'                                                    ; 936f: c9 22       ."
+    bne c937c                                                         ; 9371: d0 09       ..
+    iny                                                               ; 9373: c8          .
+    sty l001b                                                         ; 9374: 84 1b       ..
+    lda (l0019),y                                                     ; 9376: b1 19       ..
+    cmp #$22 ; '"'                                                    ; 9378: c9 22       ."
+    bne c932d                                                         ; 937a: d0 b1       ..
+; $937c referenced 1 time by $9371
+c937c
+    jsr sub_cbdd8                                                     ; 937c: 20 d8 bd     ..
+    bra loop_c9368                                                    ; 937f: 80 e7       ..
+sub_c9381
+    jsr sub_c9df3                                                     ; 9381: 20 f3 9d     ..
+    jsr sub_c9781                                                     ; 9384: 20 81 97     ..
+    jsr cbc66                                                         ; 9387: 20 66 bc     f.
+    stz l0600                                                         ; 938a: 9c 00 06    ...
+    ldy #0                                                            ; 938d: a0 00       ..
+; $938f referenced 1 time by $93b2
+c938f
+    phy                                                               ; 938f: 5a          Z
+    jsr sub_c8fa8                                                     ; 9390: 20 a8 8f     ..
+    bne c93b4                                                         ; 9393: d0 1f       ..
+    ldy l001b                                                         ; 9395: a4 1b       ..
+    jsr sub_c99d0                                                     ; 9397: 20 d0 99     ..
+    beq c93c4                                                         ; 939a: f0 28       .(
+    ply                                                               ; 939c: 7a          z
+    iny                                                               ; 939d: c8          .
+    lda l002a                                                         ; 939e: a5 2a       .*
+    sta l0600,y                                                       ; 93a0: 99 00 06    ...
+    iny                                                               ; 93a3: c8          .
+    lda l002b                                                         ; 93a4: a5 2b       .+
+    sta l0600,y                                                       ; 93a6: 99 00 06    ...
+    iny                                                               ; 93a9: c8          .
+    lda l002c                                                         ; 93aa: a5 2c       .,
+    sta l0600,y                                                       ; 93ac: 99 00 06    ...
+    inc l0600                                                         ; 93af: ee 00 06    ...
+    bra c938f                                                         ; 93b2: 80 db       ..
+; $93b4 referenced 1 time by $9393
+c93b4
+    ply                                                               ; 93b4: 7a          z
+    dec l001b                                                         ; 93b5: c6 1b       ..
+    jsr sub_c9c5a                                                     ; 93b7: 20 5a 9c     Z.
+    jsr sub_cbd26                                                     ; 93ba: 20 26 bd     &.
+    jsr sub_c93c7                                                     ; 93bd: 20 c7 93     ..
+    cld                                                               ; 93c0: d8          .
+    jmp c90ca                                                         ; 93c1: 4c ca 90    L..
+
+; $93c4 referenced 1 time by $939a
+c93c4
+    jmp cadce                                                         ; 93c4: 4c ce ad    L..
+
+; $93c7 referenced 2 times by $93bd, $ab04
+sub_c93c7
+    lda l040c                                                         ; 93c7: ad 0c 04    ...
+    lsr                                                               ; 93ca: 4a          J
+    lda l0404                                                         ; 93cb: ad 04 04    ...
+    ldx l0460                                                         ; 93ce: ae 60 04    .`.
+    ldy l0464                                                         ; 93d1: ac 64 04    .d.
+    jmp (l002a)                                                       ; 93d4: 6c 2a 00    l*.
+
+; $93d7 referenced 3 times by $93dd, $93e5, $93ea
+c93d7
+    jmp c9c2d                                                         ; 93d7: 4c 2d 9c    L-.
+
+sub_c93da
+    jsr sub_c9be2                                                     ; 93da: 20 e2 9b     ..
+    bcc c93d7                                                         ; 93dd: 90 f8       ..
+    jsr cbc66                                                         ; 93df: 20 66 bc     f.
+    jsr sub_c8da2                                                     ; 93e2: 20 a2 8d     ..
+    bne c93d7                                                         ; 93e5: d0 f0       ..
+    jsr sub_c9be2                                                     ; 93e7: 20 e2 9b     ..
+    bcc c93d7                                                         ; 93ea: 90 eb       ..
+    jsr c9c6a                                                         ; 93ec: 20 6a 9c     j.
+    lda l002a                                                         ; 93ef: a5 2a       .*
+    sta l0039                                                         ; 93f1: 85 39       .9
+    lda l002b                                                         ; 93f3: a5 2b       .+
+    sta l003a                                                         ; 93f5: 85 3a       .:
+    jsr sub_cbd26                                                     ; 93f7: 20 26 bd     &.
+; $93fa referenced 1 time by $940b
+loop_c93fa
+    jsr sub_cbac8                                                     ; 93fa: 20 c8 ba     ..
+    jsr sub_c9c8e                                                     ; 93fd: 20 8e 9c     ..
+    jsr sub_cbf2f                                                     ; 9400: 20 2f bf     /.
+    lda l0039                                                         ; 9403: a5 39       .9
+    cmp l002a                                                         ; 9405: c5 2a       .*
+    lda l003a                                                         ; 9407: a5 3a       .:
+    sbc l002b                                                         ; 9409: e5 2b       .+
+    bcs loop_c93fa                                                    ; 940b: b0 ed       ..
+    jmp c9048                                                         ; 940d: 4c 48 90    LH.
+
+; $9410 referenced 2 times by $9447, $954c
+sub_c9410
+    lda #$0a                                                          ; 9410: a9 0a       ..
+    jsr cae60                                                         ; 9412: 20 60 ae     `.
+    jsr sub_c9be2                                                     ; 9415: 20 e2 9b     ..
+    jsr cbc66                                                         ; 9418: 20 66 bc     f.
+    lda #$0a                                                          ; 941b: a9 0a       ..
+    jsr cae60                                                         ; 941d: 20 60 ae     `.
+    jsr sub_c8da2                                                     ; 9420: 20 a2 8d     ..
+    bne c9433                                                         ; 9423: d0 0e       ..
+    jsr sub_c9be2                                                     ; 9425: 20 e2 9b     ..
+    lda l002b                                                         ; 9428: a5 2b       .+
+    bne c947f                                                         ; 942a: d0 53       .S
+    lda l002a                                                         ; 942c: a5 2a       .*
+    beq c947f                                                         ; 942e: f0 4f       .O
+    jmp c9c6a                                                         ; 9430: 4c 6a 9c    Lj.
+
+; $9433 referenced 1 time by $9423
+c9433
+    jmp c9c74                                                         ; 9433: 4c 74 9c    Lt.
+
+; $9436 referenced 2 times by $9452, $94e1
+sub_c9436
+    lda l0012                                                         ; 9436: a5 12       ..
+    sta l003b                                                         ; 9438: 85 3b       .;
+    lda l0013                                                         ; 943a: a5 13       ..
+    sta l003c                                                         ; 943c: 85 3c       .<
+; $943e referenced 1 time by $9487
+sub_c943e
+    lda l0018                                                         ; 943e: a5 18       ..
+    sta l0038                                                         ; 9440: 85 38       .8
+    ldy #1                                                            ; 9442: a0 01       ..
+    sty l0037                                                         ; 9444: 84 37       .7
+    rts                                                               ; 9446: 60          `
+
+sub_c9447
+    jsr sub_c9410                                                     ; 9447: 20 10 94     ..
+    ldx #$39 ; '9'                                                    ; 944a: a2 39       .9
+    jsr sub_cbd48                                                     ; 944c: 20 48 bd     H.
+    jsr sub_cbe25                                                     ; 944f: 20 25 be     %.
+    jsr sub_c9436                                                     ; 9452: 20 36 94     6.
+; $9455 referenced 1 time by $9474
+loop_c9455
+    lda (l0037)                                                       ; 9455: b2 37       .7
+    bmi c9487                                                         ; 9457: 30 2e       0.
+    sta (l003b)                                                       ; 9459: 92 3b       .;
+    lda (l0037),y                                                     ; 945b: b1 37       .7
+    sta (l003b),y                                                     ; 945d: 91 3b       .;
+    sec                                                               ; 945f: 38          8
+    tya                                                               ; 9460: 98          .
+    adc l003b                                                         ; 9461: 65 3b       e;
+    sta l003b                                                         ; 9463: 85 3b       .;
+    bcc c9469                                                         ; 9465: 90 02       ..
+    inc l003c                                                         ; 9467: e6 3c       .<
+; $9469 referenced 1 time by $9465
+c9469
+    cmp l0006                                                         ; 9469: c5 06       ..
+    lda l003c                                                         ; 946b: a5 3c       .<
+    sbc l0007                                                         ; 946d: e5 07       ..
+    bcs c9476                                                         ; 946f: b0 05       ..
+    jsr sub_c953d                                                     ; 9471: 20 3d 95     =.
+    bra loop_c9455                                                    ; 9474: 80 df       ..
+; $9476 referenced 1 time by $946f
+c9476
+    brk                                                               ; 9476: 00          .
+
+    !byte   0, $cc                                                    ; 9477: 00 cc       ..
+    !text " space"                                                    ; 9479: 20 73 70...  sp
+
+; $947f referenced 2 times by $942a, $942e
+c947f
+    brk                                                               ; 947f: 00          .
+
+    !byte 0                                                           ; 9480: 00          .
+    !text "Silly"                                                     ; 9481: 53 69 6c... Sil
+    !byte 0                                                           ; 9486: 00          .
+
+; $9487 referenced 1 time by $9457
+c9487
+    jsr sub_c943e                                                     ; 9487: 20 3e 94     >.
+; $948a referenced 1 time by $94a8
+loop_c948a
+    lda (l0037)                                                       ; 948a: b2 37       .7
+    bmi c94aa                                                         ; 948c: 30 1c       0.
+    lda l003a                                                         ; 948e: a5 3a       .:
+    sta (l0037)                                                       ; 9490: 92 37       .7
+    lda l0039                                                         ; 9492: a5 39       .9
+    sta (l0037),y                                                     ; 9494: 91 37       .7
+    clc                                                               ; 9496: 18          .
+    lda l0039                                                         ; 9497: a5 39       .9
+    adc l002a                                                         ; 9499: 65 2a       e*
+    sta l0039                                                         ; 949b: 85 39       .9
+    lda #0                                                            ; 949d: a9 00       ..
+    adc l003a                                                         ; 949f: 65 3a       e:
+    and #$7f                                                          ; 94a1: 29 7f       ).
+    sta l003a                                                         ; 94a3: 85 3a       .:
+    jsr sub_c953d                                                     ; 94a5: 20 3d 95     =.
+    bra loop_c948a                                                    ; 94a8: 80 e0       ..
+; $94aa referenced 1 time by $948c
+c94aa
+    lda l0018                                                         ; 94aa: a5 18       ..
+    sta l000c                                                         ; 94ac: 85 0c       ..
+    stz l000b                                                         ; 94ae: 64 0b       d.
+; $94b0 referenced 1 time by $94dc
+c94b0
+    ldy #1                                                            ; 94b0: a0 01       ..
+    lda (l000b),y                                                     ; 94b2: b1 0b       ..
+    bmi c951d                                                         ; 94b4: 30 67       0g
+    ldy #4                                                            ; 94b6: a0 04       ..
+    stz l002c                                                         ; 94b8: 64 2c       d,
+; $94ba referenced 2 times by $94d3, $950b
+c94ba
+    lda (l000b),y                                                     ; 94ba: b1 0b       ..
+    ldx l002c                                                         ; 94bc: a6 2c       .,
+    bne c94c8                                                         ; 94be: d0 08       ..
+    cmp #$8d                                                          ; 94c0: c9 8d       ..
+    beq c94de                                                         ; 94c2: f0 1a       ..
+    cmp #$f4                                                          ; 94c4: c9 f4       ..
+    beq c94d5                                                         ; 94c6: f0 0d       ..
+; $94c8 referenced 1 time by $94be
+c94c8
+    iny                                                               ; 94c8: c8          .
+    cmp #$22 ; '"'                                                    ; 94c9: c9 22       ."
+    bne c94d1                                                         ; 94cb: d0 04       ..
+    eor l002c                                                         ; 94cd: 45 2c       E,
+    sta l002c                                                         ; 94cf: 85 2c       .,
+; $94d1 referenced 1 time by $94cb
+c94d1
+    cmp #$0d                                                          ; 94d1: c9 0d       ..
+    bne c94ba                                                         ; 94d3: d0 e5       ..
+; $94d5 referenced 1 time by $94c6
+c94d5
+    ldy #3                                                            ; 94d5: a0 03       ..
+    lda (l000b),y                                                     ; 94d7: b1 0b       ..
+    jsr sub_c9cb8                                                     ; 94d9: 20 b8 9c     ..
+    bra c94b0                                                         ; 94dc: 80 d2       ..
+; $94de referenced 1 time by $94c2
+c94de
+    jsr sub_c9bee                                                     ; 94de: 20 ee 9b     ..
+    jsr sub_c9436                                                     ; 94e1: 20 36 94     6.
+; $94e4 referenced 2 times by $9517, $951b
+c94e4
+    lda (l0037)                                                       ; 94e4: b2 37       .7
+    bmi c951f                                                         ; 94e6: 30 37       07
+    lda (l003b)                                                       ; 94e8: b2 3b       .;
+    cmp l002b                                                         ; 94ea: c5 2b       .+
+    bne c950d                                                         ; 94ec: d0 1f       ..
+    lda (l003b),y                                                     ; 94ee: b1 3b       .;
+    cmp l002a                                                         ; 94f0: c5 2a       .*
+    bne c950d                                                         ; 94f2: d0 19       ..
+    lda (l0037),y                                                     ; 94f4: b1 37       .7
+    sta l003d                                                         ; 94f6: 85 3d       .=
+    lda (l0037)                                                       ; 94f8: b2 37       .7
+    tax                                                               ; 94fa: aa          .
+    ldy l000a                                                         ; 94fb: a4 0a       ..
+    dey                                                               ; 94fd: 88          .
+    lda l000b                                                         ; 94fe: a5 0b       ..
+    sta l0039                                                         ; 9500: 85 39       .9
+    lda l000c                                                         ; 9502: a5 0c       ..
+    sta l003a                                                         ; 9504: 85 3a       .:
+    jsr sub_c8e1f                                                     ; 9506: 20 1f 8e     ..
+; $9509 referenced 1 time by $953b
+c9509
+    ldy l000a                                                         ; 9509: a4 0a       ..
+    bra c94ba                                                         ; 950b: 80 ad       ..
+; $950d referenced 2 times by $94ec, $94f2
+c950d
+    clc                                                               ; 950d: 18          .
+    jsr sub_c953d                                                     ; 950e: 20 3d 95     =.
+    lda l003b                                                         ; 9511: a5 3b       .;
+    adc #2                                                            ; 9513: 69 02       i.
+    sta l003b                                                         ; 9515: 85 3b       .;
+    bcc c94e4                                                         ; 9517: 90 cb       ..
+    inc l003c                                                         ; 9519: e6 3c       .<
+    bra c94e4                                                         ; 951b: 80 c7       ..
+; $951d referenced 1 time by $94b4
+c951d
+    bra c9579                                                         ; 951d: 80 5a       .Z
+; $951f referenced 1 time by $94e6
+c951f
+    jsr sub_cbf0f                                                     ; 951f: 20 0f bf     ..
+    lsr l0061                                                         ; 9522: 46 61       Fa
+    adc #$6c ; 'l'                                                    ; 9524: 69 6c       il
+    adc l0064                                                         ; 9526: 65 64       ed
+    jsr l7461                                                         ; 9528: 20 61 74     at
+    jsr l0bb1                                                         ; 952b: 20 b1 0b     ..
+    sta l002b                                                         ; 952e: 85 2b       .+
+    iny                                                               ; 9530: c8          .
+    lda (l000b),y                                                     ; 9531: b1 0b       ..
+    sta l002a                                                         ; 9533: 85 2a       .*
+    jsr sub_ca0e8                                                     ; 9535: 20 e8 a0     ..
+    jsr sub_cbac2                                                     ; 9538: 20 c2 ba     ..
+    bra c9509                                                         ; 953b: 80 cc       ..
+; $953d referenced 3 times by $9471, $94a5, $950e
+sub_c953d
+    iny                                                               ; 953d: c8          .
+    lda (l0037),y                                                     ; 953e: b1 37       .7
+    ldy #1                                                            ; 9540: a0 01       ..
+    adc l0037                                                         ; 9542: 65 37       e7
+    sta l0037                                                         ; 9544: 85 37       .7
+    bcc c954b                                                         ; 9546: 90 03       ..
+    inc l0038                                                         ; 9548: e6 38       .8
+    clc                                                               ; 954a: 18          .
+; $954b referenced 1 time by $9546
+c954b
+    rts                                                               ; 954b: 60          `
+
+sub_c954c
+    jsr sub_c9410                                                     ; 954c: 20 10 94     ..
+    lda l002a                                                         ; 954f: a5 2a       .*
+    pha                                                               ; 9551: 48          H
+    jsr sub_cbd26                                                     ; 9552: 20 26 bd     &.
+; $9555 referenced 2 times by $9573, $9577
+c9555
+    jsr cbc66                                                         ; 9555: 20 66 bc     f.
+    jsr sub_ca0ec                                                     ; 9558: 20 ec a0     ..
+    jsr sub_cbaa4                                                     ; 955b: 20 a4 ba     ..
+    jsr sub_cbd26                                                     ; 955e: 20 26 bd     &.
+    jsr sub_c8ea4                                                     ; 9561: 20 a4 8e     ..
+    ldy #0                                                            ; 9564: a0 00       ..
+    jsr sub_cbb38                                                     ; 9566: 20 38 bb     8.
+    jsr sub_cbbdc                                                     ; 9569: 20 dc bb     ..
+    pla                                                               ; 956c: 68          h
+    pha                                                               ; 956d: 48          H
+    clc                                                               ; 956e: 18          .
+    adc l002a                                                         ; 956f: 65 2a       e*
+    sta l002a                                                         ; 9571: 85 2a       .*
+    bcc c9555                                                         ; 9573: 90 e0       ..
+    inc l002b                                                         ; 9575: e6 2b       .+
+    bpl c9555                                                         ; 9577: 10 dc       ..
+; $9579 referenced 1 time by $951d
+c9579
+    jmp c9048                                                         ; 9579: 4c 48 90    LH.
+
+; $957c referenced 1 time by $95a6
+c957c
+    jmp c96ca                                                         ; 957c: 4c ca 96    L..
+
+; $957f referenced 1 time by $9632
+c957f
+    dec l000a                                                         ; 957f: c6 0a       ..
+    jsr sub_c997d                                                     ; 9581: 20 7d 99     }.
+    beq c95f1                                                         ; 9584: f0 6b       .k
+    bcs c95f1                                                         ; 9586: b0 69       .i
+    jsr sub_cbc83                                                     ; 9588: 20 83 bc     ..
+    jsr sub_c9774                                                     ; 958b: 20 74 97     t.
+    jsr sub_cbf2f                                                     ; 958e: 20 2f bf     /.
+    lda l002d                                                         ; 9591: a5 2d       .-
+    ora l002c                                                         ; 9593: 05 2c       .,
+    bne c95f1                                                         ; 9595: d0 5a       .Z
+    clc                                                               ; 9597: 18          .
+    lda l002a                                                         ; 9598: a5 2a       .*
+    adc l0002                                                         ; 959a: 65 02       e.
+    tay                                                               ; 959c: a8          .
+    lda l002b                                                         ; 959d: a5 2b       .+
+    adc l0003                                                         ; 959f: 65 03       e.
+    tax                                                               ; 95a1: aa          .
+    cpy l0004                                                         ; 95a2: c4 04       ..
+    sbc l0005                                                         ; 95a4: e5 05       ..
+    bcs c957c                                                         ; 95a6: b0 d4       ..
+    lda l0002                                                         ; 95a8: a5 02       ..
+    sta l002a                                                         ; 95aa: 85 2a       .*
+    lda l0003                                                         ; 95ac: a5 03       ..
+    sta l002b                                                         ; 95ae: 85 2b       .+
+    sty l0002                                                         ; 95b0: 84 02       ..
+    stx l0003                                                         ; 95b2: 86 03       ..
+    lda #$40 ; '@'                                                    ; 95b4: a9 40       .@
+    sta l0027                                                         ; 95b6: 85 27       .'
+    jsr sub_cb365                                                     ; 95b8: 20 65 b3     e.
+    jsr c9338                                                         ; 95bb: 20 38 93     8.
+; $95be referenced 1 time by $96c7
+c95be
+    jsr sub_c8da2                                                     ; 95be: 20 a2 8d     ..
+    beq c95f9                                                         ; 95c1: f0 36       .6
+    jmp c90c5                                                         ; 95c3: 4c c5 90    L..
+
+; $95c6 referenced 1 time by $966d
+sub_c95c6
+    ldx #$3f ; '?'                                                    ; 95c6: a2 3f       .?
+    jsr sub_cbd48                                                     ; 95c8: 20 48 bd     H.
+; $95cb referenced 2 times by $9680, $9b1b
+sub_c95cb
+    ldx #0                                                            ; 95cb: a2 00       ..
+    ldy #0                                                            ; 95cd: a0 00       ..
+; $95cf referenced 1 time by $95ea
+loop_c95cf
+    lsr l0040                                                         ; 95cf: 46 40       F@
+    ror l003f                                                         ; 95d1: 66 3f       f?
+    bcc c95e0                                                         ; 95d3: 90 0b       ..
+    clc                                                               ; 95d5: 18          .
+    tya                                                               ; 95d6: 98          .
+    adc l002a                                                         ; 95d7: 65 2a       e*
+    tay                                                               ; 95d9: a8          .
+    txa                                                               ; 95da: 8a          .
+    adc l002b                                                         ; 95db: 65 2b       e+
+    tax                                                               ; 95dd: aa          .
+    bcs c95f1                                                         ; 95de: b0 11       ..
+; $95e0 referenced 1 time by $95d3
+c95e0
+    asl l002a                                                         ; 95e0: 06 2a       .*
+    rol l002b                                                         ; 95e2: 26 2b       &+
+    bcs c95f1                                                         ; 95e4: b0 0b       ..
+    lda l003f                                                         ; 95e6: a5 3f       .?
+    ora l0040                                                         ; 95e8: 05 40       .@
+    bne loop_c95cf                                                    ; 95ea: d0 e3       ..
+    sty l002a                                                         ; 95ec: 84 2a       .*
+    stx l002b                                                         ; 95ee: 86 2b       .+
+    rts                                                               ; 95f0: 60          `
+
+; $95f1 referenced 8 times by $9584, $9586, $9595, $95de, $95e4, $961a, $963b, $965c
+c95f1
+    brk                                                               ; 95f1: 00          .
+
+    !byte $0a                                                         ; 95f2: 0a          .
+    !text "Bad "                                                      ; 95f3: 42 61 64... Bad
+    !byte $de,   0                                                    ; 95f7: de 00       ..
+
+; $95f9 referenced 1 time by $95c1
+c95f9
+    jsr c8f9d                                                         ; 95f9: 20 9d 8f     ..
+    tya                                                               ; 95fc: 98          .
+    clc                                                               ; 95fd: 18          .
+    adc l000b                                                         ; 95fe: 65 0b       e.
+    ldx l000c                                                         ; 9600: a6 0c       ..
+    bcc c9606                                                         ; 9602: 90 02       ..
+    inx                                                               ; 9604: e8          .
+    clc                                                               ; 9605: 18          .
+; $9606 referenced 1 time by $9602
+c9606
+    sbc #0                                                            ; 9606: e9 00       ..
+    sta l0037                                                         ; 9608: 85 37       .7
+    txa                                                               ; 960a: 8a          .
+    sbc #0                                                            ; 960b: e9 00       ..
+    sta l0038                                                         ; 960d: 85 38       .8
+    ldx #5                                                            ; 960f: a2 05       ..
+    stx l003f                                                         ; 9611: 86 3f       .?
+    ldx l000a                                                         ; 9613: a6 0a       ..
+    jsr sub_c9bba                                                     ; 9615: 20 ba 9b     ..
+    cpy #1                                                            ; 9618: c0 01       ..
+    beq c95f1                                                         ; 961a: f0 d5       ..
+    cmp #$28 ; '('                                                    ; 961c: c9 28       .(
+    beq c9635                                                         ; 961e: f0 15       ..
+    cmp #$24 ; '$'                                                    ; 9620: c9 24       .$
+    beq c9628                                                         ; 9622: f0 04       ..
+    cmp #$25 ; '%'                                                    ; 9624: c9 25       .%
+    bne c9632                                                         ; 9626: d0 0a       ..
+; $9628 referenced 1 time by $9622
+c9628
+    dec l003f                                                         ; 9628: c6 3f       .?
+    iny                                                               ; 962a: c8          .
+    inx                                                               ; 962b: e8          .
+    lda (l0037),y                                                     ; 962c: b1 37       .7
+    cmp #$28 ; '('                                                    ; 962e: c9 28       .(
+    beq c9635                                                         ; 9630: f0 03       ..
+; $9632 referenced 1 time by $9626
+c9632
+    jmp c957f                                                         ; 9632: 4c 7f 95    L..
+
+; $9635 referenced 2 times by $961e, $9630
+c9635
+    iny                                                               ; 9635: c8          .
+    stx l000a                                                         ; 9636: 86 0a       ..
+    jsr sub_c8149                                                     ; 9638: 20 49 81     I.
+; $963b referenced 1 time by $9677
+c963b
+    bne c95f1                                                         ; 963b: d0 b4       ..
+    jsr sub_c9923                                                     ; 963d: 20 23 99     #.
+    ldx #1                                                            ; 9640: a2 01       ..
+    jsr sub_c9952                                                     ; 9642: 20 52 99     R.
+    lda l003f                                                         ; 9645: a5 3f       .?
+    pha                                                               ; 9647: 48          H
+    lda #1                                                            ; 9648: a9 01       ..
+    pha                                                               ; 964a: 48          H
+    jsr cae60                                                         ; 964b: 20 60 ae     `.
+; $964e referenced 1 time by $9673
+c964e
+    jsr cbc66                                                         ; 964e: 20 66 bc     f.
+    jsr sub_c9332                                                     ; 9651: 20 32 93     2.
+    lda l002b                                                         ; 9654: a5 2b       .+
+    and #$c0                                                          ; 9656: 29 c0       ).
+    ora l002c                                                         ; 9658: 05 2c       .,
+    ora l002d                                                         ; 965a: 05 2d       .-
+    bne c95f1                                                         ; 965c: d0 93       ..
+    jsr sub_cbf2f                                                     ; 965e: 20 2f bf     /.
+    ply                                                               ; 9661: 7a          z
+    lda l002a                                                         ; 9662: a5 2a       .*
+    sta (l0002),y                                                     ; 9664: 91 02       ..
+    iny                                                               ; 9666: c8          .
+    lda l002b                                                         ; 9667: a5 2b       .+
+    sta (l0002),y                                                     ; 9669: 91 02       ..
+    iny                                                               ; 966b: c8          .
+    phy                                                               ; 966c: 5a          Z
+    jsr sub_c95c6                                                     ; 966d: 20 c6 95     ..
+    jsr sub_c8da2                                                     ; 9670: 20 a2 8d     ..
+    beq c964e                                                         ; 9673: f0 d9       ..
+    cmp #$29 ; ')'                                                    ; 9675: c9 29       .)
+    bne c963b                                                         ; 9677: d0 c2       ..
+    plx                                                               ; 9679: fa          .
+    pla                                                               ; 967a: 68          h
+    phx                                                               ; 967b: da          .
+    sta l003f                                                         ; 967c: 85 3f       .?
+    stz l0040                                                         ; 967e: 64 40       d@
+    jsr sub_c95cb                                                     ; 9680: 20 cb 95     ..
+    pla                                                               ; 9683: 68          h
+    pha                                                               ; 9684: 48          H
+    adc l002a                                                         ; 9685: 65 2a       e*
+    sta l002a                                                         ; 9687: 85 2a       .*
+    bcc c968d                                                         ; 9689: 90 02       ..
+    inc l002b                                                         ; 968b: e6 2b       .+
+; $968d referenced 1 time by $9689
+c968d
+    lda l0003                                                         ; 968d: a5 03       ..
+    sta l0038                                                         ; 968f: 85 38       .8
+    lda l0002                                                         ; 9691: a5 02       ..
+    sta l0037                                                         ; 9693: 85 37       .7
+    clc                                                               ; 9695: 18          .
+    adc l002a                                                         ; 9696: 65 2a       e*
+    tay                                                               ; 9698: a8          .
+    lda l002b                                                         ; 9699: a5 2b       .+
+    adc l0003                                                         ; 969b: 65 03       e.
+    bcs c96ca                                                         ; 969d: b0 2b       .+
+    tax                                                               ; 969f: aa          .
+    cpy l0004                                                         ; 96a0: c4 04       ..
+    sbc l0005                                                         ; 96a2: e5 05       ..
+    bcs c96ca                                                         ; 96a4: b0 24       .$
+    sty l0002                                                         ; 96a6: 84 02       ..
+    stx l0003                                                         ; 96a8: 86 03       ..
+    pla                                                               ; 96aa: 68          h
+    sta (l0037)                                                       ; 96ab: 92 37       .7
+    adc l0037                                                         ; 96ad: 65 37       e7
+    tay                                                               ; 96af: a8          .
+    lda #0                                                            ; 96b0: a9 00       ..
+    stz l0037                                                         ; 96b2: 64 37       d7
+    bcc c96b8                                                         ; 96b4: 90 02       ..
+    inc l0038                                                         ; 96b6: e6 38       .8
+; $96b8 referenced 3 times by $96b4, $96c1, $96c5
+c96b8
+    sta (l0037),y                                                     ; 96b8: 91 37       .7
+    iny                                                               ; 96ba: c8          .
+    bne c96bf                                                         ; 96bb: d0 02       ..
+    inc l0038                                                         ; 96bd: e6 38       .8
+; $96bf referenced 1 time by $96bb
+c96bf
+    cpy l0002                                                         ; 96bf: c4 02       ..
+    bne c96b8                                                         ; 96c1: d0 f5       ..
+    cpx l0038                                                         ; 96c3: e4 38       .8
+    bne c96b8                                                         ; 96c5: d0 f1       ..
+    jmp c95be                                                         ; 96c7: 4c be 95    L..
+
+; $96ca referenced 3 times by $957c, $969d, $96a4
+c96ca
+    brk                                                               ; 96ca: 00          .
+
+    !byte $0b, $de                                                    ; 96cb: 0b de       ..
+    !text " space"                                                    ; 96cd: 20 73 70...  sp
+    !byte 0                                                           ; 96d3: 00          .
+
+sub_c96d4
+    jsr sub_c977e                                                     ; 96d4: 20 7e 97     ~.
+    lda l002a                                                         ; 96d7: a5 2a       .*
+    sta l0006                                                         ; 96d9: 85 06       ..
+    sta l0004                                                         ; 96db: 85 04       ..
+    lda l002b                                                         ; 96dd: a5 2b       .+
+    sta l0007                                                         ; 96df: 85 07       ..
+    sta l0005                                                         ; 96e1: 85 05       ..
+    bra c9700                                                         ; 96e3: 80 1b       ..
+sub_c96e5
+    jsr sub_c977e                                                     ; 96e5: 20 7e 97     ~.
+    lda l002a                                                         ; 96e8: a5 2a       .*
+    sta l0000                                                         ; 96ea: 85 00       ..
+    sta l0002                                                         ; 96ec: 85 02       ..
+    lda l002b                                                         ; 96ee: a5 2b       .+
+    sta l0001                                                         ; 96f0: 85 01       ..
+    sta l0003                                                         ; 96f2: 85 03       ..
+    jsr sub_cbbeb                                                     ; 96f4: 20 eb bb     ..
+    bra c9700                                                         ; 96f7: 80 07       ..
+sub_c96f9
+    jsr sub_c977e                                                     ; 96f9: 20 7e 97     ~.
+    lda l002b                                                         ; 96fc: a5 2b       .+
+    sta l0018                                                         ; 96fe: 85 18       ..
+; $9700 referenced 4 times by $96e3, $96f7, $9709, $972a
+c9700
+    jmp c90ca                                                         ; 9700: 4c ca 90    L..
+
+sub_c9703
+    jsr c9c6a                                                         ; 9703: 20 6a 9c     j.
+    jsr sub_cbbdc                                                     ; 9706: 20 dc bb     ..
+    bra c9700                                                         ; 9709: 80 f5       ..
+sub_c970b
+    jsr sub_c9be2                                                     ; 970b: 20 e2 9b     ..
+    bcs c971b                                                         ; 970e: b0 0b       ..
+    cmp #$ee                                                          ; 9710: c9 ee       ..
+    beq c972c                                                         ; 9712: f0 18       ..
+    cmp #$87                                                          ; 9714: c9 87       ..
+    beq c9735                                                         ; 9716: f0 1d       ..
+    jsr sub_c9332                                                     ; 9718: 20 32 93     2.
+; $971b referenced 1 time by $970e
+c971b
+    jsr c9c6a                                                         ; 971b: 20 6a 9c     j.
+    lda l002a                                                         ; 971e: a5 2a       .*
+    sta l0021                                                         ; 9720: 85 21       .!
+    lda l002b                                                         ; 9722: a5 2b       .+
+; $9724 referenced 1 time by $9733
+loop_c9724
+    sta l0022                                                         ; 9724: 85 22       ."
+    lda #$ff                                                          ; 9726: a9 ff       ..
+; $9728 referenced 1 time by $973c
+loop_c9728
+    sta l0020                                                         ; 9728: 85 20       .
+    bra c9700                                                         ; 972a: 80 d4       ..
+; $972c referenced 1 time by $9712
+c972c
+    inc l000a                                                         ; 972c: e6 0a       ..
+    jsr c9c6a                                                         ; 972e: 20 6a 9c     j.
+    lda #$ff                                                          ; 9731: a9 ff       ..
+    bne loop_c9724                                                    ; 9733: d0 ef       ..
+; $9735 referenced 1 time by $9716
+c9735
+    inc l000a                                                         ; 9735: e6 0a       ..
+    jsr c9c6a                                                         ; 9737: 20 6a 9c     j.
+    lda #0                                                            ; 973a: a9 00       ..
+    bra loop_c9728                                                    ; 973c: 80 ea       ..
+sub_c973e
+    iny                                                               ; 973e: c8          .
+    lda (l000b),y                                                     ; 973f: b1 0b       ..
+    cmp #$24 ; '$'                                                    ; 9741: c9 24       .$
+    beq c9753                                                         ; 9743: f0 0e       ..
+    jsr sub_c977e                                                     ; 9745: 20 7e 97     ~.
+    stz l002e                                                         ; 9748: 64 2e       d.
+    ldx #$2a ; '*'                                                    ; 974a: a2 2a       .*
+    ldy #0                                                            ; 974c: a0 00       ..
+    lda #2                                                            ; 974e: a9 02       ..
+; $9750 referenced 1 time by $9767
+loop_c9750
+    jmp cb34c                                                         ; 9750: 4c 4c b3    LL.
+
+; $9753 referenced 1 time by $9743
+c9753
+    inc l000a                                                         ; 9753: e6 0a       ..
+    jsr sub_c9c0a                                                     ; 9755: 20 0a 9c     ..
+    lda l0027                                                         ; 9758: a5 27       .'
+    bne c979c                                                         ; 975a: d0 40       .@
+    lda #$0f                                                          ; 975c: a9 0f       ..
+    ldy l0036                                                         ; 975e: a4 36       .6
+    sty l05ff                                                         ; 9760: 8c ff 05    ...
+    ldx #$ff                                                          ; 9763: a2 ff       ..
+    ldy #5                                                            ; 9765: a0 05       ..
+    bra loop_c9750                                                    ; 9767: 80 e7       ..
+; $9769 referenced 2 times by $aca3, $aec8
+sub_c9769
+    jsr cbc91                                                         ; 9769: 20 91 bc     ..
+; $976c referenced 6 times by $92f3, $9b2a, $9b4c, $aa9c, $ac60, $af2c
+sub_c976c
+    jsr cadee                                                         ; 976c: 20 ee ad     ..
+    bra c9784                                                         ; 976f: 80 13       ..
+; $9771 referenced 6 times by $9816, $9886, $988c, $b30e, $b32f, $bf01
+sub_c9771
+    jsr sub_c8fb4                                                     ; 9771: 20 b4 8f     ..
+; $9774 referenced 7 times by $8fae, $9304, $958b, $9ae9, $af18, $b67d, $b6a2
+sub_c9774
+    jsr sub_c9dff                                                     ; 9774: 20 ff 9d     ..
+    bra c9784                                                         ; 9777: 80 0b       ..
+; $9779 referenced 10 times by $931e, $99a5, $99ad, $9a8b, $aa6e, $aaeb, $ab01, $ae34, $b269, $ba81
+sub_c9779
+    jsr cad78                                                         ; 9779: 20 78 ad     x.
+    bra c9784                                                         ; 977c: 80 06       ..
+; $977e referenced 4 times by $96d4, $96e5, $96f9, $9745
+sub_c977e
+    jsr sub_c9c0a                                                     ; 977e: 20 0a 9c     ..
+; $9781 referenced 4 times by $9384, $987b, $ba4d, $bee1
+sub_c9781
+    lda l0027                                                         ; 9781: a5 27       .'
+; $9783 referenced 7 times by $81bd, $81cd, $9e13, $9e2d, $9e3f, $9e4d, $9e56
+sub_c9783
+    tay                                                               ; 9783: a8          .
+; $9784 referenced 5 times by $9335, $976f, $9777, $977c, $9a82
+c9784
+    beq c979c                                                         ; 9784: f0 16       ..
+    bpl c979b                                                         ; 9786: 10 13       ..
+; $9788 referenced 5 times by $9cd3, $a134, $a998, $aab9, $b37d
+sub_c9788
+    jsr sub_c834f                                                     ; 9788: 20 4f 83     O.
+; $978b referenced 1 time by $abfd
+sub_c978b
+    lda l0031                                                         ; 978b: a5 31       .1
+    sta l002d                                                         ; 978d: 85 2d       .-
+    lda l0032                                                         ; 978f: a5 32       .2
+    sta l002c                                                         ; 9791: 85 2c       .,
+    lda l0033                                                         ; 9793: a5 33       .3
+    sta l002b                                                         ; 9795: 85 2b       .+
+    lda l0034                                                         ; 9797: a5 34       .4
+    sta l002a                                                         ; 9799: 85 2a       .*
+; $979b referenced 2 times by $9786, $97a4
+c979b
+    rts                                                               ; 979b: 60          `
+
+; $979c referenced 3 times by $975a, $9784, $97a2
+c979c
+    jmp c9155                                                         ; 979c: 4c 55 91    LU.
+
+; $979f referenced 8 times by $a7ac, $a808, $a901, $a919, $a9b5, $a9ca, $a9d1, $aa17
+sub_c979f
+    jsr cad78                                                         ; 979f: 20 78 ad     x.
+; $97a2 referenced 5 times by $9d30, $b6d4, $b6f2, $bc21, $bc37
+sub_c97a2
+    beq c979c                                                         ; 97a2: f0 f8       ..
+    bmi c979b                                                         ; 97a4: 30 f5       0.
+    jmp c828d                                                         ; 97a6: 4c 8d 82    L..
+
+sub_c97a9
+    lda l000b                                                         ; 97a9: a5 0b       ..
+    sta l0019                                                         ; 97ab: 85 19       ..
+    lda l000c                                                         ; 97ad: a5 0c       ..
+    sta l001a                                                         ; 97af: 85 1a       ..
+    lda l000a                                                         ; 97b1: a5 0a       ..
+    sta l001b                                                         ; 97b3: 85 1b       ..
+    lda #$f2                                                          ; 97b5: a9 f2       ..
+    jsr sub_cb057                                                     ; 97b7: 20 57 b0     W.
+    jsr sub_c9c5a                                                     ; 97ba: 20 5a 9c     Z.
+    jmp c90ca                                                         ; 97bd: 4c ca 90    L..
+
+; $97c0 referenced 1 time by $97c8
+loop_c97c0
+    lda #$0d                                                          ; 97c0: a9 0d       ..
+    sta (l002a)                                                       ; 97c2: 92 2a       .*
+    bra c97ee                                                         ; 97c4: 80 28       .(
+; $97c6 referenced 1 time by $97e1
+loop_c97c6
+    cpy #$80                                                          ; 97c6: c0 80       ..
+    beq loop_c97c0                                                    ; 97c8: f0 f6       ..
+    ldy #3                                                            ; 97ca: a0 03       ..
+    lda #0                                                            ; 97cc: a9 00       ..
+    sta (l002a),y                                                     ; 97ce: 91 2a       .*
+    beq c97ee                                                         ; 97d0: f0 1c       ..
+; $97d2 referenced 1 time by $97f9
+c97d2
+    tsx                                                               ; 97d2: ba          .
+    cpx #$fc                                                          ; 97d3: e0 fc       ..
+    bcs c9801                                                         ; 97d5: b0 2a       .*
+    jsr sub_c997d                                                     ; 97d7: 20 7d 99     }.
+    beq c97fe                                                         ; 97da: f0 22       ."
+    jsr sub_cb1bf                                                     ; 97dc: 20 bf b1     ..
+    ldy l002c                                                         ; 97df: a4 2c       .,
+    bmi loop_c97c6                                                    ; 97e1: 30 e3       0.
+    jsr sub_cbc83                                                     ; 97e3: 20 83 bc     ..
+    jsr cac38                                                         ; 97e6: 20 38 ac     8.
+    sta l0027                                                         ; 97e9: 85 27       .'
+    jsr sub_cb365                                                     ; 97eb: 20 65 b3     e.
+; $97ee referenced 2 times by $97c4, $97d0
+c97ee
+    tsx                                                               ; 97ee: ba          .
+    inc l0106,x                                                       ; 97ef: fe 06 01    ...
+    ldy l001b                                                         ; 97f2: a4 1b       ..
+    sty l000a                                                         ; 97f4: 84 0a       ..
+    jsr sub_c8da2                                                     ; 97f6: 20 a2 8d     ..
+    beq c97d2                                                         ; 97f9: f0 d7       ..
+    jmp c90c5                                                         ; 97fb: 4c c5 90    L..
+
+; $97fe referenced 1 time by $97da
+c97fe
+    jmp c90c7                                                         ; 97fe: 4c c7 90    L..
+
+; $9801 referenced 1 time by $97d5
+c9801
+    brk                                                               ; 9801: 00          .
+
+    !byte $0c                                                         ; 9802: 0c          .
+    !text "Not "                                                      ; 9803: 4e 6f 74... Not
+    !byte $ea                                                         ; 9807: ea          .
+
+; $9808 referenced 4 times by $9841, $9847, $9855, $985c
+c9808
+    brk                                                               ; 9808: 00          .
+
+    !byte $19                                                         ; 9809: 19          .
+    !text "Bad "                                                      ; 980a: 42 61 64... Bad
+    !byte $eb,   0                                                    ; 980e: eb 00       ..
+
+sub_c9810
+    jsr sub_c9332                                                     ; 9810: 20 32 93     2.
+    lda l002a                                                         ; 9813: a5 2a       .*
+    pha                                                               ; 9815: 48          H
+    jsr sub_c9771                                                     ; 9816: 20 71 97     q.
+    jsr sub_c9c5a                                                     ; 9819: 20 5a 9c     Z.
+    lda #$12                                                          ; 981c: a9 12       ..
+    jsr oswrch                                                        ; 981e: 20 ee ff     ..
+    pla                                                               ; 9821: 68          h
+    bra c986a                                                         ; 9822: 80 46       .F
+sub_c9824
+    jsr sub_c9332                                                     ; 9824: 20 32 93     2.
+    jsr c9c6a                                                         ; 9827: 20 6a 9c     j.
+    lda #$11                                                          ; 982a: a9 11       ..
+    bra c986a                                                         ; 982c: 80 3c       .<
+sub_c982e
+    jsr sub_c9332                                                     ; 982e: 20 32 93     2.
+    jsr c9c6a                                                         ; 9831: 20 6a 9c     j.
+    jsr sub_cbe8b                                                     ; 9834: 20 8b be     ..
+    inx                                                               ; 9837: e8          .
+    bne c9866                                                         ; 9838: d0 2c       .,
+    iny                                                               ; 983a: c8          .
+    bne c9866                                                         ; 983b: d0 29       .)
+    lda l0004                                                         ; 983d: a5 04       ..
+    cmp l0006                                                         ; 983f: c5 06       ..
+    bne c9808                                                         ; 9841: d0 c5       ..
+    lda l0005                                                         ; 9843: a5 05       ..
+    cmp l0007                                                         ; 9845: c5 07       ..
+    bne c9808                                                         ; 9847: d0 bf       ..
+    ldx l002a                                                         ; 9849: a6 2a       .*
+    lda #osbyte_read_himem_for_mode                                   ; 984b: a9 85       ..
+    jsr osbyte                                                        ; 984d: 20 f4 ff     ..
+    cpx l0002                                                         ; 9850: e4 02       ..
+    tya                                                               ; 9852: 98          .
+    sbc l0003                                                         ; 9853: e5 03       ..
+    bcc c9808                                                         ; 9855: 90 b1       ..
+    cpx l0012                                                         ; 9857: e4 12       ..
+    tya                                                               ; 9859: 98          .
+    sbc l0013                                                         ; 985a: e5 13       ..
+    bcc c9808                                                         ; 985c: 90 aa       ..
+    stx l0006                                                         ; 985e: 86 06       ..
+    stx l0004                                                         ; 9860: 86 04       ..
+    sty l0007                                                         ; 9862: 84 07       ..
+    sty l0005                                                         ; 9864: 84 05       ..
+; $9866 referenced 2 times by $9838, $983b
+c9866
+    stz l001e                                                         ; 9866: 64 1e       d.
+    lda #$16                                                          ; 9868: a9 16       ..
+; $986a referenced 2 times by $9822, $982c
+c986a
+    jsr oswrch                                                        ; 986a: 20 ee ff     ..
+    lda l002a                                                         ; 986d: a5 2a       .*
+    bra c98bd                                                         ; 986f: 80 4c       .L
+sub_c9871
+    lda #4                                                            ; 9871: a9 04       ..
+    bra c9877                                                         ; 9873: 80 02       ..
+sub_c9875
+    lda #5                                                            ; 9875: a9 05       ..
+; $9877 referenced 1 time by $9873
+c9877
+    pha                                                               ; 9877: 48          H
+    jsr sub_c9df3                                                     ; 9878: 20 f3 9d     ..
+    jsr sub_c9781                                                     ; 987b: 20 81 97     ..
+    bra c9889                                                         ; 987e: 80 09       ..
+sub_c9880
+    jsr sub_c9332                                                     ; 9880: 20 32 93     2.
+    lda l002a                                                         ; 9883: a5 2a       .*
+    pha                                                               ; 9885: 48          H
+    jsr sub_c9771                                                     ; 9886: 20 71 97     q.
+; $9889 referenced 1 time by $987e
+c9889
+    jsr cbc66                                                         ; 9889: 20 66 bc     f.
+    jsr sub_c9771                                                     ; 988c: 20 71 97     q.
+    jsr sub_c9c5a                                                     ; 988f: 20 5a 9c     Z.
+    lda #$19                                                          ; 9892: a9 19       ..
+    jsr oswrch                                                        ; 9894: 20 ee ff     ..
+    pla                                                               ; 9897: 68          h
+    jsr oswrch                                                        ; 9898: 20 ee ff     ..
+    jsr sub_cbd46                                                     ; 989b: 20 46 bd     F.
+    lda l0037                                                         ; 989e: a5 37       .7
+    jsr oswrch                                                        ; 98a0: 20 ee ff     ..
+    lda l0038                                                         ; 98a3: a5 38       .8
+    jsr oswrch                                                        ; 98a5: 20 ee ff     ..
+    jsr sub_c990f                                                     ; 98a8: 20 0f 99     ..
+    lda l002b                                                         ; 98ab: a5 2b       .+
+    bra c98bd                                                         ; 98ad: 80 0e       ..
+sub_c98af
+    jsr c9c6a                                                         ; 98af: 20 6a 9c     j.
+    lda #$10                                                          ; 98b2: a9 10       ..
+    bra c98bd                                                         ; 98b4: 80 07       ..
+sub_c98b6
+    jsr c9c6a                                                         ; 98b6: 20 6a 9c     j.
+    stz l001e                                                         ; 98b9: 64 1e       d.
+    lda #$0c                                                          ; 98bb: a9 0c       ..
+; $98bd referenced 3 times by $986f, $98ad, $98b4
+c98bd
+    jsr oswrch                                                        ; 98bd: 20 ee ff     ..
+; $98c0 referenced 2 times by $98cd, $98d5
+c98c0
+    jmp c90ca                                                         ; 98c0: 4c ca 90    L..
+
+sub_c98c3
+    jsr c9c6a                                                         ; 98c3: 20 6a 9c     j.
+    jsr sub_cbac2                                                     ; 98c6: 20 c2 ba     ..
+    ldy #1                                                            ; 98c9: a0 01       ..
+; $98cb referenced 1 time by $98d3
+loop_c98cb
+    lda (l00fd),y                                                     ; 98cb: b1 fd       ..
+    beq c98c0                                                         ; 98cd: f0 f1       ..
+    jsr sub_cbd77                                                     ; 98cf: 20 77 bd     w.
+    iny                                                               ; 98d2: c8          .
+    bne loop_c98cb                                                    ; 98d3: d0 f6       ..
+    bra c98c0                                                         ; 98d5: 80 e9       ..
+; $98d7 referenced 1 time by $98fa
+c98d7
+    lda l002b                                                         ; 98d7: a5 2b       .+
+    jsr oswrch                                                        ; 98d9: 20 ee ff     ..
+; $98dc referenced 2 times by $98f6, $990a
+c98dc
+    jsr c8f9d                                                         ; 98dc: 20 9d 8f     ..
+; $98df referenced 1 time by $98fe
+loop_c98df
+    cmp #$3a ; ':'                                                    ; 98df: c9 3a       .:
+    beq c990c                                                         ; 98e1: f0 29       .)
+    cmp #$0d                                                          ; 98e3: c9 0d       ..
+    beq c990c                                                         ; 98e5: f0 25       .%
+    cmp #$8b                                                          ; 98e7: c9 8b       ..
+    beq c990c                                                         ; 98e9: f0 21       .!
+    dec l000a                                                         ; 98eb: c6 0a       ..
+    jsr sub_c9332                                                     ; 98ed: 20 32 93     2.
+    jsr sub_c990f                                                     ; 98f0: 20 0f 99     ..
+    jsr sub_c8da2                                                     ; 98f3: 20 a2 8d     ..
+    beq c98dc                                                         ; 98f6: f0 e4       ..
+    cmp #$3b ; ';'                                                    ; 98f8: c9 3b       .;
+    beq c98d7                                                         ; 98fa: f0 db       ..
+    cmp #$7c ; '|'                                                    ; 98fc: c9 7c       .|
+    bne loop_c98df                                                    ; 98fe: d0 df       ..
+    lda #0                                                            ; 9900: a9 00       ..
+    ldy #9                                                            ; 9902: a0 09       ..
+; $9904 referenced 1 time by $9908
+loop_c9904
+    jsr oswrch                                                        ; 9904: 20 ee ff     ..
+    dey                                                               ; 9907: 88          .
+    bne loop_c9904                                                    ; 9908: d0 fa       ..
+    bra c98dc                                                         ; 990a: 80 d0       ..
+; $990c referenced 3 times by $98e1, $98e5, $98e9
+c990c
+    jmp c90c5                                                         ; 990c: 4c c5 90    L..
+
+; $990f referenced 3 times by $92ff, $98a8, $98f0
+sub_c990f
+    lda l002a                                                         ; 990f: a5 2a       .*
+    jmp (wrchv)                                                       ; 9911: 6c 0e 02    l..
+
+; $9914 referenced 1 time by $b031
+sub_c9914
+    ldy #1                                                            ; 9914: a0 01       ..
+    lda (l0037),y                                                     ; 9916: b1 37       .7
+    tax                                                               ; 9918: aa          .
+    lda #$f6                                                          ; 9919: a9 f6       ..
+    cpx #$f2                                                          ; 991b: e0 f2       ..
+    beq c9928                                                         ; 991d: f0 09       ..
+    lda #$f8                                                          ; 991f: a9 f8       ..
+    bra c9928                                                         ; 9921: 80 05       ..
+; $9923 referenced 3 times by $90fe, $963d, $9984
+sub_c9923
+    ldy #1                                                            ; 9923: a0 01       ..
+    lda (l0037),y                                                     ; 9925: b1 37       .7
+    asl                                                               ; 9927: 0a          .
+; $9928 referenced 2 times by $991d, $9921
+c9928
+    ldx #4                                                            ; 9928: a2 04       ..
+; $992a referenced 1 time by $9935
+loop_c992a
+    sta l003a                                                         ; 992a: 85 3a       .:
+    stx l003b                                                         ; 992c: 86 3b       .;
+    lda (l003a),y                                                     ; 992e: b1 3a       .:
+    beq c9937                                                         ; 9930: f0 05       ..
+    tax                                                               ; 9932: aa          .
+    lda (l003a)                                                       ; 9933: b2 3a       .:
+    bra loop_c992a                                                    ; 9935: 80 f3       ..
+; $9937 referenced 1 time by $9930
+c9937
+    lda l0003                                                         ; 9937: a5 03       ..
+    sta (l003a),y                                                     ; 9939: 91 3a       .:
+    lda l0002                                                         ; 993b: a5 02       ..
+    sta (l003a)                                                       ; 993d: 92 3a       .:
+    lda #0                                                            ; 993f: a9 00       ..
+    sta (l0002),y                                                     ; 9941: 91 02       ..
+    iny                                                               ; 9943: c8          .
+    cpy l0039                                                         ; 9944: c4 39       .9
+    beq c9979                                                         ; 9946: f0 31       .1
+; $9948 referenced 1 time by $994f
+loop_c9948
+    lda (l0037),y                                                     ; 9948: b1 37       .7
+    sta (l0002),y                                                     ; 994a: 91 02       ..
+    iny                                                               ; 994c: c8          .
+    cpy l0039                                                         ; 994d: c4 39       .9
+    bne loop_c9948                                                    ; 994f: d0 f7       ..
+    rts                                                               ; 9951: 60          `
+
+; $9952 referenced 4 times by $9108, $9642, $997a, $b036
+sub_c9952
+    lda #0                                                            ; 9952: a9 00       ..
+; $9954 referenced 1 time by $9958
+loop_c9954
+    sta (l0002),y                                                     ; 9954: 91 02       ..
+    iny                                                               ; 9956: c8          .
+    dex                                                               ; 9957: ca          .
+    bne loop_c9954                                                    ; 9958: d0 fa       ..
+; $995a referenced 1 time by $b044
+sub_c995a
+    clc                                                               ; 995a: 18          .
+    tya                                                               ; 995b: 98          .
+    adc l0002                                                         ; 995c: 65 02       e.
+    bcc c9962                                                         ; 995e: 90 02       ..
+    inc l0003                                                         ; 9960: e6 03       ..
+; $9962 referenced 1 time by $995e
+c9962
+    ldy l0003                                                         ; 9962: a4 03       ..
+    cpy l0005                                                         ; 9964: c4 05       ..
+    bcc c9977                                                         ; 9966: 90 0f       ..
+    bne c996e                                                         ; 9968: d0 04       ..
+    cmp l0004                                                         ; 996a: c5 04       ..
+    bcc c9977                                                         ; 996c: 90 09       ..
+; $996e referenced 1 time by $9968
+c996e
+    lda #0                                                            ; 996e: a9 00       ..
+    ldy #1                                                            ; 9970: a0 01       ..
+    sta (l003a),y                                                     ; 9972: 91 3a       .:
+    jmp c9164                                                         ; 9974: 4c 64 91    Ld.
+
+; $9977 referenced 2 times by $9966, $996c
+c9977
+    sta l0002                                                         ; 9977: 85 02       ..
+; $9979 referenced 1 time by $9946
+c9979
+    rts                                                               ; 9979: 60          `
+
+; $997a referenced 2 times by $998b, $998e
+c997a
+    jsr sub_c9952                                                     ; 997a: 20 52 99     R.
+; $997d referenced 9 times by $8a91, $910d, $9581, $97d7, $b112, $b649, $b887, $b91f, $b9ad
+sub_c997d
+    jsr sub_c99c4                                                     ; 997d: 20 c4 99     ..
+    bne c999f                                                         ; 9980: d0 1d       ..
+    bcs c999f                                                         ; 9982: b0 1b       ..
+    jsr sub_c9923                                                     ; 9984: 20 23 99     #.
+    ldx #5                                                            ; 9987: a2 05       ..
+    cpx l002c                                                         ; 9989: e4 2c       .,
+    bne c997a                                                         ; 998b: d0 ed       ..
+    inx                                                               ; 998d: e8          .
+    bra c997a                                                         ; 998e: 80 ea       ..
+; $9990 referenced 1 time by $99da
+c9990
+    cmp #$21 ; '!'                                                    ; 9990: c9 21       .!
+    beq c99a0                                                         ; 9992: f0 0c       ..
+    cmp #$24 ; '$'                                                    ; 9994: c9 24       .$
+    beq c99ab                                                         ; 9996: f0 13       ..
+    eor #$3f ; '?'                                                    ; 9998: 49 3f       I?
+    beq c99a2                                                         ; 999a: f0 06       ..
+    lda #0                                                            ; 999c: a9 00       ..
+    sec                                                               ; 999e: 38          8
+; $999f referenced 2 times by $9980, $9982
+c999f
+    rts                                                               ; 999f: 60          `
+
+; $99a0 referenced 1 time by $9992
+c99a0
+    lda #4                                                            ; 99a0: a9 04       ..
+; $99a2 referenced 1 time by $999a
+c99a2
+    pha                                                               ; 99a2: 48          H
+    inc l001b                                                         ; 99a3: e6 1b       ..
+    jsr sub_c9779                                                     ; 99a5: 20 79 97     y.
+    jmp c9a99                                                         ; 99a8: 4c 99 9a    L..
+
+; $99ab referenced 1 time by $9996
+c99ab
+    inc l001b                                                         ; 99ab: e6 1b       ..
+    jsr sub_c9779                                                     ; 99ad: 20 79 97     y.
+    lda l002b                                                         ; 99b0: a5 2b       .+
+    beq c99ba                                                         ; 99b2: f0 06       ..
+    lda #$80                                                          ; 99b4: a9 80       ..
+    sta l002c                                                         ; 99b6: 85 2c       .,
+    sec                                                               ; 99b8: 38          8
+    rts                                                               ; 99b9: 60          `
+
+; $99ba referenced 1 time by $99b2
+c99ba
+    brk                                                               ; 99ba: 00          .
+
+    !byte 8                                                           ; 99bb: 08          .
+    !text "$ range"                                                   ; 99bc: 24 20 72... $ r
+    !byte 0                                                           ; 99c3: 00          .
+
+; $99c4 referenced 2 times by $997d, $b522
+sub_c99c4
+    lda l000b                                                         ; 99c4: a5 0b       ..
+    sta l0019                                                         ; 99c6: 85 19       ..
+    lda l000c                                                         ; 99c8: a5 0c       ..
+    sta l001a                                                         ; 99ca: 85 1a       ..
+    ldy l000a                                                         ; 99cc: a4 0a       ..
+    dey                                                               ; 99ce: 88          .
+; $99cf referenced 1 time by $99d4
+loop_c99cf
+    iny                                                               ; 99cf: c8          .
+; $99d0 referenced 1 time by $9397
+sub_c99d0
+    lda (l0019),y                                                     ; 99d0: b1 19       ..
+    cmp #$20 ; ' '                                                    ; 99d2: c9 20       .
+    beq loop_c99cf                                                    ; 99d4: f0 f9       ..
+; $99d6 referenced 1 time by $90f2
+sub_c99d6
+    sty l001b                                                         ; 99d6: 84 1b       ..
+; $99d8 referenced 1 time by $adae
+sub_c99d8
+    cmp #$40 ; '@'                                                    ; 99d8: c9 40       .@
+    bcc c9990                                                         ; 99da: 90 b4       ..
+    cmp #$5b ; '['                                                    ; 99dc: c9 5b       .[
+    bcs c99fa                                                         ; 99de: b0 1a       ..
+    asl                                                               ; 99e0: 0a          .
+    asl                                                               ; 99e1: 0a          .
+    sta l002a                                                         ; 99e2: 85 2a       .*
+    iny                                                               ; 99e4: c8          .
+    lda (l0019),y                                                     ; 99e5: b1 19       ..
+    cmp #$25 ; '%'                                                    ; 99e7: c9 25       .%
+    bne c99fa                                                         ; 99e9: d0 0f       ..
+    lda #4                                                            ; 99eb: a9 04       ..
+    sta l002b                                                         ; 99ed: 85 2b       .+
+    ldx #4                                                            ; 99ef: a2 04       ..
+    stx l002c                                                         ; 99f1: 86 2c       .,
+    iny                                                               ; 99f3: c8          .
+    lda (l0019),y                                                     ; 99f4: b1 19       ..
+    cmp #$28 ; '('                                                    ; 99f6: c9 28       .(
+    bne c9a67                                                         ; 99f8: d0 6d       .m
+; $99fa referenced 2 times by $99de, $99e9
+c99fa
+    ldx #5                                                            ; 99fa: a2 05       ..
+    stx l002c                                                         ; 99fc: 86 2c       .,
+    clc                                                               ; 99fe: 18          .
+    ldy l001a                                                         ; 99ff: a4 1a       ..
+    lda l001b                                                         ; 9a01: a5 1b       ..
+    tax                                                               ; 9a03: aa          .
+    bne c9a0e                                                         ; 9a04: d0 08       ..
+    dec                                                               ; 9a06: 3a          :
+    adc l0019                                                         ; 9a07: 65 19       e.
+    bcs c9a14                                                         ; 9a09: b0 09       ..
+    dey                                                               ; 9a0b: 88          .
+    bra c9a14                                                         ; 9a0c: 80 06       ..
+; $9a0e referenced 1 time by $9a04
+c9a0e
+    dec                                                               ; 9a0e: 3a          :
+    adc l0019                                                         ; 9a0f: 65 19       e.
+    bcc c9a14                                                         ; 9a11: 90 01       ..
+    iny                                                               ; 9a13: c8          .
+; $9a14 referenced 3 times by $9a09, $9a0c, $9a11
+c9a14
+    sta l0037                                                         ; 9a14: 85 37       .7
+    sty l0038                                                         ; 9a16: 84 38       .8
+    ldy #1                                                            ; 9a18: a0 01       ..
+    lda (l0037),y                                                     ; 9a1a: b1 37       .7
+    cmp #$41 ; 'A'                                                    ; 9a1c: c9 41       .A
+    bcs c9a3a                                                         ; 9a1e: b0 1a       ..
+    cmp #$30 ; '0'                                                    ; 9a20: c9 30       .0
+    bcc c9a46                                                         ; 9a22: 90 22       ."
+    cmp #$3a ; ':'                                                    ; 9a24: c9 3a       .:
+    bcs c9a46                                                         ; 9a26: b0 1e       ..
+; $9a28 referenced 3 times by $9a36, $9a3c, $9a44
+c9a28
+    inx                                                               ; 9a28: e8          .
+    iny                                                               ; 9a29: c8          .
+    lda (l0037),y                                                     ; 9a2a: b1 37       .7
+    cmp #$41 ; 'A'                                                    ; 9a2c: c9 41       .A
+    bcs c9a3a                                                         ; 9a2e: b0 0a       ..
+    cmp #$30 ; '0'                                                    ; 9a30: c9 30       .0
+    bcc c9a46                                                         ; 9a32: 90 12       ..
+    cmp #$3a ; ':'                                                    ; 9a34: c9 3a       .:
+    bcc c9a28                                                         ; 9a36: 90 f0       ..
+    bra c9a46                                                         ; 9a38: 80 0c       ..
+; $9a3a referenced 2 times by $9a1e, $9a2e
+c9a3a
+    cmp #$5b ; '['                                                    ; 9a3a: c9 5b       .[
+    bcc c9a28                                                         ; 9a3c: 90 ea       ..
+    cmp #$5f ; '_'                                                    ; 9a3e: c9 5f       ._
+    bcc c9a46                                                         ; 9a40: 90 04       ..
+    cmp #$7b ; '{'                                                    ; 9a42: c9 7b       .{
+    bcc c9a28                                                         ; 9a44: 90 e2       ..
+; $9a46 referenced 5 times by $9a22, $9a26, $9a32, $9a38, $9a40
+c9a46
+    cpy #1                                                            ; 9a46: c0 01       ..
+    beq c9a76                                                         ; 9a48: f0 2c       .,
+    cmp #$24 ; '$'                                                    ; 9a4a: c9 24       .$
+    beq c9aa5                                                         ; 9a4c: f0 57       .W
+    cmp #$25 ; '%'                                                    ; 9a4e: c9 25       .%
+    bne c9a58                                                         ; 9a50: d0 06       ..
+    dec l002c                                                         ; 9a52: c6 2c       .,
+    inx                                                               ; 9a54: e8          .
+    iny                                                               ; 9a55: c8          .
+    lda (l0037),y                                                     ; 9a56: b1 37       .7
+; $9a58 referenced 1 time by $9a50
+c9a58
+    cmp #$28 ; '('                                                    ; 9a58: c9 28       .(
+    beq c9aa0                                                         ; 9a5a: f0 44       .D
+    jsr sub_c8149                                                     ; 9a5c: 20 49 81     I.
+    beq c9a75                                                         ; 9a5f: f0 14       ..
+    stx l001b                                                         ; 9a61: 86 1b       ..
+; $9a63 referenced 1 time by $9aa3
+c9a63
+    ldy l001b                                                         ; 9a63: a4 1b       ..
+    lda (l0019),y                                                     ; 9a65: b1 19       ..
+; $9a67 referenced 1 time by $99f8
+c9a67
+    cmp #$21 ; '!'                                                    ; 9a67: c9 21       .!
+    beq c9a79                                                         ; 9a69: f0 0e       ..
+    eor #$3f ; '?'                                                    ; 9a6b: 49 3f       I?
+    beq c9a7b                                                         ; 9a6d: f0 0c       ..
+    clc                                                               ; 9a6f: 18          .
+    sty l001b                                                         ; 9a70: 84 1b       ..
+    lda #$ff                                                          ; 9a72: a9 ff       ..
+    rts                                                               ; 9a74: 60          `
+
+; $9a75 referenced 2 times by $9a5f, $9ab2
+c9a75
+    clc                                                               ; 9a75: 18          .
+; $9a76 referenced 1 time by $9a48
+c9a76
+    lda #0                                                            ; 9a76: a9 00       ..
+    rts                                                               ; 9a78: 60          `
+
+; $9a79 referenced 1 time by $9a69
+c9a79
+    lda #4                                                            ; 9a79: a9 04       ..
+; $9a7b referenced 1 time by $9a6d
+c9a7b
+    pha                                                               ; 9a7b: 48          H
+    iny                                                               ; 9a7c: c8          .
+    sty l001b                                                         ; 9a7d: 84 1b       ..
+    jsr cb1de                                                         ; 9a7f: 20 de b1     ..
+    jsr c9784                                                         ; 9a82: 20 84 97     ..
+    lda l002b                                                         ; 9a85: a5 2b       .+
+    pha                                                               ; 9a87: 48          H
+    lda l002a                                                         ; 9a88: a5 2a       .*
+    pha                                                               ; 9a8a: 48          H
+    jsr sub_c9779                                                     ; 9a8b: 20 79 97     y.
+    clc                                                               ; 9a8e: 18          .
+    pla                                                               ; 9a8f: 68          h
+    adc l002a                                                         ; 9a90: 65 2a       e*
+    sta l002a                                                         ; 9a92: 85 2a       .*
+    pla                                                               ; 9a94: 68          h
+    adc l002b                                                         ; 9a95: 65 2b       e+
+    sta l002b                                                         ; 9a97: 85 2b       .+
+; $9a99 referenced 1 time by $99a8
+c9a99
+    pla                                                               ; 9a99: 68          h
+    sta l002c                                                         ; 9a9a: 85 2c       .,
+    clc                                                               ; 9a9c: 18          .
+    lda #$ff                                                          ; 9a9d: a9 ff       ..
+    rts                                                               ; 9a9f: 60          `
+
+; $9aa0 referenced 1 time by $9a5a
+c9aa0
+    jsr sub_c9ac9                                                     ; 9aa0: 20 c9 9a     ..
+    bra c9a63                                                         ; 9aa3: 80 be       ..
+; $9aa5 referenced 1 time by $9a4c
+c9aa5
+    dec l002c                                                         ; 9aa5: c6 2c       .,
+    inx                                                               ; 9aa7: e8          .
+    iny                                                               ; 9aa8: c8          .
+    lda (l0037),y                                                     ; 9aa9: b1 37       .7
+    cmp #$28 ; '('                                                    ; 9aab: c9 28       .(
+    beq c9abc                                                         ; 9aad: f0 0d       ..
+    jsr sub_c8149                                                     ; 9aaf: 20 49 81     I.
+    beq c9a75                                                         ; 9ab2: f0 c1       ..
+    stx l001b                                                         ; 9ab4: 86 1b       ..
+; $9ab6 referenced 1 time by $9abf
+loop_c9ab6
+    lda #$81                                                          ; 9ab6: a9 81       ..
+    sta l002c                                                         ; 9ab8: 85 2c       .,
+    sec                                                               ; 9aba: 38          8
+    rts                                                               ; 9abb: 60          `
+
+; $9abc referenced 1 time by $9aad
+c9abc
+    jsr sub_c9ac9                                                     ; 9abc: 20 c9 9a     ..
+    bra loop_c9ab6                                                    ; 9abf: 80 f5       ..
+; $9ac1 referenced 2 times by $9ace, $9af0
+c9ac1
+    brk                                                               ; 9ac1: 00          .
+
+    !byte $0e                                                         ; 9ac2: 0e          .
+    !text "Array"                                                     ; 9ac3: 41 72 72... Arr
+    !byte 0                                                           ; 9ac8: 00          .
+
+; $9ac9 referenced 2 times by $9aa0, $9abc
+sub_c9ac9
+    inx                                                               ; 9ac9: e8          .
+    iny                                                               ; 9aca: c8          .
+    jsr sub_c8149                                                     ; 9acb: 20 49 81     I.
+    beq c9ac1                                                         ; 9ace: f0 f1       ..
+    stx l001b                                                         ; 9ad0: 86 1b       ..
+    lda l002c                                                         ; 9ad2: a5 2c       .,
+    pha                                                               ; 9ad4: 48          H
+    lda l002a                                                         ; 9ad5: a5 2a       .*
+    pha                                                               ; 9ad7: 48          H
+    lda l002b                                                         ; 9ad8: a5 2b       .+
+    pha                                                               ; 9ada: 48          H
+    lda (l002a)                                                       ; 9adb: b2 2a       .*
+    cmp #4                                                            ; 9add: c9 04       ..
+    bcc c9b4c                                                         ; 9adf: 90 6b       .k
+    jsr cac38                                                         ; 9ae1: 20 38 ac     8.
+    inc l002d                                                         ; 9ae4: e6 2d       .-
+; $9ae6 referenced 1 time by $9b25
+c9ae6
+    jsr cbc66                                                         ; 9ae6: 20 66 bc     f.
+    jsr sub_c9774                                                     ; 9ae9: 20 74 97     t.
+    inc l001b                                                         ; 9aec: e6 1b       ..
+    cpx #$2c ; ','                                                    ; 9aee: e0 2c       .,
+    bne c9ac1                                                         ; 9af0: d0 cf       ..
+    ldx #$39 ; '9'                                                    ; 9af2: a2 39       .9
+    jsr sub_cbd48                                                     ; 9af4: 20 48 bd     H.
+    pla                                                               ; 9af7: 68          h
+    sta l0038                                                         ; 9af8: 85 38       .8
+    ply                                                               ; 9afa: 7a          z
+    sty l0037                                                         ; 9afb: 84 37       .7
+    phy                                                               ; 9afd: 5a          Z
+    pha                                                               ; 9afe: 48          H
+    ldy l003c                                                         ; 9aff: a4 3c       .<
+    jsr sub_c9b97                                                     ; 9b01: 20 97 9b     ..
+    sty l002d                                                         ; 9b04: 84 2d       .-
+    lda (l0037),y                                                     ; 9b06: b1 37       .7
+    sta l003f                                                         ; 9b08: 85 3f       .?
+    iny                                                               ; 9b0a: c8          .
+    lda (l0037),y                                                     ; 9b0b: b1 37       .7
+    sta l0040                                                         ; 9b0d: 85 40       .@
+    lda l002a                                                         ; 9b0f: a5 2a       .*
+    adc l0039                                                         ; 9b11: 65 39       e9
+    sta l002a                                                         ; 9b13: 85 2a       .*
+    lda l002b                                                         ; 9b15: a5 2b       .+
+    adc l003a                                                         ; 9b17: 65 3a       e:
+    sta l002b                                                         ; 9b19: 85 2b       .+
+    jsr sub_c95cb                                                     ; 9b1b: 20 cb 95     ..
+    sec                                                               ; 9b1e: 38          8
+    lda (l0037)                                                       ; 9b1f: b2 37       .7
+    sbc l002d                                                         ; 9b21: e5 2d       .-
+    cmp #3                                                            ; 9b23: c9 03       ..
+    bcs c9ae6                                                         ; 9b25: b0 bf       ..
+    jsr cbc66                                                         ; 9b27: 20 66 bc     f.
+    jsr sub_c976c                                                     ; 9b2a: 20 6c 97     l.
+    pla                                                               ; 9b2d: 68          h
+    sta l0038                                                         ; 9b2e: 85 38       .8
+    pla                                                               ; 9b30: 68          h
+    sta l0037                                                         ; 9b31: 85 37       .7
+    ldx #$39 ; '9'                                                    ; 9b33: a2 39       .9
+    jsr sub_cbd48                                                     ; 9b35: 20 48 bd     H.
+    ldy l003c                                                         ; 9b38: a4 3c       .<
+    jsr sub_c9b97                                                     ; 9b3a: 20 97 9b     ..
+    clc                                                               ; 9b3d: 18          .
+    lda l0039                                                         ; 9b3e: a5 39       .9
+    adc l002a                                                         ; 9b40: 65 2a       e*
+    sta l002a                                                         ; 9b42: 85 2a       .*
+    lda l003a                                                         ; 9b44: a5 3a       .:
+    adc l002b                                                         ; 9b46: 65 2b       e+
+    sta l002b                                                         ; 9b48: 85 2b       .+
+    bcc c9b5a                                                         ; 9b4a: 90 0e       ..
+; $9b4c referenced 1 time by $9adf
+c9b4c
+    jsr sub_c976c                                                     ; 9b4c: 20 6c 97     l.
+    pla                                                               ; 9b4f: 68          h
+    sta l0038                                                         ; 9b50: 85 38       .8
+    pla                                                               ; 9b52: 68          h
+    sta l0037                                                         ; 9b53: 85 37       .7
+    ldy #1                                                            ; 9b55: a0 01       ..
+    jsr sub_c9b97                                                     ; 9b57: 20 97 9b     ..
+; $9b5a referenced 1 time by $9b4a
+c9b5a
+    pla                                                               ; 9b5a: 68          h
+    sta l002c                                                         ; 9b5b: 85 2c       .,
+    cmp #5                                                            ; 9b5d: c9 05       ..
+    bne c9b78                                                         ; 9b5f: d0 17       ..
+    ldx l002b                                                         ; 9b61: a6 2b       .+
+    lda l002a                                                         ; 9b63: a5 2a       .*
+    asl l002a                                                         ; 9b65: 06 2a       .*
+    rol l002b                                                         ; 9b67: 26 2b       &+
+    asl l002a                                                         ; 9b69: 06 2a       .*
+    rol l002b                                                         ; 9b6b: 26 2b       &+
+    adc l002a                                                         ; 9b6d: 65 2a       e*
+    sta l002a                                                         ; 9b6f: 85 2a       .*
+    txa                                                               ; 9b71: 8a          .
+    adc l002b                                                         ; 9b72: 65 2b       e+
+    sta l002b                                                         ; 9b74: 85 2b       .+
+    bra c9b80                                                         ; 9b76: 80 08       ..
+; $9b78 referenced 1 time by $9b5f
+c9b78
+    asl l002a                                                         ; 9b78: 06 2a       .*
+    rol l002b                                                         ; 9b7a: 26 2b       &+
+    asl l002a                                                         ; 9b7c: 06 2a       .*
+    rol l002b                                                         ; 9b7e: 26 2b       &+
+; $9b80 referenced 1 time by $9b76
+c9b80
+    tya                                                               ; 9b80: 98          .
+    adc l002a                                                         ; 9b81: 65 2a       e*
+    sta l002a                                                         ; 9b83: 85 2a       .*
+    bcc c9b8a                                                         ; 9b85: 90 03       ..
+    inc l002b                                                         ; 9b87: e6 2b       .+
+    clc                                                               ; 9b89: 18          .
+; $9b8a referenced 1 time by $9b85
+c9b8a
+    lda l0037                                                         ; 9b8a: a5 37       .7
+    adc l002a                                                         ; 9b8c: 65 2a       e*
+    sta l002a                                                         ; 9b8e: 85 2a       .*
+    lda l0038                                                         ; 9b90: a5 38       .8
+    adc l002b                                                         ; 9b92: 65 2b       e+
+    sta l002b                                                         ; 9b94: 85 2b       .+
+    rts                                                               ; 9b96: 60          `
+
+; $9b97 referenced 3 times by $9b01, $9b3a, $9b57
+sub_c9b97
+    lda l002b                                                         ; 9b97: a5 2b       .+
+    and #$c0                                                          ; 9b99: 29 c0       ).
+    ora l002c                                                         ; 9b9b: 05 2c       .,
+    ora l002d                                                         ; 9b9d: 05 2d       .-
+    bne c9bae                                                         ; 9b9f: d0 0d       ..
+    lda l002a                                                         ; 9ba1: a5 2a       .*
+    cmp (l0037),y                                                     ; 9ba3: d1 37       .7
+    iny                                                               ; 9ba5: c8          .
+    lda l002b                                                         ; 9ba6: a5 2b       .+
+    sbc (l0037),y                                                     ; 9ba8: f1 37       .7
+    bcs c9bae                                                         ; 9baa: b0 02       ..
+    iny                                                               ; 9bac: c8          .
+    rts                                                               ; 9bad: 60          `
+
+; $9bae referenced 2 times by $9b9f, $9baa
+c9bae
+    brk                                                               ; 9bae: 00          .
+
+    !byte $0f                                                         ; 9baf: 0f          .
+    !text "Subscript"                                                 ; 9bb0: 53 75 62... Sub
+    !byte 0                                                           ; 9bb9: 00          .
+
+; $9bba referenced 1 time by $9615
+sub_c9bba
+    ldy #1                                                            ; 9bba: a0 01       ..
+; $9bbc referenced 2 times by $9bd0, $b095
+c9bbc
+    lda (l0037),y                                                     ; 9bbc: b1 37       .7
+    cmp #$30 ; '0'                                                    ; 9bbe: c9 30       .0
+    bcc c9bda                                                         ; 9bc0: 90 18       ..
+    cmp #$40 ; '@'                                                    ; 9bc2: c9 40       .@
+    bcs c9bd2                                                         ; 9bc4: b0 0c       ..
+    cmp #$3a ; ':'                                                    ; 9bc6: c9 3a       .:
+    bcs c9bda                                                         ; 9bc8: b0 10       ..
+    cpy #1                                                            ; 9bca: c0 01       ..
+    beq c9bda                                                         ; 9bcc: f0 0c       ..
+; $9bce referenced 2 times by $9bd8, $9bdd
+c9bce
+    inx                                                               ; 9bce: e8          .
+    iny                                                               ; 9bcf: c8          .
+    bne c9bbc                                                         ; 9bd0: d0 ea       ..
+; $9bd2 referenced 1 time by $9bc4
+c9bd2
+    cmp #$5f ; '_'                                                    ; 9bd2: c9 5f       ._
+    bcs c9bdb                                                         ; 9bd4: b0 05       ..
+    cmp #$5b ; '['                                                    ; 9bd6: c9 5b       .[
+    bcc c9bce                                                         ; 9bd8: 90 f4       ..
+; $9bda referenced 3 times by $9bc0, $9bc8, $9bcc
+c9bda
+    rts                                                               ; 9bda: 60          `
+
+; $9bdb referenced 1 time by $9bd4
+c9bdb
+    cmp #$7b ; '{'                                                    ; 9bdb: c9 7b       .{
+    bcc c9bce                                                         ; 9bdd: 90 ef       ..
+    rts                                                               ; 9bdf: 60          `
+
+; $9be0 referenced 1 time by $9be8
+loop_c9be0
+    inc l000a                                                         ; 9be0: e6 0a       ..
+; $9be2 referenced 10 times by $93da, $93e7, $9415, $9425, $970b, $9ced, $b3d6, $b3fb, $b85a, $bb33
+sub_c9be2
+    ldy l000a                                                         ; 9be2: a4 0a       ..
+    lda (l000b),y                                                     ; 9be4: b1 0b       ..
+    cmp #$20 ; ' '                                                    ; 9be6: c9 20       .
+    beq loop_c9be0                                                    ; 9be8: f0 f6       ..
+    cmp #$8d                                                          ; 9bea: c9 8d       ..
+    bne c9c08                                                         ; 9bec: d0 1a       ..
+; $9bee referenced 2 times by $94de, $b500
+sub_c9bee
+    iny                                                               ; 9bee: c8          .
+    lda (l000b),y                                                     ; 9bef: b1 0b       ..
+    asl                                                               ; 9bf1: 0a          .
+    asl                                                               ; 9bf2: 0a          .
+    tax                                                               ; 9bf3: aa          .
+    and #$c0                                                          ; 9bf4: 29 c0       ).
+    iny                                                               ; 9bf6: c8          .
+    eor (l000b),y                                                     ; 9bf7: 51 0b       Q.
+    sta l002a                                                         ; 9bf9: 85 2a       .*
+    txa                                                               ; 9bfb: 8a          .
+    asl                                                               ; 9bfc: 0a          .
+    asl                                                               ; 9bfd: 0a          .
+    iny                                                               ; 9bfe: c8          .
+    eor (l000b),y                                                     ; 9bff: 51 0b       Q.
+    sta l002b                                                         ; 9c01: 85 2b       .+
+    iny                                                               ; 9c03: c8          .
+    sty l000a                                                         ; 9c04: 84 0a       ..
+    sec                                                               ; 9c06: 38          8
+    rts                                                               ; 9c07: 60          `
+
+; $9c08 referenced 1 time by $9bec
+c9c08
+    clc                                                               ; 9c08: 18          .
+    rts                                                               ; 9c09: 60          `
+
+; $9c0a referenced 2 times by $9755, $977e
+sub_c9c0a
+    lda l000b                                                         ; 9c0a: a5 0b       ..
+    sta l0019                                                         ; 9c0c: 85 19       ..
+    lda l000c                                                         ; 9c0e: a5 0c       ..
+    sta l001a                                                         ; 9c10: 85 1a       ..
+    lda l000a                                                         ; 9c12: a5 0a       ..
+    sta l001b                                                         ; 9c14: 85 1b       ..
+; $9c16 referenced 4 times by $9117, $913e, $9c1e, $bede
+c9c16
+    ldy l001b                                                         ; 9c16: a4 1b       ..
+    inc l001b                                                         ; 9c18: e6 1b       ..
+    lda (l0019),y                                                     ; 9c1a: b1 19       ..
+    cmp #$20 ; ' '                                                    ; 9c1c: c9 20       .
+    beq c9c16                                                         ; 9c1e: f0 f6       ..
+    cmp #$3d ; '='                                                    ; 9c20: c9 3d       .=
+    beq c9c52                                                         ; 9c22: f0 2e       ..
+; $9c24 referenced 1 time by $9c4f
+c9c24
+    brk                                                               ; 9c24: 00          .
+
+    !byte 4                                                           ; 9c25: 04          .
+    !text "Mistake"                                                   ; 9c26: 4d 69 73... Mis
+
+; $9c2d referenced 7 times by $8af2, $8d61, $9146, $93d7, $9c7e, $b52d, $b86f
+c9c2d
+    brk                                                               ; 9c2d: 00          .
+
+    !byte $10                                                         ; 9c2e: 10          .
+    !text "Syntax error"                                              ; 9c2f: 53 79 6e... Syn
+
+; $9c3b referenced 2 times by $9c61, $9c68
+c9c3b
+    brk                                                               ; 9c3b: 00          .
+
+    !byte $0d                                                         ; 9c3c: 0d          .
+    !text "No "                                                       ; 9c3d: 4e 6f 20    No
+    !byte $f2                                                         ; 9c40: f2          .
+
+; $9c41 referenced 2 times by $9c90, $babf
+c9c41
+    brk                                                               ; 9c41: 00          .
+
+    !byte $11                                                         ; 9c42: 11          .
+    !text "Escape"                                                    ; 9c43: 45 73 63... Esc
+    !byte 0                                                           ; 9c49: 00          .
+
+; $9c4a referenced 2 times by $90fb, $b653
+sub_c9c4a
+    jsr c8f92                                                         ; 9c4a: 20 92 8f     ..
+    cmp #$3d ; '='                                                    ; 9c4d: c9 3d       .=
+    bne c9c24                                                         ; 9c4f: d0 d3       ..
+    rts                                                               ; 9c51: 60          `
+
+; $9c52 referenced 1 time by $9c22
+c9c52
+    jsr sub_c9dff                                                     ; 9c52: 20 ff 9d     ..
+; $9c55 referenced 3 times by $9132, $ba4a, $be7e
+c9c55
+    txa                                                               ; 9c55: 8a          .
+    ldy l001b                                                         ; 9c56: a4 1b       ..
+    bra c9c74                                                         ; 9c58: 80 1a       ..
+; $9c5a referenced 9 times by $93b7, $97ba, $9819, $988f, $b315, $b336, $b354, $bef1, $bf04
+sub_c9c5a
+    ldy l001b                                                         ; 9c5a: a4 1b       ..
+    bra c9c6c                                                         ; 9c5c: 80 0e       ..
+sub_c9c5e
+    tsx                                                               ; 9c5e: ba          .
+    cpx #$fc                                                          ; 9c5f: e0 fc       ..
+    bcs c9c3b                                                         ; 9c61: b0 d8       ..
+    lda l01ff                                                         ; 9c63: ad ff 01    ...
+    cmp #$f2                                                          ; 9c66: c9 f2       ..
+    bne c9c3b                                                         ; 9c68: d0 d1       ..
+; $9c6a referenced 24 times by $8fc5, $8fd7, $8fea, $9042, $90c7, $9149, $93ec, $9430, $9703, $971b, $972e, $9737, $9827, $9831, $98af, $98b6, $98c3, $9c93, $b41e, $b70c, $b737, $b750, $b769, $b997
+c9c6a
+    ldy l000a                                                         ; 9c6a: a4 0a       ..
+; $9c6c referenced 2 times by $8a79, $9c5c
+c9c6c
+    dey                                                               ; 9c6c: 88          .
+; $9c6d referenced 1 time by $9c72
+loop_c9c6d
+    iny                                                               ; 9c6d: c8          .
+    lda (l000b),y                                                     ; 9c6e: b1 0b       ..
+    cmp #$20 ; ' '                                                    ; 9c70: c9 20       .
+    beq loop_c9c6d                                                    ; 9c72: f0 f9       ..
+; $9c74 referenced 3 times by $9433, $9c58, $b428
+c9c74
+    cmp #$3a ; ':'                                                    ; 9c74: c9 3a       .:
+    beq c9c80                                                         ; 9c76: f0 08       ..
+    cmp #$0d                                                          ; 9c78: c9 0d       ..
+    beq c9c80                                                         ; 9c7a: f0 04       ..
+    cmp #$8b                                                          ; 9c7c: c9 8b       ..
+    bne c9c2d                                                         ; 9c7e: d0 ad       ..
+; $9c80 referenced 10 times by $89e4, $9069, $907d, $9c76, $9c7a, $b02e, $b40d, $b451, $b77b, $ba8e
+c9c80
+    clc                                                               ; 9c80: 18          .
+    tya                                                               ; 9c81: 98          .
+    adc l000b                                                         ; 9c82: 65 0b       e.
+    sta l000b                                                         ; 9c84: 85 0b       ..
+    bcc c9c8a                                                         ; 9c86: 90 02       ..
+    inc l000c                                                         ; 9c88: e6 0c       ..
+; $9c8a referenced 4 times by $9c86, $9cf5, $b5d9, $b7f4
+c9c8a
+    ldy #1                                                            ; 9c8a: a0 01       ..
+    sty l000a                                                         ; 9c8c: 84 0a       ..
+; $9c8e referenced 1 time by $93fd
+sub_c9c8e
+    bit l00ff                                                         ; 9c8e: 24 ff       $.
+    bmi c9c41                                                         ; 9c90: 30 af       0.
+; $9c92 referenced 1 time by $9c9a
+loop_c9c92
+    rts                                                               ; 9c92: 60          `
+
+; $9c93 referenced 1 time by $b6bf
+sub_c9c93
+    jsr c9c6a                                                         ; 9c93: 20 6a 9c     j.
+    lda (l000b)                                                       ; 9c96: b2 0b       ..
+    cmp #$3a ; ':'                                                    ; 9c98: c9 3a       .:
+    beq loop_c9c92                                                    ; 9c9a: f0 f6       ..
+    lda l000c                                                         ; 9c9c: a5 0c       ..
+    cmp #7                                                            ; 9c9e: c9 07       ..
+    beq c9cc6                                                         ; 9ca0: f0 24       .$
+; $9ca2 referenced 1 time by $8a8b
+sub_c9ca2
+    ldy #1                                                            ; 9ca2: a0 01       ..
+    lda (l000b),y                                                     ; 9ca4: b1 0b       ..
+    bmi c9cc6                                                         ; 9ca6: 30 1e       0.
+    ldx l0020                                                         ; 9ca8: a6 20       .
+    beq c9cb6                                                         ; 9caa: f0 0a       ..
+    sta l002b                                                         ; 9cac: 85 2b       .+
+    iny                                                               ; 9cae: c8          .
+    lda (l000b),y                                                     ; 9caf: b1 0b       ..
+    sta l002a                                                         ; 9cb1: 85 2a       .*
+    jsr sub_c9d0f                                                     ; 9cb3: 20 0f 9d     ..
+; $9cb6 referenced 1 time by $9caa
+c9cb6
+    lda #3                                                            ; 9cb6: a9 03       ..
+; $9cb8 referenced 1 time by $94d9
+sub_c9cb8
+    clc                                                               ; 9cb8: 18          .
+    adc l000b                                                         ; 9cb9: 65 0b       e.
+    sta l000b                                                         ; 9cbb: 85 0b       ..
+    bcc c9cc1                                                         ; 9cbd: 90 02       ..
+    inc l000c                                                         ; 9cbf: e6 0c       ..
+; $9cc1 referenced 1 time by $9cbd
+c9cc1
+    ldy #1                                                            ; 9cc1: a0 01       ..
+    sty l000a                                                         ; 9cc3: 84 0a       ..
+; $9cc5 referenced 1 time by $9d17
+c9cc5
+    rts                                                               ; 9cc5: 60          `
+
+; $9cc6 referenced 2 times by $9ca0, $9ca6
+c9cc6
+    jmp c904b                                                         ; 9cc6: 4c 4b 90    LK.
+
+; $9cc9 referenced 1 time by $9ccf
+loop_c9cc9
+    jmp c9155                                                         ; 9cc9: 4c 55 91    LU.
+
+sub_c9ccc
+    jsr sub_c9df3                                                     ; 9ccc: 20 f3 9d     ..
+    beq loop_c9cc9                                                    ; 9ccf: f0 f8       ..
+    bpl c9cd6                                                         ; 9cd1: 10 03       ..
+    jsr sub_c9788                                                     ; 9cd3: 20 88 97     ..
+; $9cd6 referenced 1 time by $9cd1
+c9cd6
+    ldy l001b                                                         ; 9cd6: a4 1b       ..
+    sty l000a                                                         ; 9cd8: 84 0a       ..
+    lda l002a                                                         ; 9cda: a5 2a       .*
+    ora l002b                                                         ; 9cdc: 05 2b       .+
+    ora l002c                                                         ; 9cde: 05 2c       .,
+    ora l002d                                                         ; 9ce0: 05 2d       .-
+    beq c9cfb                                                         ; 9ce2: f0 17       ..
+    cpx #$8c                                                          ; 9ce4: e0 8c       ..
+    beq c9ceb                                                         ; 9ce6: f0 03       ..
+; $9ce8 referenced 1 time by $9cf0
+loop_c9ce8
+    jmp c90d0                                                         ; 9ce8: 4c d0 90    L..
+
+; $9ceb referenced 1 time by $9ce6
+c9ceb
+    inc l000a                                                         ; 9ceb: e6 0a       ..
+; $9ced referenced 2 times by $9d0a, $b849
+c9ced
+    jsr sub_c9be2                                                     ; 9ced: 20 e2 9b     ..
+    bcc loop_c9ce8                                                    ; 9cf0: 90 f6       ..
+    jsr cb866                                                         ; 9cf2: 20 66 b8     f.
+    jsr c9c8a                                                         ; 9cf5: 20 8a 9c     ..
+    jmp cb753                                                         ; 9cf8: 4c 53 b7    LS.
+
+; $9cfb referenced 1 time by $9ce2
+c9cfb
+    ldy l000a                                                         ; 9cfb: a4 0a       ..
+; $9cfd referenced 1 time by $9d06
+loop_c9cfd
+    lda (l000b),y                                                     ; 9cfd: b1 0b       ..
+    cmp #$0d                                                          ; 9cff: c9 0d       ..
+    beq c9d0c                                                         ; 9d01: f0 09       ..
+    iny                                                               ; 9d03: c8          .
+    cmp #$8b                                                          ; 9d04: c9 8b       ..
+    bne loop_c9cfd                                                    ; 9d06: d0 f5       ..
+    sty l000a                                                         ; 9d08: 84 0a       ..
+    beq c9ced                                                         ; 9d0a: f0 e1       ..
+; $9d0c referenced 1 time by $9d01
+c9d0c
+    jmp c907d                                                         ; 9d0c: 4c 7d 90    L}.
+
+; $9d0f referenced 3 times by $909d, $9cb3, $b757
+sub_c9d0f
+    lda l002a                                                         ; 9d0f: a5 2a       .*
+    cmp l0021                                                         ; 9d11: c5 21       .!
+    lda l002b                                                         ; 9d13: a5 2b       .+
+    sbc l0022                                                         ; 9d15: e5 22       ."
+    bcs c9cc5                                                         ; 9d17: b0 ac       ..
+    lda #$5b ; '['                                                    ; 9d19: a9 5b       .[
+    jsr sub_cbdd8                                                     ; 9d1b: 20 d8 bd     ..
+    jsr sub_ca0e8                                                     ; 9d1e: 20 e8 a0     ..
+    lda #$5d ; ']'                                                    ; 9d21: a9 5d       .]
+    jsr sub_cbdd8                                                     ; 9d23: 20 d8 bd     ..
+    jmp cbdd2                                                         ; 9d26: 4c d2 bd    L..
+
+; $9d29 referenced 1 time by $9d84
+c9d29
+    jsr cbc3a                                                         ; 9d29: 20 3a bc     :.
+    jsr sub_c9f07                                                     ; 9d2c: 20 07 9f     ..
+    tay                                                               ; 9d2f: a8          .
+    jsr sub_c97a2                                                     ; 9d30: 20 a2 97     ..
+    jsr sub_cbc24                                                     ; 9d33: 20 24 bc     $.
+; $9d36 referenced 1 time by $b614
+sub_c9d36
+    jsr sub_ca514                                                     ; 9d36: 20 14 a5     ..
+    lda l002e                                                         ; 9d39: a5 2e       ..
+    eor l003b                                                         ; 9d3b: 45 3b       E;
+    bpl c9d57                                                         ; 9d3d: 10 18       ..
+    asl l002e                                                         ; 9d3f: 06 2e       ..
+    bra c9d79                                                         ; 9d41: 80 36       .6
+; $9d43 referenced 1 time by $9db8
+c9d43
+    sty l002d                                                         ; 9d43: 84 2d       .-
+    pla                                                               ; 9d45: 68          h
+    sta l002c                                                         ; 9d46: 85 2c       .,
+    pla                                                               ; 9d48: 68          h
+    sta l002b                                                         ; 9d49: 85 2b       .+
+    pla                                                               ; 9d4b: 68          h
+    sta l002a                                                         ; 9d4c: 85 2a       .*
+    jsr sub_c828a                                                     ; 9d4e: 20 8a 82     ..
+    lda l003b                                                         ; 9d51: a5 3b       .;
+    eor #$80                                                          ; 9d53: 49 80       I.
+    sta l003b                                                         ; 9d55: 85 3b       .;
+; $9d57 referenced 1 time by $9d3d
+c9d57
+    lda l003c                                                         ; 9d57: a5 3c       .<
+    cmp l0030                                                         ; 9d59: c5 30       .0
+    bne c9d75                                                         ; 9d5b: d0 18       ..
+    lda l003d                                                         ; 9d5d: a5 3d       .=
+    cmp l0031                                                         ; 9d5f: c5 31       .1
+    bne c9d75                                                         ; 9d61: d0 12       ..
+    lda l003e                                                         ; 9d63: a5 3e       .>
+    cmp l0032                                                         ; 9d65: c5 32       .2
+    bne c9d75                                                         ; 9d67: d0 0c       ..
+    lda l003f                                                         ; 9d69: a5 3f       .?
+    cmp l0033                                                         ; 9d6b: c5 33       .3
+    bne c9d75                                                         ; 9d6d: d0 06       ..
+    lda l0040                                                         ; 9d6f: a5 40       .@
+    sbc l0034                                                         ; 9d71: e5 34       .4
+    beq c9d7b                                                         ; 9d73: f0 06       ..
+; $9d75 referenced 4 times by $9d5b, $9d61, $9d67, $9d6d
+c9d75
+    ror                                                               ; 9d75: 6a          j
+    eor l003b                                                         ; 9d76: 45 3b       E;
+    rol                                                               ; 9d78: 2a          *
+; $9d79 referenced 1 time by $9d41
+c9d79
+    lda #$ff                                                          ; 9d79: a9 ff       ..
+; $9d7b referenced 1 time by $9d73
+c9d7b
+    rts                                                               ; 9d7b: 60          `
+
+; $9d7c referenced 2 times by $9d98, $9dcb
+c9d7c
+    jmp c9155                                                         ; 9d7c: 4c 55 91    LU.
+
+; $9d7f referenced 3 times by $9ea6, $9ead, $9ec2
+sub_c9d7f
+    inc l001b                                                         ; 9d7f: e6 1b       ..
+; $9d81 referenced 2 times by $9e9d, $9ebb
+sub_c9d81
+    txa                                                               ; 9d81: 8a          .
+; $9d82 referenced 1 time by $9e80
+sub_c9d82
+    beq c9dc4                                                         ; 9d82: f0 40       .@
+    bmi c9d29                                                         ; 9d84: 30 a3       0.
+    lda l002a                                                         ; 9d86: a5 2a       .*
+    pha                                                               ; 9d88: 48          H
+    lda l002b                                                         ; 9d89: a5 2b       .+
+    pha                                                               ; 9d8b: 48          H
+    lda l002c                                                         ; 9d8c: a5 2c       .,
+    pha                                                               ; 9d8e: 48          H
+    lda l002d                                                         ; 9d8f: a5 2d       .-
+    pha                                                               ; 9d91: 48          H
+    jsr sub_c9f07                                                     ; 9d92: 20 07 9f     ..
+    tay                                                               ; 9d95: a8          .
+    bmi c9db4                                                         ; 9d96: 30 1c       0.
+    beq c9d7c                                                         ; 9d98: f0 e2       ..
+    pla                                                               ; 9d9a: 68          h
+    tay                                                               ; 9d9b: a8          .
+    eor l002d                                                         ; 9d9c: 45 2d       E-
+    bmi c9dba                                                         ; 9d9e: 30 1a       0.
+    cpy l002d                                                         ; 9da0: c4 2d       .-
+    bne c9dbe                                                         ; 9da2: d0 1a       ..
+    pla                                                               ; 9da4: 68          h
+    cmp l002c                                                         ; 9da5: c5 2c       .,
+    bne c9dbf                                                         ; 9da7: d0 16       ..
+    pla                                                               ; 9da9: 68          h
+    cmp l002b                                                         ; 9daa: c5 2b       .+
+    bne c9dc0                                                         ; 9dac: d0 12       ..
+    pla                                                               ; 9dae: 68          h
+    sbc l002a                                                         ; 9daf: e5 2a       .*
+    bne c9dc1                                                         ; 9db1: d0 0e       ..
+    rts                                                               ; 9db3: 60          `
+
+; $9db4 referenced 1 time by $9d96
+c9db4
+    pla                                                               ; 9db4: 68          h
+    tay                                                               ; 9db5: a8          .
+    eor l002e                                                         ; 9db6: 45 2e       E.
+    bpl c9d43                                                         ; 9db8: 10 89       ..
+; $9dba referenced 1 time by $9d9e
+c9dba
+    tya                                                               ; 9dba: 98          .
+    eor #$ff                                                          ; 9dbb: 49 ff       I.
+    asl                                                               ; 9dbd: 0a          .
+; $9dbe referenced 1 time by $9da2
+c9dbe
+    pla                                                               ; 9dbe: 68          h
+; $9dbf referenced 1 time by $9da7
+c9dbf
+    pla                                                               ; 9dbf: 68          h
+; $9dc0 referenced 1 time by $9dac
+c9dc0
+    pla                                                               ; 9dc0: 68          h
+; $9dc1 referenced 2 times by $9db1, $9dee
+c9dc1
+    lda #$ff                                                          ; 9dc1: a9 ff       ..
+    rts                                                               ; 9dc3: 60          `
+
+; $9dc4 referenced 1 time by $9d82
+c9dc4
+    jsr cbc91                                                         ; 9dc4: 20 91 bc     ..
+    jsr sub_c9f07                                                     ; 9dc7: 20 07 9f     ..
+    tay                                                               ; 9dca: a8          .
+    bne c9d7c                                                         ; 9dcb: d0 af       ..
+    lda (l0004)                                                       ; 9dcd: b2 04       ..
+    cmp l0036                                                         ; 9dcf: c5 36       .6
+    bcc c9dd5                                                         ; 9dd1: 90 02       ..
+    lda l0036                                                         ; 9dd3: a5 36       .6
+; $9dd5 referenced 1 time by $9dd1
+c9dd5
+    sta l0037                                                         ; 9dd5: 85 37       .7
+; $9dd7 referenced 1 time by $9de1
+loop_c9dd7
+    cpy l0037                                                         ; 9dd7: c4 37       .7
+    beq c9de5                                                         ; 9dd9: f0 0a       ..
+    iny                                                               ; 9ddb: c8          .
+    lda (l0004),y                                                     ; 9ddc: b1 04       ..
+    cmp l05ff,y                                                       ; 9dde: d9 ff 05    ...
+    beq loop_c9dd7                                                    ; 9de1: f0 f4       ..
+    bra c9de9                                                         ; 9de3: 80 04       ..
+; $9de5 referenced 1 time by $9dd9
+c9de5
+    lda (l0004)                                                       ; 9de5: b2 04       ..
+    cmp l0036                                                         ; 9de7: c5 36       .6
+; $9de9 referenced 1 time by $9de3
+c9de9
+    php                                                               ; 9de9: 08          .
+    jsr cbd21                                                         ; 9dea: 20 21 bd     !.
+    plp                                                               ; 9ded: 28          (
+    bne c9dc1                                                         ; 9dee: d0 d1       ..
+    lda #0                                                            ; 9df0: a9 00       ..
+    rts                                                               ; 9df2: 60          `
+
+; $9df3 referenced 8 times by $8d77, $912f, $9332, $9381, $9878, $9ccc, $ba47, $be76
+sub_c9df3
+    lda l000b                                                         ; 9df3: a5 0b       ..
+    sta l0019                                                         ; 9df5: 85 19       ..
+    lda l000c                                                         ; 9df7: a5 0c       ..
+    sta l001a                                                         ; 9df9: 85 1a       ..
+    lda l000a                                                         ; 9dfb: a5 0a       ..
+    sta l001b                                                         ; 9dfd: 85 1b       ..
+; $9dff referenced 14 times by $920d, $92b7, $9774, $9c52, $ab8b, $ac7f, $ac8d, $adee, $aebd, $af0a, $b146, $b362, $b6d1, $b6ef
+sub_c9dff
+    jsr sub_c9e45                                                     ; 9dff: 20 45 9e     E.
+; $9e02 referenced 1 time by $9e28
+c9e02
+    cpx #$84                                                          ; 9e02: e0 84       ..
+    beq c9e10                                                         ; 9e04: f0 0a       ..
+    cpx #$82                                                          ; 9e06: e0 82       ..
+    beq c9e2a                                                         ; 9e08: f0 20       .
+    dec l001b                                                         ; 9e0a: c6 1b       ..
+    tay                                                               ; 9e0c: a8          .
+    sta l0027                                                         ; 9e0d: 85 27       .'
+    rts                                                               ; 9e0f: 60          `
+
+; $9e10 referenced 1 time by $9e04
+c9e10
+    jsr sub_c9e3f                                                     ; 9e10: 20 3f 9e     ?.
+    jsr sub_c9783                                                     ; 9e13: 20 83 97     ..
+    ldy #3                                                            ; 9e16: a0 03       ..
+; $9e18 referenced 1 time by $9e21
+loop_c9e18
+    lda (l0004),y                                                     ; 9e18: b1 04       ..
+    ora l002a,y                                                       ; 9e1a: 19 2a 00    .*.
+    sta l002a,y                                                       ; 9e1d: 99 2a 00    .*.
+    dey                                                               ; 9e20: 88          .
+    bpl loop_c9e18                                                    ; 9e21: 10 f5       ..
+; $9e23 referenced 1 time by $9e3d
+loop_c9e23
+    jsr cbd3a                                                         ; 9e23: 20 3a bd     :.
+    lda #$40 ; '@'                                                    ; 9e26: a9 40       .@
+    bra c9e02                                                         ; 9e28: 80 d8       ..
+; $9e2a referenced 1 time by $9e08
+c9e2a
+    jsr sub_c9e3f                                                     ; 9e2a: 20 3f 9e     ?.
+    jsr sub_c9783                                                     ; 9e2d: 20 83 97     ..
+    ldy #3                                                            ; 9e30: a0 03       ..
+; $9e32 referenced 1 time by $9e3b
+loop_c9e32
+    lda (l0004),y                                                     ; 9e32: b1 04       ..
+    eor l002a,y                                                       ; 9e34: 59 2a 00    Y*.
+    sta l002a,y                                                       ; 9e37: 99 2a 00    .*.
+    dey                                                               ; 9e3a: 88          .
+    bpl loop_c9e32                                                    ; 9e3b: 10 f5       ..
+    bra loop_c9e23                                                    ; 9e3d: 80 e4       ..
+; $9e3f referenced 2 times by $9e10, $9e2a
+sub_c9e3f
+    jsr sub_c9783                                                     ; 9e3f: 20 83 97     ..
+    jsr cbc66                                                         ; 9e42: 20 66 bc     f.
+; $9e45 referenced 1 time by $9dff
+sub_c9e45
+    jsr sub_c9e6d                                                     ; 9e45: 20 6d 9e     m.
+; $9e48 referenced 1 time by $9e6b
+c9e48
+    cpx #$80                                                          ; 9e48: e0 80       ..
+    beq c9e4d                                                         ; 9e4a: f0 01       ..
+    rts                                                               ; 9e4c: 60          `
+
+; $9e4d referenced 1 time by $9e4a
+c9e4d
+    jsr sub_c9783                                                     ; 9e4d: 20 83 97     ..
+    jsr cbc66                                                         ; 9e50: 20 66 bc     f.
+    jsr sub_c9e6d                                                     ; 9e53: 20 6d 9e     m.
+    jsr sub_c9783                                                     ; 9e56: 20 83 97     ..
+    ldy #3                                                            ; 9e59: a0 03       ..
+; $9e5b referenced 1 time by $9e64
+loop_c9e5b
+    lda (l0004),y                                                     ; 9e5b: b1 04       ..
+    and l002a,y                                                       ; 9e5d: 39 2a 00    9*.
+    sta l002a,y                                                       ; 9e60: 99 2a 00    .*.
+    dey                                                               ; 9e63: 88          .
+    bpl loop_c9e5b                                                    ; 9e64: 10 f5       ..
+    jsr cbd3a                                                         ; 9e66: 20 3a bd     :.
+    lda #$40 ; '@'                                                    ; 9e69: a9 40       .@
+    bra c9e48                                                         ; 9e6b: 80 db       ..
+; $9e6d referenced 2 times by $9e45, $9e53
+sub_c9e6d
+    jsr sub_c9f07                                                     ; 9e6d: 20 07 9f     ..
+    cpx #$3f ; '?'                                                    ; 9e70: e0 3f       .?
+    bcs c9e78                                                         ; 9e72: b0 04       ..
+    cpx #$3c ; '<'                                                    ; 9e74: e0 3c       .<
+    bcs c9e79                                                         ; 9e76: b0 01       ..
+; $9e78 referenced 1 time by $9e72
+c9e78
+    rts                                                               ; 9e78: 60          `
+
+; $9e79 referenced 1 time by $9e76
+c9e79
+    beq c9e90                                                         ; 9e79: f0 15       ..
+    cpx #$3e ; '>'                                                    ; 9e7b: e0 3e       .>
+    beq c9eb2                                                         ; 9e7d: f0 33       .3
+    tax                                                               ; 9e7f: aa          .
+    jsr sub_c9d82                                                     ; 9e80: 20 82 9d     ..
+; $9e83 referenced 5 times by $9ea4, $9eab, $9ec0, $9ec5, $9ec7
+c9e83
+    eor #$ff                                                          ; 9e83: 49 ff       I.
+; $9e85 referenced 6 times by $9ea0, $9ea2, $9ea9, $9eb0, $9ebe, $9ec9
+c9e85
+    sta l002a                                                         ; 9e85: 85 2a       .*
+    sta l002b                                                         ; 9e87: 85 2b       .+
+    sta l002c                                                         ; 9e89: 85 2c       .,
+    sta l002d                                                         ; 9e8b: 85 2d       .-
+    lda #$40 ; '@'                                                    ; 9e8d: a9 40       .@
+    rts                                                               ; 9e8f: 60          `
+
+; $9e90 referenced 1 time by $9e79
+c9e90
+    tax                                                               ; 9e90: aa          .
+    ldy l001b                                                         ; 9e91: a4 1b       ..
+    lda (l0019),y                                                     ; 9e93: b1 19       ..
+    cmp #$3d ; '='                                                    ; 9e95: c9 3d       .=
+    beq c9ea6                                                         ; 9e97: f0 0d       ..
+    cmp #$3e ; '>'                                                    ; 9e99: c9 3e       .>
+    beq c9ead                                                         ; 9e9b: f0 10       ..
+    jsr sub_c9d81                                                     ; 9e9d: 20 81 9d     ..
+    bcc c9e85                                                         ; 9ea0: 90 e3       ..
+    beq c9e85                                                         ; 9ea2: f0 e1       ..
+    bra c9e83                                                         ; 9ea4: 80 dd       ..
+; $9ea6 referenced 1 time by $9e97
+c9ea6
+    jsr sub_c9d7f                                                     ; 9ea6: 20 7f 9d     ..
+    bcc c9e85                                                         ; 9ea9: 90 da       ..
+    bra c9e83                                                         ; 9eab: 80 d6       ..
+; $9ead referenced 1 time by $9e9b
+c9ead
+    jsr sub_c9d7f                                                     ; 9ead: 20 7f 9d     ..
+    bra c9e85                                                         ; 9eb0: 80 d3       ..
+; $9eb2 referenced 1 time by $9e7d
+c9eb2
+    tax                                                               ; 9eb2: aa          .
+    ldy l001b                                                         ; 9eb3: a4 1b       ..
+    lda (l0019),y                                                     ; 9eb5: b1 19       ..
+    cmp #$3d ; '='                                                    ; 9eb7: c9 3d       .=
+    beq c9ec2                                                         ; 9eb9: f0 07       ..
+    jsr sub_c9d81                                                     ; 9ebb: 20 81 9d     ..
+    bcs c9e85                                                         ; 9ebe: b0 c5       ..
+    bra c9e83                                                         ; 9ec0: 80 c1       ..
+; $9ec2 referenced 1 time by $9eb9
+c9ec2
+    jsr sub_c9d7f                                                     ; 9ec2: 20 7f 9d     ..
+    bcc c9e83                                                         ; 9ec5: 90 bc       ..
+    beq c9e83                                                         ; 9ec7: f0 ba       ..
+    bra c9e85                                                         ; 9ec9: 80 ba       ..
+; $9ecb referenced 2 times by $9eec, $afbe
+c9ecb
+    brk                                                               ; 9ecb: 00          .
+
+    !byte $13                                                         ; 9ecc: 13          .
+    !text "String too long"                                           ; 9ecd: 53 74 72... Str
+    !byte 0                                                           ; 9edc: 00          .
+
+; $9edd referenced 1 time by $9f16
+c9edd
+    jsr cbc91                                                         ; 9edd: 20 91 bc     ..
+    jsr sub_ca06c                                                     ; 9ee0: 20 6c a0     l.
+    tay                                                               ; 9ee3: a8          .
+    bne c9f4c                                                         ; 9ee4: d0 66       .f
+    clc                                                               ; 9ee6: 18          .
+    phx                                                               ; 9ee7: da          .
+    lda (l0004)                                                       ; 9ee8: b2 04       ..
+    adc l0036                                                         ; 9eea: 65 36       e6
+    bcs c9ecb                                                         ; 9eec: b0 dd       ..
+    tax                                                               ; 9eee: aa          .
+    pha                                                               ; 9eef: 48          H
+    ldy l0036                                                         ; 9ef0: a4 36       .6
+; $9ef2 referenced 1 time by $9efa
+loop_c9ef2
+    lda l05ff,y                                                       ; 9ef2: b9 ff 05    ...
+    sta l05ff,x                                                       ; 9ef5: 9d ff 05    ...
+    dex                                                               ; 9ef8: ca          .
+    dey                                                               ; 9ef9: 88          .
+    bne loop_c9ef2                                                    ; 9efa: d0 f6       ..
+    jsr sub_cbd12                                                     ; 9efc: 20 12 bd     ..
+    pla                                                               ; 9eff: 68          h
+    sta l0036                                                         ; 9f00: 85 36       .6
+    plx                                                               ; 9f02: fa          .
+    lda #0                                                            ; 9f03: a9 00       ..
+    bra c9f0a                                                         ; 9f05: 80 03       ..
+; $9f07 referenced 4 times by $9d2c, $9d92, $9dc7, $9e6d
+sub_c9f07
+    jsr sub_ca026                                                     ; 9f07: 20 26 a0     &.
+; $9f0a referenced 4 times by $9f05, $9f46, $9f4a, $9f57
+c9f0a
+    cpx #$2b ; '+'                                                    ; 9f0a: e0 2b       .+
+    beq c9f13                                                         ; 9f0c: f0 05       ..
+    cpx #$2d ; '-'                                                    ; 9f0e: e0 2d       .-
+    beq c9f70                                                         ; 9f10: f0 5e       .^
+    rts                                                               ; 9f12: 60          `
+
+; $9f13 referenced 1 time by $9f0c
+c9f13
+    tay                                                               ; 9f13: a8          .
+    bmi c9f4f                                                         ; 9f14: 30 39       09
+    beq c9edd                                                         ; 9f16: f0 c5       ..
+    jsr sub_ca023                                                     ; 9f18: 20 23 a0     #.
+    tay                                                               ; 9f1b: a8          .
+    bmi c9f64                                                         ; 9f1c: 30 46       0F
+    beq c9f4c                                                         ; 9f1e: f0 2c       .,
+    clc                                                               ; 9f20: 18          .
+    lda (l0004)                                                       ; 9f21: b2 04       ..
+    adc l002a                                                         ; 9f23: 65 2a       e*
+    sta l002a                                                         ; 9f25: 85 2a       .*
+    ldy #1                                                            ; 9f27: a0 01       ..
+    lda (l0004),y                                                     ; 9f29: b1 04       ..
+    adc l002b                                                         ; 9f2b: 65 2b       e+
+    sta l002b                                                         ; 9f2d: 85 2b       .+
+    iny                                                               ; 9f2f: c8          .
+    lda (l0004),y                                                     ; 9f30: b1 04       ..
+    adc l002c                                                         ; 9f32: 65 2c       e,
+    sta l002c                                                         ; 9f34: 85 2c       .,
+    iny                                                               ; 9f36: c8          .
+    lda (l0004),y                                                     ; 9f37: b1 04       ..
+    adc l002d                                                         ; 9f39: 65 2d       e-
+; $9f3b referenced 1 time by $9f98
+c9f3b
+    sta l002d                                                         ; 9f3b: 85 2d       .-
+    clc                                                               ; 9f3d: 18          .
+    lda l0004                                                         ; 9f3e: a5 04       ..
+    adc #4                                                            ; 9f40: 69 04       i.
+    sta l0004                                                         ; 9f42: 85 04       ..
+    lda #$40 ; '@'                                                    ; 9f44: a9 40       .@
+    bcc c9f0a                                                         ; 9f46: 90 c2       ..
+    inc l0005                                                         ; 9f48: e6 05       ..
+    bra c9f0a                                                         ; 9f4a: 80 be       ..
+; $9f4c referenced 5 times by $9ee4, $9f1e, $9f73, $9f7b, $9fbb
+c9f4c
+    jmp c9155                                                         ; 9f4c: 4c 55 91    LU.
+
+; $9f4f referenced 1 time by $9f14
+c9f4f
+    jsr sub_cbc18                                                     ; 9f4f: 20 18 bc     ..
+    jsr ca70a                                                         ; 9f52: 20 0a a7     ..
+; $9f55 referenced 2 times by $9f5f, $9f6e
+c9f55
+    ldx l0027                                                         ; 9f55: a6 27       .'
+    bra c9f0a                                                         ; 9f57: 80 b1       ..
+; $9f59 referenced 1 time by $9f71
+loop_c9f59
+    jsr sub_cbc18                                                     ; 9f59: 20 18 bc     ..
+    jsr ca704                                                         ; 9f5c: 20 04 a7     ..
+    bra c9f55                                                         ; 9f5f: 80 f4       ..
+; $9f61 referenced 1 time by $9f79
+loop_c9f61
+    jsr cad10                                                         ; 9f61: 20 10 ad     ..
+; $9f64 referenced 1 time by $9f1c
+c9f64
+    stx l0027                                                         ; 9f64: 86 27       .'
+    jsr sub_c8287                                                     ; 9f66: 20 87 82     ..
+    lda l003d                                                         ; 9f69: a5 3d       .=
+    jsr sub_ca70d                                                     ; 9f6b: 20 0d a7     ..
+    bra c9f55                                                         ; 9f6e: 80 e5       ..
+; $9f70 referenced 1 time by $9f10
+c9f70
+    tay                                                               ; 9f70: a8          .
+    bmi loop_c9f59                                                    ; 9f71: 30 e6       0.
+    beq c9f4c                                                         ; 9f73: f0 d7       ..
+    jsr sub_ca023                                                     ; 9f75: 20 23 a0     #.
+    tay                                                               ; 9f78: a8          .
+    bmi loop_c9f61                                                    ; 9f79: 30 e6       0.
+    beq c9f4c                                                         ; 9f7b: f0 cf       ..
+    sec                                                               ; 9f7d: 38          8
+    lda (l0004)                                                       ; 9f7e: b2 04       ..
+    sbc l002a                                                         ; 9f80: e5 2a       .*
+    sta l002a                                                         ; 9f82: 85 2a       .*
+    ldy #1                                                            ; 9f84: a0 01       ..
+    lda (l0004),y                                                     ; 9f86: b1 04       ..
+    sbc l002b                                                         ; 9f88: e5 2b       .+
+    sta l002b                                                         ; 9f8a: 85 2b       .+
+    iny                                                               ; 9f8c: c8          .
+    lda (l0004),y                                                     ; 9f8d: b1 04       ..
+    sbc l002c                                                         ; 9f8f: e5 2c       .,
+    sta l002c                                                         ; 9f91: 85 2c       .,
+    iny                                                               ; 9f93: c8          .
+    lda (l0004),y                                                     ; 9f94: b1 04       ..
+    sbc l002d                                                         ; 9f96: e5 2d       .-
+    bra c9f3b                                                         ; 9f98: 80 a1       ..
+; $9f9a referenced 2 times by $9fdb, $9fdf
+c9f9a
+    jsr c828d                                                         ; 9f9a: 20 8d 82     ..
+; $9f9d referenced 1 time by $9fce
+c9f9d
+    jsr sub_c8287                                                     ; 9f9d: 20 87 82     ..
+    and l003d                                                         ; 9fa0: 25 3d       %=
+    jsr sub_ca6eb                                                     ; 9fa2: 20 eb a6     ..
+    bra c9fb6                                                         ; 9fa5: 80 0f       ..
+; $9fa7 referenced 2 times by $9fc4, $9fc8
+c9fa7
+    jsr c828d                                                         ; 9fa7: 20 8d 82     ..
+; $9faa referenced 1 time by $9fb9
+loop_c9faa
+    jsr cbc3a                                                         ; 9faa: 20 3a bc     :.
+    jsr sub_ca06c                                                     ; 9fad: 20 6c a0     l.
+    jsr sub_cbc20                                                     ; 9fb0: 20 20 bc      .
+    jsr ca6e4                                                         ; 9fb3: 20 e4 a6     ..
+; $9fb6 referenced 1 time by $9fa5
+c9fb6
+    bra ca029                                                         ; 9fb6: 80 71       .q
+; $9fb8 referenced 1 time by $a02b
+c9fb8
+    tay                                                               ; 9fb8: a8          .
+    bmi loop_c9faa                                                    ; 9fb9: 30 ef       0.
+; $9fbb referenced 1 time by $9fd0
+loop_c9fbb
+    beq c9f4c                                                         ; 9fbb: f0 8f       ..
+    lda l002b                                                         ; 9fbd: a5 2b       .+
+    asl                                                               ; 9fbf: 0a          .
+    lda l002c                                                         ; 9fc0: a5 2c       .,
+    adc #0                                                            ; 9fc2: 69 00       i.
+    bne c9fa7                                                         ; 9fc4: d0 e1       ..
+    adc l002d                                                         ; 9fc6: 65 2d       e-
+    bne c9fa7                                                         ; 9fc8: d0 dd       ..
+    jsr sub_ca069                                                     ; 9fca: 20 69 a0     i.
+    tay                                                               ; 9fcd: a8          .
+    bmi c9f9d                                                         ; 9fce: 30 cd       0.
+    beq loop_c9fbb                                                    ; 9fd0: f0 e9       ..
+    lda l002b                                                         ; 9fd2: a5 2b       .+
+    sta l0038                                                         ; 9fd4: 85 38       .8
+    asl                                                               ; 9fd6: 0a          .
+    lda l002c                                                         ; 9fd7: a5 2c       .,
+    adc #0                                                            ; 9fd9: 69 00       i.
+    bne c9f9a                                                         ; 9fdb: d0 bd       ..
+    adc l002d                                                         ; 9fdd: 65 2d       e-
+    bne c9f9a                                                         ; 9fdf: d0 b9       ..
+    bcc c9fe6                                                         ; 9fe1: 90 03       ..
+    jsr cad20                                                         ; 9fe3: 20 20 ad      .
+; $9fe6 referenced 1 time by $9fe1
+c9fe6
+    stx l0027                                                         ; 9fe6: 86 27       .'
+    ldx #$3d ; '='                                                    ; 9fe8: a2 3d       .=
+    jsr sub_cbe06                                                     ; 9fea: 20 06 be     ..
+    jsr sub_cbd26                                                     ; 9fed: 20 26 bd     &.
+    ldy #0                                                            ; 9ff0: a0 00       ..
+    ldx #0                                                            ; 9ff2: a2 00       ..
+; $9ff4 referenced 1 time by $a01b
+c9ff4
+    lsr l003e                                                         ; 9ff4: 46 3e       F>
+    ror l003d                                                         ; 9ff6: 66 3d       f=
+    bcc ca00f                                                         ; 9ff8: 90 15       ..
+    clc                                                               ; 9ffa: 18          .
+    tya                                                               ; 9ffb: 98          .
+    adc l002a                                                         ; 9ffc: 65 2a       e*
+    tay                                                               ; 9ffe: a8          .
+    txa                                                               ; 9fff: 8a          .
+    adc l002b                                                         ; a000: 65 2b       e+
+    tax                                                               ; a002: aa          .
+    lda l003f                                                         ; a003: a5 3f       .?
+    adc l002c                                                         ; a005: 65 2c       e,
+    sta l003f                                                         ; a007: 85 3f       .?
+    lda l0040                                                         ; a009: a5 40       .@
+    adc l002d                                                         ; a00b: 65 2d       e-
+    sta l0040                                                         ; a00d: 85 40       .@
+; $a00f referenced 1 time by $9ff8
+ca00f
+    asl l002a                                                         ; a00f: 06 2a       .*
+    rol l002b                                                         ; a011: 26 2b       &+
+    rol l002c                                                         ; a013: 26 2c       &,
+    rol l002d                                                         ; a015: 26 2d       &-
+    lda l003d                                                         ; a017: a5 3d       .=
+    ora l003e                                                         ; a019: 05 3e       .>
+    bne c9ff4                                                         ; a01b: d0 d7       ..
+    sty l003d                                                         ; a01d: 84 3d       .=
+    stx l003e                                                         ; a01f: 86 3e       .>
+    bra ca04d                                                         ; a021: 80 2a       .*
+; $a023 referenced 2 times by $9f18, $9f75
+sub_ca023
+    jsr cbc66                                                         ; a023: 20 66 bc     f.
+; $a026 referenced 2 times by $9f07, $bc1b
+sub_ca026
+    jsr sub_ca06c                                                     ; a026: 20 6c a0     l.
+; $a029 referenced 2 times by $9fb6, $a05d
+ca029
+    cpx #$2a ; '*'                                                    ; a029: e0 2a       .*
+    beq c9fb8                                                         ; a02b: f0 8b       ..
+    cpx #$2f ; '/'                                                    ; a02d: e0 2f       ./
+    bcc ca03b                                                         ; a02f: 90 0a       ..
+    beq ca03c                                                         ; a031: f0 09       ..
+    cpx #$83                                                          ; a033: e0 83       ..
+    beq ca04a                                                         ; a035: f0 13       ..
+    cpx #$81                                                          ; a037: e0 81       ..
+    beq ca05f                                                         ; a039: f0 24       .$
+; $a03b referenced 1 time by $a02f
+ca03b
+    rts                                                               ; a03b: 60          `
+
+; $a03c referenced 1 time by $a031
+ca03c
+    jsr sub_cbc36                                                     ; a03c: 20 36 bc     6.
+    jsr sub_ca06c                                                     ; a03f: 20 6c a0     l.
+    jsr sub_cbc1e                                                     ; a042: 20 1e bc     ..
+    jsr ca634                                                         ; a045: 20 34 a6     4.
+    bra ca05b                                                         ; a048: 80 11       ..
+; $a04a referenced 1 time by $a035
+ca04a
+    jsr sub_c81bd                                                     ; a04a: 20 bd 81     ..
+; $a04d referenced 1 time by $a021
+ca04d
+    lda l0038                                                         ; a04d: a5 38       .8
+    php                                                               ; a04f: 08          .
+    ldx #$3d ; '='                                                    ; a050: a2 3d       .=
+; $a052 referenced 1 time by $a067
+loop_ca052
+    jsr sub_caad8                                                     ; a052: 20 d8 aa     ..
+    plp                                                               ; a055: 28          (
+    bpl ca05b                                                         ; a056: 10 03       ..
+    jsr cad20                                                         ; a058: 20 20 ad      .
+; $a05b referenced 2 times by $a048, $a056
+ca05b
+    ldx l0027                                                         ; a05b: a6 27       .'
+    bra ca029                                                         ; a05d: 80 ca       ..
+; $a05f referenced 1 time by $a039
+ca05f
+    jsr sub_c81bd                                                     ; a05f: 20 bd 81     ..
+    bit l0037                                                         ; a062: 24 37       $7
+    php                                                               ; a064: 08          .
+    ldx #$39 ; '9'                                                    ; a065: a2 39       .9
+    bra loop_ca052                                                    ; a067: 80 e9       ..
+; $a069 referenced 2 times by $81c8, $9fca
+sub_ca069
+    jsr cbc66                                                         ; a069: 20 66 bc     f.
+; $a06c referenced 4 times by $9ee0, $9fad, $a026, $a03f
+sub_ca06c
+    jsr cad78                                                         ; a06c: 20 78 ad     x.
+; $a06f referenced 2 times by $a0cf, $a0e6
+ca06f
+    pha                                                               ; a06f: 48          H
+; $a070 referenced 1 time by $a078
+loop_ca070
+    ldy l001b                                                         ; a070: a4 1b       ..
+    inc l001b                                                         ; a072: e6 1b       ..
+    lda (l0019),y                                                     ; a074: b1 19       ..
+    cmp #$20 ; ' '                                                    ; a076: c9 20       .
+    beq loop_ca070                                                    ; a078: f0 f6       ..
+    tax                                                               ; a07a: aa          .
+    pla                                                               ; a07b: 68          h
+    cpx #$5e ; '^'                                                    ; a07c: e0 5e       .^
+    beq ca081                                                         ; a07e: f0 01       ..
+    rts                                                               ; a080: 60          `
+
+; $a081 referenced 2 times by $a07e, $a089
+ca081
+    jsr sub_cbc36                                                     ; a081: 20 36 bc     6.
+    jsr cad78                                                         ; a084: 20 78 ad     x.
+    bmi ca09f                                                         ; a087: 30 16       0.
+    beq ca081                                                         ; a089: f0 f6       ..
+    lda l002a                                                         ; a08b: a5 2a       .*
+    asl                                                               ; a08d: 0a          .
+    lda #0                                                            ; a08e: a9 00       ..
+    adc l002b                                                         ; a090: 65 2b       e+
+    bne ca09c                                                         ; a092: d0 08       ..
+    adc l002c                                                         ; a094: 65 2c       e,
+    bne ca09c                                                         ; a096: d0 04       ..
+    adc l002d                                                         ; a098: 65 2d       e-
+    beq ca0c7                                                         ; a09a: f0 2b       .+
+; $a09c referenced 2 times by $a092, $a096
+ca09c
+    jsr c828d                                                         ; a09c: 20 8d 82     ..
+; $a09f referenced 1 time by $a087
+ca09f
+    lda l0030                                                         ; a09f: a5 30       .0
+    beq ca0c5                                                         ; a0a1: f0 22       ."
+    cmp #$87                                                          ; a0a3: c9 87       ..
+    bcs ca0d1                                                         ; a0a5: b0 2a       .*
+    cmp #$81                                                          ; a0a7: c9 81       ..
+    bcc ca0d1                                                         ; a0a9: 90 26       .&
+    ora #$78 ; 'x'                                                    ; a0ab: 09 78       .x
+    tay                                                               ; a0ad: a8          .
+    lda l0032                                                         ; a0ae: a5 32       .2
+    ora l0033                                                         ; a0b0: 05 33       .3
+    ora l0034                                                         ; a0b2: 05 34       .4
+    bne ca0d1                                                         ; a0b4: d0 1b       ..
+    lda l0031                                                         ; a0b6: a5 31       .1
+; $a0b8 referenced 1 time by $a0bc
+loop_ca0b8
+    lsr                                                               ; a0b8: 4a          J
+    bcs ca0d1                                                         ; a0b9: b0 16       ..
+    iny                                                               ; a0bb: c8          .
+    bmi loop_ca0b8                                                    ; a0bc: 30 fa       0.
+    ldy l002e                                                         ; a0be: a4 2e       ..
+    bpl ca0c5                                                         ; a0c0: 10 03       ..
+    eor #$ff                                                          ; a0c2: 49 ff       I.
+    inc                                                               ; a0c4: 1a          .
+; $a0c5 referenced 2 times by $a0a1, $a0c0
+ca0c5
+    sta l002a                                                         ; a0c5: 85 2a       .*
+; $a0c7 referenced 1 time by $a09a
+ca0c7
+    jsr sub_ca56d                                                     ; a0c7: 20 6d a5     m.
+    lda l002a                                                         ; a0ca: a5 2a       .*
+    jsr sub_ca5f9                                                     ; a0cc: 20 f9 a5     ..
+    bra ca06f                                                         ; a0cf: 80 9e       ..
+; $a0d1 referenced 4 times by $a0a5, $a0a9, $a0b4, $a0b9
+ca0d1
+    lda #$71 ; 'q'                                                    ; a0d1: a9 71       .q
+    jsr ca547                                                         ; a0d3: 20 47 a5     G.
+    jsr sub_ca56d                                                     ; a0d6: 20 6d a5     m.
+    jsr sub_ca7af                                                     ; a0d9: 20 af a7     ..
+    lda #$71 ; 'q'                                                    ; a0dc: a9 71       .q
+    ldy #4                                                            ; a0de: a0 04       ..
+    jsr sub_ca9c3                                                     ; a0e0: 20 c3 a9     ..
+    jsr sub_caa1a                                                     ; a0e3: 20 1a aa     ..
+    bra ca06f                                                         ; a0e6: 80 87       ..
+; $a0e8 referenced 3 times by $9535, $9d1e, $b505
+sub_ca0e8
+    lda #0                                                            ; a0e8: a9 00       ..
+    bra ca0ee                                                         ; a0ea: 80 02       ..
+; $a0ec referenced 2 times by $9558, $b4c6
+sub_ca0ec
+    lda #5                                                            ; a0ec: a9 05       ..
+; $a0ee referenced 1 time by $a0ea
+ca0ee
+    sta l0014                                                         ; a0ee: 85 14       ..
+    ldx #4                                                            ; a0f0: a2 04       ..
+; $a0f2 referenced 1 time by $a10b
+loop_ca0f2
+    stz l003f,x                                                       ; a0f2: 74 3f       t?
+    sec                                                               ; a0f4: 38          8
+; $a0f5 referenced 1 time by $a108
+loop_ca0f5
+    lda l002a                                                         ; a0f5: a5 2a       .*
+    sbc l80e2,x                                                       ; a0f7: fd e2 80    ...
+    tay                                                               ; a0fa: a8          .
+    lda l002b                                                         ; a0fb: a5 2b       .+
+    sbc l80dd,x                                                       ; a0fd: fd dd 80    ...
+    bcc ca10a                                                         ; a100: 90 08       ..
+    sta l002b                                                         ; a102: 85 2b       .+
+    sty l002a                                                         ; a104: 84 2a       .*
+    inc l003f,x                                                       ; a106: f6 3f       .?
+    bra loop_ca0f5                                                    ; a108: 80 eb       ..
+; $a10a referenced 1 time by $a100
+ca10a
+    dex                                                               ; a10a: ca          .
+    bpl loop_ca0f2                                                    ; a10b: 10 e5       ..
+    ldx #5                                                            ; a10d: a2 05       ..
+; $a10f referenced 1 time by $a114
+loop_ca10f
+    dex                                                               ; a10f: ca          .
+    beq ca116                                                         ; a110: f0 04       ..
+    lda l003f,x                                                       ; a112: b5 3f       .?
+    beq loop_ca10f                                                    ; a114: f0 f9       ..
+; $a116 referenced 1 time by $a110
+ca116
+    stx l0037                                                         ; a116: 86 37       .7
+    lda l0014                                                         ; a118: a5 14       ..
+    beq ca126                                                         ; a11a: f0 0a       ..
+    sbc l0037                                                         ; a11c: e5 37       .7
+    beq ca126                                                         ; a11e: f0 06       ..
+    tax                                                               ; a120: aa          .
+    jsr cbdff                                                         ; a121: 20 ff bd     ..
+    ldx l0037                                                         ; a124: a6 37       .7
+; $a126 referenced 3 times by $a11a, $a11e, $a12e
+ca126
+    lda l003f,x                                                       ; a126: b5 3f       .?
+    ora #$30 ; '0'                                                    ; a128: 09 30       .0
+    jsr cbdd4                                                         ; a12a: 20 d4 bd     ..
+    dex                                                               ; a12d: ca          .
+    bpl ca126                                                         ; a12e: 10 f6       ..
+    rts                                                               ; a130: 60          `
+
+; $a131 referenced 1 time by $a1a7
+ca131
+    tya                                                               ; a131: 98          .
+    bpl ca137                                                         ; a132: 10 03       ..
+    jsr sub_c9788                                                     ; a134: 20 88 97     ..
+; $a137 referenced 1 time by $a132
+ca137
+    ldx #0                                                            ; a137: a2 00       ..
+    ldy #0                                                            ; a139: a0 00       ..
+; $a13b referenced 1 time by $a14f
+loop_ca13b
+    lda l002a,y                                                       ; a13b: b9 2a 00    .*.
+    pha                                                               ; a13e: 48          H
+    and #$0f                                                          ; a13f: 29 0f       ).
+    sta l003f,x                                                       ; a141: 95 3f       .?
+    pla                                                               ; a143: 68          h
+    lsr                                                               ; a144: 4a          J
+    lsr                                                               ; a145: 4a          J
+    lsr                                                               ; a146: 4a          J
+    lsr                                                               ; a147: 4a          J
+    inx                                                               ; a148: e8          .
+    sta l003f,x                                                       ; a149: 95 3f       .?
+    inx                                                               ; a14b: e8          .
+    iny                                                               ; a14c: c8          .
+    cpy #4                                                            ; a14d: c0 04       ..
+    bne loop_ca13b                                                    ; a14f: d0 ea       ..
+; $a151 referenced 1 time by $a156
+loop_ca151
+    dex                                                               ; a151: ca          .
+    beq ca158                                                         ; a152: f0 04       ..
+    lda l003f,x                                                       ; a154: b5 3f       .?
+    beq loop_ca151                                                    ; a156: f0 f9       ..
+; $a158 referenced 2 times by $a152, $a166
+ca158
+    lda l003f,x                                                       ; a158: b5 3f       .?
+    cmp #$0a                                                          ; a15a: c9 0a       ..
+    bcc ca160                                                         ; a15c: 90 02       ..
+    adc #6                                                            ; a15e: 69 06       i.
+; $a160 referenced 1 time by $a15c
+ca160
+    adc #$30 ; '0'                                                    ; a160: 69 30       i0
+    jsr ca2cc                                                         ; a162: 20 cc a2     ..
+    dex                                                               ; a165: ca          .
+    bpl ca158                                                         ; a166: 10 f0       ..
+    rts                                                               ; a168: 60          `
+
+; $a169 referenced 1 time by $a1b1
+ca169
+    lda l002e                                                         ; a169: a5 2e       ..
+    bpl ca174                                                         ; a16b: 10 07       ..
+    lda #$2d ; '-'                                                    ; a16d: a9 2d       .-
+    stz l002e                                                         ; a16f: 64 2e       d.
+    jsr ca2cc                                                         ; a171: 20 cc a2     ..
+; $a174 referenced 3 times by $a16b, $a17f, $a1d2
+ca174
+    lda l0030                                                         ; a174: a5 30       .0
+    cmp #$81                                                          ; a176: c9 81       ..
+    bcs ca1c1                                                         ; a178: b0 47       .G
+    jsr sub_ca46b                                                     ; a17a: 20 6b a4     k.
+    dec l0048                                                         ; a17d: c6 48       .H
+    bra ca174                                                         ; a17f: 80 f3       ..
+; $a181 referenced 2 times by $92c7, $af83
+sub_ca181
+    ldx l0402                                                         ; a181: ae 02 04    ...
+    cpx #3                                                            ; a184: e0 03       ..
+    bcc ca18a                                                         ; a186: 90 02       ..
+    ldx #0                                                            ; a188: a2 00       ..
+; $a18a referenced 1 time by $a186
+ca18a
+    stx l0037                                                         ; a18a: 86 37       .7
+    lda l0401                                                         ; a18c: ad 01 04    ...
+    beq ca197                                                         ; a18f: f0 06       ..
+    cmp #$0a                                                          ; a191: c9 0a       ..
+    bcs ca19b                                                         ; a193: b0 06       ..
+    bra ca19d                                                         ; a195: 80 06       ..
+; $a197 referenced 1 time by $a18f
+ca197
+    cpx #2                                                            ; a197: e0 02       ..
+    beq ca19d                                                         ; a199: f0 02       ..
+; $a19b referenced 2 times by $a193, $af7e
+ca19b
+    lda #$0a                                                          ; a19b: a9 0a       ..
+; $a19d referenced 2 times by $a195, $a199
+ca19d
+    sta l0038                                                         ; a19d: 85 38       .8
+    sta l004d                                                         ; a19f: 85 4d       .M
+    stz l0036                                                         ; a1a1: 64 36       d6
+    stz l0048                                                         ; a1a3: 64 48       dH
+    bit l0015                                                         ; a1a5: 24 15       $.
+    bmi ca131                                                         ; a1a7: 30 88       0.
+    tya                                                               ; a1a9: 98          .
+    bmi ca1af                                                         ; a1aa: 30 03       0.
+    jsr c828d                                                         ; a1ac: 20 8d 82     ..
+; $a1af referenced 1 time by $a1aa
+ca1af
+    lda l0031                                                         ; a1af: a5 31       .1
+    bne ca169                                                         ; a1b1: d0 b6       ..
+    lda l0037                                                         ; a1b3: a5 37       .7
+    bne ca21c                                                         ; a1b5: d0 65       .e
+    lda #$30 ; '0'                                                    ; a1b7: a9 30       .0
+    jmp ca2cc                                                         ; a1b9: 4c cc a2    L..
+
+; $a1bc referenced 1 time by $a216
+ca1bc
+    jsr ca622                                                         ; a1bc: 20 22 a6     ".
+    bra ca1d0                                                         ; a1bf: 80 0f       ..
+; $a1c1 referenced 1 time by $a178
+ca1c1
+    cmp #$84                                                          ; a1c1: c9 84       ..
+    bcc ca1d4                                                         ; a1c3: 90 0f       ..
+    bne ca1cd                                                         ; a1c5: d0 06       ..
+    lda l0031                                                         ; a1c7: a5 31       .1
+    cmp #$a0                                                          ; a1c9: c9 a0       ..
+    bcc ca1d4                                                         ; a1cb: 90 07       ..
+; $a1cd referenced 1 time by $a1c5
+ca1cd
+    jsr sub_ca4ba                                                     ; a1cd: 20 ba a4     ..
+; $a1d0 referenced 1 time by $a1bf
+ca1d0
+    inc l0048                                                         ; a1d0: e6 48       .H
+    bra ca174                                                         ; a1d2: 80 a0       ..
+; $a1d4 referenced 2 times by $a1c3, $a1cb
+ca1d4
+    jsr sub_ca3ed                                                     ; a1d4: 20 ed a3     ..
+    lda l004d                                                         ; a1d7: a5 4d       .M
+    sta l0038                                                         ; a1d9: 85 38       .8
+    ldx l0037                                                         ; a1db: a6 37       .7
+    cpx #2                                                            ; a1dd: e0 02       ..
+    bne ca1ef                                                         ; a1df: d0 0e       ..
+    adc l0048                                                         ; a1e1: 65 48       eH
+    bmi ca220                                                         ; a1e3: 30 3b       0;
+    cmp #$0b                                                          ; a1e5: c9 0b       ..
+    bcc ca1ed                                                         ; a1e7: 90 04       ..
+    lda #$0a                                                          ; a1e9: a9 0a       ..
+    stz l0037                                                         ; a1eb: 64 37       d7
+; $a1ed referenced 1 time by $a1e7
+ca1ed
+    sta l0038                                                         ; a1ed: 85 38       .8
+; $a1ef referenced 1 time by $a1df
+ca1ef
+    lda l0038                                                         ; a1ef: a5 38       .8
+    eor #$ff                                                          ; a1f1: 49 ff       I.
+    lsr                                                               ; a1f3: 4a          J
+    php                                                               ; a1f4: 08          .
+    asl                                                               ; a1f5: 0a          .
+    asl                                                               ; a1f6: 0a          .
+    adc #$bc                                                          ; a1f7: 69 bc       i.
+    jsr sub_ca572                                                     ; a1f9: 20 72 a5     r.
+    dec l0030                                                         ; a1fc: c6 30       .0
+    plp                                                               ; a1fe: 28          (
+    bcc ca204                                                         ; a1ff: 90 03       ..
+    jsr sub_ca46b                                                     ; a201: 20 6b a4     k.
+; $a204 referenced 1 time by $a1ff
+ca204
+    jsr sub_c8429                                                     ; a204: 20 29 84     ).
+; $a207 referenced 1 time by $a210
+loop_ca207
+    lda l0030                                                         ; a207: a5 30       .0
+    cmp #$84                                                          ; a209: c9 84       ..
+    bcs ca212                                                         ; a20b: b0 05       ..
+    jsr ca4a9                                                         ; a20d: 20 a9 a4     ..
+    bne loop_ca207                                                    ; a210: d0 f5       ..
+; $a212 referenced 1 time by $a20b
+ca212
+    lda l0031                                                         ; a212: a5 31       .1
+    cmp #$a0                                                          ; a214: c9 a0       ..
+    bcs ca1bc                                                         ; a216: b0 a4       ..
+    lda l0038                                                         ; a218: a5 38       .8
+    bne ca22a                                                         ; a21a: d0 0e       ..
+; $a21c referenced 1 time by $a1b5
+ca21c
+    cmp #1                                                            ; a21c: c9 01       ..
+    beq ca261                                                         ; a21e: f0 41       .A
+; $a220 referenced 2 times by $89d0, $a1e3
+ca220
+    jsr ca72b                                                         ; a220: 20 2b a7     +.
+    stz l0048                                                         ; a223: 64 48       dH
+    lda l004d                                                         ; a225: a5 4d       .M
+    inc                                                               ; a227: 1a          .
+    sta l0038                                                         ; a228: 85 38       .8
+; $a22a referenced 1 time by $a21a
+ca22a
+    lda #1                                                            ; a22a: a9 01       ..
+    cmp l0037                                                         ; a22c: c5 37       .7
+    beq ca261                                                         ; a22e: f0 31       .1
+    ldy l0048                                                         ; a230: a4 48       .H
+    bmi ca23e                                                         ; a232: 30 0a       0.
+    cpy l0038                                                         ; a234: c4 38       .8
+    bcs ca261                                                         ; a236: b0 29       .)
+    stz l0048                                                         ; a238: 64 48       dH
+    iny                                                               ; a23a: c8          .
+    tya                                                               ; a23b: 98          .
+    bne ca261                                                         ; a23c: d0 23       .#
+; $a23e referenced 1 time by $a232
+ca23e
+    lda l0037                                                         ; a23e: a5 37       .7
+    cmp #2                                                            ; a240: c9 02       ..
+    beq ca24a                                                         ; a242: f0 06       ..
+    lda #1                                                            ; a244: a9 01       ..
+    cpy #$ff                                                          ; a246: c0 ff       ..
+    bne ca261                                                         ; a248: d0 17       ..
+; $a24a referenced 1 time by $a242
+ca24a
+    lda #$30 ; '0'                                                    ; a24a: a9 30       .0
+    jsr ca2cc                                                         ; a24c: 20 cc a2     ..
+    lda #$2e ; '.'                                                    ; a24f: a9 2e       ..
+    jsr ca2cc                                                         ; a251: 20 cc a2     ..
+    lda #$30 ; '0'                                                    ; a254: a9 30       .0
+; $a256 referenced 1 time by $a25d
+loop_ca256
+    inc l0048                                                         ; a256: e6 48       .H
+    beq ca25f                                                         ; a258: f0 05       ..
+    jsr ca2cc                                                         ; a25a: 20 cc a2     ..
+    bra loop_ca256                                                    ; a25d: 80 f7       ..
+; $a25f referenced 1 time by $a258
+ca25f
+    lda #$80                                                          ; a25f: a9 80       ..
+; $a261 referenced 5 times by $a21e, $a22e, $a236, $a23c, $a248
+ca261
+    sta l004d                                                         ; a261: 85 4d       .M
+; $a263 referenced 1 time by $a271
+loop_ca263
+    jsr sub_ca40a                                                     ; a263: 20 0a a4     ..
+    dec l004d                                                         ; a266: c6 4d       .M
+    bne ca26f                                                         ; a268: d0 05       ..
+    lda #$2e ; '.'                                                    ; a26a: a9 2e       ..
+    jsr ca2cc                                                         ; a26c: 20 cc a2     ..
+; $a26f referenced 1 time by $a268
+ca26f
+    dec l0038                                                         ; a26f: c6 38       .8
+    bne loop_ca263                                                    ; a271: d0 f0       ..
+    ldy l0037                                                         ; a273: a4 37       .7
+    dey                                                               ; a275: 88          .
+    beq ca290                                                         ; a276: f0 18       ..
+    dey                                                               ; a278: 88          .
+    beq ca28c                                                         ; a279: f0 11       ..
+    ldy l0036                                                         ; a27b: a4 36       .6
+; $a27d referenced 1 time by $a283
+loop_ca27d
+    dey                                                               ; a27d: 88          .
+    lda l0600,y                                                       ; a27e: b9 00 06    ...
+    cmp #$30 ; '0'                                                    ; a281: c9 30       .0
+    beq loop_ca27d                                                    ; a283: f0 f8       ..
+    cmp #$2e ; '.'                                                    ; a285: c9 2e       ..
+    beq ca28a                                                         ; a287: f0 01       ..
+    iny                                                               ; a289: c8          .
+; $a28a referenced 1 time by $a287
+ca28a
+    sty l0036                                                         ; a28a: 84 36       .6
+; $a28c referenced 1 time by $a279
+ca28c
+    lda l0048                                                         ; a28c: a5 48       .H
+    beq ca2b7                                                         ; a28e: f0 27       .'
+; $a290 referenced 1 time by $a276
+ca290
+    lda #$45 ; 'E'                                                    ; a290: a9 45       .E
+    jsr ca2cc                                                         ; a292: 20 cc a2     ..
+    lda l0048                                                         ; a295: a5 48       .H
+    bpl ca2a3                                                         ; a297: 10 0a       ..
+    lda #$2d ; '-'                                                    ; a299: a9 2d       .-
+    jsr ca2cc                                                         ; a29b: 20 cc a2     ..
+    sec                                                               ; a29e: 38          8
+    lda #0                                                            ; a29f: a9 00       ..
+    sbc l0048                                                         ; a2a1: e5 48       .H
+; $a2a3 referenced 1 time by $a297
+ca2a3
+    jsr sub_ca2b8                                                     ; a2a3: 20 b8 a2     ..
+    lda l0037                                                         ; a2a6: a5 37       .7
+    beq ca2b7                                                         ; a2a8: f0 0d       ..
+    lda #$20 ; ' '                                                    ; a2aa: a9 20       .
+    ldy l0048                                                         ; a2ac: a4 48       .H
+    bmi ca2b3                                                         ; a2ae: 30 03       0.
+    jsr ca2cc                                                         ; a2b0: 20 cc a2     ..
+; $a2b3 referenced 1 time by $a2ae
+ca2b3
+    cpx #0                                                            ; a2b3: e0 00       ..
+    beq ca2cc                                                         ; a2b5: f0 15       ..
+; $a2b7 referenced 2 times by $a28e, $a2a8
+ca2b7
+    rts                                                               ; a2b7: 60          `
+
+; $a2b8 referenced 1 time by $a2a3
+sub_ca2b8
+    ldx #$ff                                                          ; a2b8: a2 ff       ..
+    sec                                                               ; a2ba: 38          8
+; $a2bb referenced 1 time by $a2be
+loop_ca2bb
+    inx                                                               ; a2bb: e8          .
+    sbc #$0a                                                          ; a2bc: e9 0a       ..
+    bcs loop_ca2bb                                                    ; a2be: b0 fb       ..
+    adc #$0a                                                          ; a2c0: 69 0a       i.
+    pha                                                               ; a2c2: 48          H
+    txa                                                               ; a2c3: 8a          .
+    beq ca2c9                                                         ; a2c4: f0 03       ..
+    jsr sub_ca2ca                                                     ; a2c6: 20 ca a2     ..
+; $a2c9 referenced 1 time by $a2c4
+ca2c9
+    pla                                                               ; a2c9: 68          h
+; $a2ca referenced 2 times by $a2c6, $a410
+sub_ca2ca
+    ora #$30 ; '0'                                                    ; a2ca: 09 30       .0
+; $a2cc referenced 11 times by $a162, $a171, $a1b9, $a24c, $a251, $a25a, $a26c, $a292, $a29b, $a2b0, $a2b5
+ca2cc
+    phx                                                               ; a2cc: da          .
+    ldx l0036                                                         ; a2cd: a6 36       .6
+    sta l0600,x                                                       ; a2cf: 9d 00 06    ...
+    plx                                                               ; a2d2: fa          .
+    inc l0036                                                         ; a2d3: e6 36       .6
+    rts                                                               ; a2d5: 60          `
+
+; $a2d6 referenced 2 times by $a2f5, $a2f9
+ca2d6
+    clc                                                               ; a2d6: 18          .
+    lda #$ff                                                          ; a2d7: a9 ff       ..
+    jmp c82dd                                                         ; a2d9: 4c dd 82    L..
+
+    !byte $60                                                         ; a2dc: 60          `
+
+; $a2dd referenced 3 times by $abcb, $abd5, $adb6
+sub_ca2dd
+    stz l0031                                                         ; a2dd: 64 31       d1
+    stz l0032                                                         ; a2df: 64 32       d2
+    stz l0033                                                         ; a2e1: 64 33       d3
+    stz l0034                                                         ; a2e3: 64 34       d4
+    stz l0035                                                         ; a2e5: 64 35       d5
+    stz l0047                                                         ; a2e7: 64 47       dG
+    stz l0048                                                         ; a2e9: 64 48       dH
+    ldx #$ff                                                          ; a2eb: a2 ff       ..
+    stx l0049                                                         ; a2ed: 86 49       .I
+    cmp #$2e ; '.'                                                    ; a2ef: c9 2e       ..
+    beq ca348                                                         ; a2f1: f0 55       .U
+    cmp #$3a ; ':'                                                    ; a2f3: c9 3a       .:
+    bcs ca2d6                                                         ; a2f5: b0 df       ..
+    sbc #$2f ; '/'                                                    ; a2f7: e9 2f       ./
+    bmi ca2d6                                                         ; a2f9: 30 db       0.
+; $a2fb referenced 4 times by $a31f, $a323, $a337, $a33c
+ca2fb
+    sta l0035                                                         ; a2fb: 85 35       .5
+; $a2fd referenced 1 time by $a340
+ca2fd
+    lda l0047                                                         ; a2fd: a5 47       .G
+    beq ca303                                                         ; a2ff: f0 02       ..
+    dec l0048                                                         ; a301: c6 48       .H
+; $a303 referenced 2 times by $a2ff, $a34a
+ca303
+    iny                                                               ; a303: c8          .
+    lda (l0019),y                                                     ; a304: b1 19       ..
+    cmp #$3a ; ':'                                                    ; a306: c9 3a       .:
+    bcs ca34c                                                         ; a308: b0 42       .B
+    sbc #$2f ; '/'                                                    ; a30a: e9 2f       ./
+    bcc ca342                                                         ; a30c: 90 34       .4
+    sta l0042                                                         ; a30e: 85 42       .B
+    ldx l0049                                                         ; a310: a6 49       .I
+    bpl ca325                                                         ; a312: 10 11       ..
+    lda l0035                                                         ; a314: a5 35       .5
+    asl                                                               ; a316: 0a          .
+    asl                                                               ; a317: 0a          .
+    adc l0035                                                         ; a318: 65 35       e5
+    asl                                                               ; a31a: 0a          .
+    adc l0042                                                         ; a31b: 65 42       eB
+    cmp #$19                                                          ; a31d: c9 19       ..
+    bcc ca2fb                                                         ; a31f: 90 da       ..
+    stz l0049                                                         ; a321: 64 49       dI
+    bra ca2fb                                                         ; a323: 80 d6       ..
+; $a325 referenced 1 time by $a312
+ca325
+    cpx #2                                                            ; a325: e0 02       ..
+    bcs ca33e                                                         ; a327: b0 15       ..
+    jsr sub_ca419                                                     ; a329: 20 19 a4     ..
+    cmp #$19                                                          ; a32c: c9 19       ..
+    bcc ca333                                                         ; a32e: 90 03       ..
+    inc l0049                                                         ; a330: e6 49       .I
+    clc                                                               ; a332: 18          .
+; $a333 referenced 1 time by $a32e
+ca333
+    lda l0042                                                         ; a333: a5 42       .B
+    adc l0035                                                         ; a335: 65 35       e5
+    bcc ca2fb                                                         ; a337: 90 c2       ..
+    jsr sub_ca503                                                     ; a339: 20 03 a5     ..
+    bra ca2fb                                                         ; a33c: 80 bd       ..
+; $a33e referenced 1 time by $a327
+ca33e
+    inc l0048                                                         ; a33e: e6 48       .H
+    bra ca2fd                                                         ; a340: 80 bb       ..
+; $a342 referenced 1 time by $a30c
+ca342
+    eor #$fe                                                          ; a342: 49 fe       I.
+    ora l0047                                                         ; a344: 05 47       .G
+    bne ca357                                                         ; a346: d0 0f       ..
+; $a348 referenced 1 time by $a2f1
+ca348
+    inc l0047                                                         ; a348: e6 47       .G
+    bra ca303                                                         ; a34a: 80 b7       ..
+; $a34c referenced 1 time by $a308
+ca34c
+    cmp #$45 ; 'E'                                                    ; a34c: c9 45       .E
+    bne ca357                                                         ; a34e: d0 07       ..
+    jsr sub_ca3b5                                                     ; a350: 20 b5 a3     ..
+    adc l0048                                                         ; a353: 65 48       eH
+    sta l0048                                                         ; a355: 85 48       .H
+; $a357 referenced 2 times by $a346, $a34e
+ca357
+    sty l001b                                                         ; a357: 84 1b       ..
+    ldy l0031                                                         ; a359: a4 31       .1
+    bne ca385                                                         ; a35b: d0 28       .(
+    lda l0032                                                         ; a35d: a5 32       .2
+    bmi ca385                                                         ; a35f: 30 24       0$
+    sta l002d                                                         ; a361: 85 2d       .-
+    beq ca36b                                                         ; a363: f0 06       ..
+    lda l0048                                                         ; a365: a5 48       .H
+    ora l0047                                                         ; a367: 05 47       .G
+    bne ca385                                                         ; a369: d0 1a       ..
+; $a36b referenced 1 time by $a363
+ca36b
+    lda l0035                                                         ; a36b: a5 35       .5
+    sta l002a                                                         ; a36d: 85 2a       .*
+    lda l0034                                                         ; a36f: a5 34       .4
+    sta l002b                                                         ; a371: 85 2b       .+
+    lda l0033                                                         ; a373: a5 33       .3
+    sta l002c                                                         ; a375: 85 2c       .,
+    lda l0048                                                         ; a377: a5 48       .H
+    bne ca37e                                                         ; a379: d0 03       ..
+    inc                                                               ; a37b: 1a          .
+    sec                                                               ; a37c: 38          8
+    rts                                                               ; a37d: 60          `
+
+; $a37e referenced 1 time by $a379
+ca37e
+    jsr c828d                                                         ; a37e: 20 8d 82     ..
+    bne ca393                                                         ; a381: d0 10       ..
+    bra ca3aa                                                         ; a383: 80 25       .%
+; $a385 referenced 3 times by $a35b, $a35f, $a369
+ca385
+    lda #$a8                                                          ; a385: a9 a8       ..
+    sta l0030                                                         ; a387: 85 30       .0
+    stz l002e                                                         ; a389: 64 2e       d.
+    stz l002f                                                         ; a38b: 64 2f       d/
+    tya                                                               ; a38d: 98          .
+    sta l0031                                                         ; a38e: 85 31       .1
+    jsr c8304                                                         ; a390: 20 04 83     ..
+; $a393 referenced 1 time by $a381
+ca393
+    ldy l0048                                                         ; a393: a4 48       .H
+    bmi ca3a1                                                         ; a395: 30 0a       0.
+    beq ca3a7                                                         ; a397: f0 0e       ..
+; $a399 referenced 1 time by $a39d
+loop_ca399
+    jsr sub_ca46b                                                     ; a399: 20 6b a4     k.
+    dey                                                               ; a39c: 88          .
+    bne loop_ca399                                                    ; a39d: d0 fa       ..
+    bra ca3a7                                                         ; a39f: 80 06       ..
+; $a3a1 referenced 2 times by $a395, $a3a5
+ca3a1
+    jsr sub_ca4ba                                                     ; a3a1: 20 ba a4     ..
+    iny                                                               ; a3a4: c8          .
+    bne ca3a1                                                         ; a3a5: d0 fa       ..
+; $a3a7 referenced 2 times by $a397, $a39f
+ca3a7
+    jsr ca712                                                         ; a3a7: 20 12 a7     ..
+; $a3aa referenced 1 time by $a383
+ca3aa
+    sec                                                               ; a3aa: 38          8
+    lda #$ff                                                          ; a3ab: a9 ff       ..
+    rts                                                               ; a3ad: 60          `
+
+; $a3ae referenced 1 time by $a3ba
+loop_ca3ae
+    jsr sub_ca3c0                                                     ; a3ae: 20 c0 a3     ..
+    eor #$ff                                                          ; a3b1: 49 ff       I.
+    sec                                                               ; a3b3: 38          8
+    rts                                                               ; a3b4: 60          `
+
+; $a3b5 referenced 1 time by $a350
+sub_ca3b5
+    iny                                                               ; a3b5: c8          .
+    lda (l0019),y                                                     ; a3b6: b1 19       ..
+    cmp #$2d ; '-'                                                    ; a3b8: c9 2d       .-
+    beq loop_ca3ae                                                    ; a3ba: f0 f2       ..
+    cmp #$2b ; '+'                                                    ; a3bc: c9 2b       .+
+    bne ca3c3                                                         ; a3be: d0 03       ..
+; $a3c0 referenced 1 time by $a3ae
+sub_ca3c0
+    iny                                                               ; a3c0: c8          .
+    lda (l0019),y                                                     ; a3c1: b1 19       ..
+; $a3c3 referenced 1 time by $a3be
+ca3c3
+    cmp #$3a ; ':'                                                    ; a3c3: c9 3a       .:
+    bcs ca3e9                                                         ; a3c5: b0 22       ."
+    sbc #$2f ; '/'                                                    ; a3c7: e9 2f       ./
+    bcc ca3e9                                                         ; a3c9: 90 1e       ..
+    sta l0049                                                         ; a3cb: 85 49       .I
+    iny                                                               ; a3cd: c8          .
+    lda (l0019),y                                                     ; a3ce: b1 19       ..
+    cmp #$3a ; ':'                                                    ; a3d0: c9 3a       .:
+    bcs ca3e5                                                         ; a3d2: b0 11       ..
+    sbc #$2f ; '/'                                                    ; a3d4: e9 2f       ./
+    bcc ca3e5                                                         ; a3d6: 90 0d       ..
+    iny                                                               ; a3d8: c8          .
+    sta l0042                                                         ; a3d9: 85 42       .B
+    lda l0049                                                         ; a3db: a5 49       .I
+    asl                                                               ; a3dd: 0a          .
+    asl                                                               ; a3de: 0a          .
+    adc l0049                                                         ; a3df: 65 49       eI
+    asl                                                               ; a3e1: 0a          .
+    adc l0042                                                         ; a3e2: 65 42       eB
+    rts                                                               ; a3e4: 60          `
+
+; $a3e5 referenced 2 times by $a3d2, $a3d6
+ca3e5
+    lda l0049                                                         ; a3e5: a5 49       .I
+    clc                                                               ; a3e7: 18          .
+    rts                                                               ; a3e8: 60          `
+
+; $a3e9 referenced 2 times by $a3c5, $a3c9
+ca3e9
+    lda #0                                                            ; a3e9: a9 00       ..
+    clc                                                               ; a3eb: 18          .
+    rts                                                               ; a3ec: 60          `
+
+; $a3ed referenced 3 times by $828a, $a1d4, $a6ce
+sub_ca3ed
+    lda l002e                                                         ; a3ed: a5 2e       ..
+    sta l003b                                                         ; a3ef: 85 3b       .;
+    lda l0030                                                         ; a3f1: a5 30       .0
+    sta l003c                                                         ; a3f3: 85 3c       .<
+    lda l0031                                                         ; a3f5: a5 31       .1
+    sta l003d                                                         ; a3f7: 85 3d       .=
+    lda l0032                                                         ; a3f9: a5 32       .2
+    sta l003e                                                         ; a3fb: 85 3e       .>
+    lda l0033                                                         ; a3fd: a5 33       .3
+    sta l003f                                                         ; a3ff: 85 3f       .?
+    lda l0034                                                         ; a401: a5 34       .4
+    sta l0040                                                         ; a403: 85 40       .@
+    lda l0035                                                         ; a405: a5 35       .5
+    sta l0041                                                         ; a407: 85 41       .A
+    rts                                                               ; a409: 60          `
+
+; $a40a referenced 1 time by $a263
+sub_ca40a
+    lda l0031                                                         ; a40a: a5 31       .1
+    lsr                                                               ; a40c: 4a          J
+    lsr                                                               ; a40d: 4a          J
+    lsr                                                               ; a40e: 4a          J
+    lsr                                                               ; a40f: 4a          J
+    jsr sub_ca2ca                                                     ; a410: 20 ca a2     ..
+    lda #$f0                                                          ; a413: a9 f0       ..
+    trb l0031                                                         ; a415: 14 31       .1
+    ldx #1                                                            ; a417: a2 01       ..
+; $a419 referenced 1 time by $a329
+sub_ca419
+    asl l0035                                                         ; a419: 06 35       .5
+    rol l0034                                                         ; a41b: 26 34       &4
+    rol l0033                                                         ; a41d: 26 33       &3
+    txa                                                               ; a41f: 8a          .
+    beq ca42c                                                         ; a420: f0 0a       ..
+    rol l0032                                                         ; a422: 26 32       &2
+    rol l0031                                                         ; a424: 26 31       &1
+; $a426 referenced 4 times by $a474, $a478, $a4c6, $a4ca
+ca426
+    lda l0031                                                         ; a426: a5 31       .1
+    pha                                                               ; a428: 48          H
+    lda l0032                                                         ; a429: a5 32       .2
+    pha                                                               ; a42b: 48          H
+; $a42c referenced 1 time by $a420
+ca42c
+    lda l0033                                                         ; a42c: a5 33       .3
+    pha                                                               ; a42e: 48          H
+    lda l0034                                                         ; a42f: a5 34       .4
+    pha                                                               ; a431: 48          H
+    lda l0035                                                         ; a432: a5 35       .5
+    cpx #0                                                            ; a434: e0 00       ..
+    bmi ca47a                                                         ; a436: 30 42       0B
+    bne ca446                                                         ; a438: d0 0c       ..
+    asl                                                               ; a43a: 0a          .
+    rol l0034                                                         ; a43b: 26 34       &4
+    rol l0033                                                         ; a43d: 26 33       &3
+    asl                                                               ; a43f: 0a          .
+    rol l0034                                                         ; a440: 26 34       &4
+    rol l0033                                                         ; a442: 26 33       &3
+    bra ca452                                                         ; a444: 80 0c       ..
+; $a446 referenced 2 times by $a438, $a450
+ca446
+    asl                                                               ; a446: 0a          .
+    rol l0034                                                         ; a447: 26 34       &4
+    rol l0033                                                         ; a449: 26 33       &3
+    rol l0032                                                         ; a44b: 26 32       &2
+    rol l0031                                                         ; a44d: 26 31       &1
+    dex                                                               ; a44f: ca          .
+    bpl ca446                                                         ; a450: 10 f4       ..
+; $a452 referenced 2 times by $a444, $a487
+ca452
+    adc l0035                                                         ; a452: 65 35       e5
+    sta l0035                                                         ; a454: 85 35       .5
+    pla                                                               ; a456: 68          h
+    adc l0034                                                         ; a457: 65 34       e4
+    sta l0034                                                         ; a459: 85 34       .4
+    pla                                                               ; a45b: 68          h
+    adc l0033                                                         ; a45c: 65 33       e3
+    sta l0033                                                         ; a45e: 85 33       .3
+    inx                                                               ; a460: e8          .
+    bne ca4b9                                                         ; a461: d0 56       .V
+    pla                                                               ; a463: 68          h
+    adc l0032                                                         ; a464: 65 32       e2
+    sta l0032                                                         ; a466: 85 32       .2
+    pla                                                               ; a468: 68          h
+    bra ca4a3                                                         ; a469: 80 38       .8
+; $a46b referenced 3 times by $a17a, $a201, $a399
+sub_ca46b
+    clc                                                               ; a46b: 18          .
+    lda l0030                                                         ; a46c: a5 30       .0
+    adc #3                                                            ; a46e: 69 03       i.
+    ldx #$fe                                                          ; a470: a2 fe       ..
+    sta l0030                                                         ; a472: 85 30       .0
+    bcc ca426                                                         ; a474: 90 b0       ..
+    inc l002f                                                         ; a476: e6 2f       ./
+    bra ca426                                                         ; a478: 80 ac       ..
+; $a47a referenced 2 times by $a436, $a484
+ca47a
+    lsr l0031                                                         ; a47a: 46 31       F1
+    ror l0032                                                         ; a47c: 66 32       f2
+    ror l0033                                                         ; a47e: 66 33       f3
+    ror l0034                                                         ; a480: 66 34       f4
+    ror                                                               ; a482: 6a          j
+    inx                                                               ; a483: e8          .
+    bne ca47a                                                         ; a484: d0 f4       ..
+    dex                                                               ; a486: ca          .
+    bra ca452                                                         ; a487: 80 c9       ..
+; $a489 referenced 1 time by $84aa
+ca489
+    lda l0035                                                         ; a489: a5 35       .5
+    adc l0041                                                         ; a48b: 65 41       eA
+    sta l0035                                                         ; a48d: 85 35       .5
+    lda l0034                                                         ; a48f: a5 34       .4
+    adc l0040                                                         ; a491: 65 40       e@
+    sta l0034                                                         ; a493: 85 34       .4
+    lda l0033                                                         ; a495: a5 33       .3
+    adc l003f                                                         ; a497: 65 3f       e?
+    sta l0033                                                         ; a499: 85 33       .3
+    lda l0032                                                         ; a49b: a5 32       .2
+    adc l003e                                                         ; a49d: 65 3e       e>
+    sta l0032                                                         ; a49f: 85 32       .2
+    lda l003d                                                         ; a4a1: a5 3d       .=
+; $a4a3 referenced 1 time by $a469
+ca4a3
+    adc l0031                                                         ; a4a3: 65 31       e1
+    sta l0031                                                         ; a4a5: 85 31       .1
+    bcc ca4b9                                                         ; a4a7: 90 10       ..
+; $a4a9 referenced 3 times by $a20d, $a4f2, $a511
+ca4a9
+    ror l0031                                                         ; a4a9: 66 31       f1
+    ror l0032                                                         ; a4ab: 66 32       f2
+    ror l0033                                                         ; a4ad: 66 33       f3
+    ror l0034                                                         ; a4af: 66 34       f4
+    ror l0035                                                         ; a4b1: 66 35       f5
+    inc l0030                                                         ; a4b3: e6 30       .0
+    bne ca4b9                                                         ; a4b5: d0 02       ..
+    inc l002f                                                         ; a4b7: e6 2f       ./
+; $a4b9 referenced 3 times by $a461, $a4a7, $a4b5
+ca4b9
+    rts                                                               ; a4b9: 60          `
+
+; $a4ba referenced 2 times by $a1cd, $a3a1
+sub_ca4ba
+    clc                                                               ; a4ba: 18          .
+    lda #$fc                                                          ; a4bb: a9 fc       ..
+    tax                                                               ; a4bd: aa          .
+    adc l0030                                                         ; a4be: 65 30       e0
+    bcs ca4c4                                                         ; a4c0: b0 02       ..
+    dec l002f                                                         ; a4c2: c6 2f       ./
+; $a4c4 referenced 1 time by $a4c0
+ca4c4
+    sta l0030                                                         ; a4c4: 85 30       .0
+    jsr ca426                                                         ; a4c6: 20 26 a4     &.
+    dex                                                               ; a4c9: ca          .
+    jsr ca426                                                         ; a4ca: 20 26 a4     &.
+    inx                                                               ; a4cd: e8          .
+; $a4ce referenced 1 time by $a4f6
+ca4ce
+    lda l0034,x                                                       ; a4ce: b5 34       .4
+    rol                                                               ; a4d0: 2a          *
+    lda l0033,x                                                       ; a4d1: b5 33       .3
+    adc l0035                                                         ; a4d3: 65 35       e5
+    sta l0035                                                         ; a4d5: 85 35       .5
+    lda l0032,x                                                       ; a4d7: b5 32       .2
+    adc l0034                                                         ; a4d9: 65 34       e4
+    sta l0034                                                         ; a4db: 85 34       .4
+    lda l0031,x                                                       ; a4dd: b5 31       .1
+    adc l0033                                                         ; a4df: 65 33       e3
+    sta l0033                                                         ; a4e1: 85 33       .3
+    txa                                                               ; a4e3: 8a          .
+    beq ca4e8                                                         ; a4e4: f0 02       ..
+    lda l0031                                                         ; a4e6: a5 31       .1
+; $a4e8 referenced 1 time by $a4e4
+ca4e8
+    adc l0032                                                         ; a4e8: 65 32       e2
+    sta l0032                                                         ; a4ea: 85 32       .2
+    bcc ca4f5                                                         ; a4ec: 90 07       ..
+    inc l0031                                                         ; a4ee: e6 31       .1
+    bne ca4f5                                                         ; a4f0: d0 03       ..
+    jsr ca4a9                                                         ; a4f2: 20 a9 a4     ..
+; $a4f5 referenced 2 times by $a4ec, $a4f0
+ca4f5
+    dex                                                               ; a4f5: ca          .
+    bpl ca4ce                                                         ; a4f6: 10 d6       ..
+    lda l0032                                                         ; a4f8: a5 32       .2
+    rol                                                               ; a4fa: 2a          *
+    lda l0031                                                         ; a4fb: a5 31       .1
+    adc l0035                                                         ; a4fd: 65 35       e5
+    sta l0035                                                         ; a4ff: 85 35       .5
+    bcc ca513                                                         ; a501: 90 10       ..
+; $a503 referenced 1 time by $a339
+sub_ca503
+    inc l0034                                                         ; a503: e6 34       .4
+    bne ca513                                                         ; a505: d0 0c       ..
+; $a507 referenced 1 time by $a722
+sub_ca507
+    inc l0033                                                         ; a507: e6 33       .3
+    bne ca513                                                         ; a509: d0 08       ..
+; $a50b referenced 1 time by $a6df
+sub_ca50b
+    inc l0032                                                         ; a50b: e6 32       .2
+    bne ca513                                                         ; a50d: d0 04       ..
+    inc l0031                                                         ; a50f: e6 31       .1
+    beq ca4a9                                                         ; a511: f0 96       ..
+; $a513 referenced 4 times by $a501, $a505, $a509, $a50d
+ca513
+    rts                                                               ; a513: 60          `
+
+; $a514 referenced 5 times by $9d36, $a638, $a6e8, $a70a, $a9a3
+sub_ca514
+    stz l0041                                                         ; a514: 64 41       dA
+    ldy #4                                                            ; a516: a0 04       ..
+    lda (l004a),y                                                     ; a518: b1 4a       .J
+    sta l0040                                                         ; a51a: 85 40       .@
+    dey                                                               ; a51c: 88          .
+    lda (l004a),y                                                     ; a51d: b1 4a       .J
+    sta l003f                                                         ; a51f: 85 3f       .?
+    dey                                                               ; a521: 88          .
+    lda (l004a),y                                                     ; a522: b1 4a       .J
+    sta l003e                                                         ; a524: 85 3e       .>
+    dey                                                               ; a526: 88          .
+    lda (l004a),y                                                     ; a527: b1 4a       .J
+    sta l003b                                                         ; a529: 85 3b       .;
+    tay                                                               ; a52b: a8          .
+    lda (l004a)                                                       ; a52c: b2 4a       .J
+    sta l003c                                                         ; a52e: 85 3c       .<
+    bne ca53b                                                         ; a530: d0 09       ..
+    tya                                                               ; a532: 98          .
+    ora l003e                                                         ; a533: 05 3e       .>
+    ora l003f                                                         ; a535: 05 3f       .?
+    ora l0040                                                         ; a537: 05 40       .@
+    beq ca53e                                                         ; a539: f0 03       ..
+; $a53b referenced 1 time by $a530
+ca53b
+    tya                                                               ; a53b: 98          .
+    ora #$80                                                          ; a53c: 09 80       ..
+; $a53e referenced 1 time by $a539
+ca53e
+    sta l003d                                                         ; a53e: 85 3d       .=
+    rts                                                               ; a540: 60          `
+
+; $a541 referenced 1 time by $a8db
+sub_ca541
+    lda #$76 ; 'v'                                                    ; a541: a9 76       .v
+    bra ca547                                                         ; a543: 80 02       ..
+; $a545 referenced 8 times by $9210, $a5c4, $a5ec, $a6cb, $a7ef, $a97b, $a9e9, $a9f2
+sub_ca545
+    lda #$6c ; 'l'                                                    ; a545: a9 6c       .l
+; $a547 referenced 2 times by $a0d3, $a543
+ca547
+    sta l004a                                                         ; a547: 85 4a       .J
+    lda #4                                                            ; a549: a9 04       ..
+    sta l004b                                                         ; a54b: 85 4b       .K
+; $a54d referenced 2 times by $b6e2, $b704
+sub_ca54d
+    lda l0030                                                         ; a54d: a5 30       .0
+    sta (l004a)                                                       ; a54f: 92 4a       .J
+    ldy #1                                                            ; a551: a0 01       ..
+    lda l002e                                                         ; a553: a5 2e       ..
+    eor l0031                                                         ; a555: 45 31       E1
+    and #$80                                                          ; a557: 29 80       ).
+    eor l0031                                                         ; a559: 45 31       E1
+    sta (l004a),y                                                     ; a55b: 91 4a       .J
+    lda l0032                                                         ; a55d: a5 32       .2
+    iny                                                               ; a55f: c8          .
+    sta (l004a),y                                                     ; a560: 91 4a       .J
+    lda l0033                                                         ; a562: a5 33       .3
+    iny                                                               ; a564: c8          .
+    sta (l004a),y                                                     ; a565: 91 4a       .J
+    lda l0034                                                         ; a567: a5 34       .4
+    iny                                                               ; a569: c8          .
+    sta (l004a),y                                                     ; a56a: 91 4a       .J
+    rts                                                               ; a56c: 60          `
+
+; $a56d referenced 2 times by $a0c7, $a0d6
+sub_ca56d
+    jsr sub_cbc24                                                     ; a56d: 20 24 bc     $.
+    bra ca57e                                                         ; a570: 80 0c       ..
+; $a572 referenced 1 time by $a1f9
+sub_ca572
+    ldy #$bf                                                          ; a572: a0 bf       ..
+    bra ca57a                                                         ; a574: 80 04       ..
+; $a576 referenced 1 time by $b8d7
+sub_ca576
+    lda #$6c ; 'l'                                                    ; a576: a9 6c       .l
+    ldy #4                                                            ; a578: a0 04       ..
+; $a57a referenced 1 time by $a574
+ca57a
+    sta l004a                                                         ; a57a: 85 4a       .J
+    sty l004b                                                         ; a57c: 84 4b       .K
+; $a57e referenced 2 times by $a570, $b19e
+ca57e
+    stz l0035                                                         ; a57e: 64 35       d5
+    stz l002f                                                         ; a580: 64 2f       d/
+    ldy #4                                                            ; a582: a0 04       ..
+    lda (l004a),y                                                     ; a584: b1 4a       .J
+    sta l0034                                                         ; a586: 85 34       .4
+    dey                                                               ; a588: 88          .
+    lda (l004a),y                                                     ; a589: b1 4a       .J
+    sta l0033                                                         ; a58b: 85 33       .3
+    dey                                                               ; a58d: 88          .
+    lda (l004a),y                                                     ; a58e: b1 4a       .J
+    sta l0032                                                         ; a590: 85 32       .2
+    dey                                                               ; a592: 88          .
+    lda (l004a),y                                                     ; a593: b1 4a       .J
+    sta l002e                                                         ; a595: 85 2e       ..
+    tay                                                               ; a597: a8          .
+    lda (l004a)                                                       ; a598: b2 4a       .J
+    sta l0030                                                         ; a59a: 85 30       .0
+    bne ca5a7                                                         ; a59c: d0 09       ..
+    tya                                                               ; a59e: 98          .
+    ora l0032                                                         ; a59f: 05 32       .2
+    ora l0033                                                         ; a5a1: 05 33       .3
+    ora l0034                                                         ; a5a3: 05 34       .4
+    beq ca5aa                                                         ; a5a5: f0 03       ..
+; $a5a7 referenced 1 time by $a59c
+ca5a7
+    tya                                                               ; a5a7: 98          .
+    ora #$80                                                          ; a5a8: 09 80       ..
+; $a5aa referenced 1 time by $a5a5
+ca5aa
+    sta l0031                                                         ; a5aa: 85 31       .1
+    rts                                                               ; a5ac: 60          `
+
+; $a5ad referenced 3 times by $a8e0, $a8ee, $a9a0
+sub_ca5ad
+    clc                                                               ; a5ad: 18          .
+    lda l004c                                                         ; a5ae: a5 4c       .L
+    adc #5                                                            ; a5b0: 69 05       i.
+; $a5b2 referenced 1 time by $aa50
+sub_ca5b2
+    sta l004c                                                         ; a5b2: 85 4c       .L
+; $a5b4 referenced 3 times by $a631, $a701, $a7fc
+sub_ca5b4
+    ldy #$bf                                                          ; a5b4: a0 bf       ..
+; $a5b6 referenced 1 time by $a5bf
+loop_ca5b6
+    sta l004a                                                         ; a5b6: 85 4a       .J
+    sty l004b                                                         ; a5b8: 84 4b       .K
+; $a5ba referenced 1 time by $a5e8
+ca5ba
+    rts                                                               ; a5ba: 60          `
+
+; $a5bb referenced 2 times by $a8f8, $a9af
+sub_ca5bb
+    lda #$6c ; 'l'                                                    ; a5bb: a9 6c       .l
+; $a5bd referenced 1 time by $a8e8
+sub_ca5bd
+    ldy #4                                                            ; a5bd: a0 04       ..
+    bra loop_ca5b6                                                    ; a5bf: 80 f5       ..
+; $a5c1 referenced 1 time by $aa41
+sub_ca5c1
+    jsr cad10                                                         ; a5c1: 20 10 ad     ..
+; $a5c4 referenced 1 time by $a95d
+sub_ca5c4
+    jsr sub_ca545                                                     ; a5c4: 20 45 a5     E.
+    jsr sub_ca5f4                                                     ; a5c7: 20 f4 a5     ..
+    inc l0030                                                         ; a5ca: e6 30       .0
+; $a5cc referenced 2 times by $a5e3, $a90a
+sub_ca5cc
+    jsr cad10                                                         ; a5cc: 20 10 ad     ..
+; $a5cf referenced 2 times by $a5f4, $aa39
+sub_ca5cf
+    stz l003b                                                         ; a5cf: 64 3b       d;
+; $a5d1 referenced 1 time by $a993
+sub_ca5d1
+    ldy #$80                                                          ; a5d1: a0 80       ..
+    sty l003d                                                         ; a5d3: 84 3d       .=
+    iny                                                               ; a5d5: c8          .
+    sty l003c                                                         ; a5d6: 84 3c       .<
+    stz l003e                                                         ; a5d8: 64 3e       d>
+    stz l003f                                                         ; a5da: 64 3f       d?
+    stz l0040                                                         ; a5dc: 64 40       d@
+    stz l0041                                                         ; a5de: 64 41       dA
+    jmp ca70f                                                         ; a5e0: 4c 0f a7    L..
+
+; $a5e3 referenced 2 times by $a7de, $a929
+sub_ca5e3
+    jsr sub_ca5cc                                                     ; a5e3: 20 cc a5     ..
+    ldx l0031                                                         ; a5e6: a6 31       .1
+    beq ca5ba                                                         ; a5e8: f0 d0       ..
+    dec l0030                                                         ; a5ea: c6 30       .0
+    jsr sub_ca545                                                     ; a5ec: 20 45 a5     E.
+    txa                                                               ; a5ef: 8a          .
+    eor l002e                                                         ; a5f0: 45 2e       E.
+; $a5f2 referenced 1 time by $a96e
+sub_ca5f2
+    sta l002e                                                         ; a5f2: 85 2e       ..
+; $a5f4 referenced 2 times by $a5c7, $a962
+sub_ca5f4
+    jsr sub_ca5cf                                                     ; a5f4: 20 cf a5     ..
+    bra ca634                                                         ; a5f7: 80 3b       .;
+; $a5f9 referenced 1 time by $a0cc
+sub_ca5f9
+    ldx #0                                                            ; a5f9: a2 00       ..
+    tay                                                               ; a5fb: a8          .
+    beq ca622                                                         ; a5fc: f0 24       .$
+    bpl ca608                                                         ; a5fe: 10 08       ..
+    dec                                                               ; a600: 3a          :
+    eor #$ff                                                          ; a601: 49 ff       I.
+    pha                                                               ; a603: 48          H
+    jsr sub_ca62f                                                     ; a604: 20 2f a6     /.
+; $a607 referenced 1 time by $a615
+loop_ca607
+    pla                                                               ; a607: 68          h
+; $a608 referenced 1 time by $a5fe
+ca608
+    lsr                                                               ; a608: 4a          J
+    beq ca61d                                                         ; a609: f0 12       ..
+    pha                                                               ; a60b: 48          H
+    bcc ca612                                                         ; a60c: 90 04       ..
+    inx                                                               ; a60e: e8          .
+    jsr cbc3a                                                         ; a60f: 20 3a bc     :.
+; $a612 referenced 1 time by $a60c
+ca612
+    jsr ca6ce                                                         ; a612: 20 ce a6     ..
+    bra loop_ca607                                                    ; a615: 80 f0       ..
+; $a617 referenced 1 time by $a61e
+loop_ca617
+    jsr sub_cbc24                                                     ; a617: 20 24 bc     $.
+    jsr ca6e4                                                         ; a61a: 20 e4 a6     ..
+; $a61d referenced 1 time by $a609
+ca61d
+    dex                                                               ; a61d: ca          .
+    bpl loop_ca617                                                    ; a61e: 10 f7       ..
+    txa                                                               ; a620: 8a          .
+    rts                                                               ; a621: 60          `
+
+; $a622 referenced 3 times by $a1bc, $a5fc, $b6e5
+ca622
+    lda #$80                                                          ; a622: a9 80       ..
+    sta l0031                                                         ; a624: 85 31       .1
+    inc                                                               ; a626: 1a          .
+    sta l0030                                                         ; a627: 85 30       .0
+    jmp ca72f                                                         ; a629: 4c 2f a7    L/.
+
+; $a62c referenced 1 time by $a636
+loop_ca62c
+    jmp c81ea                                                         ; a62c: 4c ea 81    L..
+
+; $a62f referenced 3 times by $a604, $a92f, $a975
+sub_ca62f
+    lda #$b9                                                          ; a62f: a9 b9       ..
+; $a631 referenced 1 time by $a8d8
+sub_ca631
+    jsr sub_ca5b4                                                     ; a631: 20 b4 a5     ..
+; $a634 referenced 5 times by $a045, $a5f7, $a8e3, $a8fb, $a914
+ca634
+    lda l0031                                                         ; a634: a5 31       .1
+    beq loop_ca62c                                                    ; a636: f0 f4       ..
+    jsr sub_ca514                                                     ; a638: 20 14 a5     ..
+    bne ca640                                                         ; a63b: d0 03       ..
+    jmp ca72b                                                         ; a63d: 4c 2b a7    L+.
+
+; $a640 referenced 1 time by $a63b
+ca640
+    lda l003b                                                         ; a640: a5 3b       .;
+    eor l002e                                                         ; a642: 45 2e       E.
+    sta l002e                                                         ; a644: 85 2e       ..
+    sec                                                               ; a646: 38          8
+    lda l003c                                                         ; a647: a5 3c       .<
+    adc #$81                                                          ; a649: 69 81       i.
+    rol l002f                                                         ; a64b: 26 2f       &/
+    sbc l0030                                                         ; a64d: e5 30       .0
+    bcs ca653                                                         ; a64f: b0 02       ..
+    dec l002f                                                         ; a651: c6 2f       ./
+; $a653 referenced 1 time by $a64f
+ca653
+    sta l0030                                                         ; a653: 85 30       .0
+    lda l003d                                                         ; a655: a5 3d       .=
+    clc                                                               ; a657: 18          .
+    ldy #4                                                            ; a658: a0 04       ..
+    sty l003c                                                         ; a65a: 84 3c       .<
+; $a65c referenced 1 time by $a69e
+ca65c
+    ldx #8                                                            ; a65c: a2 08       ..
+; $a65e referenced 1 time by $a697
+ca65e
+    bcs ca676                                                         ; a65e: b0 16       ..
+    cmp l0031                                                         ; a660: c5 31       .1
+    bne ca674                                                         ; a662: d0 10       ..
+    ldy l003e                                                         ; a664: a4 3e       .>
+    cpy l0032                                                         ; a666: c4 32       .2
+    bne ca674                                                         ; a668: d0 0a       ..
+    ldy l003f                                                         ; a66a: a4 3f       .?
+    cpy l0033                                                         ; a66c: c4 33       .3
+    bne ca674                                                         ; a66e: d0 04       ..
+    ldy l0040                                                         ; a670: a4 40       .@
+    cpy l0034                                                         ; a672: c4 34       .4
+; $a674 referenced 3 times by $a662, $a668, $a66e
+ca674
+    bcc ca68d                                                         ; a674: 90 17       ..
+; $a676 referenced 1 time by $a65e
+ca676
+    tay                                                               ; a676: a8          .
+    lda l0040                                                         ; a677: a5 40       .@
+    sbc l0034                                                         ; a679: e5 34       .4
+    sta l0040                                                         ; a67b: 85 40       .@
+    lda l003f                                                         ; a67d: a5 3f       .?
+    sbc l0033                                                         ; a67f: e5 33       .3
+    sta l003f                                                         ; a681: 85 3f       .?
+    lda l003e                                                         ; a683: a5 3e       .>
+    sbc l0032                                                         ; a685: e5 32       .2
+    sta l003e                                                         ; a687: 85 3e       .>
+    tya                                                               ; a689: 98          .
+    sbc l0031                                                         ; a68a: e5 31       .1
+    sec                                                               ; a68c: 38          8
+; $a68d referenced 1 time by $a674
+ca68d
+    rol l003b                                                         ; a68d: 26 3b       &;
+    asl l0040                                                         ; a68f: 06 40       .@
+    rol l003f                                                         ; a691: 26 3f       &?
+    rol l003e                                                         ; a693: 26 3e       &>
+    rol                                                               ; a695: 2a          *
+    dex                                                               ; a696: ca          .
+    bne ca65e                                                         ; a697: d0 c5       ..
+    ldx l003b                                                         ; a699: a6 3b       .;
+    phx                                                               ; a69b: da          .
+    dec l003c                                                         ; a69c: c6 3c       .<
+    bne ca65c                                                         ; a69e: d0 bc       ..
+    plx                                                               ; a6a0: fa          .
+    ror                                                               ; a6a1: 6a          j
+; $a6a2 referenced 1 time by $a8b0
+ca6a2
+    lsr l0031                                                         ; a6a2: 46 31       F1
+    stx l0034                                                         ; a6a4: 86 34       .4
+    ldx #3                                                            ; a6a6: a2 03       ..
+; $a6a8 referenced 1 time by $a6b1
+loop_ca6a8
+    cmp l0031                                                         ; a6a8: c5 31       .1
+    bcc ca6ae                                                         ; a6aa: 90 02       ..
+    sbc l0031                                                         ; a6ac: e5 31       .1
+; $a6ae referenced 1 time by $a6aa
+ca6ae
+    php                                                               ; a6ae: 08          .
+    asl                                                               ; a6af: 0a          .
+    dex                                                               ; a6b0: ca          .
+    bne loop_ca6a8                                                    ; a6b1: d0 f5       ..
+    plp                                                               ; a6b3: 28          (
+    ror                                                               ; a6b4: 6a          j
+    plp                                                               ; a6b5: 28          (
+    ror                                                               ; a6b6: 6a          j
+    plp                                                               ; a6b7: 28          (
+    ror                                                               ; a6b8: 6a          j
+    sta l0035                                                         ; a6b9: 85 35       .5
+    pla                                                               ; a6bb: 68          h
+    sta l0033                                                         ; a6bc: 85 33       .3
+    pla                                                               ; a6be: 68          h
+    sta l0032                                                         ; a6bf: 85 32       .2
+    pla                                                               ; a6c1: 68          h
+    sta l0031                                                         ; a6c2: 85 31       .1
+; $a6c4 referenced 1 time by $aa97
+ca6c4
+    bmi ca712                                                         ; a6c4: 30 4c       0L
+    jsr c8306                                                         ; a6c6: 20 06 83     ..
+    bra ca712                                                         ; a6c9: 80 47       .G
+; $a6cb referenced 2 times by $a8bc, $a907
+sub_ca6cb
+    jsr sub_ca545                                                     ; a6cb: 20 45 a5     E.
+; $a6ce referenced 2 times by $a612, $a9ef
+ca6ce
+    jsr sub_ca3ed                                                     ; a6ce: 20 ed a3     ..
+    lda l0030                                                         ; a6d1: a5 30       .0
+    beq ca72b                                                         ; a6d3: f0 56       .V
+    stz l0034                                                         ; a6d5: 64 34       d4
+    asl l0040                                                         ; a6d7: 06 40       .@
+    bcc ca6ed                                                         ; a6d9: 90 12       ..
+    inc l0033                                                         ; a6db: e6 33       .3
+    bne ca6ed                                                         ; a6dd: d0 0e       ..
+    jsr sub_ca50b                                                     ; a6df: 20 0b a5     ..
+    bra ca6ed                                                         ; a6e2: 80 09       ..
+; $a6e4 referenced 3 times by $9fb3, $a61a, $a9c7
+ca6e4
+    lda l0031                                                         ; a6e4: a5 31       .1
+    beq ca73b                                                         ; a6e6: f0 53       .S
+    jsr sub_ca514                                                     ; a6e8: 20 14 a5     ..
+; $a6eb referenced 1 time by $9fa2
+sub_ca6eb
+    beq ca72b                                                         ; a6eb: f0 3e       .>
+; $a6ed referenced 3 times by $a6d9, $a6dd, $a6e2
+ca6ed
+    jsr sub_ca73e                                                     ; a6ed: 20 3e a7     >.
+    bra ca712                                                         ; a6f0: 80 20       .
+; $a6f2 referenced 2 times by $8362, $a729
+ca6f2
+    brk                                                               ; a6f2: 00          .
+
+    !byte $14                                                         ; a6f3: 14          .
+    !text "Too big"                                                   ; a6f4: 54 6f 6f... Too
+    !byte 0                                                           ; a6fb: 00          .
+
+sub_ca6fc
+    jsr sub_ca901                                                     ; a6fc: 20 01 a9     ..
+; $a6ff referenced 3 times by $a940, $a948, $ab56
+sub_ca6ff
+    lda #$90                                                          ; a6ff: a9 90       ..
+    jsr sub_ca5b4                                                     ; a701: 20 b4 a5     ..
+; $a704 referenced 2 times by $9f5c, $a9b2
+ca704
+    lda l0031                                                         ; a704: a5 31       .1
+    eor l002e                                                         ; a706: 45 2e       E.
+    sta l002e                                                         ; a708: 85 2e       ..
+; $a70a referenced 5 times by $9f52, $a8eb, $a8f1, $a8fe, $b5fe
+ca70a
+    jsr sub_ca514                                                     ; a70a: 20 14 a5     ..
+; $a70d referenced 1 time by $9f6b
+sub_ca70d
+    beq ca73b                                                         ; a70d: f0 2c       .,
+; $a70f referenced 1 time by $a5e0
+ca70f
+    jsr sub_c8429                                                     ; a70f: 20 29 84     ).
+; $a712 referenced 5 times by $a3a7, $a6c4, $a6c9, $a6f0, $a802
+ca712
+    lda l0035                                                         ; a712: a5 35       .5
+    bpl ca725                                                         ; a714: 10 0f       ..
+    asl                                                               ; a716: 0a          .
+    bne ca71e                                                         ; a717: d0 05       ..
+    rol                                                               ; a719: 2a          *
+    and l0034                                                         ; a71a: 25 34       %4
+    bne ca725                                                         ; a71c: d0 07       ..
+; $a71e referenced 1 time by $a717
+ca71e
+    inc l0034                                                         ; a71e: e6 34       .4
+    bne ca725                                                         ; a720: d0 03       ..
+    jsr sub_ca507                                                     ; a722: 20 07 a5     ..
+; $a725 referenced 3 times by $a714, $a71c, $a720
+ca725
+    lda l002f                                                         ; a725: a5 2f       ./
+    beq ca739                                                         ; a727: f0 10       ..
+    bpl ca6f2                                                         ; a729: 10 c7       ..
+; $a72b referenced 7 times by $835b, $84cb, $a220, $a63d, $a6d3, $a6eb, $a9f5
+ca72b
+    stz l0030                                                         ; a72b: 64 30       d0
+    stz l0031                                                         ; a72d: 64 31       d1
+; $a72f referenced 1 time by $a629
+ca72f
+    stz l002e                                                         ; a72f: 64 2e       d.
+; $a731 referenced 1 time by $82e8
+sub_ca731
+    stz l002f                                                         ; a731: 64 2f       d/
+    stz l0032                                                         ; a733: 64 32       d2
+    stz l0033                                                         ; a735: 64 33       d3
+    stz l0034                                                         ; a737: 64 34       d4
+; $a739 referenced 1 time by $a727
+ca739
+    stz l0035                                                         ; a739: 64 35       d5
+; $a73b referenced 2 times by $a6e6, $a70d
+ca73b
+    lda #$ff                                                          ; a73b: a9 ff       ..
+; $a73d referenced 1 time by $a7a7
+ca73d
+    rts                                                               ; a73d: 60          `
+
+; $a73e referenced 3 times by $a6ed, $a9ac, $aab6
+sub_ca73e
+    clc                                                               ; a73e: 18          .
+    lda l0030                                                         ; a73f: a5 30       .0
+    adc l003c                                                         ; a741: 65 3c       e<
+    rol l002f                                                         ; a743: 26 2f       &/
+    sbc #$7f                                                          ; a745: e9 7f       ..
+    sta l0030                                                         ; a747: 85 30       .0
+    bcs ca74d                                                         ; a749: b0 02       ..
+    dec l002f                                                         ; a74b: c6 2f       ./
+; $a74d referenced 1 time by $a749
+ca74d
+    lda l002e                                                         ; a74d: a5 2e       ..
+    eor l003b                                                         ; a74f: 45 3b       E;
+    sta l002e                                                         ; a751: 85 2e       ..
+    phx                                                               ; a753: da          .
+    ldx #$f8                                                          ; a754: a2 f8       ..
+    ldy #4                                                            ; a756: a0 04       ..
+; $a758 referenced 1 time by $a761
+loop_ca758
+    lda l0039,x                                                       ; a758: b5 39       .9
+    stz l0039,x                                                       ; a75a: 74 39       t9
+    sta l0041,y                                                       ; a75c: 99 41 00    .A.
+    inx                                                               ; a75f: e8          .
+    dey                                                               ; a760: 88          .
+    bne loop_ca758                                                    ; a761: d0 f5       ..
+    stz l003c                                                         ; a763: 64 3c       d<
+    stz l003b                                                         ; a765: 64 3b       d;
+    stz l003a                                                         ; a767: 64 3a       d:
+    bra ca79b                                                         ; a769: 80 30       .0
+; $a76b referenced 1 time by $a79d
+ca76b
+    phx                                                               ; a76b: da          .
+    lsr l003d                                                         ; a76c: 46 3d       F=
+    ror l003e                                                         ; a76e: 66 3e       f>
+    ror l003f                                                         ; a770: 66 3f       f?
+    ror l0040                                                         ; a772: 66 40       f@
+    ror l0041                                                         ; a774: 66 41       fA
+; $a776 referenced 1 time by $a798
+ca776
+    asl l0046,x                                                       ; a776: 16 46       .F
+    bcc ca797                                                         ; a778: 90 1d       ..
+    clc                                                               ; a77a: 18          .
+    tya                                                               ; a77b: 98          .
+    adc l0042,x                                                       ; a77c: 75 42       uB
+    tay                                                               ; a77e: a8          .
+    lda l0034                                                         ; a77f: a5 34       .4
+    adc l0041,x                                                       ; a781: 75 41       uA
+    sta l0034                                                         ; a783: 85 34       .4
+    lda l0033                                                         ; a785: a5 33       .3
+    adc l0040,x                                                       ; a787: 75 40       u@
+    sta l0033                                                         ; a789: 85 33       .3
+    lda l0032                                                         ; a78b: a5 32       .2
+    adc l003f,x                                                       ; a78d: 75 3f       u?
+    sta l0032                                                         ; a78f: 85 32       .2
+    lda l0031                                                         ; a791: a5 31       .1
+    adc l003e,x                                                       ; a793: 75 3e       u>
+    sta l0031                                                         ; a795: 85 31       .1
+; $a797 referenced 1 time by $a778
+ca797
+    inx                                                               ; a797: e8          .
+    bmi ca776                                                         ; a798: 30 dc       0.
+    plx                                                               ; a79a: fa          .
+; $a79b referenced 2 times by $a769, $a7a0
+ca79b
+    lda l0046,x                                                       ; a79b: b5 46       .F
+    bne ca76b                                                         ; a79d: d0 cc       ..
+    inx                                                               ; a79f: e8          .
+    bmi ca79b                                                         ; a7a0: 30 f9       0.
+    plx                                                               ; a7a2: fa          .
+    sty l0035                                                         ; a7a3: 84 35       .5
+    lda l0031                                                         ; a7a5: a5 31       .1
+    bmi ca73d                                                         ; a7a7: 30 94       0.
+    jmp c8306                                                         ; a7a9: 4c 06 83    L..
+
+; $a7ac referenced 1 time by $a9bc
+sub_ca7ac
+    jsr sub_c979f                                                     ; a7ac: 20 9f 97     ..
+; $a7af referenced 1 time by $a0d9
+sub_ca7af
+    lda l0031                                                         ; a7af: a5 31       .1
+    eor l002e                                                         ; a7b1: 45 2e       E.
+    bmi ca7cd                                                         ; a7b3: 30 18       0.
+    brk                                                               ; a7b5: 00          .
+
+    !byte $16                                                         ; a7b6: 16          .
+    !text "Log range"                                                 ; a7b7: 4c 6f 67... Log
+
+; $a7c0 referenced 1 time by $a811
+ca7c0
+    brk                                                               ; a7c0: 00          .
+
+    !byte $15                                                         ; a7c1: 15          .
+    !text "-ve roo"                                                   ; a7c2: 2d 76 65... -ve
+; $a7c9 referenced 1 time by $a985
+la7c9
+    !byte $74,   0, $86, $8e                                          ; a7c9: 74 00 86... t..
+
+; $a7cd referenced 1 time by $a7b3
+ca7cd
+    ldy #$80                                                          ; a7cd: a0 80       ..
+    ldx l0030                                                         ; a7cf: a6 30       .0
+    beq ca7db                                                         ; a7d1: f0 08       ..
+    lda l0031                                                         ; a7d3: a5 31       .1
+    cmp #$b5                                                          ; a7d5: c9 b5       ..
+    bcs ca7db                                                         ; a7d7: b0 02       ..
+    dex                                                               ; a7d9: ca          .
+    iny                                                               ; a7da: c8          .
+; $a7db referenced 2 times by $a7d1, $a7d7
+ca7db
+    phx                                                               ; a7db: da          .
+    sty l0030                                                         ; a7dc: 84 30       .0
+    jsr sub_ca5e3                                                     ; a7de: 20 e3 a5     ..
+    lda l0030                                                         ; a7e1: a5 30       .0
+    beq ca7ef                                                         ; a7e3: f0 0a       ..
+    cmp #$6e ; 'n'                                                    ; a7e5: c9 6e       .n
+    bcc ca7ed                                                         ; a7e7: 90 04       ..
+    clc                                                               ; a7e9: 18          .
+    jsr sub_ca8b9                                                     ; a7ea: 20 b9 a8     ..
+; $a7ed referenced 1 time by $a7e7
+ca7ed
+    inc l0030                                                         ; a7ed: e6 30       .0
+; $a7ef referenced 1 time by $a7e3
+ca7ef
+    jsr sub_ca545                                                     ; a7ef: 20 45 a5     E.
+    pla                                                               ; a7f2: 68          h
+    eor #$80                                                          ; a7f3: 49 80       I.
+    beq ca805                                                         ; a7f5: f0 0e       ..
+    jsr sub_c82e6                                                     ; a7f7: 20 e6 82     ..
+    lda #$9f                                                          ; a7fa: a9 9f       ..
+    jsr sub_ca5b4                                                     ; a7fc: 20 b4 a5     ..
+    jsr sub_ca9a3                                                     ; a7ff: 20 a3 a9     ..
+    jsr ca712                                                         ; a802: 20 12 a7     ..
+; $a805 referenced 2 times by $a7f5, $a80d
+ca805
+    jmp cad10                                                         ; a805: 4c 10 ad    L..
+
+sub_ca808
+    jsr sub_c979f                                                     ; a808: 20 9f 97     ..
+; $a80b referenced 1 time by $a911
+sub_ca80b
+    lda l0031                                                         ; a80b: a5 31       .1
+    beq ca805                                                         ; a80d: f0 f6       ..
+    lda l002e                                                         ; a80f: a5 2e       ..
+    bmi ca7c0                                                         ; a811: 30 ad       0.
+    lda l0030                                                         ; a813: a5 30       .0
+    lsr                                                               ; a815: 4a          J
+    php                                                               ; a816: 08          .
+    adc #$41 ; 'A'                                                    ; a817: 69 41       iA
+    sta l0030                                                         ; a819: 85 30       .0
+    lda l0031                                                         ; a81b: a5 31       .1
+    plp                                                               ; a81d: 28          (
+    bcc ca829                                                         ; a81e: 90 09       ..
+    lsr                                                               ; a820: 4a          J
+    ror l0032                                                         ; a821: 66 32       f2
+    ror l0033                                                         ; a823: 66 33       f3
+    ror l0034                                                         ; a825: 66 34       f4
+    ror l0035                                                         ; a827: 66 35       f5
+; $a829 referenced 1 time by $a81e
+ca829
+    stz l003e                                                         ; a829: 64 3e       d>
+    stz l003f                                                         ; a82b: 64 3f       d?
+    ldx #$68 ; 'h'                                                    ; a82d: a2 68       .h
+    sec                                                               ; a82f: 38          8
+    sbc #$90                                                          ; a830: e9 90       ..
+    bcs ca838                                                         ; a832: b0 04       ..
+    adc #$50 ; 'P'                                                    ; a834: 69 50       iP
+    ldx #$48 ; 'H'                                                    ; a836: a2 48       .H
+; $a838 referenced 1 time by $a832
+ca838
+    sta l0031                                                         ; a838: 85 31       .1
+    txa                                                               ; a83a: 8a          .
+    ldx #$fc                                                          ; a83b: a2 fc       ..
+    ldy #$0c                                                          ; a83d: a0 0c       ..
+; $a83f referenced 1 time by $a89e
+ca83f
+    sta l0041,x                                                       ; a83f: 95 41       .A
+; $a841 referenced 1 time by $a87d
+ca841
+    asl l0033                                                         ; a841: 06 33       .3
+    rol l0032                                                         ; a843: 26 32       &2
+    rol l0031                                                         ; a845: 26 31       &1
+    lda l0031                                                         ; a847: a5 31       .1
+    cmp l003d                                                         ; a849: c5 3d       .=
+    bne ca857                                                         ; a84b: d0 0a       ..
+    lda l0032                                                         ; a84d: a5 32       .2
+    cmp l003e                                                         ; a84f: c5 3e       .>
+    bne ca857                                                         ; a851: d0 04       ..
+    lda l0033                                                         ; a853: a5 33       .3
+    cmp l003f                                                         ; a855: c5 3f       .?
+; $a857 referenced 2 times by $a84b, $a851
+ca857
+    bcc ca875                                                         ; a857: 90 1c       ..
+    lda l0033                                                         ; a859: a5 33       .3
+    sbc l003f                                                         ; a85b: e5 3f       .?
+    sta l0033                                                         ; a85d: 85 33       .3
+    lda l0032                                                         ; a85f: a5 32       .2
+    sbc l003e                                                         ; a861: e5 3e       .>
+    sta l0032                                                         ; a863: 85 32       .2
+    lda l0031                                                         ; a865: a5 31       .1
+    sbc l003d                                                         ; a867: e5 3d       .=
+    sta l0031                                                         ; a869: 85 31       .1
+    tya                                                               ; a86b: 98          .
+    clc                                                               ; a86c: 18          .
+    adc l0041,x                                                       ; a86d: 75 41       uA
+    bcc ca878                                                         ; a86f: 90 07       ..
+    inc l0040,x                                                       ; a871: f6 40       .@
+    bra ca878                                                         ; a873: 80 03       ..
+; $a875 referenced 1 time by $a857
+ca875
+    tya                                                               ; a875: 98          .
+    eor l0041,x                                                       ; a876: 55 41       UA
+; $a878 referenced 2 times by $a86f, $a873
+ca878
+    sta l0041,x                                                       ; a878: 95 41       .A
+    tya                                                               ; a87a: 98          .
+    lsr                                                               ; a87b: 4a          J
+    tay                                                               ; a87c: a8          .
+    bne ca841                                                         ; a87d: d0 c2       ..
+    ldy l0040,x                                                       ; a87f: b4 40       .@
+    phy                                                               ; a881: 5a          Z
+    cpx #$fd                                                          ; a882: e0 fd       ..
+    bne ca88a                                                         ; a884: d0 04       ..
+    lda l0034                                                         ; a886: a5 34       .4
+    sta l0033                                                         ; a888: 85 33       .3
+; $a88a referenced 1 time by $a884
+ca88a
+    bcs ca899                                                         ; a88a: b0 0d       ..
+    ply                                                               ; a88c: 7a          z
+    ldy #4                                                            ; a88d: a0 04       ..
+; $a88f referenced 1 time by $a895
+loop_ca88f
+    asl l0035                                                         ; a88f: 06 35       .5
+    rol l0034                                                         ; a891: 26 34       &4
+    rol                                                               ; a893: 2a          *
+    dey                                                               ; a894: 88          .
+    bne loop_ca88f                                                    ; a895: d0 f8       ..
+    tsb l0033                                                         ; a897: 04 33       .3
+; $a899 referenced 1 time by $a88a
+ca899
+    lda #$80                                                          ; a899: a9 80       ..
+    ldy #$c0                                                          ; a89b: a0 c0       ..
+    inx                                                               ; a89d: e8          .
+    bne ca83f                                                         ; a89e: d0 9f       ..
+    ldx l003d                                                         ; a8a0: a6 3d       .=
+    lda l0031                                                         ; a8a2: a5 31       .1
+    stx l0031                                                         ; a8a4: 86 31       .1
+    ldx l0040                                                         ; a8a6: a6 40       .@
+    asl                                                               ; a8a8: 0a          .
+    cmp l0031                                                         ; a8a9: c5 31       .1
+    bcc ca8b0                                                         ; a8ab: 90 03       ..
+    sbc l0031                                                         ; a8ad: e5 31       .1
+    inx                                                               ; a8af: e8          .
+; $a8b0 referenced 1 time by $a8ab
+ca8b0
+    jmp ca6a2                                                         ; a8b0: 4c a2 a6    L..
+
+; $a8b3 referenced 2 times by $a9e6, $aa3e
+sub_ca8b3
+    ldx #$ca                                                          ; a8b3: a2 ca       ..
+    dec l0030                                                         ; a8b5: c6 30       .0
+    bra ca8bb                                                         ; a8b7: 80 02       ..
+; $a8b9 referenced 2 times by $a7ea, $a938
+sub_ca8b9
+    ldx #$e7                                                          ; a8b9: a2 e7       ..
+; $a8bb referenced 1 time by $a8b7
+ca8bb
+    php                                                               ; a8bb: 08          .
+    jsr sub_ca6cb                                                     ; a8bc: 20 cb a6     ..
+    plp                                                               ; a8bf: 28          (
+    ror l002e                                                         ; a8c0: 66 2e       f.
+    txa                                                               ; a8c2: 8a          .
+    jsr sub_caa55                                                     ; a8c3: 20 55 aa     U.
+    dec                                                               ; a8c6: 3a          :
+    dec                                                               ; a8c7: 3a          :
+    sta l0047                                                         ; a8c8: 85 47       .G
+    txa                                                               ; a8ca: 8a          .
+    iny                                                               ; a8cb: c8          .
+    clc                                                               ; a8cc: 18          .
+; $a8cd referenced 1 time by $a8d0
+loop_ca8cd
+    adc #$0a                                                          ; a8cd: 69 0a       i.
+    dey                                                               ; a8cf: 88          .
+    bpl loop_ca8cd                                                    ; a8d0: 10 fb       ..
+    adc #$f1                                                          ; a8d2: 69 f1       i.
+    sta l004c                                                         ; a8d4: 85 4c       .L
+    lda #$be                                                          ; a8d6: a9 be       ..
+    jsr sub_ca631                                                     ; a8d8: 20 31 a6     1.
+    jsr sub_ca541                                                     ; a8db: 20 41 a5     A.
+    bra ca8ee                                                         ; a8de: 80 0e       ..
+; $a8e0 referenced 1 time by $a8f6
+loop_ca8e0
+    jsr sub_ca5ad                                                     ; a8e0: 20 ad a5     ..
+    jsr ca634                                                         ; a8e3: 20 34 a6     4.
+    lda #$76 ; 'v'                                                    ; a8e6: a9 76       .v
+    jsr sub_ca5bd                                                     ; a8e8: 20 bd a5     ..
+    jsr ca70a                                                         ; a8eb: 20 0a a7     ..
+; $a8ee referenced 1 time by $a8de
+ca8ee
+    jsr sub_ca5ad                                                     ; a8ee: 20 ad a5     ..
+    jsr ca70a                                                         ; a8f1: 20 0a a7     ..
+    inc l0047                                                         ; a8f4: e6 47       .G
+    bmi loop_ca8e0                                                    ; a8f6: 30 e8       0.
+    jsr sub_ca5bb                                                     ; a8f8: 20 bb a5     ..
+    jsr ca634                                                         ; a8fb: 20 34 a6     4.
+    jmp ca70a                                                         ; a8fe: 4c 0a a7    L..
+
+; $a901 referenced 1 time by $a6fc
+sub_ca901
+    jsr sub_c979f                                                     ; a901: 20 9f 97     ..
+    lda l002e                                                         ; a904: a5 2e       ..
+    pha                                                               ; a906: 48          H
+    jsr sub_ca6cb                                                     ; a907: 20 cb a6     ..
+    jsr sub_ca5cc                                                     ; a90a: 20 cc a5     ..
+    lda l0031                                                         ; a90d: a5 31       .1
+    beq ca948                                                         ; a90f: f0 37       .7
+    jsr sub_ca80b                                                     ; a911: 20 0b a8     ..
+    jsr ca634                                                         ; a914: 20 34 a6     4.
+    bra ca91f                                                         ; a917: 80 06       ..
+sub_ca919
+    jsr sub_c979f                                                     ; a919: 20 9f 97     ..
+    lda l002e                                                         ; a91c: a5 2e       ..
+    pha                                                               ; a91e: 48          H
+; $a91f referenced 1 time by $a917
+ca91f
+    stz l002e                                                         ; a91f: 64 2e       d.
+    lda #$c7                                                          ; a921: a9 c7       ..
+    jsr sub_caa55                                                     ; a923: 20 55 aa     U.
+    php                                                               ; a926: 08          .
+    bne ca92d                                                         ; a927: d0 04       ..
+    jsr sub_ca5e3                                                     ; a929: 20 e3 a5     ..
+    sec                                                               ; a92c: 38          8
+; $a92d referenced 1 time by $a927
+ca92d
+    bcs ca932                                                         ; a92d: b0 03       ..
+    jsr sub_ca62f                                                     ; a92f: 20 2f a6     /.
+; $a932 referenced 1 time by $a92d
+ca932
+    lda l0030                                                         ; a932: a5 30       .0
+    cmp #$6d ; 'm'                                                    ; a934: c9 6d       .m
+    bcc ca93b                                                         ; a936: 90 03       ..
+    jsr sub_ca8b9                                                     ; a938: 20 b9 a8     ..
+; $a93b referenced 1 time by $a936
+ca93b
+    plp                                                               ; a93b: 28          (
+    bne ca946                                                         ; a93c: d0 08       ..
+    inc l0030                                                         ; a93e: e6 30       .0
+    jsr sub_ca6ff                                                     ; a940: 20 ff a6     ..
+    dec l0030                                                         ; a943: c6 30       .0
+    sec                                                               ; a945: 38          8
+; $a946 referenced 1 time by $a93c
+ca946
+    bcs ca94b                                                         ; a946: b0 03       ..
+; $a948 referenced 1 time by $a90f
+ca948
+    jsr sub_ca6ff                                                     ; a948: 20 ff a6     ..
+; $a94b referenced 1 time by $a946
+ca94b
+    pla                                                               ; a94b: 68          h
+    jmp cad14                                                         ; a94c: 4c 14 ad    L..
+
+sub_ca94f
+    jsr sub_ca9d1                                                     ; a94f: 20 d1 a9     ..
+    bra ca959                                                         ; a952: 80 05       ..
+sub_ca954
+    jsr sub_ca9d1                                                     ; a954: 20 d1 a9     ..
+    inc l0049                                                         ; a957: e6 49       .I
+; $a959 referenced 1 time by $a952
+ca959
+    lsr l0049                                                         ; a959: 46 49       FI
+    bcc ca962                                                         ; a95b: 90 05       ..
+    jsr sub_ca5c4                                                     ; a95d: 20 c4 a5     ..
+    bra ca965                                                         ; a960: 80 03       ..
+; $a962 referenced 1 time by $a95b
+ca962
+    jsr sub_ca5f4                                                     ; a962: 20 f4 a5     ..
+; $a965 referenced 1 time by $a960
+ca965
+    lsr l0049                                                         ; a965: 46 49       FI
+    bcs ca978                                                         ; a967: b0 0f       ..
+; $a969 referenced 1 time by $a973
+loop_ca969
+    tay                                                               ; a969: a8          .
+    rts                                                               ; a96a: 60          `
+
+sub_ca96b
+    jsr sub_ca9d1                                                     ; a96b: 20 d1 a9     ..
+    jsr sub_ca5f2                                                     ; a96e: 20 f2 a5     ..
+    lsr l0049                                                         ; a971: 46 49       FI
+    bcc loop_ca969                                                    ; a973: 90 f4       ..
+    jsr sub_ca62f                                                     ; a975: 20 2f a6     /.
+; $a978 referenced 1 time by $a967
+ca978
+    jmp cad10                                                         ; a978: 4c 10 ad    L..
+
+; $a97b referenced 2 times by $a9dd, $aa30
+sub_ca97b
+    jsr sub_ca545                                                     ; a97b: 20 45 a5     E.
+    lda l0030                                                         ; a97e: a5 30       .0
+    ldx #0                                                            ; a980: a2 00       ..
+; $a982 referenced 1 time by $a988
+loop_ca982
+    dey                                                               ; a982: 88          .
+    stx l0031,y                                                       ; a983: 96 31       .1
+    cmp la7c9,y                                                       ; a985: d9 c9 a7    ...
+    bcc loop_ca982                                                    ; a988: 90 f8       ..
+    lda l004c                                                         ; a98a: a5 4c       .L
+    jsr ca9c1                                                         ; a98c: 20 c1 a9     ..
+    lda l002e                                                         ; a98f: a5 2e       ..
+    sta l003b                                                         ; a991: 85 3b       .;
+    jsr sub_ca5d1                                                     ; a993: 20 d1 a5     ..
+    dec l0030                                                         ; a996: c6 30       .0
+    jsr sub_c9788                                                     ; a998: 20 88 97     ..
+    sta l0049                                                         ; a99b: 85 49       .I
+    jsr c828d                                                         ; a99d: 20 8d 82     ..
+    jsr sub_ca5ad                                                     ; a9a0: 20 ad a5     ..
+; $a9a3 referenced 1 time by $a7ff
+sub_ca9a3
+    jsr sub_ca514                                                     ; a9a3: 20 14 a5     ..
+    ldy #5                                                            ; a9a6: a0 05       ..
+    lda (l004a),y                                                     ; a9a8: b1 4a       .J
+    sta l0041                                                         ; a9aa: 85 41       .A
+    jsr sub_ca73e                                                     ; a9ac: 20 3e a7     >.
+    jsr sub_ca5bb                                                     ; a9af: 20 bb a5     ..
+    jmp ca704                                                         ; a9b2: 4c 04 a7    L..
+
+sub_ca9b5
+    jsr sub_c979f                                                     ; a9b5: 20 9f 97     ..
+    lda #$ca                                                          ; a9b8: a9 ca       ..
+    bra ca9c1                                                         ; a9ba: 80 05       ..
+sub_ca9bc
+    jsr sub_ca7ac                                                     ; a9bc: 20 ac a7     ..
+    lda #$82                                                          ; a9bf: a9 82       ..
+; $a9c1 referenced 3 times by $a98c, $a9ba, $a9cf
+ca9c1
+    ldy #$bf                                                          ; a9c1: a0 bf       ..
+; $a9c3 referenced 1 time by $a0e0
+sub_ca9c3
+    sty l004b                                                         ; a9c3: 84 4b       .K
+    sta l004a                                                         ; a9c5: 85 4a       .J
+    jmp ca6e4                                                         ; a9c7: 4c e4 a6    L..
+
+sub_ca9ca
+    jsr sub_c979f                                                     ; a9ca: 20 9f 97     ..
+    lda #$cf                                                          ; a9cd: a9 cf       ..
+    bra ca9c1                                                         ; a9cf: 80 f0       ..
+; $a9d1 referenced 3 times by $a94f, $a954, $a96b
+sub_ca9d1
+    jsr sub_c979f                                                     ; a9d1: 20 9f 97     ..
+    lda #$8b                                                          ; a9d4: a9 8b       ..
+    jsr sub_caa50                                                     ; a9d6: 20 50 aa     P.
+    bcc caa07                                                         ; a9d9: 90 2c       .,
+    bne ca9e0                                                         ; a9db: d0 03       ..
+    jsr sub_ca97b                                                     ; a9dd: 20 7b a9     {.
+; $a9e0 referenced 1 time by $a9db
+ca9e0
+    lda #$6e ; 'n'                                                    ; a9e0: a9 6e       .n
+    cmp l0030                                                         ; a9e2: c5 30       .0
+    bcs ca9f2                                                         ; a9e4: b0 0c       ..
+    jsr sub_ca8b3                                                     ; a9e6: 20 b3 a8     ..
+    jsr sub_ca545                                                     ; a9e9: 20 45 a5     E.
+    inc l046c                                                         ; a9ec: ee 6c 04    .l.
+; $a9ef referenced 1 time by $aa4d
+ca9ef
+    jmp ca6ce                                                         ; a9ef: 4c ce a6    L..
+
+; $a9f2 referenced 1 time by $a9e4
+ca9f2
+    jsr sub_ca545                                                     ; a9f2: 20 45 a5     E.
+; $a9f5 referenced 1 time by $a9fa
+loop_ca9f5
+    jmp ca72b                                                         ; a9f5: 4c 2b a7    L+.
+
+; $a9f8 referenced 1 time by $aa1f
+ca9f8
+    lda l002e                                                         ; a9f8: a5 2e       ..
+    bmi loop_ca9f5                                                    ; a9fa: 30 f9       0.
+    brk                                                               ; a9fc: 00          .
+
+    !byte $18                                                         ; a9fd: 18          .
+    !text "Exp range"                                                 ; a9fe: 45 78 70... Exp
+
+; $aa07 referenced 1 time by $a9d9
+caa07
+    brk                                                               ; aa07: 00          .
+
+    !byte $17                                                         ; aa08: 17          .
+    !text "Accuracy lost"                                             ; aa09: 41 63 63... Acc
+    !byte 0                                                           ; aa16: 00          .
+
+sub_caa17
+    jsr sub_c979f                                                     ; aa17: 20 9f 97     ..
+; $aa1a referenced 1 time by $a0e3
+sub_caa1a
+    lda #$9a                                                          ; aa1a: a9 9a       ..
+    jsr sub_caa50                                                     ; aa1c: 20 50 aa     P.
+    bcc ca9f8                                                         ; aa1f: 90 d7       ..
+    bne caa2c                                                         ; aa21: d0 09       ..
+    lda l0030                                                         ; aa23: a5 30       .0
+    inc                                                               ; aa25: 1a          .
+    and #8                                                            ; aa26: 29 08       ).
+    beq caa2c                                                         ; aa28: f0 02       ..
+    dec l0030                                                         ; aa2a: c6 30       .0
+; $aa2c referenced 2 times by $aa21, $aa28
+caa2c
+    dec                                                               ; aa2c: 3a          :
+    pha                                                               ; aa2d: 48          H
+    beq caa33                                                         ; aa2e: f0 03       ..
+    jsr sub_ca97b                                                     ; aa30: 20 7b a9     {.
+; $aa33 referenced 1 time by $aa2e
+caa33
+    lda l0030                                                         ; aa33: a5 30       .0
+    cmp #$6a ; 'j'                                                    ; aa35: c9 6a       .j
+    bcs caa3e                                                         ; aa37: b0 05       ..
+    jsr sub_ca5cf                                                     ; aa39: 20 cf a5     ..
+    bra caa44                                                         ; aa3c: 80 06       ..
+; $aa3e referenced 1 time by $aa37
+caa3e
+    jsr sub_ca8b3                                                     ; aa3e: 20 b3 a8     ..
+    jsr sub_ca5c1                                                     ; aa41: 20 c1 a5     ..
+; $aa44 referenced 1 time by $aa3c
+caa44
+    clc                                                               ; aa44: 18          .
+    lda l0030                                                         ; aa45: a5 30       .0
+    adc l0049                                                         ; aa47: 65 49       eI
+    sta l0030                                                         ; aa49: 85 30       .0
+    pla                                                               ; aa4b: 68          h
+    dec                                                               ; aa4c: 3a          :
+    bpl ca9ef                                                         ; aa4d: 10 a0       ..
+    rts                                                               ; aa4f: 60          `
+
+; $aa50 referenced 2 times by $a9d6, $aa1c
+sub_caa50
+    jsr sub_ca5b2                                                     ; aa50: 20 b2 a5     ..
+    stz l0049                                                         ; aa53: 64 49       dI
+; $aa55 referenced 2 times by $a8c3, $a923
+sub_caa55
+    phx                                                               ; aa55: da          .
+    tax                                                               ; aa56: aa          .
+    ldy #1                                                            ; aa57: a0 01       ..
+; $aa59 referenced 1 time by $aa69
+loop_caa59
+    dex                                                               ; aa59: ca          .
+    lda cbf00,x                                                       ; aa5a: bd 00 bf    ...
+    cmp l0030                                                         ; aa5d: c5 30       .0
+    bne caa66                                                         ; aa5f: d0 05       ..
+    lda lbefe,x                                                       ; aa61: bd fe be    ...
+    cmp l0031                                                         ; aa64: c5 31       .1
+; $aa66 referenced 1 time by $aa5f
+caa66
+    bcs caa6b                                                         ; aa66: b0 03       ..
+    dey                                                               ; aa68: 88          .
+    bpl loop_caa59                                                    ; aa69: 10 ee       ..
+; $aa6b referenced 1 time by $aa66
+caa6b
+    plx                                                               ; aa6b: fa          .
+    tya                                                               ; aa6c: 98          .
+    rts                                                               ; aa6d: 60          `
+
+; $aa6e referenced 2 times by $ac12, $aefb
+sub_caa6e
+    jsr sub_c9779                                                     ; aa6e: 20 79 97     y.
+    lda #osbyte_inkey                                                 ; aa71: a9 81       ..
+    ldx l002a                                                         ; aa73: a6 2a       .*
+    ldy l002b                                                         ; aa75: a4 2b       .+
+    jmp osbyte                                                        ; aa77: 4c f4 ff    L..
+
+; $aa7a referenced 2 times by $aaae, $aab0
+caa7a
+    jsr sub_c83d3                                                     ; aa7a: 20 d3 83     ..
+; $aa7d referenced 1 time by $aaab
+caa7d
+    stz l002e                                                         ; aa7d: 64 2e       d.
+    stz l002f                                                         ; aa7f: 64 2f       d/
+    stz l0035                                                         ; aa81: 64 35       d5
+    lda #$80                                                          ; aa83: a9 80       ..
+    sta l0030                                                         ; aa85: 85 30       .0
+    eor l000d                                                         ; aa87: 45 0d       E.
+    sta l0034                                                         ; aa89: 85 34       .4
+    eor l000e                                                         ; aa8b: 45 0e       E.
+    sta l0033                                                         ; aa8d: 85 33       .3
+    eor l000f                                                         ; aa8f: 45 0f       E.
+    sta l0032                                                         ; aa91: 85 32       .2
+    eor l0010                                                         ; aa93: 45 10       E.
+    sta l0031                                                         ; aa95: 85 31       .1
+    jmp ca6c4                                                         ; aa97: 4c c4 a6    L..
+
+; $aa9a referenced 1 time by $aad1
+caa9a
+    inc l001b                                                         ; aa9a: e6 1b       ..
+    jsr sub_c976c                                                     ; aa9c: 20 6c 97     l.
+    lda l002d                                                         ; aa9f: a5 2d       .-
+    bmi caac1                                                         ; aaa1: 30 1e       0.
+    ora l002c                                                         ; aaa3: 05 2c       .,
+    ora l002b                                                         ; aaa5: 05 2b       .+
+    bne caab0                                                         ; aaa7: d0 07       ..
+    lda l002a                                                         ; aaa9: a5 2a       .*
+    beq caa7d                                                         ; aaab: f0 d0       ..
+    dec                                                               ; aaad: 3a          :
+    beq caa7a                                                         ; aaae: f0 ca       ..
+; $aab0 referenced 1 time by $aaa7
+caab0
+    jsr caa7a                                                         ; aab0: 20 7a aa     z.
+    jsr sub_c828a                                                     ; aab3: 20 8a 82     ..
+    jsr sub_ca73e                                                     ; aab6: 20 3e a7     >.
+    jsr sub_c9788                                                     ; aab9: 20 88 97     ..
+    jsr sub_cbf2f                                                     ; aabc: 20 2f bf     /.
+    bra caae8                                                         ; aabf: 80 27       .'
+; $aac1 referenced 1 time by $aaa1
+caac1
+    ldx #$0d                                                          ; aac1: a2 0d       ..
+    jsr sub_cbe06                                                     ; aac3: 20 06 be     ..
+    lda #$40 ; '@'                                                    ; aac6: a9 40       .@
+    sta l0011                                                         ; aac8: 85 11       ..
+    rts                                                               ; aaca: 60          `
+
+sub_caacb
+    ldy l001b                                                         ; aacb: a4 1b       ..
+    lda (l0019),y                                                     ; aacd: b1 19       ..
+    cmp #$28 ; '('                                                    ; aacf: c9 28       .(
+    beq caa9a                                                         ; aad1: f0 c7       ..
+    jsr sub_c83d3                                                     ; aad3: 20 d3 83     ..
+    ldx #$0d                                                          ; aad6: a2 0d       ..
+; $aad8 referenced 2 times by $a052, $b1d8
+sub_caad8
+    lda l0000,x                                                       ; aad8: b5 00       ..
+    sta l002a                                                         ; aada: 85 2a       .*
+    lda l0001,x                                                       ; aadc: b5 01       ..
+    sta l002b                                                         ; aade: 85 2b       .+
+    lda l0002,x                                                       ; aae0: b5 02       ..
+    sta l002c                                                         ; aae2: 85 2c       .,
+    lda l0003,x                                                       ; aae4: b5 03       ..
+    sta l002d                                                         ; aae6: 85 2d       .-
+; $aae8 referenced 4 times by $aabf, $aaf9, $ab12, $ab2d
+caae8
+    lda #$40 ; '@'                                                    ; aae8: a9 40       .@
+    rts                                                               ; aaea: 60          `
+
+sub_caaeb
+    jsr sub_c9779                                                     ; aaeb: 20 79 97     y.
+    ldx #3                                                            ; aaee: a2 03       ..
+; $aaf0 referenced 1 time by $aaf7
+loop_caaf0
+    lda l002a,x                                                       ; aaf0: b5 2a       .*
+    eor #$ff                                                          ; aaf2: 49 ff       I.
+    sta l002a,x                                                       ; aaf4: 95 2a       .*
+    dex                                                               ; aaf6: ca          .
+    bpl loop_caaf0                                                    ; aaf7: 10 f7       ..
+    bra caae8                                                         ; aaf9: 80 ed       ..
+sub_caafb
+    jsr sub_cab14                                                     ; aafb: 20 14 ab     ..
+    stx l002a                                                         ; aafe: 86 2a       .*
+    rts                                                               ; ab00: 60          `
+
+sub_cab01
+    jsr sub_c9779                                                     ; ab01: 20 79 97     y.
+    jsr sub_c93c7                                                     ; ab04: 20 c7 93     ..
+    sta l002a                                                         ; ab07: 85 2a       .*
+    stx l002b                                                         ; ab09: 86 2b       .+
+    sty l002c                                                         ; ab0b: 84 2c       .,
+    php                                                               ; ab0d: 08          .
+    pla                                                               ; ab0e: 68          h
+    sta l002d                                                         ; ab0f: 85 2d       .-
+    cld                                                               ; ab11: d8          .
+    bra caae8                                                         ; ab12: 80 d4       ..
+; $ab14 referenced 1 time by $aafb
+sub_cab14
+    lda #osbyte_read_text_cursor_pos                                  ; ab14: a9 86       ..
+    jsr osbyte                                                        ; ab16: 20 f4 ff     ..
+    tya                                                               ; ab19: 98          .
+; $ab1a referenced 2 times by $ab35, $ab52
+cab1a
+    jmp cae60                                                         ; ab1a: 4c 60 ae    L`.
+
+sub_cab1d
+    lda #2                                                            ; ab1d: a9 02       ..
+    bra cab23                                                         ; ab1f: 80 02       ..
+sub_cab21
+    lda #0                                                            ; ab21: a9 00       ..
+; $ab23 referenced 1 time by $ab1f
+cab23
+    pha                                                               ; ab23: 48          H
+    jsr sub_cba7a                                                     ; ab24: 20 7a ba     z.
+    ldx #$2a ; '*'                                                    ; ab27: a2 2a       .*
+    pla                                                               ; ab29: 68          h
+    jsr osargs                                                        ; ab2a: 20 da ff     ..
+    bra caae8                                                         ; ab2d: 80 b9       ..
+sub_cab2f
+    jsr sub_cba7a                                                     ; ab2f: 20 7a ba     z.
+    jsr osbget                                                        ; ab32: 20 d7 ff     ..
+    bra cab1a                                                         ; ab35: 80 e3       ..
+sub_cab37
+    lda #$40 ; '@'                                                    ; ab37: a9 40       .@
+    bra cab41                                                         ; ab39: 80 06       ..
+sub_cab3b
+    lda #$80                                                          ; ab3b: a9 80       ..
+    bra cab41                                                         ; ab3d: 80 02       ..
+sub_cab3f
+    lda #$c0                                                          ; ab3f: a9 c0       ..
+; $ab41 referenced 2 times by $ab39, $ab3d
+cab41
+    pha                                                               ; ab41: 48          H
+    jsr cad78                                                         ; ab42: 20 78 ad     x.
+    bne cab9d                                                         ; ab45: d0 56       .V
+    jsr sub_cbe6b                                                     ; ab47: 20 6b be     k.
+    ldx #0                                                            ; ab4a: a2 00       ..
+    ldy #6                                                            ; ab4c: a0 06       ..
+    pla                                                               ; ab4e: 68          h
+    jsr osfind                                                        ; ab4f: 20 ce ff     ..
+    bra cab1a                                                         ; ab52: 80 c6       ..
+sub_cab54
+    stz l0031                                                         ; ab54: 64 31       d1
+    jsr sub_ca6ff                                                     ; ab56: 20 ff a6     ..
+    inc l0030                                                         ; ab59: e6 30       .0
+    rts                                                               ; ab5b: 60          `
+
+sub_cab5c
+    jsr cad78                                                         ; ab5c: 20 78 ad     x.
+    bne cab9d                                                         ; ab5f: d0 3c       .<
+    inc l0036                                                         ; ab61: e6 36       .6
+    ldy l0036                                                         ; ab63: a4 36       .6
+    lda #$0d                                                          ; ab65: a9 0d       ..
+    sta l05ff,y                                                       ; ab67: 99 ff 05    ...
+    jsr cbc91                                                         ; ab6a: 20 91 bc     ..
+    lda l0019                                                         ; ab6d: a5 19       ..
+    pha                                                               ; ab6f: 48          H
+    lda l001a                                                         ; ab70: a5 1a       ..
+    pha                                                               ; ab72: 48          H
+    lda l001b                                                         ; ab73: a5 1b       ..
+    pha                                                               ; ab75: 48          H
+    ldy l0004                                                         ; ab76: a4 04       ..
+    ldx l0005                                                         ; ab78: a6 05       ..
+    iny                                                               ; ab7a: c8          .
+    sty l0019                                                         ; ab7b: 84 19       ..
+    sty l0037                                                         ; ab7d: 84 37       .7
+    bne cab82                                                         ; ab7f: d0 01       ..
+    inx                                                               ; ab81: e8          .
+; $ab82 referenced 1 time by $ab7f
+cab82
+    stx l001a                                                         ; ab82: 86 1a       ..
+    stx l0038                                                         ; ab84: 86 38       .8
+    jsr c8edc                                                         ; ab86: 20 dc 8e     ..
+    stz l001b                                                         ; ab89: 64 1b       d.
+    jsr sub_c9dff                                                     ; ab8b: 20 ff 9d     ..
+    jsr cbd21                                                         ; ab8e: 20 21 bd     !.
+; $ab91 referenced 1 time by $abdf
+cab91
+    pla                                                               ; ab91: 68          h
+    sta l001b                                                         ; ab92: 85 1b       ..
+    pla                                                               ; ab94: 68          h
+    sta l001a                                                         ; ab95: 85 1a       ..
+    pla                                                               ; ab97: 68          h
+    sta l0019                                                         ; ab98: 85 19       ..
+    lda l0027                                                         ; ab9a: a5 27       .'
+    rts                                                               ; ab9c: 60          `
+
+; $ab9d referenced 3 times by $ab45, $ab5f, $aba3
+cab9d
+    jmp c9155                                                         ; ab9d: 4c 55 91    LU.
+
+sub_caba0
+    jsr cad78                                                         ; aba0: 20 78 ad     x.
+    bne cab9d                                                         ; aba3: d0 f8       ..
+; $aba5 referenced 1 time by $b96e
+sub_caba5
+    ldx l0036                                                         ; aba5: a6 36       .6
+    stz l0600,x                                                       ; aba7: 9e 00 06    ...
+    lda l0019                                                         ; abaa: a5 19       ..
+    pha                                                               ; abac: 48          H
+    lda l001a                                                         ; abad: a5 1a       ..
+    pha                                                               ; abaf: 48          H
+    lda l001b                                                         ; abb0: a5 1b       ..
+    pha                                                               ; abb2: 48          H
+    stz l001b                                                         ; abb3: 64 1b       d.
+    stz l0019                                                         ; abb5: 64 19       d.
+    lda #6                                                            ; abb7: a9 06       ..
+    sta l001a                                                         ; abb9: 85 1a       ..
+    jsr c8f92                                                         ; abbb: 20 92 8f     ..
+    cmp #$2d ; '-'                                                    ; abbe: c9 2d       .-
+    beq cabd0                                                         ; abc0: f0 0e       ..
+    cmp #$2b ; '+'                                                    ; abc2: c9 2b       .+
+    bne cabc9                                                         ; abc4: d0 03       ..
+    jsr c8f92                                                         ; abc6: 20 92 8f     ..
+; $abc9 referenced 1 time by $abc4
+cabc9
+    dec l001b                                                         ; abc9: c6 1b       ..
+    jsr sub_ca2dd                                                     ; abcb: 20 dd a2     ..
+    bra cabdd                                                         ; abce: 80 0d       ..
+; $abd0 referenced 1 time by $abc0
+cabd0
+    jsr c8f92                                                         ; abd0: 20 92 8f     ..
+    dec l001b                                                         ; abd3: c6 1b       ..
+    jsr sub_ca2dd                                                     ; abd5: 20 dd a2     ..
+    bcc cabdd                                                         ; abd8: 90 03       ..
+    jsr sub_cad1c                                                     ; abda: 20 1c ad     ..
+; $abdd referenced 2 times by $abce, $abd8
+cabdd
+    sta l0027                                                         ; abdd: 85 27       .'
+    bra cab91                                                         ; abdf: 80 b0       ..
+sub_cabe1
+    jsr cad78                                                         ; abe1: 20 78 ad     x.
+    beq cac1c                                                         ; abe4: f0 36       .6
+    bpl cac02                                                         ; abe6: 10 1a       ..
+    lda l002e                                                         ; abe8: a5 2e       ..
+    php                                                               ; abea: 08          .
+    stz l002e                                                         ; abeb: 64 2e       d.
+    jsr sub_c8349                                                     ; abed: 20 49 83     I.
+    plp                                                               ; abf0: 28          (
+    bpl cabfd                                                         ; abf1: 10 0a       ..
+    lda l003d                                                         ; abf3: a5 3d       .=
+    beq cabfa                                                         ; abf5: f0 03       ..
+    jsr sub_c83c2                                                     ; abf7: 20 c2 83     ..
+; $abfa referenced 1 time by $abf5
+cabfa
+    jsr sub_c83aa                                                     ; abfa: 20 aa 83     ..
+; $abfd referenced 1 time by $abf1
+cabfd
+    jsr sub_c978b                                                     ; abfd: 20 8b 97     ..
+    lda #$40 ; '@'                                                    ; ac00: a9 40       .@
+; $ac02 referenced 1 time by $abe6
+cac02
+    rts                                                               ; ac02: 60          `
+
+sub_cac03
+    jsr cad78                                                         ; ac03: 20 78 ad     x.
+    bne cac1c                                                         ; ac06: d0 14       ..
+    lda l0036                                                         ; ac08: a5 36       .6
+    beq cac2b                                                         ; ac0a: f0 1f       ..
+    lda l0600                                                         ; ac0c: ad 00 06    ...
+; $ac0f referenced 1 time by $ac5b
+cac0f
+    jmp cae60                                                         ; ac0f: 4c 60 ae    L`.
+
+sub_cac12
+    jsr sub_caa6e                                                     ; ac12: 20 6e aa     n.
+    tya                                                               ; ac15: 98          .
+    bne cac2b                                                         ; ac16: d0 13       ..
+    txa                                                               ; ac18: 8a          .
+    jmp cae62                                                         ; ac19: 4c 62 ae    Lb.
+
+; $ac1c referenced 5 times by $abe4, $ac06, $ac4b, $ac82, $ac90
+cac1c
+    jmp c9155                                                         ; ac1c: 4c 55 91    LU.
+
+sub_cac1f
+    jsr sub_cba7a                                                     ; ac1f: 20 7a ba     z.
+    tax                                                               ; ac22: aa          .
+    lda #osbyte_check_eof                                             ; ac23: a9 7f       ..
+    jsr osbyte                                                        ; ac25: 20 f4 ff     ..
+    txa                                                               ; ac28: 8a          .
+    beq cac2d                                                         ; ac29: f0 02       ..
+; $ac2b referenced 6 times by $ac0a, $ac16, $ac44, $ac4f, $ac7b, $b3dd
+cac2b
+    ldx #$ff                                                          ; ac2b: a2 ff       ..
+; $ac2d referenced 2 times by $ac29, $ac3a
+cac2d
+    stx l002a                                                         ; ac2d: 86 2a       .*
+    stx l002b                                                         ; ac2f: 86 2b       .+
+    stx l002c                                                         ; ac31: 86 2c       .,
+    stx l002d                                                         ; ac33: 86 2d       .-
+; $ac35 referenced 1 time by $ac57
+cac35
+    lda #$40 ; '@'                                                    ; ac35: a9 40       .@
+    rts                                                               ; ac37: 60          `
+
+; $ac38 referenced 5 times by $97e6, $9ae1, $ac3e, $adf9, $b3d3
+cac38
+    ldx #0                                                            ; ac38: a2 00       ..
+    bra cac2d                                                         ; ac3a: 80 f1       ..
+; $ac3c referenced 1 time by $ac49
+loop_cac3c
+    lda l0031                                                         ; ac3c: a5 31       .1
+    beq cac38                                                         ; ac3e: f0 f8       ..
+    lda l002e                                                         ; ac40: a5 2e       ..
+    bpl cac59                                                         ; ac42: 10 15       ..
+    bra cac2b                                                         ; ac44: 80 e5       ..
+sub_cac46
+    jsr cad78                                                         ; ac46: 20 78 ad     x.
+    bmi loop_cac3c                                                    ; ac49: 30 f1       0.
+    beq cac1c                                                         ; ac4b: f0 cf       ..
+    lda l002d                                                         ; ac4d: a5 2d       .-
+    bmi cac2b                                                         ; ac4f: 30 da       0.
+    ora l002c                                                         ; ac51: 05 2c       .,
+    ora l002b                                                         ; ac53: 05 2b       .+
+    ora l002a                                                         ; ac55: 05 2a       .*
+    beq cac35                                                         ; ac57: f0 dc       ..
+; $ac59 referenced 1 time by $ac42
+cac59
+    lda #1                                                            ; ac59: a9 01       ..
+; $ac5b referenced 1 time by $ac7d
+cac5b
+    bra cac0f                                                         ; ac5b: 80 b2       ..
+sub_cac5d
+    jsr sub_c8fae                                                     ; ac5d: 20 ae 8f     ..
+    jsr sub_c976c                                                     ; ac60: 20 6c 97     l.
+    lda l002a                                                         ; ac63: a5 2a       .*
+    pha                                                               ; ac65: 48          H
+    ldx l002b                                                         ; ac66: a6 2b       .+
+    jsr sub_cbd26                                                     ; ac68: 20 26 bd     &.
+    stx l002d                                                         ; ac6b: 86 2d       .-
+    pla                                                               ; ac6d: 68          h
+    sta l002c                                                         ; ac6e: 85 2c       .,
+    ldy #>(l002a)                                                     ; ac70: a0 00       ..
+    ldx #<(l002a)                                                     ; ac72: a2 2a       .*
+    lda #osword_read_pixel                                            ; ac74: a9 09       ..
+    jsr osword                                                        ; ac76: 20 f1 ff     ..
+    lda l002e                                                         ; ac79: a5 2e       ..
+    bmi cac2b                                                         ; ac7b: 30 ae       0.
+    bra cac5b                                                         ; ac7d: 80 dc       ..
+sub_cac7f
+    jsr sub_c9dff                                                     ; ac7f: 20 ff 9d     ..
+    bne cac1c                                                         ; ac82: d0 98       ..
+    cpx #$2c ; ','                                                    ; ac84: e0 2c       .,
+    bne caca0                                                         ; ac86: d0 18       ..
+    inc l001b                                                         ; ac88: e6 1b       ..
+    jsr cbc91                                                         ; ac8a: 20 91 bc     ..
+    jsr sub_c9dff                                                     ; ac8d: 20 ff 9d     ..
+    bne cac1c                                                         ; ac90: d0 8a       ..
+    lda #1                                                            ; ac92: a9 01       ..
+    sta l002a                                                         ; ac94: 85 2a       .*
+    inc l001b                                                         ; ac96: e6 1b       ..
+    cpx #$29 ; ')'                                                    ; ac98: e0 29       .)
+    beq caca9                                                         ; ac9a: f0 0d       ..
+    cpx #$2c ; ','                                                    ; ac9c: e0 2c       .,
+    beq caca3                                                         ; ac9e: f0 03       ..
+; $aca0 referenced 1 time by $ac86
+caca0
+    jmp c8fbb                                                         ; aca0: 4c bb 8f    L..
+
+; $aca3 referenced 1 time by $ac9e
+caca3
+    jsr sub_c9769                                                     ; aca3: 20 69 97     i.
+    jsr sub_cbd12                                                     ; aca6: 20 12 bd     ..
+; $aca9 referenced 1 time by $ac9a
+caca9
+    ldx l002a                                                         ; aca9: a6 2a       .*
+    bne cacaf                                                         ; acab: d0 02       ..
+    ldx #1                                                            ; acad: a2 01       ..
+; $acaf referenced 1 time by $acab
+cacaf
+    stx l002a                                                         ; acaf: 86 2a       .*
+    txa                                                               ; acb1: 8a          .
+    dex                                                               ; acb2: ca          .
+    stx l002d                                                         ; acb3: 86 2d       .-
+    clc                                                               ; acb5: 18          .
+    adc l0004                                                         ; acb6: 65 04       e.
+    sta l0037                                                         ; acb8: 85 37       .7
+    lda #0                                                            ; acba: a9 00       ..
+    adc l0005                                                         ; acbc: 65 05       e.
+    sta l0038                                                         ; acbe: 85 38       .8
+    lda (l0004)                                                       ; acc0: b2 04       ..
+    sec                                                               ; acc2: 38          8
+    sbc l002d                                                         ; acc3: e5 2d       .-
+    bcc cace8                                                         ; acc5: 90 21       .!
+    sbc l0036                                                         ; acc7: e5 36       .6
+    bcc cace8                                                         ; acc9: 90 1d       ..
+    adc #0                                                            ; accb: 69 00       i.
+    sta l002b                                                         ; accd: 85 2b       .+
+    jsr cbd21                                                         ; accf: 20 21 bd     !.
+; $acd2 referenced 2 times by $acf7, $acfb
+cacd2
+    ldy #0                                                            ; acd2: a0 00       ..
+    ldx l0036                                                         ; acd4: a6 36       .6
+    beq cace3                                                         ; acd6: f0 0b       ..
+; $acd8 referenced 1 time by $ace1
+loop_cacd8
+    lda (l0037),y                                                     ; acd8: b1 37       .7
+    cmp l0600,y                                                       ; acda: d9 00 06    ...
+    bne cacef                                                         ; acdd: d0 10       ..
+    iny                                                               ; acdf: c8          .
+    dex                                                               ; ace0: ca          .
+    bne loop_cacd8                                                    ; ace1: d0 f5       ..
+; $ace3 referenced 1 time by $acd6
+cace3
+    lda l002a                                                         ; ace3: a5 2a       .*
+; $ace5 referenced 1 time by $aced
+loop_cace5
+    jmp cae60                                                         ; ace5: 4c 60 ae    L`.
+
+; $ace8 referenced 2 times by $acc5, $acc9
+cace8
+    jsr cbd21                                                         ; ace8: 20 21 bd     !.
+; $aceb referenced 1 time by $acf3
+loop_caceb
+    lda #0                                                            ; aceb: a9 00       ..
+    bra loop_cace5                                                    ; aced: 80 f6       ..
+; $acef referenced 1 time by $acdd
+cacef
+    inc l002a                                                         ; acef: e6 2a       .*
+    dec l002b                                                         ; acf1: c6 2b       .+
+    beq loop_caceb                                                    ; acf3: f0 f6       ..
+    inc l0037                                                         ; acf5: e6 37       .7
+    bne cacd2                                                         ; acf7: d0 d9       ..
+    inc l0038                                                         ; acf9: e6 38       .8
+    bra cacd2                                                         ; acfb: 80 d5       ..
+; $acfd referenced 2 times by $ad05, $ad1c
+cacfd
+    jmp c9155                                                         ; acfd: 4c 55 91    LU.
+
+sub_cad00
+    jsr cad78                                                         ; ad00: 20 78 ad     x.
+    bmi cad0d                                                         ; ad03: 30 08       0.
+    beq cacfd                                                         ; ad05: f0 f6       ..
+; $ad07 referenced 1 time by $81d7
+sub_cad07
+    bit l002d                                                         ; ad07: 24 2d       $-
+    bmi cad20                                                         ; ad09: 30 15       0.
+    bra cad37                                                         ; ad0b: 80 2a       .*
+; $ad0d referenced 1 time by $ad03
+cad0d
+    stz l002e                                                         ; ad0d: 64 2e       d.
+    rts                                                               ; ad0f: 60          `
+
+; $ad10 referenced 6 times by $9f61, $a5c1, $a5cc, $a805, $a978, $ad1e
+cad10
+    lda l0031                                                         ; ad10: a5 31       .1
+    eor l002e                                                         ; ad12: 45 2e       E.
+; $ad14 referenced 1 time by $a94c
+cad14
+    sta l002e                                                         ; ad14: 85 2e       ..
+    lda #$ff                                                          ; ad16: a9 ff       ..
+    rts                                                               ; ad18: 60          `
+
+; $ad19 referenced 1 time by $ad84
+cad19
+    jsr sub_cad8e                                                     ; ad19: 20 8e ad     ..
+; $ad1c referenced 1 time by $abda
+sub_cad1c
+    beq cacfd                                                         ; ad1c: f0 df       ..
+    bmi cad10                                                         ; ad1e: 30 f0       0.
+; $ad20 referenced 5 times by $81c5, $8295, $9fe3, $a058, $ad09
+cad20
+    sec                                                               ; ad20: 38          8
+    lda #0                                                            ; ad21: a9 00       ..
+    tay                                                               ; ad23: a8          .
+    sbc l002a                                                         ; ad24: e5 2a       .*
+    sta l002a                                                         ; ad26: 85 2a       .*
+    tya                                                               ; ad28: 98          .
+    sbc l002b                                                         ; ad29: e5 2b       .+
+    sta l002b                                                         ; ad2b: 85 2b       .+
+    tya                                                               ; ad2d: 98          .
+    sbc l002c                                                         ; ad2e: e5 2c       .,
+    sta l002c                                                         ; ad30: 85 2c       .,
+    tya                                                               ; ad32: 98          .
+    sbc l002d                                                         ; ad33: e5 2d       .-
+    sta l002d                                                         ; ad35: 85 2d       .-
+; $ad37 referenced 1 time by $ad0b
+cad37
+    lda #$40 ; '@'                                                    ; ad37: a9 40       .@
+    rts                                                               ; ad39: 60          `
+
+; $ad3a referenced 2 times by $b957, $b9c5
+sub_cad3a
+    jsr c8f92                                                         ; ad3a: 20 92 8f     ..
+    cmp #$22 ; '"'                                                    ; ad3d: c9 22       ."
+    beq cad5b                                                         ; ad3f: f0 1a       ..
+    ldx #0                                                            ; ad41: a2 00       ..
+; $ad43 referenced 1 time by $ad50
+loop_cad43
+    lda (l0019),y                                                     ; ad43: b1 19       ..
+    sta l0600,x                                                       ; ad45: 9d 00 06    ...
+    iny                                                               ; ad48: c8          .
+    inx                                                               ; ad49: e8          .
+    cmp #$0d                                                          ; ad4a: c9 0d       ..
+    beq cad52                                                         ; ad4c: f0 04       ..
+    cmp #$2c ; ','                                                    ; ad4e: c9 2c       .,
+    bne loop_cad43                                                    ; ad50: d0 f1       ..
+; $ad52 referenced 1 time by $ad4c
+cad52
+    dey                                                               ; ad52: 88          .
+; $ad53 referenced 1 time by $ad73
+cad53
+    dex                                                               ; ad53: ca          .
+    stx l0036                                                         ; ad54: 86 36       .6
+    sty l001b                                                         ; ad56: 84 1b       ..
+    lda #0                                                            ; ad58: a9 00       ..
+    rts                                                               ; ad5a: 60          `
+
+; $ad5b referenced 2 times by $ad3f, $ad88
+cad5b
+    ldx #0                                                            ; ad5b: a2 00       ..
+; $ad5d referenced 1 time by $ad71
+loop_cad5d
+    iny                                                               ; ad5d: c8          .
+; $ad5e referenced 1 time by $ad6b
+loop_cad5e
+    lda (l0019),y                                                     ; ad5e: b1 19       ..
+    cmp #$0d                                                          ; ad60: c9 0d       ..
+    beq cad75                                                         ; ad62: f0 11       ..
+    sta l0600,x                                                       ; ad64: 9d 00 06    ...
+    iny                                                               ; ad67: c8          .
+    inx                                                               ; ad68: e8          .
+    cmp #$22 ; '"'                                                    ; ad69: c9 22       ."
+    bne loop_cad5e                                                    ; ad6b: d0 f1       ..
+    lda (l0019),y                                                     ; ad6d: b1 19       ..
+    cmp #$22 ; '"'                                                    ; ad6f: c9 22       ."
+    beq loop_cad5d                                                    ; ad71: f0 ea       ..
+    bne cad53                                                         ; ad73: d0 de       ..
+; $ad75 referenced 1 time by $ad62
+cad75
+    jmp c9357                                                         ; ad75: 4c 57 93    LW.
+
+; $ad78 referenced 14 times by $9779, $979f, $a06c, $a084, $ab42, $ab5c, $aba0, $abe1, $ac03, $ac46, $ad00, $ad80, $ae59, $af6e
+cad78
+    ldy l001b                                                         ; ad78: a4 1b       ..
+    inc l001b                                                         ; ad7a: e6 1b       ..
+    lda (l0019),y                                                     ; ad7c: b1 19       ..
+    cmp #$20 ; ' '                                                    ; ad7e: c9 20       .
+    beq cad78                                                         ; ad80: f0 f6       ..
+    cmp #$2d ; '-'                                                    ; ad82: c9 2d       .-
+    beq cad19                                                         ; ad84: f0 93       ..
+    cmp #$22 ; '"'                                                    ; ad86: c9 22       ."
+    beq cad5b                                                         ; ad88: f0 d1       ..
+    cmp #$2b ; '+'                                                    ; ad8a: c9 2b       .+
+    bne cad91                                                         ; ad8c: d0 03       ..
+; $ad8e referenced 1 time by $ad19
+sub_cad8e
+    jsr c8f92                                                         ; ad8e: 20 92 8f     ..
+; $ad91 referenced 1 time by $ad8c
+cad91
+    cmp #$8e                                                          ; ad91: c9 8e       ..
+    bcc cad9c                                                         ; ad93: 90 07       ..
+    cmp #$c6                                                          ; ad95: c9 c6       ..
+    bcs cadce                                                         ; ad97: b0 35       .5
+    jmp c90de                                                         ; ad99: 4c de 90    L..
+
+; $ad9c referenced 1 time by $ad93
+cad9c
+    cmp #$3f ; '?'                                                    ; ad9c: c9 3f       .?
+    bcs cadac                                                         ; ad9e: b0 0c       ..
+    cmp #$2e ; '.'                                                    ; ada0: c9 2e       ..
+    bcs cadb6                                                         ; ada2: b0 12       ..
+    cmp #$26 ; '&'                                                    ; ada4: c9 26       .&
+    beq cadf9                                                         ; ada6: f0 51       .Q
+    cmp #$28 ; '('                                                    ; ada8: c9 28       .(
+    beq cadee                                                         ; adaa: f0 42       .B
+; $adac referenced 1 time by $ad9e
+cadac
+    dec l001b                                                         ; adac: c6 1b       ..
+    jsr sub_c99d8                                                     ; adae: 20 d8 99     ..
+    beq cadbc                                                         ; adb1: f0 09       ..
+    jmp cb1de                                                         ; adb3: 4c de b1    L..
+
+; $adb6 referenced 1 time by $ada2
+cadb6
+    jsr sub_ca2dd                                                     ; adb6: 20 dd a2     ..
+    bcc cadce                                                         ; adb9: 90 13       ..
+    rts                                                               ; adbb: 60          `
+
+; $adbc referenced 1 time by $adb1
+cadbc
+    lda l0028                                                         ; adbc: a5 28       .(
+    and #2                                                            ; adbe: 29 02       ).
+    bne cadce                                                         ; adc0: d0 0c       ..
+    bcs cadce                                                         ; adc2: b0 0a       ..
+    stx l001b                                                         ; adc4: 86 1b       ..
+; $adc6 referenced 1 time by $8a9b
+sub_cadc6
+    lda l0440                                                         ; adc6: ad 40 04    .@.
+    ldy l0441                                                         ; adc9: ac 41 04    .A.
+    bra cae3f                                                         ; adcc: 80 71       .q
+; $adce referenced 6 times by $93c4, $ad97, $adb9, $adc0, $adc2, $ae46
+cadce
+    brk                                                               ; adce: 00          .
+
+    !byte $1a                                                         ; adcf: 1a          .
+    !text "No such variable"                                          ; add0: 4e 6f 20... No
+
+; $ade0 referenced 1 time by $adf5
+loop_cade0
+    brk                                                               ; ade0: 00          .
+
+    !byte $1b, $8d, $29                                               ; ade1: 1b 8d 29    ..)
+
+; $ade4 referenced 1 time by $ae18
+cade4
+    brk                                                               ; ade4: 00          .
+
+    !byte $1c                                                         ; ade5: 1c          .
+    !text "Bad Hex"                                                   ; ade6: 42 61 64... Bad
+    !byte 0                                                           ; aded: 00          .
+
+; $adee referenced 3 times by $976c, $adaa, $af8e
+cadee
+    jsr sub_c9dff                                                     ; adee: 20 ff 9d     ..
+    inc l001b                                                         ; adf1: e6 1b       ..
+    cpx #$29 ; ')'                                                    ; adf3: e0 29       .)
+    bne loop_cade0                                                    ; adf5: d0 e9       ..
+    tay                                                               ; adf7: a8          .
+    rts                                                               ; adf8: 60          `
+
+; $adf9 referenced 1 time by $ada6
+cadf9
+    jsr cac38                                                         ; adf9: 20 38 ac     8.
+    bra cae00                                                         ; adfc: 80 02       ..
+; $adfe referenced 1 time by $ae11
+loop_cadfe
+    inx                                                               ; adfe: e8          .
+    pha                                                               ; adff: 48          H
+; $ae00 referenced 1 time by $adfc
+cae00
+    iny                                                               ; ae00: c8          .
+    lda (l0019),y                                                     ; ae01: b1 19       ..
+    cmp #$41 ; 'A'                                                    ; ae03: c9 41       .A
+    bcc cae0d                                                         ; ae05: 90 06       ..
+    sbc #$37 ; '7'                                                    ; ae07: e9 37       .7
+    cmp #$10                                                          ; ae09: c9 10       ..
+    bra cae11                                                         ; ae0b: 80 04       ..
+; $ae0d referenced 1 time by $ae05
+cae0d
+    sbc #$2f ; '/'                                                    ; ae0d: e9 2f       ./
+    cmp #$0a                                                          ; ae0f: c9 0a       ..
+; $ae11 referenced 1 time by $ae0b
+cae11
+    bcc loop_cadfe                                                    ; ae11: 90 eb       ..
+    sty l001b                                                         ; ae13: 84 1b       ..
+    dex                                                               ; ae15: ca          .
+    cpx #8                                                            ; ae16: e0 08       ..
+    bcs cade4                                                         ; ae18: b0 ca       ..
+    txa                                                               ; ae1a: 8a          .
+    tay                                                               ; ae1b: a8          .
+    ldx #0                                                            ; ae1c: a2 00       ..
+; $ae1e referenced 1 time by $ae2f
+loop_cae1e
+    pla                                                               ; ae1e: 68          h
+    sta l002a,x                                                       ; ae1f: 95 2a       .*
+    dey                                                               ; ae21: 88          .
+    bmi cae31                                                         ; ae22: 30 0d       0.
+    inx                                                               ; ae24: e8          .
+    pla                                                               ; ae25: 68          h
+    asl                                                               ; ae26: 0a          .
+    asl                                                               ; ae27: 0a          .
+    asl                                                               ; ae28: 0a          .
+    asl                                                               ; ae29: 0a          .
+    ora l0029,x                                                       ; ae2a: 15 29       .)
+    sta l0029,x                                                       ; ae2c: 95 29       .)
+    dey                                                               ; ae2e: 88          .
+    bpl loop_cae1e                                                    ; ae2f: 10 ed       ..
+; $ae31 referenced 1 time by $ae22
+cae31
+    lda #$40 ; '@'                                                    ; ae31: a9 40       .@
+    rts                                                               ; ae33: 60          `
+
+sub_cae34
+    jsr sub_c9779                                                     ; ae34: 20 79 97     y.
+    ldx l002a                                                         ; ae37: a6 2a       .*
+    lda #osbyte_read_adc_or_get_buffer_status                         ; ae39: a9 80       ..
+    jsr osbyte                                                        ; ae3b: 20 f4 ff     ..
+    txa                                                               ; ae3e: 8a          .
+; $ae3f referenced 1 time by $adcc
+cae3f
+    bra cae62                                                         ; ae3f: 80 21       .!
+sub_cae41
+    iny                                                               ; ae41: c8          .
+    lda (l0019),y                                                     ; ae42: b1 19       ..
+    cmp #$50 ; 'P'                                                    ; ae44: c9 50       .P
+    bne cadce                                                         ; ae46: d0 86       ..
+    inc l001b                                                         ; ae48: e6 1b       ..
+    lda l0012                                                         ; ae4a: a5 12       ..
+    ldy l0013                                                         ; ae4c: a4 13       ..
+    bra cae62                                                         ; ae4e: 80 12       ..
+sub_cae50
+    ldy l0018                                                         ; ae50: a4 18       ..
+    lda #0                                                            ; ae52: a9 00       ..
+    bra cae62                                                         ; ae54: 80 0c       ..
+; $ae56 referenced 2 times by $ae5c, $aec0
+cae56
+    jmp c9155                                                         ; ae56: 4c 55 91    LU.
+
+sub_cae59
+    jsr cad78                                                         ; ae59: 20 78 ad     x.
+    bne cae56                                                         ; ae5c: d0 f8       ..
+    lda l0036                                                         ; ae5e: a5 36       .6
+; $ae60 referenced 11 times by $8ff4, $9412, $941d, $964b, $ab1a, $ac0f, $ace5, $ae6f, $ae85, $ae8a, $b698
+cae60
+    ldy #0                                                            ; ae60: a0 00       ..
+; $ae62 referenced 8 times by $ac19, $ae3f, $ae4e, $ae54, $ae75, $ae7b, $ae81, $b202
+cae62
+    sta l002a                                                         ; ae62: 85 2a       .*
+    sty l002b                                                         ; ae64: 84 2b       .+
+    stz l002c                                                         ; ae66: 64 2c       d,
+    stz l002d                                                         ; ae68: 64 2d       d-
+    lda #$40 ; '@'                                                    ; ae6a: a9 40       .@
+    rts                                                               ; ae6c: 60          `
+
+sub_cae6d
+    lda l001e                                                         ; ae6d: a5 1e       ..
+    bra cae60                                                         ; ae6f: 80 ef       ..
+sub_cae71
+    lda l0000                                                         ; ae71: a5 00       ..
+    ldy l0001                                                         ; ae73: a4 01       ..
+    bra cae62                                                         ; ae75: 80 eb       ..
+sub_cae77
+    lda l0006                                                         ; ae77: a5 06       ..
+    ldy l0007                                                         ; ae79: a4 07       ..
+    bra cae62                                                         ; ae7b: 80 e5       ..
+sub_cae7d
+    ldy l0009                                                         ; ae7d: a4 09       ..
+    lda l0008                                                         ; ae7f: a5 08       ..
+    bra cae62                                                         ; ae81: 80 df       ..
+sub_cae83
+    lda (l00fd)                                                       ; ae83: b2 fd       ..
+    bra cae60                                                         ; ae85: 80 d9       ..
+sub_cae87
+    jsr osrdch                                                        ; ae87: 20 e0 ff     ..
+    bra cae60                                                         ; ae8a: 80 d4       ..
+sub_cae8c
+    iny                                                               ; ae8c: c8          .
+    lda (l0019),y                                                     ; ae8d: b1 19       ..
+    cmp #$24 ; '$'                                                    ; ae8f: c9 24       .$
+    beq cae9f                                                         ; ae91: f0 0c       ..
+    ldx #<(l002a)                                                     ; ae93: a2 2a       .*
+    ldy #>(l002a)                                                     ; ae95: a0 00       ..
+    lda #osword_read_clock                                            ; ae97: a9 01       ..
+    jsr osword                                                        ; ae99: 20 f1 ff     ..
+    lda #$40 ; '@'                                                    ; ae9c: a9 40       .@
+    rts                                                               ; ae9e: 60          `
+
+; $ae9f referenced 1 time by $ae91
+cae9f
+    inc l001b                                                         ; ae9f: e6 1b       ..
+    lda #osword_read_cmos_clock                                       ; aea1: a9 0e       ..
+    ldx #<(l0600)                                                     ; aea3: a2 00       ..
+    ldy #>(l0600)                                                     ; aea5: a0 06       ..
+    stz l0600                                                         ; aea7: 9c 00 06    ...
+    jsr osword                                                        ; aeaa: 20 f1 ff     ..
+    lda #$18                                                          ; aead: a9 18       ..
+    bra caed7                                                         ; aeaf: 80 26       .&
+sub_caeb1
+    jsr osrdch                                                        ; aeb1: 20 e0 ff     ..
+; $aeb4 referenced 2 times by $af01, $b26e
+caeb4
+    sta l0600                                                         ; aeb4: 8d 00 06    ...
+    lda #1                                                            ; aeb7: a9 01       ..
+    bra caed7                                                         ; aeb9: 80 1c       ..
+sub_caebb
+    clc                                                               ; aebb: 18          .
+sub_caebc
+    php                                                               ; aebc: 08          .
+    jsr sub_c9dff                                                     ; aebd: 20 ff 9d     ..
+    bne cae56                                                         ; aec0: d0 94       ..
+    cpx #$2c ; ','                                                    ; aec2: e0 2c       .,
+    bne caf07                                                         ; aec4: d0 41       .A
+    inc l001b                                                         ; aec6: e6 1b       ..
+    jsr sub_c9769                                                     ; aec8: 20 69 97     i.
+    jsr sub_cbd12                                                     ; aecb: 20 12 bd     ..
+    plp                                                               ; aece: 28          (
+    bcs caedc                                                         ; aecf: b0 0b       ..
+    lda l002a                                                         ; aed1: a5 2a       .*
+    cmp l0036                                                         ; aed3: c5 36       .6
+    bcs caed9                                                         ; aed5: b0 02       ..
+; $aed7 referenced 3 times by $aeaf, $aeb9, $af05
+caed7
+    sta l0036                                                         ; aed7: 85 36       .6
+; $aed9 referenced 3 times by $aed5, $aee0, $aef9
+caed9
+    lda #0                                                            ; aed9: a9 00       ..
+; $aedb referenced 2 times by $aee2, $aee9
+caedb
+    rts                                                               ; aedb: 60          `
+
+; $aedc referenced 1 time by $aecf
+caedc
+    lda l0036                                                         ; aedc: a5 36       .6
+    sbc l002a                                                         ; aede: e5 2a       .*
+    bcc caed9                                                         ; aee0: 90 f7       ..
+    beq caedb                                                         ; aee2: f0 f7       ..
+    tax                                                               ; aee4: aa          .
+    lda l002a                                                         ; aee5: a5 2a       .*
+    sta l0036                                                         ; aee7: 85 36       .6
+    beq caedb                                                         ; aee9: f0 f0       ..
+    ldy #0                                                            ; aeeb: a0 00       ..
+; $aeed referenced 1 time by $aef7
+loop_caeed
+    lda l0600,x                                                       ; aeed: bd 00 06    ...
+    sta l0600,y                                                       ; aef0: 99 00 06    ...
+    inx                                                               ; aef3: e8          .
+    iny                                                               ; aef4: c8          .
+    dec l002a                                                         ; aef5: c6 2a       .*
+    bne loop_caeed                                                    ; aef7: d0 f4       ..
+    bra caed9                                                         ; aef9: 80 de       ..
+sub_caefb
+    jsr sub_caa6e                                                     ; aefb: 20 6e aa     n.
+    txa                                                               ; aefe: 8a          .
+    cpy #0                                                            ; aeff: c0 00       ..
+    beq caeb4                                                         ; af01: f0 b1       ..
+; $af03 referenced 2 times by $af39, $af4f
+caf03
+    lda #0                                                            ; af03: a9 00       ..
+    bra caed7                                                         ; af05: 80 d0       ..
+; $af07 referenced 3 times by $aec4, $af11, $af2a
+caf07
+    jmp c8fbb                                                         ; af07: 4c bb 8f    L..
+
+sub_caf0a
+    jsr sub_c9dff                                                     ; af0a: 20 ff 9d     ..
+    bne caf88                                                         ; af0d: d0 79       .y
+    cpx #$2c ; ','                                                    ; af0f: e0 2c       .,
+    bne caf07                                                         ; af11: d0 f4       ..
+    jsr cbc91                                                         ; af13: 20 91 bc     ..
+    inc l001b                                                         ; af16: e6 1b       ..
+    jsr sub_c9774                                                     ; af18: 20 74 97     t.
+    lda l002a                                                         ; af1b: a5 2a       .*
+    pha                                                               ; af1d: 48          H
+    lda #$ff                                                          ; af1e: a9 ff       ..
+    sta l002a                                                         ; af20: 85 2a       .*
+    inc l001b                                                         ; af22: e6 1b       ..
+    cpx #$29 ; ')'                                                    ; af24: e0 29       .)
+    beq caf2f                                                         ; af26: f0 07       ..
+    cpx #$2c ; ','                                                    ; af28: e0 2c       .,
+    bne caf07                                                         ; af2a: d0 db       ..
+    jsr sub_c976c                                                     ; af2c: 20 6c 97     l.
+; $af2f referenced 1 time by $af26
+caf2f
+    jsr sub_cbd12                                                     ; af2f: 20 12 bd     ..
+    pla                                                               ; af32: 68          h
+    tay                                                               ; af33: a8          .
+    clc                                                               ; af34: 18          .
+    beq caf3d                                                         ; af35: f0 06       ..
+    sbc l0036                                                         ; af37: e5 36       .6
+    bcs caf03                                                         ; af39: b0 c8       ..
+    dey                                                               ; af3b: 88          .
+    tya                                                               ; af3c: 98          .
+; $af3d referenced 1 time by $af35
+caf3d
+    sta l002c                                                         ; af3d: 85 2c       .,
+    tax                                                               ; af3f: aa          .
+    ldy #0                                                            ; af40: a0 00       ..
+    lda l0036                                                         ; af42: a5 36       .6
+    sec                                                               ; af44: 38          8
+    sbc l002c                                                         ; af45: e5 2c       .,
+    cmp l002a                                                         ; af47: c5 2a       .*
+    bcs caf4d                                                         ; af49: b0 02       ..
+    sta l002a                                                         ; af4b: 85 2a       .*
+; $af4d referenced 1 time by $af49
+caf4d
+    lda l002a                                                         ; af4d: a5 2a       .*
+    beq caf03                                                         ; af4f: f0 b2       ..
+; $af51 referenced 1 time by $af5b
+loop_caf51
+    lda l0600,x                                                       ; af51: bd 00 06    ...
+    sta l0600,y                                                       ; af54: 99 00 06    ...
+    iny                                                               ; af57: c8          .
+    inx                                                               ; af58: e8          .
+    cpy l002a                                                         ; af59: c4 2a       .*
+    bne loop_caf51                                                    ; af5b: d0 f4       ..
+    sty l0036                                                         ; af5d: 84 36       .6
+    bra cafb8                                                         ; af5f: 80 57       .W
+sub_caf61
+    jsr c8f92                                                         ; af61: 20 92 8f     ..
+    ldy #$ff                                                          ; af64: a0 ff       ..
+    cmp #$7e ; '~'                                                    ; af66: c9 7e       .~
+    beq caf6d                                                         ; af68: f0 03       ..
+    iny                                                               ; af6a: c8          .
+    dec l001b                                                         ; af6b: c6 1b       ..
+; $af6d referenced 1 time by $af68
+caf6d
+    phy                                                               ; af6d: 5a          Z
+    jsr cad78                                                         ; af6e: 20 78 ad     x.
+    beq caf88                                                         ; af71: f0 15       ..
+    tay                                                               ; af73: a8          .
+    pla                                                               ; af74: 68          h
+    sta l0015                                                         ; af75: 85 15       ..
+    lda l0403                                                         ; af77: ad 03 04    ...
+    bne caf83                                                         ; af7a: d0 07       ..
+    sta l0037                                                         ; af7c: 85 37       .7
+    jsr ca19b                                                         ; af7e: 20 9b a1     ..
+    bra cafb8                                                         ; af81: 80 35       .5
+; $af83 referenced 1 time by $af7a
+caf83
+    jsr sub_ca181                                                     ; af83: 20 81 a1     ..
+    bra cafb8                                                         ; af86: 80 30       .0
+; $af88 referenced 3 times by $af0d, $af71, $af91
+caf88
+    jmp c9155                                                         ; af88: 4c 55 91    LU.
+
+sub_caf8b
+    jsr sub_c8fae                                                     ; af8b: 20 ae 8f     ..
+    jsr cadee                                                         ; af8e: 20 ee ad     ..
+    bne caf88                                                         ; af91: d0 f5       ..
+    jsr sub_cbd26                                                     ; af93: 20 26 bd     &.
+    ldy l0036                                                         ; af96: a4 36       .6
+    beq cafb8                                                         ; af98: f0 1e       ..
+    lda l002a                                                         ; af9a: a5 2a       .*
+    beq cafbb                                                         ; af9c: f0 1d       ..
+    dec l002a                                                         ; af9e: c6 2a       .*
+    beq cafb8                                                         ; afa0: f0 16       ..
+; $afa2 referenced 1 time by $afb4
+loop_cafa2
+    ldx #0                                                            ; afa2: a2 00       ..
+; $afa4 referenced 1 time by $afb0
+loop_cafa4
+    lda l0600,x                                                       ; afa4: bd 00 06    ...
+    sta l0600,y                                                       ; afa7: 99 00 06    ...
+    inx                                                               ; afaa: e8          .
+    iny                                                               ; afab: c8          .
+    beq cafbe                                                         ; afac: f0 10       ..
+    cpx l0036                                                         ; afae: e4 36       .6
+    bcc loop_cafa4                                                    ; afb0: 90 f2       ..
+    dec l002a                                                         ; afb2: c6 2a       .*
+    bne loop_cafa2                                                    ; afb4: d0 ec       ..
+    sty l0036                                                         ; afb6: 84 36       .6
+; $afb8 referenced 5 times by $af5f, $af81, $af86, $af98, $afa0
+cafb8
+    lda #0                                                            ; afb8: a9 00       ..
+    rts                                                               ; afba: 60          `
+
+; $afbb referenced 1 time by $af9c
+cafbb
+    sta l0036                                                         ; afbb: 85 36       .6
+    rts                                                               ; afbd: 60          `
+
+; $afbe referenced 1 time by $afac
+cafbe
+    jmp c9ecb                                                         ; afbe: 4c cb 9e    L..
+
+; $afc1 referenced 1 time by $afdf
+loop_cafc1
+    pla                                                               ; afc1: 68          h
+    sta l000c                                                         ; afc2: 85 0c       ..
+    pla                                                               ; afc4: 68          h
+    sta l000b                                                         ; afc5: 85 0b       ..
+    brk                                                               ; afc7: 00          .
+
+    !byte $1d                                                         ; afc8: 1d          .
+    !text "No such "                                                  ; afc9: 4e 6f 20... No
+    !byte $a4, $2f, $f2,   0                                          ; afd1: a4 2f f2... ./.
+
+; $afd5 referenced 1 time by $b0a3
+cafd5
+    lda l0018                                                         ; afd5: a5 18       ..
+    sta l000c                                                         ; afd7: 85 0c       ..
+    stz l000b                                                         ; afd9: 64 0b       d.
+; $afdb referenced 2 times by $aff7, $affb
+cafdb
+    ldy #1                                                            ; afdb: a0 01       ..
+    lda (l000b),y                                                     ; afdd: b1 0b       ..
+    bmi loop_cafc1                                                    ; afdf: 30 e0       0.
+    ldy #3                                                            ; afe1: a0 03       ..
+; $afe3 referenced 1 time by $afe8
+loop_cafe3
+    iny                                                               ; afe3: c8          .
+    lda (l000b),y                                                     ; afe4: b1 0b       ..
+    cmp #$20 ; ' '                                                    ; afe6: c9 20       .
+    beq loop_cafe3                                                    ; afe8: f0 f9       ..
+    cmp #$dd                                                          ; afea: c9 dd       ..
+    beq caffd                                                         ; afec: f0 0f       ..
+; $afee referenced 2 times by $b01e, $b02a
+cafee
+    ldy #3                                                            ; afee: a0 03       ..
+    lda (l000b),y                                                     ; aff0: b1 0b       ..
+    clc                                                               ; aff2: 18          .
+    adc l000b                                                         ; aff3: 65 0b       e.
+    sta l000b                                                         ; aff5: 85 0b       ..
+    bcc cafdb                                                         ; aff7: 90 e2       ..
+    inc l000c                                                         ; aff9: e6 0c       ..
+    bra cafdb                                                         ; affb: 80 de       ..
+; $affd referenced 1 time by $afec
+caffd
+    iny                                                               ; affd: c8          .
+    sty l000a                                                         ; affe: 84 0a       ..
+    jsr c8f9d                                                         ; b000: 20 9d 8f     ..
+    tya                                                               ; b003: 98          .
+    tax                                                               ; b004: aa          .
+    clc                                                               ; b005: 18          .
+    adc l000b                                                         ; b006: 65 0b       e.
+    ldy l000c                                                         ; b008: a4 0c       ..
+    bcc cb00e                                                         ; b00a: 90 02       ..
+    iny                                                               ; b00c: c8          .
+    clc                                                               ; b00d: 18          .
+; $b00e referenced 1 time by $b00a
+cb00e
+    sbc #0                                                            ; b00e: e9 00       ..
+    sta l003c                                                         ; b010: 85 3c       .<
+    tya                                                               ; b012: 98          .
+    sbc #0                                                            ; b013: e9 00       ..
+    sta l003d                                                         ; b015: 85 3d       .=
+    ldy #1                                                            ; b017: a0 01       ..
+; $b019 referenced 1 time by $b023
+loop_cb019
+    inx                                                               ; b019: e8          .
+    lda (l003c),y                                                     ; b01a: b1 3c       .<
+    cmp (l0037),y                                                     ; b01c: d1 37       .7
+    bne cafee                                                         ; b01e: d0 ce       ..
+    iny                                                               ; b020: c8          .
+    cpy l0039                                                         ; b021: c4 39       .9
+    bne loop_cb019                                                    ; b023: d0 f4       ..
+    lda (l003c),y                                                     ; b025: b1 3c       .<
+    jsr sub_c8e41                                                     ; b027: 20 41 8e     A.
+    bcs cafee                                                         ; b02a: b0 c2       ..
+    txa                                                               ; b02c: 8a          .
+    tay                                                               ; b02d: a8          .
+    jsr c9c80                                                         ; b02e: 20 80 9c     ..
+    jsr sub_c9914                                                     ; b031: 20 14 99     ..
+    ldx #1                                                            ; b034: a2 01       ..
+    jsr sub_c9952                                                     ; b036: 20 52 99     R.
+    lda l000b                                                         ; b039: a5 0b       ..
+    sta (l0002)                                                       ; b03b: 92 02       ..
+    ldy #1                                                            ; b03d: a0 01       ..
+    lda l000c                                                         ; b03f: a5 0c       ..
+    sta (l0002),y                                                     ; b041: 91 02       ..
+    iny                                                               ; b043: c8          .
+    jsr sub_c995a                                                     ; b044: 20 5a 99     Z.
+    jmp cb0b0                                                         ; b047: 4c b0 b0    L..
+
+; $b04a referenced 1 time by $b09a
+cb04a
+    brk                                                               ; b04a: 00          .
+
+    !byte $1e                                                         ; b04b: 1e          .
+    !text "Bad call"                                                  ; b04c: 42 61 64... Bad
+    !byte 0                                                           ; b054: 00          .
+
+sub_cb055
+    lda #$a4                                                          ; b055: a9 a4       ..
+; $b057 referenced 2 times by $97b7, $b83c
+sub_cb057
+    sta l0027                                                         ; b057: 85 27       .'
+    tsx                                                               ; b059: ba          .
+    txa                                                               ; b05a: 8a          .
+    clc                                                               ; b05b: 18          .
+    adc l0004                                                         ; b05c: 65 04       e.
+    jsr sub_cbd5e                                                     ; b05e: 20 5e bd     ^.
+    txa                                                               ; b061: 8a          .
+    sta (l0004)                                                       ; b062: 92 04       ..
+    ldy #0                                                            ; b064: a0 00       ..
+; $b066 referenced 1 time by $b06f
+loop_cb066
+    inx                                                               ; b066: e8          .
+    iny                                                               ; b067: c8          .
+    lda l0100,x                                                       ; b068: bd 00 01    ...
+    sta (l0004),y                                                     ; b06b: 91 04       ..
+    cpx #$ff                                                          ; b06d: e0 ff       ..
+    bne loop_cb066                                                    ; b06f: d0 f5       ..
+    txs                                                               ; b071: 9a          .
+    lda l0027                                                         ; b072: a5 27       .'
+    pha                                                               ; b074: 48          H
+    lda l000a                                                         ; b075: a5 0a       ..
+    pha                                                               ; b077: 48          H
+    lda l000b                                                         ; b078: a5 0b       ..
+    pha                                                               ; b07a: 48          H
+    lda l000c                                                         ; b07b: a5 0c       ..
+    pha                                                               ; b07d: 48          H
+    lda l001b                                                         ; b07e: a5 1b       ..
+    tax                                                               ; b080: aa          .
+    clc                                                               ; b081: 18          .
+    adc l0019                                                         ; b082: 65 19       e.
+    ldy l001a                                                         ; b084: a4 1a       ..
+    bcc cb08a                                                         ; b086: 90 02       ..
+    iny                                                               ; b088: c8          .
+    clc                                                               ; b089: 18          .
+; $b08a referenced 1 time by $b086
+cb08a
+    sbc #1                                                            ; b08a: e9 01       ..
+    sta l0037                                                         ; b08c: 85 37       .7
+    tya                                                               ; b08e: 98          .
+    sbc #0                                                            ; b08f: e9 00       ..
+    sta l0038                                                         ; b091: 85 38       .8
+    ldy #2                                                            ; b093: a0 02       ..
+    jsr c9bbc                                                         ; b095: 20 bc 9b     ..
+    cpy #2                                                            ; b098: c0 02       ..
+    beq cb04a                                                         ; b09a: f0 ae       ..
+    stx l001b                                                         ; b09c: 86 1b       ..
+    jsr sub_c8139                                                     ; b09e: 20 39 81     9.
+    bne cb0a6                                                         ; b0a1: d0 03       ..
+    jmp cafd5                                                         ; b0a3: 4c d5 af    L..
+
+; $b0a6 referenced 1 time by $b0a1
+cb0a6
+    lda (l002a)                                                       ; b0a6: b2 2a       .*
+    sta l000b                                                         ; b0a8: 85 0b       ..
+    ldy #1                                                            ; b0aa: a0 01       ..
+    lda (l002a),y                                                     ; b0ac: b1 2a       .*
+    sta l000c                                                         ; b0ae: 85 0c       ..
+; $b0b0 referenced 1 time by $b047
+cb0b0
+    lda #0                                                            ; b0b0: a9 00       ..
+    pha                                                               ; b0b2: 48          H
+    stz l000a                                                         ; b0b3: 64 0a       d.
+    jsr c8f9d                                                         ; b0b5: 20 9d 8f     ..
+    cmp #$28 ; '('                                                    ; b0b8: c9 28       .(
+    beq cb109                                                         ; b0ba: f0 4d       .M
+    dec l000a                                                         ; b0bc: c6 0a       ..
+; $b0be referenced 1 time by $b1bc
+cb0be
+    lda l001b                                                         ; b0be: a5 1b       ..
+    pha                                                               ; b0c0: 48          H
+    lda l0019                                                         ; b0c1: a5 19       ..
+    pha                                                               ; b0c3: 48          H
+    lda l001a                                                         ; b0c4: a5 1a       ..
+    pha                                                               ; b0c6: 48          H
+    jsr c90d0                                                         ; b0c7: 20 d0 90     ..
+    pla                                                               ; b0ca: 68          h
+    sta l001a                                                         ; b0cb: 85 1a       ..
+    pla                                                               ; b0cd: 68          h
+    sta l0019                                                         ; b0ce: 85 19       ..
+    pla                                                               ; b0d0: 68          h
+    sta l001b                                                         ; b0d1: 85 1b       ..
+    pla                                                               ; b0d3: 68          h
+    beq cb0e2                                                         ; b0d4: f0 0c       ..
+    sta l003f                                                         ; b0d6: 85 3f       .?
+; $b0d8 referenced 1 time by $b0e0
+loop_cb0d8
+    jsr sub_cbd46                                                     ; b0d8: 20 46 bd     F.
+    jsr sub_cbcaa                                                     ; b0db: 20 aa bc     ..
+    dec l003f                                                         ; b0de: c6 3f       .?
+    bne loop_cb0d8                                                    ; b0e0: d0 f6       ..
+; $b0e2 referenced 1 time by $b0d4
+cb0e2
+    pla                                                               ; b0e2: 68          h
+    sta l000c                                                         ; b0e3: 85 0c       ..
+    pla                                                               ; b0e5: 68          h
+    sta l000b                                                         ; b0e6: 85 0b       ..
+    pla                                                               ; b0e8: 68          h
+    sta l000a                                                         ; b0e9: 85 0a       ..
+    pla                                                               ; b0eb: 68          h
+    lda (l0004)                                                       ; b0ec: b2 04       ..
+    tax                                                               ; b0ee: aa          .
+    txs                                                               ; b0ef: 9a          .
+    ldy #0                                                            ; b0f0: a0 00       ..
+; $b0f2 referenced 1 time by $b0fb
+loop_cb0f2
+    iny                                                               ; b0f2: c8          .
+    inx                                                               ; b0f3: e8          .
+    lda (l0004),y                                                     ; b0f4: b1 04       ..
+    sta l0100,x                                                       ; b0f6: 9d 00 01    ...
+    cpx #$ff                                                          ; b0f9: e0 ff       ..
+    bne loop_cb0f2                                                    ; b0fb: d0 f5       ..
+    tya                                                               ; b0fd: 98          .
+    adc l0004                                                         ; b0fe: 65 04       e.
+    sta l0004                                                         ; b100: 85 04       ..
+    bcc cb106                                                         ; b102: 90 02       ..
+    inc l0005                                                         ; b104: e6 05       ..
+; $b106 referenced 1 time by $b102
+cb106
+    lda l0027                                                         ; b106: a5 27       .'
+    rts                                                               ; b108: 60          `
+
+; $b109 referenced 2 times by $b0ba, $b136
+cb109
+    lda l001b                                                         ; b109: a5 1b       ..
+    pha                                                               ; b10b: 48          H
+    lda l0019                                                         ; b10c: a5 19       ..
+    pha                                                               ; b10e: 48          H
+    lda l001a                                                         ; b10f: a5 1a       ..
+    pha                                                               ; b111: 48          H
+    jsr sub_c997d                                                     ; b112: 20 7d 99     }.
+    beq cb169                                                         ; b115: f0 52       .R
+    lda l001b                                                         ; b117: a5 1b       ..
+    sta l000a                                                         ; b119: 85 0a       ..
+    pla                                                               ; b11b: 68          h
+    sta l001a                                                         ; b11c: 85 1a       ..
+    pla                                                               ; b11e: 68          h
+    sta l0019                                                         ; b11f: 85 19       ..
+    pla                                                               ; b121: 68          h
+    sta l001b                                                         ; b122: 85 1b       ..
+    plx                                                               ; b124: fa          .
+    lda l002c                                                         ; b125: a5 2c       .,
+    pha                                                               ; b127: 48          H
+    lda l002b                                                         ; b128: a5 2b       .+
+    pha                                                               ; b12a: 48          H
+    lda l002a                                                         ; b12b: a5 2a       .*
+    pha                                                               ; b12d: 48          H
+    inx                                                               ; b12e: e8          .
+    phx                                                               ; b12f: da          .
+    jsr sub_cb1bf                                                     ; b130: 20 bf b1     ..
+    jsr sub_c8da2                                                     ; b133: 20 a2 8d     ..
+    beq cb109                                                         ; b136: f0 d1       ..
+    cmp #$29 ; ')'                                                    ; b138: c9 29       .)
+    bne cb169                                                         ; b13a: d0 2d       .-
+    lda #0                                                            ; b13c: a9 00       ..
+    pha                                                               ; b13e: 48          H
+    jsr c8f92                                                         ; b13f: 20 92 8f     ..
+    cmp #$28 ; '('                                                    ; b142: c9 28       .(
+    bne cb169                                                         ; b144: d0 23       .#
+; $b146 referenced 1 time by $b159
+loop_cb146
+    jsr sub_c9dff                                                     ; b146: 20 ff 9d     ..
+    jsr sub_cbc62                                                     ; b149: 20 62 bc     b.
+    lda l0027                                                         ; b14c: a5 27       .'
+    sta l002d                                                         ; b14e: 85 2d       .-
+    jsr cbc66                                                         ; b150: 20 66 bc     f.
+    plx                                                               ; b153: fa          .
+    inx                                                               ; b154: e8          .
+    phx                                                               ; b155: da          .
+    jsr sub_c8fa8                                                     ; b156: 20 a8 8f     ..
+    beq loop_cb146                                                    ; b159: f0 eb       ..
+    cmp #$29 ; ')'                                                    ; b15b: c9 29       .)
+    bne cb169                                                         ; b15d: d0 0a       ..
+    pla                                                               ; b15f: 68          h
+    pla                                                               ; b160: 68          h
+    sta l004c                                                         ; b161: 85 4c       .L
+    sta l004d                                                         ; b163: 85 4d       .M
+    cpx l004c                                                         ; b165: e4 4c       .L
+    beq cb17e                                                         ; b167: f0 15       ..
+; $b169 referenced 6 times by $b115, $b13a, $b144, $b15d, $b18e, $b1ad
+cb169
+    ldx #$fb                                                          ; b169: a2 fb       ..
+    txs                                                               ; b16b: 9a          .
+    pla                                                               ; b16c: 68          h
+    sta l000c                                                         ; b16d: 85 0c       ..
+    pla                                                               ; b16f: 68          h
+    sta l000b                                                         ; b170: 85 0b       ..
+    brk                                                               ; b172: 00          .
+
+    !byte $1f                                                         ; b173: 1f          .
+    !text "Arguments"                                                 ; b174: 41 72 67... Arg
+    !byte 0                                                           ; b17d: 00          .
+
+; $b17e referenced 2 times by $b167, $b1b7
+cb17e
+    jsr sub_cbd26                                                     ; b17e: 20 26 bd     &.
+    pla                                                               ; b181: 68          h
+    sta l002a                                                         ; b182: 85 2a       .*
+    pla                                                               ; b184: 68          h
+    sta l002b                                                         ; b185: 85 2b       .+
+    pla                                                               ; b187: 68          h
+    sta l002c                                                         ; b188: 85 2c       .,
+    bmi cb1ab                                                         ; b18a: 30 1f       0.
+    lda l002d                                                         ; b18c: a5 2d       .-
+    beq cb169                                                         ; b18e: f0 d9       ..
+    sta l0027                                                         ; b190: 85 27       .'
+    ldx #$37 ; '7'                                                    ; b192: a2 37       .7
+    jsr sub_cbe06                                                     ; b194: 20 06 be     ..
+    lda l0027                                                         ; b197: a5 27       .'
+    bpl cb1a3                                                         ; b199: 10 08       ..
+    jsr sub_cbc24                                                     ; b19b: 20 24 bc     $.
+    jsr ca57e                                                         ; b19e: 20 7e a5     ~.
+    bra cb1a6                                                         ; b1a1: 80 03       ..
+; $b1a3 referenced 1 time by $b199
+cb1a3
+    jsr sub_cbd26                                                     ; b1a3: 20 26 bd     &.
+; $b1a6 referenced 1 time by $b1a1
+cb1a6
+    jsr sub_cb372                                                     ; b1a6: 20 72 b3     r.
+    bra cb1b5                                                         ; b1a9: 80 0a       ..
+; $b1ab referenced 1 time by $b18a
+cb1ab
+    lda l002d                                                         ; b1ab: a5 2d       .-
+    bne cb169                                                         ; b1ad: d0 ba       ..
+    jsr sub_cbd12                                                     ; b1af: 20 12 bd     ..
+    jsr sub_c9171                                                     ; b1b2: 20 71 91     q.
+; $b1b5 referenced 1 time by $b1a9
+cb1b5
+    dec l004c                                                         ; b1b5: c6 4c       .L
+    bne cb17e                                                         ; b1b7: d0 c5       ..
+    lda l004d                                                         ; b1b9: a5 4d       .M
+    pha                                                               ; b1bb: 48          H
+    jmp cb0be                                                         ; b1bc: 4c be b0    L..
+
+; $b1bf referenced 2 times by $97dc, $b130
+sub_cb1bf
+    ldy l002c                                                         ; b1bf: a4 2c       .,
+    cpy #5                                                            ; b1c1: c0 05       ..
+    bcs cb1ca                                                         ; b1c3: b0 05       ..
+    ldx #$37 ; '7'                                                    ; b1c5: a2 37       .7
+    jsr sub_cbe06                                                     ; b1c7: 20 06 be     ..
+; $b1ca referenced 1 time by $b1c3
+cb1ca
+    jsr cb1de                                                         ; b1ca: 20 de b1     ..
+    php                                                               ; b1cd: 08          .
+    jsr sub_cbc62                                                     ; b1ce: 20 62 bc     b.
+    plp                                                               ; b1d1: 28          (
+    beq cb1db                                                         ; b1d2: f0 07       ..
+    bmi cb1db                                                         ; b1d4: 30 05       0.
+    ldx #$37 ; '7'                                                    ; b1d6: a2 37       .7
+    jsr sub_caad8                                                     ; b1d8: 20 d8 aa     ..
+; $b1db referenced 2 times by $b1d2, $b1d4
+cb1db
+    jmp cbc66                                                         ; b1db: 4c 66 bc    Lf.
+
+; $b1de referenced 3 times by $9a7f, $adb3, $b1ca
+cb1de
+    ldy l002c                                                         ; b1de: a4 2c       .,
+    bmi cb235                                                         ; b1e0: 30 53       0S
+    beq cb200                                                         ; b1e2: f0 1c       ..
+    cpy #5                                                            ; b1e4: c0 05       ..
+    beq cb205                                                         ; b1e6: f0 1d       ..
+    ldy #3                                                            ; b1e8: a0 03       ..
+    lda (l002a),y                                                     ; b1ea: b1 2a       .*
+    sta l002d                                                         ; b1ec: 85 2d       .-
+    dey                                                               ; b1ee: 88          .
+    lda (l002a),y                                                     ; b1ef: b1 2a       .*
+    sta l002c                                                         ; b1f1: 85 2c       .,
+    dey                                                               ; b1f3: 88          .
+    lda (l002a),y                                                     ; b1f4: b1 2a       .*
+    tax                                                               ; b1f6: aa          .
+    lda (l002a)                                                       ; b1f7: b2 2a       .*
+    sta l002a                                                         ; b1f9: 85 2a       .*
+    stx l002b                                                         ; b1fb: 86 2b       .+
+    lda #$40 ; '@'                                                    ; b1fd: a9 40       .@
+    rts                                                               ; b1ff: 60          `
+
+; $b200 referenced 1 time by $b1e2
+cb200
+    lda (l002a),y                                                     ; b200: b1 2a       .*
+    jmp cae62                                                         ; b202: 4c 62 ae    Lb.
+
+; $b205 referenced 2 times by $b1e6, $b5f1
+cb205
+    stz l0035                                                         ; b205: 64 35       d5
+    stz l002f                                                         ; b207: 64 2f       d/
+    dey                                                               ; b209: 88          .
+    lda (l002a),y                                                     ; b20a: b1 2a       .*
+    sta l0034                                                         ; b20c: 85 34       .4
+    dey                                                               ; b20e: 88          .
+    lda (l002a),y                                                     ; b20f: b1 2a       .*
+    sta l0033                                                         ; b211: 85 33       .3
+    dey                                                               ; b213: 88          .
+    lda (l002a),y                                                     ; b214: b1 2a       .*
+    sta l0032                                                         ; b216: 85 32       .2
+    dey                                                               ; b218: 88          .
+    lda (l002a),y                                                     ; b219: b1 2a       .*
+    sta l002e                                                         ; b21b: 85 2e       ..
+    tay                                                               ; b21d: a8          .
+    lda (l002a)                                                       ; b21e: b2 2a       .*
+    sta l0030                                                         ; b220: 85 30       .0
+    bne cb22d                                                         ; b222: d0 09       ..
+    tya                                                               ; b224: 98          .
+    ora l0032                                                         ; b225: 05 32       .2
+    ora l0033                                                         ; b227: 05 33       .3
+    ora l0034                                                         ; b229: 05 34       .4
+    beq cb230                                                         ; b22b: f0 03       ..
+; $b22d referenced 1 time by $b222
+cb22d
+    tya                                                               ; b22d: 98          .
+    ora #$80                                                          ; b22e: 09 80       ..
+; $b230 referenced 1 time by $b22b
+cb230
+    sta l0031                                                         ; b230: 85 31       .1
+    lda #$ff                                                          ; b232: a9 ff       ..
+    rts                                                               ; b234: 60          `
+
+; $b235 referenced 1 time by $b1e0
+cb235
+    cpy #$80                                                          ; b235: c0 80       ..
+    beq cb257                                                         ; b237: f0 1e       ..
+    ldy #3                                                            ; b239: a0 03       ..
+    lda (l002a),y                                                     ; b23b: b1 2a       .*
+    sta l0036                                                         ; b23d: 85 36       .6
+    beq cb256                                                         ; b23f: f0 15       ..
+    ldy #1                                                            ; b241: a0 01       ..
+    lda (l002a),y                                                     ; b243: b1 2a       .*
+    sta l0038                                                         ; b245: 85 38       .8
+    lda (l002a)                                                       ; b247: b2 2a       .*
+    sta l0037                                                         ; b249: 85 37       .7
+    ldy l0036                                                         ; b24b: a4 36       .6
+; $b24d referenced 1 time by $b254
+loop_cb24d
+    dey                                                               ; b24d: 88          .
+    lda (l0037),y                                                     ; b24e: b1 37       .7
+    sta l0600,y                                                       ; b250: 99 00 06    ...
+    tya                                                               ; b253: 98          .
+    bne loop_cb24d                                                    ; b254: d0 f7       ..
+; $b256 referenced 1 time by $b23f
+cb256
+    rts                                                               ; b256: 60          `
+
+; $b257 referenced 1 time by $b237
+cb257
+    ldy #0                                                            ; b257: a0 00       ..
+; $b259 referenced 1 time by $b263
+loop_cb259
+    lda (l002a),y                                                     ; b259: b1 2a       .*
+    sta l0600,y                                                       ; b25b: 99 00 06    ...
+    eor #$0d                                                          ; b25e: 49 0d       I.
+    beq cb266                                                         ; b260: f0 04       ..
+    iny                                                               ; b262: c8          .
+    bne loop_cb259                                                    ; b263: d0 f4       ..
+    tya                                                               ; b265: 98          .
+; $b266 referenced 1 time by $b260
+cb266
+    sty l0036                                                         ; b266: 84 36       .6
+    rts                                                               ; b268: 60          `
+
+sub_cb269
+    jsr sub_c9779                                                     ; b269: 20 79 97     y.
+    lda l002a                                                         ; b26c: a5 2a       .*
+    jmp caeb4                                                         ; b26e: 4c b4 ae    L..
+
+    !byte $a4, $0a, $f0,   1, $88, $20, $80, $9c, $64,   8, $64,   9  ; b271: a4 0a f0... ...
+    !byte $a6, $18, $86                                               ; b27d: a6 18 86    ...
+    !text "8d7"                                                       ; b280: 38 64 37    8d7
+    !byte $a4, $0c, $c0,   7, $f0, $28, $a6, $0b, $20, $5d, $8e, $c9  ; b283: a4 0c c0... ...
+    !byte $0d, $d0, $18, $e4, $37, $98, $e5, $38, $90, $18, $20, $5d  ; b28f: 0d d0 18... ...
+    !byte $8e,   9,   0, $30, $11, $85,   9, $20, $5d, $8e, $85,   8  ; b29b: 8e 09 00... ...
+    !byte $20, $5d, $8e, $e4, $37, $98, $e5, $38, $b0, $da, $60, $a2  ; b2a7: 20 5d 8e...  ].
+    !byte $ff, $86, $28, $9a, $e8, $a0,   0, $a9, $da, $20, $f4, $ff  ; b2b3: ff 86 28... ..(
+    !byte $a9, $7e, $20, $f4, $ff, $20, $71, $b2, $64, $20, $b2, $fd  ; b2bf: a9 7e 20... .~
+    !byte $d0,   3, $20, $e0, $b2, $a5, $16, $85, $0b, $a5, $17, $85  ; b2cb: d0 03 20... ..
+    !byte $0c, $64, $0a, $20, $ff, $bb, $4c, $d0, $90                 ; b2d7: 0c 64 0a... .d.
+
+; $b2e0 referenced 3 times by $9051, $905f, $b76c
+sub_cb2e0
+    lda #$e9                                                          ; b2e0: a9 e9       ..
+    sta l0016                                                         ; b2e2: 85 16       ..
+    lda #$b2                                                          ; b2e4: a9 b2       ..
+    sta l0017                                                         ; b2e6: 85 17       ..
+    rts                                                               ; b2e8: 60          `
+
+    !byte $f6, $3a, $e7, $9e, $f1                                     ; b2e9: f6 3a e7... .:.
+    !text '"', " at line ", '"', ";"                                  ; b2ee: 22 20 61... " a
+    !byte $9e, $3a, $e0, $8b, $f1, $3a, $e0, $0d                      ; b2fa: 9e 3a e0... .:.
+
+sub_cb302
+    jsr sub_c9332                                                     ; b302: 20 32 93     2.
+    ldx #3                                                            ; b305: a2 03       ..
+; $b307 referenced 1 time by $b313
+loop_cb307
+    lda l002a                                                         ; b307: a5 2a       .*
+    pha                                                               ; b309: 48          H
+    lda l002b                                                         ; b30a: a5 2b       .+
+    pha                                                               ; b30c: 48          H
+    phx                                                               ; b30d: da          .
+    jsr sub_c9771                                                     ; b30e: 20 71 97     q.
+    plx                                                               ; b311: fa          .
+    dex                                                               ; b312: ca          .
+    bne loop_cb307                                                    ; b313: d0 f2       ..
+    jsr sub_c9c5a                                                     ; b315: 20 5a 9c     Z.
+    lda l002a                                                         ; b318: a5 2a       .*
+    sta l003d                                                         ; b31a: 85 3d       .=
+    lda l002b                                                         ; b31c: a5 2b       .+
+    sta l003e                                                         ; b31e: 85 3e       .>
+    ldy #7                                                            ; b320: a0 07       ..
+    ldx #5                                                            ; b322: a2 05       ..
+    bra cb341                                                         ; b324: 80 1b       ..
+sub_cb326
+    jsr sub_c9332                                                     ; b326: 20 32 93     2.
+    ldx #$0d                                                          ; b329: a2 0d       ..
+; $b32b referenced 1 time by $b334
+loop_cb32b
+    lda l002a                                                         ; b32b: a5 2a       .*
+    pha                                                               ; b32d: 48          H
+    phx                                                               ; b32e: da          .
+    jsr sub_c9771                                                     ; b32f: 20 71 97     q.
+    plx                                                               ; b332: fa          .
+    dex                                                               ; b333: ca          .
+    bne loop_cb32b                                                    ; b334: d0 f5       ..
+    jsr sub_c9c5a                                                     ; b336: 20 5a 9c     Z.
+    lda l002a                                                         ; b339: a5 2a       .*
+    sta l0044                                                         ; b33b: 85 44       .D
+    ldx #$0c                                                          ; b33d: a2 0c       ..
+    ldy #8                                                            ; b33f: a0 08       ..
+; $b341 referenced 2 times by $b324, $b345
+cb341
+    pla                                                               ; b341: 68          h
+    sta l0037,x                                                       ; b342: 95 37       .7
+    dex                                                               ; b344: ca          .
+    bpl cb341                                                         ; b345: 10 fa       ..
+    tya                                                               ; b347: 98          .
+    ldx #<(l0037)                                                     ; b348: a2 37       .7
+    ldy #>(l0037)                                                     ; b34a: a0 00       ..
+; $b34c referenced 1 time by $9750
+cb34c
+    jsr osword                                                        ; b34c: 20 f1 ff     ..
+    bra cb35c                                                         ; b34f: 80 0b       ..
+sub_cb351
+    jsr sub_c9332                                                     ; b351: 20 32 93     2.
+    jsr sub_c9c5a                                                     ; b354: 20 5a 9c     Z.
+    ldy l002a                                                         ; b357: a4 2a       .*
+    dey                                                               ; b359: 88          .
+    sty l0023                                                         ; b35a: 84 23       .#
+; $b35c referenced 1 time by $b34f
+cb35c
+    jmp c90ca                                                         ; b35c: 4c ca 90    L..
+
+; $b35f referenced 1 time by $b377
+loop_cb35f
+    jmp c9155                                                         ; b35f: 4c 55 91    LU.
+
+; $b362 referenced 2 times by $b656, $b9ba
+sub_cb362
+    jsr sub_c9dff                                                     ; b362: 20 ff 9d     ..
+; $b365 referenced 5 times by $8aa0, $9141, $95b8, $97eb, $b971
+sub_cb365
+    ply                                                               ; b365: 7a          z
+    plx                                                               ; b366: fa          .
+    pla                                                               ; b367: 68          h
+    sta l0039                                                         ; b368: 85 39       .9
+    pla                                                               ; b36a: 68          h
+    sta l0038                                                         ; b36b: 85 38       .8
+    pla                                                               ; b36d: 68          h
+    sta l0037                                                         ; b36e: 85 37       .7
+    phx                                                               ; b370: da          .
+    phy                                                               ; b371: 5a          Z
+; $b372 referenced 2 times by $b1a6, $b8dd
+sub_cb372
+    lda l0039                                                         ; b372: a5 39       .9
+    lsr                                                               ; b374: 4a          J
+    lda l0027                                                         ; b375: a5 27       .'
+    beq loop_cb35f                                                    ; b377: f0 e6       ..
+    bcs cb399                                                         ; b379: b0 1e       ..
+    bpl cb380                                                         ; b37b: 10 03       ..
+    jsr sub_c9788                                                     ; b37d: 20 88 97     ..
+; $b380 referenced 1 time by $b37b
+cb380
+    lda l002a                                                         ; b380: a5 2a       .*
+    sta (l0037)                                                       ; b382: 92 37       .7
+    lda l0039                                                         ; b384: a5 39       .9
+    beq cb398                                                         ; b386: f0 10       ..
+    lda l002b                                                         ; b388: a5 2b       .+
+    ldy #1                                                            ; b38a: a0 01       ..
+    sta (l0037),y                                                     ; b38c: 91 37       .7
+    lda l002c                                                         ; b38e: a5 2c       .,
+    iny                                                               ; b390: c8          .
+    sta (l0037),y                                                     ; b391: 91 37       .7
+    lda l002d                                                         ; b393: a5 2d       .-
+    iny                                                               ; b395: c8          .
+    sta (l0037),y                                                     ; b396: 91 37       .7
+; $b398 referenced 1 time by $b386
+cb398
+    rts                                                               ; b398: 60          `
+
+; $b399 referenced 1 time by $b379
+cb399
+    bmi cb39e                                                         ; b399: 30 03       0.
+    jsr c828d                                                         ; b39b: 20 8d 82     ..
+; $b39e referenced 2 times by $b399, $b609
+cb39e
+    lda l0030                                                         ; b39e: a5 30       .0
+    sta (l0037)                                                       ; b3a0: 92 37       .7
+    ldy #1                                                            ; b3a2: a0 01       ..
+    lda l002e                                                         ; b3a4: a5 2e       ..
+    eor l0031                                                         ; b3a6: 45 31       E1
+    and #$80                                                          ; b3a8: 29 80       ).
+    eor l0031                                                         ; b3aa: 45 31       E1
+    sta (l0037),y                                                     ; b3ac: 91 37       .7
+    iny                                                               ; b3ae: c8          .
+    lda l0032                                                         ; b3af: a5 32       .2
+    sta (l0037),y                                                     ; b3b1: 91 37       .7
+    iny                                                               ; b3b3: c8          .
+    lda l0033                                                         ; b3b4: a5 33       .3
+    sta (l0037),y                                                     ; b3b6: 91 37       .7
+    iny                                                               ; b3b8: c8          .
+    lda l0034                                                         ; b3b9: a5 34       .4
+    sta (l0037),y                                                     ; b3bb: 91 37       .7
+    rts                                                               ; b3bd: 60          `
+
+; $b3be referenced 1 time by $bf56
+lb3be
+    !text "EDIT 12,2"                                                 ; b3be: 45 44 49... EDI
+    !byte $0d                                                         ; b3c7: 0d          .
+
+sub_cb3c8
+    jsr sub_cbbdc                                                     ; b3c8: 20 dc bb     ..
+    lda #$80                                                          ; b3cb: a9 80       ..
+    sta l001f                                                         ; b3cd: 85 1f       ..
+; $b3cf referenced 1 time by $b417
+cb3cf
+    stz l003b                                                         ; b3cf: 64 3b       d;
+    stz l003c                                                         ; b3d1: 64 3c       d<
+    jsr cac38                                                         ; b3d3: 20 38 ac     8.
+    jsr sub_c9be2                                                     ; b3d6: 20 e2 9b     ..
+    php                                                               ; b3d9: 08          .
+    jsr cbc66                                                         ; b3da: 20 66 bc     f.
+    jsr cac2b                                                         ; b3dd: 20 2b ac     +.
+    lsr l002b                                                         ; b3e0: 46 2b       F+
+    plp                                                               ; b3e2: 28          (
+    bcc cb3f4                                                         ; b3e3: 90 0f       ..
+    jsr sub_c8da2                                                     ; b3e5: 20 a2 8d     ..
+    beq cb3fb                                                         ; b3e8: f0 11       ..
+    jsr sub_cbd26                                                     ; b3ea: 20 26 bd     &.
+    jsr cbc66                                                         ; b3ed: 20 66 bc     f.
+    dec l000a                                                         ; b3f0: c6 0a       ..
+    bra cb3fe                                                         ; b3f2: 80 0a       ..
+; $b3f4 referenced 1 time by $b3e3
+cb3f4
+    jsr sub_c8da2                                                     ; b3f4: 20 a2 8d     ..
+    beq cb3fb                                                         ; b3f7: f0 02       ..
+    dec l000a                                                         ; b3f9: c6 0a       ..
+; $b3fb referenced 2 times by $b3e8, $b3f7
+cb3fb
+    jsr sub_c9be2                                                     ; b3fb: 20 e2 9b     ..
+; $b3fe referenced 1 time by $b3f2
+cb3fe
+    ldx #$31 ; '1'                                                    ; b3fe: a2 31       .1
+    jsr sub_cbe06                                                     ; b400: 20 06 be     ..
+    jsr c8f9d                                                         ; b403: 20 9d 8f     ..
+    cmp #$e7                                                          ; b406: c9 e7       ..
+    bne cb428                                                         ; b408: d0 1e       ..
+    jsr c8f9d                                                         ; b40a: 20 9d 8f     ..
+    jsr c9c80                                                         ; b40d: 20 80 9c     ..
+    bra cb42b                                                         ; b410: 80 19       ..
+sub_cb412
+    iny                                                               ; b412: c8          .
+    lda (l000b),y                                                     ; b413: b1 0b       ..
+    cmp #$4f ; 'O'                                                    ; b415: c9 4f       .O
+    bne cb3cf                                                         ; b417: d0 b6       ..
+    inc l000a                                                         ; b419: e6 0a       ..
+    jsr sub_c9332                                                     ; b41b: 20 32 93     2.
+    jsr c9c6a                                                         ; b41e: 20 6a 9c     j.
+    lda l002a                                                         ; b421: a5 2a       .*
+    sta l001f                                                         ; b423: 85 1f       ..
+; $b425 referenced 1 time by $b46a
+cb425
+    jmp c904b                                                         ; b425: 4c 4b 90    LK.
+
+; $b428 referenced 1 time by $b408
+cb428
+    jsr c9c74                                                         ; b428: 20 74 9c     t.
+; $b42b referenced 1 time by $b410
+cb42b
+    lda l000b                                                         ; b42b: a5 0b       ..
+    sta l0019                                                         ; b42d: 85 19       ..
+    jsr sub_cbe25                                                     ; b42f: 20 25 be     %.
+    jsr sub_cbd26                                                     ; b432: 20 26 bd     &.
+    jsr sub_c8191                                                     ; b435: 20 91 81     ..
+    lda l003d                                                         ; b438: a5 3d       .=
+    sta l000b                                                         ; b43a: 85 0b       ..
+    lda l003e                                                         ; b43c: a5 3e       .>
+    sta l000c                                                         ; b43e: 85 0c       ..
+    bcs cb45d                                                         ; b440: b0 1b       ..
+    dey                                                               ; b442: 88          .
+    bra cb454                                                         ; b443: 80 0f       ..
+; $b445 referenced 1 time by $b4b8
+cb445
+    jsr cbdd4                                                         ; b445: 20 d4 bd     ..
+    bit l001f                                                         ; b448: 24 1f       $.
+    bmi cb451                                                         ; b44a: 30 05       0.
+    lda #$0a                                                          ; b44c: a9 0a       ..
+    jsr oswrch                                                        ; b44e: 20 ee ff     ..
+; $b451 referenced 2 times by $b44a, $b4c4
+cb451
+    jsr c9c80                                                         ; b451: 20 80 9c     ..
+; $b454 referenced 1 time by $b443
+cb454
+    lda (l000b),y                                                     ; b454: b1 0b       ..
+    sta l002b                                                         ; b456: 85 2b       .+
+    iny                                                               ; b458: c8          .
+    lda (l000b),y                                                     ; b459: b1 0b       ..
+    sta l002a                                                         ; b45b: 85 2a       .*
+; $b45d referenced 1 time by $b440
+cb45d
+    lda l002a                                                         ; b45d: a5 2a       .*
+    clc                                                               ; b45f: 18          .
+    sbc l0031                                                         ; b460: e5 31       .1
+    lda l002b                                                         ; b462: a5 2b       .+
+    sbc l0032                                                         ; b464: e5 32       .2
+    bcc cb46f                                                         ; b466: 90 07       ..
+    bit l001f                                                         ; b468: 24 1f       $.
+    bpl cb425                                                         ; b46a: 10 b9       ..
+    jmp cbf54                                                         ; b46c: 4c 54 bf    LT.
+
+; $b46f referenced 1 time by $b466
+cb46f
+    stz l004c                                                         ; b46f: 64 4c       dL
+    stz l004d                                                         ; b471: 64 4d       dM
+    ldy #4                                                            ; b473: a0 04       ..
+    sty l000a                                                         ; b475: 84 0a       ..
+    sty l001b                                                         ; b477: 84 1b       ..
+    bit l003b                                                         ; b479: 24 3b       $;
+    bpl cb47f                                                         ; b47b: 10 02       ..
+    stz l003b                                                         ; b47d: 64 3b       d;
+; $b47f referenced 1 time by $b47b
+cb47f
+    bit l003c                                                         ; b47f: 24 3c       $<
+    bpl cb485                                                         ; b481: 10 02       ..
+    stz l003c                                                         ; b483: 64 3c       d<
+; $b485 referenced 2 times by $b481, $b4c0
+cb485
+    lda (l000b),y                                                     ; b485: b1 0b       ..
+    cmp #$0d                                                          ; b487: c9 0d       ..
+    beq cb4c2                                                         ; b489: f0 37       .7
+    cmp #$f4                                                          ; b48b: c9 f4       ..
+    beq cb495                                                         ; b48d: f0 06       ..
+    cmp #$22 ; '"'                                                    ; b48f: c9 22       ."
+    bne cb497                                                         ; b491: d0 04       ..
+    eor l004c                                                         ; b493: 45 4c       EL
+; $b495 referenced 1 time by $b48d
+cb495
+    sta l004c                                                         ; b495: 85 4c       .L
+; $b497 referenced 1 time by $b491
+cb497
+    ldx l004c                                                         ; b497: a6 4c       .L
+    bne cb4a7                                                         ; b499: d0 0c       ..
+    cmp #$ed                                                          ; b49b: c9 ed       ..
+    bne cb4a1                                                         ; b49d: d0 02       ..
+    dec l003b                                                         ; b49f: c6 3b       .;
+; $b4a1 referenced 1 time by $b49d
+cb4a1
+    cmp #$fd                                                          ; b4a1: c9 fd       ..
+    bne cb4a7                                                         ; b4a3: d0 02       ..
+    dec l003c                                                         ; b4a5: c6 3c       .<
+; $b4a7 referenced 2 times by $b499, $b4a3
+cb4a7
+    ldx l0019                                                         ; b4a7: a6 19       ..
+; $b4a9 referenced 1 time by $b4b6
+loop_cb4a9
+    lda l0700,x                                                       ; b4a9: bd 00 07    ...
+    cmp #$0d                                                          ; b4ac: c9 0d       ..
+    beq cb4ba                                                         ; b4ae: f0 0a       ..
+    cmp (l000b),y                                                     ; b4b0: d1 0b       ..
+    bne cb4bc                                                         ; b4b2: d0 08       ..
+    iny                                                               ; b4b4: c8          .
+    inx                                                               ; b4b5: e8          .
+    bra loop_cb4a9                                                    ; b4b6: 80 f1       ..
+; $b4b8 referenced 1 time by $b4e6
+cb4b8
+    bra cb445                                                         ; b4b8: 80 8b       ..
+; $b4ba referenced 1 time by $b4ae
+cb4ba
+    sta l004d                                                         ; b4ba: 85 4d       .M
+; $b4bc referenced 1 time by $b4b2
+cb4bc
+    inc l001b                                                         ; b4bc: e6 1b       ..
+    ldy l001b                                                         ; b4be: a4 1b       ..
+    bra cb485                                                         ; b4c0: 80 c3       ..
+; $b4c2 referenced 1 time by $b489
+cb4c2
+    lda l004d                                                         ; b4c2: a5 4d       .M
+    beq cb451                                                         ; b4c4: f0 8b       ..
+    jsr sub_ca0ec                                                     ; b4c6: 20 ec a0     ..
+    lda #1                                                            ; b4c9: a9 01       ..
+    inx                                                               ; b4cb: e8          .
+    sec                                                               ; b4cc: 38          8
+    jsr sub_cbdf4                                                     ; b4cd: 20 f4 bd     ..
+    ldx l003b                                                         ; b4d0: a6 3b       .;
+    lda #2                                                            ; b4d2: a9 02       ..
+    jsr sub_cbdf3                                                     ; b4d4: 20 f3 bd     ..
+    ldx l003c                                                         ; b4d7: a6 3c       .<
+    lda #4                                                            ; b4d9: a9 04       ..
+    jsr sub_cbdf3                                                     ; b4db: 20 f3 bd     ..
+    stz l004c                                                         ; b4de: 64 4c       dL
+; $b4e0 referenced 1 time by $b508
+cb4e0
+    ldy l000a                                                         ; b4e0: a4 0a       ..
+; $b4e2 referenced 2 times by $b4f6, $b520
+cb4e2
+    lda (l000b),y                                                     ; b4e2: b1 0b       ..
+    cmp #$0d                                                          ; b4e4: c9 0d       ..
+    beq cb4b8                                                         ; b4e6: f0 d0       ..
+    cmp #$22 ; '"'                                                    ; b4e8: c9 22       ."
+    bne cb4f8                                                         ; b4ea: d0 0c       ..
+    eor l004c                                                         ; b4ec: 45 4c       EL
+    sta l004c                                                         ; b4ee: 85 4c       .L
+    lda #$22 ; '"'                                                    ; b4f0: a9 22       ."
+; $b4f2 referenced 1 time by $b4fa
+loop_cb4f2
+    jsr cbdd4                                                         ; b4f2: 20 d4 bd     ..
+    iny                                                               ; b4f5: c8          .
+    bra cb4e2                                                         ; b4f6: 80 ea       ..
+; $b4f8 referenced 1 time by $b4ea
+cb4f8
+    ldx l004c                                                         ; b4f8: a6 4c       .L
+    bne loop_cb4f2                                                    ; b4fa: d0 f6       ..
+    cmp #$8d                                                          ; b4fc: c9 8d       ..
+    bne cb50a                                                         ; b4fe: d0 0a       ..
+    jsr sub_c9bee                                                     ; b500: 20 ee 9b     ..
+    sty l000a                                                         ; b503: 84 0a       ..
+    jsr sub_ca0e8                                                     ; b505: 20 e8 a0     ..
+    bra cb4e0                                                         ; b508: 80 d6       ..
+; $b50a referenced 1 time by $b4fe
+cb50a
+    cmp #$e3                                                          ; b50a: c9 e3       ..
+    bne cb510                                                         ; b50c: d0 02       ..
+    inc l003b                                                         ; b50e: e6 3b       .;
+; $b510 referenced 1 time by $b50c
+cb510
+    cmp #$f5                                                          ; b510: c9 f5       ..
+    bne cb516                                                         ; b512: d0 02       ..
+    inc l003c                                                         ; b514: e6 3c       .<
+; $b516 referenced 1 time by $b512
+cb516
+    cmp #$f4                                                          ; b516: c9 f4       ..
+    bne cb51c                                                         ; b518: d0 02       ..
+    sta l004c                                                         ; b51a: 85 4c       .L
+; $b51c referenced 1 time by $b518
+cb51c
+    jsr sub_cbd77                                                     ; b51c: 20 77 bd     w.
+    iny                                                               ; b51f: c8          .
+    bra cb4e2                                                         ; b520: 80 c0       ..
+; $b522 referenced 1 time by $b5ee
+cb522
+    jsr sub_c99c4                                                     ; b522: 20 c4 99     ..
+    bne cb530                                                         ; b525: d0 09       ..
+    ldx l0026                                                         ; b527: a6 26       .&
+    beq cb563                                                         ; b529: f0 38       .8
+    bcs cb56a                                                         ; b52b: b0 3d       .=
+; $b52d referenced 1 time by $b530
+loop_cb52d
+    jmp c9c2d                                                         ; b52d: 4c 2d 9c    L-.
+
+; $b530 referenced 1 time by $b525
+cb530
+    bcs loop_cb52d                                                    ; b530: b0 fb       ..
+    ldx l0026                                                         ; b532: a6 26       .&
+    beq cb563                                                         ; b534: f0 2d       .-
+; $b536 referenced 1 time by $b552
+loop_cb536
+    lda l002a                                                         ; b536: a5 2a       .*
+    cmp l0519,x                                                       ; b538: dd 19 05    ...
+    bne cb54b                                                         ; b53b: d0 0e       ..
+    lda l002b                                                         ; b53d: a5 2b       .+
+    cmp l051a,x                                                       ; b53f: dd 1a 05    ...
+    bne cb54b                                                         ; b542: d0 07       ..
+    lda l002c                                                         ; b544: a5 2c       .,
+    cmp l051b,x                                                       ; b546: dd 1b 05    ...
+    beq cb56a                                                         ; b549: f0 1f       ..
+; $b54b referenced 2 times by $b53b, $b542
+cb54b
+    txa                                                               ; b54b: 8a          .
+    sec                                                               ; b54c: 38          8
+    sbc #$0f                                                          ; b54d: e9 0f       ..
+    tax                                                               ; b54f: aa          .
+    stx l0026                                                         ; b550: 86 26       .&
+    bne loop_cb536                                                    ; b552: d0 e2       ..
+    brk                                                               ; b554: 00          .
+
+    !text "!Can't match "                                             ; b555: 21 43 61... !Ca
+    !byte $e3                                                         ; b562: e3          .
+
+; $b563 referenced 2 times by $b529, $b534
+cb563
+    brk                                                               ; b563: 00          .
+
+    !text " No "                                                      ; b564: 20 4e 6f...  No
+    !byte $e3,   0                                                    ; b568: e3 00       ..
+
+; $b56a referenced 2 times by $b52b, $b549
+cb56a
+    lda l0519,x                                                       ; b56a: bd 19 05    ...
+    sta l002a                                                         ; b56d: 85 2a       .*
+    lda l051a,x                                                       ; b56f: bd 1a 05    ...
+    sta l002b                                                         ; b572: 85 2b       .+
+    ldy l051b,x                                                       ; b574: bc 1b 05    ...
+    cpy #5                                                            ; b577: c0 05       ..
+    beq cb5f1                                                         ; b579: f0 76       .v
+    lda (l002a)                                                       ; b57b: b2 2a       .*
+    adc l051c,x                                                       ; b57d: 7d 1c 05    }..
+    sta (l002a)                                                       ; b580: 92 2a       .*
+    sta l0037                                                         ; b582: 85 37       .7
+    ldy #1                                                            ; b584: a0 01       ..
+    lda (l002a),y                                                     ; b586: b1 2a       .*
+    adc l051d,x                                                       ; b588: 7d 1d 05    }..
+    sta (l002a),y                                                     ; b58b: 91 2a       .*
+    sta l0038                                                         ; b58d: 85 38       .8
+    iny                                                               ; b58f: c8          .
+    lda (l002a),y                                                     ; b590: b1 2a       .*
+    adc l051e,x                                                       ; b592: 7d 1e 05    }..
+    sta (l002a),y                                                     ; b595: 91 2a       .*
+    sta l0039                                                         ; b597: 85 39       .9
+    iny                                                               ; b599: c8          .
+    lda (l002a),y                                                     ; b59a: b1 2a       .*
+    adc l051f,x                                                       ; b59c: 7d 1f 05    }..
+    sta (l002a),y                                                     ; b59f: 91 2a       .*
+    tay                                                               ; b5a1: a8          .
+    lda l0037                                                         ; b5a2: a5 37       .7
+    sec                                                               ; b5a4: 38          8
+    sbc l0521,x                                                       ; b5a5: fd 21 05    .!.
+    sta l0037                                                         ; b5a8: 85 37       .7
+    lda l0038                                                         ; b5aa: a5 38       .8
+    sbc l0522,x                                                       ; b5ac: fd 22 05    .".
+    tsb l0037                                                         ; b5af: 04 37       .7
+    lda l0039                                                         ; b5b1: a5 39       .9
+    sbc l0523,x                                                       ; b5b3: fd 23 05    .#.
+    tsb l0037                                                         ; b5b6: 04 37       .7
+    tya                                                               ; b5b8: 98          .
+    sbc l0524,x                                                       ; b5b9: fd 24 05    .$.
+    ora l0037                                                         ; b5bc: 05 37       .7
+    beq cb5cf                                                         ; b5be: f0 0f       ..
+    tya                                                               ; b5c0: 98          .
+    eor l051f,x                                                       ; b5c1: 5d 1f 05    ]..
+    eor l0524,x                                                       ; b5c4: 5d 24 05    ]$.
+    bpl cb5cd                                                         ; b5c7: 10 04       ..
+    bcs cb5cf                                                         ; b5c9: b0 04       ..
+    bra cb5df                                                         ; b5cb: 80 12       ..
+; $b5cd referenced 1 time by $b5c7
+cb5cd
+    bcs cb5df                                                         ; b5cd: b0 10       ..
+; $b5cf referenced 5 times by $b5be, $b5c9, $b617, $b61e, $b622
+cb5cf
+    ldy l0526,x                                                       ; b5cf: bc 26 05    .&.
+    lda l0527,x                                                       ; b5d2: bd 27 05    .'.
+    sty l000b                                                         ; b5d5: 84 0b       ..
+    sta l000c                                                         ; b5d7: 85 0c       ..
+    jsr c9c8a                                                         ; b5d9: 20 8a 9c     ..
+    jmp c90d0                                                         ; b5dc: 4c d0 90    L..
+
+; $b5df referenced 4 times by $b5cb, $b5cd, $b620, $b624
+cb5df
+    txa                                                               ; b5df: 8a          .
+    sec                                                               ; b5e0: 38          8
+    sbc #$0f                                                          ; b5e1: e9 0f       ..
+    sta l0026                                                         ; b5e3: 85 26       .&
+    ldy l001b                                                         ; b5e5: a4 1b       ..
+    sty l000a                                                         ; b5e7: 84 0a       ..
+    jsr sub_c8da2                                                     ; b5e9: 20 a2 8d     ..
+    bne cb626                                                         ; b5ec: d0 38       .8
+    jmp cb522                                                         ; b5ee: 4c 22 b5    L".
+
+; $b5f1 referenced 1 time by $b579
+cb5f1
+    jsr cb205                                                         ; b5f1: 20 05 b2     ..
+    txa                                                               ; b5f4: 8a          .
+    clc                                                               ; b5f5: 18          .
+    adc #$1c                                                          ; b5f6: 69 1c       i.
+    sta l004a                                                         ; b5f8: 85 4a       .J
+    lda #5                                                            ; b5fa: a9 05       ..
+    sta l004b                                                         ; b5fc: 85 4b       .K
+    jsr ca70a                                                         ; b5fe: 20 0a a7     ..
+    lda l002a                                                         ; b601: a5 2a       .*
+    sta l0037                                                         ; b603: 85 37       .7
+    lda l002b                                                         ; b605: a5 2b       .+
+    sta l0038                                                         ; b607: 85 38       .8
+    jsr cb39e                                                         ; b609: 20 9e b3     ..
+    ldx l0026                                                         ; b60c: a6 26       .&
+    txa                                                               ; b60e: 8a          .
+    clc                                                               ; b60f: 18          .
+    adc #$21 ; '!'                                                    ; b610: 69 21       i!
+    sta l004a                                                         ; b612: 85 4a       .J
+    jsr sub_c9d36                                                     ; b614: 20 36 9d     6.
+    beq cb5cf                                                         ; b617: f0 b6       ..
+    lda l051d,x                                                       ; b619: bd 1d 05    ...
+    bmi cb622                                                         ; b61c: 30 04       0.
+    bcs cb5cf                                                         ; b61e: b0 af       ..
+    bra cb5df                                                         ; b620: 80 bd       ..
+; $b622 referenced 1 time by $b61c
+cb622
+    bcc cb5cf                                                         ; b622: 90 ab       ..
+    bra cb5df                                                         ; b624: 80 b9       ..
+; $b626 referenced 1 time by $b5ec
+cb626
+    jmp c90c5                                                         ; b626: 4c c5 90    L..
+
+; $b629 referenced 2 times by $b64c, $b64e
+cb629
+    brk                                                               ; b629: 00          .
+
+    !byte $22, $e3                                                    ; b62a: 22 e3       ".
+    !text " variable"                                                 ; b62c: 20 76 61...  va
+
+; $b635 referenced 1 time by $b664
+cb635
+    brk                                                               ; b635: 00          .
+
+    !text "#Too many "                                                ; b636: 23 54 6f... #To
+    !byte $e3, $73                                                    ; b640: e3 73       .s
+
+; $b642 referenced 1 time by $b65e
+loop_cb642
+    brk                                                               ; b642: 00          .
+
+    !text "$No "                                                      ; b643: 24 4e 6f... $No
+    !byte $b8,   0                                                    ; b647: b8 00       ..
+
+sub_cb649
+    jsr sub_c997d                                                     ; b649: 20 7d 99     }.
+    beq cb629                                                         ; b64c: f0 db       ..
+    bcs cb629                                                         ; b64e: b0 d9       ..
+    jsr sub_cbc83                                                     ; b650: 20 83 bc     ..
+    jsr sub_c9c4a                                                     ; b653: 20 4a 9c     J.
+    jsr sub_cb362                                                     ; b656: 20 62 b3     b.
+    jsr c8f92                                                         ; b659: 20 92 8f     ..
+    cmp #$b8                                                          ; b65c: c9 b8       ..
+    bne loop_cb642                                                    ; b65e: d0 e2       ..
+    ldy l0026                                                         ; b660: a4 26       .&
+    cpy #$96                                                          ; b662: c0 96       ..
+    bcs cb635                                                         ; b664: b0 cf       ..
+    tya                                                               ; b666: 98          .
+    adc #$0f                                                          ; b667: 69 0f       i.
+    sta l0026                                                         ; b669: 85 26       .&
+    lda l0037                                                         ; b66b: a5 37       .7
+    sta l0528,y                                                       ; b66d: 99 28 05    .(.
+    lda l0038                                                         ; b670: a5 38       .8
+    sta l0529,y                                                       ; b672: 99 29 05    .).
+    lda l0039                                                         ; b675: a5 39       .9
+    sta l052a,y                                                       ; b677: 99 2a 05    .*.
+    lsr                                                               ; b67a: 4a          J
+    bcs cb6d1                                                         ; b67b: b0 54       .T
+    jsr sub_c9774                                                     ; b67d: 20 74 97     t.
+    ldy l0026                                                         ; b680: a4 26       .&
+    lda l002a                                                         ; b682: a5 2a       .*
+    sta l0521,y                                                       ; b684: 99 21 05    .!.
+    lda l002b                                                         ; b687: a5 2b       .+
+    sta l0522,y                                                       ; b689: 99 22 05    .".
+    lda l002c                                                         ; b68c: a5 2c       .,
+    sta l0523,y                                                       ; b68e: 99 23 05    .#.
+    lda l002d                                                         ; b691: a5 2d       .-
+    sta l0524,y                                                       ; b693: 99 24 05    .$.
+    lda #1                                                            ; b696: a9 01       ..
+    jsr cae60                                                         ; b698: 20 60 ae     `.
+    jsr c8f92                                                         ; b69b: 20 92 8f     ..
+    cmp #$88                                                          ; b69e: c9 88       ..
+    bne cb6a7                                                         ; b6a0: d0 05       ..
+    jsr sub_c9774                                                     ; b6a2: 20 74 97     t.
+    ldy l001b                                                         ; b6a5: a4 1b       ..
+; $b6a7 referenced 1 time by $b6a0
+cb6a7
+    sty l000a                                                         ; b6a7: 84 0a       ..
+    ldy l0026                                                         ; b6a9: a4 26       .&
+    lda l002a                                                         ; b6ab: a5 2a       .*
+    sta l051c,y                                                       ; b6ad: 99 1c 05    ...
+    lda l002b                                                         ; b6b0: a5 2b       .+
+    sta l051d,y                                                       ; b6b2: 99 1d 05    ...
+    lda l002c                                                         ; b6b5: a5 2c       .,
+    sta l051e,y                                                       ; b6b7: 99 1e 05    ...
+    lda l002d                                                         ; b6ba: a5 2d       .-
+    sta l051f,y                                                       ; b6bc: 99 1f 05    ...
+; $b6bf referenced 1 time by $b707
+cb6bf
+    jsr sub_c9c93                                                     ; b6bf: 20 93 9c     ..
+    ldy l0026                                                         ; b6c2: a4 26       .&
+    lda l000b                                                         ; b6c4: a5 0b       ..
+    sta l0526,y                                                       ; b6c6: 99 26 05    .&.
+    lda l000c                                                         ; b6c9: a5 0c       ..
+    sta l0527,y                                                       ; b6cb: 99 27 05    .'.
+    jmp c90d0                                                         ; b6ce: 4c d0 90    L..
+
+; $b6d1 referenced 1 time by $b67b
+cb6d1
+    jsr sub_c9dff                                                     ; b6d1: 20 ff 9d     ..
+    jsr sub_c97a2                                                     ; b6d4: 20 a2 97     ..
+    lda l0026                                                         ; b6d7: a5 26       .&
+    clc                                                               ; b6d9: 18          .
+    adc #$21 ; '!'                                                    ; b6da: 69 21       i!
+    sta l004a                                                         ; b6dc: 85 4a       .J
+    lda #5                                                            ; b6de: a9 05       ..
+    sta l004b                                                         ; b6e0: 85 4b       .K
+    jsr sub_ca54d                                                     ; b6e2: 20 4d a5     M.
+    jsr ca622                                                         ; b6e5: 20 22 a6     ".
+    jsr c8f92                                                         ; b6e8: 20 92 8f     ..
+    cmp #$88                                                          ; b6eb: c9 88       ..
+    bne cb6f7                                                         ; b6ed: d0 08       ..
+    jsr sub_c9dff                                                     ; b6ef: 20 ff 9d     ..
+    jsr sub_c97a2                                                     ; b6f2: 20 a2 97     ..
+    ldy l001b                                                         ; b6f5: a4 1b       ..
+; $b6f7 referenced 1 time by $b6ed
+cb6f7
+    sty l000a                                                         ; b6f7: 84 0a       ..
+    lda l0026                                                         ; b6f9: a5 26       .&
+    clc                                                               ; b6fb: 18          .
+    adc #$1c                                                          ; b6fc: 69 1c       i.
+    sta l004a                                                         ; b6fe: 85 4a       .J
+    lda #5                                                            ; b700: a9 05       ..
+    sta l004b                                                         ; b702: 85 4b       .K
+    jsr sub_ca54d                                                     ; b704: 20 4d a5     M.
+    bra cb6bf                                                         ; b707: 80 b6       ..
+sub_cb709
+    jsr sub_cb85a                                                     ; b709: 20 5a b8     Z.
+; $b70c referenced 1 time by $b802
+cb70c
+    jsr c9c6a                                                         ; b70c: 20 6a 9c     j.
+    ldy l0025                                                         ; b70f: a4 25       .%
+    cpy #$1a                                                          ; b711: c0 1a       ..
+    bcs cb723                                                         ; b713: b0 0e       ..
+    lda l000b                                                         ; b715: a5 0b       ..
+    sta l05cc,y                                                       ; b717: 99 cc 05    ...
+    lda l000c                                                         ; b71a: a5 0c       ..
+    sta l05e6,y                                                       ; b71c: 99 e6 05    ...
+    inc l0025                                                         ; b71f: e6 25       .%
+    bra cb753                                                         ; b721: 80 30       .0
+; $b723 referenced 1 time by $b713
+cb723
+    brk                                                               ; b723: 00          .
+
+    !text "%Too many "                                                ; b724: 25 54 6f... %To
+    !byte $e4, $73                                                    ; b72e: e4 73       .s
+
+; $b730 referenced 1 time by $b73c
+loop_cb730
+    brk                                                               ; b730: 00          .
+
+    !text "&No "                                                      ; b731: 26 4e 6f... &No
+    !byte $e4,   0                                                    ; b735: e4 00       ..
+
+sub_cb737
+    jsr c9c6a                                                         ; b737: 20 6a 9c     j.
+    ldx l0025                                                         ; b73a: a6 25       .%
+    beq loop_cb730                                                    ; b73c: f0 f2       ..
+    dec l0025                                                         ; b73e: c6 25       .%
+    ldy l05cb,x                                                       ; b740: bc cb 05    ...
+    lda l05e5,x                                                       ; b743: bd e5 05    ...
+    sty l000b                                                         ; b746: 84 0b       ..
+    sta l000c                                                         ; b748: 85 0c       ..
+; $b74a referenced 1 time by $b76f
+cb74a
+    jmp c90ca                                                         ; b74a: 4c ca 90    L..
+
+sub_cb74d
+    jsr sub_cb85a                                                     ; b74d: 20 5a b8     Z.
+    jsr c9c6a                                                         ; b750: 20 6a 9c     j.
+; $b753 referenced 3 times by $9cf8, $b721, $b7f7
+cb753
+    lda l0020                                                         ; b753: a5 20       .
+    beq cb75a                                                         ; b755: f0 03       ..
+    jsr sub_c9d0f                                                     ; b757: 20 0f 9d     ..
+; $b75a referenced 1 time by $b755
+cb75a
+    ldy #4                                                            ; b75a: a0 04       ..
+    sty l000a                                                         ; b75c: 84 0a       ..
+    ldy l003d                                                         ; b75e: a4 3d       .=
+    lda l003e                                                         ; b760: a5 3e       .>
+; $b762 referenced 1 time by $ba69
+cb762
+    sty l000b                                                         ; b762: 84 0b       ..
+    sta l000c                                                         ; b764: 85 0c       ..
+    jmp c90d0                                                         ; b766: 4c d0 90    L..
+
+; $b769 referenced 1 time by $b776
+loop_cb769
+    jsr c9c6a                                                         ; b769: 20 6a 9c     j.
+    jsr sub_cb2e0                                                     ; b76c: 20 e0 b2     ..
+    bra cb74a                                                         ; b76f: 80 d9       ..
+; $b771 referenced 1 time by $b790
+loop_cb771
+    jsr c8f9d                                                         ; b771: 20 9d 8f     ..
+    cmp #$87                                                          ; b774: c9 87       ..
+    beq loop_cb769                                                    ; b776: f0 f1       ..
+    ldy l000a                                                         ; b778: a4 0a       ..
+    dey                                                               ; b77a: 88          .
+    jsr c9c80                                                         ; b77b: 20 80 9c     ..
+    stz l000a                                                         ; b77e: 64 0a       d.
+    lda l000b                                                         ; b780: a5 0b       ..
+    sta l0016                                                         ; b782: 85 16       ..
+    lda l000c                                                         ; b784: a5 0c       ..
+    sta l0017                                                         ; b786: 85 17       ..
+    jmp c9073                                                         ; b788: 4c 73 90    Ls.
+
+sub_cb78b
+    jsr c8f9d                                                         ; b78b: 20 9d 8f     ..
+    cmp #$85                                                          ; b78e: c9 85       ..
+    beq loop_cb771                                                    ; b790: f0 df       ..
+    dec l000a                                                         ; b792: c6 0a       ..
+    jsr sub_c9332                                                     ; b794: 20 32 93     2.
+    cpx #$f2                                                          ; b797: e0 f2       ..
+    beq cb7a4                                                         ; b799: f0 09       ..
+    iny                                                               ; b79b: c8          .
+    cpx #$e5                                                          ; b79c: e0 e5       ..
+    beq cb7a4                                                         ; b79e: f0 04       ..
+    cpx #$e4                                                          ; b7a0: e0 e4       ..
+    bne cb81a                                                         ; b7a2: d0 76       .v
+; $b7a4 referenced 2 times by $b799, $b79e
+cb7a4
+    phx                                                               ; b7a4: da          .
+    lda l002b                                                         ; b7a5: a5 2b       .+
+    ora l002c                                                         ; b7a7: 05 2c       .,
+    ora l002d                                                         ; b7a9: 05 2d       .-
+    bne cb805                                                         ; b7ab: d0 58       .X
+    dec l002a                                                         ; b7ad: c6 2a       .*
+    beq cb7e6                                                         ; b7af: f0 35       .5
+    bmi cb805                                                         ; b7b1: 30 52       0R
+; $b7b3 referenced 4 times by $b7cc, $b7dc, $b7e0, $b7e4
+cb7b3
+    lda (l000b),y                                                     ; b7b3: b1 0b       ..
+    cmp #$0d                                                          ; b7b5: c9 0d       ..
+    beq cb805                                                         ; b7b7: f0 4c       .L
+    cmp #$3a ; ':'                                                    ; b7b9: c9 3a       .:
+    beq cb805                                                         ; b7bb: f0 48       .H
+    cmp #$8b                                                          ; b7bd: c9 8b       ..
+    beq cb805                                                         ; b7bf: f0 44       .D
+    iny                                                               ; b7c1: c8          .
+    cmp #$22 ; '"'                                                    ; b7c2: c9 22       ."
+    bne cb7ca                                                         ; b7c4: d0 04       ..
+    eor l002b                                                         ; b7c6: 45 2b       E+
+    sta l002b                                                         ; b7c8: 85 2b       .+
+; $b7ca referenced 1 time by $b7c4
+cb7ca
+    ldx l002b                                                         ; b7ca: a6 2b       .+
+    bne cb7b3                                                         ; b7cc: d0 e5       ..
+    cmp #$29 ; ')'                                                    ; b7ce: c9 29       .)
+    bne cb7d4                                                         ; b7d0: d0 02       ..
+    dec l002c                                                         ; b7d2: c6 2c       .,
+; $b7d4 referenced 1 time by $b7d0
+cb7d4
+    cmp #$28 ; '('                                                    ; b7d4: c9 28       .(
+    bne cb7da                                                         ; b7d6: d0 02       ..
+    inc l002c                                                         ; b7d8: e6 2c       .,
+; $b7da referenced 1 time by $b7d6
+cb7da
+    cmp #$2c ; ','                                                    ; b7da: c9 2c       .,
+    bne cb7b3                                                         ; b7dc: d0 d5       ..
+    ldx l002c                                                         ; b7de: a6 2c       .,
+    bne cb7b3                                                         ; b7e0: d0 d1       ..
+    dec l002a                                                         ; b7e2: c6 2a       .*
+    bne cb7b3                                                         ; b7e4: d0 cd       ..
+; $b7e6 referenced 1 time by $b7af
+cb7e6
+    pla                                                               ; b7e6: 68          h
+    cmp #$f2                                                          ; b7e7: c9 f2       ..
+    beq cb833                                                         ; b7e9: f0 48       .H
+    sty l000a                                                         ; b7eb: 84 0a       ..
+    cmp #$e4                                                          ; b7ed: c9 e4       ..
+    beq cb7fa                                                         ; b7ef: f0 09       ..
+    jsr sub_cb85a                                                     ; b7f1: 20 5a b8     Z.
+    jsr c9c8a                                                         ; b7f4: 20 8a 9c     ..
+    jmp cb753                                                         ; b7f7: 4c 53 b7    LS.
+
+; $b7fa referenced 1 time by $b7ef
+cb7fa
+    jsr sub_cb85a                                                     ; b7fa: 20 5a b8     Z.
+    ldy l000a                                                         ; b7fd: a4 0a       ..
+    jsr sub_cb84d                                                     ; b7ff: 20 4d b8     M.
+    jmp cb70c                                                         ; b802: 4c 0c b7    L..
+
+; $b805 referenced 5 times by $b7ab, $b7b1, $b7b7, $b7bb, $b7bf
+cb805
+    pla                                                               ; b805: 68          h
+; $b806 referenced 1 time by $b80f
+loop_cb806
+    lda (l000b),y                                                     ; b806: b1 0b       ..
+    iny                                                               ; b808: c8          .
+    cmp #$8b                                                          ; b809: c9 8b       ..
+    beq cb847                                                         ; b80b: f0 3a       .:
+    cmp #$0d                                                          ; b80d: c9 0d       ..
+    bne loop_cb806                                                    ; b80f: d0 f5       ..
+    brk                                                               ; b811: 00          .
+
+    !byte $28, $ee                                                    ; b812: 28 ee       (.
+    !text " range"                                                    ; b814: 20 72 61...  ra
+
+; $b81a referenced 2 times by $b7a2, $b83a
+cb81a
+    brk                                                               ; b81a: 00          .
+
+    !byte $27, $ee                                                    ; b81b: 27 ee       '.
+    !text " syntax"                                                   ; b81d: 20 73 79...  sy
+
+; $b824 referenced 1 time by $b869
+cb824
+    brk                                                               ; b824: 00          .
+
+    !text ")No such line"                                             ; b825: 29 4e 6f... )No
+    !byte 0                                                           ; b832: 00          .
+
+; $b833 referenced 1 time by $b7e9
+cb833
+    sty l001b                                                         ; b833: 84 1b       ..
+    jsr c8f92                                                         ; b835: 20 92 8f     ..
+    cmp #$f2                                                          ; b838: c9 f2       ..
+    bne cb81a                                                         ; b83a: d0 de       ..
+    jsr sub_cb057                                                     ; b83c: 20 57 b0     W.
+    ldy l001b                                                         ; b83f: a4 1b       ..
+    jsr sub_cb84d                                                     ; b841: 20 4d b8     M.
+    jmp c90c7                                                         ; b844: 4c c7 90    L..
+
+; $b847 referenced 1 time by $b80b
+cb847
+    sty l000a                                                         ; b847: 84 0a       ..
+    jmp c9ced                                                         ; b849: 4c ed 9c    L..
+
+; $b84c referenced 1 time by $b855
+loop_cb84c
+    iny                                                               ; b84c: c8          .
+; $b84d referenced 2 times by $b7ff, $b841
+sub_cb84d
+    lda (l000b),y                                                     ; b84d: b1 0b       ..
+    cmp #$0d                                                          ; b84f: c9 0d       ..
+    beq cb857                                                         ; b851: f0 04       ..
+    cmp #$3a ; ':'                                                    ; b853: c9 3a       .:
+    bne loop_cb84c                                                    ; b855: d0 f5       ..
+; $b857 referenced 1 time by $b851
+cb857
+    sty l000a                                                         ; b857: 84 0a       ..
+    rts                                                               ; b859: 60          `
+
+; $b85a referenced 5 times by $b709, $b74d, $b7f1, $b7fa, $b994
+sub_cb85a
+    jsr sub_c9be2                                                     ; b85a: 20 e2 9b     ..
+    bcs cb866                                                         ; b85d: b0 07       ..
+    jsr sub_c9332                                                     ; b85f: 20 32 93     2.
+    lda #$80                                                          ; b862: a9 80       ..
+    trb l002b                                                         ; b864: 14 2b       .+
+; $b866 referenced 2 times by $9cf2, $b85d
+cb866
+    jsr sub_c8191                                                     ; b866: 20 91 81     ..
+    bcc cb824                                                         ; b869: 90 b9       ..
+    rts                                                               ; b86b: 60          `
+
+; $b86c referenced 2 times by $b8a2, $b8bc
+cb86c
+    jmp c9155                                                         ; b86c: 4c 55 91    LU.
+
+; $b86f referenced 1 time by $b88a
+loop_cb86f
+    jmp c9c2d                                                         ; b86f: 4c 2d 9c    L-.
+
+; $b872 referenced 1 time by $b882
+loop_cb872
+    sty l000a                                                         ; b872: 84 0a       ..
+; $b874 referenced 1 time by $b8e4
+cb874
+    jmp c90c7                                                         ; b874: 4c c7 90    L..
+
+; $b877 referenced 1 time by $b8e9
+cb877
+    jsr sub_cba6c                                                     ; b877: 20 6c ba     l.
+    sty l004c                                                         ; b87a: 84 4c       .L
+    jsr c9338                                                         ; b87c: 20 38 93     8.
+; $b87f referenced 2 times by $b8b8, $b8e0
+cb87f
+    jsr sub_c8da2                                                     ; b87f: 20 a2 8d     ..
+    bne loop_cb872                                                    ; b882: d0 ee       ..
+    lda l004c                                                         ; b884: a5 4c       .L
+    pha                                                               ; b886: 48          H
+    jsr sub_c997d                                                     ; b887: 20 7d 99     }.
+    beq loop_cb86f                                                    ; b88a: f0 e3       ..
+    jsr c9338                                                         ; b88c: 20 38 93     8.
+    pla                                                               ; b88f: 68          h
+    sta l004c                                                         ; b890: 85 4c       .L
+    php                                                               ; b892: 08          .
+    jsr cbc66                                                         ; b893: 20 66 bc     f.
+sub_cb896
+    ldy l004c                                                         ; b896: a4 4c       .L
+    jsr osbget                                                        ; b898: 20 d7 ff     ..
+    sta l0027                                                         ; b89b: 85 27       .'
+    plp                                                               ; b89d: 28          (
+    bcc cb8ba                                                         ; b89e: 90 1a       ..
+    lda l0027                                                         ; b8a0: a5 27       .'
+    bne cb86c                                                         ; b8a2: d0 c8       ..
+    jsr osbget                                                        ; b8a4: 20 d7 ff     ..
+    sta l0036                                                         ; b8a7: 85 36       .6
+    tax                                                               ; b8a9: aa          .
+    beq cb8b5                                                         ; b8aa: f0 09       ..
+; $b8ac referenced 1 time by $b8b3
+loop_cb8ac
+    jsr osbget                                                        ; b8ac: 20 d7 ff     ..
+    sta l05ff,x                                                       ; b8af: 9d ff 05    ...
+    dex                                                               ; b8b2: ca          .
+    bne loop_cb8ac                                                    ; b8b3: d0 f7       ..
+; $b8b5 referenced 1 time by $b8aa
+cb8b5
+    jsr sub_c916e                                                     ; b8b5: 20 6e 91     n.
+    bra cb87f                                                         ; b8b8: 80 c5       ..
+; $b8ba referenced 1 time by $b89e
+cb8ba
+    lda l0027                                                         ; b8ba: a5 27       .'
+    beq cb86c                                                         ; b8bc: f0 ae       ..
+    bmi cb8cc                                                         ; b8be: 30 0c       0.
+    ldx #3                                                            ; b8c0: a2 03       ..
+; $b8c2 referenced 1 time by $b8c8
+loop_cb8c2
+    jsr osbget                                                        ; b8c2: 20 d7 ff     ..
+    sta l002a,x                                                       ; b8c5: 95 2a       .*
+    dex                                                               ; b8c7: ca          .
+    bpl loop_cb8c2                                                    ; b8c8: 10 f8       ..
+    bra cb8da                                                         ; b8ca: 80 0e       ..
+; $b8cc referenced 1 time by $b8be
+cb8cc
+    ldx #4                                                            ; b8cc: a2 04       ..
+; $b8ce referenced 1 time by $b8d5
+loop_cb8ce
+    jsr osbget                                                        ; b8ce: 20 d7 ff     ..
+    sta l046c,x                                                       ; b8d1: 9d 6c 04    .l.
+    dex                                                               ; b8d4: ca          .
+    bpl loop_cb8ce                                                    ; b8d5: 10 f7       ..
+    jsr sub_ca576                                                     ; b8d7: 20 76 a5     v.
+; $b8da referenced 1 time by $b8ca
+cb8da
+    jsr sub_cbd46                                                     ; b8da: 20 46 bd     F.
+    jsr sub_cb372                                                     ; b8dd: 20 72 b3     r.
+    bra cb87f                                                         ; b8e0: 80 9d       ..
+; $b8e2 referenced 1 time by $b922
+cb8e2
+    pla                                                               ; b8e2: 68          h
+    pla                                                               ; b8e3: 68          h
+    bra cb874                                                         ; b8e4: 80 8e       ..
+sub_cb8e6
+    jsr sub_c8d9c                                                     ; b8e6: 20 9c 8d     ..
+    beq cb877                                                         ; b8e9: f0 8c       ..
+    cmp #$86                                                          ; b8eb: c9 86       ..
+    beq cb8f2                                                         ; b8ed: f0 03       ..
+    dec l000a                                                         ; b8ef: c6 0a       ..
+    clc                                                               ; b8f1: 18          .
+; $b8f2 referenced 1 time by $b8ed
+cb8f2
+    ror l004c                                                         ; b8f2: 66 4c       fL
+    lsr l004c                                                         ; b8f4: 46 4c       FL
+    lda #$ff                                                          ; b8f6: a9 ff       ..
+    sta l004d                                                         ; b8f8: 85 4d       .M
+; $b8fa referenced 3 times by $b911, $b915, $b974
+cb8fa
+    jsr sub_c935c                                                     ; b8fa: 20 5c 93     \.
+    bcs cb909                                                         ; b8fd: b0 0a       ..
+; $b8ff referenced 1 time by $b902
+loop_cb8ff
+    jsr sub_c935c                                                     ; b8ff: 20 5c 93     \.
+    bcc loop_cb8ff                                                    ; b902: 90 fb       ..
+    ldx #$ff                                                          ; b904: a2 ff       ..
+    stx l004d                                                         ; b906: 86 4d       .M
+    clc                                                               ; b908: 18          .
+; $b909 referenced 1 time by $b8fd
+cb909
+    php                                                               ; b909: 08          .
+    asl l004c                                                         ; b90a: 06 4c       .L
+    plp                                                               ; b90c: 28          (
+    ror l004c                                                         ; b90d: 66 4c       fL
+    cmp #$2c ; ','                                                    ; b90f: c9 2c       .,
+    beq cb8fa                                                         ; b911: f0 e7       ..
+    cmp #$3b ; ';'                                                    ; b913: c9 3b       .;
+    beq cb8fa                                                         ; b915: f0 e3       ..
+    dec l000a                                                         ; b917: c6 0a       ..
+    lda l004c                                                         ; b919: a5 4c       .L
+    pha                                                               ; b91b: 48          H
+    lda l004d                                                         ; b91c: a5 4d       .M
+    pha                                                               ; b91e: 48          H
+    jsr sub_c997d                                                     ; b91f: 20 7d 99     }.
+    beq cb8e2                                                         ; b922: f0 be       ..
+    pla                                                               ; b924: 68          h
+    sta l004d                                                         ; b925: 85 4d       .M
+    pla                                                               ; b927: 68          h
+    sta l004c                                                         ; b928: 85 4c       .L
+    jsr c9338                                                         ; b92a: 20 38 93     8.
+    php                                                               ; b92d: 08          .
+    bit l004c                                                         ; b92e: 24 4c       $L
+    bvs cb938                                                         ; b930: 70 06       p.
+    lda l004d                                                         ; b932: a5 4d       .M
+    cmp #$ff                                                          ; b934: c9 ff       ..
+    bne cb94f                                                         ; b936: d0 17       ..
+; $b938 referenced 1 time by $b930
+cb938
+    bit l004c                                                         ; b938: 24 4c       $L
+    bpl cb941                                                         ; b93a: 10 05       ..
+    lda #$3f ; '?'                                                    ; b93c: a9 3f       .?
+    jsr oswrch                                                        ; b93e: 20 ee ff     ..
+; $b941 referenced 1 time by $b93a
+cb941
+    jsr sub_cbaa0                                                     ; b941: 20 a0 ba     ..
+    sty l0036                                                         ; b944: 84 36       .6
+    asl l004c                                                         ; b946: 06 4c       .L
+    clc                                                               ; b948: 18          .
+    ror l004c                                                         ; b949: 66 4c       fL
+    bit l004c                                                         ; b94b: 24 4c       $L
+    bvs cb968                                                         ; b94d: 70 19       p.
+; $b94f referenced 1 time by $b936
+cb94f
+    sta l001b                                                         ; b94f: 85 1b       ..
+    stz l0019                                                         ; b951: 64 19       d.
+    lda #6                                                            ; b953: a9 06       ..
+    sta l001a                                                         ; b955: 85 1a       ..
+    jsr sub_cad3a                                                     ; b957: 20 3a ad     :.
+; $b95a referenced 1 time by $b961
+loop_cb95a
+    jsr sub_c8fa8                                                     ; b95a: 20 a8 8f     ..
+    beq cb965                                                         ; b95d: f0 06       ..
+    cmp #$0d                                                          ; b95f: c9 0d       ..
+    bne loop_cb95a                                                    ; b961: d0 f7       ..
+    ldy #$fe                                                          ; b963: a0 fe       ..
+; $b965 referenced 1 time by $b95d
+cb965
+    iny                                                               ; b965: c8          .
+    sty l004d                                                         ; b966: 84 4d       .M
+; $b968 referenced 1 time by $b94d
+cb968
+    plp                                                               ; b968: 28          (
+    bcs cb976                                                         ; b969: b0 0b       ..
+    jsr sub_cbc83                                                     ; b96b: 20 83 bc     ..
+    jsr sub_caba5                                                     ; b96e: 20 a5 ab     ..
+    jsr sub_cb365                                                     ; b971: 20 65 b3     e.
+; $b974 referenced 1 time by $b97b
+loop_cb974
+    bra cb8fa                                                         ; b974: 80 84       ..
+; $b976 referenced 1 time by $b969
+cb976
+    stz l0027                                                         ; b976: 64 27       d'
+    jsr sub_c9171                                                     ; b978: 20 71 91     q.
+    bra loop_cb974                                                    ; b97b: 80 f7       ..
+sub_cb97d
+    stz l003d                                                         ; b97d: 64 3d       d=
+    ldy l0018                                                         ; b97f: a4 18       ..
+    sty l003e                                                         ; b981: 84 3e       .>
+    jsr c8f9d                                                         ; b983: 20 9d 8f     ..
+    dec l000a                                                         ; b986: c6 0a       ..
+    cmp #$3a ; ':'                                                    ; b988: c9 3a       .:
+    beq cb997                                                         ; b98a: f0 0b       ..
+    cmp #$0d                                                          ; b98c: c9 0d       ..
+    beq cb997                                                         ; b98e: f0 07       ..
+    cmp #$8b                                                          ; b990: c9 8b       ..
+    beq cb997                                                         ; b992: f0 03       ..
+    jsr sub_cb85a                                                     ; b994: 20 5a b8     Z.
+; $b997 referenced 3 times by $b98a, $b98e, $b992
+cb997
+    jsr c9c6a                                                         ; b997: 20 6a 9c     j.
+    lda l003d                                                         ; b99a: a5 3d       .=
+    sta l001c                                                         ; b99c: 85 1c       ..
+    lda l003e                                                         ; b99e: a5 3e       .>
+    sta l001d                                                         ; b9a0: 85 1d       ..
+    jmp c90ca                                                         ; b9a2: 4c ca 90    L..
+
+; $b9a5 referenced 2 times by $b9b0, $b9da
+cb9a5
+    jsr sub_c8da2                                                     ; b9a5: 20 a2 8d     ..
+    beq cb9ad                                                         ; b9a8: f0 03       ..
+    jmp c90c5                                                         ; b9aa: 4c c5 90    L..
+
+; $b9ad referenced 1 time by $b9a8
+cb9ad
+    jsr sub_c997d                                                     ; b9ad: 20 7d 99     }.
+    beq cb9a5                                                         ; b9b0: f0 f3       ..
+    bcs cb9bf                                                         ; b9b2: b0 0b       ..
+    jsr sub_cb9dc                                                     ; b9b4: 20 dc b9     ..
+    jsr sub_cbc83                                                     ; b9b7: 20 83 bc     ..
+    jsr sub_cb362                                                     ; b9ba: 20 62 b3     b.
+    bra cb9cd                                                         ; b9bd: 80 0e       ..
+; $b9bf referenced 1 time by $b9b2
+cb9bf
+    jsr sub_cb9dc                                                     ; b9bf: 20 dc b9     ..
+    jsr cbc66                                                         ; b9c2: 20 66 bc     f.
+    jsr sub_cad3a                                                     ; b9c5: 20 3a ad     :.
+    sta l0027                                                         ; b9c8: 85 27       .'
+    jsr sub_c916e                                                     ; b9ca: 20 6e 91     n.
+; $b9cd referenced 1 time by $b9bd
+cb9cd
+    clc                                                               ; b9cd: 18          .
+    lda l001b                                                         ; b9ce: a5 1b       ..
+    adc l0019                                                         ; b9d0: 65 19       e.
+    sta l001c                                                         ; b9d2: 85 1c       ..
+    lda l001a                                                         ; b9d4: a5 1a       ..
+    adc #0                                                            ; b9d6: 69 00       i.
+    sta l001d                                                         ; b9d8: 85 1d       ..
+    bra cb9a5                                                         ; b9da: 80 c9       ..
+; $b9dc referenced 2 times by $b9b4, $b9bf
+sub_cb9dc
+    jsr c9338                                                         ; b9dc: 20 38 93     8.
+    lda l001c                                                         ; b9df: a5 1c       ..
+    sta l0019                                                         ; b9e1: 85 19       ..
+    lda l001d                                                         ; b9e3: a5 1d       ..
+    sta l001a                                                         ; b9e5: 85 1a       ..
+    stz l001b                                                         ; b9e7: 64 1b       d.
+    jsr sub_c8fa8                                                     ; b9e9: 20 a8 8f     ..
+    beq cba46                                                         ; b9ec: f0 58       .X
+    cmp #$dc                                                          ; b9ee: c9 dc       ..
+    beq cba46                                                         ; b9f0: f0 54       .T
+    cmp #$0d                                                          ; b9f2: c9 0d       ..
+    beq cb9ff                                                         ; b9f4: f0 09       ..
+; $b9f6 referenced 1 time by $b9fd
+loop_cb9f6
+    jsr sub_c8fa8                                                     ; b9f6: 20 a8 8f     ..
+    beq cba46                                                         ; b9f9: f0 4b       .K
+    cmp #$0d                                                          ; b9fb: c9 0d       ..
+    bne loop_cb9f6                                                    ; b9fd: d0 f7       ..
+; $b9ff referenced 3 times by $b9f4, $ba1b, $ba1f
+cb9ff
+    ldy l001b                                                         ; b9ff: a4 1b       ..
+    lda (l0019),y                                                     ; ba01: b1 19       ..
+    bmi cba21                                                         ; ba03: 30 1c       0.
+    iny                                                               ; ba05: c8          .
+    iny                                                               ; ba06: c8          .
+    lda (l0019),y                                                     ; ba07: b1 19       ..
+    tax                                                               ; ba09: aa          .
+; $ba0a referenced 1 time by $ba0f
+loop_cba0a
+    iny                                                               ; ba0a: c8          .
+    lda (l0019),y                                                     ; ba0b: b1 19       ..
+    cmp #$20 ; ' '                                                    ; ba0d: c9 20       .
+    beq loop_cba0a                                                    ; ba0f: f0 f9       ..
+    cmp #$dc                                                          ; ba11: c9 dc       ..
+    beq cba43                                                         ; ba13: f0 2e       ..
+    txa                                                               ; ba15: 8a          .
+    clc                                                               ; ba16: 18          .
+    adc l0019                                                         ; ba17: 65 19       e.
+    sta l0019                                                         ; ba19: 85 19       ..
+    bcc cb9ff                                                         ; ba1b: 90 e2       ..
+    inc l001a                                                         ; ba1d: e6 1a       ..
+    bra cb9ff                                                         ; ba1f: 80 de       ..
+; $ba21 referenced 1 time by $ba03
+cba21
+    brk                                                               ; ba21: 00          .
+
+    !text "*Out of "                                                  ; ba22: 2a 4f 75... *Ou
+    !byte $dc                                                         ; ba2a: dc          .
+
+; $ba2b referenced 1 time by $ba52
+cba2b
+    brk                                                               ; ba2b: 00          .
+
+    !text "+No "                                                      ; ba2c: 2b 4e 6f... +No
+    !byte $f5                                                         ; ba30: f5          .
+
+; $ba31 referenced 1 time by $ba7f
+cba31
+    brk                                                               ; ba31: 00          .
+
+    !byte $2d, $8d, $23                                               ; ba32: 2d 8d 23    -.#
+
+; $ba35 referenced 1 time by $ba8c
+cba35
+    brk                                                               ; ba35: 00          .
+
+    !text ",Too many "                                                ; ba36: 2c 54 6f... ,To
+    !byte $f5, $73,   0                                               ; ba40: f5 73 00    .s.
+
+; $ba43 referenced 1 time by $ba13
+cba43
+    iny                                                               ; ba43: c8          .
+    sty l001b                                                         ; ba44: 84 1b       ..
+; $ba46 referenced 3 times by $b9ec, $b9f0, $b9f9
+cba46
+    rts                                                               ; ba46: 60          `
+
+sub_cba47
+    jsr sub_c9df3                                                     ; ba47: 20 f3 9d     ..
+    jsr c9c55                                                         ; ba4a: 20 55 9c     U.
+    jsr sub_c9781                                                     ; ba4d: 20 81 97     ..
+    ldx l0024                                                         ; ba50: a6 24       .$
+    beq cba2b                                                         ; ba52: f0 d7       ..
+    lda l002a                                                         ; ba54: a5 2a       .*
+    ora l002b                                                         ; ba56: 05 2b       .+
+    ora l002c                                                         ; ba58: 05 2c       .,
+    ora l002d                                                         ; ba5a: 05 2d       .-
+    beq cba63                                                         ; ba5c: f0 05       ..
+    dec l0024                                                         ; ba5e: c6 24       .$
+    jmp c90ca                                                         ; ba60: 4c ca 90    L..
+
+; $ba63 referenced 1 time by $ba5c
+cba63
+    ldy l04ff,x                                                       ; ba63: bc ff 04    ...
+    lda l0513,x                                                       ; ba66: bd 13 05    ...
+    jmp cb762                                                         ; ba69: 4c 62 b7    Lb.
+
+; $ba6c referenced 2 times by $9204, $b877
+sub_cba6c
+    dec l000a                                                         ; ba6c: c6 0a       ..
+; $ba6e referenced 3 times by $beda, $beee, $befd
+sub_cba6e
+    lda l000a                                                         ; ba6e: a5 0a       ..
+    sta l001b                                                         ; ba70: 85 1b       ..
+    lda l000b                                                         ; ba72: a5 0b       ..
+    sta l0019                                                         ; ba74: 85 19       ..
+    lda l000c                                                         ; ba76: a5 0c       ..
+    sta l001a                                                         ; ba78: 85 1a       ..
+; $ba7a referenced 3 times by $ab24, $ab2f, $ac1f
+sub_cba7a
+    jsr c8f92                                                         ; ba7a: 20 92 8f     ..
+    cmp #$23 ; '#'                                                    ; ba7d: c9 23       .#
+    bne cba31                                                         ; ba7f: d0 b0       ..
+    jsr sub_c9779                                                     ; ba81: 20 79 97     y.
+    ldy l002a                                                         ; ba84: a4 2a       .*
+    tya                                                               ; ba86: 98          .
+    rts                                                               ; ba87: 60          `
+
+sub_cba88
+    ldx l0024                                                         ; ba88: a6 24       .$
+    cpx #$14                                                          ; ba8a: e0 14       ..
+    bcs cba35                                                         ; ba8c: b0 a7       ..
+    jsr c9c80                                                         ; ba8e: 20 80 9c     ..
+    lda l000b                                                         ; ba91: a5 0b       ..
+    sta l0500,x                                                       ; ba93: 9d 00 05    ...
+    lda l000c                                                         ; ba96: a5 0c       ..
+    sta l0514,x                                                       ; ba98: 9d 14 05    ...
+    inc l0024                                                         ; ba9b: e6 24       .$
+    jmp c90d0                                                         ; ba9d: 4c d0 90    L..
+
+; $baa0 referenced 1 time by $b941
+sub_cbaa0
+    lda #6                                                            ; baa0: a9 06       ..
+    bra cbaa6                                                         ; baa2: 80 02       ..
+; $baa4 referenced 2 times by $9059, $955b
+sub_cbaa4
+    lda #7                                                            ; baa4: a9 07       ..
+; $baa6 referenced 1 time by $baa2
+cbaa6
+    stz l0037                                                         ; baa6: 64 37       d7
+    sta l0038                                                         ; baa8: 85 38       .8
+    lda #$ee                                                          ; baaa: a9 ee       ..
+    sta l0039                                                         ; baac: 85 39       .9
+    lda #$20 ; ' '                                                    ; baae: a9 20       .
+    sta l003a                                                         ; bab0: 85 3a       .:
+    ldy #$ff                                                          ; bab2: a0 ff       ..
+    sty l003b                                                         ; bab4: 84 3b       .;
+    iny                                                               ; bab6: c8          .
+    ldx #$37 ; '7'                                                    ; bab7: a2 37       .7
+    tya                                                               ; bab9: 98          .
+    jsr osword                                                        ; baba: 20 f1 ff     ..
+    bcc cbac5                                                         ; babd: 90 06       ..
+    jmp c9c41                                                         ; babf: 4c 41 9c    LA.
+
+; $bac2 referenced 8 times by $8a14, $8a68, $9285, $9319, $932a, $9538, $98c6, $bdc6
+sub_cbac2
+    jsr osnewl                                                        ; bac2: 20 e7 ff     ..
+; $bac5 referenced 2 times by $babd, $bddf
+cbac5
+    stz l001e                                                         ; bac5: 64 1e       d.
+    rts                                                               ; bac7: 60          `
+
+; $bac8 referenced 2 times by $93fa, $bb47
+sub_cbac8
+    jsr sub_c8191                                                     ; bac8: 20 91 81     ..
+    bcc cbb1a                                                         ; bacb: 90 4d       .M
+    lda l003d                                                         ; bacd: a5 3d       .=
+    sta l0037                                                         ; bacf: 85 37       .7
+    sta l0012                                                         ; bad1: 85 12       ..
+    lda l003e                                                         ; bad3: a5 3e       .>
+    sta l0038                                                         ; bad5: 85 38       .8
+    sta l0013                                                         ; bad7: 85 13       ..
+    ldy #3                                                            ; bad9: a0 03       ..
+    lda (l0037),y                                                     ; badb: b1 37       .7
+    clc                                                               ; badd: 18          .
+    adc l0037                                                         ; bade: 65 37       e7
+    sta l0037                                                         ; bae0: 85 37       .7
+    bcc cbae6                                                         ; bae2: 90 02       ..
+    inc l0038                                                         ; bae4: e6 38       .8
+; $bae6 referenced 1 time by $bae2
+cbae6
+    ldy #0                                                            ; bae6: a0 00       ..
+; $bae8 referenced 2 times by $bb04, $bb0a
+cbae8
+    lda (l0037),y                                                     ; bae8: b1 37       .7
+    sta (l0012),y                                                     ; baea: 91 12       ..
+    cmp #$0d                                                          ; baec: c9 0d       ..
+    bne cbb03                                                         ; baee: d0 13       ..
+    iny                                                               ; baf0: c8          .
+    bne cbaf7                                                         ; baf1: d0 04       ..
+    inc l0038                                                         ; baf3: e6 38       .8
+    inc l0013                                                         ; baf5: e6 13       ..
+; $baf7 referenced 1 time by $baf1
+cbaf7
+    lda (l0037),y                                                     ; baf7: b1 37       .7
+    sta (l0012),y                                                     ; baf9: 91 12       ..
+    bmi cbb0c                                                         ; bafb: 30 0f       0.
+    jsr sub_cbb0f                                                     ; bafd: 20 0f bb     ..
+    jsr sub_cbb0f                                                     ; bb00: 20 0f bb     ..
+; $bb03 referenced 1 time by $baee
+cbb03
+    iny                                                               ; bb03: c8          .
+    bne cbae8                                                         ; bb04: d0 e2       ..
+    inc l0038                                                         ; bb06: e6 38       .8
+    inc l0013                                                         ; bb08: e6 13       ..
+    bra cbae8                                                         ; bb0a: 80 dc       ..
+; $bb0c referenced 1 time by $bafb
+cbb0c
+    jmp cbe45                                                         ; bb0c: 4c 45 be    LE.
+
+; $bb0f referenced 2 times by $bafd, $bb00
+sub_cbb0f
+    iny                                                               ; bb0f: c8          .
+    bne cbb16                                                         ; bb10: d0 04       ..
+    inc l0013                                                         ; bb12: e6 13       ..
+    inc l0038                                                         ; bb14: e6 38       .8
+; $bb16 referenced 1 time by $bb10
+cbb16
+    lda (l0037),y                                                     ; bb16: b1 37       .7
+    sta (l0012),y                                                     ; bb18: 91 12       ..
+; $bb1a referenced 3 times by $bacb, $bb36, $bb54
+cbb1a
+    rts                                                               ; bb1a: 60          `
+
+; $bb1b referenced 2 times by $903d, $9062
+sub_cbb1b
+    ldx #$ff                                                          ; bb1b: a2 ff       ..
+    stx l0028                                                         ; bb1d: 86 28       .(
+    stx l003c                                                         ; bb1f: 86 3c       .<
+    jsr sub_cbbff                                                     ; bb21: 20 ff bb     ..
+    lda l000b                                                         ; bb24: a5 0b       ..
+    sta l0037                                                         ; bb26: 85 37       .7
+    lda l000c                                                         ; bb28: a5 0c       ..
+    sta l0038                                                         ; bb2a: 85 38       .8
+    stz l003b                                                         ; bb2c: 64 3b       d;
+    stz l000a                                                         ; bb2e: 64 0a       d.
+    jsr c8e6f                                                         ; bb30: 20 6f 8e     o.
+    jsr sub_c9be2                                                     ; bb33: 20 e2 9b     ..
+    bcc cbb1a                                                         ; bb36: 90 e2       ..
+; $bb38 referenced 1 time by $9566
+sub_cbb38
+    lda l001f                                                         ; bb38: a5 1f       ..
+    beq cbb45                                                         ; bb3a: f0 09       ..
+; $bb3c referenced 1 time by $bb42
+loop_cbb3c
+    lda l0700,y                                                       ; bb3c: b9 00 07    ...
+    iny                                                               ; bb3f: c8          .
+    cmp #$20 ; ' '                                                    ; bb40: c9 20       .
+    beq loop_cbb3c                                                    ; bb42: f0 f8       ..
+    dey                                                               ; bb44: 88          .
+; $bb45 referenced 1 time by $bb3a
+cbb45
+    sty l003b                                                         ; bb45: 84 3b       .;
+    jsr sub_cbac8                                                     ; bb47: 20 c8 ba     ..
+    ldy #7                                                            ; bb4a: a0 07       ..
+    sty l003c                                                         ; bb4c: 84 3c       .<
+    ldy #0                                                            ; bb4e: a0 00       ..
+    lda #$0d                                                          ; bb50: a9 0d       ..
+    cmp (l003b)                                                       ; bb52: d2 3b       .;
+    beq cbb1a                                                         ; bb54: f0 c4       ..
+; $bb56 referenced 1 time by $bb59
+loop_cbb56
+    iny                                                               ; bb56: c8          .
+    cmp (l003b),y                                                     ; bb57: d1 3b       .;
+    bne loop_cbb56                                                    ; bb59: d0 fb       ..
+    lda #$20 ; ' '                                                    ; bb5b: a9 20       .
+; $bb5d referenced 1 time by $bb62
+loop_cbb5d
+    dey                                                               ; bb5d: 88          .
+    beq cbb64                                                         ; bb5e: f0 04       ..
+    cmp (l003b),y                                                     ; bb60: d1 3b       .;
+    beq loop_cbb5d                                                    ; bb62: f0 f9       ..
+; $bb64 referenced 1 time by $bb5e
+cbb64
+    iny                                                               ; bb64: c8          .
+    lda #$0d                                                          ; bb65: a9 0d       ..
+    sta (l003b),y                                                     ; bb67: 91 3b       .;
+    iny                                                               ; bb69: c8          .
+    iny                                                               ; bb6a: c8          .
+    iny                                                               ; bb6b: c8          .
+    iny                                                               ; bb6c: c8          .
+    sty l003f                                                         ; bb6d: 84 3f       .?
+    lda l0012                                                         ; bb6f: a5 12       ..
+    sta l0039                                                         ; bb71: 85 39       .9
+    lda l0013                                                         ; bb73: a5 13       ..
+    sta l003a                                                         ; bb75: 85 3a       .:
+    jsr sub_cbe44                                                     ; bb77: 20 44 be     D.
+    sta l0037                                                         ; bb7a: 85 37       .7
+    lda l0013                                                         ; bb7c: a5 13       ..
+    sta l0038                                                         ; bb7e: 85 38       .8
+    dey                                                               ; bb80: 88          .
+    lda l0006                                                         ; bb81: a5 06       ..
+    cmp l0012                                                         ; bb83: c5 12       ..
+    lda l0007                                                         ; bb85: a5 07       ..
+    sbc l0013                                                         ; bb87: e5 13       ..
+    bcs cbb9b                                                         ; bb89: b0 10       ..
+    jsr sub_cbe25                                                     ; bb8b: 20 25 be     %.
+    jsr sub_cbbdc                                                     ; bb8e: 20 dc bb     ..
+    brk                                                               ; bb91: 00          .
+
+    !byte   0, $86                                                    ; bb92: 00 86       ..
+    !text " space"                                                    ; bb94: 20 73 70...  sp
+    !byte 0                                                           ; bb9a: 00          .
+
+; $bb9b referenced 2 times by $bb89, $bbb4
+cbb9b
+    lda (l0039),y                                                     ; bb9b: b1 39       .9
+    sta (l0037),y                                                     ; bb9d: 91 37       .7
+    tya                                                               ; bb9f: 98          .
+    bne cbba6                                                         ; bba0: d0 04       ..
+    dec l003a                                                         ; bba2: c6 3a       .:
+    dec l0038                                                         ; bba4: c6 38       .8
+; $bba6 referenced 1 time by $bba0
+cbba6
+    dey                                                               ; bba6: 88          .
+    tya                                                               ; bba7: 98          .
+    adc l0039                                                         ; bba8: 65 39       e9
+    ldx l003a                                                         ; bbaa: a6 3a       .:
+    bcc cbbaf                                                         ; bbac: 90 01       ..
+    inx                                                               ; bbae: e8          .
+; $bbaf referenced 1 time by $bbac
+cbbaf
+    cmp l003d                                                         ; bbaf: c5 3d       .=
+    txa                                                               ; bbb1: 8a          .
+    sbc l003e                                                         ; bbb2: e5 3e       .>
+    bcs cbb9b                                                         ; bbb4: b0 e5       ..
+    ldy #1                                                            ; bbb6: a0 01       ..
+    lda l002b                                                         ; bbb8: a5 2b       .+
+    sta (l003d),y                                                     ; bbba: 91 3d       .=
+    iny                                                               ; bbbc: c8          .
+    lda l002a                                                         ; bbbd: a5 2a       .*
+    sta (l003d),y                                                     ; bbbf: 91 3d       .=
+    iny                                                               ; bbc1: c8          .
+    lda l003f                                                         ; bbc2: a5 3f       .?
+    sta (l003d),y                                                     ; bbc4: 91 3d       .=
+    sec                                                               ; bbc6: 38          8
+    tya                                                               ; bbc7: 98          .
+    adc l003d                                                         ; bbc8: 65 3d       e=
+    sta l003d                                                         ; bbca: 85 3d       .=
+    bcc cbbd0                                                         ; bbcc: 90 02       ..
+    inc l003e                                                         ; bbce: e6 3e       .>
+; $bbd0 referenced 1 time by $bbcc
+cbbd0
+    ldy #$ff                                                          ; bbd0: a0 ff       ..
+; $bbd2 referenced 1 time by $bbd9
+loop_cbbd2
+    iny                                                               ; bbd2: c8          .
+    lda (l003b),y                                                     ; bbd3: b1 3b       .;
+    sta (l003d),y                                                     ; bbd5: 91 3d       .=
+    cmp #$0d                                                          ; bbd7: c9 0d       ..
+    bne loop_cbbd2                                                    ; bbd9: d0 f7       ..
+    rts                                                               ; bbdb: 60          `
+
+; $bbdc referenced 7 times by $8fda, $9048, $9569, $9706, $b3c8, $bb8e, $bd71
+sub_cbbdc
+    lda l0012                                                         ; bbdc: a5 12       ..
+    sta l0000                                                         ; bbde: 85 00       ..
+    sta l0002                                                         ; bbe0: 85 02       ..
+    lda l0013                                                         ; bbe2: a5 13       ..
+    sta l0001                                                         ; bbe4: 85 01       ..
+    sta l0003                                                         ; bbe6: 85 03       ..
+    jsr sub_cbbff                                                     ; bbe8: 20 ff bb     ..
+; $bbeb referenced 1 time by $96f4
+sub_cbbeb
+    ldx #$10                                                          ; bbeb: a2 10       ..
+; $bbed referenced 1 time by $bbf4
+loop_cbbed
+    lda lbf71,x                                                       ; bbed: bd 71 bf    .q.
+    sta l07ef,x                                                       ; bbf0: 9d ef 07    ...
+    dex                                                               ; bbf3: ca          .
+    bne loop_cbbed                                                    ; bbf4: d0 f7       ..
+    ldx #$80                                                          ; bbf6: a2 80       ..
+; $bbf8 referenced 1 time by $bbfc
+loop_cbbf8
+    stz l047f,x                                                       ; bbf8: 9e 7f 04    ...
+    dex                                                               ; bbfb: ca          .
+    bne loop_cbbf8                                                    ; bbfc: d0 fa       ..
+    rts                                                               ; bbfe: 60          `
+
+; $bbff referenced 2 times by $bb21, $bbe8
+sub_cbbff
+    lda l0018                                                         ; bbff: a5 18       ..
+    sta l001d                                                         ; bc01: 85 1d       ..
+    lda l0006                                                         ; bc03: a5 06       ..
+    sta l0004                                                         ; bc05: 85 04       ..
+    lda l0007                                                         ; bc07: a5 07       ..
+    sta l0005                                                         ; bc09: 85 05       ..
+    lda #$80                                                          ; bc0b: a9 80       ..
+    trb l001f                                                         ; bc0d: 14 1f       ..
+    stz l0024                                                         ; bc0f: 64 24       d$
+    stz l0026                                                         ; bc11: 64 26       d&
+    stz l0025                                                         ; bc13: 64 25       d%
+    stz l001c                                                         ; bc15: 64 1c       d.
+    rts                                                               ; bc17: 60          `
+
+; $bc18 referenced 2 times by $9f4f, $9f59
+sub_cbc18
+    jsr cbc3a                                                         ; bc18: 20 3a bc     :.
+    jsr sub_ca026                                                     ; bc1b: 20 26 a0     &.
+; $bc1e referenced 1 time by $a042
+sub_cbc1e
+    stx l0027                                                         ; bc1e: 86 27       .'
+; $bc20 referenced 1 time by $9fb0
+sub_cbc20
+    tay                                                               ; bc20: a8          .
+    jsr sub_c97a2                                                     ; bc21: 20 a2 97     ..
+; $bc24 referenced 4 times by $9d33, $a56d, $a617, $b19b
+sub_cbc24
+    lda l0004                                                         ; bc24: a5 04       ..
+    clc                                                               ; bc26: 18          .
+    sta l004a                                                         ; bc27: 85 4a       .J
+    adc #5                                                            ; bc29: 69 05       i.
+    sta l0004                                                         ; bc2b: 85 04       ..
+    lda l0005                                                         ; bc2d: a5 05       ..
+    sta l004b                                                         ; bc2f: 85 4b       .K
+    adc #0                                                            ; bc31: 69 00       i.
+    sta l0005                                                         ; bc33: 85 05       ..
+    rts                                                               ; bc35: 60          `
+
+; $bc36 referenced 2 times by $a03c, $a081
+sub_cbc36
+    tay                                                               ; bc36: a8          .
+    jsr sub_c97a2                                                     ; bc37: 20 a2 97     ..
+; $bc3a referenced 5 times by $9d29, $9faa, $a60f, $bc18, $bc64
+cbc3a
+    lda l0004                                                         ; bc3a: a5 04       ..
+    sec                                                               ; bc3c: 38          8
+    sbc #5                                                            ; bc3d: e9 05       ..
+    jsr sub_cbd5e                                                     ; bc3f: 20 5e bd     ^.
+    lda l0030                                                         ; bc42: a5 30       .0
+    sta (l0004)                                                       ; bc44: 92 04       ..
+    ldy #1                                                            ; bc46: a0 01       ..
+    lda l002e                                                         ; bc48: a5 2e       ..
+    eor l0031                                                         ; bc4a: 45 31       E1
+    and #$80                                                          ; bc4c: 29 80       ).
+    eor l0031                                                         ; bc4e: 45 31       E1
+    sta (l0004),y                                                     ; bc50: 91 04       ..
+    iny                                                               ; bc52: c8          .
+    lda l0032                                                         ; bc53: a5 32       .2
+    sta (l0004),y                                                     ; bc55: 91 04       ..
+    iny                                                               ; bc57: c8          .
+    lda l0033                                                         ; bc58: a5 33       .3
+    sta (l0004),y                                                     ; bc5a: 91 04       ..
+    iny                                                               ; bc5c: c8          .
+    lda l0034                                                         ; bc5d: a5 34       .4
+    sta (l0004),y                                                     ; bc5f: 91 04       ..
+    rts                                                               ; bc61: 60          `
+
+; $bc62 referenced 2 times by $b149, $b1ce
+sub_cbc62
+    beq cbc91                                                         ; bc62: f0 2d       .-
+    bmi cbc3a                                                         ; bc64: 30 d4       0.
+; $bc66 referenced 20 times by $8fb1, $9114, $9387, $93df, $9418, $9555, $964e, $9889, $9ae6, $9b27, $9e42, $9e50, $a023, $a069, $b150, $b1db, $b3da, $b3ed, $b893, $b9c2
+cbc66
+    lda l0004                                                         ; bc66: a5 04       ..
+    sec                                                               ; bc68: 38          8
+    sbc #4                                                            ; bc69: e9 04       ..
+    jsr sub_cbd5e                                                     ; bc6b: 20 5e bd     ^.
+    ldy #3                                                            ; bc6e: a0 03       ..
+    lda l002d                                                         ; bc70: a5 2d       .-
+    sta (l0004),y                                                     ; bc72: 91 04       ..
+    dey                                                               ; bc74: 88          .
+    lda l002c                                                         ; bc75: a5 2c       .,
+    sta (l0004),y                                                     ; bc77: 91 04       ..
+    dey                                                               ; bc79: 88          .
+    lda l002b                                                         ; bc7a: a5 2b       .+
+    sta (l0004),y                                                     ; bc7c: 91 04       ..
+    lda l002a                                                         ; bc7e: a5 2a       .*
+    sta (l0004)                                                       ; bc80: 92 04       ..
+    rts                                                               ; bc82: 60          `
+
+; $bc83 referenced 6 times by $8a98, $9588, $97e3, $b650, $b96b, $b9b7
+sub_cbc83
+    ply                                                               ; bc83: 7a          z
+    plx                                                               ; bc84: fa          .
+    lda l002a                                                         ; bc85: a5 2a       .*
+    pha                                                               ; bc87: 48          H
+    lda l002b                                                         ; bc88: a5 2b       .+
+    pha                                                               ; bc8a: 48          H
+    lda l002c                                                         ; bc8b: a5 2c       .,
+    pha                                                               ; bc8d: 48          H
+    phx                                                               ; bc8e: da          .
+    phy                                                               ; bc8f: 5a          Z
+    rts                                                               ; bc90: 60          `
+
+; $bc91 referenced 7 times by $9769, $9dc4, $9edd, $ab6a, $ac8a, $af13, $bc62
+cbc91
+    clc                                                               ; bc91: 18          .
+    lda l0004                                                         ; bc92: a5 04       ..
+    sbc l0036                                                         ; bc94: e5 36       .6
+    jsr sub_cbd5e                                                     ; bc96: 20 5e bd     ^.
+    ldy l0036                                                         ; bc99: a4 36       .6
+    beq cbca5                                                         ; bc9b: f0 08       ..
+; $bc9d referenced 1 time by $bca3
+loop_cbc9d
+    lda l05ff,y                                                       ; bc9d: b9 ff 05    ...
+    sta (l0004),y                                                     ; bca0: 91 04       ..
+    dey                                                               ; bca2: 88          .
+    bne loop_cbc9d                                                    ; bca3: d0 f8       ..
+; $bca5 referenced 1 time by $bc9b
+cbca5
+    lda l0036                                                         ; bca5: a5 36       .6
+    sta (l0004)                                                       ; bca7: 92 04       ..
+    rts                                                               ; bca9: 60          `
+
+; $bcaa referenced 1 time by $b0db
+sub_cbcaa
+    lda l0039                                                         ; bcaa: a5 39       .9
+    cmp #$80                                                          ; bcac: c9 80       ..
+    beq cbcd5                                                         ; bcae: f0 25       .%
+    bcc cbcea                                                         ; bcb0: 90 38       .8
+    lda (l0004)                                                       ; bcb2: b2 04       ..
+    tax                                                               ; bcb4: aa          .
+    beq cbccd                                                         ; bcb5: f0 16       ..
+    lda (l0037)                                                       ; bcb7: b2 37       .7
+    sbc #1                                                            ; bcb9: e9 01       ..
+    sta l0039                                                         ; bcbb: 85 39       .9
+    ldy #1                                                            ; bcbd: a0 01       ..
+    lda (l0037),y                                                     ; bcbf: b1 37       .7
+    sbc #0                                                            ; bcc1: e9 00       ..
+    sta l003a                                                         ; bcc3: 85 3a       .:
+; $bcc5 referenced 1 time by $bccb
+loop_cbcc5
+    lda (l0004),y                                                     ; bcc5: b1 04       ..
+    sta (l0039),y                                                     ; bcc7: 91 39       .9
+    iny                                                               ; bcc9: c8          .
+    dex                                                               ; bcca: ca          .
+    bne loop_cbcc5                                                    ; bccb: d0 f8       ..
+; $bccd referenced 1 time by $bcb5
+cbccd
+    lda (l0004)                                                       ; bccd: b2 04       ..
+    ldy #3                                                            ; bccf: a0 03       ..
+; $bcd1 referenced 1 time by $bce8
+loop_cbcd1
+    sta (l0037),y                                                     ; bcd1: 91 37       .7
+    bra cbd21                                                         ; bcd3: 80 4c       .L
+; $bcd5 referenced 1 time by $bcae
+cbcd5
+    lda (l0004)                                                       ; bcd5: b2 04       ..
+    ldy #0                                                            ; bcd7: a0 00       ..
+    tax                                                               ; bcd9: aa          .
+    beq cbce6                                                         ; bcda: f0 0a       ..
+; $bcdc referenced 1 time by $bce4
+loop_cbcdc
+    iny                                                               ; bcdc: c8          .
+    lda (l0004),y                                                     ; bcdd: b1 04       ..
+    dey                                                               ; bcdf: 88          .
+    sta (l0037),y                                                     ; bce0: 91 37       .7
+    iny                                                               ; bce2: c8          .
+    dex                                                               ; bce3: ca          .
+    bne loop_cbcdc                                                    ; bce4: d0 f6       ..
+; $bce6 referenced 1 time by $bcda
+cbce6
+    lda #$0d                                                          ; bce6: a9 0d       ..
+    bne loop_cbcd1                                                    ; bce8: d0 e7       ..
+; $bcea referenced 1 time by $bcb0
+cbcea
+    lda (l0004)                                                       ; bcea: b2 04       ..
+    sta (l0037)                                                       ; bcec: 92 37       .7
+    ldy #4                                                            ; bcee: a0 04       ..
+    lda l0039                                                         ; bcf0: a5 39       .9
+    beq cbd0e                                                         ; bcf2: f0 1a       ..
+    ldy #1                                                            ; bcf4: a0 01       ..
+    lda (l0004),y                                                     ; bcf6: b1 04       ..
+    sta (l0037),y                                                     ; bcf8: 91 37       .7
+    iny                                                               ; bcfa: c8          .
+    lda (l0004),y                                                     ; bcfb: b1 04       ..
+    sta (l0037),y                                                     ; bcfd: 91 37       .7
+    iny                                                               ; bcff: c8          .
+    lda (l0004),y                                                     ; bd00: b1 04       ..
+    sta (l0037),y                                                     ; bd02: 91 37       .7
+    iny                                                               ; bd04: c8          .
+    cpy l0039                                                         ; bd05: c4 39       .9
+    bcs cbd0e                                                         ; bd07: b0 05       ..
+    lda (l0004),y                                                     ; bd09: b1 04       ..
+    sta (l0037),y                                                     ; bd0b: 91 37       .7
+    iny                                                               ; bd0d: c8          .
+; $bd0e referenced 2 times by $bcf2, $bd07
+cbd0e
+    tya                                                               ; bd0e: 98          .
+    clc                                                               ; bd0f: 18          .
+    bra cbd3d                                                         ; bd10: 80 2b       .+
+; $bd12 referenced 5 times by $9efc, $aca6, $aecb, $af2f, $b1af
+sub_cbd12
+    lda (l0004)                                                       ; bd12: b2 04       ..
+    sta l0036                                                         ; bd14: 85 36       .6
+    beq cbd23                                                         ; bd16: f0 0b       ..
+    tay                                                               ; bd18: a8          .
+; $bd19 referenced 1 time by $bd1f
+loop_cbd19
+    lda (l0004),y                                                     ; bd19: b1 04       ..
+    sta l05ff,y                                                       ; bd1b: 99 ff 05    ...
+    dey                                                               ; bd1e: 88          .
+    bne loop_cbd19                                                    ; bd1f: d0 f8       ..
+; $bd21 referenced 5 times by $9dea, $ab8e, $accf, $ace8, $bcd3
+cbd21
+    lda (l0004)                                                       ; bd21: b2 04       ..
+; $bd23 referenced 1 time by $bd16
+cbd23
+    sec                                                               ; bd23: 38          8
+    bra cbd3d                                                         ; bd24: 80 17       ..
+; $bd26 referenced 13 times by $8287, $916e, $93ba, $93f7, $9552, $955e, $9fed, $ac68, $af93, $b17e, $b1a3, $b3ea, $b432
+sub_cbd26
+    ldy #3                                                            ; bd26: a0 03       ..
+    lda (l0004),y                                                     ; bd28: b1 04       ..
+    sta l002d                                                         ; bd2a: 85 2d       .-
+    dey                                                               ; bd2c: 88          .
+    lda (l0004),y                                                     ; bd2d: b1 04       ..
+    sta l002c                                                         ; bd2f: 85 2c       .,
+    dey                                                               ; bd31: 88          .
+    lda (l0004),y                                                     ; bd32: b1 04       ..
+    sta l002b                                                         ; bd34: 85 2b       .+
+    lda (l0004)                                                       ; bd36: b2 04       ..
+    sta l002a                                                         ; bd38: 85 2a       .*
+; $bd3a referenced 3 times by $9e23, $9e66, $bd5c
+cbd3a
+    clc                                                               ; bd3a: 18          .
+    lda #4                                                            ; bd3b: a9 04       ..
+; $bd3d referenced 2 times by $bd10, $bd24
+cbd3d
+    adc l0004                                                         ; bd3d: 65 04       e.
+    sta l0004                                                         ; bd3f: 85 04       ..
+    bcc cbd45                                                         ; bd41: 90 02       ..
+    inc l0005                                                         ; bd43: e6 05       ..
+; $bd45 referenced 1 time by $bd41
+cbd45
+    rts                                                               ; bd45: 60          `
+
+; $bd46 referenced 3 times by $989b, $b0d8, $b8da
+sub_cbd46
+    ldx #$37 ; '7'                                                    ; bd46: a2 37       .7
+; $bd48 referenced 5 times by $81dc, $944c, $95c8, $9af4, $9b35
+sub_cbd48
+    ldy #3                                                            ; bd48: a0 03       ..
+    lda (l0004),y                                                     ; bd4a: b1 04       ..
+    sta l0003,x                                                       ; bd4c: 95 03       ..
+    dey                                                               ; bd4e: 88          .
+    lda (l0004),y                                                     ; bd4f: b1 04       ..
+    sta l0002,x                                                       ; bd51: 95 02       ..
+    dey                                                               ; bd53: 88          .
+    lda (l0004),y                                                     ; bd54: b1 04       ..
+    sta l0001,x                                                       ; bd56: 95 01       ..
+    lda (l0004)                                                       ; bd58: b2 04       ..
+    sta l0000,x                                                       ; bd5a: 95 00       ..
+    bra cbd3a                                                         ; bd5c: 80 dc       ..
+; $bd5e referenced 4 times by $b05e, $bc3f, $bc6b, $bc96
+sub_cbd5e
+    sta l0004                                                         ; bd5e: 85 04       ..
+    bcs cbd64                                                         ; bd60: b0 02       ..
+    dec l0005                                                         ; bd62: c6 05       ..
+; $bd64 referenced 1 time by $bd60
+cbd64
+    ldy l0005                                                         ; bd64: a4 05       ..
+    cpy l0003                                                         ; bd66: c4 03       ..
+    bcc cbd74                                                         ; bd68: 90 0a       ..
+    bne cbd70                                                         ; bd6a: d0 04       ..
+    cmp l0002                                                         ; bd6c: c5 02       ..
+    bcc cbd74                                                         ; bd6e: 90 04       ..
+; $bd70 referenced 1 time by $bd6a
+cbd70
+    rts                                                               ; bd70: 60          `
+
+; $bd71 referenced 1 time by $bdef
+cbd71
+    jsr sub_cbbdc                                                     ; bd71: 20 dc bb     ..
+; $bd74 referenced 2 times by $bd68, $bd6e
+cbd74
+    jmp c9164                                                         ; bd74: 4c 64 91    Ld.
+
+; $bd77 referenced 4 times by $8a3c, $8a5e, $98cf, $b51c
+sub_cbd77
+    sta l0037                                                         ; bd77: 85 37       .7
+    cmp #$80                                                          ; bd79: c9 80       ..
+    bcc cbdd4                                                         ; bd7b: 90 57       .W
+    lda #$13                                                          ; bd7d: a9 13       ..
+    sta l0038                                                         ; bd7f: 85 38       .8
+    lda #$85                                                          ; bd81: a9 85       ..
+    sta l0039                                                         ; bd83: 85 39       .9
+    phy                                                               ; bd85: 5a          Z
+; $bd86 referenced 2 times by $bd98, $bd9c
+cbd86
+    ldy #0                                                            ; bd86: a0 00       ..
+; $bd88 referenced 1 time by $bd8b
+loop_cbd88
+    iny                                                               ; bd88: c8          .
+    lda (l0038),y                                                     ; bd89: b1 38       .8
+    bpl loop_cbd88                                                    ; bd8b: 10 fb       ..
+    cmp l0037                                                         ; bd8d: c5 37       .7
+    beq cbd9e                                                         ; bd8f: f0 0d       ..
+    iny                                                               ; bd91: c8          .
+    tya                                                               ; bd92: 98          .
+    sec                                                               ; bd93: 38          8
+    adc l0038                                                         ; bd94: 65 38       e8
+    sta l0038                                                         ; bd96: 85 38       .8
+    bcc cbd86                                                         ; bd98: 90 ec       ..
+    inc l0039                                                         ; bd9a: e6 39       .9
+    bra cbd86                                                         ; bd9c: 80 e8       ..
+; $bd9e referenced 1 time by $bd8f
+cbd9e
+    ldy #0                                                            ; bd9e: a0 00       ..
+; $bda0 referenced 1 time by $bda8
+loop_cbda0
+    lda (l0038),y                                                     ; bda0: b1 38       .8
+    bmi cbdaa                                                         ; bda2: 30 06       0.
+    jsr cbdd4                                                         ; bda4: 20 d4 bd     ..
+    iny                                                               ; bda7: c8          .
+    bne loop_cbda0                                                    ; bda8: d0 f6       ..
+; $bdaa referenced 1 time by $bda2
+cbdaa
+    ply                                                               ; bdaa: 7a          z
+    rts                                                               ; bdab: 60          `
+
+; $bdac referenced 2 times by $89fb, $bdcf
+sub_cbdac
+    pha                                                               ; bdac: 48          H
+    lsr                                                               ; bdad: 4a          J
+    lsr                                                               ; bdae: 4a          J
+    lsr                                                               ; bdaf: 4a          J
+    lsr                                                               ; bdb0: 4a          J
+    jsr sub_cbdb7                                                     ; bdb1: 20 b7 bd     ..
+    pla                                                               ; bdb4: 68          h
+    and #$0f                                                          ; bdb5: 29 0f       ).
+; $bdb7 referenced 1 time by $bdb1
+sub_cbdb7
+    cmp #$0a                                                          ; bdb7: c9 0a       ..
+    bcc cbdbd                                                         ; bdb9: 90 02       ..
+    adc #6                                                            ; bdbb: 69 06       i.
+; $bdbd referenced 1 time by $bdb9
+cbdbd
+    adc #$30 ; '0'                                                    ; bdbd: 69 30       i0
+; $bdbf referenced 1 time by $bdda
+loop_cbdbf
+    pha                                                               ; bdbf: 48          H
+    lda l0023                                                         ; bdc0: a5 23       .#
+    cmp l001e                                                         ; bdc2: c5 1e       ..
+    bcs cbdc9                                                         ; bdc4: b0 03       ..
+    jsr sub_cbac2                                                     ; bdc6: 20 c2 ba     ..
+; $bdc9 referenced 1 time by $bdc4
+cbdc9
+    pla                                                               ; bdc9: 68          h
+    inc l001e                                                         ; bdca: e6 1e       ..
+    jmp (wrchv)                                                       ; bdcc: 6c 0e 02    l..
+
+; $bdcf referenced 2 times by $8a00, $8a20
+sub_cbdcf
+    jsr sub_cbdac                                                     ; bdcf: 20 ac bd     ..
+; $bdd2 referenced 4 times by $9268, $92d4, $9d26, $bdff
+cbdd2
+    lda #$20 ; ' '                                                    ; bdd2: a9 20       .
+; $bdd4 referenced 5 times by $a12a, $b445, $b4f2, $bd7b, $bda4
+cbdd4
+    bit l001f                                                         ; bdd4: 24 1f       $.
+    bmi cbde2                                                         ; bdd6: 30 0a       0.
+; $bdd8 referenced 4 times by $92e3, $937c, $9d1b, $9d23
+sub_cbdd8
+    cmp #$0d                                                          ; bdd8: c9 0d       ..
+    bne loop_cbdbf                                                    ; bdda: d0 e3       ..
+    jsr oswrch                                                        ; bddc: 20 ee ff     ..
+    jmp cbac5                                                         ; bddf: 4c c5 ba    L..
+
+; $bde2 referenced 1 time by $bdd6
+cbde2
+    sta (l0002)                                                       ; bde2: 92 02       ..
+    inc l0002                                                         ; bde4: e6 02       ..
+    bne cbe05                                                         ; bde6: d0 1d       ..
+    inc l0003                                                         ; bde8: e6 03       ..
+    pha                                                               ; bdea: 48          H
+    lda l0003                                                         ; bdeb: a5 03       ..
+    eor l0007                                                         ; bded: 45 07       E.
+    beq cbd71                                                         ; bdef: f0 80       ..
+    pla                                                               ; bdf1: 68          h
+    rts                                                               ; bdf2: 60          `
+
+; $bdf3 referenced 2 times by $b4d4, $b4db
+sub_cbdf3
+    clc                                                               ; bdf3: 18          .
+; $bdf4 referenced 1 time by $b4cd
+sub_cbdf4
+    and l001f                                                         ; bdf4: 25 1f       %.
+    beq cbe05                                                         ; bdf6: f0 0d       ..
+    txa                                                               ; bdf8: 8a          .
+    bmi cbe05                                                         ; bdf9: 30 0a       0.
+    rol                                                               ; bdfb: 2a          *
+    tax                                                               ; bdfc: aa          .
+    beq cbe05                                                         ; bdfd: f0 06       ..
+; $bdff referenced 6 times by $8a19, $8a2f, $8a4b, $9325, $a121, $be03
+cbdff
+    jsr cbdd2                                                         ; bdff: 20 d2 bd     ..
+    dex                                                               ; be02: ca          .
+    bne cbdff                                                         ; be03: d0 fa       ..
+; $be05 referenced 4 times by $bde6, $bdf6, $bdf9, $bdfd
+cbe05
+    rts                                                               ; be05: 60          `
+
+; $be06 referenced 6 times by $8d6a, $9fea, $aac3, $b194, $b1c7, $b400
+sub_cbe06
+    lda l002a                                                         ; be06: a5 2a       .*
+    sta l0000,x                                                       ; be08: 95 00       ..
+    lda l002b                                                         ; be0a: a5 2b       .+
+    sta l0001,x                                                       ; be0c: 95 01       ..
+    lda l002c                                                         ; be0e: a5 2c       .,
+    sta l0002,x                                                       ; be10: 95 02       ..
+    lda l002d                                                         ; be12: a5 2d       .-
+    sta l0003,x                                                       ; be14: 95 03       ..
+    rts                                                               ; be16: 60          `
+
+; $be17 referenced 2 times by $8fc0, $8fe5
+sub_cbe17
+    jsr sub_cbe81                                                     ; be17: 20 81 be     ..
+    stz l003d                                                         ; be1a: 64 3d       d=
+    ldy #>(l0037)                                                     ; be1c: a0 00       ..
+    lda #osfile_load                                                  ; be1e: a9 ff       ..
+    ldx #<(l0037)                                                     ; be20: a2 37       .7
+    jsr osfile                                                        ; be22: 20 dd ff     ..
+; $be25 referenced 6 times by $8fd2, $8fed, $944f, $b42f, $bb8b, $be95
+sub_cbe25
+    lda l0018                                                         ; be25: a5 18       ..
+    sta l0013                                                         ; be27: 85 13       ..
+    stz l0012                                                         ; be29: 64 12       d.
+    ldy #1                                                            ; be2b: a0 01       ..
+; $be2d referenced 1 time by $be41
+loop_cbe2d
+    lda (l0012)                                                       ; be2d: b2 12       ..
+    cmp #$0d                                                          ; be2f: c9 0d       ..
+    bne cbe51                                                         ; be31: d0 1e       ..
+    lda (l0012),y                                                     ; be33: b1 12       ..
+    bmi cbe43                                                         ; be35: 30 0c       0.
+    ldy #3                                                            ; be37: a0 03       ..
+    lda (l0012),y                                                     ; be39: b1 12       ..
+    beq cbe51                                                         ; be3b: f0 14       ..
+    clc                                                               ; be3d: 18          .
+    jsr sub_cbe46                                                     ; be3e: 20 46 be     F.
+    bra loop_cbe2d                                                    ; be41: 80 ea       ..
+; $be43 referenced 1 time by $be35
+cbe43
+    iny                                                               ; be43: c8          .
+; $be44 referenced 1 time by $bb77
+sub_cbe44
+    clc                                                               ; be44: 18          .
+; $be45 referenced 1 time by $bb0c
+cbe45
+    tya                                                               ; be45: 98          .
+; $be46 referenced 1 time by $be3e
+sub_cbe46
+    adc l0012                                                         ; be46: 65 12       e.
+    sta l0012                                                         ; be48: 85 12       ..
+    bcc cbe4e                                                         ; be4a: 90 02       ..
+    inc l0013                                                         ; be4c: e6 13       ..
+; $be4e referenced 1 time by $be4a
+cbe4e
+    ldy #1                                                            ; be4e: a0 01       ..
+    rts                                                               ; be50: 60          `
+
+; $be51 referenced 2 times by $be31, $be3b
+cbe51
+    jsr sub_cbf0f                                                     ; be51: 20 0f bf     ..
+    ora l6142                                                         ; be54: 0d 42 61    .Ba
+    stz l0020                                                         ; be57: 64 20       d
+    bvs lbecd                                                         ; be59: 70 72       pr
+    !text "ogram"                                                     ; be5b: 6f 67 72... ogr
+    !byte $0d, $ea, $4c, $4b, $90                                     ; be60: 0d ea 4c... ..L
+
+; $be65 referenced 1 time by $be7b
+sub_cbe65
+    stz l0037                                                         ; be65: 64 37       d7
+    lda #6                                                            ; be67: a9 06       ..
+    sta l0038                                                         ; be69: 85 38       .8
+; $be6b referenced 2 times by $91ef, $ab47
+sub_cbe6b
+    ldy l0036                                                         ; be6b: a4 36       .6
+    lda #$0d                                                          ; be6d: a9 0d       ..
+    sta l0600,y                                                       ; be6f: 99 00 06    ...
+    rts                                                               ; be72: 60          `
+
+; $be73 referenced 1 time by $be79
+loop_cbe73
+    jmp c9155                                                         ; be73: 4c 55 91    LU.
+
+; $be76 referenced 2 times by $be81, $bec7
+sub_cbe76
+    jsr sub_c9df3                                                     ; be76: 20 f3 9d     ..
+    bne loop_cbe73                                                    ; be79: d0 f8       ..
+    jsr sub_cbe65                                                     ; be7b: 20 65 be     e.
+    jmp c9c55                                                         ; be7e: 4c 55 9c    LU.
+
+; $be81 referenced 2 times by $be17, $be98
+sub_cbe81
+    jsr sub_cbe76                                                     ; be81: 20 76 be     v.
+    dey                                                               ; be84: 88          .
+    sty l0039                                                         ; be85: 84 39       .9
+    lda l0018                                                         ; be87: a5 18       ..
+    sta l003a                                                         ; be89: 85 3a       .:
+; $be8b referenced 1 time by $9834
+sub_cbe8b
+    lda #osbyte_read_high_order_address                               ; be8b: a9 82       ..
+    jsr osbyte                                                        ; be8d: 20 f4 ff     ..
+    stx l003b                                                         ; be90: 86 3b       .;
+    sty l003c                                                         ; be92: 84 3c       .<
+    rts                                                               ; be94: 60          `
+
+sub_cbe95
+    jsr sub_cbe25                                                     ; be95: 20 25 be     %.
+    jsr sub_cbe81                                                     ; be98: 20 81 be     ..
+    stx l003f                                                         ; be9b: 86 3f       .?
+    sty l0040                                                         ; be9d: 84 40       .@
+    stx l0043                                                         ; be9f: 86 43       .C
+    sty l0044                                                         ; bea1: 84 44       .D
+    stx l0047                                                         ; bea3: 86 47       .G
+    sty l0048                                                         ; bea5: 84 48       .H
+    stz l0041                                                         ; bea7: 64 41       dA
+    ldx l0012                                                         ; bea9: a6 12       ..
+    stx l0045                                                         ; beab: 86 45       .E
+    ldx l0013                                                         ; bead: a6 13       ..
+    stx l0046                                                         ; beaf: 86 46       .F
+    ldx #$e7                                                          ; beb1: a2 e7       ..
+    stx l003d                                                         ; beb3: 86 3d       .=
+    ldx #$80                                                          ; beb5: a2 80       ..
+    stx l003e                                                         ; beb7: 86 3e       .>
+    ldx l0018                                                         ; beb9: a6 18       ..
+    stx l0042                                                         ; bebb: 86 42       .B
+    lda #osfile_save                                                  ; bebd: a9 00       ..
+    tay                                                               ; bebf: a8          .
+    ldx #<(l0037)                                                     ; bec0: a2 37       .7
+    jsr osfile                                                        ; bec2: 20 dd ff     ..
+    bra cbeeb                                                         ; bec5: 80 24       .$
+sub_cbec7
+    jsr sub_cbe76                                                     ; bec7: 20 76 be     v.
+    ldx #<(l0600)                                                     ; beca: a2 00       ..
+sub_cbecc
+lbecd = sub_cbecc+1
+    ldy #>(l0600)                                                     ; becc: a0 06       ..
+; overlapping: asl l0020                                              ; becd: 06 20       .
+; $becd referenced 1 time by $be59
+    jsr oscli                                                         ; bece: 20 f7 ff     ..
+    bra cbeeb                                                         ; bed1: 80 18       ..
+; $bed3 referenced 1 time by $90ad
+cbed3
+    lda #3                                                            ; bed3: a9 03       ..
+    bra cbed9                                                         ; bed5: 80 02       ..
+sub_cbed7
+    lda #1                                                            ; bed7: a9 01       ..
+; $bed9 referenced 1 time by $bed5
+cbed9
+    pha                                                               ; bed9: 48          H
+    jsr sub_cba6e                                                     ; beda: 20 6e ba     n.
+    phy                                                               ; bedd: 5a          Z
+    jsr c9c16                                                         ; bede: 20 16 9c     ..
+    jsr sub_c9781                                                     ; bee1: 20 81 97     ..
+    ply                                                               ; bee4: 7a          z
+    ldx #$2a ; '*'                                                    ; bee5: a2 2a       .*
+    pla                                                               ; bee7: 68          h
+    jsr osargs                                                        ; bee8: 20 da ff     ..
+; $beeb referenced 4 times by $bec5, $bed1, $befb, $bf0d
+cbeeb
+    jmp c90ca                                                         ; beeb: 4c ca 90    L..
+
+sub_cbeee
+    jsr sub_cba6e                                                     ; beee: 20 6e ba     n.
+    jsr sub_c9c5a                                                     ; bef1: 20 5a 9c     Z.
+    ldy l002a                                                         ; bef4: a4 2a       .*
+    lda #0                                                            ; bef6: a9 00       ..
+    jsr osfind                                                        ; bef8: 20 ce ff     ..
+    bra cbeeb                                                         ; befb: 80 ee       ..
+sub_cbefd
+lbefe = sub_cbefd+1
+    jsr sub_cba6e                                                     ; befd: 20 6e ba     n.
+; $befe referenced 1 time by $aa61
+; $bf00 referenced 1 time by $aa5a
+cbf00
+    pha                                                               ; bf00: 48          H
+    jsr sub_c9771                                                     ; bf01: 20 71 97     q.
+    jsr sub_c9c5a                                                     ; bf04: 20 5a 9c     Z.
+    ply                                                               ; bf07: 7a          z
+    lda l002a                                                         ; bf08: a5 2a       .*
+    jsr osbput                                                        ; bf0a: 20 d4 ff     ..
+    bra cbeeb                                                         ; bf0d: 80 dc       ..
+; $bf0f referenced 2 times by $951f, $be51
+sub_cbf0f
+    pla                                                               ; bf0f: 68          h
+    sta l0037                                                         ; bf10: 85 37       .7
+    pla                                                               ; bf12: 68          h
+    sta l0038                                                         ; bf13: 85 38       .8
+    bra cbf1a                                                         ; bf15: 80 03       ..
+; $bf17 referenced 1 time by $bf1d
+loop_cbf17
+    jsr osasci                                                        ; bf17: 20 e3 ff     ..
+; $bf1a referenced 1 time by $bf15
+cbf1a
+    jsr sub_c8e66                                                     ; bf1a: 20 66 8e     f.
+    bpl loop_cbf17                                                    ; bf1d: 10 f8       ..
+    jmp (l0037)                                                       ; bf1f: 6c 37 00    l7.
+
+; $bf22 referenced 4 times by $8ff7, $8ffb, $9007, $9012
+sub_cbf22
+    lda #osword_read_io_memory                                        ; bf22: a9 05       ..
+    phx                                                               ; bf24: da          .
+    ldx #<(l002a)                                                     ; bf25: a2 2a       .*
+    ldy #>(l002a)                                                     ; bf27: a0 00       ..
+    jsr osword                                                        ; bf29: 20 f1 ff     ..
+    plx                                                               ; bf2c: fa          .
+    lda l002e                                                         ; bf2d: a5 2e       ..
+; $bf2f referenced 4 times by $9400, $958e, $965e, $aabc
+sub_cbf2f
+    inc l002a                                                         ; bf2f: e6 2a       .*
+    bne cbf3d                                                         ; bf31: d0 0a       ..
+    inc l002b                                                         ; bf33: e6 2b       .+
+    bne cbf3d                                                         ; bf35: d0 06       ..
+    inc l002c                                                         ; bf37: e6 2c       .,
+    bne cbf3d                                                         ; bf39: d0 02       ..
+    inc l002d                                                         ; bf3b: e6 2d       .-
+; $bf3d referenced 3 times by $bf31, $bf35, $bf39
+cbf3d
+    rts                                                               ; bf3d: 60          `
+
+; $bf3e referenced 2 times by $9019, $9045
+sub_cbf3e
+    lda #$0d                                                          ; bf3e: a9 0d       ..
+    ldy l0018                                                         ; bf40: a4 18       ..
+    sty l0013                                                         ; bf42: 84 13       ..
+    stz l0012                                                         ; bf44: 64 12       d.
+    stz l0020                                                         ; bf46: 64 20       d
+    sta (l0012)                                                       ; bf48: 92 12       ..
+    lda #$ff                                                          ; bf4a: a9 ff       ..
+    ldy #1                                                            ; bf4c: a0 01       ..
+    sta (l0012),y                                                     ; bf4e: 91 12       ..
+    iny                                                               ; bf50: c8          .
+    sty l0012                                                         ; bf51: 84 12       ..
+    rts                                                               ; bf53: 60          `
+
+; $bf54 referenced 1 time by $b46c
+cbf54
+    ldy #9                                                            ; bf54: a0 09       ..
+; $bf56 referenced 1 time by $bf5d
+loop_cbf56
+    lda lb3be,y                                                       ; bf56: b9 be b3    ...
+    sta l0600,y                                                       ; bf59: 99 00 06    ...
+    dey                                                               ; bf5c: 88          .
+    bpl loop_cbf56                                                    ; bf5d: 10 f7       ..
+    ldx #<(l0600)                                                     ; bf5f: a2 00       ..
+    ldy #>(l0600)                                                     ; bf61: a0 06       ..
+    jmp oscli                                                         ; bf63: 4c f7 ff    L..
+
+; $bf66 referenced 1 time by $80ac
+sub_cbf66
+    lda #osbyte_read_tube_presence                                    ; bf66: a9 ea       ..
+    ldx #0                                                            ; bf68: a2 00       ..
+    ldy #$ff                                                          ; bf6a: a0 ff       ..
+    jsr osbyte                                                        ; bf6c: 20 f4 ff     ..
+    txa                                                               ; bf6f: 8a          .
+    rts                                                               ; bf70: 60          `
+
+; $bf71 referenced 1 time by $bbed
+lbf71
+    !byte $52, $0b, $a8, $34, $a6, $e4, $a6, $0a, $a7, $10, $ad, $7e  ; bf71: 52 0b a8... R..
+    !byte $a5, $4d, $a5, $4a, $2e, $7f, $5e, $5b, $d8, $aa,   0, $ca  ; bf7d: a5 4d a5... .M.
+    !byte $98, $80, $81, $22, $f9, $83, $6e, $81, $49, $0f, $da, $a2  ; bf89: 98 80 81... ...
+    !byte $21, $b3, $b2, $87, $80, $82, $38, $aa, $3b, $29, $80, $31  ; bf95: 21 b3 b2... !..
+    !byte $72, $17, $f7, $d1, $5f, $5b, $e6, $ff, $66, $2b, $cc, $77  ; bfa1: 72 17 f7... r..
+    !byte $6d,   6, $37, $bd, $73, $51, $b7, $17, $7a, $23, $d7, $0a  ; bfad: 6d 06 37... m.7
+    !byte $81,   0,   0,   0,   0, $82, $40,   0,   0,   0, $9a, $d4  ; bfb9: 81 00 00... ...
+    !byte $82, $7f, $b9, $ff, $78, $7b, $0e, $fa, $35, $12, $86, $65  ; bfc5: 82 7f b9... ...
+    !byte $2e, $e0, $d3, $7e, $88, $88, $88, $89, $7b, $8c            ; bfd1: 2e e0 d3... ...
+    !text "o-Y"                                                       ; bfdb: 6f 2d 59    o-Y
+    !byte $81, $99, $99, $99, $9a, $f3, $9e, $7b, $77, $81, $c0,   0  ; bfde: 81 99 99... ...
+    !byte   0,   0, $80, $93, $e6, $90,   0, $81, $c4                 ; bfea: 00 00 80... ...
+    !text "DDD"                                                       ; bff3: 44 44 44    DDD
+    !byte $80, $9d, $fd, $13,   4, $81, $e6                           ; bff6: 80 9d fd... ...
+    !text "fff"                                                       ; bffd: 66 66 66    fff
+pydis_end
+
+; Label references by decreasing frequency:
+;     l002a:              206
+;     l0037:              133
+;     l002b:              119
+;     l0031:               88
+;     l000b:               82
+;     l001b:               82
+;     l000a:               81
+;     l003d:               78
+;     l0004:               75
+;     l002c:               75
+;     l0033:               66
+;     l0032:               65
+;     l0034:               63
+;     l0039:               59
+;     l0038:               58
+;     l0030:               57
+;     l002d:               56
+;     l0019:               52
+;     l003f:               52
+;     l0036:               51
+;     l003b:               49
+;     l002e:               48
+;     l003e:               48
+;     l0035:               42
+;     l000c:               37
+;     l003c:               36
+;     l0040:               34
+;     l004c:               31
+;     l0002:               29
+;     l003a:               29
+;     l0600:               29
+;     c8f9d:               29
+;     l0027:               28
+;     l004a:               25
+;     c9c6a:               24
+;     sub_c9332:           23
+;     l0003:               22
+;     l001a:               22
+;     l0012:               21
+;     l0041:               21
+;     l0048:               21
+;     cbc66:               20
+;     sub_c8da2:           18
+;     l0005:               17
+;     l002f:               17
+;     l004d:               16
+;     c8f92:               16
+;     l0013:               15
+;     l0018:               15
+;     l0049:               15
+;     oswrch:              15
+;     c9155:               14
+;     sub_c9dff:           14
+;     cad78:               14
+;     l0026:               13
+;     sub_cbd26:           13
+;     l0029:               12
+;     c90ca:               11
+;     ca2cc:               11
+;     cae60:               11
+;     osbyte:              11
+;     l0007:               10
+;     l000d:               10
+;     l0028:               10
+;     l0042:               10
+;     sub_c9779:           10
+;     sub_c9be2:           10
+;     c9c80:               10
+;     l000f:                9
+;     l001f:                9
+;     l05ff:                9
+;     sub_c8e5f:            9
+;     sub_c997d:            9
+;     sub_c9c5a:            9
+;     l0000:                8
+;     l0001:                8
+;     l0006:                8
+;     l001e:                8
+;     l0047:                8
+;     l004b:                8
+;     c828d:                8
+;     sub_c8d86:            8
+;     c90d0:                8
+;     c9338:                8
+;     c95f1:                8
+;     sub_c979f:            8
+;     sub_c9df3:            8
+;     sub_ca545:            8
+;     cae62:                8
+;     sub_cbac2:            8
+;     l0014:                7
+;     sub_c8fa8:            7
+;     c9048:                7
+;     sub_c9774:            7
+;     sub_c9783:            7
+;     c9c2d:                7
+;     ca72b:                7
+;     sub_cbbdc:            7
+;     cbc91:                7
+;     l000e:                6
+;     l0015:                6
+;     l0020:                6
+;     romsel_copy:          6
+;     c8b1b:                6
+;     c8bf9:                6
+;     sub_c8d9c:            6
+;     sub_c8e41:            6
+;     c8e6c:                6
+;     c904b:                6
+;     c90c5:                6
+;     sub_c976c:            6
+;     sub_c9771:            6
+;     c9e85:                6
+;     cac2b:                6
+;     cad10:                6
+;     cadce:                6
+;     cb169:                6
+;     sub_cbc83:            6
+;     cbdff:                6
+;     sub_cbe06:            6
+;     sub_cbe25:            6
+;     osbput:               6
+;     osbget:               6
+;     osword:               6
+;     l0010:                5
+;     l0024:                5
+;     l0025:                5
+;     os_text_ptr:          5
+;     l0400:                5
+;     c84ce:                5
+;     sub_c8d94:            5
+;     c932d:                5
+;     c9784:                5
+;     sub_c9788:            5
+;     sub_c97a2:            5
+;     c9a46:                5
+;     c9e83:                5
+;     c9f4c:                5
+;     ca261:                5
+;     sub_ca514:            5
+;     ca634:                5
+;     ca70a:                5
+;     ca712:                5
+;     cac1c:                5
+;     cac38:                5
+;     cad20:                5
+;     cafb8:                5
+;     sub_cb365:            5
+;     cb5cf:                5
+;     cb805:                5
+;     sub_cb85a:            5
+;     cbc3a:                5
+;     sub_cbd12:            5
+;     cbd21:                5
+;     sub_cbd48:            5
+;     cbdd4:                5
+;     l0011:                4
+;     l001c:                4
+;     l001d:                4
+;     l0046:                4
+;     l0100:                4
+;     l0440:                4
+;     l0441:                4
+;     sub_c8149:            4
+;     c815d:                4
+;     c820f:                4
+;     c84a3:                4
+;     c8af2:                4
+;     c8ce3:                4
+;     c8dfc:                4
+;     c8e51:                4
+;     c8ee7:                4
+;     c9045:                4
+;     c90c7:                4
+;     c9207:                4
+;     c9700:                4
+;     sub_c977e:            4
+;     sub_c9781:            4
+;     c9808:                4
+;     sub_c9952:            4
+;     c9c16:                4
+;     c9c8a:                4
+;     c9d75:                4
+;     sub_c9f07:            4
+;     c9f0a:                4
+;     sub_ca06c:            4
+;     ca0d1:                4
+;     ca2fb:                4
+;     ca426:                4
+;     ca513:                4
+;     caae8:                4
+;     cb5df:                4
+;     cb7b3:                4
+;     sub_cbc24:            4
+;     sub_cbd5e:            4
+;     sub_cbd77:            4
+;     cbdd2:                4
+;     sub_cbdd8:            4
+;     cbe05:                4
+;     cbeeb:                4
+;     sub_cbf22:            4
+;     sub_cbf2f:            4
+;     l0016:                3
+;     l0023:                3
+;     l00fd:                3
+;     l0401:                3
+;     l046c:                3
+;     l051d:                3
+;     l051f:                3
+;     l0524:                3
+;     c806a:                3
+;     sub_c80d8:            3
+;     c8190:                3
+;     sub_c8191:            3
+;     c827c:                3
+;     c82dd:                3
+;     c8304:                3
+;     c83d2:                3
+;     c8b10:                3
+;     c8bb2:                3
+;     c8c1b:                3
+;     c8c1e:                3
+;     c8cbb:                3
+;     c8d64:                3
+;     sub_c8d89:            3
+;     sub_c8d8c:            3
+;     c8e3f:                3
+;     sub_c8e66:            3
+;     c8e6f:                3
+;     c8e9c:                3
+;     c8ed0:                3
+;     c8edc:                3
+;     c8fbb:                3
+;     c9164:                3
+;     sub_c916e:            3
+;     c926e:                3
+;     c9276:                3
+;     c9288:                3
+;     c92da:                3
+;     sub_c9330:            3
+;     c93d7:                3
+;     sub_c953d:            3
+;     c96b8:                3
+;     c96ca:                3
+;     c979c:                3
+;     c98bd:                3
+;     c990c:                3
+;     sub_c990f:            3
+;     sub_c9923:            3
+;     c9a14:                3
+;     c9a28:                3
+;     sub_c9b97:            3
+;     c9bda:                3
+;     c9c55:                3
+;     c9c74:                3
+;     sub_c9d0f:            3
+;     sub_c9d7f:            3
+;     sub_ca0e8:            3
+;     ca126:                3
+;     ca174:                3
+;     sub_ca2dd:            3
+;     ca385:                3
+;     sub_ca3ed:            3
+;     sub_ca46b:            3
+;     ca4a9:                3
+;     ca4b9:                3
+;     sub_ca5ad:            3
+;     sub_ca5b4:            3
+;     ca622:                3
+;     sub_ca62f:            3
+;     ca674:                3
+;     ca6e4:                3
+;     ca6ed:                3
+;     sub_ca6ff:            3
+;     ca725:                3
+;     sub_ca73e:            3
+;     ca9c1:                3
+;     sub_ca9d1:            3
+;     cab9d:                3
+;     cadee:                3
+;     caed7:                3
+;     caed9:                3
+;     caf07:                3
+;     caf88:                3
+;     cb1de:                3
+;     sub_cb2e0:            3
+;     cb753:                3
+;     cb8fa:                3
+;     cb997:                3
+;     cb9ff:                3
+;     cba46:                3
+;     sub_cba6e:            3
+;     sub_cba7a:            3
+;     cbb1a:                3
+;     cbd3a:                3
+;     sub_cbd46:            3
+;     cbf3d:                3
+;     osnewl:               3
+;     oscli:                3
+;     l0017:                2
+;     l0021:                2
+;     l0022:                2
+;     l0044:                2
+;     l004e:                2
+;     l01ff:                2
+;     wrchv:                2
+;     l0402:                2
+;     l0403:                2
+;     l043c:                2
+;     l043d:                2
+;     l0519:                2
+;     l051a:                2
+;     l051b:                2
+;     l051c:                2
+;     l051e:                2
+;     l0521:                2
+;     l0522:                2
+;     l0523:                2
+;     l0526:                2
+;     l0527:                2
+;     l0700:                2
+;     c8067:                2
+;     c808f:                2
+;     c80a8:                2
+;     c80cc:                2
+;     c8151:                2
+;     c8197:                2
+;     c81b9:                2
+;     sub_c81bd:            2
+;     sub_c8287:            2
+;     sub_c828a:            2
+;     c82ae:                2
+;     c82f4:                2
+;     c82fb:                2
+;     c8306:                2
+;     sub_c83d3:            2
+;     c840a:                2
+;     sub_c8429:            2
+;     c89dd:                2
+;     c8b40:                2
+;     c8b5f:                2
+;     c8b62:                2
+;     c8b83:                2
+;     c8c31:                2
+;     c8c99:                2
+;     c8ca4:                2
+;     c8cbd:                2
+;     c8d34:                2
+;     c8d6e:                2
+;     sub_c8da8:            2
+;     c8dc9:                2
+;     c8e57:                2
+;     c8e7d:                2
+;     c8eb6:                2
+;     c8f1a:                2
+;     c8f26:                2
+;     c8f41:                2
+;     c8f5d:                2
+;     sub_c8fae:            2
+;     c9073:                2
+;     c90de:                2
+;     c914f:                2
+;     sub_c9171:            2
+;     c9193:                2
+;     c91ad:                2
+;     c91d1:                2
+;     c9285:                2
+;     sub_c933d:            2
+;     c9357:                2
+;     sub_c935c:            2
+;     sub_c93c7:            2
+;     sub_c9410:            2
+;     sub_c9436:            2
+;     c947f:                2
+;     c94ba:                2
+;     c94e4:                2
+;     c950d:                2
+;     c9555:                2
+;     sub_c95cb:            2
+;     c9635:                2
+;     sub_c9769:            2
+;     c979b:                2
+;     c97ee:                2
+;     c9866:                2
+;     c986a:                2
+;     c98c0:                2
+;     c98dc:                2
+;     c9928:                2
+;     c9977:                2
+;     c997a:                2
+;     c999f:                2
+;     sub_c99c4:            2
+;     c99fa:                2
+;     c9a3a:                2
+;     c9a75:                2
+;     c9ac1:                2
+;     sub_c9ac9:            2
+;     c9bae:                2
+;     c9bbc:                2
+;     c9bce:                2
+;     sub_c9bee:            2
+;     sub_c9c0a:            2
+;     c9c3b:                2
+;     c9c41:                2
+;     sub_c9c4a:            2
+;     c9c6c:                2
+;     c9cc6:                2
+;     c9ced:                2
+;     c9d7c:                2
+;     sub_c9d81:            2
+;     c9dc1:                2
+;     sub_c9e3f:            2
+;     sub_c9e6d:            2
+;     c9ecb:                2
+;     c9f55:                2
+;     c9f9a:                2
+;     c9fa7:                2
+;     sub_ca023:            2
+;     sub_ca026:            2
+;     ca029:                2
+;     ca05b:                2
+;     sub_ca069:            2
+;     ca06f:                2
+;     ca081:                2
+;     ca09c:                2
+;     ca0c5:                2
+;     sub_ca0ec:            2
+;     ca158:                2
+;     sub_ca181:            2
+;     ca19b:                2
+;     ca19d:                2
+;     ca1d4:                2
+;     ca220:                2
+;     ca2b7:                2
+;     sub_ca2ca:            2
+;     ca2d6:                2
+;     ca303:                2
+;     ca357:                2
+;     ca3a1:                2
+;     ca3a7:                2
+;     ca3e5:                2
+;     ca3e9:                2
+;     ca446:                2
+;     ca452:                2
+;     ca47a:                2
+;     sub_ca4ba:            2
+;     ca4f5:                2
+;     ca547:                2
+;     sub_ca54d:            2
+;     sub_ca56d:            2
+;     ca57e:                2
+;     sub_ca5bb:            2
+;     sub_ca5cc:            2
+;     sub_ca5cf:            2
+;     sub_ca5e3:            2
+;     sub_ca5f4:            2
+;     sub_ca6cb:            2
+;     ca6ce:                2
+;     ca6f2:                2
+;     ca704:                2
+;     ca73b:                2
+;     ca79b:                2
+;     ca7db:                2
+;     ca805:                2
+;     ca857:                2
+;     ca878:                2
+;     sub_ca8b3:            2
+;     sub_ca8b9:            2
+;     sub_ca97b:            2
+;     caa2c:                2
+;     sub_caa50:            2
+;     sub_caa55:            2
+;     sub_caa6e:            2
+;     caa7a:                2
+;     sub_caad8:            2
+;     cab1a:                2
+;     cab41:                2
+;     cabdd:                2
+;     cac2d:                2
+;     cacd2:                2
+;     cace8:                2
+;     cacfd:                2
+;     sub_cad3a:            2
+;     cad5b:                2
+;     cae56:                2
+;     caeb4:                2
+;     caedb:                2
+;     caf03:                2
+;     cafdb:                2
+;     cafee:                2
+;     sub_cb057:            2
+;     cb109:                2
+;     cb17e:                2
+;     sub_cb1bf:            2
+;     cb1db:                2
+;     cb205:                2
+;     cb341:                2
+;     sub_cb362:            2
+;     sub_cb372:            2
+;     cb39e:                2
+;     cb3fb:                2
+;     cb451:                2
+;     cb485:                2
+;     cb4a7:                2
+;     cb4e2:                2
+;     cb54b:                2
+;     cb563:                2
+;     cb56a:                2
+;     cb629:                2
+;     cb7a4:                2
+;     cb81a:                2
+;     sub_cb84d:            2
+;     cb866:                2
+;     cb86c:                2
+;     cb87f:                2
+;     cb9a5:                2
+;     sub_cb9dc:            2
+;     sub_cba6c:            2
+;     sub_cbaa4:            2
+;     cbac5:                2
+;     sub_cbac8:            2
+;     cbae8:                2
+;     sub_cbb0f:            2
+;     sub_cbb1b:            2
+;     cbb9b:                2
+;     sub_cbbff:            2
+;     sub_cbc18:            2
+;     sub_cbc36:            2
+;     sub_cbc62:            2
+;     cbd0e:                2
+;     cbd3d:                2
+;     cbd74:                2
+;     cbd86:                2
+;     sub_cbdac:            2
+;     sub_cbdcf:            2
+;     sub_cbdf3:            2
+;     sub_cbe17:            2
+;     cbe51:                2
+;     sub_cbe6b:            2
+;     sub_cbe76:            2
+;     sub_cbe81:            2
+;     sub_cbf0f:            2
+;     sub_cbf3e:            2
+;     osfind:               2
+;     osargs:               2
+;     osfile:               2
+;     osrdch:               2
+;     osasci:               2
+;     l0008:                1
+;     l0009:                1
+;     l0043:                1
+;     l0045:                1
+;     l0061:                1
+;     l0064:                1
+;     l0066:                1
+;     l00c1:                1
+;     l00e1:                1
+;     l00e6:                1
+;     l00fe:                1
+;     l00ff:                1
+;     l0106:                1
+;     brkv:                 1
+;     brkv+1:               1
+;     l0404:                1
+;     l040c:                1
+;     l0460:                1
+;     l0464:                1
+;     l0469:                1
+;     l047f:                1
+;     l04ff:                1
+;     l0500:                1
+;     l0513:                1
+;     l0514:                1
+;     l0528:                1
+;     l0529:                1
+;     l052a:                1
+;     l05cb:                1
+;     l05cc:                1
+;     l05e5:                1
+;     l05e6:                1
+;     l07ef:                1
+;     l0bb1:                1
+;     l0e4e:                1
+;     l4e4e:                1
+;     l5252:                1
+;     l6142:                1
+;     l7461:                1
+;     l7f0e:                1
+;     l7f13:                1
+;     service_handler:      1
+;     c8040:                1
+;     c804c:                1
+;     loop_c8057:           1
+;     c805e:                1
+;     c8070:                1
+;     loop_c8091:           1
+;     copy_to_stack_loop:   1
+;     l80c2:                1
+;     l80dd:                1
+;     l80e2:                1
+;     language_handler:     1
+;     c80ff:                1
+;     sub_c8139:            1
+;     c8168:                1
+;     loop_c8176:           1
+;     c817a:                1
+;     c8187:                1
+;     loop_c819f:           1
+;     c81ad:                1
+;     c81c8:                1
+;     loop_c81e1:           1
+;     c81ea:                1
+;     c81fd:                1
+;     loop_c8206:           1
+;     c8210:                1
+;     c8230:                1
+;     loop_c8235:           1
+;     c823f:                1
+;     c8242:                1
+;     c8246:                1
+;     loop_c8252:           1
+;     c825b:                1
+;     c829a:                1
+;     loop_c82b2:           1
+;     c82be:                1
+;     c82c8:                1
+;     c82d8:                1
+;     sub_c82e6:            1
+;     loop_c82f7:           1
+;     loop_c8314:           1
+;     c832f:                1
+;     loop_c8331:           1
+;     c833b:                1
+;     c8345:                1
+;     c8346:                1
+;     sub_c8349:            1
+;     sub_c834f:            1
+;     c8353:                1
+;     c835e:                1
+;     c8362:                1
+;     loop_c8365:           1
+;     c8371:                1
+;     c8372:                1
+;     c8392:                1
+;     loop_c839e:           1
+;     c83a6:                1
+;     sub_c83aa:            1
+;     c83c1:                1
+;     sub_c83c2:            1
+;     c83d5:                1
+;     loop_c8428:           1
+;     loop_c8440:           1
+;     c8456:                1
+;     loop_c845b:           1
+;     c846a:                1
+;     loop_c847b:           1
+;     c8491:                1
+;     loop_c8496:           1
+;     c84ad:                1
+;     c84f4:                1
+;     l880a:                1
+;     l8909:                1
+;     l894e:                1
+;     l8993:                1
+;     c89bf:                1
+;     loop_c89d7:           1
+;     c89f4:                1
+;     c8a0b:                1
+;     loop_c8a11:           1
+;     c8a1e:                1
+;     c8a28:                1
+;     loop_c8a2a:           1
+;     c8a34:                1
+;     loop_c8a3c:           1
+;     c8a44:                1
+;     c8a4b:                1
+;     loop_c8a4f:           1
+;     loop_c8a54:           1
+;     loop_c8a5e:           1
+;     c8a64:                1
+;     c8a68:                1
+;     c8a6b:                1
+;     loop_c8a6e:           1
+;     c8a79:                1
+;     c8a8b:                1
+;     c8a8e:                1
+;     c8a91:                1
+;     sub_c8aa8:            1
+;     loop_c8ac3:           1
+;     loop_c8ad4:           1
+;     c8adf:                1
+;     loop_c8ae3:           1
+;     c8aef:                1
+;     c8af5:                1
+;     c8b33:                1
+;     c8b4b:                1
+;     c8b55:                1
+;     c8b63:                1
+;     c8b98:                1
+;     c8b9b:                1
+;     c8b9c:                1
+;     loop_c8b9e:           1
+;     c8ba3:                1
+;     c8baf:                1
+;     c8bb4:                1
+;     c8bb6:                1
+;     c8bbd:                1
+;     c8bc4:                1
+;     c8bde:                1
+;     c8be9:                1
+;     c8c01:                1
+;     loop_c8c15:           1
+;     c8c24:                1
+;     c8c41:                1
+;     c8c43:                1
+;     c8c55:                1
+;     c8c57:                1
+;     c8c5e:                1
+;     c8c74:                1
+;     c8c84:                1
+;     c8c87:                1
+;     c8c96:                1
+;     loop_c8c9b:           1
+;     c8ca7:                1
+;     c8cb8:                1
+;     c8cc0:                1
+;     c8ce6:                1
+;     c8cfd:                1
+;     c8d16:                1
+;     c8d37:                1
+;     c8d44:                1
+;     loop_c8d71:           1
+;     c8d74:                1
+;     loop_c8db7:           1
+;     sub_c8dc1:            1
+;     c8dff:                1
+;     loop_c8e16:           1
+;     sub_c8e1f:            1
+;     sub_c8e58:            1
+;     c8e8d:                1
+;     loop_c8e91:           1
+;     c8e9d:                1
+;     sub_c8ea4:            1
+;     c8ea6:                1
+;     c8eaa:                1
+;     c8ebe:                1
+;     loop_c8ee2:           1
+;     c8ef3:                1
+;     c8f03:                1
+;     loop_c8f0b:           1
+;     c8f25:                1
+;     c8f32:                1
+;     c8f3d:                1
+;     c8f52:                1
+;     c8f6d:                1
+;     c8f74:                1
+;     loop_c8f7a:           1
+;     c8f86:                1
+;     c8f87:                1
+;     c8f8c:                1
+;     c8f9c:                1
+;     loop_c8fa7:           1
+;     sub_c8fb4:            1
+;     c8fda:                1
+;     c8ff2:                1
+;     loop_c9004:           1
+;     c901c:                1
+;     loop_c9024:           1
+;     c9033:                1
+;     c905c:                1
+;     c9069:                1
+;     loop_c9078:           1
+;     c907d:                1
+;     c9082:                1
+;     c9086:                1
+;     c90a0:                1
+;     loop_c90a6:           1
+;     loop_c90ad:           1
+;     c90b0:                1
+;     c90d2:                1
+;     c90e3:                1
+;     c90ea:                1
+;     c9108:                1
+;     c9112:                1
+;     c9123:                1
+;     c9135:                1
+;     c9146:                1
+;     loop_c91e4:           1
+;     c91ee:                1
+;     c91ef:                1
+;     loop_c91f6:           1
+;     c9201:                1
+;     c9204:                1
+;     loop_c9220:           1
+;     c922a:                1
+;     loop_c922c:           1
+;     c9237:                1
+;     loop_c923f:           1
+;     c924a:                1
+;     c9259:                1
+;     loop_c9260:           1
+;     loop_c9268:           1
+;     c9274:                1
+;     loop_c928b:           1
+;     c929e:                1
+;     loop_c92d4:           1
+;     loop_c92e0:           1
+;     c92ed:                1
+;     loop_c92f0:           1
+;     c9304:                1
+;     c931e:                1
+;     c9321:                1
+;     c9325:                1
+;     c932a:                1
+;     loop_c9355:           1
+;     loop_c9356:           1
+;     loop_c9368:           1
+;     c937c:                1
+;     c938f:                1
+;     c93b4:                1
+;     c93c4:                1
+;     loop_c93fa:           1
+;     c9433:                1
+;     sub_c943e:            1
+;     loop_c9455:           1
+;     c9469:                1
+;     c9476:                1
+;     c9487:                1
+;     loop_c948a:           1
+;     c94aa:                1
+;     c94b0:                1
+;     c94c8:                1
+;     c94d1:                1
+;     c94d5:                1
+;     c94de:                1
+;     c9509:                1
+;     c951d:                1
+;     c951f:                1
+;     c954b:                1
+;     c9579:                1
+;     c957c:                1
+;     c957f:                1
+;     c95be:                1
+;     sub_c95c6:            1
+;     loop_c95cf:           1
+;     c95e0:                1
+;     c95f9:                1
+;     c9606:                1
+;     c9628:                1
+;     c9632:                1
+;     c963b:                1
+;     c964e:                1
+;     c968d:                1
+;     c96bf:                1
+;     c971b:                1
+;     loop_c9724:           1
+;     loop_c9728:           1
+;     c972c:                1
+;     c9735:                1
+;     loop_c9750:           1
+;     c9753:                1
+;     sub_c978b:            1
+;     loop_c97c0:           1
+;     loop_c97c6:           1
+;     c97d2:                1
+;     c97fe:                1
+;     c9801:                1
+;     c9877:                1
+;     c9889:                1
+;     loop_c98cb:           1
+;     c98d7:                1
+;     loop_c98df:           1
+;     loop_c9904:           1
+;     sub_c9914:            1
+;     loop_c992a:           1
+;     c9937:                1
+;     loop_c9948:           1
+;     loop_c9954:           1
+;     sub_c995a:            1
+;     c9962:                1
+;     c996e:                1
+;     c9979:                1
+;     c9990:                1
+;     c99a0:                1
+;     c99a2:                1
+;     c99ab:                1
+;     c99ba:                1
+;     loop_c99cf:           1
+;     sub_c99d0:            1
+;     sub_c99d6:            1
+;     sub_c99d8:            1
+;     c9a0e:                1
+;     c9a58:                1
+;     c9a63:                1
+;     c9a67:                1
+;     c9a76:                1
+;     c9a79:                1
+;     c9a7b:                1
+;     c9a99:                1
+;     c9aa0:                1
+;     c9aa5:                1
+;     loop_c9ab6:           1
+;     c9abc:                1
+;     c9ae6:                1
+;     c9b4c:                1
+;     c9b5a:                1
+;     c9b78:                1
+;     c9b80:                1
+;     c9b8a:                1
+;     sub_c9bba:            1
+;     c9bd2:                1
+;     c9bdb:                1
+;     loop_c9be0:           1
+;     c9c08:                1
+;     c9c24:                1
+;     c9c52:                1
+;     loop_c9c6d:           1
+;     sub_c9c8e:            1
+;     loop_c9c92:           1
+;     sub_c9c93:            1
+;     sub_c9ca2:            1
+;     c9cb6:                1
+;     sub_c9cb8:            1
+;     c9cc1:                1
+;     c9cc5:                1
+;     loop_c9cc9:           1
+;     c9cd6:                1
+;     loop_c9ce8:           1
+;     c9ceb:                1
+;     c9cfb:                1
+;     loop_c9cfd:           1
+;     c9d0c:                1
+;     c9d29:                1
+;     sub_c9d36:            1
+;     c9d43:                1
+;     c9d57:                1
+;     c9d79:                1
+;     c9d7b:                1
+;     sub_c9d82:            1
+;     c9db4:                1
+;     c9dba:                1
+;     c9dbe:                1
+;     c9dbf:                1
+;     c9dc0:                1
+;     c9dc4:                1
+;     c9dd5:                1
+;     loop_c9dd7:           1
+;     c9de5:                1
+;     c9de9:                1
+;     c9e02:                1
+;     c9e10:                1
+;     loop_c9e18:           1
+;     loop_c9e23:           1
+;     c9e2a:                1
+;     loop_c9e32:           1
+;     sub_c9e45:            1
+;     c9e48:                1
+;     c9e4d:                1
+;     loop_c9e5b:           1
+;     c9e78:                1
+;     c9e79:                1
+;     c9e90:                1
+;     c9ea6:                1
+;     c9ead:                1
+;     c9eb2:                1
+;     c9ec2:                1
+;     c9edd:                1
+;     loop_c9ef2:           1
+;     c9f13:                1
+;     c9f3b:                1
+;     c9f4f:                1
+;     loop_c9f59:           1
+;     loop_c9f61:           1
+;     c9f64:                1
+;     c9f70:                1
+;     c9f9d:                1
+;     loop_c9faa:           1
+;     c9fb6:                1
+;     c9fb8:                1
+;     loop_c9fbb:           1
+;     c9fe6:                1
+;     c9ff4:                1
+;     ca00f:                1
+;     ca03b:                1
+;     ca03c:                1
+;     ca04a:                1
+;     ca04d:                1
+;     loop_ca052:           1
+;     ca05f:                1
+;     loop_ca070:           1
+;     ca09f:                1
+;     loop_ca0b8:           1
+;     ca0c7:                1
+;     ca0ee:                1
+;     loop_ca0f2:           1
+;     loop_ca0f5:           1
+;     ca10a:                1
+;     loop_ca10f:           1
+;     ca116:                1
+;     ca131:                1
+;     ca137:                1
+;     loop_ca13b:           1
+;     loop_ca151:           1
+;     ca160:                1
+;     ca169:                1
+;     ca18a:                1
+;     ca197:                1
+;     ca1af:                1
+;     ca1bc:                1
+;     ca1c1:                1
+;     ca1cd:                1
+;     ca1d0:                1
+;     ca1ed:                1
+;     ca1ef:                1
+;     ca204:                1
+;     loop_ca207:           1
+;     ca212:                1
+;     ca21c:                1
+;     ca22a:                1
+;     ca23e:                1
+;     ca24a:                1
+;     loop_ca256:           1
+;     ca25f:                1
+;     loop_ca263:           1
+;     ca26f:                1
+;     loop_ca27d:           1
+;     ca28a:                1
+;     ca28c:                1
+;     ca290:                1
+;     ca2a3:                1
+;     ca2b3:                1
+;     sub_ca2b8:            1
+;     loop_ca2bb:           1
+;     ca2c9:                1
+;     ca2fd:                1
+;     ca325:                1
+;     ca333:                1
+;     ca33e:                1
+;     ca342:                1
+;     ca348:                1
+;     ca34c:                1
+;     ca36b:                1
+;     ca37e:                1
+;     ca393:                1
+;     loop_ca399:           1
+;     ca3aa:                1
+;     loop_ca3ae:           1
+;     sub_ca3b5:            1
+;     sub_ca3c0:            1
+;     ca3c3:                1
+;     sub_ca40a:            1
+;     sub_ca419:            1
+;     ca42c:                1
+;     ca489:                1
+;     ca4a3:                1
+;     ca4c4:                1
+;     ca4ce:                1
+;     ca4e8:                1
+;     sub_ca503:            1
+;     sub_ca507:            1
+;     sub_ca50b:            1
+;     ca53b:                1
+;     ca53e:                1
+;     sub_ca541:            1
+;     sub_ca572:            1
+;     sub_ca576:            1
+;     ca57a:                1
+;     ca5a7:                1
+;     ca5aa:                1
+;     sub_ca5b2:            1
+;     loop_ca5b6:           1
+;     ca5ba:                1
+;     sub_ca5bd:            1
+;     sub_ca5c1:            1
+;     sub_ca5c4:            1
+;     sub_ca5d1:            1
+;     sub_ca5f2:            1
+;     sub_ca5f9:            1
+;     loop_ca607:           1
+;     ca608:                1
+;     ca612:                1
+;     loop_ca617:           1
+;     ca61d:                1
+;     loop_ca62c:           1
+;     sub_ca631:            1
+;     ca640:                1
+;     ca653:                1
+;     ca65c:                1
+;     ca65e:                1
+;     ca676:                1
+;     ca68d:                1
+;     ca6a2:                1
+;     loop_ca6a8:           1
+;     ca6ae:                1
+;     ca6c4:                1
+;     sub_ca6eb:            1
+;     sub_ca70d:            1
+;     ca70f:                1
+;     ca71e:                1
+;     ca72f:                1
+;     sub_ca731:            1
+;     ca739:                1
+;     ca73d:                1
+;     ca74d:                1
+;     loop_ca758:           1
+;     ca76b:                1
+;     ca776:                1
+;     ca797:                1
+;     sub_ca7ac:            1
+;     sub_ca7af:            1
+;     ca7c0:                1
+;     la7c9:                1
+;     ca7cd:                1
+;     ca7ed:                1
+;     ca7ef:                1
+;     sub_ca80b:            1
+;     ca829:                1
+;     ca838:                1
+;     ca83f:                1
+;     ca841:                1
+;     ca875:                1
+;     ca88a:                1
+;     loop_ca88f:           1
+;     ca899:                1
+;     ca8b0:                1
+;     ca8bb:                1
+;     loop_ca8cd:           1
+;     loop_ca8e0:           1
+;     ca8ee:                1
+;     sub_ca901:            1
+;     ca91f:                1
+;     ca92d:                1
+;     ca932:                1
+;     ca93b:                1
+;     ca946:                1
+;     ca948:                1
+;     ca94b:                1
+;     ca959:                1
+;     ca962:                1
+;     ca965:                1
+;     loop_ca969:           1
+;     ca978:                1
+;     loop_ca982:           1
+;     sub_ca9a3:            1
+;     sub_ca9c3:            1
+;     ca9e0:                1
+;     ca9ef:                1
+;     ca9f2:                1
+;     loop_ca9f5:           1
+;     ca9f8:                1
+;     caa07:                1
+;     sub_caa1a:            1
+;     caa33:                1
+;     caa3e:                1
+;     caa44:                1
+;     loop_caa59:           1
+;     caa66:                1
+;     caa6b:                1
+;     caa7d:                1
+;     caa9a:                1
+;     caab0:                1
+;     caac1:                1
+;     loop_caaf0:           1
+;     sub_cab14:            1
+;     cab23:                1
+;     cab82:                1
+;     cab91:                1
+;     sub_caba5:            1
+;     cabc9:                1
+;     cabd0:                1
+;     cabfa:                1
+;     cabfd:                1
+;     cac02:                1
+;     cac0f:                1
+;     cac35:                1
+;     loop_cac3c:           1
+;     cac59:                1
+;     cac5b:                1
+;     caca0:                1
+;     caca3:                1
+;     caca9:                1
+;     cacaf:                1
+;     loop_cacd8:           1
+;     cace3:                1
+;     loop_cace5:           1
+;     loop_caceb:           1
+;     cacef:                1
+;     sub_cad07:            1
+;     cad0d:                1
+;     cad14:                1
+;     cad19:                1
+;     sub_cad1c:            1
+;     cad37:                1
+;     loop_cad43:           1
+;     cad52:                1
+;     cad53:                1
+;     loop_cad5d:           1
+;     loop_cad5e:           1
+;     cad75:                1
+;     sub_cad8e:            1
+;     cad91:                1
+;     cad9c:                1
+;     cadac:                1
+;     cadb6:                1
+;     cadbc:                1
+;     sub_cadc6:            1
+;     loop_cade0:           1
+;     cade4:                1
+;     cadf9:                1
+;     loop_cadfe:           1
+;     cae00:                1
+;     cae0d:                1
+;     cae11:                1
+;     loop_cae1e:           1
+;     cae31:                1
+;     cae3f:                1
+;     cae9f:                1
+;     caedc:                1
+;     loop_caeed:           1
+;     caf2f:                1
+;     caf3d:                1
+;     caf4d:                1
+;     loop_caf51:           1
+;     caf6d:                1
+;     caf83:                1
+;     loop_cafa2:           1
+;     loop_cafa4:           1
+;     cafbb:                1
+;     cafbe:                1
+;     loop_cafc1:           1
+;     cafd5:                1
+;     loop_cafe3:           1
+;     caffd:                1
+;     cb00e:                1
+;     loop_cb019:           1
+;     cb04a:                1
+;     loop_cb066:           1
+;     cb08a:                1
+;     cb0a6:                1
+;     cb0b0:                1
+;     cb0be:                1
+;     loop_cb0d8:           1
+;     cb0e2:                1
+;     loop_cb0f2:           1
+;     cb106:                1
+;     loop_cb146:           1
+;     cb1a3:                1
+;     cb1a6:                1
+;     cb1ab:                1
+;     cb1b5:                1
+;     cb1ca:                1
+;     cb200:                1
+;     cb22d:                1
+;     cb230:                1
+;     cb235:                1
+;     loop_cb24d:           1
+;     cb256:                1
+;     cb257:                1
+;     loop_cb259:           1
+;     cb266:                1
+;     loop_cb307:           1
+;     loop_cb32b:           1
+;     cb34c:                1
+;     cb35c:                1
+;     loop_cb35f:           1
+;     cb380:                1
+;     cb398:                1
+;     cb399:                1
+;     lb3be:                1
+;     cb3cf:                1
+;     cb3f4:                1
+;     cb3fe:                1
+;     cb425:                1
+;     cb428:                1
+;     cb42b:                1
+;     cb445:                1
+;     cb454:                1
+;     cb45d:                1
+;     cb46f:                1
+;     cb47f:                1
+;     cb495:                1
+;     cb497:                1
+;     cb4a1:                1
+;     loop_cb4a9:           1
+;     cb4b8:                1
+;     cb4ba:                1
+;     cb4bc:                1
+;     cb4c2:                1
+;     cb4e0:                1
+;     loop_cb4f2:           1
+;     cb4f8:                1
+;     cb50a:                1
+;     cb510:                1
+;     cb516:                1
+;     cb51c:                1
+;     cb522:                1
+;     loop_cb52d:           1
+;     cb530:                1
+;     loop_cb536:           1
+;     cb5cd:                1
+;     cb5f1:                1
+;     cb622:                1
+;     cb626:                1
+;     cb635:                1
+;     loop_cb642:           1
+;     cb6a7:                1
+;     cb6bf:                1
+;     cb6d1:                1
+;     cb6f7:                1
+;     cb70c:                1
+;     cb723:                1
+;     loop_cb730:           1
+;     cb74a:                1
+;     cb75a:                1
+;     cb762:                1
+;     loop_cb769:           1
+;     loop_cb771:           1
+;     cb7ca:                1
+;     cb7d4:                1
+;     cb7da:                1
+;     cb7e6:                1
+;     cb7fa:                1
+;     loop_cb806:           1
+;     cb824:                1
+;     cb833:                1
+;     cb847:                1
+;     loop_cb84c:           1
+;     cb857:                1
+;     loop_cb86f:           1
+;     loop_cb872:           1
+;     cb874:                1
+;     cb877:                1
+;     loop_cb8ac:           1
+;     cb8b5:                1
+;     cb8ba:                1
+;     loop_cb8c2:           1
+;     cb8cc:                1
+;     loop_cb8ce:           1
+;     cb8da:                1
+;     cb8e2:                1
+;     cb8f2:                1
+;     loop_cb8ff:           1
+;     cb909:                1
+;     cb938:                1
+;     cb941:                1
+;     cb94f:                1
+;     loop_cb95a:           1
+;     cb965:                1
+;     cb968:                1
+;     loop_cb974:           1
+;     cb976:                1
+;     cb9ad:                1
+;     cb9bf:                1
+;     cb9cd:                1
+;     loop_cb9f6:           1
+;     loop_cba0a:           1
+;     cba21:                1
+;     cba2b:                1
+;     cba31:                1
+;     cba35:                1
+;     cba43:                1
+;     cba63:                1
+;     sub_cbaa0:            1
+;     cbaa6:                1
+;     cbae6:                1
+;     cbaf7:                1
+;     cbb03:                1
+;     cbb0c:                1
+;     cbb16:                1
+;     sub_cbb38:            1
+;     loop_cbb3c:           1
+;     cbb45:                1
+;     loop_cbb56:           1
+;     loop_cbb5d:           1
+;     cbb64:                1
+;     cbba6:                1
+;     cbbaf:                1
+;     cbbd0:                1
+;     loop_cbbd2:           1
+;     sub_cbbeb:            1
+;     loop_cbbed:           1
+;     loop_cbbf8:           1
+;     sub_cbc1e:            1
+;     sub_cbc20:            1
+;     loop_cbc9d:           1
+;     cbca5:                1
+;     sub_cbcaa:            1
+;     loop_cbcc5:           1
+;     cbccd:                1
+;     loop_cbcd1:           1
+;     cbcd5:                1
+;     loop_cbcdc:           1
+;     cbce6:                1
+;     cbcea:                1
+;     loop_cbd19:           1
+;     cbd23:                1
+;     cbd45:                1
+;     cbd64:                1
+;     cbd70:                1
+;     cbd71:                1
+;     loop_cbd88:           1
+;     cbd9e:                1
+;     loop_cbda0:           1
+;     cbdaa:                1
+;     sub_cbdb7:            1
+;     cbdbd:                1
+;     loop_cbdbf:           1
+;     cbdc9:                1
+;     cbde2:                1
+;     sub_cbdf4:            1
+;     loop_cbe2d:           1
+;     cbe43:                1
+;     sub_cbe44:            1
+;     cbe45:                1
+;     sub_cbe46:            1
+;     cbe4e:                1
+;     sub_cbe65:            1
+;     loop_cbe73:           1
+;     sub_cbe8b:            1
+;     lbecd:                1
+;     cbed3:                1
+;     cbed9:                1
+;     lbefe:                1
+;     cbf00:                1
+;     loop_cbf17:           1
+;     cbf1a:                1
+;     cbf54:                1
+;     loop_cbf56:           1
+;     sub_cbf66:            1
+;     lbf71:                1
+;     le09c:                1
+
+; Automatically generated labels:
+;     c8040
+;     c804c
+;     c805e
+;     c8067
+;     c806a
+;     c8070
+;     c808f
+;     c80a8
+;     c80cc
+;     c80ff
+;     c8151
+;     c815d
+;     c8168
+;     c817a
+;     c8187
+;     c8190
+;     c8197
+;     c81ad
+;     c81b9
+;     c81c8
+;     c81ea
+;     c81fd
+;     c820f
+;     c8210
+;     c8230
+;     c823f
+;     c8242
+;     c8246
+;     c825b
+;     c827c
+;     c828d
+;     c829a
+;     c82ae
+;     c82be
+;     c82c8
+;     c82d8
+;     c82dd
+;     c82f4
+;     c82fb
+;     c8304
+;     c8306
+;     c832f
+;     c833b
+;     c8345
+;     c8346
+;     c8353
+;     c835e
+;     c8362
+;     c8371
+;     c8372
+;     c8392
+;     c83a6
+;     c83c1
+;     c83d2
+;     c83d5
+;     c840a
+;     c8456
+;     c846a
+;     c8491
+;     c84a3
+;     c84ad
+;     c84ce
+;     c84f4
+;     c89bf
+;     c89dd
+;     c89f4
+;     c8a0b
+;     c8a1e
+;     c8a28
+;     c8a34
+;     c8a44
+;     c8a4b
+;     c8a64
+;     c8a68
+;     c8a6b
+;     c8a79
+;     c8a8b
+;     c8a8e
+;     c8a91
+;     c8adf
+;     c8aef
+;     c8af2
+;     c8af5
+;     c8b10
+;     c8b1b
+;     c8b33
+;     c8b40
+;     c8b4b
+;     c8b55
+;     c8b5f
+;     c8b62
+;     c8b63
+;     c8b83
+;     c8b98
+;     c8b9b
+;     c8b9c
+;     c8ba3
+;     c8baf
+;     c8bb2
+;     c8bb4
+;     c8bb6
+;     c8bbd
+;     c8bc4
+;     c8bde
+;     c8be9
+;     c8bf9
+;     c8c01
+;     c8c1b
+;     c8c1e
+;     c8c24
+;     c8c31
+;     c8c41
+;     c8c43
+;     c8c55
+;     c8c57
+;     c8c5e
+;     c8c74
+;     c8c84
+;     c8c87
+;     c8c96
+;     c8c99
+;     c8ca4
+;     c8ca7
+;     c8cb8
+;     c8cbb
+;     c8cbd
+;     c8cc0
+;     c8ce3
+;     c8ce6
+;     c8cfd
+;     c8d16
+;     c8d34
+;     c8d37
+;     c8d44
+;     c8d64
+;     c8d6e
+;     c8d74
+;     c8dc9
+;     c8dfc
+;     c8dff
+;     c8e3f
+;     c8e51
+;     c8e57
+;     c8e6c
+;     c8e6f
+;     c8e7d
+;     c8e8d
+;     c8e9c
+;     c8e9d
+;     c8ea6
+;     c8eaa
+;     c8eb6
+;     c8ebe
+;     c8ed0
+;     c8edc
+;     c8ee7
+;     c8ef3
+;     c8f03
+;     c8f1a
+;     c8f25
+;     c8f26
+;     c8f32
+;     c8f3d
+;     c8f41
+;     c8f52
+;     c8f5d
+;     c8f6d
+;     c8f74
+;     c8f86
+;     c8f87
+;     c8f8c
+;     c8f92
+;     c8f9c
+;     c8f9d
+;     c8fbb
+;     c8fda
+;     c8ff2
+;     c901c
+;     c9033
+;     c9045
+;     c9048
+;     c904b
+;     c905c
+;     c9069
+;     c9073
+;     c907d
+;     c9082
+;     c9086
+;     c90a0
+;     c90b0
+;     c90c5
+;     c90c7
+;     c90ca
+;     c90d0
+;     c90d2
+;     c90de
+;     c90e3
+;     c90ea
+;     c9108
+;     c9112
+;     c9123
+;     c9135
+;     c9146
+;     c914f
+;     c9155
+;     c9164
+;     c9193
+;     c91ad
+;     c91d1
+;     c91ee
+;     c91ef
+;     c9201
+;     c9204
+;     c9207
+;     c922a
+;     c9237
+;     c924a
+;     c9259
+;     c926e
+;     c9274
+;     c9276
+;     c9285
+;     c9288
+;     c929e
+;     c92da
+;     c92ed
+;     c9304
+;     c931e
+;     c9321
+;     c9325
+;     c932a
+;     c932d
+;     c9338
+;     c9357
+;     c937c
+;     c938f
+;     c93b4
+;     c93c4
+;     c93d7
+;     c9433
+;     c9469
+;     c9476
+;     c947f
+;     c9487
+;     c94aa
+;     c94b0
+;     c94ba
+;     c94c8
+;     c94d1
+;     c94d5
+;     c94de
+;     c94e4
+;     c9509
+;     c950d
+;     c951d
+;     c951f
+;     c954b
+;     c9555
+;     c9579
+;     c957c
+;     c957f
+;     c95be
+;     c95e0
+;     c95f1
+;     c95f9
+;     c9606
+;     c9628
+;     c9632
+;     c9635
+;     c963b
+;     c964e
+;     c968d
+;     c96b8
+;     c96bf
+;     c96ca
+;     c9700
+;     c971b
+;     c972c
+;     c9735
+;     c9753
+;     c9784
+;     c979b
+;     c979c
+;     c97d2
+;     c97ee
+;     c97fe
+;     c9801
+;     c9808
+;     c9866
+;     c986a
+;     c9877
+;     c9889
+;     c98bd
+;     c98c0
+;     c98d7
+;     c98dc
+;     c990c
+;     c9928
+;     c9937
+;     c9962
+;     c996e
+;     c9977
+;     c9979
+;     c997a
+;     c9990
+;     c999f
+;     c99a0
+;     c99a2
+;     c99ab
+;     c99ba
+;     c99fa
+;     c9a0e
+;     c9a14
+;     c9a28
+;     c9a3a
+;     c9a46
+;     c9a58
+;     c9a63
+;     c9a67
+;     c9a75
+;     c9a76
+;     c9a79
+;     c9a7b
+;     c9a99
+;     c9aa0
+;     c9aa5
+;     c9abc
+;     c9ac1
+;     c9ae6
+;     c9b4c
+;     c9b5a
+;     c9b78
+;     c9b80
+;     c9b8a
+;     c9bae
+;     c9bbc
+;     c9bce
+;     c9bd2
+;     c9bda
+;     c9bdb
+;     c9c08
+;     c9c16
+;     c9c24
+;     c9c2d
+;     c9c3b
+;     c9c41
+;     c9c52
+;     c9c55
+;     c9c6a
+;     c9c6c
+;     c9c74
+;     c9c80
+;     c9c8a
+;     c9cb6
+;     c9cc1
+;     c9cc5
+;     c9cc6
+;     c9cd6
+;     c9ceb
+;     c9ced
+;     c9cfb
+;     c9d0c
+;     c9d29
+;     c9d43
+;     c9d57
+;     c9d75
+;     c9d79
+;     c9d7b
+;     c9d7c
+;     c9db4
+;     c9dba
+;     c9dbe
+;     c9dbf
+;     c9dc0
+;     c9dc1
+;     c9dc4
+;     c9dd5
+;     c9de5
+;     c9de9
+;     c9e02
+;     c9e10
+;     c9e2a
+;     c9e48
+;     c9e4d
+;     c9e78
+;     c9e79
+;     c9e83
+;     c9e85
+;     c9e90
+;     c9ea6
+;     c9ead
+;     c9eb2
+;     c9ec2
+;     c9ecb
+;     c9edd
+;     c9f0a
+;     c9f13
+;     c9f3b
+;     c9f4c
+;     c9f4f
+;     c9f55
+;     c9f64
+;     c9f70
+;     c9f9a
+;     c9f9d
+;     c9fa7
+;     c9fb6
+;     c9fb8
+;     c9fe6
+;     c9ff4
+;     ca00f
+;     ca029
+;     ca03b
+;     ca03c
+;     ca04a
+;     ca04d
+;     ca05b
+;     ca05f
+;     ca06f
+;     ca081
+;     ca09c
+;     ca09f
+;     ca0c5
+;     ca0c7
+;     ca0d1
+;     ca0ee
+;     ca10a
+;     ca116
+;     ca126
+;     ca131
+;     ca137
+;     ca158
+;     ca160
+;     ca169
+;     ca174
+;     ca18a
+;     ca197
+;     ca19b
+;     ca19d
+;     ca1af
+;     ca1bc
+;     ca1c1
+;     ca1cd
+;     ca1d0
+;     ca1d4
+;     ca1ed
+;     ca1ef
+;     ca204
+;     ca212
+;     ca21c
+;     ca220
+;     ca22a
+;     ca23e
+;     ca24a
+;     ca25f
+;     ca261
+;     ca26f
+;     ca28a
+;     ca28c
+;     ca290
+;     ca2a3
+;     ca2b3
+;     ca2b7
+;     ca2c9
+;     ca2cc
+;     ca2d6
+;     ca2fb
+;     ca2fd
+;     ca303
+;     ca325
+;     ca333
+;     ca33e
+;     ca342
+;     ca348
+;     ca34c
+;     ca357
+;     ca36b
+;     ca37e
+;     ca385
+;     ca393
+;     ca3a1
+;     ca3a7
+;     ca3aa
+;     ca3c3
+;     ca3e5
+;     ca3e9
+;     ca426
+;     ca42c
+;     ca446
+;     ca452
+;     ca47a
+;     ca489
+;     ca4a3
+;     ca4a9
+;     ca4b9
+;     ca4c4
+;     ca4ce
+;     ca4e8
+;     ca4f5
+;     ca513
+;     ca53b
+;     ca53e
+;     ca547
+;     ca57a
+;     ca57e
+;     ca5a7
+;     ca5aa
+;     ca5ba
+;     ca608
+;     ca612
+;     ca61d
+;     ca622
+;     ca634
+;     ca640
+;     ca653
+;     ca65c
+;     ca65e
+;     ca674
+;     ca676
+;     ca68d
+;     ca6a2
+;     ca6ae
+;     ca6c4
+;     ca6ce
+;     ca6e4
+;     ca6ed
+;     ca6f2
+;     ca704
+;     ca70a
+;     ca70f
+;     ca712
+;     ca71e
+;     ca725
+;     ca72b
+;     ca72f
+;     ca739
+;     ca73b
+;     ca73d
+;     ca74d
+;     ca76b
+;     ca776
+;     ca797
+;     ca79b
+;     ca7c0
+;     ca7cd
+;     ca7db
+;     ca7ed
+;     ca7ef
+;     ca805
+;     ca829
+;     ca838
+;     ca83f
+;     ca841
+;     ca857
+;     ca875
+;     ca878
+;     ca88a
+;     ca899
+;     ca8b0
+;     ca8bb
+;     ca8ee
+;     ca91f
+;     ca92d
+;     ca932
+;     ca93b
+;     ca946
+;     ca948
+;     ca94b
+;     ca959
+;     ca962
+;     ca965
+;     ca978
+;     ca9c1
+;     ca9e0
+;     ca9ef
+;     ca9f2
+;     ca9f8
+;     caa07
+;     caa2c
+;     caa33
+;     caa3e
+;     caa44
+;     caa66
+;     caa6b
+;     caa7a
+;     caa7d
+;     caa9a
+;     caab0
+;     caac1
+;     caae8
+;     cab1a
+;     cab23
+;     cab41
+;     cab82
+;     cab91
+;     cab9d
+;     cabc9
+;     cabd0
+;     cabdd
+;     cabfa
+;     cabfd
+;     cac02
+;     cac0f
+;     cac1c
+;     cac2b
+;     cac2d
+;     cac35
+;     cac38
+;     cac59
+;     cac5b
+;     caca0
+;     caca3
+;     caca9
+;     cacaf
+;     cacd2
+;     cace3
+;     cace8
+;     cacef
+;     cacfd
+;     cad0d
+;     cad10
+;     cad14
+;     cad19
+;     cad20
+;     cad37
+;     cad52
+;     cad53
+;     cad5b
+;     cad75
+;     cad78
+;     cad91
+;     cad9c
+;     cadac
+;     cadb6
+;     cadbc
+;     cadce
+;     cade4
+;     cadee
+;     cadf9
+;     cae00
+;     cae0d
+;     cae11
+;     cae31
+;     cae3f
+;     cae56
+;     cae60
+;     cae62
+;     cae9f
+;     caeb4
+;     caed7
+;     caed9
+;     caedb
+;     caedc
+;     caf03
+;     caf07
+;     caf2f
+;     caf3d
+;     caf4d
+;     caf6d
+;     caf83
+;     caf88
+;     cafb8
+;     cafbb
+;     cafbe
+;     cafd5
+;     cafdb
+;     cafee
+;     caffd
+;     cb00e
+;     cb04a
+;     cb08a
+;     cb0a6
+;     cb0b0
+;     cb0be
+;     cb0e2
+;     cb106
+;     cb109
+;     cb169
+;     cb17e
+;     cb1a3
+;     cb1a6
+;     cb1ab
+;     cb1b5
+;     cb1ca
+;     cb1db
+;     cb1de
+;     cb200
+;     cb205
+;     cb22d
+;     cb230
+;     cb235
+;     cb256
+;     cb257
+;     cb266
+;     cb341
+;     cb34c
+;     cb35c
+;     cb380
+;     cb398
+;     cb399
+;     cb39e
+;     cb3cf
+;     cb3f4
+;     cb3fb
+;     cb3fe
+;     cb425
+;     cb428
+;     cb42b
+;     cb445
+;     cb451
+;     cb454
+;     cb45d
+;     cb46f
+;     cb47f
+;     cb485
+;     cb495
+;     cb497
+;     cb4a1
+;     cb4a7
+;     cb4b8
+;     cb4ba
+;     cb4bc
+;     cb4c2
+;     cb4e0
+;     cb4e2
+;     cb4f8
+;     cb50a
+;     cb510
+;     cb516
+;     cb51c
+;     cb522
+;     cb530
+;     cb54b
+;     cb563
+;     cb56a
+;     cb5cd
+;     cb5cf
+;     cb5df
+;     cb5f1
+;     cb622
+;     cb626
+;     cb629
+;     cb635
+;     cb6a7
+;     cb6bf
+;     cb6d1
+;     cb6f7
+;     cb70c
+;     cb723
+;     cb74a
+;     cb753
+;     cb75a
+;     cb762
+;     cb7a4
+;     cb7b3
+;     cb7ca
+;     cb7d4
+;     cb7da
+;     cb7e6
+;     cb7fa
+;     cb805
+;     cb81a
+;     cb824
+;     cb833
+;     cb847
+;     cb857
+;     cb866
+;     cb86c
+;     cb874
+;     cb877
+;     cb87f
+;     cb8b5
+;     cb8ba
+;     cb8cc
+;     cb8da
+;     cb8e2
+;     cb8f2
+;     cb8fa
+;     cb909
+;     cb938
+;     cb941
+;     cb94f
+;     cb965
+;     cb968
+;     cb976
+;     cb997
+;     cb9a5
+;     cb9ad
+;     cb9bf
+;     cb9cd
+;     cb9ff
+;     cba21
+;     cba2b
+;     cba31
+;     cba35
+;     cba43
+;     cba46
+;     cba63
+;     cbaa6
+;     cbac5
+;     cbae6
+;     cbae8
+;     cbaf7
+;     cbb03
+;     cbb0c
+;     cbb16
+;     cbb1a
+;     cbb45
+;     cbb64
+;     cbb9b
+;     cbba6
+;     cbbaf
+;     cbbd0
+;     cbc3a
+;     cbc66
+;     cbc91
+;     cbca5
+;     cbccd
+;     cbcd5
+;     cbce6
+;     cbcea
+;     cbd0e
+;     cbd21
+;     cbd23
+;     cbd3a
+;     cbd3d
+;     cbd45
+;     cbd64
+;     cbd70
+;     cbd71
+;     cbd74
+;     cbd86
+;     cbd9e
+;     cbdaa
+;     cbdbd
+;     cbdc9
+;     cbdd2
+;     cbdd4
+;     cbde2
+;     cbdff
+;     cbe05
+;     cbe43
+;     cbe45
+;     cbe4e
+;     cbe51
+;     cbed3
+;     cbed9
+;     cbeeb
+;     cbf00
+;     cbf1a
+;     cbf3d
+;     cbf54
+;     l0000
+;     l0001
+;     l0002
+;     l0003
+;     l0004
+;     l0005
+;     l0006
+;     l0007
+;     l0008
+;     l0009
+;     l000a
+;     l000b
+;     l000c
+;     l000d
+;     l000e
+;     l000f
+;     l0010
+;     l0011
+;     l0012
+;     l0013
+;     l0014
+;     l0015
+;     l0016
+;     l0017
+;     l0018
+;     l0019
+;     l001a
+;     l001b
+;     l001c
+;     l001d
+;     l001e
+;     l001f
+;     l0020
+;     l0021
+;     l0022
+;     l0023
+;     l0024
+;     l0025
+;     l0026
+;     l0027
+;     l0028
+;     l0029
+;     l002a
+;     l002b
+;     l002c
+;     l002d
+;     l002e
+;     l002f
+;     l0030
+;     l0031
+;     l0032
+;     l0033
+;     l0034
+;     l0035
+;     l0036
+;     l0037
+;     l0038
+;     l0039
+;     l003a
+;     l003b
+;     l003c
+;     l003d
+;     l003e
+;     l003f
+;     l0040
+;     l0041
+;     l0042
+;     l0043
+;     l0044
+;     l0045
+;     l0046
+;     l0047
+;     l0048
+;     l0049
+;     l004a
+;     l004b
+;     l004c
+;     l004d
+;     l004e
+;     l0061
+;     l0064
+;     l0066
+;     l00c1
+;     l00e1
+;     l00e6
+;     l00fd
+;     l00fe
+;     l00ff
+;     l0100
+;     l0106
+;     l01ff
+;     l0400
+;     l0401
+;     l0402
+;     l0403
+;     l0404
+;     l040c
+;     l043c
+;     l043d
+;     l0440
+;     l0441
+;     l0460
+;     l0464
+;     l0469
+;     l046c
+;     l047f
+;     l04ff
+;     l0500
+;     l0513
+;     l0514
+;     l0519
+;     l051a
+;     l051b
+;     l051c
+;     l051d
+;     l051e
+;     l051f
+;     l0521
+;     l0522
+;     l0523
+;     l0524
+;     l0526
+;     l0527
+;     l0528
+;     l0529
+;     l052a
+;     l05cb
+;     l05cc
+;     l05e5
+;     l05e6
+;     l05ff
+;     l0600
+;     l0700
+;     l07ef
+;     l0bb1
+;     l0e4e
+;     l4e4e
+;     l5252
+;     l6142
+;     l7461
+;     l7f0e
+;     l7f13
+;     l80c2
+;     l80dd
+;     l80e2
+;     l880a
+;     l8826
+;     l8909
+;     l894e
+;     l8993
+;     la7c9
+;     lb3be
+;     lbecd
+;     lbefe
+;     lbf71
+;     le09c
+;     loop_c8057
+;     loop_c8091
+;     loop_c8176
+;     loop_c819f
+;     loop_c81e1
+;     loop_c8206
+;     loop_c8235
+;     loop_c8252
+;     loop_c82b2
+;     loop_c82f7
+;     loop_c8314
+;     loop_c8331
+;     loop_c8365
+;     loop_c839e
+;     loop_c8428
+;     loop_c8440
+;     loop_c845b
+;     loop_c847b
+;     loop_c8496
+;     loop_c89d7
+;     loop_c8a11
+;     loop_c8a2a
+;     loop_c8a3c
+;     loop_c8a4f
+;     loop_c8a54
+;     loop_c8a5e
+;     loop_c8a6e
+;     loop_c8ac3
+;     loop_c8ad4
+;     loop_c8ae3
+;     loop_c8b9e
+;     loop_c8c15
+;     loop_c8c9b
+;     loop_c8d71
+;     loop_c8db7
+;     loop_c8e16
+;     loop_c8e91
+;     loop_c8ee2
+;     loop_c8f0b
+;     loop_c8f7a
+;     loop_c8fa7
+;     loop_c9004
+;     loop_c9024
+;     loop_c9078
+;     loop_c90a6
+;     loop_c90ad
+;     loop_c91e4
+;     loop_c91f6
+;     loop_c9220
+;     loop_c922c
+;     loop_c923f
+;     loop_c9260
+;     loop_c9268
+;     loop_c928b
+;     loop_c92d4
+;     loop_c92e0
+;     loop_c92f0
+;     loop_c9355
+;     loop_c9356
+;     loop_c9368
+;     loop_c93fa
+;     loop_c9455
+;     loop_c948a
+;     loop_c95cf
+;     loop_c9724
+;     loop_c9728
+;     loop_c9750
+;     loop_c97c0
+;     loop_c97c6
+;     loop_c98cb
+;     loop_c98df
+;     loop_c9904
+;     loop_c992a
+;     loop_c9948
+;     loop_c9954
+;     loop_c99cf
+;     loop_c9ab6
+;     loop_c9be0
+;     loop_c9c6d
+;     loop_c9c92
+;     loop_c9cc9
+;     loop_c9ce8
+;     loop_c9cfd
+;     loop_c9dd7
+;     loop_c9e18
+;     loop_c9e23
+;     loop_c9e32
+;     loop_c9e5b
+;     loop_c9ef2
+;     loop_c9f59
+;     loop_c9f61
+;     loop_c9faa
+;     loop_c9fbb
+;     loop_ca052
+;     loop_ca070
+;     loop_ca0b8
+;     loop_ca0f2
+;     loop_ca0f5
+;     loop_ca10f
+;     loop_ca13b
+;     loop_ca151
+;     loop_ca207
+;     loop_ca256
+;     loop_ca263
+;     loop_ca27d
+;     loop_ca2bb
+;     loop_ca399
+;     loop_ca3ae
+;     loop_ca5b6
+;     loop_ca607
+;     loop_ca617
+;     loop_ca62c
+;     loop_ca6a8
+;     loop_ca758
+;     loop_ca88f
+;     loop_ca8cd
+;     loop_ca8e0
+;     loop_ca969
+;     loop_ca982
+;     loop_ca9f5
+;     loop_caa59
+;     loop_caaf0
+;     loop_cac3c
+;     loop_cacd8
+;     loop_cace5
+;     loop_caceb
+;     loop_cad43
+;     loop_cad5d
+;     loop_cad5e
+;     loop_cade0
+;     loop_cadfe
+;     loop_cae1e
+;     loop_caeed
+;     loop_caf51
+;     loop_cafa2
+;     loop_cafa4
+;     loop_cafc1
+;     loop_cafe3
+;     loop_cb019
+;     loop_cb066
+;     loop_cb0d8
+;     loop_cb0f2
+;     loop_cb146
+;     loop_cb24d
+;     loop_cb259
+;     loop_cb307
+;     loop_cb32b
+;     loop_cb35f
+;     loop_cb4a9
+;     loop_cb4f2
+;     loop_cb52d
+;     loop_cb536
+;     loop_cb642
+;     loop_cb730
+;     loop_cb769
+;     loop_cb771
+;     loop_cb806
+;     loop_cb84c
+;     loop_cb86f
+;     loop_cb872
+;     loop_cb8ac
+;     loop_cb8c2
+;     loop_cb8ce
+;     loop_cb8ff
+;     loop_cb95a
+;     loop_cb974
+;     loop_cb9f6
+;     loop_cba0a
+;     loop_cbb3c
+;     loop_cbb56
+;     loop_cbb5d
+;     loop_cbbd2
+;     loop_cbbed
+;     loop_cbbf8
+;     loop_cbc9d
+;     loop_cbcc5
+;     loop_cbcd1
+;     loop_cbcdc
+;     loop_cbd19
+;     loop_cbd88
+;     loop_cbda0
+;     loop_cbdbf
+;     loop_cbe2d
+;     loop_cbe73
+;     loop_cbf17
+;     loop_cbf56
+;     sub_c80d8
+;     sub_c8139
+;     sub_c8149
+;     sub_c8191
+;     sub_c81bd
+;     sub_c8287
+;     sub_c828a
+;     sub_c82e6
+;     sub_c8349
+;     sub_c834b
+;     sub_c834f
+;     sub_c83aa
+;     sub_c83c2
+;     sub_c83d3
+;     sub_c8429
+;     sub_c8984
+;     sub_c8992
+;     sub_c8aa8
+;     sub_c8d86
+;     sub_c8d89
+;     sub_c8d8c
+;     sub_c8d94
+;     sub_c8d9c
+;     sub_c8da2
+;     sub_c8da8
+;     sub_c8dc1
+;     sub_c8e1f
+;     sub_c8e41
+;     sub_c8e58
+;     sub_c8e5f
+;     sub_c8e66
+;     sub_c8ea4
+;     sub_c8fa8
+;     sub_c8fae
+;     sub_c8fb4
+;     sub_c8fc0
+;     sub_c8fc5
+;     sub_c8fd7
+;     sub_c8fe5
+;     sub_c8fea
+;     sub_c9042
+;     sub_c910d
+;     sub_c9149
+;     sub_c916e
+;     sub_c9171
+;     sub_c9250
+;     sub_c9330
+;     sub_c9332
+;     sub_c933d
+;     sub_c935c
+;     sub_c9381
+;     sub_c93c7
+;     sub_c93da
+;     sub_c9410
+;     sub_c9436
+;     sub_c943e
+;     sub_c9447
+;     sub_c953d
+;     sub_c954c
+;     sub_c95c6
+;     sub_c95cb
+;     sub_c96d4
+;     sub_c96e5
+;     sub_c96f9
+;     sub_c9703
+;     sub_c970b
+;     sub_c973e
+;     sub_c9769
+;     sub_c976c
+;     sub_c9771
+;     sub_c9774
+;     sub_c9779
+;     sub_c977e
+;     sub_c9781
+;     sub_c9783
+;     sub_c9788
+;     sub_c978b
+;     sub_c979f
+;     sub_c97a2
+;     sub_c97a9
+;     sub_c9810
+;     sub_c9824
+;     sub_c982e
+;     sub_c9871
+;     sub_c9875
+;     sub_c9880
+;     sub_c98af
+;     sub_c98b6
+;     sub_c98c3
+;     sub_c990f
+;     sub_c9914
+;     sub_c9923
+;     sub_c9952
+;     sub_c995a
+;     sub_c997d
+;     sub_c99c4
+;     sub_c99d0
+;     sub_c99d6
+;     sub_c99d8
+;     sub_c9ac9
+;     sub_c9b97
+;     sub_c9bba
+;     sub_c9be2
+;     sub_c9bee
+;     sub_c9c0a
+;     sub_c9c4a
+;     sub_c9c5a
+;     sub_c9c5e
+;     sub_c9c8e
+;     sub_c9c93
+;     sub_c9ca2
+;     sub_c9cb8
+;     sub_c9ccc
+;     sub_c9d0f
+;     sub_c9d36
+;     sub_c9d7f
+;     sub_c9d81
+;     sub_c9d82
+;     sub_c9df3
+;     sub_c9dff
+;     sub_c9e3f
+;     sub_c9e45
+;     sub_c9e6d
+;     sub_c9f07
+;     sub_ca023
+;     sub_ca026
+;     sub_ca069
+;     sub_ca06c
+;     sub_ca0e8
+;     sub_ca0ec
+;     sub_ca181
+;     sub_ca2b8
+;     sub_ca2ca
+;     sub_ca2dd
+;     sub_ca3b5
+;     sub_ca3c0
+;     sub_ca3ed
+;     sub_ca40a
+;     sub_ca419
+;     sub_ca46b
+;     sub_ca4ba
+;     sub_ca503
+;     sub_ca507
+;     sub_ca50b
+;     sub_ca514
+;     sub_ca541
+;     sub_ca545
+;     sub_ca54d
+;     sub_ca56d
+;     sub_ca572
+;     sub_ca576
+;     sub_ca5ad
+;     sub_ca5b2
+;     sub_ca5b4
+;     sub_ca5bb
+;     sub_ca5bd
+;     sub_ca5c1
+;     sub_ca5c4
+;     sub_ca5cc
+;     sub_ca5cf
+;     sub_ca5d1
+;     sub_ca5e3
+;     sub_ca5f2
+;     sub_ca5f4
+;     sub_ca5f9
+;     sub_ca62f
+;     sub_ca631
+;     sub_ca6cb
+;     sub_ca6eb
+;     sub_ca6fc
+;     sub_ca6ff
+;     sub_ca70d
+;     sub_ca731
+;     sub_ca73e
+;     sub_ca7ac
+;     sub_ca7af
+;     sub_ca808
+;     sub_ca80b
+;     sub_ca8b3
+;     sub_ca8b9
+;     sub_ca901
+;     sub_ca919
+;     sub_ca94f
+;     sub_ca954
+;     sub_ca96b
+;     sub_ca97b
+;     sub_ca9a3
+;     sub_ca9b5
+;     sub_ca9bc
+;     sub_ca9c3
+;     sub_ca9ca
+;     sub_ca9d1
+;     sub_caa17
+;     sub_caa1a
+;     sub_caa50
+;     sub_caa55
+;     sub_caa6e
+;     sub_caacb
+;     sub_caad8
+;     sub_caaeb
+;     sub_caafb
+;     sub_cab01
+;     sub_cab14
+;     sub_cab1d
+;     sub_cab21
+;     sub_cab2f
+;     sub_cab37
+;     sub_cab3b
+;     sub_cab3f
+;     sub_cab54
+;     sub_cab5c
+;     sub_caba0
+;     sub_caba5
+;     sub_cabe1
+;     sub_cac03
+;     sub_cac12
+;     sub_cac1f
+;     sub_cac46
+;     sub_cac5d
+;     sub_cac7f
+;     sub_cad00
+;     sub_cad07
+;     sub_cad1c
+;     sub_cad3a
+;     sub_cad8e
+;     sub_cadc6
+;     sub_cae34
+;     sub_cae41
+;     sub_cae50
+;     sub_cae59
+;     sub_cae6d
+;     sub_cae71
+;     sub_cae77
+;     sub_cae7d
+;     sub_cae83
+;     sub_cae87
+;     sub_cae8c
+;     sub_caeb1
+;     sub_caebb
+;     sub_caebc
+;     sub_caefb
+;     sub_caf0a
+;     sub_caf61
+;     sub_caf8b
+;     sub_cb055
+;     sub_cb057
+;     sub_cb1bf
+;     sub_cb269
+;     sub_cb2e0
+;     sub_cb302
+;     sub_cb326
+;     sub_cb351
+;     sub_cb362
+;     sub_cb365
+;     sub_cb372
+;     sub_cb3c8
+;     sub_cb412
+;     sub_cb649
+;     sub_cb709
+;     sub_cb737
+;     sub_cb74d
+;     sub_cb78b
+;     sub_cb84d
+;     sub_cb85a
+;     sub_cb896
+;     sub_cb8e6
+;     sub_cb97d
+;     sub_cb9dc
+;     sub_cba47
+;     sub_cba6c
+;     sub_cba6e
+;     sub_cba7a
+;     sub_cba88
+;     sub_cbaa0
+;     sub_cbaa4
+;     sub_cbac2
+;     sub_cbac8
+;     sub_cbb0f
+;     sub_cbb1b
+;     sub_cbb38
+;     sub_cbbdc
+;     sub_cbbeb
+;     sub_cbbff
+;     sub_cbc18
+;     sub_cbc1e
+;     sub_cbc20
+;     sub_cbc24
+;     sub_cbc36
+;     sub_cbc62
+;     sub_cbc83
+;     sub_cbcaa
+;     sub_cbd12
+;     sub_cbd26
+;     sub_cbd46
+;     sub_cbd48
+;     sub_cbd5e
+;     sub_cbd77
+;     sub_cbdac
+;     sub_cbdb7
+;     sub_cbdcf
+;     sub_cbdd8
+;     sub_cbdf3
+;     sub_cbdf4
+;     sub_cbe06
+;     sub_cbe17
+;     sub_cbe25
+;     sub_cbe44
+;     sub_cbe46
+;     sub_cbe65
+;     sub_cbe6b
+;     sub_cbe76
+;     sub_cbe81
+;     sub_cbe8b
+;     sub_cbe95
+;     sub_cbec7
+;     sub_cbecc
+;     sub_cbed7
+;     sub_cbeee
+;     sub_cbefd
+;     sub_cbf0f
+;     sub_cbf22
+;     sub_cbf2f
+;     sub_cbf3e
+;     sub_cbf66
+!if (<(l002a)) != $2a {
+    !error "Assertion failed: <(l002a) == $2a"
+}
+!if (<(l002a)) != $2a {
+    !error "Assertion failed: <(l002a) == $2a"
+}
+!if (<(l002a)) != $2a {
+    !error "Assertion failed: <(l002a) == $2a"
+}
+!if (<(l0037)) != $37 {
+    !error "Assertion failed: <(l0037) == $37"
+}
+!if (<(l0037)) != $37 {
+    !error "Assertion failed: <(l0037) == $37"
+}
+!if (<(l0037)) != $37 {
+    !error "Assertion failed: <(l0037) == $37"
+}
+!if (<(l0600)) != $00 {
+    !error "Assertion failed: <(l0600) == $00"
+}
+!if (<(l0600)) != $00 {
+    !error "Assertion failed: <(l0600) == $00"
+}
+!if (<(l0600)) != $00 {
+    !error "Assertion failed: <(l0600) == $00"
+}
+!if (>(l002a)) != $00 {
+    !error "Assertion failed: >(l002a) == $00"
+}
+!if (>(l002a)) != $00 {
+    !error "Assertion failed: >(l002a) == $00"
+}
+!if (>(l002a)) != $00 {
+    !error "Assertion failed: >(l002a) == $00"
+}
+!if (>(l0037)) != $00 {
+    !error "Assertion failed: >(l0037) == $00"
+}
+!if (>(l0037)) != $00 {
+    !error "Assertion failed: >(l0037) == $00"
+}
+!if (>(l0600)) != $06 {
+    !error "Assertion failed: >(l0600) == $06"
+}
+!if (>(l0600)) != $06 {
+    !error "Assertion failed: >(l0600) == $06"
+}
+!if (>(l0600)) != $06 {
+    !error "Assertion failed: >(l0600) == $06"
+}
+!if (c9073) != $9073 {
+    !error "Assertion failed: c9073 == $9073"
+}
+!if (c9073) != $9073 {
+    !error "Assertion failed: c9073 == $9073"
+}
+!if (c9073) != $9073 {
+    !error "Assertion failed: c9073 == $9073"
+}
+!if (c95f9) != $95f9 {
+    !error "Assertion failed: c95f9 == $95f9"
+}
+!if (c97d2) != $97d2 {
+    !error "Assertion failed: c97d2 == $97d2"
+}
+!if (c98dc) != $98dc {
+    !error "Assertion failed: c98dc == $98dc"
+}
+!if (cac2b) != $ac2b {
+    !error "Assertion failed: cac2b == $ac2b"
+}
+!if (cac38) != $ac38 {
+    !error "Assertion failed: cac38 == $ac38"
+}
+!if (cb522) != $b522 {
+    !error "Assertion failed: cb522 == $b522"
+}
+!if (cb9ad) != $b9ad {
+    !error "Assertion failed: cb9ad == $b9ad"
+}
+!if (copyright - rom_header) != $13 {
+    !error "Assertion failed: copyright - rom_header == $13"
+}
+!if (osbyte_check_eof) != $7f {
+    !error "Assertion failed: osbyte_check_eof == $7f"
+}
+!if (osbyte_enter_language) != $8e {
+    !error "Assertion failed: osbyte_enter_language == $8e"
+}
+!if (osbyte_inkey) != $81 {
+    !error "Assertion failed: osbyte_inkey == $81"
+}
+!if (osbyte_read_adc_or_get_buffer_status) != $80 {
+    !error "Assertion failed: osbyte_read_adc_or_get_buffer_status == $80"
+}
+!if (osbyte_read_high_order_address) != $82 {
+    !error "Assertion failed: osbyte_read_high_order_address == $82"
+}
+!if (osbyte_read_himem) != $84 {
+    !error "Assertion failed: osbyte_read_himem == $84"
+}
+!if (osbyte_read_himem_for_mode) != $85 {
+    !error "Assertion failed: osbyte_read_himem_for_mode == $85"
+}
+!if (osbyte_read_text_cursor_pos) != $86 {
+    !error "Assertion failed: osbyte_read_text_cursor_pos == $86"
+}
+!if (osbyte_read_tube_presence) != $ea {
+    !error "Assertion failed: osbyte_read_tube_presence == $ea"
+}
+!if (osbyte_read_write_basic_rom_bank) != $bb {
+    !error "Assertion failed: osbyte_read_write_basic_rom_bank == $bb"
+}
+!if (osfile_load) != $ff {
+    !error "Assertion failed: osfile_load == $ff"
+}
+!if (osfile_save) != $00 {
+    !error "Assertion failed: osfile_save == $00"
+}
+!if (osword_read_clock) != $01 {
+    !error "Assertion failed: osword_read_clock == $01"
+}
+!if (osword_read_cmos_clock) != $0e {
+    !error "Assertion failed: osword_read_cmos_clock == $0e"
+}
+!if (osword_read_io_memory) != $05 {
+    !error "Assertion failed: osword_read_io_memory == $05"
+}
+!if (osword_read_pixel) != $09 {
+    !error "Assertion failed: osword_read_pixel == $09"
+}
+!if (sub_c834b) != $834b {
+    !error "Assertion failed: sub_c834b == $834b"
+}
+!if (sub_c8984) != $8984 {
+    !error "Assertion failed: sub_c8984 == $8984"
+}
+!if (sub_c8fc0) != $8fc0 {
+    !error "Assertion failed: sub_c8fc0 == $8fc0"
+}
+!if (sub_c8fc5) != $8fc5 {
+    !error "Assertion failed: sub_c8fc5 == $8fc5"
+}
+!if (sub_c8fd7) != $8fd7 {
+    !error "Assertion failed: sub_c8fd7 == $8fd7"
+}
+!if (sub_c8fe5) != $8fe5 {
+    !error "Assertion failed: sub_c8fe5 == $8fe5"
+}
+!if (sub_c8fea) != $8fea {
+    !error "Assertion failed: sub_c8fea == $8fea"
+}
+!if (sub_c9042) != $9042 {
+    !error "Assertion failed: sub_c9042 == $9042"
+}
+!if (sub_c910d) != $910d {
+    !error "Assertion failed: sub_c910d == $910d"
+}
+!if (sub_c9149) != $9149 {
+    !error "Assertion failed: sub_c9149 == $9149"
+}
+!if (sub_c9250) != $9250 {
+    !error "Assertion failed: sub_c9250 == $9250"
+}
+!if (sub_c9381) != $9381 {
+    !error "Assertion failed: sub_c9381 == $9381"
+}
+!if (sub_c93da) != $93da {
+    !error "Assertion failed: sub_c93da == $93da"
+}
+!if (sub_c9447) != $9447 {
+    !error "Assertion failed: sub_c9447 == $9447"
+}
+!if (sub_c954c) != $954c {
+    !error "Assertion failed: sub_c954c == $954c"
+}
+!if (sub_c96d4) != $96d4 {
+    !error "Assertion failed: sub_c96d4 == $96d4"
+}
+!if (sub_c96e5) != $96e5 {
+    !error "Assertion failed: sub_c96e5 == $96e5"
+}
+!if (sub_c96f9) != $96f9 {
+    !error "Assertion failed: sub_c96f9 == $96f9"
+}
+!if (sub_c9703) != $9703 {
+    !error "Assertion failed: sub_c9703 == $9703"
+}
+!if (sub_c970b) != $970b {
+    !error "Assertion failed: sub_c970b == $970b"
+}
+!if (sub_c973e) != $973e {
+    !error "Assertion failed: sub_c973e == $973e"
+}
+!if (sub_c97a9) != $97a9 {
+    !error "Assertion failed: sub_c97a9 == $97a9"
+}
+!if (sub_c9810) != $9810 {
+    !error "Assertion failed: sub_c9810 == $9810"
+}
+!if (sub_c9824) != $9824 {
+    !error "Assertion failed: sub_c9824 == $9824"
+}
+!if (sub_c982e) != $982e {
+    !error "Assertion failed: sub_c982e == $982e"
+}
+!if (sub_c9871) != $9871 {
+    !error "Assertion failed: sub_c9871 == $9871"
+}
+!if (sub_c9875) != $9875 {
+    !error "Assertion failed: sub_c9875 == $9875"
+}
+!if (sub_c9880) != $9880 {
+    !error "Assertion failed: sub_c9880 == $9880"
+}
+!if (sub_c98af) != $98af {
+    !error "Assertion failed: sub_c98af == $98af"
+}
+!if (sub_c98b6) != $98b6 {
+    !error "Assertion failed: sub_c98b6 == $98b6"
+}
+!if (sub_c98c3) != $98c3 {
+    !error "Assertion failed: sub_c98c3 == $98c3"
+}
+!if (sub_c9c5e) != $9c5e {
+    !error "Assertion failed: sub_c9c5e == $9c5e"
+}
+!if (sub_c9ccc) != $9ccc {
+    !error "Assertion failed: sub_c9ccc == $9ccc"
+}
+!if (sub_ca6fc) != $a6fc {
+    !error "Assertion failed: sub_ca6fc == $a6fc"
+}
+!if (sub_ca7ac) != $a7ac {
+    !error "Assertion failed: sub_ca7ac == $a7ac"
+}
+!if (sub_ca808) != $a808 {
+    !error "Assertion failed: sub_ca808 == $a808"
+}
+!if (sub_ca901) != $a901 {
+    !error "Assertion failed: sub_ca901 == $a901"
+}
+!if (sub_ca919) != $a919 {
+    !error "Assertion failed: sub_ca919 == $a919"
+}
+!if (sub_ca94f) != $a94f {
+    !error "Assertion failed: sub_ca94f == $a94f"
+}
+!if (sub_ca954) != $a954 {
+    !error "Assertion failed: sub_ca954 == $a954"
+}
+!if (sub_ca96b) != $a96b {
+    !error "Assertion failed: sub_ca96b == $a96b"
+}
+!if (sub_ca9b5) != $a9b5 {
+    !error "Assertion failed: sub_ca9b5 == $a9b5"
+}
+!if (sub_ca9bc) != $a9bc {
+    !error "Assertion failed: sub_ca9bc == $a9bc"
+}
+!if (sub_ca9ca) != $a9ca {
+    !error "Assertion failed: sub_ca9ca == $a9ca"
+}
+!if (sub_caa17) != $aa17 {
+    !error "Assertion failed: sub_caa17 == $aa17"
+}
+!if (sub_caacb) != $aacb {
+    !error "Assertion failed: sub_caacb == $aacb"
+}
+!if (sub_caaeb) != $aaeb {
+    !error "Assertion failed: sub_caaeb == $aaeb"
+}
+!if (sub_caafb) != $aafb {
+    !error "Assertion failed: sub_caafb == $aafb"
+}
+!if (sub_cab01) != $ab01 {
+    !error "Assertion failed: sub_cab01 == $ab01"
+}
+!if (sub_cab14) != $ab14 {
+    !error "Assertion failed: sub_cab14 == $ab14"
+}
+!if (sub_cab1d) != $ab1d {
+    !error "Assertion failed: sub_cab1d == $ab1d"
+}
+!if (sub_cab21) != $ab21 {
+    !error "Assertion failed: sub_cab21 == $ab21"
+}
+!if (sub_cab2f) != $ab2f {
+    !error "Assertion failed: sub_cab2f == $ab2f"
+}
+!if (sub_cab37) != $ab37 {
+    !error "Assertion failed: sub_cab37 == $ab37"
+}
+!if (sub_cab3b) != $ab3b {
+    !error "Assertion failed: sub_cab3b == $ab3b"
+}
+!if (sub_cab3f) != $ab3f {
+    !error "Assertion failed: sub_cab3f == $ab3f"
+}
+!if (sub_cab54) != $ab54 {
+    !error "Assertion failed: sub_cab54 == $ab54"
+}
+!if (sub_cab5c) != $ab5c {
+    !error "Assertion failed: sub_cab5c == $ab5c"
+}
+!if (sub_caba0) != $aba0 {
+    !error "Assertion failed: sub_caba0 == $aba0"
+}
+!if (sub_cabe1) != $abe1 {
+    !error "Assertion failed: sub_cabe1 == $abe1"
+}
+!if (sub_cac03) != $ac03 {
+    !error "Assertion failed: sub_cac03 == $ac03"
+}
+!if (sub_cac12) != $ac12 {
+    !error "Assertion failed: sub_cac12 == $ac12"
+}
+!if (sub_cac1f) != $ac1f {
+    !error "Assertion failed: sub_cac1f == $ac1f"
+}
+!if (sub_cac46) != $ac46 {
+    !error "Assertion failed: sub_cac46 == $ac46"
+}
+!if (sub_cac5d) != $ac5d {
+    !error "Assertion failed: sub_cac5d == $ac5d"
+}
+!if (sub_cac7f) != $ac7f {
+    !error "Assertion failed: sub_cac7f == $ac7f"
+}
+!if (sub_cad00) != $ad00 {
+    !error "Assertion failed: sub_cad00 == $ad00"
+}
+!if (sub_cae34) != $ae34 {
+    !error "Assertion failed: sub_cae34 == $ae34"
+}
+!if (sub_cae41) != $ae41 {
+    !error "Assertion failed: sub_cae41 == $ae41"
+}
+!if (sub_cae50) != $ae50 {
+    !error "Assertion failed: sub_cae50 == $ae50"
+}
+!if (sub_cae59) != $ae59 {
+    !error "Assertion failed: sub_cae59 == $ae59"
+}
+!if (sub_cae6d) != $ae6d {
+    !error "Assertion failed: sub_cae6d == $ae6d"
+}
+!if (sub_cae71) != $ae71 {
+    !error "Assertion failed: sub_cae71 == $ae71"
+}
+!if (sub_cae77) != $ae77 {
+    !error "Assertion failed: sub_cae77 == $ae77"
+}
+!if (sub_cae7d) != $ae7d {
+    !error "Assertion failed: sub_cae7d == $ae7d"
+}
+!if (sub_cae83) != $ae83 {
+    !error "Assertion failed: sub_cae83 == $ae83"
+}
+!if (sub_cae87) != $ae87 {
+    !error "Assertion failed: sub_cae87 == $ae87"
+}
+!if (sub_cae8c) != $ae8c {
+    !error "Assertion failed: sub_cae8c == $ae8c"
+}
+!if (sub_caeb1) != $aeb1 {
+    !error "Assertion failed: sub_caeb1 == $aeb1"
+}
+!if (sub_caebb) != $aebb {
+    !error "Assertion failed: sub_caebb == $aebb"
+}
+!if (sub_caebc) != $aebc {
+    !error "Assertion failed: sub_caebc == $aebc"
+}
+!if (sub_caefb) != $aefb {
+    !error "Assertion failed: sub_caefb == $aefb"
+}
+!if (sub_caf0a) != $af0a {
+    !error "Assertion failed: sub_caf0a == $af0a"
+}
+!if (sub_caf61) != $af61 {
+    !error "Assertion failed: sub_caf61 == $af61"
+}
+!if (sub_caf8b) != $af8b {
+    !error "Assertion failed: sub_caf8b == $af8b"
+}
+!if (sub_cb055) != $b055 {
+    !error "Assertion failed: sub_cb055 == $b055"
+}
+!if (sub_cb269) != $b269 {
+    !error "Assertion failed: sub_cb269 == $b269"
+}
+!if (sub_cb302) != $b302 {
+    !error "Assertion failed: sub_cb302 == $b302"
+}
+!if (sub_cb326) != $b326 {
+    !error "Assertion failed: sub_cb326 == $b326"
+}
+!if (sub_cb351) != $b351 {
+    !error "Assertion failed: sub_cb351 == $b351"
+}
+!if (sub_cb3c8) != $b3c8 {
+    !error "Assertion failed: sub_cb3c8 == $b3c8"
+}
+!if (sub_cb412) != $b412 {
+    !error "Assertion failed: sub_cb412 == $b412"
+}
+!if (sub_cb649) != $b649 {
+    !error "Assertion failed: sub_cb649 == $b649"
+}
+!if (sub_cb709) != $b709 {
+    !error "Assertion failed: sub_cb709 == $b709"
+}
+!if (sub_cb737) != $b737 {
+    !error "Assertion failed: sub_cb737 == $b737"
+}
+!if (sub_cb74d) != $b74d {
+    !error "Assertion failed: sub_cb74d == $b74d"
+}
+!if (sub_cb78b) != $b78b {
+    !error "Assertion failed: sub_cb78b == $b78b"
+}
+!if (sub_cb896) != $b896 {
+    !error "Assertion failed: sub_cb896 == $b896"
+}
+!if (sub_cb8e6) != $b8e6 {
+    !error "Assertion failed: sub_cb8e6 == $b8e6"
+}
+!if (sub_cb97d) != $b97d {
+    !error "Assertion failed: sub_cb97d == $b97d"
+}
+!if (sub_cba47) != $ba47 {
+    !error "Assertion failed: sub_cba47 == $ba47"
+}
+!if (sub_cba88) != $ba88 {
+    !error "Assertion failed: sub_cba88 == $ba88"
+}
+!if (sub_cbe95) != $be95 {
+    !error "Assertion failed: sub_cbe95 == $be95"
+}
+!if (sub_cbec7) != $bec7 {
+    !error "Assertion failed: sub_cbec7 == $bec7"
+}
+!if (sub_cbed7) != $bed7 {
+    !error "Assertion failed: sub_cbed7 == $bed7"
+}
+!if (sub_cbeee) != $beee {
+    !error "Assertion failed: sub_cbeee == $beee"
+}
+!if (sub_cbefd) != $befd {
+    !error "Assertion failed: sub_cbefd == $befd"
+}

--- a/examples/known_good/basic4_beebasm.asm
+++ b/examples/known_good/basic4_beebasm.asm
@@ -1,0 +1,14049 @@
+    cpu 1
+
+; Constants
+osbyte_check_eof                       = 127
+osbyte_enter_language                  = 142
+osbyte_inkey                           = 129
+osbyte_read_adc_or_get_buffer_status   = 128
+osbyte_read_high_order_address         = 130
+osbyte_read_himem                      = 132
+osbyte_read_himem_for_mode             = 133
+osbyte_read_text_cursor_pos            = 134
+osbyte_read_tube_presence              = 234
+osbyte_read_write_basic_rom_bank       = 187
+osfile_load                            = 255
+osfile_save                            = 0
+osword_read_clock                      = 1
+osword_read_cmos_clock                 = 14
+osword_read_io_memory                  = 5
+osword_read_pixel                      = 9
+
+; Memory locations
+l0000       = &0000
+l0001       = &0001
+l0002       = &0002
+l0003       = &0003
+l0004       = &0004
+l0005       = &0005
+l0006       = &0006
+l0007       = &0007
+l0008       = &0008
+l0009       = &0009
+l000a       = &000a
+l000b       = &000b
+l000c       = &000c
+l000d       = &000d
+l000e       = &000e
+l000f       = &000f
+l0010       = &0010
+l0011       = &0011
+l0012       = &0012
+l0013       = &0013
+l0014       = &0014
+l0015       = &0015
+l0016       = &0016
+l0017       = &0017
+l0018       = &0018
+l0019       = &0019
+l001a       = &001a
+l001b       = &001b
+l001c       = &001c
+l001d       = &001d
+l001e       = &001e
+l001f       = &001f
+l0020       = &0020
+l0021       = &0021
+l0022       = &0022
+l0023       = &0023
+l0024       = &0024
+l0025       = &0025
+l0026       = &0026
+l0027       = &0027
+l0028       = &0028
+l0029       = &0029
+l002a       = &002a
+l002b       = &002b
+l002c       = &002c
+l002d       = &002d
+l002e       = &002e
+l002f       = &002f
+l0030       = &0030
+l0031       = &0031
+l0032       = &0032
+l0033       = &0033
+l0034       = &0034
+l0035       = &0035
+l0036       = &0036
+l0037       = &0037
+l0038       = &0038
+l0039       = &0039
+l003a       = &003a
+l003b       = &003b
+l003c       = &003c
+l003d       = &003d
+l003e       = &003e
+l003f       = &003f
+l0040       = &0040
+l0041       = &0041
+l0042       = &0042
+l0043       = &0043
+l0044       = &0044
+l0045       = &0045
+l0046       = &0046
+l0047       = &0047
+l0048       = &0048
+l0049       = &0049
+l004a       = &004a
+l004b       = &004b
+l004c       = &004c
+l004d       = &004d
+l004e       = &004e
+l0061       = &0061
+l0064       = &0064
+l0066       = &0066
+l00c1       = &00c1
+l00e1       = &00e1
+l00e6       = &00e6
+os_text_ptr = &00f2
+romsel_copy = &00f4
+l00fd       = &00fd
+l00fe       = &00fe
+l00ff       = &00ff
+l0100       = &0100
+l0106       = &0106
+l01ff       = &01ff
+brkv        = &0202
+wrchv       = &020e
+l0400       = &0400
+l0401       = &0401
+l0402       = &0402
+l0403       = &0403
+l0404       = &0404
+l040c       = &040c
+l043c       = &043c
+l043d       = &043d
+l0440       = &0440
+l0441       = &0441
+l0460       = &0460
+l0464       = &0464
+l0469       = &0469
+l046c       = &046c
+l047f       = &047f
+l04ff       = &04ff
+l0500       = &0500
+l0513       = &0513
+l0514       = &0514
+l0519       = &0519
+l051a       = &051a
+l051b       = &051b
+l051c       = &051c
+l051d       = &051d
+l051e       = &051e
+l051f       = &051f
+l0521       = &0521
+l0522       = &0522
+l0523       = &0523
+l0524       = &0524
+l0526       = &0526
+l0527       = &0527
+l0528       = &0528
+l0529       = &0529
+l052a       = &052a
+l05cb       = &05cb
+l05cc       = &05cc
+l05e5       = &05e5
+l05e6       = &05e6
+l05ff       = &05ff
+l0600       = &0600
+l0700       = &0700
+l07ef       = &07ef
+l0bb1       = &0bb1
+l0e4e       = &0e4e
+l4e4e       = &4e4e
+l5252       = &5252
+l6142       = &6142
+l7461       = &7461
+l7f0e       = &7f0e
+l7f13       = &7f13
+le09c       = &e09c
+osfind      = &ffce
+osbput      = &ffd4
+osbget      = &ffd7
+osargs      = &ffda
+osfile      = &ffdd
+osrdch      = &ffe0
+osasci      = &ffe3
+osnewl      = &ffe7
+oswrch      = &ffee
+osword      = &fff1
+osbyte      = &fff4
+oscli       = &fff7
+
+    org &8000
+
+; Sideways ROM header
+.rom_header
+.language_entry
+.pydis_start
+    jmp language_handler                                              ; 8000: 4c e7 80    L..
+
+.service_entry
+    jmp service_handler                                               ; 8003: 4c 2c 80    L,.
+
+.rom_type
+    equb &e2                                                          ; 8006: e2          .
+.copyright_offset
+    equb copyright - rom_header                                       ; 8007: 13          .
+.binary_version
+    equb 7                                                            ; 8008: 07          .
+.title
+    equs "BASIC"                                                      ; 8009: 42 41 53... BAS
+.version
+    equb 0                                                            ; 800e: 00          .
+    equs "4r32"                                                       ; 800f: 34 72 33... 4r3
+.copyright
+    equb 0                                                            ; 8013: 00          .
+    equs "(C)1988 Acorn", &0a, &0d, 0                                 ; 8014: 28 43 29... (C)
+    equb   0, &b8, &28, &80,   0, &c0, &82,   0                       ; 8024: 00 b8 28... ..(
+
+; &802c referenced 1 time by &8003
+.service_handler
+    pha                                                               ; 802c: 48          H
+    tax                                                               ; 802d: aa          .
+    tya                                                               ; 802e: 98          .
+    pha                                                               ; 802f: 48          H
+    cpx #9                                                            ; 8030: e0 09       ..
+    beq c804c                                                         ; 8032: f0 18       ..
+    cpx #4                                                            ; 8034: e0 04       ..
+    beq c8070                                                         ; 8036: f0 38       .8
+    cpx #2                                                            ; 8038: e0 02       ..
+    beq c8040                                                         ; 803a: f0 04       ..
+    cpx #&27 ; '''                                                    ; 803c: e0 27       .'
+    bne c806a                                                         ; 803e: d0 2a       .*
+; &8040 referenced 1 time by &803a
+.c8040
+    lda #osbyte_read_write_basic_rom_bank                             ; 8040: a9 bb       ..
+    ldx romsel_copy                                                   ; 8042: a6 f4       ..
+    ldy #0                                                            ; 8044: a0 00       ..
+    jsr osbyte                                                        ; 8046: 20 f4 ff     ..
+    jmp c806a                                                         ; 8049: 4c 6a 80    Lj.
+
+; &804c referenced 1 time by &8032
+.c804c
+    lda (os_text_ptr),y                                               ; 804c: b1 f2       ..
+    cmp #&0d                                                          ; 804e: c9 0d       ..
+    bne c806a                                                         ; 8050: d0 18       ..
+    jsr osnewl                                                        ; 8052: 20 e7 ff     ..
+    ldx #&f6                                                          ; 8055: a2 f6       ..
+; &8057 referenced 1 time by &8062
+.loop_c8057
+    lda l7f13,x                                                       ; 8057: bd 13 7f    ...
+    bne c805e                                                         ; 805a: d0 02       ..
+    lda #&20 ; ' '                                                    ; 805c: a9 20       .
+; &805e referenced 1 time by &805a
+.c805e
+    jsr osasci                                                        ; 805e: 20 e3 ff     ..
+    inx                                                               ; 8061: e8          .
+    bne loop_c8057                                                    ; 8062: d0 f3       ..
+    jsr osnewl                                                        ; 8064: 20 e7 ff     ..
+; &8067 referenced 2 times by &809c, &80a6
+.c8067
+    jsr sub_c80d8                                                     ; 8067: 20 d8 80     ..
+; &806a referenced 3 times by &803e, &8049, &8050
+.c806a
+    pla                                                               ; 806a: 68          h
+    tay                                                               ; 806b: a8          .
+    ldx romsel_copy                                                   ; 806c: a6 f4       ..
+    pla                                                               ; 806e: 68          h
+    rts                                                               ; 806f: 60          `
+
+; &8070 referenced 1 time by &8036
+.c8070
+    lda (os_text_ptr),y                                               ; 8070: b1 f2       ..
+    and #&df                                                          ; 8072: 29 df       ).
+    cmp #&48 ; 'H'                                                    ; 8074: c9 48       .H
+    bne c808f                                                         ; 8076: d0 17       ..
+    iny                                                               ; 8078: c8          .
+    lda #&40 ; '@'                                                    ; 8079: a9 40       .@
+    tsb romsel_copy                                                   ; 807b: 04 f4       ..
+    lda (os_text_ptr),y                                               ; 807d: b1 f2       ..
+    iny                                                               ; 807f: c8          .
+    cmp #&2e ; '.'                                                    ; 8080: c9 2e       ..
+    beq c80a8                                                         ; 8082: f0 24       .$
+    and #&df                                                          ; 8084: 29 df       ).
+    cmp #&49 ; 'I'                                                    ; 8086: c9 49       .I
+    beq c808f                                                         ; 8088: f0 05       ..
+    jsr sub_c80d8                                                     ; 808a: 20 d8 80     ..
+    dey                                                               ; 808d: 88          .
+    dey                                                               ; 808e: 88          .
+; &808f referenced 2 times by &8076, &8088
+.c808f
+    ldx #&fb                                                          ; 808f: a2 fb       ..
+; &8091 referenced 1 time by &80a0
+.loop_c8091
+    lda (os_text_ptr),y                                               ; 8091: b1 f2       ..
+    cmp #&2e ; '.'                                                    ; 8093: c9 2e       ..
+    beq c80a8                                                         ; 8095: f0 11       ..
+    and #&df                                                          ; 8097: 29 df       ).
+    cmp l7f0e,x                                                       ; 8099: dd 0e 7f    ...
+    bne c8067                                                         ; 809c: d0 c9       ..
+    iny                                                               ; 809e: c8          .
+    inx                                                               ; 809f: e8          .
+    bne loop_c8091                                                    ; 80a0: d0 ef       ..
+    lda (os_text_ptr),y                                               ; 80a2: b1 f2       ..
+    cmp #&21 ; '!'                                                    ; 80a4: c9 21       .!
+    bcs c8067                                                         ; 80a6: b0 bf       ..
+; &80a8 referenced 2 times by &8082, &8095
+.c80a8
+    bit romsel_copy                                                   ; 80a8: 24 f4       $.
+    bvc c80cc                                                         ; 80aa: 50 20       P
+    jsr sub_cbf66                                                     ; 80ac: 20 66 bf     f.
+    bne c80cc                                                         ; 80af: d0 1b       ..
+    jsr sub_c80d8                                                     ; 80b1: 20 d8 80     ..
+    ldx #&0a                                                          ; 80b4: a2 0a       ..
+; &80b6 referenced 1 time by &80bd
+.copy_to_stack_loop
+    lda l80c2,x                                                       ; 80b6: bd c2 80    ...
+    sta l0100,x                                                       ; 80b9: 9d 00 01    ...
+    dex                                                               ; 80bc: ca          .
+    bpl copy_to_stack_loop                                            ; 80bd: 10 f7       ..
+    jmp l0100                                                         ; 80bf: 4c 00 01    L..
+
+; &80c2 referenced 1 time by &80b6
+.l80c2
+    equb 0, 0                                                         ; 80c2: 00 00       ..
+    equs "No TUBE"                                                    ; 80c4: 4e 6f 20... No
+    equb 0                                                            ; 80cb: 00          .
+
+; &80cc referenced 2 times by &80aa, &80af
+.c80cc
+    lda romsel_copy                                                   ; 80cc: a5 f4       ..
+    eor #&40 ; '@'                                                    ; 80ce: 49 40       I@
+    tax                                                               ; 80d0: aa          .
+    lda #osbyte_enter_language                                        ; 80d1: a9 8e       ..
+    ldy #0                                                            ; 80d3: a0 00       ..
+    jmp osbyte                                                        ; 80d5: 4c f4 ff    L..
+
+; &80d8 referenced 3 times by &8067, &808a, &80b1
+.sub_c80d8
+    lda #&40 ; '@'                                                    ; 80d8: a9 40       .@
+    trb romsel_copy                                                   ; 80da: 14 f4       ..
+    rts                                                               ; 80dc: 60          `
+
+; &80dd referenced 1 time by &a0fd
+.l80dd
+    equb   0,   0,   0,   3, &27                                      ; 80dd: 00 00 00... ...
+; &80e2 referenced 1 time by &a0f7
+.l80e2
+    equb   1, &0a, &64, &e8, &10                                      ; 80e2: 01 0a 64... ..d
+
+; &80e7 referenced 1 time by &8000
+.language_handler
+    and l0011                                                         ; 80e7: 25 11       %.
+    ora l000d                                                         ; 80e9: 05 0d       ..
+    ora l000e                                                         ; 80eb: 05 0e       ..
+    ora l000f                                                         ; 80ed: 05 0f       ..
+    ora l0010                                                         ; 80ef: 05 10       ..
+    bne c80ff                                                         ; 80f1: d0 0c       ..
+    lda #&41 ; 'A'                                                    ; 80f3: a9 41       .A
+    sta l000d                                                         ; 80f5: 85 0d       ..
+    eor #&13                                                          ; 80f7: 49 13       I.
+    sta l000e                                                         ; 80f9: 85 0e       ..
+    eor #5                                                            ; 80fb: 49 05       I.
+    sta l000f                                                         ; 80fd: 85 0f       ..
+; &80ff referenced 1 time by &80f1
+.c80ff
+    lda #osbyte_read_himem                                            ; 80ff: a9 84       ..
+    jsr osbyte                                                        ; 8101: 20 f4 ff     ..
+    stx l0006                                                         ; 8104: 86 06       ..
+    sty l0007                                                         ; 8106: 84 07       ..
+    dec a                                                             ; 8108: 3a          :
+    jsr osbyte                                                        ; 8109: 20 f4 ff     ..
+    sty l0018                                                         ; 810c: 84 18       ..
+    ldx #&13                                                          ; 810e: a2 13       ..
+    stx l00fd                                                         ; 8110: 86 fd       ..
+    ldx #&80                                                          ; 8112: a2 80       ..
+    stx l00fe                                                         ; 8114: 86 fe       ..
+    stz l001f                                                         ; 8116: 64 1f       d.
+    stz l0402                                                         ; 8118: 9c 02 04    ...
+    stz l0403                                                         ; 811b: 9c 03 04    ...
+    ldx #&ff                                                          ; 811e: a2 ff       ..
+    stx l0023                                                         ; 8120: 86 23       .#
+    ldx #&0a                                                          ; 8122: a2 0a       ..
+    stx l0400                                                         ; 8124: 8e 00 04    ...
+    dex                                                               ; 8127: ca          .
+    stx l0401                                                         ; 8128: 8e 01 04    ...
+    lda #&b2                                                          ; 812b: a9 b2       ..
+    sta brkv                                                          ; 812d: 8d 02 02    ...
+    lda #&b2                                                          ; 8130: a9 b2       ..
+    sta brkv+1                                                        ; 8132: 8d 03 02    ...
+    cli                                                               ; 8135: 58          X
+    jmp c8ff2                                                         ; 8136: 4c f2 8f    L..
+
+; &8139 referenced 1 time by &b09e
+.sub_c8139
+    sty l0039                                                         ; 8139: 84 39       .9
+    ldy #1                                                            ; 813b: a0 01       ..
+    lda (l0037),y                                                     ; 813d: b1 37       .7
+    ldy #&f6                                                          ; 813f: a0 f6       ..
+    cmp #&f2                                                          ; 8141: c9 f2       ..
+    beq c8151                                                         ; 8143: f0 0c       ..
+    ldy #&f8                                                          ; 8145: a0 f8       ..
+    bra c8151                                                         ; 8147: 80 08       ..
+; &8149 referenced 4 times by &9638, &9a5c, &9aaf, &9acb
+.sub_c8149
+    sty l0039                                                         ; 8149: 84 39       .9
+    ldy #1                                                            ; 814b: a0 01       ..
+    lda (l0037),y                                                     ; 814d: b1 37       .7
+    asl a                                                             ; 814f: 0a          .
+    tay                                                               ; 8150: a8          .
+; &8151 referenced 2 times by &8143, &8147
+.c8151
+    lda l0401,y                                                       ; 8151: b9 01 04    ...
+    beq c8190                                                         ; 8154: f0 3a       .:
+    sta l002b                                                         ; 8156: 85 2b       .+
+    lda l0400,y                                                       ; 8158: b9 00 04    ...
+    bra c8168                                                         ; 815b: 80 0b       ..
+; &815d referenced 4 times by &8172, &8178, &817c, &8185
+.c815d
+    ldy #1                                                            ; 815d: a0 01       ..
+    lda (l002a),y                                                     ; 815f: b1 2a       .*
+    beq c8190                                                         ; 8161: f0 2d       .-
+    tay                                                               ; 8163: a8          .
+    lda (l002a)                                                       ; 8164: b2 2a       .*
+    sty l002b                                                         ; 8166: 84 2b       .+
+; &8168 referenced 1 time by &815b
+.c8168
+    sta l002a                                                         ; 8168: 85 2a       .*
+    ldy #2                                                            ; 816a: a0 02       ..
+    lda (l002a),y                                                     ; 816c: b1 2a       .*
+    bne c817a                                                         ; 816e: d0 0a       ..
+    cpy l0039                                                         ; 8170: c4 39       .9
+    bne c815d                                                         ; 8172: d0 e9       ..
+    bra c8187                                                         ; 8174: 80 11       ..
+; &8176 referenced 1 time by &8181
+.loop_c8176
+    lda (l002a),y                                                     ; 8176: b1 2a       .*
+    beq c815d                                                         ; 8178: f0 e3       ..
+; &817a referenced 1 time by &816e
+.c817a
+    cmp (l0037),y                                                     ; 817a: d1 37       .7
+    bne c815d                                                         ; 817c: d0 df       ..
+    iny                                                               ; 817e: c8          .
+    cpy l0039                                                         ; 817f: c4 39       .9
+    bne loop_c8176                                                    ; 8181: d0 f3       ..
+    lda (l002a),y                                                     ; 8183: b1 2a       .*
+    bne c815d                                                         ; 8185: d0 d6       ..
+; &8187 referenced 1 time by &8174
+.c8187
+    tya                                                               ; 8187: 98          .
+    adc l002a                                                         ; 8188: 65 2a       e*
+    sta l002a                                                         ; 818a: 85 2a       .*
+    bcc c8190                                                         ; 818c: 90 02       ..
+    inc l002b                                                         ; 818e: e6 2b       .+
+; &8190 referenced 3 times by &8154, &8161, &818c
+.c8190
+    rts                                                               ; 8190: 60          `
+
+; &8191 referenced 3 times by &b435, &b866, &bac8
+.sub_c8191
+    stz l003d                                                         ; 8191: 64 3d       d=
+    lda l0018                                                         ; 8193: a5 18       ..
+    sta l003e                                                         ; 8195: 85 3e       .>
+; &8197 referenced 2 times by &81a7, &81ab
+.c8197
+    ldy #1                                                            ; 8197: a0 01       ..
+    lda (l003d),y                                                     ; 8199: b1 3d       .=
+    cmp l002b                                                         ; 819b: c5 2b       .+
+    bcs c81ad                                                         ; 819d: b0 0e       ..
+; &819f referenced 1 time by &81b4
+.loop_c819f
+    ldy #3                                                            ; 819f: a0 03       ..
+    lda (l003d),y                                                     ; 81a1: b1 3d       .=
+    adc l003d                                                         ; 81a3: 65 3d       e=
+    sta l003d                                                         ; 81a5: 85 3d       .=
+    bcc c8197                                                         ; 81a7: 90 ee       ..
+    inc l003e                                                         ; 81a9: e6 3e       .>
+    bra c8197                                                         ; 81ab: 80 ea       ..
+; &81ad referenced 1 time by &819d
+.c81ad
+    bne c81b9                                                         ; 81ad: d0 0a       ..
+    iny                                                               ; 81af: c8          .
+    lda (l003d),y                                                     ; 81b0: b1 3d       .=
+    cmp l002a                                                         ; 81b2: c5 2a       .*
+    bcc loop_c819f                                                    ; 81b4: 90 e9       ..
+    bne c81b9                                                         ; 81b6: d0 01       ..
+    rts                                                               ; 81b8: 60          `
+
+; &81b9 referenced 2 times by &81ad, &81b6
+.c81b9
+    ldy #2                                                            ; 81b9: a0 02       ..
+    clc                                                               ; 81bb: 18          .
+    rts                                                               ; 81bc: 60          `
+
+; &81bd referenced 2 times by &a04a, &a05f
+.sub_c81bd
+    jsr sub_c9783                                                     ; 81bd: 20 83 97     ..
+    lda l002d                                                         ; 81c0: a5 2d       .-
+    pha                                                               ; 81c2: 48          H
+    bpl c81c8                                                         ; 81c3: 10 03       ..
+    jsr cad20                                                         ; 81c5: 20 20 ad      .
+; &81c8 referenced 1 time by &81c3
+.c81c8
+    jsr sub_ca069                                                     ; 81c8: 20 69 a0     i.
+    stx l0027                                                         ; 81cb: 86 27       .'
+    jsr sub_c9783                                                     ; 81cd: 20 83 97     ..
+    pla                                                               ; 81d0: 68          h
+    sta l0038                                                         ; 81d1: 85 38       .8
+    eor l002d                                                         ; 81d3: 45 2d       E-
+    sta l0037                                                         ; 81d5: 85 37       .7
+    jsr sub_cad07                                                     ; 81d7: 20 07 ad     ..
+    ldx #&39 ; '9'                                                    ; 81da: a2 39       .9
+    jsr sub_cbd48                                                     ; 81dc: 20 48 bd     H.
+    ldx #3                                                            ; 81df: a2 03       ..
+; &81e1 referenced 1 time by &81e8
+.loop_c81e1
+    stz l003d,x                                                       ; 81e1: 74 3d       t=
+    lda l002a,x                                                       ; 81e3: b5 2a       .*
+    bne c81fd                                                         ; 81e5: d0 16       ..
+    dex                                                               ; 81e7: ca          .
+    bpl loop_c81e1                                                    ; 81e8: 10 f7       ..
+; &81ea referenced 1 time by &a62c
+.c81ea
+    brk                                                               ; 81ea: 00          .
+
+    equb &12                                                          ; 81eb: 12          .
+    equs "Division by zero"                                           ; 81ec: 44 69 76... Div
+    equb 0                                                            ; 81fc: 00          .
+
+; &81fd referenced 1 time by &81e5
+.c81fd
+    rol a                                                             ; 81fd: 2a          *
+    txa                                                               ; 81fe: 8a          .
+    tay                                                               ; 81ff: a8          .
+    adc #0                                                            ; 8200: 69 00       i.
+    sta l0042                                                         ; 8202: 85 42       .B
+    ldx #3                                                            ; 8204: a2 03       ..
+; &8206 referenced 1 time by &820d
+.loop_c8206
+    lda l0039,x                                                       ; 8206: b5 39       .9
+    stz l003d,x                                                       ; 8208: 74 3d       t=
+    bne c8230                                                         ; 820a: d0 24       .$
+    dex                                                               ; 820c: ca          .
+    bpl loop_c8206                                                    ; 820d: 10 f7       ..
+; &820f referenced 4 times by &8211, &8225, &822a, &822e
+.c820f
+    rts                                                               ; 820f: 60          `
+
+; &8210 referenced 1 time by &823d
+.c8210
+    tya                                                               ; 8210: 98          .
+    beq c820f                                                         ; 8211: f0 fc       ..
+    lda l003d,y                                                       ; 8213: b9 3d 00    .=.
+    sta l003d                                                         ; 8216: 85 3d       .=
+    lda l003e,y                                                       ; 8218: b9 3e 00    .>.
+    sta l003e                                                         ; 821b: 85 3e       .>
+    lda l003f,y                                                       ; 821d: b9 3f 00    .?.
+    sta l003f                                                         ; 8220: 85 3f       .?
+    stz l0040                                                         ; 8222: 64 40       d@
+    dey                                                               ; 8224: 88          .
+    beq c820f                                                         ; 8225: f0 e8       ..
+    stz l003f                                                         ; 8227: 64 3f       d?
+    dey                                                               ; 8229: 88          .
+    beq c820f                                                         ; 822a: f0 e3       ..
+    stz l003e                                                         ; 822c: 64 3e       d>
+    bra c820f                                                         ; 822e: 80 df       ..
+; &8230 referenced 1 time by &820a
+.c8230
+    cmp l002a,y                                                       ; 8230: d9 2a 00    .*.
+    bcs c823f                                                         ; 8233: b0 0a       ..
+; &8235 referenced 1 time by &8240
+.loop_c8235
+    lda l0039,x                                                       ; 8235: b5 39       .9
+    sta l003d,y                                                       ; 8237: 99 3d 00    .=.
+    stz l0039,x                                                       ; 823a: 74 39       t9
+    dex                                                               ; 823c: ca          .
+    bmi c8210                                                         ; 823d: 30 d1       0.
+; &823f referenced 1 time by &8233
+.c823f
+    dey                                                               ; 823f: 88          .
+    bpl loop_c8235                                                    ; 8240: 10 f3       ..
+; &8242 referenced 1 time by &8284
+.c8242
+    ldy #8                                                            ; 8242: a0 08       ..
+    stx l0041                                                         ; 8244: 86 41       .A
+; &8246 referenced 1 time by &827f
+.c8246
+    rol l0039,x                                                       ; 8246: 36 39       69
+    rol l003d                                                         ; 8248: 26 3d       &=
+    rol l003e                                                         ; 824a: 26 3e       &>
+    rol l003f                                                         ; 824c: 26 3f       &?
+    rol l0040                                                         ; 824e: 26 40       &@
+    ldx l0042                                                         ; 8250: a6 42       .B
+; &8252 referenced 1 time by &8259
+.loop_c8252
+    lda l003d,x                                                       ; 8252: b5 3d       .=
+    cmp l002a,x                                                       ; 8254: d5 2a       .*
+    bne c825b                                                         ; 8256: d0 03       ..
+    dex                                                               ; 8258: ca          .
+    bpl loop_c8252                                                    ; 8259: 10 f7       ..
+; &825b referenced 1 time by &8256
+.c825b
+    bcc c827c                                                         ; 825b: 90 1f       ..
+    lda l003d                                                         ; 825d: a5 3d       .=
+    sbc l002a                                                         ; 825f: e5 2a       .*
+    sta l003d                                                         ; 8261: 85 3d       .=
+    ldx l0042                                                         ; 8263: a6 42       .B
+    beq c827c                                                         ; 8265: f0 15       ..
+    lda l003e                                                         ; 8267: a5 3e       .>
+    sbc l002b                                                         ; 8269: e5 2b       .+
+    sta l003e                                                         ; 826b: 85 3e       .>
+    dex                                                               ; 826d: ca          .
+    beq c827c                                                         ; 826e: f0 0c       ..
+    lda l003f                                                         ; 8270: a5 3f       .?
+    sbc l002c                                                         ; 8272: e5 2c       .,
+    sta l003f                                                         ; 8274: 85 3f       .?
+    lda l0040                                                         ; 8276: a5 40       .@
+    sbc l002d                                                         ; 8278: e5 2d       .-
+    sta l0040                                                         ; 827a: 85 40       .@
+; &827c referenced 3 times by &825b, &8265, &826e
+.c827c
+    ldx l0041                                                         ; 827c: a6 41       .A
+    dey                                                               ; 827e: 88          .
+    bne c8246                                                         ; 827f: d0 c5       ..
+    rol l0039,x                                                       ; 8281: 36 39       69
+    dex                                                               ; 8283: ca          .
+    bpl c8242                                                         ; 8284: 10 bc       ..
+    rts                                                               ; 8286: 60          `
+
+; &8287 referenced 2 times by &9f66, &9f9d
+.sub_c8287
+    jsr sub_cbd26                                                     ; 8287: 20 26 bd     &.
+; &828a referenced 2 times by &9d4e, &aab3
+.sub_c828a
+    jsr sub_ca3ed                                                     ; 828a: 20 ed a3     ..
+; &828d referenced 8 times by &97a6, &9f9a, &9fa7, &a09c, &a1ac, &a37e, &a99d, &b39b
+.c828d
+    stz l0035                                                         ; 828d: 64 35       d5
+    lda l002d                                                         ; 828f: a5 2d       .-
+    sta l002e                                                         ; 8291: 85 2e       ..
+    bpl c829a                                                         ; 8293: 10 05       ..
+    jsr cad20                                                         ; 8295: 20 20 ad      .
+    lda l002d                                                         ; 8298: a5 2d       .-
+; &829a referenced 1 time by &8293
+.c829a
+    bne c82c8                                                         ; 829a: d0 2c       .,
+    stz l0034                                                         ; 829c: 64 34       d4
+    ldy l002a                                                         ; 829e: a4 2a       .*
+    lda l002c                                                         ; 82a0: a5 2c       .,
+    bne c82be                                                         ; 82a2: d0 1a       ..
+    stz l0033                                                         ; 82a4: 64 33       d3
+    lda l002b                                                         ; 82a6: a5 2b       .+
+    beq c82d8                                                         ; 82a8: f0 2e       ..
+    sty l0032                                                         ; 82aa: 84 32       .2
+    ldy #&90                                                          ; 82ac: a0 90       ..
+; &82ae referenced 2 times by &82c6, &82d6
+.c82ae
+    ora #0                                                            ; 82ae: 09 00       ..
+    bmi c82fb                                                         ; 82b0: 30 49       0I
+; &82b2 referenced 1 time by &82ba
+.loop_c82b2
+    dey                                                               ; 82b2: 88          .
+    asl l0034                                                         ; 82b3: 06 34       .4
+    rol l0033                                                         ; 82b5: 26 33       &3
+    rol l0032                                                         ; 82b7: 26 32       &2
+    rol a                                                             ; 82b9: 2a          *
+    bpl loop_c82b2                                                    ; 82ba: 10 f6       ..
+    bra c82fb                                                         ; 82bc: 80 3d       .=
+; &82be referenced 1 time by &82a2
+.c82be
+    sty l0033                                                         ; 82be: 84 33       .3
+    ldy l002b                                                         ; 82c0: a4 2b       .+
+    sty l0032                                                         ; 82c2: 84 32       .2
+    ldy #&98                                                          ; 82c4: a0 98       ..
+    bra c82ae                                                         ; 82c6: 80 e6       ..
+; &82c8 referenced 1 time by &829a
+.c82c8
+    ldy l002c                                                         ; 82c8: a4 2c       .,
+    sty l0032                                                         ; 82ca: 84 32       .2
+    ldy l002b                                                         ; 82cc: a4 2b       .+
+    sty l0033                                                         ; 82ce: 84 33       .3
+    ldy l002a                                                         ; 82d0: a4 2a       .*
+    sty l0034                                                         ; 82d2: 84 34       .4
+    ldy #&a0                                                          ; 82d4: a0 a0       ..
+    bra c82ae                                                         ; 82d6: 80 d6       ..
+; &82d8 referenced 1 time by &82a8
+.c82d8
+    stz l0032                                                         ; 82d8: 64 32       d2
+    tya                                                               ; 82da: 98          .
+    bne c82f4                                                         ; 82db: d0 17       ..
+; &82dd referenced 3 times by &82ed, &8310, &a2d9
+.c82dd
+    stz l0031                                                         ; 82dd: 64 31       d1
+    stz l002e                                                         ; 82df: 64 2e       d.
+    stz l0030                                                         ; 82e1: 64 30       d0
+    stz l002f                                                         ; 82e3: 64 2f       d/
+    rts                                                               ; 82e5: 60          `
+
+; &82e6 referenced 1 time by &a7f7
+.sub_c82e6
+    sta l002e                                                         ; 82e6: 85 2e       ..
+    jsr sub_ca731                                                     ; 82e8: 20 31 a7     1.
+    lda l002e                                                         ; 82eb: a5 2e       ..
+    beq c82dd                                                         ; 82ed: f0 ee       ..
+    bpl c82f4                                                         ; 82ef: 10 03       ..
+    eor #&ff                                                          ; 82f1: 49 ff       I.
+    inc a                                                             ; 82f3: 1a          .
+; &82f4 referenced 2 times by &82db, &82ef
+.c82f4
+    ldy #&89                                                          ; 82f4: a0 89       ..
+    lsr a                                                             ; 82f6: 4a          J
+; &82f7 referenced 1 time by &82f9
+.loop_c82f7
+    dey                                                               ; 82f7: 88          .
+    rol a                                                             ; 82f8: 2a          *
+    bpl loop_c82f7                                                    ; 82f9: 10 fc       ..
+; &82fb referenced 2 times by &82b0, &82bc
+.c82fb
+    sty l0030                                                         ; 82fb: 84 30       .0
+    stz l002f                                                         ; 82fd: 64 2f       d/
+    sta l0031                                                         ; 82ff: 85 31       .1
+    rts                                                               ; 8301: 60          `
+
+    equb &a5, &31                                                     ; 8302: a5 31       .1
+
+; &8304 referenced 3 times by &84f1, &8510, &a390
+.c8304
+    bmi c8346                                                         ; 8304: 30 40       0@
+; &8306 referenced 2 times by &a6c6, &a7a9
+.c8306
+    bne c832f                                                         ; 8306: d0 27       .'
+    ora l0032                                                         ; 8308: 05 32       .2
+    ora l0033                                                         ; 830a: 05 33       .3
+    ora l0034                                                         ; 830c: 05 34       .4
+    ora l0035                                                         ; 830e: 05 35       .5
+    beq c82dd                                                         ; 8310: f0 cb       ..
+    ldy l0030                                                         ; 8312: a4 30       .0
+; &8314 referenced 1 time by &832b
+.loop_c8314
+    lda l0032                                                         ; 8314: a5 32       .2
+    pha                                                               ; 8316: 48          H
+    lda l0033                                                         ; 8317: a5 33       .3
+    sta l0032                                                         ; 8319: 85 32       .2
+    lda l0034                                                         ; 831b: a5 34       .4
+    sta l0033                                                         ; 831d: 85 33       .3
+    lda l0035                                                         ; 831f: a5 35       .5
+    sta l0034                                                         ; 8321: 85 34       .4
+    stz l0035                                                         ; 8323: 64 35       d5
+    tya                                                               ; 8325: 98          .
+    sec                                                               ; 8326: 38          8
+    sbc #8                                                            ; 8327: e9 08       ..
+    tay                                                               ; 8329: a8          .
+    pla                                                               ; 832a: 68          h
+    beq loop_c8314                                                    ; 832b: f0 e7       ..
+    bra c833b                                                         ; 832d: 80 0c       ..
+; &832f referenced 1 time by &8306
+.c832f
+    ldy l0030                                                         ; 832f: a4 30       .0
+; &8331 referenced 1 time by &833b
+.loop_c8331
+    dey                                                               ; 8331: 88          .
+    asl l0035                                                         ; 8332: 06 35       .5
+    rol l0034                                                         ; 8334: 26 34       &4
+    rol l0033                                                         ; 8336: 26 33       &3
+    rol l0032                                                         ; 8338: 26 32       &2
+    rol a                                                             ; 833a: 2a          *
+; &833b referenced 1 time by &832d
+.c833b
+    bpl loop_c8331                                                    ; 833b: 10 f4       ..
+    cpy l0030                                                         ; 833d: c4 30       .0
+    sty l0030                                                         ; 833f: 84 30       .0
+    bcc c8345                                                         ; 8341: 90 02       ..
+    dec l002f                                                         ; 8343: c6 2f       ./
+; &8345 referenced 1 time by &8341
+.c8345
+    tay                                                               ; 8345: a8          .
+; &8346 referenced 1 time by &8304
+.c8346
+    sta l0031                                                         ; 8346: 85 31       .1
+    rts                                                               ; 8348: 60          `
+
+; &8349 referenced 1 time by &abed
+.sub_c8349
+    stz l003d                                                         ; 8349: 64 3d       d=
+.sub_c834b
+    ldy l0031                                                         ; 834b: a4 31       .1
+    bra c8353                                                         ; 834d: 80 04       ..
+; &834f referenced 1 time by &9788
+.sub_c834f
+    ldy l0031                                                         ; 834f: a4 31       .1
+    sty l003d                                                         ; 8351: 84 3d       .=
+; &8353 referenced 1 time by &834d
+.c8353
+    lda l0030                                                         ; 8353: a5 30       .0
+    cmp #&81                                                          ; 8355: c9 81       ..
+    bcs c835e                                                         ; 8357: b0 05       ..
+    sty l003d                                                         ; 8359: 84 3d       .=
+    jmp ca72b                                                         ; 835b: 4c 2b a7    L+.
+
+; &835e referenced 1 time by &8357
+.c835e
+    cmp #&a0                                                          ; 835e: c9 a0       ..
+    bcc c8372                                                         ; 8360: 90 10       ..
+; &8362 referenced 1 time by &83d0
+.c8362
+    jmp ca6f2                                                         ; 8362: 4c f2 a6    L..
+
+; &8365 referenced 1 time by &8374
+.loop_c8365
+    lsr l0031                                                         ; 8365: 46 31       F1
+    ror l0032                                                         ; 8367: 66 32       f2
+    ror l0033                                                         ; 8369: 66 33       f3
+    ror l0034                                                         ; 836b: 66 34       f4
+    bcc c8371                                                         ; 836d: 90 02       ..
+    sta l003d                                                         ; 836f: 85 3d       .=
+; &8371 referenced 1 time by &836d
+.c8371
+    inc a                                                             ; 8371: 1a          .
+; &8372 referenced 1 time by &8360
+.c8372
+    bit #7                                                            ; 8372: 89 07       ..
+    bne loop_c8365                                                    ; 8374: d0 ef       ..
+    and #&18                                                          ; 8376: 29 18       ).
+    beq c83a6                                                         ; 8378: f0 2c       .,
+    lsr a                                                             ; 837a: 4a          J
+    lsr a                                                             ; 837b: 4a          J
+    lsr a                                                             ; 837c: 4a          J
+    tay                                                               ; 837d: a8          .
+    phx                                                               ; 837e: da          .
+    eor #3                                                            ; 837f: 49 03       I.
+    tax                                                               ; 8381: aa          .
+    lda l003d                                                         ; 8382: a5 3d       .=
+    bne c8392                                                         ; 8384: d0 0c       ..
+    stz l0035                                                         ; 8386: 64 35       d5
+    lda l0034                                                         ; 8388: a5 34       .4
+    ora l0031,y                                                       ; 838a: 19 31 00    .1.
+    ora l0032,y                                                       ; 838d: 19 32 00    .2.
+    sta l003d                                                         ; 8390: 85 3d       .=
+; &8392 referenced 1 time by &8384
+.c8392
+    lda l0033                                                         ; 8392: a5 33       .3
+    sta l0034                                                         ; 8394: 85 34       .4
+    lda l0032                                                         ; 8396: a5 32       .2
+    sta l0033,x                                                       ; 8398: 95 33       .3
+    lda l0031                                                         ; 839a: a5 31       .1
+    sta l0032,x                                                       ; 839c: 95 32       .2
+; &839e referenced 1 time by &83a1
+.loop_c839e
+    stz l0031,x                                                       ; 839e: 74 31       t1
+    dex                                                               ; 83a0: ca          .
+    bpl loop_c839e                                                    ; 83a1: 10 fb       ..
+    plx                                                               ; 83a3: fa          .
+    stz l0035                                                         ; 83a4: 64 35       d5
+; &83a6 referenced 1 time by &8378
+.c83a6
+    lda l002e                                                         ; 83a6: a5 2e       ..
+    bpl c83c1                                                         ; 83a8: 10 17       ..
+; &83aa referenced 1 time by &abfa
+.sub_c83aa
+    sec                                                               ; 83aa: 38          8
+    ldy #0                                                            ; 83ab: a0 00       ..
+    tya                                                               ; 83ad: 98          .
+    sbc l0034                                                         ; 83ae: e5 34       .4
+    sta l0034                                                         ; 83b0: 85 34       .4
+    tya                                                               ; 83b2: 98          .
+    sbc l0033                                                         ; 83b3: e5 33       .3
+    sta l0033                                                         ; 83b5: 85 33       .3
+    tya                                                               ; 83b7: 98          .
+    sbc l0032                                                         ; 83b8: e5 32       .2
+    sta l0032                                                         ; 83ba: 85 32       .2
+    tya                                                               ; 83bc: 98          .
+    sbc l0031                                                         ; 83bd: e5 31       .1
+    sta l0031                                                         ; 83bf: 85 31       .1
+; &83c1 referenced 1 time by &83a8
+.c83c1
+    rts                                                               ; 83c1: 60          `
+
+; &83c2 referenced 1 time by &abf7
+.sub_c83c2
+    inc l0034                                                         ; 83c2: e6 34       .4
+    bne c83d2                                                         ; 83c4: d0 0c       ..
+    inc l0033                                                         ; 83c6: e6 33       .3
+    bne c83d2                                                         ; 83c8: d0 08       ..
+    inc l0032                                                         ; 83ca: e6 32       .2
+    bne c83d2                                                         ; 83cc: d0 04       ..
+    inc l0031                                                         ; 83ce: e6 31       .1
+    beq c8362                                                         ; 83d0: f0 90       ..
+; &83d2 referenced 3 times by &83c4, &83c8, &83cc
+.c83d2
+    rts                                                               ; 83d2: 60          `
+
+; &83d3 referenced 2 times by &aa7a, &aad3
+.sub_c83d3
+    ldy #2                                                            ; 83d3: a0 02       ..
+; &83d5 referenced 1 time by &8407
+.c83d5
+    ror l0011                                                         ; 83d5: 66 11       f.
+    ror l0010                                                         ; 83d7: 66 10       f.
+    lda l000f                                                         ; 83d9: a5 0f       ..
+    sta l0011                                                         ; 83db: 85 11       ..
+    ror a                                                             ; 83dd: 6a          j
+    pha                                                               ; 83de: 48          H
+    lda l000e                                                         ; 83df: a5 0e       ..
+    ldx l000d                                                         ; 83e1: a6 0d       ..
+    lsr l000f                                                         ; 83e3: 46 0f       F.
+    ror a                                                             ; 83e5: 6a          j
+    ror l000d                                                         ; 83e6: 66 0d       f.
+    lsr l000f                                                         ; 83e8: 46 0f       F.
+    ror a                                                             ; 83ea: 6a          j
+    ror l000d                                                         ; 83eb: 66 0d       f.
+    lsr l000f                                                         ; 83ed: 46 0f       F.
+    ror a                                                             ; 83ef: 6a          j
+    ror l000d                                                         ; 83f0: 66 0d       f.
+    lsr l000f                                                         ; 83f2: 46 0f       F.
+    ror a                                                             ; 83f4: 6a          j
+    ror l000d                                                         ; 83f5: 66 0d       f.
+    eor l0010                                                         ; 83f7: 45 10       E.
+    stx l000f                                                         ; 83f9: 86 0f       ..
+    ldx l000e                                                         ; 83fb: a6 0e       ..
+    stx l0010                                                         ; 83fd: 86 10       ..
+    sta l000e                                                         ; 83ff: 85 0e       ..
+    pla                                                               ; 8401: 68          h
+    eor l000d                                                         ; 8402: 45 0d       E.
+    sta l000d                                                         ; 8404: 85 0d       ..
+    dey                                                               ; 8406: 88          .
+    bne c83d5                                                         ; 8407: d0 cc       ..
+    rts                                                               ; 8409: 60          `
+
+; &840a referenced 2 times by &842b, &846f
+.c840a
+    lda l003b                                                         ; 840a: a5 3b       .;
+    sta l002e                                                         ; 840c: 85 2e       ..
+    stz l002f                                                         ; 840e: 64 2f       d/
+    lda l003c                                                         ; 8410: a5 3c       .<
+    sta l0030                                                         ; 8412: 85 30       .0
+    lda l003d                                                         ; 8414: a5 3d       .=
+    sta l0031                                                         ; 8416: 85 31       .1
+    lda l003e                                                         ; 8418: a5 3e       .>
+    sta l0032                                                         ; 841a: 85 32       .2
+    lda l003f                                                         ; 841c: a5 3f       .?
+    sta l0033                                                         ; 841e: 85 33       .3
+    lda l0040                                                         ; 8420: a5 40       .@
+    sta l0034                                                         ; 8422: 85 34       .4
+    lda l0041                                                         ; 8424: a5 41       .A
+    sta l0035                                                         ; 8426: 85 35       .5
+; &8428 referenced 1 time by &8438
+.loop_c8428
+    rts                                                               ; 8428: 60          `
+
+; &8429 referenced 2 times by &a204, &a70f
+.sub_c8429
+    lda l0031                                                         ; 8429: a5 31       .1
+    beq c840a                                                         ; 842b: f0 dd       ..
+    sec                                                               ; 842d: 38          8
+    lda l0030                                                         ; 842e: a5 30       .0
+    sbc l003c                                                         ; 8430: e5 3c       .<
+    beq c84a3                                                         ; 8432: f0 6f       .o
+    bcc c846a                                                         ; 8434: 90 34       .4
+    cmp #&25 ; '%'                                                    ; 8436: c9 25       .%
+    bcs loop_c8428                                                    ; 8438: b0 ee       ..
+    tay                                                               ; 843a: a8          .
+    and #&38 ; '8'                                                    ; 843b: 29 38       )8
+    beq c8456                                                         ; 843d: f0 17       ..
+    sec                                                               ; 843f: 38          8
+; &8440 referenced 1 time by &8454
+.loop_c8440
+    ldx l0040                                                         ; 8440: a6 40       .@
+    stx l0041                                                         ; 8442: 86 41       .A
+    ldx l003f                                                         ; 8444: a6 3f       .?
+    stx l0040                                                         ; 8446: 86 40       .@
+    ldx l003e                                                         ; 8448: a6 3e       .>
+    stx l003f                                                         ; 844a: 86 3f       .?
+    ldx l003d                                                         ; 844c: a6 3d       .=
+    stx l003e                                                         ; 844e: 86 3e       .>
+    stz l003d                                                         ; 8450: 64 3d       d=
+    sbc #8                                                            ; 8452: e9 08       ..
+    bne loop_c8440                                                    ; 8454: d0 ea       ..
+; &8456 referenced 1 time by &843d
+.c8456
+    tya                                                               ; 8456: 98          .
+    and #7                                                            ; 8457: 29 07       ).
+    beq c84a3                                                         ; 8459: f0 48       .H
+; &845b referenced 1 time by &8466
+.loop_c845b
+    lsr l003d                                                         ; 845b: 46 3d       F=
+    ror l003e                                                         ; 845d: 66 3e       f>
+    ror l003f                                                         ; 845f: 66 3f       f?
+    ror l0040                                                         ; 8461: 66 40       f@
+    ror l0041                                                         ; 8463: 66 41       fA
+    dec a                                                             ; 8465: 3a          :
+    bne loop_c845b                                                    ; 8466: d0 f3       ..
+    bra c84a3                                                         ; 8468: 80 39       .9
+; &846a referenced 1 time by &8434
+.c846a
+    eor #&ff                                                          ; 846a: 49 ff       I.
+    inc a                                                             ; 846c: 1a          .
+    cmp #&25 ; '%'                                                    ; 846d: c9 25       .%
+    bcs c840a                                                         ; 846f: b0 99       ..
+    ldy l003c                                                         ; 8471: a4 3c       .<
+    sty l0030                                                         ; 8473: 84 30       .0
+    tay                                                               ; 8475: a8          .
+    and #&38 ; '8'                                                    ; 8476: 29 38       )8
+    beq c8491                                                         ; 8478: f0 17       ..
+    sec                                                               ; 847a: 38          8
+; &847b referenced 1 time by &848f
+.loop_c847b
+    ldx l0034                                                         ; 847b: a6 34       .4
+    stx l0035                                                         ; 847d: 86 35       .5
+    ldx l0033                                                         ; 847f: a6 33       .3
+    stx l0034                                                         ; 8481: 86 34       .4
+    ldx l0032                                                         ; 8483: a6 32       .2
+    stx l0033                                                         ; 8485: 86 33       .3
+    ldx l0031                                                         ; 8487: a6 31       .1
+    stx l0032                                                         ; 8489: 86 32       .2
+    stz l0031                                                         ; 848b: 64 31       d1
+    sbc #8                                                            ; 848d: e9 08       ..
+    bne loop_c847b                                                    ; 848f: d0 ea       ..
+; &8491 referenced 1 time by &8478
+.c8491
+    tya                                                               ; 8491: 98          .
+    and #7                                                            ; 8492: 29 07       ).
+    beq c84a3                                                         ; 8494: f0 0d       ..
+; &8496 referenced 1 time by &84a1
+.loop_c8496
+    lsr l0031                                                         ; 8496: 46 31       F1
+    ror l0032                                                         ; 8498: 66 32       f2
+    ror l0033                                                         ; 849a: 66 33       f3
+    ror l0034                                                         ; 849c: 66 34       f4
+    ror l0035                                                         ; 849e: 66 35       f5
+    dec a                                                             ; 84a0: 3a          :
+    bne loop_c8496                                                    ; 84a1: d0 f3       ..
+; &84a3 referenced 4 times by &8432, &8459, &8468, &8494
+.c84a3
+    lda l002e                                                         ; 84a3: a5 2e       ..
+    eor l003b                                                         ; 84a5: 45 3b       E;
+    bmi c84ad                                                         ; 84a7: 30 04       0.
+    clc                                                               ; 84a9: 18          .
+    jmp ca489                                                         ; 84aa: 4c 89 a4    L..
+
+; &84ad referenced 1 time by &84a7
+.c84ad
+    lda l0031                                                         ; 84ad: a5 31       .1
+    cmp l003d                                                         ; 84af: c5 3d       .=
+    bne c84ce                                                         ; 84b1: d0 1b       ..
+    lda l0032                                                         ; 84b3: a5 32       .2
+    cmp l003e                                                         ; 84b5: c5 3e       .>
+    bne c84ce                                                         ; 84b7: d0 15       ..
+    lda l0033                                                         ; 84b9: a5 33       .3
+    cmp l003f                                                         ; 84bb: c5 3f       .?
+    bne c84ce                                                         ; 84bd: d0 0f       ..
+    lda l0034                                                         ; 84bf: a5 34       .4
+    cmp l0040                                                         ; 84c1: c5 40       .@
+    bne c84ce                                                         ; 84c3: d0 09       ..
+    lda l0035                                                         ; 84c5: a5 35       .5
+    cmp l0041                                                         ; 84c7: c5 41       .A
+    bne c84ce                                                         ; 84c9: d0 03       ..
+    jmp ca72b                                                         ; 84cb: 4c 2b a7    L+.
+
+; &84ce referenced 5 times by &84b1, &84b7, &84bd, &84c3, &84c9
+.c84ce
+    bcs c84f4                                                         ; 84ce: b0 24       .$
+    lda l003b                                                         ; 84d0: a5 3b       .;
+    sta l002e                                                         ; 84d2: 85 2e       ..
+    sec                                                               ; 84d4: 38          8
+    lda l0041                                                         ; 84d5: a5 41       .A
+    sbc l0035                                                         ; 84d7: e5 35       .5
+    sta l0035                                                         ; 84d9: 85 35       .5
+    lda l0040                                                         ; 84db: a5 40       .@
+    sbc l0034                                                         ; 84dd: e5 34       .4
+    sta l0034                                                         ; 84df: 85 34       .4
+    lda l003f                                                         ; 84e1: a5 3f       .?
+    sbc l0033                                                         ; 84e3: e5 33       .3
+    sta l0033                                                         ; 84e5: 85 33       .3
+    lda l003e                                                         ; 84e7: a5 3e       .>
+    sbc l0032                                                         ; 84e9: e5 32       .2
+    sta l0032                                                         ; 84eb: 85 32       .2
+    lda l003d                                                         ; 84ed: a5 3d       .=
+    sbc l0031                                                         ; 84ef: e5 31       .1
+    jmp c8304                                                         ; 84f1: 4c 04 83    L..
+
+; &84f4 referenced 1 time by &84ce
+.c84f4
+    lda l0035                                                         ; 84f4: a5 35       .5
+    sbc l0041                                                         ; 84f6: e5 41       .A
+    sta l0035                                                         ; 84f8: 85 35       .5
+    lda l0034                                                         ; 84fa: a5 34       .4
+    sbc l0040                                                         ; 84fc: e5 40       .@
+    sta l0034                                                         ; 84fe: 85 34       .4
+    lda l0033                                                         ; 8500: a5 33       .3
+    sbc l003f                                                         ; 8502: e5 3f       .?
+    sta l0033                                                         ; 8504: 85 33       .3
+    lda l0032                                                         ; 8506: a5 32       .2
+    sbc l003e                                                         ; 8508: e5 3e       .>
+    sta l0032                                                         ; 850a: 85 32       .2
+    lda l0031                                                         ; 850c: a5 31       .1
+    sbc l003d                                                         ; 850e: e5 3d       .=
+    jmp c8304                                                         ; 8510: 4c 04 83    L..
+
+    equs "AND"                                                        ; 8513: 41 4e 44    AND
+    equb &80,   0                                                     ; 8516: 80 00       ..
+    equs "ABS"                                                        ; 8518: 41 42 53    ABS
+    equb &94,   0                                                     ; 851b: 94 00       ..
+    equs "ACS"                                                        ; 851d: 41 43 53    ACS
+    equb &95,   0                                                     ; 8520: 95 00       ..
+    equs "ADVAL"                                                      ; 8522: 41 44 56... ADV
+    equb &96,   0                                                     ; 8527: 96 00       ..
+    equs "ASC"                                                        ; 8529: 41 53 43    ASC
+    equb &97,   0                                                     ; 852c: 97 00       ..
+    equs "ASN"                                                        ; 852e: 41 53 4e    ASN
+    equb &98,   0                                                     ; 8531: 98 00       ..
+    equs "ATN"                                                        ; 8533: 41 54 4e    ATN
+    equb &99,   0                                                     ; 8536: 99 00       ..
+    equs "AUTO"                                                       ; 8538: 41 55 54... AUT
+    equb &c6, &10                                                     ; 853c: c6 10       ..
+    equs "BGET"                                                       ; 853e: 42 47 45... BGE
+    equb &9a,   1                                                     ; 8542: 9a 01       ..
+    equs "BPUT"                                                       ; 8544: 42 50 55... BPU
+    equb &d5,   3                                                     ; 8548: d5 03       ..
+    equs "COLOUR"                                                     ; 854a: 43 4f 4c... COL
+    equb &fb,   2                                                     ; 8550: fb 02       ..
+    equs "CALL"                                                       ; 8552: 43 41 4c... CAL
+    equb &d6,   2                                                     ; 8556: d6 02       ..
+    equs "CHAIN"                                                      ; 8558: 43 48 41... CHA
+    equb &d7,   2                                                     ; 855d: d7 02       ..
+    equs "CHR$"                                                       ; 855f: 43 48 52... CHR
+    equb &bd,   0                                                     ; 8563: bd 00       ..
+    equs "CLEAR"                                                      ; 8565: 43 4c 45... CLE
+    equb &d8,   1                                                     ; 856a: d8 01       ..
+    equs "CLOSE"                                                      ; 856c: 43 4c 4f... CLO
+    equb &d9,   3                                                     ; 8571: d9 03       ..
+    equs "CLG"                                                        ; 8573: 43 4c 47    CLG
+    equb &da,   1                                                     ; 8576: da 01       ..
+    equs "CLS"                                                        ; 8578: 43 4c 53    CLS
+    equb &db,   1                                                     ; 857b: db 01       ..
+    equs "COS"                                                        ; 857d: 43 4f 53    COS
+    equb &9b,   0                                                     ; 8580: 9b 00       ..
+    equs "COUNT"                                                      ; 8582: 43 4f 55... COU
+    equb &9c,   1                                                     ; 8587: 9c 01       ..
+    equs "COLOR"                                                      ; 8589: 43 4f 4c... COL
+    equb &fb,   2                                                     ; 858e: fb 02       ..
+    equs "DATA"                                                       ; 8590: 44 41 54... DAT
+    equb &dc                                                          ; 8594: dc          .
+    equs " DEG"                                                       ; 8595: 20 44 45...  DE
+    equb &9d,   0                                                     ; 8599: 9d 00       ..
+    equs "DEF"                                                        ; 859b: 44 45 46    DEF
+    equb &dd,   0                                                     ; 859e: dd 00       ..
+    equs "DELETE"                                                     ; 85a0: 44 45 4c... DEL
+    equb &c7, &10                                                     ; 85a6: c7 10       ..
+    equs "DIV"                                                        ; 85a8: 44 49 56    DIV
+    equb &81,   0                                                     ; 85ab: 81 00       ..
+    equs "DIM"                                                        ; 85ad: 44 49 4d    DIM
+    equb &de,   2                                                     ; 85b0: de 02       ..
+    equs "DRAW"                                                       ; 85b2: 44 52 41... DRA
+    equb &df,   2                                                     ; 85b6: df 02       ..
+    equs "ENDPROC"                                                    ; 85b8: 45 4e 44... END
+    equb &e1,   1                                                     ; 85bf: e1 01       ..
+    equs "END"                                                        ; 85c1: 45 4e 44    END
+    equb &e0,   1                                                     ; 85c4: e0 01       ..
+    equs "ENVELOPE"                                                   ; 85c6: 45 4e 56... ENV
+    equb &e2,   2                                                     ; 85ce: e2 02       ..
+    equs "ELSE"                                                       ; 85d0: 45 4c 53... ELS
+    equb &8b, &14                                                     ; 85d4: 8b 14       ..
+    equs "EVAL"                                                       ; 85d6: 45 56 41... EVA
+    equb &a0,   0                                                     ; 85da: a0 00       ..
+    equs "ERL"                                                        ; 85dc: 45 52 4c    ERL
+    equb &9e,   1                                                     ; 85df: 9e 01       ..
+    equs "ERROR"                                                      ; 85e1: 45 52 52... ERR
+    equb &85,   4                                                     ; 85e6: 85 04       ..
+    equs "EOF"                                                        ; 85e8: 45 4f 46    EOF
+    equb &c5,   1                                                     ; 85eb: c5 01       ..
+    equs "EOR"                                                        ; 85ed: 45 4f 52    EOR
+    equb &82,   0                                                     ; 85f0: 82 00       ..
+    equs "ERR"                                                        ; 85f2: 45 52 52    ERR
+    equb &9f,   1                                                     ; 85f5: 9f 01       ..
+    equs "EXP"                                                        ; 85f7: 45 58 50    EXP
+    equb &a1,   0                                                     ; 85fa: a1 00       ..
+    equs "EXT"                                                        ; 85fc: 45 58 54    EXT
+    equb &a2,   1                                                     ; 85ff: a2 01       ..
+    equs "EDIT"                                                       ; 8601: 45 44 49... EDI
+    equb &ce, &10                                                     ; 8605: ce 10       ..
+    equs "FOR"                                                        ; 8607: 46 4f 52    FOR
+    equb &e3,   2                                                     ; 860a: e3 02       ..
+    equs "FALSE"                                                      ; 860c: 46 41 4c... FAL
+    equb &a3,   1, &46, &4e, &a4,   8                                 ; 8611: a3 01 46... ..F
+    equs "GOTO"                                                       ; 8617: 47 4f 54... GOT
+    equb &e5, &12                                                     ; 861b: e5 12       ..
+    equs "GET$"                                                       ; 861d: 47 45 54... GET
+    equb &be,   0                                                     ; 8621: be 00       ..
+    equs "GET"                                                        ; 8623: 47 45 54    GET
+    equb &a5,   0                                                     ; 8626: a5 00       ..
+    equs "GOSUB"                                                      ; 8628: 47 4f 53... GOS
+    equb &e4, &12                                                     ; 862d: e4 12       ..
+    equs "GCOL"                                                       ; 862f: 47 43 4f... GCO
+    equb &e6,   2                                                     ; 8633: e6 02       ..
+    equs "HIMEM"                                                      ; 8635: 48 49 4d... HIM
+    equb &93                                                          ; 863a: 93          .
+    equs "CINPUT"                                                     ; 863b: 43 49 4e... CIN
+    equb &e8,   2, &49, &46, &e7,   2                                 ; 8641: e8 02 49... ..I
+    equs "INKEY$"                                                     ; 8647: 49 4e 4b... INK
+    equb &bf,   0                                                     ; 864d: bf 00       ..
+    equs "INKEY"                                                      ; 864f: 49 4e 4b... INK
+    equb &a6,   0                                                     ; 8654: a6 00       ..
+    equs "INT"                                                        ; 8656: 49 4e 54    INT
+    equb &a8,   0                                                     ; 8659: a8 00       ..
+    equs "INSTR("                                                     ; 865b: 49 4e 53... INS
+    equb &a7,   0                                                     ; 8661: a7 00       ..
+    equs "LIST"                                                       ; 8663: 4c 49 53... LIS
+    equb &c9, &10                                                     ; 8667: c9 10       ..
+    equs "LINE"                                                       ; 8669: 4c 49 4e... LIN
+    equb &86,   0                                                     ; 866d: 86 00       ..
+    equs "LOAD"                                                       ; 866f: 4c 4f 41... LOA
+    equb &c8,   2                                                     ; 8673: c8 02       ..
+    equs "LOMEM"                                                      ; 8675: 4c 4f 4d... LOM
+    equb &92                                                          ; 867a: 92          .
+    equs "CLOCAL"                                                     ; 867b: 43 4c 4f... CLO
+    equb &ea,   2                                                     ; 8681: ea 02       ..
+    equs "LEFT$("                                                     ; 8683: 4c 45 46... LEF
+    equb &c0,   0                                                     ; 8689: c0 00       ..
+    equs "LEN"                                                        ; 868b: 4c 45 4e    LEN
+    equb &a9,   0                                                     ; 868e: a9 00       ..
+    equs "LET"                                                        ; 8690: 4c 45 54    LET
+    equb &e9,   4                                                     ; 8693: e9 04       ..
+    equs "LOG"                                                        ; 8695: 4c 4f 47    LOG
+    equb &ab,   0, &4c, &4e, &aa,   0                                 ; 8698: ab 00 4c... ..L
+    equs "MID$("                                                      ; 869e: 4d 49 44... MID
+    equb &c1,   0                                                     ; 86a3: c1 00       ..
+    equs "MODE"                                                       ; 86a5: 4d 4f 44... MOD
+    equb &eb,   2                                                     ; 86a9: eb 02       ..
+    equs "MOD"                                                        ; 86ab: 4d 4f 44    MOD
+    equb &83,   0                                                     ; 86ae: 83 00       ..
+    equs "MOVE"                                                       ; 86b0: 4d 4f 56... MOV
+    equb &ec,   2                                                     ; 86b4: ec 02       ..
+    equs "NEXT"                                                       ; 86b6: 4e 45 58... NEX
+    equb &ed,   2                                                     ; 86ba: ed 02       ..
+    equs "NEW"                                                        ; 86bc: 4e 45 57    NEW
+    equb &ca,   1                                                     ; 86bf: ca 01       ..
+    equs "NOT"                                                        ; 86c1: 4e 4f 54    NOT
+    equb &ac,   0                                                     ; 86c4: ac 00       ..
+    equs "OLD"                                                        ; 86c6: 4f 4c 44    OLD
+    equb &cb,   1, &4f, &4e, &ee,   2                                 ; 86c9: cb 01 4f... ..O
+    equs "OFF"                                                        ; 86cf: 4f 46 46    OFF
+    equb &87,   0, &4f, &52, &84,   0                                 ; 86d2: 87 00 4f... ..O
+    equs "OPENIN"                                                     ; 86d8: 4f 50 45... OPE
+    equb &8e,   0                                                     ; 86de: 8e 00       ..
+    equs "OPENOUT"                                                    ; 86e0: 4f 50 45... OPE
+    equb &ae,   0                                                     ; 86e7: ae 00       ..
+    equs "OPENUP"                                                     ; 86e9: 4f 50 45... OPE
+    equb &ad,   0                                                     ; 86ef: ad 00       ..
+    equs "OSCLI"                                                      ; 86f1: 4f 53 43... OSC
+    equb &ff,   2                                                     ; 86f6: ff 02       ..
+    equs "PRINT"                                                      ; 86f8: 50 52 49... PRI
+    equb &f1,   2                                                     ; 86fd: f1 02       ..
+    equs "PAGE"                                                       ; 86ff: 50 41 47... PAG
+    equb &90                                                          ; 8703: 90          .
+    equs "CPTR"                                                       ; 8704: 43 50 54... CPT
+    equb &8f                                                          ; 8708: 8f          .
+    equs "CPI"                                                        ; 8709: 43 50 49    CPI
+    equb &af,   1                                                     ; 870c: af 01       ..
+    equs "PLOT"                                                       ; 870e: 50 4c 4f... PLO
+    equb &f0,   2                                                     ; 8712: f0 02       ..
+    equs "POINT("                                                     ; 8714: 50 4f 49... POI
+    equb &b0,   0                                                     ; 871a: b0 00       ..
+    equs "PROC"                                                       ; 871c: 50 52 4f... PRO
+    equb &f2, &0a                                                     ; 8720: f2 0a       ..
+    equs "POS"                                                        ; 8722: 50 4f 53    POS
+    equb &b1,   1                                                     ; 8725: b1 01       ..
+    equs "RETURN"                                                     ; 8727: 52 45 54... RET
+    equb &f8,   1                                                     ; 872d: f8 01       ..
+    equs "REPEAT"                                                     ; 872f: 52 45 50... REP
+    equb &f5,   0                                                     ; 8735: f5 00       ..
+    equs "REPORT"                                                     ; 8737: 52 45 50... REP
+    equb &f6,   1                                                     ; 873d: f6 01       ..
+    equs "READ"                                                       ; 873f: 52 45 41... REA
+    equb &f3,   2                                                     ; 8743: f3 02       ..
+    equs "REM"                                                        ; 8745: 52 45 4d    REM
+    equb &f4                                                          ; 8748: f4          .
+    equs " RUN"                                                       ; 8749: 20 52 55...  RU
+    equb &f9,   1                                                     ; 874d: f9 01       ..
+    equs "RAD"                                                        ; 874f: 52 41 44    RAD
+    equb &b2,   0                                                     ; 8752: b2 00       ..
+    equs "RESTORE"                                                    ; 8754: 52 45 53... RES
+    equb &f7, &12                                                     ; 875b: f7 12       ..
+    equs "RIGHT$("                                                    ; 875d: 52 49 47... RIG
+    equb &c2,   0                                                     ; 8764: c2 00       ..
+    equs "RND"                                                        ; 8766: 52 4e 44    RND
+    equb &b3,   1                                                     ; 8769: b3 01       ..
+    equs "RENUMBER"                                                   ; 876b: 52 45 4e... REN
+    equb &cc, &10                                                     ; 8773: cc 10       ..
+    equs "STEP"                                                       ; 8775: 53 54 45... STE
+    equb &88,   0                                                     ; 8779: 88 00       ..
+    equs "SAVE"                                                       ; 877b: 53 41 56... SAV
+    equb &cd,   2                                                     ; 877f: cd 02       ..
+    equs "SGN"                                                        ; 8781: 53 47 4e    SGN
+    equb &b4,   0                                                     ; 8784: b4 00       ..
+    equs "SIN"                                                        ; 8786: 53 49 4e    SIN
+    equb &b5,   0                                                     ; 8789: b5 00       ..
+    equs "SQR"                                                        ; 878b: 53 51 52    SQR
+    equb &b6,   0                                                     ; 878e: b6 00       ..
+    equs "SPC"                                                        ; 8790: 53 50 43    SPC
+    equb &89,   0                                                     ; 8793: 89 00       ..
+    equs "STR$"                                                       ; 8795: 53 54 52... STR
+    equb &c3,   0                                                     ; 8799: c3 00       ..
+    equs "STRING$("                                                   ; 879b: 53 54 52... STR
+    equb &c4,   0                                                     ; 87a3: c4 00       ..
+    equs "SOUND"                                                      ; 87a5: 53 4f 55... SOU
+    equb &d4,   2                                                     ; 87aa: d4 02       ..
+    equs "STOP"                                                       ; 87ac: 53 54 4f... STO
+    equb &fa,   1                                                     ; 87b0: fa 01       ..
+    equs "TAN"                                                        ; 87b2: 54 41 4e    TAN
+    equb &b7,   0                                                     ; 87b5: b7 00       ..
+    equs "THEN"                                                       ; 87b7: 54 48 45... THE
+    equb &8c, &14, &54, &4f, &b8,   0                                 ; 87bb: 8c 14 54... ..T
+    equs "TAB("                                                       ; 87c1: 54 41 42... TAB
+    equb &8a,   0                                                     ; 87c5: 8a 00       ..
+    equs "TRACE"                                                      ; 87c7: 54 52 41... TRA
+    equb &fc, &12                                                     ; 87cc: fc 12       ..
+    equs "TIME"                                                       ; 87ce: 54 49 4d... TIM
+    equb &91                                                          ; 87d2: 91          .
+    equs "CTRUE"                                                      ; 87d3: 43 54 52... CTR
+    equb &b9,   1                                                     ; 87d8: b9 01       ..
+    equs "UNTIL"                                                      ; 87da: 55 4e 54... UNT
+    equb &fd,   2                                                     ; 87df: fd 02       ..
+    equs "USR"                                                        ; 87e1: 55 53 52    USR
+    equb &ba,   0                                                     ; 87e4: ba 00       ..
+    equs "VDU"                                                        ; 87e6: 56 44 55    VDU
+    equb &ef,   2                                                     ; 87e9: ef 02       ..
+    equs "VAL"                                                        ; 87eb: 56 41 4c    VAL
+    equb &bb,   0                                                     ; 87ee: bb 00       ..
+    equs "VPOS"                                                       ; 87f0: 56 50 4f... VPO
+    equb &bc,   1                                                     ; 87f4: bc 01       ..
+    equs "WIDTH"                                                      ; 87f6: 57 49 44... WID
+    equb &fe,   2                                                     ; 87fb: fe 02       ..
+    equs "PAGE"                                                       ; 87fd: 50 41 47... PAG
+    equb &d0,   0                                                     ; 8801: d0 00       ..
+    equs "PTR"                                                        ; 8803: 50 54 52    PTR
+    equb &cf,   0, &54, &49                                           ; 8806: cf 00 54... ..T
+; &880a referenced 1 time by &90e0
+.l880a
+    equb &4d, &45, &d1,   0                                           ; 880a: 4d 45 d1... ME.
+    equs "LOMEM"                                                      ; 880e: 4c 4f 4d... LOM
+    equb &d2,   0                                                     ; 8813: d2 00       ..
+    equs "HIMEM"                                                      ; 8815: 48 49 4d... HIM
+    equb &d3,   0                                                     ; 881a: d3 00       ..
+    equs "Missing "                                                   ; 881c: 4d 69 73... Mis
+    equb &8d,   0                                                     ; 8824: 8d 00       ..
+.l8826
+l8909 = l8826+227
+    equw sub_cab37, sub_cab21, sub_cae50, sub_cae8c, sub_cae71        ; 8826: 37 ab 21... 7.!
+    equw sub_cae77, sub_cad00, sub_ca6fc, sub_cae34, sub_cac03        ; 8830: 77 ae 00... w..
+    equw sub_ca901, sub_ca919, sub_cab2f, sub_ca954, sub_cae6d        ; 883a: 01 a9 19... ...
+    equw sub_ca9ca, sub_cae7d, sub_cae83, sub_cab5c, sub_caa17        ; 8844: ca a9 7d... ..}
+    equw sub_cab1d,     cac38, sub_cb055, sub_cae87, sub_cac12        ; 884e: 1d ab 38... ..8
+    equw sub_cac7f, sub_cabe1, sub_cae59, sub_ca7ac, sub_ca9bc        ; 8858: 7f ac e1... ...
+    equw sub_caaeb, sub_cab3f, sub_cab3b, sub_cab54, sub_cac5d        ; 8862: eb aa 3f... ..?
+    equw sub_caafb, sub_ca9b5, sub_caacb, sub_cac46, sub_ca94f        ; 886c: fb aa b5... ...
+    equw sub_ca808, sub_ca96b, sub_cae41,     cac2b, sub_cab01        ; 8876: 08 a8 6b... ..k
+    equw sub_caba0, sub_cab14, sub_cb269, sub_caeb1, sub_caefb        ; 8880: a0 ab 14... ...
+    equw sub_caebb, sub_caf0a, sub_caebc, sub_caf61, sub_caf8b        ; 888a: bb ae 0a... ...
+    equw sub_cac1f, sub_c954c, sub_c93da, sub_c8fe5, sub_cb412        ; 8894: 1f ac 4c... ..L
+    equw sub_c9042, sub_c8fc5, sub_c9447, sub_cbe95, sub_cb3c8        ; 889e: 42 90 c5... B..
+    equw sub_cbed7, sub_c96f9, sub_c973e, sub_c96e5, sub_c96d4        ; 88a8: d7 be f9... ...
+    equw sub_cb302, sub_cbefd, sub_c9381, sub_c8fc0, sub_c9703        ; 88b2: 02 b3 fd... ...
+    equw sub_cbeee, sub_c98af, sub_c98b6,     c9073,     c9073        ; 88bc: ee be af... ...
+    equw     c95f9, sub_c9875, sub_c8fea, sub_c9c5e, sub_cb326        ; 88c6: f9 95 75... ..u
+    equw sub_cb649, sub_cb709, sub_cb74d, sub_c9810, sub_c9ccc        ; 88d0: 49 b6 09... I..
+    equw sub_cb8e6, sub_c910d,     c97d2, sub_c982e, sub_c9871        ; 88da: e6 b8 0d... ...
+    equw     cb522, sub_cb78b,     c98dc, sub_c9880, sub_c9250        ; 88e4: 22 b5 8b... "..
+    equw sub_c97a9,     cb9ad,     c9073, sub_cba88, sub_c98c3        ; 88ee: a9 97 ad... ...
+    equw sub_cb97d, sub_cb737, sub_c8fd7, sub_c9149, sub_c9824        ; 88f8: 7d b9 37... }.7
+    equw sub_c970b, sub_cba47, sub_cb351, sub_cbec7, sub_c834b        ; 8902: 0b 97 47... ..G
+    equw sub_c8984, sub_cb896                                         ; 890c: 84 89 96... ...
+; &8909 referenced 1 time by &8ae3
+    equb &b9, &d8, &d9, &f0,   1, &10, &81, &90, &89, &93, &a3, &a4   ; 8910: b9 d8 d9... ...
+    equb &a9                                                          ; 891c: a9          .
+    equs "89x"                                                        ; 891d: 38 39 78    89x
+    equb   1, &13, &21, &a1, &c1, &19, &18, &99, &98, &63, &73, &b1   ; 8920: 01 13 21... ..!
+    equb &a9, &c5, &0c, &c3, &d3, &41, &c4, &f2, &41, &83, &b0, &81   ; 892c: a9 c5 0c... ...
+    equs "Clr"                                                        ; 8938: 43 6c 72    Clr
+    equb &ec, &f2, &a3, &c3, &92, &9a, &18, &19                       ; 893b: ec f2 a3... ...
+    equs "bB4"                                                        ; 8943: 62 42 34    bB4
+    equb &b0, &72, &98, &99, &81, &98, &99, &14                       ; 8946: b0 72 98... .r.
+; &894e referenced 1 time by &8ae8
+.l894e
+    equb &35, &0a, &0d, &0d, &0d, &0d, &10, &10                       ; 894e: 35 0a 0d... 5..
+    equs "%%9AAAAJJLLLPPRSSS"                                         ; 8956: 25 25 39... %%9
+    equb &10                                                          ; 8968: 10          .
+    equs "%AAAA"                                                      ; 8969: 25 41 41... %AA
+    equb   8,   8,   8,   9,   9, &0a, &0a, &0a, &0a,   5, &15, &3e   ; 896e: 08 08 08... ...
+    equb   4, &0d, &30, &4c,   6                                      ; 897a: 04 0d 30... ..0
+    equs "2II"                                                        ; 897f: 32 49 49    2II
+    equb &10, &25                                                     ; 8982: 10 25       .%
+
+.sub_c8984
+    ora l0e4e                                                         ; 8984: 0d 4e 0e    .N.
+    asl l5252                                                         ; 8987: 0e 52 52    .RR
+    ora #&29 ; ')'                                                    ; 898a: 09 29       .)
+    rol a                                                             ; 898c: 2a          *
+    bmi c89bf                                                         ; 898d: 30 30       00
+    lsr l4e4e                                                         ; 898f: 4e 4e 4e    NNN
+.sub_c8992
+l8993 = sub_c8992+1
+    equb &3e, <(l0016), >(l0016) ; rol+2 l0016,x                      ; 8992: 3e 16 00    >..
+; &8993 referenced 1 time by &8b10
+    clc                                                               ; 8995: 18          .
+    cld                                                               ; 8996: d8          .
+    cli                                                               ; 8997: 58          X
+    clv                                                               ; 8998: b8          .
+    dex                                                               ; 8999: ca          .
+    dey                                                               ; 899a: 88          .
+    inx                                                               ; 899b: e8          .
+    iny                                                               ; 899c: c8          .
+    nop                                                               ; 899d: ea          .
+    pha                                                               ; 899e: 48          H
+    php                                                               ; 899f: 08          .
+    pla                                                               ; 89a0: 68          h
+    plp                                                               ; 89a1: 28          (
+    rti                                                               ; 89a2: 40          @
+
+    equb &60, &38, &f8, &78, &aa, &a8, &ba, &8a, &9a, &98, &3a, &1a   ; 89a3: 60 38 f8... `8.
+    equb &5a, &da, &7a, &fa, &90, &b0, &f0, &30, &d0, &10, &50, &70   ; 89af: 5a da 7a... Z.z
+    equb &80, &21, &41,   1                                           ; 89bb: 80 21 41... .!A
+
+; &89bf referenced 1 time by &898d
+.c89bf
+    adc (l00c1,x)                                                     ; 89bf: 61 c1       a.
+    lda (l00e1,x)                                                     ; 89c1: a1 e1       ..
+    asl l0046                                                         ; 89c3: 06 46       .F
+    rol l0066                                                         ; 89c5: 26 66       &f
+    dec l00e6                                                         ; 89c7: c6 e6       ..
+    stz le09c                                                         ; 89c9: 9c 9c e0    ...
+    cpy #0                                                            ; 89cc: c0 00       ..
+    bpl c89f4                                                         ; 89ce: 10 24       .$
+    jmp ca220                                                         ; 89d0: 4c 20 a2    L .
+
+    equb &a0, &81, &86, &84                                           ; 89d3: a0 81 86... ...
+
+; &89d7 referenced 1 time by &89e2
+.loop_c89d7
+    dec a                                                             ; 89d7: 3a          :
+    sta l0028                                                         ; 89d8: 85 28       .(
+    jmp c90d0                                                         ; 89da: 4c d0 90    L..
+
+; &89dd referenced 2 times by &8a8e, &90aa
+.c89dd
+    jsr c8f9d                                                         ; 89dd: 20 9d 8f     ..
+    eor #&5d ; ']'                                                    ; 89e0: 49 5d       I]
+    beq loop_c89d7                                                    ; 89e2: f0 f3       ..
+    jsr c9c80                                                         ; 89e4: 20 80 9c     ..
+    dec l000a                                                         ; 89e7: c6 0a       ..
+    jsr sub_c8aa8                                                     ; 89e9: 20 a8 8a     ..
+    dec l000a                                                         ; 89ec: c6 0a       ..
+    lda l0028                                                         ; 89ee: a5 28       .(
+    lsr a                                                             ; 89f0: 4a          J
+    bcc c8a6b                                                         ; 89f1: 90 78       .x
+; overlapping: lda l001e                                              ; 89f3: a5 1e       ..
+    equb &a5                                                          ; 89f3: a5          .
+
+; &89f4 referenced 1 time by &89ce
+.c89f4
+    asl l0469,x                                                       ; 89f4: 1e 69 04    .i.
+; overlapping: adc #4                                                 ; 89f5: 69 04       i.
+    sta l003f                                                         ; 89f7: 85 3f       .?
+    lda l0038                                                         ; 89f9: a5 38       .8
+    jsr sub_cbdac                                                     ; 89fb: 20 ac bd     ..
+    lda l0037                                                         ; 89fe: a5 37       .7
+    jsr sub_cbdcf                                                     ; 8a00: 20 cf bd     ..
+    ldx #&fc                                                          ; 8a03: a2 fc       ..
+    ldy l0039                                                         ; 8a05: a4 39       .9
+    bpl c8a0b                                                         ; 8a07: 10 02       ..
+    ldy l0036                                                         ; 8a09: a4 36       .6
+; &8a0b referenced 1 time by &8a07
+.c8a0b
+    sty l0038                                                         ; 8a0b: 84 38       .8
+    beq c8a28                                                         ; 8a0d: f0 19       ..
+    ldy #0                                                            ; 8a0f: a0 00       ..
+; &8a11 referenced 1 time by &8a26
+.loop_c8a11
+    inx                                                               ; 8a11: e8          .
+    bne c8a1e                                                         ; 8a12: d0 0a       ..
+    jsr sub_cbac2                                                     ; 8a14: 20 c2 ba     ..
+    ldx l003f                                                         ; 8a17: a6 3f       .?
+    jsr cbdff                                                         ; 8a19: 20 ff bd     ..
+    ldx #&fd                                                          ; 8a1c: a2 fd       ..
+; &8a1e referenced 1 time by &8a12
+.c8a1e
+    lda (l003a),y                                                     ; 8a1e: b1 3a       .:
+    jsr sub_cbdcf                                                     ; 8a20: 20 cf bd     ..
+    iny                                                               ; 8a23: c8          .
+    dec l0038                                                         ; 8a24: c6 38       .8
+    bne loop_c8a11                                                    ; 8a26: d0 e9       ..
+; &8a28 referenced 1 time by &8a0d
+.c8a28
+    txa                                                               ; 8a28: 8a          .
+    tay                                                               ; 8a29: a8          .
+; &8a2a referenced 1 time by &8a32
+.loop_c8a2a
+    iny                                                               ; 8a2a: c8          .
+    beq c8a34                                                         ; 8a2b: f0 07       ..
+    ldx #3                                                            ; 8a2d: a2 03       ..
+    jsr cbdff                                                         ; 8a2f: 20 ff bd     ..
+    bra loop_c8a2a                                                    ; 8a32: 80 f6       ..
+; &8a34 referenced 1 time by &8a2b
+.c8a34
+    ldx #&0a                                                          ; 8a34: a2 0a       ..
+    lda (l000b)                                                       ; 8a36: b2 0b       ..
+    cmp #&2e ; '.'                                                    ; 8a38: c9 2e       ..
+    bne c8a4b                                                         ; 8a3a: d0 0f       ..
+; &8a3c referenced 1 time by &8a49
+.loop_c8a3c
+    jsr sub_cbd77                                                     ; 8a3c: 20 77 bd     w.
+    dex                                                               ; 8a3f: ca          .
+    bne c8a44                                                         ; 8a40: d0 02       ..
+    ldx #1                                                            ; 8a42: a2 01       ..
+; &8a44 referenced 1 time by &8a40
+.c8a44
+    iny                                                               ; 8a44: c8          .
+    lda (l000b),y                                                     ; 8a45: b1 0b       ..
+    cpy l004e                                                         ; 8a47: c4 4e       .N
+    bne loop_c8a3c                                                    ; 8a49: d0 f1       ..
+; &8a4b referenced 1 time by &8a3a
+.c8a4b
+    jsr cbdff                                                         ; 8a4b: 20 ff bd     ..
+    dey                                                               ; 8a4e: 88          .
+; &8a4f referenced 1 time by &8a52
+.loop_c8a4f
+    iny                                                               ; 8a4f: c8          .
+    cmp (l000b),y                                                     ; 8a50: d1 0b       ..
+    beq loop_c8a4f                                                    ; 8a52: f0 fb       ..
+; &8a54 referenced 1 time by &8a62
+.loop_c8a54
+    lda (l000b),y                                                     ; 8a54: b1 0b       ..
+    cmp #&3a ; ':'                                                    ; 8a56: c9 3a       .:
+    beq c8a64                                                         ; 8a58: f0 0a       ..
+    cmp #&0d                                                          ; 8a5a: c9 0d       ..
+    beq c8a68                                                         ; 8a5c: f0 0a       ..
+; &8a5e referenced 1 time by &8a66
+.loop_c8a5e
+    jsr sub_cbd77                                                     ; 8a5e: 20 77 bd     w.
+    iny                                                               ; 8a61: c8          .
+    bra loop_c8a54                                                    ; 8a62: 80 f0       ..
+; &8a64 referenced 1 time by &8a58
+.c8a64
+    cpy l000a                                                         ; 8a64: c4 0a       ..
+    bcc loop_c8a5e                                                    ; 8a66: 90 f6       ..
+; &8a68 referenced 1 time by &8a5c
+.c8a68
+    jsr sub_cbac2                                                     ; 8a68: 20 c2 ba     ..
+; &8a6b referenced 1 time by &89f1
+.c8a6b
+    ldy l000a                                                         ; 8a6b: a4 0a       ..
+    dey                                                               ; 8a6d: 88          .
+; &8a6e referenced 1 time by &8a77
+.loop_c8a6e
+    iny                                                               ; 8a6e: c8          .
+    lda (l000b),y                                                     ; 8a6f: b1 0b       ..
+    cmp #&3a ; ':'                                                    ; 8a71: c9 3a       .:
+    beq c8a79                                                         ; 8a73: f0 04       ..
+    cmp #&0d                                                          ; 8a75: c9 0d       ..
+    bne loop_c8a6e                                                    ; 8a77: d0 f5       ..
+; &8a79 referenced 1 time by &8a73
+.c8a79
+    jsr c9c6c                                                         ; 8a79: 20 6c 9c     l.
+    lda (l000b)                                                       ; 8a7c: b2 0b       ..
+    cmp #&3a ; ':'                                                    ; 8a7e: c9 3a       .:
+    beq c8a8e                                                         ; 8a80: f0 0c       ..
+    lda l000c                                                         ; 8a82: a5 0c       ..
+    cmp #7                                                            ; 8a84: c9 07       ..
+    bne c8a8b                                                         ; 8a86: d0 03       ..
+    jmp c904b                                                         ; 8a88: 4c 4b 90    LK.
+
+; &8a8b referenced 1 time by &8a86
+.c8a8b
+    jsr sub_c9ca2                                                     ; 8a8b: 20 a2 9c     ..
+; &8a8e referenced 1 time by &8a80
+.c8a8e
+    jmp c89dd                                                         ; 8a8e: 4c dd 89    L..
+
+; &8a91 referenced 1 time by &8abd
+.c8a91
+    jsr sub_c997d                                                     ; 8a91: 20 7d 99     }.
+    beq c8af2                                                         ; 8a94: f0 5c       .\
+    bcs c8af2                                                         ; 8a96: b0 5a       .Z
+    jsr sub_cbc83                                                     ; 8a98: 20 83 bc     ..
+    jsr sub_cadc6                                                     ; 8a9b: 20 c6 ad     ..
+    sta l0027                                                         ; 8a9e: 85 27       .'
+    jsr sub_cb365                                                     ; 8aa0: 20 65 b3     e.
+    jsr c9338                                                         ; 8aa3: 20 38 93     8.
+    sty l004e                                                         ; 8aa6: 84 4e       .N
+; &8aa8 referenced 1 time by &89e9
+.sub_c8aa8
+    jsr c8f9d                                                         ; 8aa8: 20 9d 8f     ..
+    ldy #0                                                            ; 8aab: a0 00       ..
+    stz l003d                                                         ; 8aad: 64 3d       d=
+    cmp #&3a ; ':'                                                    ; 8aaf: c9 3a       .:
+    beq c8b1b                                                         ; 8ab1: f0 68       .h
+    cmp #&0d                                                          ; 8ab3: c9 0d       ..
+    beq c8b1b                                                         ; 8ab5: f0 64       .d
+    cmp #&5c ; '\'                                                    ; 8ab7: c9 5c       .\
+    beq c8b1b                                                         ; 8ab9: f0 60       .`
+    cmp #&2e ; '.'                                                    ; 8abb: c9 2e       ..
+    beq c8a91                                                         ; 8abd: f0 d2       ..
+    dec l000a                                                         ; 8abf: c6 0a       ..
+    ldx #3                                                            ; 8ac1: a2 03       ..
+; &8ac3 referenced 1 time by &8add
+.loop_c8ac3
+    ldy l000a                                                         ; 8ac3: a4 0a       ..
+    inc l000a                                                         ; 8ac5: e6 0a       ..
+    lda (l000b),y                                                     ; 8ac7: b1 0b       ..
+    bmi c8af5                                                         ; 8ac9: 30 2a       0*
+    cmp #&20 ; ' '                                                    ; 8acb: c9 20       .
+    beq c8adf                                                         ; 8acd: f0 10       ..
+    ldy #5                                                            ; 8acf: a0 05       ..
+    asl a                                                             ; 8ad1: 0a          .
+    asl a                                                             ; 8ad2: 0a          .
+    asl a                                                             ; 8ad3: 0a          .
+; &8ad4 referenced 1 time by &8ada
+.loop_c8ad4
+    asl a                                                             ; 8ad4: 0a          .
+    rol l003d                                                         ; 8ad5: 26 3d       &=
+    rol l003e                                                         ; 8ad7: 26 3e       &>
+    dey                                                               ; 8ad9: 88          .
+    bne loop_c8ad4                                                    ; 8ada: d0 f8       ..
+    dex                                                               ; 8adc: ca          .
+    bne loop_c8ac3                                                    ; 8add: d0 e4       ..
+; &8adf referenced 1 time by &8acd
+.c8adf
+    ldx #&45 ; 'E'                                                    ; 8adf: a2 45       .E
+    lda l003d                                                         ; 8ae1: a5 3d       .=
+; &8ae3 referenced 1 time by &8af0
+.loop_c8ae3
+    cmp l8909,x                                                       ; 8ae3: dd 09 89    ...
+    bne c8aef                                                         ; 8ae6: d0 07       ..
+    ldy l894e,x                                                       ; 8ae8: bc 4e 89    .N.
+    cpy l003e                                                         ; 8aeb: c4 3e       .>
+    beq c8b10                                                         ; 8aed: f0 21       .!
+; &8aef referenced 1 time by &8ae6
+.c8aef
+    dex                                                               ; 8aef: ca          .
+    bne loop_c8ae3                                                    ; 8af0: d0 f1       ..
+; &8af2 referenced 4 times by &8a94, &8a96, &8b03, &8b0e
+.c8af2
+    jmp c9c2d                                                         ; 8af2: 4c 2d 9c    L-.
+
+; &8af5 referenced 1 time by &8ac9
+.c8af5
+    ldx #&29 ; ')'                                                    ; 8af5: a2 29       .)
+    cmp #&80                                                          ; 8af7: c9 80       ..
+    beq c8b10                                                         ; 8af9: f0 15       ..
+    inx                                                               ; 8afb: e8          .
+    cmp #&82                                                          ; 8afc: c9 82       ..
+    beq c8b10                                                         ; 8afe: f0 10       ..
+    inx                                                               ; 8b00: e8          .
+    cmp #&84                                                          ; 8b01: c9 84       ..
+    bne c8af2                                                         ; 8b03: d0 ed       ..
+    inc l000a                                                         ; 8b05: e6 0a       ..
+    iny                                                               ; 8b07: c8          .
+    lda (l000b),y                                                     ; 8b08: b1 0b       ..
+    and #&df                                                          ; 8b0a: 29 df       ).
+    cmp #&41 ; 'A'                                                    ; 8b0c: c9 41       .A
+    bne c8af2                                                         ; 8b0e: d0 e2       ..
+; &8b10 referenced 3 times by &8aed, &8af9, &8afe
+.c8b10
+    lda l8993,x                                                       ; 8b10: bd 93 89    ...
+    sta l0029                                                         ; 8b13: 85 29       .)
+    ldy #1                                                            ; 8b15: a0 01       ..
+    cpx #&20 ; ' '                                                    ; 8b17: e0 20       .
+    bcs c8b63                                                         ; 8b19: b0 48       .H
+; &8b1b referenced 6 times by &8ab1, &8ab5, &8ab9, &8ba0, &8cbd, &8d6e
+.c8b1b
+    lda l0440                                                         ; 8b1b: ad 40 04    .@.
+    sta l0037                                                         ; 8b1e: 85 37       .7
+    sty l0039                                                         ; 8b20: 84 39       .9
+    ldx l0028                                                         ; 8b22: a6 28       .(
+    cpx #4                                                            ; 8b24: e0 04       ..
+    ldx l0441                                                         ; 8b26: ae 41 04    .A.
+    stx l0038                                                         ; 8b29: 86 38       .8
+    bcc c8b33                                                         ; 8b2b: 90 06       ..
+    lda l043c                                                         ; 8b2d: ad 3c 04    .<.
+    ldx l043d                                                         ; 8b30: ae 3d 04    .=.
+; &8b33 referenced 1 time by &8b2b
+.c8b33
+    sta l003a                                                         ; 8b33: 85 3a       .:
+    stx l003b                                                         ; 8b35: 86 3b       .;
+    tya                                                               ; 8b37: 98          .
+    beq c8b62                                                         ; 8b38: f0 28       .(
+    bpl c8b40                                                         ; 8b3a: 10 04       ..
+    ldy l0036                                                         ; 8b3c: a4 36       .6
+    beq c8b62                                                         ; 8b3e: f0 22       ."
+; &8b40 referenced 2 times by &8b3a, &8b60
+.c8b40
+    dey                                                               ; 8b40: 88          .
+    lda l0029,y                                                       ; 8b41: b9 29 00    .).
+    bit l0039                                                         ; 8b44: 24 39       $9
+    bpl c8b4b                                                         ; 8b46: 10 03       ..
+    lda l0600,y                                                       ; 8b48: b9 00 06    ...
+; &8b4b referenced 1 time by &8b46
+.c8b4b
+    sta (l003a),y                                                     ; 8b4b: 91 3a       .:
+    inc l0440                                                         ; 8b4d: ee 40 04    .@.
+    bne c8b55                                                         ; 8b50: d0 03       ..
+    inc l0441                                                         ; 8b52: ee 41 04    .A.
+; &8b55 referenced 1 time by &8b50
+.c8b55
+    bcc c8b5f                                                         ; 8b55: 90 08       ..
+    inc l043c                                                         ; 8b57: ee 3c 04    .<.
+    bne c8b5f                                                         ; 8b5a: d0 03       ..
+    inc l043d                                                         ; 8b5c: ee 3d 04    .=.
+; &8b5f referenced 2 times by &8b55, &8b5a
+.c8b5f
+    tya                                                               ; 8b5f: 98          .
+    bne c8b40                                                         ; 8b60: d0 de       ..
+; &8b62 referenced 2 times by &8b38, &8b3e
+.c8b62
+    rts                                                               ; 8b62: 60          `
+
+; &8b63 referenced 1 time by &8b19
+.c8b63
+    cpx #&29 ; ')'                                                    ; 8b63: e0 29       .)
+    bcs c8ba3                                                         ; 8b65: b0 3c       .<
+    jsr sub_c9332                                                     ; 8b67: 20 32 93     2.
+    clc                                                               ; 8b6a: 18          .
+    lda l002a                                                         ; 8b6b: a5 2a       .*
+    sbc l0440                                                         ; 8b6d: ed 40 04    .@.
+    tay                                                               ; 8b70: a8          .
+    lda l002b                                                         ; 8b71: a5 2b       .+
+    sbc l0441                                                         ; 8b73: ed 41 04    .A.
+    cpy #1                                                            ; 8b76: c0 01       ..
+    dey                                                               ; 8b78: 88          .
+    sbc #0                                                            ; 8b79: e9 00       ..
+    beq c8b98                                                         ; 8b7b: f0 1b       ..
+    inc a                                                             ; 8b7d: 1a          .
+    bne c8b83                                                         ; 8b7e: d0 03       ..
+    tya                                                               ; 8b80: 98          .
+    bmi c8b9c                                                         ; 8b81: 30 19       0.
+; &8b83 referenced 2 times by &8b7e, &8b99
+.c8b83
+    lda l0028                                                         ; 8b83: a5 28       .(
+    and #2                                                            ; 8b85: 29 02       ).
+    beq c8b9b                                                         ; 8b87: f0 12       ..
+    brk                                                               ; 8b89: 00          .
+
+    equb 1                                                            ; 8b8a: 01          .
+    equs "Out of range"                                               ; 8b8b: 4f 75 74... Out
+    equb 0                                                            ; 8b97: 00          .
+
+; &8b98 referenced 1 time by &8b7b
+.c8b98
+    tya                                                               ; 8b98: 98          .
+    bmi c8b83                                                         ; 8b99: 30 e8       0.
+; &8b9b referenced 1 time by &8b87
+.c8b9b
+    tay                                                               ; 8b9b: a8          .
+; &8b9c referenced 1 time by &8b81
+.c8b9c
+    sty l002a                                                         ; 8b9c: 84 2a       .*
+; &8b9e referenced 1 time by &8bb4
+.loop_c8b9e
+    ldy #2                                                            ; 8b9e: a0 02       ..
+    jmp c8b1b                                                         ; 8ba0: 4c 1b 8b    L..
+
+; &8ba3 referenced 1 time by &8b65
+.c8ba3
+    cpx #&30 ; '0'                                                    ; 8ba3: e0 30       .0
+    bcs c8bbd                                                         ; 8ba5: b0 16       ..
+    jsr sub_c8d9c                                                     ; 8ba7: 20 9c 8d     ..
+    bne c8bc4                                                         ; 8baa: d0 18       ..
+    jsr sub_c8d89                                                     ; 8bac: 20 89 8d     ..
+; &8baf referenced 1 time by &8ca4
+.c8baf
+    jsr sub_c9332                                                     ; 8baf: 20 32 93     2.
+; &8bb2 referenced 3 times by &8bdc, &8be5, &8bf7
+.c8bb2
+    lda l002b                                                         ; 8bb2: a5 2b       .+
+; &8bb4 referenced 1 time by &8c22
+.c8bb4
+    beq loop_c8b9e                                                    ; 8bb4: f0 e8       ..
+; &8bb6 referenced 1 time by &8d31
+.c8bb6
+    brk                                                               ; 8bb6: 00          .
+
+    equb 2                                                            ; 8bb7: 02          .
+    equs "Byte"                                                       ; 8bb8: 42 79 74... Byt
+    equb 0                                                            ; 8bbc: 00          .
+
+; &8bbd referenced 1 time by &8ba5
+.c8bbd
+    cpx #&41 ; 'A'                                                    ; 8bbd: e0 41       .A
+    bne c8c24                                                         ; 8bbf: d0 63       .c
+    jsr c8f9d                                                         ; 8bc1: 20 9d 8f     ..
+; &8bc4 referenced 1 time by &8baa
+.c8bc4
+    cmp #&28 ; '('                                                    ; 8bc4: c9 28       .(
+    bne c8c01                                                         ; 8bc6: d0 39       .9
+    jsr sub_c9332                                                     ; 8bc8: 20 32 93     2.
+    jsr c8f9d                                                         ; 8bcb: 20 9d 8f     ..
+    cmp #&29 ; ')'                                                    ; 8bce: c9 29       .)
+    bne c8be9                                                         ; 8bd0: d0 17       ..
+    jsr sub_c8d86                                                     ; 8bd2: 20 86 8d     ..
+    jsr sub_c8da2                                                     ; 8bd5: 20 a2 8d     ..
+    beq c8bde                                                         ; 8bd8: f0 04       ..
+    inc l0029                                                         ; 8bda: e6 29       .)
+    bra c8bb2                                                         ; 8bdc: 80 d4       ..
+; &8bde referenced 1 time by &8bd8
+.c8bde
+    jsr c8f9d                                                         ; 8bde: 20 9d 8f     ..
+    and #&df                                                          ; 8be1: 29 df       ).
+    cmp #&59 ; 'Y'                                                    ; 8be3: c9 59       .Y
+    beq c8bb2                                                         ; 8be5: f0 cb       ..
+    bra c8bf9                                                         ; 8be7: 80 10       ..
+; &8be9 referenced 1 time by &8bd0
+.c8be9
+    cmp #&2c ; ','                                                    ; 8be9: c9 2c       .,
+    bne c8bf9                                                         ; 8beb: d0 0c       ..
+    jsr sub_c8d94                                                     ; 8bed: 20 94 8d     ..
+    bne c8bf9                                                         ; 8bf0: d0 07       ..
+    jsr c8f9d                                                         ; 8bf2: 20 9d 8f     ..
+    cmp #&29 ; ')'                                                    ; 8bf5: c9 29       .)
+    beq c8bb2                                                         ; 8bf7: f0 b9       ..
+; &8bf9 referenced 6 times by &8be7, &8beb, &8bf0, &8c13, &8c41, &8ce3
+.c8bf9
+    brk                                                               ; 8bf9: 00          .
+
+    equb 3                                                            ; 8bfa: 03          .
+    equs "Index"                                                      ; 8bfb: 49 6e 64... Ind
+    equb 0                                                            ; 8c00: 00          .
+
+; &8c01 referenced 1 time by &8bc6
+.c8c01
+    jsr sub_c9330                                                     ; 8c01: 20 30 93     0.
+    jsr sub_c8da2                                                     ; 8c04: 20 a2 8d     ..
+    bne c8c1b                                                         ; 8c07: d0 12       ..
+    jsr sub_c8d86                                                     ; 8c09: 20 86 8d     ..
+    jsr sub_c8d94                                                     ; 8c0c: 20 94 8d     ..
+    beq c8c1b                                                         ; 8c0f: f0 0a       ..
+    cmp #&59 ; 'Y'                                                    ; 8c11: c9 59       .Y
+    bne c8bf9                                                         ; 8c13: d0 e4       ..
+; &8c15 referenced 1 time by &8c20
+.loop_c8c15
+    jsr sub_c8d89                                                     ; 8c15: 20 89 8d     ..
+    jmp c8cbb                                                         ; 8c18: 4c bb 8c    L..
+
+; &8c1b referenced 3 times by &8c07, &8c0f, &8c99
+.c8c1b
+    jsr sub_c8d8c                                                     ; 8c1b: 20 8c 8d     ..
+; &8c1e referenced 3 times by &8c37, &8c3f, &8d34
+.c8c1e
+    lda l002b                                                         ; 8c1e: a5 2b       .+
+    bne loop_c8c15                                                    ; 8c20: d0 f3       ..
+    bra c8bb4                                                         ; 8c22: 80 90       ..
+; &8c24 referenced 1 time by &8bbf
+.c8c24
+    cpx #&36 ; '6'                                                    ; 8c24: e0 36       .6
+    bcs c8c5e                                                         ; 8c26: b0 36       .6
+    jsr c8f9d                                                         ; 8c28: 20 9d 8f     ..
+    and #&df                                                          ; 8c2b: 29 df       ).
+    cmp #&41 ; 'A'                                                    ; 8c2d: c9 41       .A
+    beq c8c43                                                         ; 8c2f: f0 12       ..
+; &8c31 referenced 2 times by &8c49, &8c9e
+.c8c31
+    jsr sub_c9330                                                     ; 8c31: 20 30 93     0.
+    jsr sub_c8da2                                                     ; 8c34: 20 a2 8d     ..
+    bne c8c1e                                                         ; 8c37: d0 e5       ..
+    jsr sub_c8d86                                                     ; 8c39: 20 86 8d     ..
+    jsr sub_c8d94                                                     ; 8c3c: 20 94 8d     ..
+    beq c8c1e                                                         ; 8c3f: f0 dd       ..
+; &8c41 referenced 1 time by &8c7d
+.c8c41
+    bra c8bf9                                                         ; 8c41: 80 b6       ..
+; &8c43 referenced 1 time by &8c2f
+.c8c43
+    iny                                                               ; 8c43: c8          .
+    lda (l000b),y                                                     ; 8c44: b1 0b       ..
+    jsr sub_c8e41                                                     ; 8c46: 20 41 8e     A.
+    bcs c8c31                                                         ; 8c49: b0 e6       ..
+    ldy #&16                                                          ; 8c4b: a0 16       ..
+    cpx #&34 ; '4'                                                    ; 8c4d: e0 34       .4
+    bcc c8c57                                                         ; 8c4f: 90 06       ..
+    bne c8c55                                                         ; 8c51: d0 02       ..
+    ldy #&36 ; '6'                                                    ; 8c53: a0 36       .6
+; &8c55 referenced 1 time by &8c51
+.c8c55
+    sty l0029                                                         ; 8c55: 84 29       .)
+; &8c57 referenced 1 time by &8c4f
+.c8c57
+    jsr sub_c8d8c                                                     ; 8c57: 20 8c 8d     ..
+    ldy #1                                                            ; 8c5a: a0 01       ..
+    bra c8cbd                                                         ; 8c5c: 80 5f       ._
+; &8c5e referenced 1 time by &8c26
+.c8c5e
+    cpx #&38 ; '8'                                                    ; 8c5e: e0 38       .8
+    bcs c8c87                                                         ; 8c60: b0 25       .%
+    jsr sub_c9332                                                     ; 8c62: 20 32 93     2.
+    ldy #3                                                            ; 8c65: a0 03       ..
+    ldx #1                                                            ; 8c67: a2 01       ..
+    lda l002b                                                         ; 8c69: a5 2b       .+
+    bne c8c74                                                         ; 8c6b: d0 07       ..
+    ldx #&0f                                                          ; 8c6d: a2 0f       ..
+    lda #&64 ; 'd'                                                    ; 8c6f: a9 64       .d
+    sta l0029                                                         ; 8c71: 85 29       .)
+    dey                                                               ; 8c73: 88          .
+; &8c74 referenced 1 time by &8c6b
+.c8c74
+    phy                                                               ; 8c74: 5a          Z
+    jsr sub_c8da2                                                     ; 8c75: 20 a2 8d     ..
+    bne c8c84                                                         ; 8c78: d0 0a       ..
+    jsr sub_c8d94                                                     ; 8c7a: 20 94 8d     ..
+    bne c8c41                                                         ; 8c7d: d0 c2       ..
+    txa                                                               ; 8c7f: 8a          .
+    adc l0029                                                         ; 8c80: 65 29       e)
+    sta l0029                                                         ; 8c82: 85 29       .)
+; &8c84 referenced 1 time by &8c78
+.c8c84
+    ply                                                               ; 8c84: 7a          z
+    bra c8cbd                                                         ; 8c85: 80 36       .6
+; &8c87 referenced 1 time by &8c60
+.c8c87
+    cpx #&3c ; '<'                                                    ; 8c87: e0 3c       .<
+    bcs c8ca7                                                         ; 8c89: b0 1c       ..
+    cpx #&3a ; ':'                                                    ; 8c8b: e0 3a       .:
+    bcs c8c96                                                         ; 8c8d: b0 07       ..
+    jsr sub_c8d9c                                                     ; 8c8f: 20 9c 8d     ..
+    beq c8ca4                                                         ; 8c92: f0 10       ..
+    dec l000a                                                         ; 8c94: c6 0a       ..
+; &8c96 referenced 1 time by &8c8d
+.c8c96
+    jsr sub_c9332                                                     ; 8c96: 20 32 93     2.
+; &8c99 referenced 2 times by &8d06, &8d14
+.c8c99
+    bra c8c1b                                                         ; 8c99: 80 80       ..
+; &8c9b referenced 1 time by &8ca7
+.loop_c8c9b
+    jsr sub_c8d9c                                                     ; 8c9b: 20 9c 8d     ..
+    bne c8c31                                                         ; 8c9e: d0 91       ..
+    ldy #&89                                                          ; 8ca0: a0 89       ..
+    sty l0029                                                         ; 8ca2: 84 29       .)
+; &8ca4 referenced 2 times by &8c92, &8cfb
+.c8ca4
+    jmp c8baf                                                         ; 8ca4: 4c af 8b    L..
+
+; &8ca7 referenced 1 time by &8c89
+.c8ca7
+    beq loop_c8c9b                                                    ; 8ca7: f0 f2       ..
+    cpx #&3e ; '>'                                                    ; 8ca9: e0 3e       .>
+    beq c8cb8                                                         ; 8cab: f0 0b       ..
+    bcs c8ce6                                                         ; 8cad: b0 37       .7
+    jsr c8f9d                                                         ; 8caf: 20 9d 8f     ..
+    cmp #&28 ; '('                                                    ; 8cb2: c9 28       .(
+    beq c8cc0                                                         ; 8cb4: f0 0a       ..
+    dec l000a                                                         ; 8cb6: c6 0a       ..
+; &8cb8 referenced 1 time by &8cab
+.c8cb8
+    jsr sub_c9332                                                     ; 8cb8: 20 32 93     2.
+; &8cbb referenced 3 times by &8c18, &8cce, &8ce1
+.c8cbb
+    ldy #3                                                            ; 8cbb: a0 03       ..
+; &8cbd referenced 2 times by &8c5c, &8c85
+.c8cbd
+    jmp c8b1b                                                         ; 8cbd: 4c 1b 8b    L..
+
+; &8cc0 referenced 1 time by &8cb4
+.c8cc0
+    jsr sub_c8d86                                                     ; 8cc0: 20 86 8d     ..
+    jsr sub_c8d86                                                     ; 8cc3: 20 86 8d     ..
+    jsr sub_c9332                                                     ; 8cc6: 20 32 93     2.
+    jsr c8f9d                                                         ; 8cc9: 20 9d 8f     ..
+    cmp #&29 ; ')'                                                    ; 8ccc: c9 29       .)
+    beq c8cbb                                                         ; 8cce: f0 eb       ..
+    cmp #&2c ; ','                                                    ; 8cd0: c9 2c       .,
+    bne c8ce3                                                         ; 8cd2: d0 0f       ..
+    jsr sub_c8d86                                                     ; 8cd4: 20 86 8d     ..
+    jsr sub_c8d94                                                     ; 8cd7: 20 94 8d     ..
+    bne c8ce3                                                         ; 8cda: d0 07       ..
+    jsr c8f9d                                                         ; 8cdc: 20 9d 8f     ..
+    cmp #&29 ; ')'                                                    ; 8cdf: c9 29       .)
+    beq c8cbb                                                         ; 8ce1: f0 d8       ..
+; &8ce3 referenced 4 times by &8cd2, &8cda, &8d0f, &8d28
+.c8ce3
+    jmp c8bf9                                                         ; 8ce3: 4c f9 8b    L..
+
+; &8ce6 referenced 1 time by &8cad
+.c8ce6
+    cpx #&44 ; 'D'                                                    ; 8ce6: e0 44       .D
+    bcs c8d37                                                         ; 8ce8: b0 4d       .M
+    lda l003d                                                         ; 8cea: a5 3d       .=
+    eor #1                                                            ; 8cec: 49 01       I.
+    and #&1f                                                          ; 8cee: 29 1f       ).
+    pha                                                               ; 8cf0: 48          H
+    cpx #&41 ; 'A'                                                    ; 8cf1: e0 41       .A
+    bcs c8d16                                                         ; 8cf3: b0 21       .!
+    jsr sub_c8d9c                                                     ; 8cf5: 20 9c 8d     ..
+    bne c8cfd                                                         ; 8cf8: d0 03       ..
+    pla                                                               ; 8cfa: 68          h
+    bra c8ca4                                                         ; 8cfb: 80 a7       ..
+; &8cfd referenced 1 time by &8cf8
+.c8cfd
+    jsr sub_c9330                                                     ; 8cfd: 20 30 93     0.
+    pla                                                               ; 8d00: 68          h
+    sta l0037                                                         ; 8d01: 85 37       .7
+    jsr sub_c8da2                                                     ; 8d03: 20 a2 8d     ..
+    bne c8c99                                                         ; 8d06: d0 91       ..
+    jsr c8f9d                                                         ; 8d08: 20 9d 8f     ..
+    and #&1f                                                          ; 8d0b: 29 1f       ).
+    cmp l0037                                                         ; 8d0d: c5 37       .7
+    bne c8ce3                                                         ; 8d0f: d0 d2       ..
+    jsr sub_c8d86                                                     ; 8d11: 20 86 8d     ..
+    bra c8c99                                                         ; 8d14: 80 83       ..
+; &8d16 referenced 1 time by &8cf3
+.c8d16
+    jsr sub_c9332                                                     ; 8d16: 20 32 93     2.
+    pla                                                               ; 8d19: 68          h
+    sta l0037                                                         ; 8d1a: 85 37       .7
+    jsr sub_c8da2                                                     ; 8d1c: 20 a2 8d     ..
+    bne c8d34                                                         ; 8d1f: d0 13       ..
+    jsr c8f9d                                                         ; 8d21: 20 9d 8f     ..
+    and #&1f                                                          ; 8d24: 29 1f       ).
+    cmp l0037                                                         ; 8d26: c5 37       .7
+    bne c8ce3                                                         ; 8d28: d0 b9       ..
+    jsr sub_c8d86                                                     ; 8d2a: 20 86 8d     ..
+    lda l002b                                                         ; 8d2d: a5 2b       .+
+    beq c8d34                                                         ; 8d2f: f0 03       ..
+    jmp c8bb6                                                         ; 8d31: 4c b6 8b    L..
+
+; &8d34 referenced 2 times by &8d1f, &8d2f
+.c8d34
+    jmp c8c1e                                                         ; 8d34: 4c 1e 8c    L..
+
+; &8d37 referenced 1 time by &8ce8
+.c8d37
+    bne c8d44                                                         ; 8d37: d0 0b       ..
+    jsr sub_c9332                                                     ; 8d39: 20 32 93     2.
+    lda l002a                                                         ; 8d3c: a5 2a       .*
+    sta l0028                                                         ; 8d3e: 85 28       .(
+    ldy #0                                                            ; 8d40: a0 00       ..
+    bra c8d6e                                                         ; 8d42: 80 2a       .*
+; &8d44 referenced 1 time by &8d37
+.c8d44
+    ldx #1                                                            ; 8d44: a2 01       ..
+    ldy l000a                                                         ; 8d46: a4 0a       ..
+    inc l000a                                                         ; 8d48: e6 0a       ..
+    lda (l000b),y                                                     ; 8d4a: b1 0b       ..
+    and #&df                                                          ; 8d4c: 29 df       ).
+    cmp #&42 ; 'B'                                                    ; 8d4e: c9 42       .B
+    beq c8d64                                                         ; 8d50: f0 12       ..
+    inx                                                               ; 8d52: e8          .
+    cmp #&57 ; 'W'                                                    ; 8d53: c9 57       .W
+    beq c8d64                                                         ; 8d55: f0 0d       ..
+    ldx #4                                                            ; 8d57: a2 04       ..
+    cmp #&44 ; 'D'                                                    ; 8d59: c9 44       .D
+    beq c8d64                                                         ; 8d5b: f0 07       ..
+    cmp #&53 ; 'S'                                                    ; 8d5d: c9 53       .S
+    beq c8d74                                                         ; 8d5f: f0 13       ..
+    jmp c9c2d                                                         ; 8d61: 4c 2d 9c    L-.
+
+; &8d64 referenced 3 times by &8d50, &8d55, &8d5b
+.c8d64
+    phx                                                               ; 8d64: da          .
+    jsr sub_c9332                                                     ; 8d65: 20 32 93     2.
+    ldx #&29 ; ')'                                                    ; 8d68: a2 29       .)
+    jsr sub_cbe06                                                     ; 8d6a: 20 06 be     ..
+    ply                                                               ; 8d6d: 7a          z
+; &8d6e referenced 2 times by &8d42, &8d84
+.c8d6e
+    jmp c8b1b                                                         ; 8d6e: 4c 1b 8b    L..
+
+; &8d71 referenced 1 time by &8d7a
+.loop_c8d71
+    jmp c9155                                                         ; 8d71: 4c 55 91    LU.
+
+; &8d74 referenced 1 time by &8d5f
+.c8d74
+    lda l0028                                                         ; 8d74: a5 28       .(
+    pha                                                               ; 8d76: 48          H
+    jsr sub_c9df3                                                     ; 8d77: 20 f3 9d     ..
+    bne loop_c8d71                                                    ; 8d7a: d0 f5       ..
+    pla                                                               ; 8d7c: 68          h
+    sta l0028                                                         ; 8d7d: 85 28       .(
+    jsr c9338                                                         ; 8d7f: 20 38 93     8.
+    ldy #&ff                                                          ; 8d82: a0 ff       ..
+    bra c8d6e                                                         ; 8d84: 80 e8       ..
+; &8d86 referenced 8 times by &8bd2, &8c09, &8c39, &8cc0, &8cc3, &8cd4, &8d11, &8d2a
+.sub_c8d86
+    jsr sub_c8d89                                                     ; 8d86: 20 89 8d     ..
+; &8d89 referenced 3 times by &8bac, &8c15, &8d86
+.sub_c8d89
+    jsr sub_c8d8c                                                     ; 8d89: 20 8c 8d     ..
+; &8d8c referenced 3 times by &8c1b, &8c57, &8d89
+.sub_c8d8c
+    lda l0029                                                         ; 8d8c: a5 29       .)
+    clc                                                               ; 8d8e: 18          .
+    adc #4                                                            ; 8d8f: 69 04       i.
+    sta l0029                                                         ; 8d91: 85 29       .)
+    rts                                                               ; 8d93: 60          `
+
+; &8d94 referenced 5 times by &8bed, &8c0c, &8c3c, &8c7a, &8cd7
+.sub_c8d94
+    jsr c8f9d                                                         ; 8d94: 20 9d 8f     ..
+    and #&df                                                          ; 8d97: 29 df       ).
+    cmp #&58 ; 'X'                                                    ; 8d99: c9 58       .X
+    rts                                                               ; 8d9b: 60          `
+
+; &8d9c referenced 6 times by &8ba7, &8c8f, &8c9b, &8cf5, &9250, &b8e6
+.sub_c8d9c
+    jsr c8f9d                                                         ; 8d9c: 20 9d 8f     ..
+    cmp #&23 ; '#'                                                    ; 8d9f: c9 23       .#
+    rts                                                               ; 8da1: 60          `
+
+; &8da2 referenced 18 times by &8bd5, &8c04, &8c34, &8c75, &8d03, &8d1c, &93e2, &9420, &95be, &9670, &97f6, &98f3, &b133, &b3e5, &b3f4, &b5e9, &b87f, &b9a5
+.sub_c8da2
+    jsr c8f9d                                                         ; 8da2: 20 9d 8f     ..
+    cmp #&2c ; ','                                                    ; 8da5: c9 2c       .,
+    rts                                                               ; 8da7: 60          `
+
+; &8da8 referenced 2 times by &8e02, &8f5e
+.sub_c8da8
+    sta (l0037)                                                       ; 8da8: 92 37       .7
+    clc                                                               ; 8daa: 18          .
+    tya                                                               ; 8dab: 98          .
+    adc l0037                                                         ; 8dac: 65 37       e7
+    sta l0039                                                         ; 8dae: 85 39       .9
+    ldy #0                                                            ; 8db0: a0 00       ..
+    tya                                                               ; 8db2: 98          .
+    adc l0038                                                         ; 8db3: 65 38       e8
+    sta l003a                                                         ; 8db5: 85 3a       .:
+; &8db7 referenced 1 time by &8dbe
+.loop_c8db7
+    iny                                                               ; 8db7: c8          .
+    lda (l0039),y                                                     ; 8db8: b1 39       .9
+    sta (l0037),y                                                     ; 8dba: 91 37       .7
+    cmp #&0d                                                          ; 8dbc: c9 0d       ..
+    bne loop_c8db7                                                    ; 8dbe: d0 f7       ..
+    rts                                                               ; 8dc0: 60          `
+
+; &8dc1 referenced 1 time by &8ecb
+.sub_c8dc1
+    and #&0f                                                          ; 8dc1: 29 0f       ).
+    sta l003d                                                         ; 8dc3: 85 3d       .=
+    ldx #0                                                            ; 8dc5: a2 00       ..
+    ldy #0                                                            ; 8dc7: a0 00       ..
+; &8dc9 referenced 2 times by &8df6, &8df9
+.c8dc9
+    iny                                                               ; 8dc9: c8          .
+    lda (l0037),y                                                     ; 8dca: b1 37       .7
+    jsr c8e51                                                         ; 8dcc: 20 51 8e     Q.
+    bcc c8dff                                                         ; 8dcf: 90 2e       ..
+    and #&0f                                                          ; 8dd1: 29 0f       ).
+    pha                                                               ; 8dd3: 48          H
+    stx l003e                                                         ; 8dd4: 86 3e       .>
+    lda l003d                                                         ; 8dd6: a5 3d       .=
+    asl a                                                             ; 8dd8: 0a          .
+    rol l003e                                                         ; 8dd9: 26 3e       &>
+    bmi c8dfc                                                         ; 8ddb: 30 1f       0.
+    asl a                                                             ; 8ddd: 0a          .
+    rol l003e                                                         ; 8dde: 26 3e       &>
+    bmi c8dfc                                                         ; 8de0: 30 1a       0.
+    adc l003d                                                         ; 8de2: 65 3d       e=
+    sta l003d                                                         ; 8de4: 85 3d       .=
+    txa                                                               ; 8de6: 8a          .
+    adc l003e                                                         ; 8de7: 65 3e       e>
+    asl l003d                                                         ; 8de9: 06 3d       .=
+    rol a                                                             ; 8deb: 2a          *
+    bmi c8dfc                                                         ; 8dec: 30 0e       0.
+    bcs c8dfc                                                         ; 8dee: b0 0c       ..
+    tax                                                               ; 8df0: aa          .
+    pla                                                               ; 8df1: 68          h
+    adc l003d                                                         ; 8df2: 65 3d       e=
+    sta l003d                                                         ; 8df4: 85 3d       .=
+    bcc c8dc9                                                         ; 8df6: 90 d1       ..
+    inx                                                               ; 8df8: e8          .
+    bpl c8dc9                                                         ; 8df9: 10 ce       ..
+    pha                                                               ; 8dfb: 48          H
+; &8dfc referenced 4 times by &8ddb, &8de0, &8dec, &8dee
+.c8dfc
+    pla                                                               ; 8dfc: 68          h
+    sec                                                               ; 8dfd: 38          8
+    rts                                                               ; 8dfe: 60          `
+
+; &8dff referenced 1 time by &8dcf
+.c8dff
+    dey                                                               ; 8dff: 88          .
+    lda #&8d                                                          ; 8e00: a9 8d       ..
+    jsr sub_c8da8                                                     ; 8e02: 20 a8 8d     ..
+    lda l0037                                                         ; 8e05: a5 37       .7
+    sta l0039                                                         ; 8e07: 85 39       .9
+    lda l0038                                                         ; 8e09: a5 38       .8
+    sta l003a                                                         ; 8e0b: 85 3a       .:
+    jsr sub_c8e5f                                                     ; 8e0d: 20 5f 8e     _.
+    jsr sub_c8e5f                                                     ; 8e10: 20 5f 8e     _.
+    jsr sub_c8e5f                                                     ; 8e13: 20 5f 8e     _.
+; &8e16 referenced 1 time by &8e1b
+.loop_c8e16
+    lda (l0039),y                                                     ; 8e16: b1 39       .9
+    sta (l0037),y                                                     ; 8e18: 91 37       .7
+    dey                                                               ; 8e1a: 88          .
+    bne loop_c8e16                                                    ; 8e1b: d0 f9       ..
+    ldy #3                                                            ; 8e1d: a0 03       ..
+; &8e1f referenced 1 time by &9506
+.sub_c8e1f
+    txa                                                               ; 8e1f: 8a          .
+    ora #&40 ; '@'                                                    ; 8e20: 09 40       .@
+    sta (l0039),y                                                     ; 8e22: 91 39       .9
+    dey                                                               ; 8e24: 88          .
+    lda l003d                                                         ; 8e25: a5 3d       .=
+    and #&3f ; '?'                                                    ; 8e27: 29 3f       )?
+    ora #&40 ; '@'                                                    ; 8e29: 09 40       .@
+    sta (l0039),y                                                     ; 8e2b: 91 39       .9
+    dey                                                               ; 8e2d: 88          .
+    lda #&3f ; '?'                                                    ; 8e2e: a9 3f       .?
+    trb l003d                                                         ; 8e30: 14 3d       .=
+    txa                                                               ; 8e32: 8a          .
+    and #&c0                                                          ; 8e33: 29 c0       ).
+    lsr a                                                             ; 8e35: 4a          J
+    lsr a                                                             ; 8e36: 4a          J
+    ora l003d                                                         ; 8e37: 05 3d       .=
+    lsr a                                                             ; 8e39: 4a          J
+    lsr a                                                             ; 8e3a: 4a          J
+    eor #&54 ; 'T'                                                    ; 8e3b: 49 54       IT
+    sta (l0039),y                                                     ; 8e3d: 91 39       .9
+; &8e3f referenced 3 times by &8e43, &8e4b, &8e53
+.c8e3f
+    clc                                                               ; 8e3f: 18          .
+    rts                                                               ; 8e40: 60          `
+
+; &8e41 referenced 6 times by &8c46, &8ee2, &8ee9, &8f4d, &8f7c, &b027
+.sub_c8e41
+    cmp #&7b ; '{'                                                    ; 8e41: c9 7b       .{
+    bcs c8e3f                                                         ; 8e43: b0 fa       ..
+    cmp #&5f ; '_'                                                    ; 8e45: c9 5f       ._
+    bcs c8e57                                                         ; 8e47: b0 0e       ..
+    cmp #&5b ; '['                                                    ; 8e49: c9 5b       .[
+    bcs c8e3f                                                         ; 8e4b: b0 f2       ..
+    cmp #&41 ; 'A'                                                    ; 8e4d: c9 41       .A
+    bcs c8e57                                                         ; 8e4f: b0 06       ..
+; &8e51 referenced 4 times by &8dcc, &8e5a, &8e80, &8ec2
+.c8e51
+    cmp #&3a ; ':'                                                    ; 8e51: c9 3a       .:
+    bcs c8e3f                                                         ; 8e53: b0 ea       ..
+    cmp #&30 ; '0'                                                    ; 8e55: c9 30       .0
+; &8e57 referenced 2 times by &8e47, &8e4f
+.c8e57
+    rts                                                               ; 8e57: 60          `
+
+; &8e58 referenced 1 time by &8ed2
+.sub_c8e58
+    cmp #&2e ; '.'                                                    ; 8e58: c9 2e       ..
+    bne c8e51                                                         ; 8e5a: d0 f5       ..
+    rts                                                               ; 8e5c: 60          `
+
+    equb &b2, &37                                                     ; 8e5d: b2 37       .7
+
+; &8e5f referenced 9 times by &8e0d, &8e10, &8e13, &8e66, &8e6c, &8ea1, &8ed7, &8eee, &8f81
+.sub_c8e5f
+    inc l0037                                                         ; 8e5f: e6 37       .7
+    bne c8e9c                                                         ; 8e61: d0 39       .9
+    inc l0038                                                         ; 8e63: e6 38       .8
+    rts                                                               ; 8e65: 60          `
+
+; &8e66 referenced 3 times by &8e7d, &8e91, &bf1a
+.sub_c8e66
+    jsr sub_c8e5f                                                     ; 8e66: 20 5f 8e     _.
+    lda (l0037)                                                       ; 8e69: b2 37       .7
+    rts                                                               ; 8e6b: 60          `
+
+; &8e6c referenced 6 times by &8e77, &8e96, &8eac, &8ebc, &8ece, &8f8f
+.c8e6c
+    jsr sub_c8e5f                                                     ; 8e6c: 20 5f 8e     _.
+; &8e6f referenced 3 times by &8e87, &8ea8, &bb30
+.c8e6f
+    lda (l0037)                                                       ; 8e6f: b2 37       .7
+    cmp #&0d                                                          ; 8e71: c9 0d       ..
+    beq c8e9c                                                         ; 8e73: f0 27       .'
+    cmp #&20 ; ' '                                                    ; 8e75: c9 20       .
+    beq c8e6c                                                         ; 8e77: f0 f3       ..
+    cmp #&26 ; '&'                                                    ; 8e79: c9 26       .&
+    bne c8e8d                                                         ; 8e7b: d0 10       ..
+; &8e7d referenced 2 times by &8e83, &8e8b
+.c8e7d
+    jsr sub_c8e66                                                     ; 8e7d: 20 66 8e     f.
+    jsr c8e51                                                         ; 8e80: 20 51 8e     Q.
+    bcs c8e7d                                                         ; 8e83: b0 f8       ..
+    cmp #&41 ; 'A'                                                    ; 8e85: c9 41       .A
+    bcc c8e6f                                                         ; 8e87: 90 e6       ..
+    cmp #&47 ; 'G'                                                    ; 8e89: c9 47       .G
+    bcc c8e7d                                                         ; 8e8b: 90 f0       ..
+; &8e8d referenced 1 time by &8e7b
+.c8e8d
+    cmp #&22 ; '"'                                                    ; 8e8d: c9 22       ."
+    bne c8e9d                                                         ; 8e8f: d0 0c       ..
+; &8e91 referenced 1 time by &8e9a
+.loop_c8e91
+    jsr sub_c8e66                                                     ; 8e91: 20 66 8e     f.
+    cmp #&22 ; '"'                                                    ; 8e94: c9 22       ."
+    beq c8e6c                                                         ; 8e96: f0 d4       ..
+    cmp #&0d                                                          ; 8e98: c9 0d       ..
+    bne loop_c8e91                                                    ; 8e9a: d0 f5       ..
+; &8e9c referenced 3 times by &8e61, &8e73, &8eb4
+.c8e9c
+    rts                                                               ; 8e9c: 60          `
+
+; &8e9d referenced 1 time by &8e8f
+.c8e9d
+    cmp #&3a ; ':'                                                    ; 8e9d: c9 3a       .:
+    bne c8eaa                                                         ; 8e9f: d0 09       ..
+    jsr sub_c8e5f                                                     ; 8ea1: 20 5f 8e     _.
+; &8ea4 referenced 1 time by &9561
+.sub_c8ea4
+    stz l003b                                                         ; 8ea4: 64 3b       d;
+; &8ea6 referenced 1 time by &8ee0
+.c8ea6
+    stz l003c                                                         ; 8ea6: 64 3c       d<
+    bra c8e6f                                                         ; 8ea8: 80 c5       ..
+; &8eaa referenced 1 time by &8e9f
+.c8eaa
+    cmp #&2c ; ','                                                    ; 8eaa: c9 2c       .,
+    beq c8e6c                                                         ; 8eac: f0 be       ..
+    cmp #&2a ; '*'                                                    ; 8eae: c9 2a       .*
+    bne c8ebe                                                         ; 8eb0: d0 0c       ..
+    lda l003b                                                         ; 8eb2: a5 3b       .;
+    beq c8e9c                                                         ; 8eb4: f0 e6       ..
+; &8eb6 referenced 2 times by &8ee5, &8ef5
+.c8eb6
+    ldx #&ff                                                          ; 8eb6: a2 ff       ..
+    stx l003b                                                         ; 8eb8: 86 3b       .;
+    stz l003c                                                         ; 8eba: 64 3c       d<
+    bra c8e6c                                                         ; 8ebc: 80 ae       ..
+; &8ebe referenced 1 time by &8eb0
+.c8ebe
+    cmp #&2e ; '.'                                                    ; 8ebe: c9 2e       ..
+    beq c8ed0                                                         ; 8ec0: f0 0e       ..
+    jsr c8e51                                                         ; 8ec2: 20 51 8e     Q.
+    bcc c8ef3                                                         ; 8ec5: 90 2c       .,
+    ldx l003c                                                         ; 8ec7: a6 3c       .<
+    beq c8ed0                                                         ; 8ec9: f0 05       ..
+    jsr sub_c8dc1                                                     ; 8ecb: 20 c1 8d     ..
+    bcc c8e6c                                                         ; 8ece: 90 9c       ..
+; &8ed0 referenced 3 times by &8ec0, &8ec9, &8eda
+.c8ed0
+    lda (l0037)                                                       ; 8ed0: b2 37       .7
+    jsr sub_c8e58                                                     ; 8ed2: 20 58 8e     X.
+    bcc c8edc                                                         ; 8ed5: 90 05       ..
+    jsr sub_c8e5f                                                     ; 8ed7: 20 5f 8e     _.
+    bra c8ed0                                                         ; 8eda: 80 f4       ..
+; &8edc referenced 3 times by &8ed5, &8eec, &ab86
+.c8edc
+    ldx #&ff                                                          ; 8edc: a2 ff       ..
+    stx l003b                                                         ; 8ede: 86 3b       .;
+    bra c8ea6                                                         ; 8ee0: 80 c4       ..
+; &8ee2 referenced 1 time by &8ef9
+.loop_c8ee2
+    jsr sub_c8e41                                                     ; 8ee2: 20 41 8e     A.
+    bcc c8eb6                                                         ; 8ee5: 90 cf       ..
+; &8ee7 referenced 4 times by &8ef1, &8f07, &8f23, &8f50
+.c8ee7
+    lda (l0037)                                                       ; 8ee7: b2 37       .7
+    jsr sub_c8e41                                                     ; 8ee9: 20 41 8e     A.
+    bcc c8edc                                                         ; 8eec: 90 ee       ..
+    jsr sub_c8e5f                                                     ; 8eee: 20 5f 8e     _.
+    bra c8ee7                                                         ; 8ef1: 80 f4       ..
+; &8ef3 referenced 1 time by &8ec5
+.c8ef3
+    cmp #&41 ; 'A'                                                    ; 8ef3: c9 41       .A
+    bcc c8eb6                                                         ; 8ef5: 90 bf       ..
+    cmp #&58 ; 'X'                                                    ; 8ef7: c9 58       .X
+    bcs loop_c8ee2                                                    ; 8ef9: b0 e7       ..
+    ldx #&13                                                          ; 8efb: a2 13       ..
+    stx l0039                                                         ; 8efd: 86 39       .9
+    ldx #&85                                                          ; 8eff: a2 85       ..
+    stx l003a                                                         ; 8f01: 86 3a       .:
+; &8f03 referenced 1 time by &8f3f
+.c8f03
+    ldy #0                                                            ; 8f03: a0 00       ..
+    cmp (l0039)                                                       ; 8f05: d2 39       .9
+    bcc c8ee7                                                         ; 8f07: 90 de       ..
+    bne c8f1a                                                         ; 8f09: d0 0f       ..
+; &8f0b referenced 1 time by &8f12
+.loop_c8f0b
+    iny                                                               ; 8f0b: c8          .
+    lda (l0039),y                                                     ; 8f0c: b1 39       .9
+    bmi c8f41                                                         ; 8f0e: 30 31       01
+    cmp (l0037),y                                                     ; 8f10: d1 37       .7
+    beq loop_c8f0b                                                    ; 8f12: f0 f7       ..
+    lda (l0037),y                                                     ; 8f14: b1 37       .7
+    cmp #&2e ; '.'                                                    ; 8f16: c9 2e       ..
+    beq c8f25                                                         ; 8f18: f0 0b       ..
+; &8f1a referenced 2 times by &8f09, &8f1d
+.c8f1a
+    iny                                                               ; 8f1a: c8          .
+    lda (l0039),y                                                     ; 8f1b: b1 39       .9
+    bpl c8f1a                                                         ; 8f1d: 10 fb       ..
+    cmp #&fe                                                          ; 8f1f: c9 fe       ..
+    bne c8f32                                                         ; 8f21: d0 0f       ..
+    bcs c8ee7                                                         ; 8f23: b0 c2       ..
+; &8f25 referenced 1 time by &8f18
+.c8f25
+    iny                                                               ; 8f25: c8          .
+; &8f26 referenced 2 times by &8f2c, &8f30
+.c8f26
+    lda (l0039),y                                                     ; 8f26: b1 39       .9
+    bmi c8f41                                                         ; 8f28: 30 17       0.
+    inc l0039                                                         ; 8f2a: e6 39       .9
+    bne c8f26                                                         ; 8f2c: d0 f8       ..
+    inc l003a                                                         ; 8f2e: e6 3a       .:
+    bra c8f26                                                         ; 8f30: 80 f4       ..
+; &8f32 referenced 1 time by &8f21
+.c8f32
+    sec                                                               ; 8f32: 38          8
+    iny                                                               ; 8f33: c8          .
+    tya                                                               ; 8f34: 98          .
+    adc l0039                                                         ; 8f35: 65 39       e9
+    sta l0039                                                         ; 8f37: 85 39       .9
+    bcc c8f3d                                                         ; 8f39: 90 02       ..
+    inc l003a                                                         ; 8f3b: e6 3a       .:
+; &8f3d referenced 1 time by &8f39
+.c8f3d
+    lda (l0037)                                                       ; 8f3d: b2 37       .7
+    bra c8f03                                                         ; 8f3f: 80 c2       ..
+; &8f41 referenced 2 times by &8f0e, &8f28
+.c8f41
+    tax                                                               ; 8f41: aa          .
+    iny                                                               ; 8f42: c8          .
+    lda (l0039),y                                                     ; 8f43: b1 39       .9
+    sta l003d                                                         ; 8f45: 85 3d       .=
+    dey                                                               ; 8f47: 88          .
+    lsr a                                                             ; 8f48: 4a          J
+    bcc c8f52                                                         ; 8f49: 90 07       ..
+    lda (l0037),y                                                     ; 8f4b: b1 37       .7
+    jsr sub_c8e41                                                     ; 8f4d: 20 41 8e     A.
+    bcs c8ee7                                                         ; 8f50: b0 95       ..
+; &8f52 referenced 1 time by &8f49
+.c8f52
+    txa                                                               ; 8f52: 8a          .
+    bit l003d                                                         ; 8f53: 24 3d       $=
+    bvc c8f5d                                                         ; 8f55: 50 06       P.
+    ldx l003b                                                         ; 8f57: a6 3b       .;
+    bne c8f5d                                                         ; 8f59: d0 02       ..
+    adc #&40 ; '@'                                                    ; 8f5b: 69 40       i@
+; &8f5d referenced 2 times by &8f55, &8f59
+.c8f5d
+    dey                                                               ; 8f5d: 88          .
+    jsr sub_c8da8                                                     ; 8f5e: 20 a8 8d     ..
+    ldx #&ff                                                          ; 8f61: a2 ff       ..
+    lda l003d                                                         ; 8f63: a5 3d       .=
+    lsr a                                                             ; 8f65: 4a          J
+    lsr a                                                             ; 8f66: 4a          J
+    bcc c8f6d                                                         ; 8f67: 90 04       ..
+    stx l003b                                                         ; 8f69: 86 3b       .;
+    stz l003c                                                         ; 8f6b: 64 3c       d<
+; &8f6d referenced 1 time by &8f67
+.c8f6d
+    lsr a                                                             ; 8f6d: 4a          J
+    bcc c8f74                                                         ; 8f6e: 90 04       ..
+    stz l003b                                                         ; 8f70: 64 3b       d;
+    stz l003c                                                         ; 8f72: 64 3c       d<
+; &8f74 referenced 1 time by &8f6e
+.c8f74
+    lsr a                                                             ; 8f74: 4a          J
+    bcc c8f87                                                         ; 8f75: 90 10       ..
+    pha                                                               ; 8f77: 48          H
+    ldy #1                                                            ; 8f78: a0 01       ..
+; &8f7a referenced 1 time by &8f84
+.loop_c8f7a
+    lda (l0037),y                                                     ; 8f7a: b1 37       .7
+    jsr sub_c8e41                                                     ; 8f7c: 20 41 8e     A.
+    bcc c8f86                                                         ; 8f7f: 90 05       ..
+    jsr sub_c8e5f                                                     ; 8f81: 20 5f 8e     _.
+    bra loop_c8f7a                                                    ; 8f84: 80 f4       ..
+; &8f86 referenced 1 time by &8f7f
+.c8f86
+    pla                                                               ; 8f86: 68          h
+; &8f87 referenced 1 time by &8f75
+.c8f87
+    lsr a                                                             ; 8f87: 4a          J
+    bcc c8f8c                                                         ; 8f88: 90 02       ..
+    stx l003c                                                         ; 8f8a: 86 3c       .<
+; &8f8c referenced 1 time by &8f88
+.c8f8c
+    lsr a                                                             ; 8f8c: 4a          J
+    bcs c8f9c                                                         ; 8f8d: b0 0d       ..
+    jmp c8e6c                                                         ; 8f8f: 4c 6c 8e    Ll.
+
+; &8f92 referenced 16 times by &8f9a, &8fa8, &8fb4, &9c4a, &abbb, &abc6, &abd0, &ad3a, &ad8e, &af61, &b13f, &b659, &b69b, &b6e8, &b835, &ba7a
+.c8f92
+    ldy l001b                                                         ; 8f92: a4 1b       ..
+    inc l001b                                                         ; 8f94: e6 1b       ..
+    lda (l0019),y                                                     ; 8f96: b1 19       ..
+    cmp #&20 ; ' '                                                    ; 8f98: c9 20       .
+    beq c8f92                                                         ; 8f9a: f0 f6       ..
+; &8f9c referenced 1 time by &8f8d
+.c8f9c
+    rts                                                               ; 8f9c: 60          `
+
+; &8f9d referenced 29 times by &89dd, &8aa8, &8bc1, &8bcb, &8bde, &8bf2, &8c28, &8caf, &8cc9, &8cdc, &8d08, &8d21, &8d94, &8d9c, &8da2, &8fa5, &90e3, &9276, &928f, &935c, &95f9, &98dc, &b000, &b0b5, &b403, &b40a, &b771, &b78b, &b983
+.c8f9d
+    ldy l000a                                                         ; 8f9d: a4 0a       ..
+    inc l000a                                                         ; 8f9f: e6 0a       ..
+    lda (l000b),y                                                     ; 8fa1: b1 0b       ..
+    cmp #&20 ; ' '                                                    ; 8fa3: c9 20       .
+    beq c8f9d                                                         ; 8fa5: f0 f6       ..
+; &8fa7 referenced 1 time by &8fb9
+.loop_c8fa7
+    rts                                                               ; 8fa7: 60          `
+
+; &8fa8 referenced 7 times by &9208, &9307, &9390, &b156, &b95a, &b9e9, &b9f6
+.sub_c8fa8
+    jsr c8f92                                                         ; 8fa8: 20 92 8f     ..
+    cmp #&2c ; ','                                                    ; 8fab: c9 2c       .,
+    rts                                                               ; 8fad: 60          `
+
+; &8fae referenced 2 times by &ac5d, &af8b
+.sub_c8fae
+    jsr sub_c9774                                                     ; 8fae: 20 74 97     t.
+    jsr cbc66                                                         ; 8fb1: 20 66 bc     f.
+; &8fb4 referenced 1 time by &9771
+.sub_c8fb4
+    jsr c8f92                                                         ; 8fb4: 20 92 8f     ..
+    cmp #&2c ; ','                                                    ; 8fb7: c9 2c       .,
+    beq loop_c8fa7                                                    ; 8fb9: f0 ec       ..
+; &8fbb referenced 3 times by &92ed, &aca0, &af07
+.c8fbb
+    brk                                                               ; 8fbb: 00          .
+
+    equb   5, &8d, &2c,   0                                           ; 8fbc: 05 8d 2c... ..,
+
+.sub_c8fc0
+    jsr sub_cbe17                                                     ; 8fc0: 20 17 be     ..
+    bra c8fda                                                         ; 8fc3: 80 15       ..
+.sub_c8fc5
+    jsr c9c6a                                                         ; 8fc5: 20 6a 9c     j.
+    lda l0018                                                         ; 8fc8: a5 18       ..
+    sta l0038                                                         ; 8fca: 85 38       .8
+    stz l0037                                                         ; 8fcc: 64 37       d7
+    lda #0                                                            ; 8fce: a9 00       ..
+    sta (l0037),y                                                     ; 8fd0: 91 37       .7
+    jsr sub_cbe25                                                     ; 8fd2: 20 25 be     %.
+    bra c9048                                                         ; 8fd5: 80 71       .q
+.sub_c8fd7
+    jsr c9c6a                                                         ; 8fd7: 20 6a 9c     j.
+; &8fda referenced 1 time by &8fc3
+.c8fda
+    jsr sub_cbbdc                                                     ; 8fda: 20 dc bb     ..
+    lda l0018                                                         ; 8fdd: a5 18       ..
+    sta l000c                                                         ; 8fdf: 85 0c       ..
+    stz l000b                                                         ; 8fe1: 64 0b       d.
+    bra c905c                                                         ; 8fe3: 80 77       .w
+.sub_c8fe5
+    jsr sub_cbe17                                                     ; 8fe5: 20 17 be     ..
+    bra c9048                                                         ; 8fe8: 80 5e       .^
+.sub_c8fea
+    jsr c9c6a                                                         ; 8fea: 20 6a 9c     j.
+    jsr sub_cbe25                                                     ; 8fed: 20 25 be     %.
+    bra c904b                                                         ; 8ff0: 80 59       .Y
+; &8ff2 referenced 1 time by &8136
+.c8ff2
+    lda #&f2                                                          ; 8ff2: a9 f2       ..
+    jsr cae60                                                         ; 8ff4: 20 60 ae     `.
+    jsr sub_cbf22                                                     ; 8ff7: 20 22 bf     ".
+    tax                                                               ; 8ffa: aa          .
+    jsr sub_cbf22                                                     ; 8ffb: 20 22 bf     ".
+    sta l002b                                                         ; 8ffe: 85 2b       .+
+    stx l002a                                                         ; 9000: 86 2a       .*
+    ldx #&14                                                          ; 9002: a2 14       ..
+; &9004 referenced 1 time by &9010
+.loop_c9004
+    dex                                                               ; 9004: ca          .
+    beq c9045                                                         ; 9005: f0 3e       .>
+    jsr sub_cbf22                                                     ; 9007: 20 22 bf     ".
+    cmp #&0d                                                          ; 900a: c9 0d       ..
+    beq c9045                                                         ; 900c: f0 37       .7
+    cmp #&40 ; '@'                                                    ; 900e: c9 40       .@
+    bne loop_c9004                                                    ; 9010: d0 f2       ..
+    jsr sub_cbf22                                                     ; 9012: 20 22 bf     ".
+    cmp #&0d                                                          ; 9015: c9 0d       ..
+    bne c9045                                                         ; 9017: d0 2c       .,
+    jsr sub_cbf3e                                                     ; 9019: 20 3e bf     >.
+; &901c referenced 1 time by &9040
+.c901c
+    ldy #0                                                            ; 901c: a0 00       ..
+    stz l000b                                                         ; 901e: 64 0b       d.
+    lda #7                                                            ; 9020: a9 07       ..
+    sta l000c                                                         ; 9022: 85 0c       ..
+; &9024 referenced 1 time by &9035
+.loop_c9024
+    lda (l0000)                                                       ; 9024: b2 00       ..
+    beq c9048                                                         ; 9026: f0 20       .
+    sta (l000b),y                                                     ; 9028: 91 0b       ..
+    iny                                                               ; 902a: c8          .
+    beq c9045                                                         ; 902b: f0 18       ..
+    inc l0000                                                         ; 902d: e6 00       ..
+    bne c9033                                                         ; 902f: d0 02       ..
+    inc l0001                                                         ; 9031: e6 01       ..
+; &9033 referenced 1 time by &902f
+.c9033
+    cmp #&0d                                                          ; 9033: c9 0d       ..
+    bne loop_c9024                                                    ; 9035: d0 ed       ..
+    lda l0001                                                         ; 9037: a5 01       ..
+    cmp l0007                                                         ; 9039: c5 07       ..
+    bcs c9048                                                         ; 903b: b0 0b       ..
+    jsr sub_cbb1b                                                     ; 903d: 20 1b bb     ..
+    bra c901c                                                         ; 9040: 80 da       ..
+.sub_c9042
+    jsr c9c6a                                                         ; 9042: 20 6a 9c     j.
+; &9045 referenced 4 times by &9005, &900c, &9017, &902b
+.c9045
+    jsr sub_cbf3e                                                     ; 9045: 20 3e bf     >.
+; &9048 referenced 7 times by &8fd5, &8fe8, &9026, &903b, &9065, &940d, &9579
+.c9048
+    jsr sub_cbbdc                                                     ; 9048: 20 dc bb     ..
+; &904b referenced 6 times by &8a88, &8ff0, &908a, &9090, &9cc6, &b425
+.c904b
+    ldy #7                                                            ; 904b: a0 07       ..
+    sty l000c                                                         ; 904d: 84 0c       ..
+    stz l000b                                                         ; 904f: 64 0b       d.
+    jsr sub_cb2e0                                                     ; 9051: 20 e0 b2     ..
+    lda #&3e ; '>'                                                    ; 9054: a9 3e       .>
+    jsr oswrch                                                        ; 9056: 20 ee ff     ..
+    jsr sub_cbaa4                                                     ; 9059: 20 a4 ba     ..
+; &905c referenced 1 time by &8fe3
+.c905c
+    ldx #&ff                                                          ; 905c: a2 ff       ..
+    txs                                                               ; 905e: 9a          .
+    jsr sub_cb2e0                                                     ; 905f: 20 e0 b2     ..
+    jsr sub_cbb1b                                                     ; 9062: 20 1b bb     ..
+    bcs c9048                                                         ; 9065: b0 e1       ..
+    bra c90e3                                                         ; 9067: 80 7a       .z
+; &9069 referenced 1 time by &90b7
+.c9069
+    jsr c9c80                                                         ; 9069: 20 80 9c     ..
+    ldx l000b                                                         ; 906c: a6 0b       ..
+    ldy l000c                                                         ; 906e: a4 0c       ..
+    jsr oscli                                                         ; 9070: 20 f7 ff     ..
+; &9073 referenced 2 times by &9084, &b788
+.c9073
+    lda #&0d                                                          ; 9073: a9 0d       ..
+    ldy l000a                                                         ; 9075: a4 0a       ..
+    dey                                                               ; 9077: 88          .
+; &9078 referenced 1 time by &907b
+.loop_c9078
+    iny                                                               ; 9078: c8          .
+    cmp (l000b),y                                                     ; 9079: d1 0b       ..
+    bne loop_c9078                                                    ; 907b: d0 fb       ..
+; &907d referenced 1 time by &9d0c
+.c907d
+    jsr c9c80                                                         ; 907d: 20 80 9c     ..
+    bra c9086                                                         ; 9080: 80 04       ..
+; &9082 referenced 1 time by &90ce
+.c9082
+    cmp #&0d                                                          ; 9082: c9 0d       ..
+    bne c9073                                                         ; 9084: d0 ed       ..
+; &9086 referenced 1 time by &9080
+.c9086
+    lda l000c                                                         ; 9086: a5 0c       ..
+    cmp #7                                                            ; 9088: c9 07       ..
+    beq c904b                                                         ; 908a: f0 bf       ..
+    ldy #1                                                            ; 908c: a0 01       ..
+    lda (l000b),y                                                     ; 908e: b1 0b       ..
+    bmi c904b                                                         ; 9090: 30 b9       0.
+    ldx l0020                                                         ; 9092: a6 20       .
+    beq c90a0                                                         ; 9094: f0 0a       ..
+    sta l002b                                                         ; 9096: 85 2b       .+
+    iny                                                               ; 9098: c8          .
+    lda (l000b),y                                                     ; 9099: b1 0b       ..
+    sta l002a                                                         ; 909b: 85 2a       .*
+    jsr sub_c9d0f                                                     ; 909d: 20 0f 9d     ..
+; &90a0 referenced 1 time by &9094
+.c90a0
+    ldy #4                                                            ; 90a0: a0 04       ..
+    sty l000a                                                         ; 90a2: 84 0a       ..
+    bra c90d2                                                         ; 90a4: 80 2c       .,
+; &90a6 referenced 1 time by &90bb
+.loop_c90a6
+    lda #3                                                            ; 90a6: a9 03       ..
+    sta l0028                                                         ; 90a8: 85 28       .(
+    jmp c89dd                                                         ; 90aa: 4c dd 89    L..
+
+; &90ad referenced 1 time by &90bf
+.loop_c90ad
+    jmp cbed3                                                         ; 90ad: 4c d3 be    L..
+
+; &90b0 referenced 1 time by &90f7
+.c90b0
+    ldy l000a                                                         ; 90b0: a4 0a       ..
+    dey                                                               ; 90b2: 88          .
+    lda (l000b),y                                                     ; 90b3: b1 0b       ..
+    cmp #&2a ; '*'                                                    ; 90b5: c9 2a       .*
+    beq c9069                                                         ; 90b7: f0 b0       ..
+    cmp #&5b ; '['                                                    ; 90b9: c9 5b       .[
+    beq loop_c90a6                                                    ; 90bb: f0 e9       ..
+    cmp #&a2                                                          ; 90bd: c9 a2       ..
+    beq loop_c90ad                                                    ; 90bf: f0 ec       ..
+    cmp #&3d ; '='                                                    ; 90c1: c9 3d       .=
+    beq c9123                                                         ; 90c3: f0 5e       .^
+; &90c5 referenced 6 times by &9288, &95c3, &97fb, &990c, &b626, &b9aa
+.c90c5
+    dec l000a                                                         ; 90c5: c6 0a       ..
+; &90c7 referenced 4 times by &924d, &97fe, &b844, &b874
+.c90c7
+    jsr c9c6a                                                         ; 90c7: 20 6a 9c     j.
+; &90ca referenced 11 times by &9121, &9144, &93c1, &9700, &97bd, &98c0, &b35c, &b74a, &b9a2, &ba60, &beeb
+.c90ca
+    lda (l000b)                                                       ; 90ca: b2 0b       ..
+    cmp #&3a ; ':'                                                    ; 90cc: c9 3a       .:
+    bne c9082                                                         ; 90ce: d0 b2       ..
+; &90d0 referenced 8 times by &89da, &90d8, &9ce8, &b0c7, &b5dc, &b6ce, &b766, &ba9d
+.c90d0
+    ldy l000a                                                         ; 90d0: a4 0a       ..
+; &90d2 referenced 1 time by &90a4
+.c90d2
+    inc l000a                                                         ; 90d2: e6 0a       ..
+    lda (l000b),y                                                     ; 90d4: b1 0b       ..
+    cmp #&20 ; ' '                                                    ; 90d6: c9 20       .
+    beq c90d0                                                         ; 90d8: f0 f6       ..
+    cmp #&cf                                                          ; 90da: c9 cf       ..
+    bcc c90ea                                                         ; 90dc: 90 0c       ..
+; &90de referenced 2 times by &90e8, &ad99
+.c90de
+    asl a                                                             ; 90de: 0a          .
+    tax                                                               ; 90df: aa          .
+    jmp (l880a,x)                                                     ; 90e0: 7c 0a 88    |..
+
+; &90e3 referenced 1 time by &9067
+.c90e3
+    jsr c8f9d                                                         ; 90e3: 20 9d 8f     ..
+    cmp #&c6                                                          ; 90e6: c9 c6       ..
+    bcs c90de                                                         ; 90e8: b0 f4       ..
+; &90ea referenced 1 time by &90dc
+.c90ea
+    ldx l000b                                                         ; 90ea: a6 0b       ..
+    stx l0019                                                         ; 90ec: 86 19       ..
+    ldx l000c                                                         ; 90ee: a6 0c       ..
+    stx l001a                                                         ; 90f0: 86 1a       ..
+    jsr sub_c99d6                                                     ; 90f2: 20 d6 99     ..
+    bne c9112                                                         ; 90f5: d0 1b       ..
+    bcs c90b0                                                         ; 90f7: b0 b7       ..
+    stx l001b                                                         ; 90f9: 86 1b       ..
+    jsr sub_c9c4a                                                     ; 90fb: 20 4a 9c     J.
+    jsr sub_c9923                                                     ; 90fe: 20 23 99     #.
+    ldx #5                                                            ; 9101: a2 05       ..
+    cpx l002c                                                         ; 9103: e4 2c       .,
+    bne c9108                                                         ; 9105: d0 01       ..
+    inx                                                               ; 9107: e8          .
+; &9108 referenced 1 time by &9105
+.c9108
+    jsr sub_c9952                                                     ; 9108: 20 52 99     R.
+    dec l000a                                                         ; 910b: c6 0a       ..
+.sub_c910d
+    jsr sub_c997d                                                     ; 910d: 20 7d 99     }.
+    beq c9146                                                         ; 9110: f0 34       .4
+; &9112 referenced 1 time by &90f5
+.c9112
+    bcc c9135                                                         ; 9112: 90 21       .!
+    jsr cbc66                                                         ; 9114: 20 66 bc     f.
+    jsr c9c16                                                         ; 9117: 20 16 9c     ..
+    lda l0027                                                         ; 911a: a5 27       .'
+    bne c9155                                                         ; 911c: d0 37       .7
+    jsr sub_c916e                                                     ; 911e: 20 6e 91     n.
+    bra c90ca                                                         ; 9121: 80 a7       ..
+; &9123 referenced 1 time by &90c3
+.c9123
+    tsx                                                               ; 9123: ba          .
+    cpx #&fc                                                          ; 9124: e0 fc       ..
+    bcs c914f                                                         ; 9126: b0 27       .'
+    lda l01ff                                                         ; 9128: ad ff 01    ...
+    cmp #&a4                                                          ; 912b: c9 a4       ..
+    bne c914f                                                         ; 912d: d0 20       .
+    jsr sub_c9df3                                                     ; 912f: 20 f3 9d     ..
+    jmp c9c55                                                         ; 9132: 4c 55 9c    LU.
+
+; &9135 referenced 1 time by &9112
+.c9135
+    lda l002a                                                         ; 9135: a5 2a       .*
+    pha                                                               ; 9137: 48          H
+    lda l002b                                                         ; 9138: a5 2b       .+
+    pha                                                               ; 913a: 48          H
+    lda l002c                                                         ; 913b: a5 2c       .,
+    pha                                                               ; 913d: 48          H
+    jsr c9c16                                                         ; 913e: 20 16 9c     ..
+    jsr sub_cb365                                                     ; 9141: 20 65 b3     e.
+    bra c90ca                                                         ; 9144: 80 84       ..
+; &9146 referenced 1 time by &9110
+.c9146
+    jmp c9c2d                                                         ; 9146: 4c 2d 9c    L-.
+
+.sub_c9149
+    jsr c9c6a                                                         ; 9149: 20 6a 9c     j.
+    brk                                                               ; 914c: 00          .
+
+    equb   0, &fa                                                     ; 914d: 00 fa       ..
+
+; &914f referenced 2 times by &9126, &912d
+.c914f
+    brk                                                               ; 914f: 00          .
+
+    equb 7                                                            ; 9150: 07          .
+    equs "No "                                                        ; 9151: 4e 6f 20    No
+    equb &a4                                                          ; 9154: a4          .
+
+; &9155 referenced 14 times by &8d71, &911c, &979c, &9cc9, &9d7c, &9f4c, &ab9d, &ac1c, &acfd, &ae56, &af88, &b35f, &b86c, &be73
+.c9155
+    brk                                                               ; 9155: 00          .
+
+    equb 6                                                            ; 9156: 06          .
+    equs "Type mismatch"                                              ; 9157: 54 79 70... Typ
+
+; &9164 referenced 3 times by &91bb, &9974, &bd74
+.c9164
+    brk                                                               ; 9164: 00          .
+
+    equb 0                                                            ; 9165: 00          .
+    equs "No room"                                                    ; 9166: 4e 6f 20... No
+    equb 0                                                            ; 916d: 00          .
+
+; &916e referenced 3 times by &911e, &b8b5, &b9ca
+.sub_c916e
+    jsr sub_cbd26                                                     ; 916e: 20 26 bd     &.
+; &9171 referenced 2 times by &b1b2, &b978
+.sub_c9171
+    lda l002c                                                         ; 9171: a5 2c       .,
+    cmp #&80                                                          ; 9173: c9 80       ..
+    beq c91ef                                                         ; 9175: f0 78       .x
+    ldy #2                                                            ; 9177: a0 02       ..
+    lda (l002a),y                                                     ; 9179: b1 2a       .*
+    cmp l0036                                                         ; 917b: c5 36       .6
+    bcs c91d1                                                         ; 917d: b0 52       .R
+    lda l0002                                                         ; 917f: a5 02       ..
+    sta l002c                                                         ; 9181: 85 2c       .,
+    lda l0003                                                         ; 9183: a5 03       ..
+    sta l002d                                                         ; 9185: 85 2d       .-
+    lda l0036                                                         ; 9187: a5 36       .6
+    cmp #8                                                            ; 9189: c9 08       ..
+    bcc c9193                                                         ; 918b: 90 06       ..
+    adc #7                                                            ; 918d: 69 07       i.
+    bcc c9193                                                         ; 918f: 90 02       ..
+    lda #&ff                                                          ; 9191: a9 ff       ..
+; &9193 referenced 2 times by &918b, &918f
+.c9193
+    clc                                                               ; 9193: 18          .
+    pha                                                               ; 9194: 48          H
+    tax                                                               ; 9195: aa          .
+    lda (l002a),y                                                     ; 9196: b1 2a       .*
+    adc (l002a)                                                       ; 9198: 72 2a       r*
+    eor l0002                                                         ; 919a: 45 02       E.
+    bne c91ad                                                         ; 919c: d0 0f       ..
+    dey                                                               ; 919e: 88          .
+    adc (l002a),y                                                     ; 919f: 71 2a       q*
+    eor l0003                                                         ; 91a1: 45 03       E.
+    bne c91ad                                                         ; 91a3: d0 08       ..
+    sta l002d                                                         ; 91a5: 85 2d       .-
+    txa                                                               ; 91a7: 8a          .
+    iny                                                               ; 91a8: c8          .
+    sec                                                               ; 91a9: 38          8
+    sbc (l002a),y                                                     ; 91aa: f1 2a       .*
+    tax                                                               ; 91ac: aa          .
+; &91ad referenced 2 times by &919c, &91a3
+.c91ad
+    txa                                                               ; 91ad: 8a          .
+    clc                                                               ; 91ae: 18          .
+    adc l0002                                                         ; 91af: 65 02       e.
+    tay                                                               ; 91b1: a8          .
+    lda l0003                                                         ; 91b2: a5 03       ..
+    adc #0                                                            ; 91b4: 69 00       i.
+    tax                                                               ; 91b6: aa          .
+    cpy l0004                                                         ; 91b7: c4 04       ..
+    sbc l0005                                                         ; 91b9: e5 05       ..
+    bcs c9164                                                         ; 91bb: b0 a7       ..
+    sty l0002                                                         ; 91bd: 84 02       ..
+    stx l0003                                                         ; 91bf: 86 03       ..
+    pla                                                               ; 91c1: 68          h
+    ldy #2                                                            ; 91c2: a0 02       ..
+    sta (l002a),y                                                     ; 91c4: 91 2a       .*
+    dey                                                               ; 91c6: 88          .
+    lda l002d                                                         ; 91c7: a5 2d       .-
+    beq c91d1                                                         ; 91c9: f0 06       ..
+    sta (l002a),y                                                     ; 91cb: 91 2a       .*
+    lda l002c                                                         ; 91cd: a5 2c       .,
+    sta (l002a)                                                       ; 91cf: 92 2a       .*
+; &91d1 referenced 2 times by &917d, &91c9
+.c91d1
+    ldy #3                                                            ; 91d1: a0 03       ..
+    lda l0036                                                         ; 91d3: a5 36       .6
+    sta (l002a),y                                                     ; 91d5: 91 2a       .*
+    beq c91ee                                                         ; 91d7: f0 15       ..
+    ldy #1                                                            ; 91d9: a0 01       ..
+    lda (l002a),y                                                     ; 91db: b1 2a       .*
+    sta l002d                                                         ; 91dd: 85 2d       .-
+    lda (l002a)                                                       ; 91df: b2 2a       .*
+    sta l002c                                                         ; 91e1: 85 2c       .,
+    dey                                                               ; 91e3: 88          .
+; &91e4 referenced 1 time by &91ec
+.loop_c91e4
+    lda l0600,y                                                       ; 91e4: b9 00 06    ...
+    sta (l002c),y                                                     ; 91e7: 91 2c       .,
+    iny                                                               ; 91e9: c8          .
+    cpy l0036                                                         ; 91ea: c4 36       .6
+    bne loop_c91e4                                                    ; 91ec: d0 f6       ..
+; &91ee referenced 1 time by &91d7
+.c91ee
+    rts                                                               ; 91ee: 60          `
+
+; &91ef referenced 1 time by &9175
+.c91ef
+    jsr sub_cbe6b                                                     ; 91ef: 20 6b be     k.
+    cpy #0                                                            ; 91f2: c0 00       ..
+    beq c9201                                                         ; 91f4: f0 0b       ..
+; &91f6 referenced 1 time by &91fc
+.loop_c91f6
+    lda l0600,y                                                       ; 91f6: b9 00 06    ...
+    sta (l002a),y                                                     ; 91f9: 91 2a       .*
+    dey                                                               ; 91fb: 88          .
+    bne loop_c91f6                                                    ; 91fc: d0 f8       ..
+    lda l0600                                                         ; 91fe: ad 00 06    ...
+; &9201 referenced 1 time by &91f4
+.c9201
+    sta (l002a)                                                       ; 9201: 92 2a       .*
+    rts                                                               ; 9203: 60          `
+
+; &9204 referenced 1 time by &9253
+.c9204
+    jsr sub_cba6c                                                     ; 9204: 20 6c ba     l.
+; &9207 referenced 4 times by &9228, &9235, &923d, &9248
+.c9207
+    phy                                                               ; 9207: 5a          Z
+    jsr sub_c8fa8                                                     ; 9208: 20 a8 8f     ..
+    bne c924a                                                         ; 920b: d0 3d       .=
+    jsr sub_c9dff                                                     ; 920d: 20 ff 9d     ..
+    jsr sub_ca545                                                     ; 9210: 20 45 a5     E.
+    ply                                                               ; 9213: 7a          z
+    lda l0027                                                         ; 9214: a5 27       .'
+    jsr osbput                                                        ; 9216: 20 d4 ff     ..
+    tax                                                               ; 9219: aa          .
+    beq c9237                                                         ; 921a: f0 1b       ..
+    bmi c922a                                                         ; 921c: 30 0c       0.
+    ldx #3                                                            ; 921e: a2 03       ..
+; &9220 referenced 1 time by &9226
+.loop_c9220
+    lda l002a,x                                                       ; 9220: b5 2a       .*
+    jsr osbput                                                        ; 9222: 20 d4 ff     ..
+    dex                                                               ; 9225: ca          .
+    bpl loop_c9220                                                    ; 9226: 10 f8       ..
+    bra c9207                                                         ; 9228: 80 dd       ..
+; &922a referenced 1 time by &921c
+.c922a
+    ldx #4                                                            ; 922a: a2 04       ..
+; &922c referenced 1 time by &9233
+.loop_c922c
+    lda l046c,x                                                       ; 922c: bd 6c 04    .l.
+    jsr osbput                                                        ; 922f: 20 d4 ff     ..
+    dex                                                               ; 9232: ca          .
+    bpl loop_c922c                                                    ; 9233: 10 f7       ..
+    bra c9207                                                         ; 9235: 80 d0       ..
+; &9237 referenced 1 time by &921a
+.c9237
+    lda l0036                                                         ; 9237: a5 36       .6
+    jsr osbput                                                        ; 9239: 20 d4 ff     ..
+    tax                                                               ; 923c: aa          .
+    beq c9207                                                         ; 923d: f0 c8       ..
+; &923f referenced 1 time by &9246
+.loop_c923f
+    lda l05ff,x                                                       ; 923f: bd ff 05    ...
+    jsr osbput                                                        ; 9242: 20 d4 ff     ..
+    dex                                                               ; 9245: ca          .
+    bne loop_c923f                                                    ; 9246: d0 f7       ..
+    bra c9207                                                         ; 9248: 80 bd       ..
+; &924a referenced 1 time by &920b
+.c924a
+    pla                                                               ; 924a: 68          h
+    sty l000a                                                         ; 924b: 84 0a       ..
+    jmp c90c7                                                         ; 924d: 4c c7 90    L..
+
+.sub_c9250
+    jsr sub_c8d9c                                                     ; 9250: 20 9c 8d     ..
+    beq c9204                                                         ; 9253: f0 af       ..
+    dec l000a                                                         ; 9255: c6 0a       ..
+    bra c926e                                                         ; 9257: 80 15       ..
+; &9259 referenced 1 time by &92a4
+.c9259
+    lda l0400                                                         ; 9259: ad 00 04    ...
+    beq c926e                                                         ; 925c: f0 10       ..
+    lda l001e                                                         ; 925e: a5 1e       ..
+; &9260 referenced 1 time by &9265
+.loop_c9260
+    beq c926e                                                         ; 9260: f0 0c       ..
+    sbc l0400                                                         ; 9262: ed 00 04    ...
+    bcs loop_c9260                                                    ; 9265: b0 f9       ..
+    tay                                                               ; 9267: a8          .
+; &9268 referenced 1 time by &926c
+.loop_c9268
+    jsr cbdd2                                                         ; 9268: 20 d2 bd     ..
+    iny                                                               ; 926b: c8          .
+    bne loop_c9268                                                    ; 926c: d0 fa       ..
+; &926e referenced 3 times by &9257, &925c, &9260
+.c926e
+    clc                                                               ; 926e: 18          .
+    lda l0400                                                         ; 926f: ad 00 04    ...
+    sta l0014                                                         ; 9272: 85 14       ..
+; &9274 referenced 1 time by &92a0
+.c9274
+    ror l0015                                                         ; 9274: 66 15       f.
+; &9276 referenced 3 times by &92ad, &92dc, &92eb
+.c9276
+    jsr c8f9d                                                         ; 9276: 20 9d 8f     ..
+    cmp #&3a ; ':'                                                    ; 9279: c9 3a       .:
+    beq c9285                                                         ; 927b: f0 08       ..
+    cmp #&0d                                                          ; 927d: c9 0d       ..
+    beq c9285                                                         ; 927f: f0 04       ..
+    cmp #&8b                                                          ; 9281: c9 8b       ..
+    bne c929e                                                         ; 9283: d0 19       ..
+; &9285 referenced 2 times by &927b, &927f
+.c9285
+    jsr sub_cbac2                                                     ; 9285: 20 c2 ba     ..
+; &9288 referenced 3 times by &9294, &9298, &929c
+.c9288
+    jmp c90c5                                                         ; 9288: 4c c5 90    L..
+
+; &928b referenced 1 time by &92a8
+.loop_c928b
+    stz l0014                                                         ; 928b: 64 14       d.
+    stz l0015                                                         ; 928d: 64 15       d.
+    jsr c8f9d                                                         ; 928f: 20 9d 8f     ..
+    cmp #&3a ; ':'                                                    ; 9292: c9 3a       .:
+    beq c9288                                                         ; 9294: f0 f2       ..
+    cmp #&0d                                                          ; 9296: c9 0d       ..
+    beq c9288                                                         ; 9298: f0 ee       ..
+    cmp #&8b                                                          ; 929a: c9 8b       ..
+    beq c9288                                                         ; 929c: f0 ea       ..
+; &929e referenced 1 time by &9283
+.c929e
+    cmp #&7e ; '~'                                                    ; 929e: c9 7e       .~
+    beq c9274                                                         ; 92a0: f0 d2       ..
+    cmp #&2c ; ','                                                    ; 92a2: c9 2c       .,
+    beq c9259                                                         ; 92a4: f0 b3       ..
+    cmp #&3b ; ';'                                                    ; 92a6: c9 3b       .;
+    beq loop_c928b                                                    ; 92a8: f0 e1       ..
+    jsr sub_c933d                                                     ; 92aa: 20 3d 93     =.
+    bcc c9276                                                         ; 92ad: 90 c7       ..
+    lda l0014                                                         ; 92af: a5 14       ..
+    pha                                                               ; 92b1: 48          H
+    lda l0015                                                         ; 92b2: a5 15       ..
+    pha                                                               ; 92b4: 48          H
+    dec l001b                                                         ; 92b5: c6 1b       ..
+    jsr sub_c9dff                                                     ; 92b7: 20 ff 9d     ..
+    pla                                                               ; 92ba: 68          h
+    sta l0015                                                         ; 92bb: 85 15       ..
+    pla                                                               ; 92bd: 68          h
+    sta l0014                                                         ; 92be: 85 14       ..
+    lda l001b                                                         ; 92c0: a5 1b       ..
+    sta l000a                                                         ; 92c2: 85 0a       ..
+    tya                                                               ; 92c4: 98          .
+    beq c92da                                                         ; 92c5: f0 13       ..
+    jsr sub_ca181                                                     ; 92c7: 20 81 a1     ..
+    lda l0014                                                         ; 92ca: a5 14       ..
+    sec                                                               ; 92cc: 38          8
+    sbc l0036                                                         ; 92cd: e5 36       .6
+    bcc c92da                                                         ; 92cf: 90 09       ..
+    beq c92da                                                         ; 92d1: f0 07       ..
+    tay                                                               ; 92d3: a8          .
+; &92d4 referenced 1 time by &92d8
+.loop_c92d4
+    jsr cbdd2                                                         ; 92d4: 20 d2 bd     ..
+    dey                                                               ; 92d7: 88          .
+    bne loop_c92d4                                                    ; 92d8: d0 fa       ..
+; &92da referenced 3 times by &92c5, &92cf, &92d1
+.c92da
+    lda l0036                                                         ; 92da: a5 36       .6
+    beq c9276                                                         ; 92dc: f0 98       ..
+    ldy #0                                                            ; 92de: a0 00       ..
+; &92e0 referenced 1 time by &92e9
+.loop_c92e0
+    lda l0600,y                                                       ; 92e0: b9 00 06    ...
+    jsr sub_cbdd8                                                     ; 92e3: 20 d8 bd     ..
+    iny                                                               ; 92e6: c8          .
+    cpy l0036                                                         ; 92e7: c4 36       .6
+    bne loop_c92e0                                                    ; 92e9: d0 f5       ..
+    bra c9276                                                         ; 92eb: 80 89       ..
+; &92ed referenced 1 time by &930e
+.c92ed
+    jmp c8fbb                                                         ; 92ed: 4c bb 8f    L..
+
+; &92f0 referenced 1 time by &930a
+.loop_c92f0
+    lda l002a                                                         ; 92f0: a5 2a       .*
+    pha                                                               ; 92f2: 48          H
+    jsr sub_c976c                                                     ; 92f3: 20 6c 97     l.
+    lda #&1f                                                          ; 92f6: a9 1f       ..
+    jsr oswrch                                                        ; 92f8: 20 ee ff     ..
+    pla                                                               ; 92fb: 68          h
+    jsr oswrch                                                        ; 92fc: 20 ee ff     ..
+    jsr sub_c990f                                                     ; 92ff: 20 0f 99     ..
+    bra c932d                                                         ; 9302: 80 29       .)
+; &9304 referenced 1 time by &934f
+.c9304
+    jsr sub_c9774                                                     ; 9304: 20 74 97     t.
+    jsr sub_c8fa8                                                     ; 9307: 20 a8 8f     ..
+    beq loop_c92f0                                                    ; 930a: f0 e4       ..
+    cmp #&29 ; ')'                                                    ; 930c: c9 29       .)
+    bne c92ed                                                         ; 930e: d0 dd       ..
+    lda l002a                                                         ; 9310: a5 2a       .*
+    sbc l001e                                                         ; 9312: e5 1e       ..
+    beq c932d                                                         ; 9314: f0 17       ..
+    tax                                                               ; 9316: aa          .
+    bcs c9325                                                         ; 9317: b0 0c       ..
+    jsr sub_cbac2                                                     ; 9319: 20 c2 ba     ..
+    bra c9321                                                         ; 931c: 80 03       ..
+; &931e referenced 1 time by &9353
+.c931e
+    jsr sub_c9779                                                     ; 931e: 20 79 97     y.
+; &9321 referenced 1 time by &931c
+.c9321
+    ldx l002a                                                         ; 9321: a6 2a       .*
+    beq c932d                                                         ; 9323: f0 08       ..
+; &9325 referenced 1 time by &9317
+.c9325
+    jsr cbdff                                                         ; 9325: 20 ff bd     ..
+    bra c932d                                                         ; 9328: 80 03       ..
+; &932a referenced 1 time by &934b
+.c932a
+    jsr sub_cbac2                                                     ; 932a: 20 c2 ba     ..
+; &932d referenced 5 times by &9302, &9314, &9323, &9328, &937a
+.c932d
+    clc                                                               ; 932d: 18          .
+    bra c9338                                                         ; 932e: 80 08       ..
+; &9330 referenced 3 times by &8c01, &8c31, &8cfd
+.sub_c9330
+    dec l000a                                                         ; 9330: c6 0a       ..
+; &9332 referenced 23 times by &8b67, &8baf, &8bc8, &8c62, &8c96, &8cb8, &8cc6, &8d16, &8d39, &8d65, &9651, &9718, &9810, &9824, &982e, &9880, &98ed, &b302, &b326, &b351, &b41b, &b794, &b85f
+.sub_c9332
+    jsr sub_c9df3                                                     ; 9332: 20 f3 9d     ..
+    jsr c9784                                                         ; 9335: 20 84 97     ..
+; &9338 referenced 8 times by &8aa3, &8d7f, &932e, &95bb, &b87c, &b88c, &b92a, &b9dc
+.c9338
+    ldy l001b                                                         ; 9338: a4 1b       ..
+    sty l000a                                                         ; 933a: 84 0a       ..
+    rts                                                               ; 933c: 60          `
+
+; &933d referenced 2 times by &92aa, &935f
+.sub_c933d
+    ldx l000b                                                         ; 933d: a6 0b       ..
+    stx l0019                                                         ; 933f: 86 19       ..
+    ldx l000c                                                         ; 9341: a6 0c       ..
+    stx l001a                                                         ; 9343: 86 1a       ..
+    ldx l000a                                                         ; 9345: a6 0a       ..
+    stx l001b                                                         ; 9347: 86 1b       ..
+    cmp #&27 ; '''                                                    ; 9349: c9 27       .'
+    beq c932a                                                         ; 934b: f0 dd       ..
+    cmp #&8a                                                          ; 934d: c9 8a       ..
+    beq c9304                                                         ; 934f: f0 b3       ..
+    cmp #&89                                                          ; 9351: c9 89       ..
+    beq c931e                                                         ; 9353: f0 c9       ..
+; &9355 referenced 1 time by &9366
+.loop_c9355
+    sec                                                               ; 9355: 38          8
+; &9356 referenced 1 time by &9362
+.loop_c9356
+    rts                                                               ; 9356: 60          `
+
+; &9357 referenced 2 times by &936d, &ad75
+.c9357
+    brk                                                               ; 9357: 00          .
+
+    equb   9, &8d, &22,   0                                           ; 9358: 09 8d 22... .."
+
+; &935c referenced 2 times by &b8fa, &b8ff
+.sub_c935c
+    jsr c8f9d                                                         ; 935c: 20 9d 8f     ..
+    jsr sub_c933d                                                     ; 935f: 20 3d 93     =.
+    bcc loop_c9356                                                    ; 9362: 90 f2       ..
+    cmp #&22 ; '"'                                                    ; 9364: c9 22       ."
+    bne loop_c9355                                                    ; 9366: d0 ed       ..
+; &9368 referenced 1 time by &937f
+.loop_c9368
+    iny                                                               ; 9368: c8          .
+    lda (l0019),y                                                     ; 9369: b1 19       ..
+    cmp #&0d                                                          ; 936b: c9 0d       ..
+    beq c9357                                                         ; 936d: f0 e8       ..
+    cmp #&22 ; '"'                                                    ; 936f: c9 22       ."
+    bne c937c                                                         ; 9371: d0 09       ..
+    iny                                                               ; 9373: c8          .
+    sty l001b                                                         ; 9374: 84 1b       ..
+    lda (l0019),y                                                     ; 9376: b1 19       ..
+    cmp #&22 ; '"'                                                    ; 9378: c9 22       ."
+    bne c932d                                                         ; 937a: d0 b1       ..
+; &937c referenced 1 time by &9371
+.c937c
+    jsr sub_cbdd8                                                     ; 937c: 20 d8 bd     ..
+    bra loop_c9368                                                    ; 937f: 80 e7       ..
+.sub_c9381
+    jsr sub_c9df3                                                     ; 9381: 20 f3 9d     ..
+    jsr sub_c9781                                                     ; 9384: 20 81 97     ..
+    jsr cbc66                                                         ; 9387: 20 66 bc     f.
+    stz l0600                                                         ; 938a: 9c 00 06    ...
+    ldy #0                                                            ; 938d: a0 00       ..
+; &938f referenced 1 time by &93b2
+.c938f
+    phy                                                               ; 938f: 5a          Z
+    jsr sub_c8fa8                                                     ; 9390: 20 a8 8f     ..
+    bne c93b4                                                         ; 9393: d0 1f       ..
+    ldy l001b                                                         ; 9395: a4 1b       ..
+    jsr sub_c99d0                                                     ; 9397: 20 d0 99     ..
+    beq c93c4                                                         ; 939a: f0 28       .(
+    ply                                                               ; 939c: 7a          z
+    iny                                                               ; 939d: c8          .
+    lda l002a                                                         ; 939e: a5 2a       .*
+    sta l0600,y                                                       ; 93a0: 99 00 06    ...
+    iny                                                               ; 93a3: c8          .
+    lda l002b                                                         ; 93a4: a5 2b       .+
+    sta l0600,y                                                       ; 93a6: 99 00 06    ...
+    iny                                                               ; 93a9: c8          .
+    lda l002c                                                         ; 93aa: a5 2c       .,
+    sta l0600,y                                                       ; 93ac: 99 00 06    ...
+    inc l0600                                                         ; 93af: ee 00 06    ...
+    bra c938f                                                         ; 93b2: 80 db       ..
+; &93b4 referenced 1 time by &9393
+.c93b4
+    ply                                                               ; 93b4: 7a          z
+    dec l001b                                                         ; 93b5: c6 1b       ..
+    jsr sub_c9c5a                                                     ; 93b7: 20 5a 9c     Z.
+    jsr sub_cbd26                                                     ; 93ba: 20 26 bd     &.
+    jsr sub_c93c7                                                     ; 93bd: 20 c7 93     ..
+    cld                                                               ; 93c0: d8          .
+    jmp c90ca                                                         ; 93c1: 4c ca 90    L..
+
+; &93c4 referenced 1 time by &939a
+.c93c4
+    jmp cadce                                                         ; 93c4: 4c ce ad    L..
+
+; &93c7 referenced 2 times by &93bd, &ab04
+.sub_c93c7
+    lda l040c                                                         ; 93c7: ad 0c 04    ...
+    lsr a                                                             ; 93ca: 4a          J
+    lda l0404                                                         ; 93cb: ad 04 04    ...
+    ldx l0460                                                         ; 93ce: ae 60 04    .`.
+    ldy l0464                                                         ; 93d1: ac 64 04    .d.
+    jmp (l002a)                                                       ; 93d4: 6c 2a 00    l*.
+
+; &93d7 referenced 3 times by &93dd, &93e5, &93ea
+.c93d7
+    jmp c9c2d                                                         ; 93d7: 4c 2d 9c    L-.
+
+.sub_c93da
+    jsr sub_c9be2                                                     ; 93da: 20 e2 9b     ..
+    bcc c93d7                                                         ; 93dd: 90 f8       ..
+    jsr cbc66                                                         ; 93df: 20 66 bc     f.
+    jsr sub_c8da2                                                     ; 93e2: 20 a2 8d     ..
+    bne c93d7                                                         ; 93e5: d0 f0       ..
+    jsr sub_c9be2                                                     ; 93e7: 20 e2 9b     ..
+    bcc c93d7                                                         ; 93ea: 90 eb       ..
+    jsr c9c6a                                                         ; 93ec: 20 6a 9c     j.
+    lda l002a                                                         ; 93ef: a5 2a       .*
+    sta l0039                                                         ; 93f1: 85 39       .9
+    lda l002b                                                         ; 93f3: a5 2b       .+
+    sta l003a                                                         ; 93f5: 85 3a       .:
+    jsr sub_cbd26                                                     ; 93f7: 20 26 bd     &.
+; &93fa referenced 1 time by &940b
+.loop_c93fa
+    jsr sub_cbac8                                                     ; 93fa: 20 c8 ba     ..
+    jsr sub_c9c8e                                                     ; 93fd: 20 8e 9c     ..
+    jsr sub_cbf2f                                                     ; 9400: 20 2f bf     /.
+    lda l0039                                                         ; 9403: a5 39       .9
+    cmp l002a                                                         ; 9405: c5 2a       .*
+    lda l003a                                                         ; 9407: a5 3a       .:
+    sbc l002b                                                         ; 9409: e5 2b       .+
+    bcs loop_c93fa                                                    ; 940b: b0 ed       ..
+    jmp c9048                                                         ; 940d: 4c 48 90    LH.
+
+; &9410 referenced 2 times by &9447, &954c
+.sub_c9410
+    lda #&0a                                                          ; 9410: a9 0a       ..
+    jsr cae60                                                         ; 9412: 20 60 ae     `.
+    jsr sub_c9be2                                                     ; 9415: 20 e2 9b     ..
+    jsr cbc66                                                         ; 9418: 20 66 bc     f.
+    lda #&0a                                                          ; 941b: a9 0a       ..
+    jsr cae60                                                         ; 941d: 20 60 ae     `.
+    jsr sub_c8da2                                                     ; 9420: 20 a2 8d     ..
+    bne c9433                                                         ; 9423: d0 0e       ..
+    jsr sub_c9be2                                                     ; 9425: 20 e2 9b     ..
+    lda l002b                                                         ; 9428: a5 2b       .+
+    bne c947f                                                         ; 942a: d0 53       .S
+    lda l002a                                                         ; 942c: a5 2a       .*
+    beq c947f                                                         ; 942e: f0 4f       .O
+    jmp c9c6a                                                         ; 9430: 4c 6a 9c    Lj.
+
+; &9433 referenced 1 time by &9423
+.c9433
+    jmp c9c74                                                         ; 9433: 4c 74 9c    Lt.
+
+; &9436 referenced 2 times by &9452, &94e1
+.sub_c9436
+    lda l0012                                                         ; 9436: a5 12       ..
+    sta l003b                                                         ; 9438: 85 3b       .;
+    lda l0013                                                         ; 943a: a5 13       ..
+    sta l003c                                                         ; 943c: 85 3c       .<
+; &943e referenced 1 time by &9487
+.sub_c943e
+    lda l0018                                                         ; 943e: a5 18       ..
+    sta l0038                                                         ; 9440: 85 38       .8
+    ldy #1                                                            ; 9442: a0 01       ..
+    sty l0037                                                         ; 9444: 84 37       .7
+    rts                                                               ; 9446: 60          `
+
+.sub_c9447
+    jsr sub_c9410                                                     ; 9447: 20 10 94     ..
+    ldx #&39 ; '9'                                                    ; 944a: a2 39       .9
+    jsr sub_cbd48                                                     ; 944c: 20 48 bd     H.
+    jsr sub_cbe25                                                     ; 944f: 20 25 be     %.
+    jsr sub_c9436                                                     ; 9452: 20 36 94     6.
+; &9455 referenced 1 time by &9474
+.loop_c9455
+    lda (l0037)                                                       ; 9455: b2 37       .7
+    bmi c9487                                                         ; 9457: 30 2e       0.
+    sta (l003b)                                                       ; 9459: 92 3b       .;
+    lda (l0037),y                                                     ; 945b: b1 37       .7
+    sta (l003b),y                                                     ; 945d: 91 3b       .;
+    sec                                                               ; 945f: 38          8
+    tya                                                               ; 9460: 98          .
+    adc l003b                                                         ; 9461: 65 3b       e;
+    sta l003b                                                         ; 9463: 85 3b       .;
+    bcc c9469                                                         ; 9465: 90 02       ..
+    inc l003c                                                         ; 9467: e6 3c       .<
+; &9469 referenced 1 time by &9465
+.c9469
+    cmp l0006                                                         ; 9469: c5 06       ..
+    lda l003c                                                         ; 946b: a5 3c       .<
+    sbc l0007                                                         ; 946d: e5 07       ..
+    bcs c9476                                                         ; 946f: b0 05       ..
+    jsr sub_c953d                                                     ; 9471: 20 3d 95     =.
+    bra loop_c9455                                                    ; 9474: 80 df       ..
+; &9476 referenced 1 time by &946f
+.c9476
+    brk                                                               ; 9476: 00          .
+
+    equb   0, &cc                                                     ; 9477: 00 cc       ..
+    equs " space"                                                     ; 9479: 20 73 70...  sp
+
+; &947f referenced 2 times by &942a, &942e
+.c947f
+    brk                                                               ; 947f: 00          .
+
+    equb 0                                                            ; 9480: 00          .
+    equs "Silly"                                                      ; 9481: 53 69 6c... Sil
+    equb 0                                                            ; 9486: 00          .
+
+; &9487 referenced 1 time by &9457
+.c9487
+    jsr sub_c943e                                                     ; 9487: 20 3e 94     >.
+; &948a referenced 1 time by &94a8
+.loop_c948a
+    lda (l0037)                                                       ; 948a: b2 37       .7
+    bmi c94aa                                                         ; 948c: 30 1c       0.
+    lda l003a                                                         ; 948e: a5 3a       .:
+    sta (l0037)                                                       ; 9490: 92 37       .7
+    lda l0039                                                         ; 9492: a5 39       .9
+    sta (l0037),y                                                     ; 9494: 91 37       .7
+    clc                                                               ; 9496: 18          .
+    lda l0039                                                         ; 9497: a5 39       .9
+    adc l002a                                                         ; 9499: 65 2a       e*
+    sta l0039                                                         ; 949b: 85 39       .9
+    lda #0                                                            ; 949d: a9 00       ..
+    adc l003a                                                         ; 949f: 65 3a       e:
+    and #&7f                                                          ; 94a1: 29 7f       ).
+    sta l003a                                                         ; 94a3: 85 3a       .:
+    jsr sub_c953d                                                     ; 94a5: 20 3d 95     =.
+    bra loop_c948a                                                    ; 94a8: 80 e0       ..
+; &94aa referenced 1 time by &948c
+.c94aa
+    lda l0018                                                         ; 94aa: a5 18       ..
+    sta l000c                                                         ; 94ac: 85 0c       ..
+    stz l000b                                                         ; 94ae: 64 0b       d.
+; &94b0 referenced 1 time by &94dc
+.c94b0
+    ldy #1                                                            ; 94b0: a0 01       ..
+    lda (l000b),y                                                     ; 94b2: b1 0b       ..
+    bmi c951d                                                         ; 94b4: 30 67       0g
+    ldy #4                                                            ; 94b6: a0 04       ..
+    stz l002c                                                         ; 94b8: 64 2c       d,
+; &94ba referenced 2 times by &94d3, &950b
+.c94ba
+    lda (l000b),y                                                     ; 94ba: b1 0b       ..
+    ldx l002c                                                         ; 94bc: a6 2c       .,
+    bne c94c8                                                         ; 94be: d0 08       ..
+    cmp #&8d                                                          ; 94c0: c9 8d       ..
+    beq c94de                                                         ; 94c2: f0 1a       ..
+    cmp #&f4                                                          ; 94c4: c9 f4       ..
+    beq c94d5                                                         ; 94c6: f0 0d       ..
+; &94c8 referenced 1 time by &94be
+.c94c8
+    iny                                                               ; 94c8: c8          .
+    cmp #&22 ; '"'                                                    ; 94c9: c9 22       ."
+    bne c94d1                                                         ; 94cb: d0 04       ..
+    eor l002c                                                         ; 94cd: 45 2c       E,
+    sta l002c                                                         ; 94cf: 85 2c       .,
+; &94d1 referenced 1 time by &94cb
+.c94d1
+    cmp #&0d                                                          ; 94d1: c9 0d       ..
+    bne c94ba                                                         ; 94d3: d0 e5       ..
+; &94d5 referenced 1 time by &94c6
+.c94d5
+    ldy #3                                                            ; 94d5: a0 03       ..
+    lda (l000b),y                                                     ; 94d7: b1 0b       ..
+    jsr sub_c9cb8                                                     ; 94d9: 20 b8 9c     ..
+    bra c94b0                                                         ; 94dc: 80 d2       ..
+; &94de referenced 1 time by &94c2
+.c94de
+    jsr sub_c9bee                                                     ; 94de: 20 ee 9b     ..
+    jsr sub_c9436                                                     ; 94e1: 20 36 94     6.
+; &94e4 referenced 2 times by &9517, &951b
+.c94e4
+    lda (l0037)                                                       ; 94e4: b2 37       .7
+    bmi c951f                                                         ; 94e6: 30 37       07
+    lda (l003b)                                                       ; 94e8: b2 3b       .;
+    cmp l002b                                                         ; 94ea: c5 2b       .+
+    bne c950d                                                         ; 94ec: d0 1f       ..
+    lda (l003b),y                                                     ; 94ee: b1 3b       .;
+    cmp l002a                                                         ; 94f0: c5 2a       .*
+    bne c950d                                                         ; 94f2: d0 19       ..
+    lda (l0037),y                                                     ; 94f4: b1 37       .7
+    sta l003d                                                         ; 94f6: 85 3d       .=
+    lda (l0037)                                                       ; 94f8: b2 37       .7
+    tax                                                               ; 94fa: aa          .
+    ldy l000a                                                         ; 94fb: a4 0a       ..
+    dey                                                               ; 94fd: 88          .
+    lda l000b                                                         ; 94fe: a5 0b       ..
+    sta l0039                                                         ; 9500: 85 39       .9
+    lda l000c                                                         ; 9502: a5 0c       ..
+    sta l003a                                                         ; 9504: 85 3a       .:
+    jsr sub_c8e1f                                                     ; 9506: 20 1f 8e     ..
+; &9509 referenced 1 time by &953b
+.c9509
+    ldy l000a                                                         ; 9509: a4 0a       ..
+    bra c94ba                                                         ; 950b: 80 ad       ..
+; &950d referenced 2 times by &94ec, &94f2
+.c950d
+    clc                                                               ; 950d: 18          .
+    jsr sub_c953d                                                     ; 950e: 20 3d 95     =.
+    lda l003b                                                         ; 9511: a5 3b       .;
+    adc #2                                                            ; 9513: 69 02       i.
+    sta l003b                                                         ; 9515: 85 3b       .;
+    bcc c94e4                                                         ; 9517: 90 cb       ..
+    inc l003c                                                         ; 9519: e6 3c       .<
+    bra c94e4                                                         ; 951b: 80 c7       ..
+; &951d referenced 1 time by &94b4
+.c951d
+    bra c9579                                                         ; 951d: 80 5a       .Z
+; &951f referenced 1 time by &94e6
+.c951f
+    jsr sub_cbf0f                                                     ; 951f: 20 0f bf     ..
+    lsr l0061                                                         ; 9522: 46 61       Fa
+    adc #&6c ; 'l'                                                    ; 9524: 69 6c       il
+    adc l0064                                                         ; 9526: 65 64       ed
+    jsr l7461                                                         ; 9528: 20 61 74     at
+    jsr l0bb1                                                         ; 952b: 20 b1 0b     ..
+    sta l002b                                                         ; 952e: 85 2b       .+
+    iny                                                               ; 9530: c8          .
+    lda (l000b),y                                                     ; 9531: b1 0b       ..
+    sta l002a                                                         ; 9533: 85 2a       .*
+    jsr sub_ca0e8                                                     ; 9535: 20 e8 a0     ..
+    jsr sub_cbac2                                                     ; 9538: 20 c2 ba     ..
+    bra c9509                                                         ; 953b: 80 cc       ..
+; &953d referenced 3 times by &9471, &94a5, &950e
+.sub_c953d
+    iny                                                               ; 953d: c8          .
+    lda (l0037),y                                                     ; 953e: b1 37       .7
+    ldy #1                                                            ; 9540: a0 01       ..
+    adc l0037                                                         ; 9542: 65 37       e7
+    sta l0037                                                         ; 9544: 85 37       .7
+    bcc c954b                                                         ; 9546: 90 03       ..
+    inc l0038                                                         ; 9548: e6 38       .8
+    clc                                                               ; 954a: 18          .
+; &954b referenced 1 time by &9546
+.c954b
+    rts                                                               ; 954b: 60          `
+
+.sub_c954c
+    jsr sub_c9410                                                     ; 954c: 20 10 94     ..
+    lda l002a                                                         ; 954f: a5 2a       .*
+    pha                                                               ; 9551: 48          H
+    jsr sub_cbd26                                                     ; 9552: 20 26 bd     &.
+; &9555 referenced 2 times by &9573, &9577
+.c9555
+    jsr cbc66                                                         ; 9555: 20 66 bc     f.
+    jsr sub_ca0ec                                                     ; 9558: 20 ec a0     ..
+    jsr sub_cbaa4                                                     ; 955b: 20 a4 ba     ..
+    jsr sub_cbd26                                                     ; 955e: 20 26 bd     &.
+    jsr sub_c8ea4                                                     ; 9561: 20 a4 8e     ..
+    ldy #0                                                            ; 9564: a0 00       ..
+    jsr sub_cbb38                                                     ; 9566: 20 38 bb     8.
+    jsr sub_cbbdc                                                     ; 9569: 20 dc bb     ..
+    pla                                                               ; 956c: 68          h
+    pha                                                               ; 956d: 48          H
+    clc                                                               ; 956e: 18          .
+    adc l002a                                                         ; 956f: 65 2a       e*
+    sta l002a                                                         ; 9571: 85 2a       .*
+    bcc c9555                                                         ; 9573: 90 e0       ..
+    inc l002b                                                         ; 9575: e6 2b       .+
+    bpl c9555                                                         ; 9577: 10 dc       ..
+; &9579 referenced 1 time by &951d
+.c9579
+    jmp c9048                                                         ; 9579: 4c 48 90    LH.
+
+; &957c referenced 1 time by &95a6
+.c957c
+    jmp c96ca                                                         ; 957c: 4c ca 96    L..
+
+; &957f referenced 1 time by &9632
+.c957f
+    dec l000a                                                         ; 957f: c6 0a       ..
+    jsr sub_c997d                                                     ; 9581: 20 7d 99     }.
+    beq c95f1                                                         ; 9584: f0 6b       .k
+    bcs c95f1                                                         ; 9586: b0 69       .i
+    jsr sub_cbc83                                                     ; 9588: 20 83 bc     ..
+    jsr sub_c9774                                                     ; 958b: 20 74 97     t.
+    jsr sub_cbf2f                                                     ; 958e: 20 2f bf     /.
+    lda l002d                                                         ; 9591: a5 2d       .-
+    ora l002c                                                         ; 9593: 05 2c       .,
+    bne c95f1                                                         ; 9595: d0 5a       .Z
+    clc                                                               ; 9597: 18          .
+    lda l002a                                                         ; 9598: a5 2a       .*
+    adc l0002                                                         ; 959a: 65 02       e.
+    tay                                                               ; 959c: a8          .
+    lda l002b                                                         ; 959d: a5 2b       .+
+    adc l0003                                                         ; 959f: 65 03       e.
+    tax                                                               ; 95a1: aa          .
+    cpy l0004                                                         ; 95a2: c4 04       ..
+    sbc l0005                                                         ; 95a4: e5 05       ..
+    bcs c957c                                                         ; 95a6: b0 d4       ..
+    lda l0002                                                         ; 95a8: a5 02       ..
+    sta l002a                                                         ; 95aa: 85 2a       .*
+    lda l0003                                                         ; 95ac: a5 03       ..
+    sta l002b                                                         ; 95ae: 85 2b       .+
+    sty l0002                                                         ; 95b0: 84 02       ..
+    stx l0003                                                         ; 95b2: 86 03       ..
+    lda #&40 ; '@'                                                    ; 95b4: a9 40       .@
+    sta l0027                                                         ; 95b6: 85 27       .'
+    jsr sub_cb365                                                     ; 95b8: 20 65 b3     e.
+    jsr c9338                                                         ; 95bb: 20 38 93     8.
+; &95be referenced 1 time by &96c7
+.c95be
+    jsr sub_c8da2                                                     ; 95be: 20 a2 8d     ..
+    beq c95f9                                                         ; 95c1: f0 36       .6
+    jmp c90c5                                                         ; 95c3: 4c c5 90    L..
+
+; &95c6 referenced 1 time by &966d
+.sub_c95c6
+    ldx #&3f ; '?'                                                    ; 95c6: a2 3f       .?
+    jsr sub_cbd48                                                     ; 95c8: 20 48 bd     H.
+; &95cb referenced 2 times by &9680, &9b1b
+.sub_c95cb
+    ldx #0                                                            ; 95cb: a2 00       ..
+    ldy #0                                                            ; 95cd: a0 00       ..
+; &95cf referenced 1 time by &95ea
+.loop_c95cf
+    lsr l0040                                                         ; 95cf: 46 40       F@
+    ror l003f                                                         ; 95d1: 66 3f       f?
+    bcc c95e0                                                         ; 95d3: 90 0b       ..
+    clc                                                               ; 95d5: 18          .
+    tya                                                               ; 95d6: 98          .
+    adc l002a                                                         ; 95d7: 65 2a       e*
+    tay                                                               ; 95d9: a8          .
+    txa                                                               ; 95da: 8a          .
+    adc l002b                                                         ; 95db: 65 2b       e+
+    tax                                                               ; 95dd: aa          .
+    bcs c95f1                                                         ; 95de: b0 11       ..
+; &95e0 referenced 1 time by &95d3
+.c95e0
+    asl l002a                                                         ; 95e0: 06 2a       .*
+    rol l002b                                                         ; 95e2: 26 2b       &+
+    bcs c95f1                                                         ; 95e4: b0 0b       ..
+    lda l003f                                                         ; 95e6: a5 3f       .?
+    ora l0040                                                         ; 95e8: 05 40       .@
+    bne loop_c95cf                                                    ; 95ea: d0 e3       ..
+    sty l002a                                                         ; 95ec: 84 2a       .*
+    stx l002b                                                         ; 95ee: 86 2b       .+
+    rts                                                               ; 95f0: 60          `
+
+; &95f1 referenced 8 times by &9584, &9586, &9595, &95de, &95e4, &961a, &963b, &965c
+.c95f1
+    brk                                                               ; 95f1: 00          .
+
+    equb &0a                                                          ; 95f2: 0a          .
+    equs "Bad "                                                       ; 95f3: 42 61 64... Bad
+    equb &de,   0                                                     ; 95f7: de 00       ..
+
+; &95f9 referenced 1 time by &95c1
+.c95f9
+    jsr c8f9d                                                         ; 95f9: 20 9d 8f     ..
+    tya                                                               ; 95fc: 98          .
+    clc                                                               ; 95fd: 18          .
+    adc l000b                                                         ; 95fe: 65 0b       e.
+    ldx l000c                                                         ; 9600: a6 0c       ..
+    bcc c9606                                                         ; 9602: 90 02       ..
+    inx                                                               ; 9604: e8          .
+    clc                                                               ; 9605: 18          .
+; &9606 referenced 1 time by &9602
+.c9606
+    sbc #0                                                            ; 9606: e9 00       ..
+    sta l0037                                                         ; 9608: 85 37       .7
+    txa                                                               ; 960a: 8a          .
+    sbc #0                                                            ; 960b: e9 00       ..
+    sta l0038                                                         ; 960d: 85 38       .8
+    ldx #5                                                            ; 960f: a2 05       ..
+    stx l003f                                                         ; 9611: 86 3f       .?
+    ldx l000a                                                         ; 9613: a6 0a       ..
+    jsr sub_c9bba                                                     ; 9615: 20 ba 9b     ..
+    cpy #1                                                            ; 9618: c0 01       ..
+    beq c95f1                                                         ; 961a: f0 d5       ..
+    cmp #&28 ; '('                                                    ; 961c: c9 28       .(
+    beq c9635                                                         ; 961e: f0 15       ..
+    cmp #&24 ; '$'                                                    ; 9620: c9 24       .$
+    beq c9628                                                         ; 9622: f0 04       ..
+    cmp #&25 ; '%'                                                    ; 9624: c9 25       .%
+    bne c9632                                                         ; 9626: d0 0a       ..
+; &9628 referenced 1 time by &9622
+.c9628
+    dec l003f                                                         ; 9628: c6 3f       .?
+    iny                                                               ; 962a: c8          .
+    inx                                                               ; 962b: e8          .
+    lda (l0037),y                                                     ; 962c: b1 37       .7
+    cmp #&28 ; '('                                                    ; 962e: c9 28       .(
+    beq c9635                                                         ; 9630: f0 03       ..
+; &9632 referenced 1 time by &9626
+.c9632
+    jmp c957f                                                         ; 9632: 4c 7f 95    L..
+
+; &9635 referenced 2 times by &961e, &9630
+.c9635
+    iny                                                               ; 9635: c8          .
+    stx l000a                                                         ; 9636: 86 0a       ..
+    jsr sub_c8149                                                     ; 9638: 20 49 81     I.
+; &963b referenced 1 time by &9677
+.c963b
+    bne c95f1                                                         ; 963b: d0 b4       ..
+    jsr sub_c9923                                                     ; 963d: 20 23 99     #.
+    ldx #1                                                            ; 9640: a2 01       ..
+    jsr sub_c9952                                                     ; 9642: 20 52 99     R.
+    lda l003f                                                         ; 9645: a5 3f       .?
+    pha                                                               ; 9647: 48          H
+    lda #1                                                            ; 9648: a9 01       ..
+    pha                                                               ; 964a: 48          H
+    jsr cae60                                                         ; 964b: 20 60 ae     `.
+; &964e referenced 1 time by &9673
+.c964e
+    jsr cbc66                                                         ; 964e: 20 66 bc     f.
+    jsr sub_c9332                                                     ; 9651: 20 32 93     2.
+    lda l002b                                                         ; 9654: a5 2b       .+
+    and #&c0                                                          ; 9656: 29 c0       ).
+    ora l002c                                                         ; 9658: 05 2c       .,
+    ora l002d                                                         ; 965a: 05 2d       .-
+    bne c95f1                                                         ; 965c: d0 93       ..
+    jsr sub_cbf2f                                                     ; 965e: 20 2f bf     /.
+    ply                                                               ; 9661: 7a          z
+    lda l002a                                                         ; 9662: a5 2a       .*
+    sta (l0002),y                                                     ; 9664: 91 02       ..
+    iny                                                               ; 9666: c8          .
+    lda l002b                                                         ; 9667: a5 2b       .+
+    sta (l0002),y                                                     ; 9669: 91 02       ..
+    iny                                                               ; 966b: c8          .
+    phy                                                               ; 966c: 5a          Z
+    jsr sub_c95c6                                                     ; 966d: 20 c6 95     ..
+    jsr sub_c8da2                                                     ; 9670: 20 a2 8d     ..
+    beq c964e                                                         ; 9673: f0 d9       ..
+    cmp #&29 ; ')'                                                    ; 9675: c9 29       .)
+    bne c963b                                                         ; 9677: d0 c2       ..
+    plx                                                               ; 9679: fa          .
+    pla                                                               ; 967a: 68          h
+    phx                                                               ; 967b: da          .
+    sta l003f                                                         ; 967c: 85 3f       .?
+    stz l0040                                                         ; 967e: 64 40       d@
+    jsr sub_c95cb                                                     ; 9680: 20 cb 95     ..
+    pla                                                               ; 9683: 68          h
+    pha                                                               ; 9684: 48          H
+    adc l002a                                                         ; 9685: 65 2a       e*
+    sta l002a                                                         ; 9687: 85 2a       .*
+    bcc c968d                                                         ; 9689: 90 02       ..
+    inc l002b                                                         ; 968b: e6 2b       .+
+; &968d referenced 1 time by &9689
+.c968d
+    lda l0003                                                         ; 968d: a5 03       ..
+    sta l0038                                                         ; 968f: 85 38       .8
+    lda l0002                                                         ; 9691: a5 02       ..
+    sta l0037                                                         ; 9693: 85 37       .7
+    clc                                                               ; 9695: 18          .
+    adc l002a                                                         ; 9696: 65 2a       e*
+    tay                                                               ; 9698: a8          .
+    lda l002b                                                         ; 9699: a5 2b       .+
+    adc l0003                                                         ; 969b: 65 03       e.
+    bcs c96ca                                                         ; 969d: b0 2b       .+
+    tax                                                               ; 969f: aa          .
+    cpy l0004                                                         ; 96a0: c4 04       ..
+    sbc l0005                                                         ; 96a2: e5 05       ..
+    bcs c96ca                                                         ; 96a4: b0 24       .$
+    sty l0002                                                         ; 96a6: 84 02       ..
+    stx l0003                                                         ; 96a8: 86 03       ..
+    pla                                                               ; 96aa: 68          h
+    sta (l0037)                                                       ; 96ab: 92 37       .7
+    adc l0037                                                         ; 96ad: 65 37       e7
+    tay                                                               ; 96af: a8          .
+    lda #0                                                            ; 96b0: a9 00       ..
+    stz l0037                                                         ; 96b2: 64 37       d7
+    bcc c96b8                                                         ; 96b4: 90 02       ..
+    inc l0038                                                         ; 96b6: e6 38       .8
+; &96b8 referenced 3 times by &96b4, &96c1, &96c5
+.c96b8
+    sta (l0037),y                                                     ; 96b8: 91 37       .7
+    iny                                                               ; 96ba: c8          .
+    bne c96bf                                                         ; 96bb: d0 02       ..
+    inc l0038                                                         ; 96bd: e6 38       .8
+; &96bf referenced 1 time by &96bb
+.c96bf
+    cpy l0002                                                         ; 96bf: c4 02       ..
+    bne c96b8                                                         ; 96c1: d0 f5       ..
+    cpx l0038                                                         ; 96c3: e4 38       .8
+    bne c96b8                                                         ; 96c5: d0 f1       ..
+    jmp c95be                                                         ; 96c7: 4c be 95    L..
+
+; &96ca referenced 3 times by &957c, &969d, &96a4
+.c96ca
+    brk                                                               ; 96ca: 00          .
+
+    equb &0b, &de                                                     ; 96cb: 0b de       ..
+    equs " space"                                                     ; 96cd: 20 73 70...  sp
+    equb 0                                                            ; 96d3: 00          .
+
+.sub_c96d4
+    jsr sub_c977e                                                     ; 96d4: 20 7e 97     ~.
+    lda l002a                                                         ; 96d7: a5 2a       .*
+    sta l0006                                                         ; 96d9: 85 06       ..
+    sta l0004                                                         ; 96db: 85 04       ..
+    lda l002b                                                         ; 96dd: a5 2b       .+
+    sta l0007                                                         ; 96df: 85 07       ..
+    sta l0005                                                         ; 96e1: 85 05       ..
+    bra c9700                                                         ; 96e3: 80 1b       ..
+.sub_c96e5
+    jsr sub_c977e                                                     ; 96e5: 20 7e 97     ~.
+    lda l002a                                                         ; 96e8: a5 2a       .*
+    sta l0000                                                         ; 96ea: 85 00       ..
+    sta l0002                                                         ; 96ec: 85 02       ..
+    lda l002b                                                         ; 96ee: a5 2b       .+
+    sta l0001                                                         ; 96f0: 85 01       ..
+    sta l0003                                                         ; 96f2: 85 03       ..
+    jsr sub_cbbeb                                                     ; 96f4: 20 eb bb     ..
+    bra c9700                                                         ; 96f7: 80 07       ..
+.sub_c96f9
+    jsr sub_c977e                                                     ; 96f9: 20 7e 97     ~.
+    lda l002b                                                         ; 96fc: a5 2b       .+
+    sta l0018                                                         ; 96fe: 85 18       ..
+; &9700 referenced 4 times by &96e3, &96f7, &9709, &972a
+.c9700
+    jmp c90ca                                                         ; 9700: 4c ca 90    L..
+
+.sub_c9703
+    jsr c9c6a                                                         ; 9703: 20 6a 9c     j.
+    jsr sub_cbbdc                                                     ; 9706: 20 dc bb     ..
+    bra c9700                                                         ; 9709: 80 f5       ..
+.sub_c970b
+    jsr sub_c9be2                                                     ; 970b: 20 e2 9b     ..
+    bcs c971b                                                         ; 970e: b0 0b       ..
+    cmp #&ee                                                          ; 9710: c9 ee       ..
+    beq c972c                                                         ; 9712: f0 18       ..
+    cmp #&87                                                          ; 9714: c9 87       ..
+    beq c9735                                                         ; 9716: f0 1d       ..
+    jsr sub_c9332                                                     ; 9718: 20 32 93     2.
+; &971b referenced 1 time by &970e
+.c971b
+    jsr c9c6a                                                         ; 971b: 20 6a 9c     j.
+    lda l002a                                                         ; 971e: a5 2a       .*
+    sta l0021                                                         ; 9720: 85 21       .!
+    lda l002b                                                         ; 9722: a5 2b       .+
+; &9724 referenced 1 time by &9733
+.loop_c9724
+    sta l0022                                                         ; 9724: 85 22       ."
+    lda #&ff                                                          ; 9726: a9 ff       ..
+; &9728 referenced 1 time by &973c
+.loop_c9728
+    sta l0020                                                         ; 9728: 85 20       .
+    bra c9700                                                         ; 972a: 80 d4       ..
+; &972c referenced 1 time by &9712
+.c972c
+    inc l000a                                                         ; 972c: e6 0a       ..
+    jsr c9c6a                                                         ; 972e: 20 6a 9c     j.
+    lda #&ff                                                          ; 9731: a9 ff       ..
+    bne loop_c9724                                                    ; 9733: d0 ef       ..
+; &9735 referenced 1 time by &9716
+.c9735
+    inc l000a                                                         ; 9735: e6 0a       ..
+    jsr c9c6a                                                         ; 9737: 20 6a 9c     j.
+    lda #0                                                            ; 973a: a9 00       ..
+    bra loop_c9728                                                    ; 973c: 80 ea       ..
+.sub_c973e
+    iny                                                               ; 973e: c8          .
+    lda (l000b),y                                                     ; 973f: b1 0b       ..
+    cmp #&24 ; '$'                                                    ; 9741: c9 24       .$
+    beq c9753                                                         ; 9743: f0 0e       ..
+    jsr sub_c977e                                                     ; 9745: 20 7e 97     ~.
+    stz l002e                                                         ; 9748: 64 2e       d.
+    ldx #&2a ; '*'                                                    ; 974a: a2 2a       .*
+    ldy #0                                                            ; 974c: a0 00       ..
+    lda #2                                                            ; 974e: a9 02       ..
+; &9750 referenced 1 time by &9767
+.loop_c9750
+    jmp cb34c                                                         ; 9750: 4c 4c b3    LL.
+
+; &9753 referenced 1 time by &9743
+.c9753
+    inc l000a                                                         ; 9753: e6 0a       ..
+    jsr sub_c9c0a                                                     ; 9755: 20 0a 9c     ..
+    lda l0027                                                         ; 9758: a5 27       .'
+    bne c979c                                                         ; 975a: d0 40       .@
+    lda #&0f                                                          ; 975c: a9 0f       ..
+    ldy l0036                                                         ; 975e: a4 36       .6
+    sty l05ff                                                         ; 9760: 8c ff 05    ...
+    ldx #&ff                                                          ; 9763: a2 ff       ..
+    ldy #5                                                            ; 9765: a0 05       ..
+    bra loop_c9750                                                    ; 9767: 80 e7       ..
+; &9769 referenced 2 times by &aca3, &aec8
+.sub_c9769
+    jsr cbc91                                                         ; 9769: 20 91 bc     ..
+; &976c referenced 6 times by &92f3, &9b2a, &9b4c, &aa9c, &ac60, &af2c
+.sub_c976c
+    jsr cadee                                                         ; 976c: 20 ee ad     ..
+    bra c9784                                                         ; 976f: 80 13       ..
+; &9771 referenced 6 times by &9816, &9886, &988c, &b30e, &b32f, &bf01
+.sub_c9771
+    jsr sub_c8fb4                                                     ; 9771: 20 b4 8f     ..
+; &9774 referenced 7 times by &8fae, &9304, &958b, &9ae9, &af18, &b67d, &b6a2
+.sub_c9774
+    jsr sub_c9dff                                                     ; 9774: 20 ff 9d     ..
+    bra c9784                                                         ; 9777: 80 0b       ..
+; &9779 referenced 10 times by &931e, &99a5, &99ad, &9a8b, &aa6e, &aaeb, &ab01, &ae34, &b269, &ba81
+.sub_c9779
+    jsr cad78                                                         ; 9779: 20 78 ad     x.
+    bra c9784                                                         ; 977c: 80 06       ..
+; &977e referenced 4 times by &96d4, &96e5, &96f9, &9745
+.sub_c977e
+    jsr sub_c9c0a                                                     ; 977e: 20 0a 9c     ..
+; &9781 referenced 4 times by &9384, &987b, &ba4d, &bee1
+.sub_c9781
+    lda l0027                                                         ; 9781: a5 27       .'
+; &9783 referenced 7 times by &81bd, &81cd, &9e13, &9e2d, &9e3f, &9e4d, &9e56
+.sub_c9783
+    tay                                                               ; 9783: a8          .
+; &9784 referenced 5 times by &9335, &976f, &9777, &977c, &9a82
+.c9784
+    beq c979c                                                         ; 9784: f0 16       ..
+    bpl c979b                                                         ; 9786: 10 13       ..
+; &9788 referenced 5 times by &9cd3, &a134, &a998, &aab9, &b37d
+.sub_c9788
+    jsr sub_c834f                                                     ; 9788: 20 4f 83     O.
+; &978b referenced 1 time by &abfd
+.sub_c978b
+    lda l0031                                                         ; 978b: a5 31       .1
+    sta l002d                                                         ; 978d: 85 2d       .-
+    lda l0032                                                         ; 978f: a5 32       .2
+    sta l002c                                                         ; 9791: 85 2c       .,
+    lda l0033                                                         ; 9793: a5 33       .3
+    sta l002b                                                         ; 9795: 85 2b       .+
+    lda l0034                                                         ; 9797: a5 34       .4
+    sta l002a                                                         ; 9799: 85 2a       .*
+; &979b referenced 2 times by &9786, &97a4
+.c979b
+    rts                                                               ; 979b: 60          `
+
+; &979c referenced 3 times by &975a, &9784, &97a2
+.c979c
+    jmp c9155                                                         ; 979c: 4c 55 91    LU.
+
+; &979f referenced 8 times by &a7ac, &a808, &a901, &a919, &a9b5, &a9ca, &a9d1, &aa17
+.sub_c979f
+    jsr cad78                                                         ; 979f: 20 78 ad     x.
+; &97a2 referenced 5 times by &9d30, &b6d4, &b6f2, &bc21, &bc37
+.sub_c97a2
+    beq c979c                                                         ; 97a2: f0 f8       ..
+    bmi c979b                                                         ; 97a4: 30 f5       0.
+    jmp c828d                                                         ; 97a6: 4c 8d 82    L..
+
+.sub_c97a9
+    lda l000b                                                         ; 97a9: a5 0b       ..
+    sta l0019                                                         ; 97ab: 85 19       ..
+    lda l000c                                                         ; 97ad: a5 0c       ..
+    sta l001a                                                         ; 97af: 85 1a       ..
+    lda l000a                                                         ; 97b1: a5 0a       ..
+    sta l001b                                                         ; 97b3: 85 1b       ..
+    lda #&f2                                                          ; 97b5: a9 f2       ..
+    jsr sub_cb057                                                     ; 97b7: 20 57 b0     W.
+    jsr sub_c9c5a                                                     ; 97ba: 20 5a 9c     Z.
+    jmp c90ca                                                         ; 97bd: 4c ca 90    L..
+
+; &97c0 referenced 1 time by &97c8
+.loop_c97c0
+    lda #&0d                                                          ; 97c0: a9 0d       ..
+    sta (l002a)                                                       ; 97c2: 92 2a       .*
+    bra c97ee                                                         ; 97c4: 80 28       .(
+; &97c6 referenced 1 time by &97e1
+.loop_c97c6
+    cpy #&80                                                          ; 97c6: c0 80       ..
+    beq loop_c97c0                                                    ; 97c8: f0 f6       ..
+    ldy #3                                                            ; 97ca: a0 03       ..
+    lda #0                                                            ; 97cc: a9 00       ..
+    sta (l002a),y                                                     ; 97ce: 91 2a       .*
+    beq c97ee                                                         ; 97d0: f0 1c       ..
+; &97d2 referenced 1 time by &97f9
+.c97d2
+    tsx                                                               ; 97d2: ba          .
+    cpx #&fc                                                          ; 97d3: e0 fc       ..
+    bcs c9801                                                         ; 97d5: b0 2a       .*
+    jsr sub_c997d                                                     ; 97d7: 20 7d 99     }.
+    beq c97fe                                                         ; 97da: f0 22       ."
+    jsr sub_cb1bf                                                     ; 97dc: 20 bf b1     ..
+    ldy l002c                                                         ; 97df: a4 2c       .,
+    bmi loop_c97c6                                                    ; 97e1: 30 e3       0.
+    jsr sub_cbc83                                                     ; 97e3: 20 83 bc     ..
+    jsr cac38                                                         ; 97e6: 20 38 ac     8.
+    sta l0027                                                         ; 97e9: 85 27       .'
+    jsr sub_cb365                                                     ; 97eb: 20 65 b3     e.
+; &97ee referenced 2 times by &97c4, &97d0
+.c97ee
+    tsx                                                               ; 97ee: ba          .
+    inc l0106,x                                                       ; 97ef: fe 06 01    ...
+    ldy l001b                                                         ; 97f2: a4 1b       ..
+    sty l000a                                                         ; 97f4: 84 0a       ..
+    jsr sub_c8da2                                                     ; 97f6: 20 a2 8d     ..
+    beq c97d2                                                         ; 97f9: f0 d7       ..
+    jmp c90c5                                                         ; 97fb: 4c c5 90    L..
+
+; &97fe referenced 1 time by &97da
+.c97fe
+    jmp c90c7                                                         ; 97fe: 4c c7 90    L..
+
+; &9801 referenced 1 time by &97d5
+.c9801
+    brk                                                               ; 9801: 00          .
+
+    equb &0c                                                          ; 9802: 0c          .
+    equs "Not "                                                       ; 9803: 4e 6f 74... Not
+    equb &ea                                                          ; 9807: ea          .
+
+; &9808 referenced 4 times by &9841, &9847, &9855, &985c
+.c9808
+    brk                                                               ; 9808: 00          .
+
+    equb &19                                                          ; 9809: 19          .
+    equs "Bad "                                                       ; 980a: 42 61 64... Bad
+    equb &eb,   0                                                     ; 980e: eb 00       ..
+
+.sub_c9810
+    jsr sub_c9332                                                     ; 9810: 20 32 93     2.
+    lda l002a                                                         ; 9813: a5 2a       .*
+    pha                                                               ; 9815: 48          H
+    jsr sub_c9771                                                     ; 9816: 20 71 97     q.
+    jsr sub_c9c5a                                                     ; 9819: 20 5a 9c     Z.
+    lda #&12                                                          ; 981c: a9 12       ..
+    jsr oswrch                                                        ; 981e: 20 ee ff     ..
+    pla                                                               ; 9821: 68          h
+    bra c986a                                                         ; 9822: 80 46       .F
+.sub_c9824
+    jsr sub_c9332                                                     ; 9824: 20 32 93     2.
+    jsr c9c6a                                                         ; 9827: 20 6a 9c     j.
+    lda #&11                                                          ; 982a: a9 11       ..
+    bra c986a                                                         ; 982c: 80 3c       .<
+.sub_c982e
+    jsr sub_c9332                                                     ; 982e: 20 32 93     2.
+    jsr c9c6a                                                         ; 9831: 20 6a 9c     j.
+    jsr sub_cbe8b                                                     ; 9834: 20 8b be     ..
+    inx                                                               ; 9837: e8          .
+    bne c9866                                                         ; 9838: d0 2c       .,
+    iny                                                               ; 983a: c8          .
+    bne c9866                                                         ; 983b: d0 29       .)
+    lda l0004                                                         ; 983d: a5 04       ..
+    cmp l0006                                                         ; 983f: c5 06       ..
+    bne c9808                                                         ; 9841: d0 c5       ..
+    lda l0005                                                         ; 9843: a5 05       ..
+    cmp l0007                                                         ; 9845: c5 07       ..
+    bne c9808                                                         ; 9847: d0 bf       ..
+    ldx l002a                                                         ; 9849: a6 2a       .*
+    lda #osbyte_read_himem_for_mode                                   ; 984b: a9 85       ..
+    jsr osbyte                                                        ; 984d: 20 f4 ff     ..
+    cpx l0002                                                         ; 9850: e4 02       ..
+    tya                                                               ; 9852: 98          .
+    sbc l0003                                                         ; 9853: e5 03       ..
+    bcc c9808                                                         ; 9855: 90 b1       ..
+    cpx l0012                                                         ; 9857: e4 12       ..
+    tya                                                               ; 9859: 98          .
+    sbc l0013                                                         ; 985a: e5 13       ..
+    bcc c9808                                                         ; 985c: 90 aa       ..
+    stx l0006                                                         ; 985e: 86 06       ..
+    stx l0004                                                         ; 9860: 86 04       ..
+    sty l0007                                                         ; 9862: 84 07       ..
+    sty l0005                                                         ; 9864: 84 05       ..
+; &9866 referenced 2 times by &9838, &983b
+.c9866
+    stz l001e                                                         ; 9866: 64 1e       d.
+    lda #&16                                                          ; 9868: a9 16       ..
+; &986a referenced 2 times by &9822, &982c
+.c986a
+    jsr oswrch                                                        ; 986a: 20 ee ff     ..
+    lda l002a                                                         ; 986d: a5 2a       .*
+    bra c98bd                                                         ; 986f: 80 4c       .L
+.sub_c9871
+    lda #4                                                            ; 9871: a9 04       ..
+    bra c9877                                                         ; 9873: 80 02       ..
+.sub_c9875
+    lda #5                                                            ; 9875: a9 05       ..
+; &9877 referenced 1 time by &9873
+.c9877
+    pha                                                               ; 9877: 48          H
+    jsr sub_c9df3                                                     ; 9878: 20 f3 9d     ..
+    jsr sub_c9781                                                     ; 987b: 20 81 97     ..
+    bra c9889                                                         ; 987e: 80 09       ..
+.sub_c9880
+    jsr sub_c9332                                                     ; 9880: 20 32 93     2.
+    lda l002a                                                         ; 9883: a5 2a       .*
+    pha                                                               ; 9885: 48          H
+    jsr sub_c9771                                                     ; 9886: 20 71 97     q.
+; &9889 referenced 1 time by &987e
+.c9889
+    jsr cbc66                                                         ; 9889: 20 66 bc     f.
+    jsr sub_c9771                                                     ; 988c: 20 71 97     q.
+    jsr sub_c9c5a                                                     ; 988f: 20 5a 9c     Z.
+    lda #&19                                                          ; 9892: a9 19       ..
+    jsr oswrch                                                        ; 9894: 20 ee ff     ..
+    pla                                                               ; 9897: 68          h
+    jsr oswrch                                                        ; 9898: 20 ee ff     ..
+    jsr sub_cbd46                                                     ; 989b: 20 46 bd     F.
+    lda l0037                                                         ; 989e: a5 37       .7
+    jsr oswrch                                                        ; 98a0: 20 ee ff     ..
+    lda l0038                                                         ; 98a3: a5 38       .8
+    jsr oswrch                                                        ; 98a5: 20 ee ff     ..
+    jsr sub_c990f                                                     ; 98a8: 20 0f 99     ..
+    lda l002b                                                         ; 98ab: a5 2b       .+
+    bra c98bd                                                         ; 98ad: 80 0e       ..
+.sub_c98af
+    jsr c9c6a                                                         ; 98af: 20 6a 9c     j.
+    lda #&10                                                          ; 98b2: a9 10       ..
+    bra c98bd                                                         ; 98b4: 80 07       ..
+.sub_c98b6
+    jsr c9c6a                                                         ; 98b6: 20 6a 9c     j.
+    stz l001e                                                         ; 98b9: 64 1e       d.
+    lda #&0c                                                          ; 98bb: a9 0c       ..
+; &98bd referenced 3 times by &986f, &98ad, &98b4
+.c98bd
+    jsr oswrch                                                        ; 98bd: 20 ee ff     ..
+; &98c0 referenced 2 times by &98cd, &98d5
+.c98c0
+    jmp c90ca                                                         ; 98c0: 4c ca 90    L..
+
+.sub_c98c3
+    jsr c9c6a                                                         ; 98c3: 20 6a 9c     j.
+    jsr sub_cbac2                                                     ; 98c6: 20 c2 ba     ..
+    ldy #1                                                            ; 98c9: a0 01       ..
+; &98cb referenced 1 time by &98d3
+.loop_c98cb
+    lda (l00fd),y                                                     ; 98cb: b1 fd       ..
+    beq c98c0                                                         ; 98cd: f0 f1       ..
+    jsr sub_cbd77                                                     ; 98cf: 20 77 bd     w.
+    iny                                                               ; 98d2: c8          .
+    bne loop_c98cb                                                    ; 98d3: d0 f6       ..
+    bra c98c0                                                         ; 98d5: 80 e9       ..
+; &98d7 referenced 1 time by &98fa
+.c98d7
+    lda l002b                                                         ; 98d7: a5 2b       .+
+    jsr oswrch                                                        ; 98d9: 20 ee ff     ..
+; &98dc referenced 2 times by &98f6, &990a
+.c98dc
+    jsr c8f9d                                                         ; 98dc: 20 9d 8f     ..
+; &98df referenced 1 time by &98fe
+.loop_c98df
+    cmp #&3a ; ':'                                                    ; 98df: c9 3a       .:
+    beq c990c                                                         ; 98e1: f0 29       .)
+    cmp #&0d                                                          ; 98e3: c9 0d       ..
+    beq c990c                                                         ; 98e5: f0 25       .%
+    cmp #&8b                                                          ; 98e7: c9 8b       ..
+    beq c990c                                                         ; 98e9: f0 21       .!
+    dec l000a                                                         ; 98eb: c6 0a       ..
+    jsr sub_c9332                                                     ; 98ed: 20 32 93     2.
+    jsr sub_c990f                                                     ; 98f0: 20 0f 99     ..
+    jsr sub_c8da2                                                     ; 98f3: 20 a2 8d     ..
+    beq c98dc                                                         ; 98f6: f0 e4       ..
+    cmp #&3b ; ';'                                                    ; 98f8: c9 3b       .;
+    beq c98d7                                                         ; 98fa: f0 db       ..
+    cmp #&7c ; '|'                                                    ; 98fc: c9 7c       .|
+    bne loop_c98df                                                    ; 98fe: d0 df       ..
+    lda #0                                                            ; 9900: a9 00       ..
+    ldy #9                                                            ; 9902: a0 09       ..
+; &9904 referenced 1 time by &9908
+.loop_c9904
+    jsr oswrch                                                        ; 9904: 20 ee ff     ..
+    dey                                                               ; 9907: 88          .
+    bne loop_c9904                                                    ; 9908: d0 fa       ..
+    bra c98dc                                                         ; 990a: 80 d0       ..
+; &990c referenced 3 times by &98e1, &98e5, &98e9
+.c990c
+    jmp c90c5                                                         ; 990c: 4c c5 90    L..
+
+; &990f referenced 3 times by &92ff, &98a8, &98f0
+.sub_c990f
+    lda l002a                                                         ; 990f: a5 2a       .*
+    jmp (wrchv)                                                       ; 9911: 6c 0e 02    l..
+
+; &9914 referenced 1 time by &b031
+.sub_c9914
+    ldy #1                                                            ; 9914: a0 01       ..
+    lda (l0037),y                                                     ; 9916: b1 37       .7
+    tax                                                               ; 9918: aa          .
+    lda #&f6                                                          ; 9919: a9 f6       ..
+    cpx #&f2                                                          ; 991b: e0 f2       ..
+    beq c9928                                                         ; 991d: f0 09       ..
+    lda #&f8                                                          ; 991f: a9 f8       ..
+    bra c9928                                                         ; 9921: 80 05       ..
+; &9923 referenced 3 times by &90fe, &963d, &9984
+.sub_c9923
+    ldy #1                                                            ; 9923: a0 01       ..
+    lda (l0037),y                                                     ; 9925: b1 37       .7
+    asl a                                                             ; 9927: 0a          .
+; &9928 referenced 2 times by &991d, &9921
+.c9928
+    ldx #4                                                            ; 9928: a2 04       ..
+; &992a referenced 1 time by &9935
+.loop_c992a
+    sta l003a                                                         ; 992a: 85 3a       .:
+    stx l003b                                                         ; 992c: 86 3b       .;
+    lda (l003a),y                                                     ; 992e: b1 3a       .:
+    beq c9937                                                         ; 9930: f0 05       ..
+    tax                                                               ; 9932: aa          .
+    lda (l003a)                                                       ; 9933: b2 3a       .:
+    bra loop_c992a                                                    ; 9935: 80 f3       ..
+; &9937 referenced 1 time by &9930
+.c9937
+    lda l0003                                                         ; 9937: a5 03       ..
+    sta (l003a),y                                                     ; 9939: 91 3a       .:
+    lda l0002                                                         ; 993b: a5 02       ..
+    sta (l003a)                                                       ; 993d: 92 3a       .:
+    lda #0                                                            ; 993f: a9 00       ..
+    sta (l0002),y                                                     ; 9941: 91 02       ..
+    iny                                                               ; 9943: c8          .
+    cpy l0039                                                         ; 9944: c4 39       .9
+    beq c9979                                                         ; 9946: f0 31       .1
+; &9948 referenced 1 time by &994f
+.loop_c9948
+    lda (l0037),y                                                     ; 9948: b1 37       .7
+    sta (l0002),y                                                     ; 994a: 91 02       ..
+    iny                                                               ; 994c: c8          .
+    cpy l0039                                                         ; 994d: c4 39       .9
+    bne loop_c9948                                                    ; 994f: d0 f7       ..
+    rts                                                               ; 9951: 60          `
+
+; &9952 referenced 4 times by &9108, &9642, &997a, &b036
+.sub_c9952
+    lda #0                                                            ; 9952: a9 00       ..
+; &9954 referenced 1 time by &9958
+.loop_c9954
+    sta (l0002),y                                                     ; 9954: 91 02       ..
+    iny                                                               ; 9956: c8          .
+    dex                                                               ; 9957: ca          .
+    bne loop_c9954                                                    ; 9958: d0 fa       ..
+; &995a referenced 1 time by &b044
+.sub_c995a
+    clc                                                               ; 995a: 18          .
+    tya                                                               ; 995b: 98          .
+    adc l0002                                                         ; 995c: 65 02       e.
+    bcc c9962                                                         ; 995e: 90 02       ..
+    inc l0003                                                         ; 9960: e6 03       ..
+; &9962 referenced 1 time by &995e
+.c9962
+    ldy l0003                                                         ; 9962: a4 03       ..
+    cpy l0005                                                         ; 9964: c4 05       ..
+    bcc c9977                                                         ; 9966: 90 0f       ..
+    bne c996e                                                         ; 9968: d0 04       ..
+    cmp l0004                                                         ; 996a: c5 04       ..
+    bcc c9977                                                         ; 996c: 90 09       ..
+; &996e referenced 1 time by &9968
+.c996e
+    lda #0                                                            ; 996e: a9 00       ..
+    ldy #1                                                            ; 9970: a0 01       ..
+    sta (l003a),y                                                     ; 9972: 91 3a       .:
+    jmp c9164                                                         ; 9974: 4c 64 91    Ld.
+
+; &9977 referenced 2 times by &9966, &996c
+.c9977
+    sta l0002                                                         ; 9977: 85 02       ..
+; &9979 referenced 1 time by &9946
+.c9979
+    rts                                                               ; 9979: 60          `
+
+; &997a referenced 2 times by &998b, &998e
+.c997a
+    jsr sub_c9952                                                     ; 997a: 20 52 99     R.
+; &997d referenced 9 times by &8a91, &910d, &9581, &97d7, &b112, &b649, &b887, &b91f, &b9ad
+.sub_c997d
+    jsr sub_c99c4                                                     ; 997d: 20 c4 99     ..
+    bne c999f                                                         ; 9980: d0 1d       ..
+    bcs c999f                                                         ; 9982: b0 1b       ..
+    jsr sub_c9923                                                     ; 9984: 20 23 99     #.
+    ldx #5                                                            ; 9987: a2 05       ..
+    cpx l002c                                                         ; 9989: e4 2c       .,
+    bne c997a                                                         ; 998b: d0 ed       ..
+    inx                                                               ; 998d: e8          .
+    bra c997a                                                         ; 998e: 80 ea       ..
+; &9990 referenced 1 time by &99da
+.c9990
+    cmp #&21 ; '!'                                                    ; 9990: c9 21       .!
+    beq c99a0                                                         ; 9992: f0 0c       ..
+    cmp #&24 ; '$'                                                    ; 9994: c9 24       .$
+    beq c99ab                                                         ; 9996: f0 13       ..
+    eor #&3f ; '?'                                                    ; 9998: 49 3f       I?
+    beq c99a2                                                         ; 999a: f0 06       ..
+    lda #0                                                            ; 999c: a9 00       ..
+    sec                                                               ; 999e: 38          8
+; &999f referenced 2 times by &9980, &9982
+.c999f
+    rts                                                               ; 999f: 60          `
+
+; &99a0 referenced 1 time by &9992
+.c99a0
+    lda #4                                                            ; 99a0: a9 04       ..
+; &99a2 referenced 1 time by &999a
+.c99a2
+    pha                                                               ; 99a2: 48          H
+    inc l001b                                                         ; 99a3: e6 1b       ..
+    jsr sub_c9779                                                     ; 99a5: 20 79 97     y.
+    jmp c9a99                                                         ; 99a8: 4c 99 9a    L..
+
+; &99ab referenced 1 time by &9996
+.c99ab
+    inc l001b                                                         ; 99ab: e6 1b       ..
+    jsr sub_c9779                                                     ; 99ad: 20 79 97     y.
+    lda l002b                                                         ; 99b0: a5 2b       .+
+    beq c99ba                                                         ; 99b2: f0 06       ..
+    lda #&80                                                          ; 99b4: a9 80       ..
+    sta l002c                                                         ; 99b6: 85 2c       .,
+    sec                                                               ; 99b8: 38          8
+    rts                                                               ; 99b9: 60          `
+
+; &99ba referenced 1 time by &99b2
+.c99ba
+    brk                                                               ; 99ba: 00          .
+
+    equb 8                                                            ; 99bb: 08          .
+    equs "$ range"                                                    ; 99bc: 24 20 72... $ r
+    equb 0                                                            ; 99c3: 00          .
+
+; &99c4 referenced 2 times by &997d, &b522
+.sub_c99c4
+    lda l000b                                                         ; 99c4: a5 0b       ..
+    sta l0019                                                         ; 99c6: 85 19       ..
+    lda l000c                                                         ; 99c8: a5 0c       ..
+    sta l001a                                                         ; 99ca: 85 1a       ..
+    ldy l000a                                                         ; 99cc: a4 0a       ..
+    dey                                                               ; 99ce: 88          .
+; &99cf referenced 1 time by &99d4
+.loop_c99cf
+    iny                                                               ; 99cf: c8          .
+; &99d0 referenced 1 time by &9397
+.sub_c99d0
+    lda (l0019),y                                                     ; 99d0: b1 19       ..
+    cmp #&20 ; ' '                                                    ; 99d2: c9 20       .
+    beq loop_c99cf                                                    ; 99d4: f0 f9       ..
+; &99d6 referenced 1 time by &90f2
+.sub_c99d6
+    sty l001b                                                         ; 99d6: 84 1b       ..
+; &99d8 referenced 1 time by &adae
+.sub_c99d8
+    cmp #&40 ; '@'                                                    ; 99d8: c9 40       .@
+    bcc c9990                                                         ; 99da: 90 b4       ..
+    cmp #&5b ; '['                                                    ; 99dc: c9 5b       .[
+    bcs c99fa                                                         ; 99de: b0 1a       ..
+    asl a                                                             ; 99e0: 0a          .
+    asl a                                                             ; 99e1: 0a          .
+    sta l002a                                                         ; 99e2: 85 2a       .*
+    iny                                                               ; 99e4: c8          .
+    lda (l0019),y                                                     ; 99e5: b1 19       ..
+    cmp #&25 ; '%'                                                    ; 99e7: c9 25       .%
+    bne c99fa                                                         ; 99e9: d0 0f       ..
+    lda #4                                                            ; 99eb: a9 04       ..
+    sta l002b                                                         ; 99ed: 85 2b       .+
+    ldx #4                                                            ; 99ef: a2 04       ..
+    stx l002c                                                         ; 99f1: 86 2c       .,
+    iny                                                               ; 99f3: c8          .
+    lda (l0019),y                                                     ; 99f4: b1 19       ..
+    cmp #&28 ; '('                                                    ; 99f6: c9 28       .(
+    bne c9a67                                                         ; 99f8: d0 6d       .m
+; &99fa referenced 2 times by &99de, &99e9
+.c99fa
+    ldx #5                                                            ; 99fa: a2 05       ..
+    stx l002c                                                         ; 99fc: 86 2c       .,
+    clc                                                               ; 99fe: 18          .
+    ldy l001a                                                         ; 99ff: a4 1a       ..
+    lda l001b                                                         ; 9a01: a5 1b       ..
+    tax                                                               ; 9a03: aa          .
+    bne c9a0e                                                         ; 9a04: d0 08       ..
+    dec a                                                             ; 9a06: 3a          :
+    adc l0019                                                         ; 9a07: 65 19       e.
+    bcs c9a14                                                         ; 9a09: b0 09       ..
+    dey                                                               ; 9a0b: 88          .
+    bra c9a14                                                         ; 9a0c: 80 06       ..
+; &9a0e referenced 1 time by &9a04
+.c9a0e
+    dec a                                                             ; 9a0e: 3a          :
+    adc l0019                                                         ; 9a0f: 65 19       e.
+    bcc c9a14                                                         ; 9a11: 90 01       ..
+    iny                                                               ; 9a13: c8          .
+; &9a14 referenced 3 times by &9a09, &9a0c, &9a11
+.c9a14
+    sta l0037                                                         ; 9a14: 85 37       .7
+    sty l0038                                                         ; 9a16: 84 38       .8
+    ldy #1                                                            ; 9a18: a0 01       ..
+    lda (l0037),y                                                     ; 9a1a: b1 37       .7
+    cmp #&41 ; 'A'                                                    ; 9a1c: c9 41       .A
+    bcs c9a3a                                                         ; 9a1e: b0 1a       ..
+    cmp #&30 ; '0'                                                    ; 9a20: c9 30       .0
+    bcc c9a46                                                         ; 9a22: 90 22       ."
+    cmp #&3a ; ':'                                                    ; 9a24: c9 3a       .:
+    bcs c9a46                                                         ; 9a26: b0 1e       ..
+; &9a28 referenced 3 times by &9a36, &9a3c, &9a44
+.c9a28
+    inx                                                               ; 9a28: e8          .
+    iny                                                               ; 9a29: c8          .
+    lda (l0037),y                                                     ; 9a2a: b1 37       .7
+    cmp #&41 ; 'A'                                                    ; 9a2c: c9 41       .A
+    bcs c9a3a                                                         ; 9a2e: b0 0a       ..
+    cmp #&30 ; '0'                                                    ; 9a30: c9 30       .0
+    bcc c9a46                                                         ; 9a32: 90 12       ..
+    cmp #&3a ; ':'                                                    ; 9a34: c9 3a       .:
+    bcc c9a28                                                         ; 9a36: 90 f0       ..
+    bra c9a46                                                         ; 9a38: 80 0c       ..
+; &9a3a referenced 2 times by &9a1e, &9a2e
+.c9a3a
+    cmp #&5b ; '['                                                    ; 9a3a: c9 5b       .[
+    bcc c9a28                                                         ; 9a3c: 90 ea       ..
+    cmp #&5f ; '_'                                                    ; 9a3e: c9 5f       ._
+    bcc c9a46                                                         ; 9a40: 90 04       ..
+    cmp #&7b ; '{'                                                    ; 9a42: c9 7b       .{
+    bcc c9a28                                                         ; 9a44: 90 e2       ..
+; &9a46 referenced 5 times by &9a22, &9a26, &9a32, &9a38, &9a40
+.c9a46
+    cpy #1                                                            ; 9a46: c0 01       ..
+    beq c9a76                                                         ; 9a48: f0 2c       .,
+    cmp #&24 ; '$'                                                    ; 9a4a: c9 24       .$
+    beq c9aa5                                                         ; 9a4c: f0 57       .W
+    cmp #&25 ; '%'                                                    ; 9a4e: c9 25       .%
+    bne c9a58                                                         ; 9a50: d0 06       ..
+    dec l002c                                                         ; 9a52: c6 2c       .,
+    inx                                                               ; 9a54: e8          .
+    iny                                                               ; 9a55: c8          .
+    lda (l0037),y                                                     ; 9a56: b1 37       .7
+; &9a58 referenced 1 time by &9a50
+.c9a58
+    cmp #&28 ; '('                                                    ; 9a58: c9 28       .(
+    beq c9aa0                                                         ; 9a5a: f0 44       .D
+    jsr sub_c8149                                                     ; 9a5c: 20 49 81     I.
+    beq c9a75                                                         ; 9a5f: f0 14       ..
+    stx l001b                                                         ; 9a61: 86 1b       ..
+; &9a63 referenced 1 time by &9aa3
+.c9a63
+    ldy l001b                                                         ; 9a63: a4 1b       ..
+    lda (l0019),y                                                     ; 9a65: b1 19       ..
+; &9a67 referenced 1 time by &99f8
+.c9a67
+    cmp #&21 ; '!'                                                    ; 9a67: c9 21       .!
+    beq c9a79                                                         ; 9a69: f0 0e       ..
+    eor #&3f ; '?'                                                    ; 9a6b: 49 3f       I?
+    beq c9a7b                                                         ; 9a6d: f0 0c       ..
+    clc                                                               ; 9a6f: 18          .
+    sty l001b                                                         ; 9a70: 84 1b       ..
+    lda #&ff                                                          ; 9a72: a9 ff       ..
+    rts                                                               ; 9a74: 60          `
+
+; &9a75 referenced 2 times by &9a5f, &9ab2
+.c9a75
+    clc                                                               ; 9a75: 18          .
+; &9a76 referenced 1 time by &9a48
+.c9a76
+    lda #0                                                            ; 9a76: a9 00       ..
+    rts                                                               ; 9a78: 60          `
+
+; &9a79 referenced 1 time by &9a69
+.c9a79
+    lda #4                                                            ; 9a79: a9 04       ..
+; &9a7b referenced 1 time by &9a6d
+.c9a7b
+    pha                                                               ; 9a7b: 48          H
+    iny                                                               ; 9a7c: c8          .
+    sty l001b                                                         ; 9a7d: 84 1b       ..
+    jsr cb1de                                                         ; 9a7f: 20 de b1     ..
+    jsr c9784                                                         ; 9a82: 20 84 97     ..
+    lda l002b                                                         ; 9a85: a5 2b       .+
+    pha                                                               ; 9a87: 48          H
+    lda l002a                                                         ; 9a88: a5 2a       .*
+    pha                                                               ; 9a8a: 48          H
+    jsr sub_c9779                                                     ; 9a8b: 20 79 97     y.
+    clc                                                               ; 9a8e: 18          .
+    pla                                                               ; 9a8f: 68          h
+    adc l002a                                                         ; 9a90: 65 2a       e*
+    sta l002a                                                         ; 9a92: 85 2a       .*
+    pla                                                               ; 9a94: 68          h
+    adc l002b                                                         ; 9a95: 65 2b       e+
+    sta l002b                                                         ; 9a97: 85 2b       .+
+; &9a99 referenced 1 time by &99a8
+.c9a99
+    pla                                                               ; 9a99: 68          h
+    sta l002c                                                         ; 9a9a: 85 2c       .,
+    clc                                                               ; 9a9c: 18          .
+    lda #&ff                                                          ; 9a9d: a9 ff       ..
+    rts                                                               ; 9a9f: 60          `
+
+; &9aa0 referenced 1 time by &9a5a
+.c9aa0
+    jsr sub_c9ac9                                                     ; 9aa0: 20 c9 9a     ..
+    bra c9a63                                                         ; 9aa3: 80 be       ..
+; &9aa5 referenced 1 time by &9a4c
+.c9aa5
+    dec l002c                                                         ; 9aa5: c6 2c       .,
+    inx                                                               ; 9aa7: e8          .
+    iny                                                               ; 9aa8: c8          .
+    lda (l0037),y                                                     ; 9aa9: b1 37       .7
+    cmp #&28 ; '('                                                    ; 9aab: c9 28       .(
+    beq c9abc                                                         ; 9aad: f0 0d       ..
+    jsr sub_c8149                                                     ; 9aaf: 20 49 81     I.
+    beq c9a75                                                         ; 9ab2: f0 c1       ..
+    stx l001b                                                         ; 9ab4: 86 1b       ..
+; &9ab6 referenced 1 time by &9abf
+.loop_c9ab6
+    lda #&81                                                          ; 9ab6: a9 81       ..
+    sta l002c                                                         ; 9ab8: 85 2c       .,
+    sec                                                               ; 9aba: 38          8
+    rts                                                               ; 9abb: 60          `
+
+; &9abc referenced 1 time by &9aad
+.c9abc
+    jsr sub_c9ac9                                                     ; 9abc: 20 c9 9a     ..
+    bra loop_c9ab6                                                    ; 9abf: 80 f5       ..
+; &9ac1 referenced 2 times by &9ace, &9af0
+.c9ac1
+    brk                                                               ; 9ac1: 00          .
+
+    equb &0e                                                          ; 9ac2: 0e          .
+    equs "Array"                                                      ; 9ac3: 41 72 72... Arr
+    equb 0                                                            ; 9ac8: 00          .
+
+; &9ac9 referenced 2 times by &9aa0, &9abc
+.sub_c9ac9
+    inx                                                               ; 9ac9: e8          .
+    iny                                                               ; 9aca: c8          .
+    jsr sub_c8149                                                     ; 9acb: 20 49 81     I.
+    beq c9ac1                                                         ; 9ace: f0 f1       ..
+    stx l001b                                                         ; 9ad0: 86 1b       ..
+    lda l002c                                                         ; 9ad2: a5 2c       .,
+    pha                                                               ; 9ad4: 48          H
+    lda l002a                                                         ; 9ad5: a5 2a       .*
+    pha                                                               ; 9ad7: 48          H
+    lda l002b                                                         ; 9ad8: a5 2b       .+
+    pha                                                               ; 9ada: 48          H
+    lda (l002a)                                                       ; 9adb: b2 2a       .*
+    cmp #4                                                            ; 9add: c9 04       ..
+    bcc c9b4c                                                         ; 9adf: 90 6b       .k
+    jsr cac38                                                         ; 9ae1: 20 38 ac     8.
+    inc l002d                                                         ; 9ae4: e6 2d       .-
+; &9ae6 referenced 1 time by &9b25
+.c9ae6
+    jsr cbc66                                                         ; 9ae6: 20 66 bc     f.
+    jsr sub_c9774                                                     ; 9ae9: 20 74 97     t.
+    inc l001b                                                         ; 9aec: e6 1b       ..
+    cpx #&2c ; ','                                                    ; 9aee: e0 2c       .,
+    bne c9ac1                                                         ; 9af0: d0 cf       ..
+    ldx #&39 ; '9'                                                    ; 9af2: a2 39       .9
+    jsr sub_cbd48                                                     ; 9af4: 20 48 bd     H.
+    pla                                                               ; 9af7: 68          h
+    sta l0038                                                         ; 9af8: 85 38       .8
+    ply                                                               ; 9afa: 7a          z
+    sty l0037                                                         ; 9afb: 84 37       .7
+    phy                                                               ; 9afd: 5a          Z
+    pha                                                               ; 9afe: 48          H
+    ldy l003c                                                         ; 9aff: a4 3c       .<
+    jsr sub_c9b97                                                     ; 9b01: 20 97 9b     ..
+    sty l002d                                                         ; 9b04: 84 2d       .-
+    lda (l0037),y                                                     ; 9b06: b1 37       .7
+    sta l003f                                                         ; 9b08: 85 3f       .?
+    iny                                                               ; 9b0a: c8          .
+    lda (l0037),y                                                     ; 9b0b: b1 37       .7
+    sta l0040                                                         ; 9b0d: 85 40       .@
+    lda l002a                                                         ; 9b0f: a5 2a       .*
+    adc l0039                                                         ; 9b11: 65 39       e9
+    sta l002a                                                         ; 9b13: 85 2a       .*
+    lda l002b                                                         ; 9b15: a5 2b       .+
+    adc l003a                                                         ; 9b17: 65 3a       e:
+    sta l002b                                                         ; 9b19: 85 2b       .+
+    jsr sub_c95cb                                                     ; 9b1b: 20 cb 95     ..
+    sec                                                               ; 9b1e: 38          8
+    lda (l0037)                                                       ; 9b1f: b2 37       .7
+    sbc l002d                                                         ; 9b21: e5 2d       .-
+    cmp #3                                                            ; 9b23: c9 03       ..
+    bcs c9ae6                                                         ; 9b25: b0 bf       ..
+    jsr cbc66                                                         ; 9b27: 20 66 bc     f.
+    jsr sub_c976c                                                     ; 9b2a: 20 6c 97     l.
+    pla                                                               ; 9b2d: 68          h
+    sta l0038                                                         ; 9b2e: 85 38       .8
+    pla                                                               ; 9b30: 68          h
+    sta l0037                                                         ; 9b31: 85 37       .7
+    ldx #&39 ; '9'                                                    ; 9b33: a2 39       .9
+    jsr sub_cbd48                                                     ; 9b35: 20 48 bd     H.
+    ldy l003c                                                         ; 9b38: a4 3c       .<
+    jsr sub_c9b97                                                     ; 9b3a: 20 97 9b     ..
+    clc                                                               ; 9b3d: 18          .
+    lda l0039                                                         ; 9b3e: a5 39       .9
+    adc l002a                                                         ; 9b40: 65 2a       e*
+    sta l002a                                                         ; 9b42: 85 2a       .*
+    lda l003a                                                         ; 9b44: a5 3a       .:
+    adc l002b                                                         ; 9b46: 65 2b       e+
+    sta l002b                                                         ; 9b48: 85 2b       .+
+    bcc c9b5a                                                         ; 9b4a: 90 0e       ..
+; &9b4c referenced 1 time by &9adf
+.c9b4c
+    jsr sub_c976c                                                     ; 9b4c: 20 6c 97     l.
+    pla                                                               ; 9b4f: 68          h
+    sta l0038                                                         ; 9b50: 85 38       .8
+    pla                                                               ; 9b52: 68          h
+    sta l0037                                                         ; 9b53: 85 37       .7
+    ldy #1                                                            ; 9b55: a0 01       ..
+    jsr sub_c9b97                                                     ; 9b57: 20 97 9b     ..
+; &9b5a referenced 1 time by &9b4a
+.c9b5a
+    pla                                                               ; 9b5a: 68          h
+    sta l002c                                                         ; 9b5b: 85 2c       .,
+    cmp #5                                                            ; 9b5d: c9 05       ..
+    bne c9b78                                                         ; 9b5f: d0 17       ..
+    ldx l002b                                                         ; 9b61: a6 2b       .+
+    lda l002a                                                         ; 9b63: a5 2a       .*
+    asl l002a                                                         ; 9b65: 06 2a       .*
+    rol l002b                                                         ; 9b67: 26 2b       &+
+    asl l002a                                                         ; 9b69: 06 2a       .*
+    rol l002b                                                         ; 9b6b: 26 2b       &+
+    adc l002a                                                         ; 9b6d: 65 2a       e*
+    sta l002a                                                         ; 9b6f: 85 2a       .*
+    txa                                                               ; 9b71: 8a          .
+    adc l002b                                                         ; 9b72: 65 2b       e+
+    sta l002b                                                         ; 9b74: 85 2b       .+
+    bra c9b80                                                         ; 9b76: 80 08       ..
+; &9b78 referenced 1 time by &9b5f
+.c9b78
+    asl l002a                                                         ; 9b78: 06 2a       .*
+    rol l002b                                                         ; 9b7a: 26 2b       &+
+    asl l002a                                                         ; 9b7c: 06 2a       .*
+    rol l002b                                                         ; 9b7e: 26 2b       &+
+; &9b80 referenced 1 time by &9b76
+.c9b80
+    tya                                                               ; 9b80: 98          .
+    adc l002a                                                         ; 9b81: 65 2a       e*
+    sta l002a                                                         ; 9b83: 85 2a       .*
+    bcc c9b8a                                                         ; 9b85: 90 03       ..
+    inc l002b                                                         ; 9b87: e6 2b       .+
+    clc                                                               ; 9b89: 18          .
+; &9b8a referenced 1 time by &9b85
+.c9b8a
+    lda l0037                                                         ; 9b8a: a5 37       .7
+    adc l002a                                                         ; 9b8c: 65 2a       e*
+    sta l002a                                                         ; 9b8e: 85 2a       .*
+    lda l0038                                                         ; 9b90: a5 38       .8
+    adc l002b                                                         ; 9b92: 65 2b       e+
+    sta l002b                                                         ; 9b94: 85 2b       .+
+    rts                                                               ; 9b96: 60          `
+
+; &9b97 referenced 3 times by &9b01, &9b3a, &9b57
+.sub_c9b97
+    lda l002b                                                         ; 9b97: a5 2b       .+
+    and #&c0                                                          ; 9b99: 29 c0       ).
+    ora l002c                                                         ; 9b9b: 05 2c       .,
+    ora l002d                                                         ; 9b9d: 05 2d       .-
+    bne c9bae                                                         ; 9b9f: d0 0d       ..
+    lda l002a                                                         ; 9ba1: a5 2a       .*
+    cmp (l0037),y                                                     ; 9ba3: d1 37       .7
+    iny                                                               ; 9ba5: c8          .
+    lda l002b                                                         ; 9ba6: a5 2b       .+
+    sbc (l0037),y                                                     ; 9ba8: f1 37       .7
+    bcs c9bae                                                         ; 9baa: b0 02       ..
+    iny                                                               ; 9bac: c8          .
+    rts                                                               ; 9bad: 60          `
+
+; &9bae referenced 2 times by &9b9f, &9baa
+.c9bae
+    brk                                                               ; 9bae: 00          .
+
+    equb &0f                                                          ; 9baf: 0f          .
+    equs "Subscript"                                                  ; 9bb0: 53 75 62... Sub
+    equb 0                                                            ; 9bb9: 00          .
+
+; &9bba referenced 1 time by &9615
+.sub_c9bba
+    ldy #1                                                            ; 9bba: a0 01       ..
+; &9bbc referenced 2 times by &9bd0, &b095
+.c9bbc
+    lda (l0037),y                                                     ; 9bbc: b1 37       .7
+    cmp #&30 ; '0'                                                    ; 9bbe: c9 30       .0
+    bcc c9bda                                                         ; 9bc0: 90 18       ..
+    cmp #&40 ; '@'                                                    ; 9bc2: c9 40       .@
+    bcs c9bd2                                                         ; 9bc4: b0 0c       ..
+    cmp #&3a ; ':'                                                    ; 9bc6: c9 3a       .:
+    bcs c9bda                                                         ; 9bc8: b0 10       ..
+    cpy #1                                                            ; 9bca: c0 01       ..
+    beq c9bda                                                         ; 9bcc: f0 0c       ..
+; &9bce referenced 2 times by &9bd8, &9bdd
+.c9bce
+    inx                                                               ; 9bce: e8          .
+    iny                                                               ; 9bcf: c8          .
+    bne c9bbc                                                         ; 9bd0: d0 ea       ..
+; &9bd2 referenced 1 time by &9bc4
+.c9bd2
+    cmp #&5f ; '_'                                                    ; 9bd2: c9 5f       ._
+    bcs c9bdb                                                         ; 9bd4: b0 05       ..
+    cmp #&5b ; '['                                                    ; 9bd6: c9 5b       .[
+    bcc c9bce                                                         ; 9bd8: 90 f4       ..
+; &9bda referenced 3 times by &9bc0, &9bc8, &9bcc
+.c9bda
+    rts                                                               ; 9bda: 60          `
+
+; &9bdb referenced 1 time by &9bd4
+.c9bdb
+    cmp #&7b ; '{'                                                    ; 9bdb: c9 7b       .{
+    bcc c9bce                                                         ; 9bdd: 90 ef       ..
+    rts                                                               ; 9bdf: 60          `
+
+; &9be0 referenced 1 time by &9be8
+.loop_c9be0
+    inc l000a                                                         ; 9be0: e6 0a       ..
+; &9be2 referenced 10 times by &93da, &93e7, &9415, &9425, &970b, &9ced, &b3d6, &b3fb, &b85a, &bb33
+.sub_c9be2
+    ldy l000a                                                         ; 9be2: a4 0a       ..
+    lda (l000b),y                                                     ; 9be4: b1 0b       ..
+    cmp #&20 ; ' '                                                    ; 9be6: c9 20       .
+    beq loop_c9be0                                                    ; 9be8: f0 f6       ..
+    cmp #&8d                                                          ; 9bea: c9 8d       ..
+    bne c9c08                                                         ; 9bec: d0 1a       ..
+; &9bee referenced 2 times by &94de, &b500
+.sub_c9bee
+    iny                                                               ; 9bee: c8          .
+    lda (l000b),y                                                     ; 9bef: b1 0b       ..
+    asl a                                                             ; 9bf1: 0a          .
+    asl a                                                             ; 9bf2: 0a          .
+    tax                                                               ; 9bf3: aa          .
+    and #&c0                                                          ; 9bf4: 29 c0       ).
+    iny                                                               ; 9bf6: c8          .
+    eor (l000b),y                                                     ; 9bf7: 51 0b       Q.
+    sta l002a                                                         ; 9bf9: 85 2a       .*
+    txa                                                               ; 9bfb: 8a          .
+    asl a                                                             ; 9bfc: 0a          .
+    asl a                                                             ; 9bfd: 0a          .
+    iny                                                               ; 9bfe: c8          .
+    eor (l000b),y                                                     ; 9bff: 51 0b       Q.
+    sta l002b                                                         ; 9c01: 85 2b       .+
+    iny                                                               ; 9c03: c8          .
+    sty l000a                                                         ; 9c04: 84 0a       ..
+    sec                                                               ; 9c06: 38          8
+    rts                                                               ; 9c07: 60          `
+
+; &9c08 referenced 1 time by &9bec
+.c9c08
+    clc                                                               ; 9c08: 18          .
+    rts                                                               ; 9c09: 60          `
+
+; &9c0a referenced 2 times by &9755, &977e
+.sub_c9c0a
+    lda l000b                                                         ; 9c0a: a5 0b       ..
+    sta l0019                                                         ; 9c0c: 85 19       ..
+    lda l000c                                                         ; 9c0e: a5 0c       ..
+    sta l001a                                                         ; 9c10: 85 1a       ..
+    lda l000a                                                         ; 9c12: a5 0a       ..
+    sta l001b                                                         ; 9c14: 85 1b       ..
+; &9c16 referenced 4 times by &9117, &913e, &9c1e, &bede
+.c9c16
+    ldy l001b                                                         ; 9c16: a4 1b       ..
+    inc l001b                                                         ; 9c18: e6 1b       ..
+    lda (l0019),y                                                     ; 9c1a: b1 19       ..
+    cmp #&20 ; ' '                                                    ; 9c1c: c9 20       .
+    beq c9c16                                                         ; 9c1e: f0 f6       ..
+    cmp #&3d ; '='                                                    ; 9c20: c9 3d       .=
+    beq c9c52                                                         ; 9c22: f0 2e       ..
+; &9c24 referenced 1 time by &9c4f
+.c9c24
+    brk                                                               ; 9c24: 00          .
+
+    equb 4                                                            ; 9c25: 04          .
+    equs "Mistake"                                                    ; 9c26: 4d 69 73... Mis
+
+; &9c2d referenced 7 times by &8af2, &8d61, &9146, &93d7, &9c7e, &b52d, &b86f
+.c9c2d
+    brk                                                               ; 9c2d: 00          .
+
+    equb &10                                                          ; 9c2e: 10          .
+    equs "Syntax error"                                               ; 9c2f: 53 79 6e... Syn
+
+; &9c3b referenced 2 times by &9c61, &9c68
+.c9c3b
+    brk                                                               ; 9c3b: 00          .
+
+    equb &0d                                                          ; 9c3c: 0d          .
+    equs "No "                                                        ; 9c3d: 4e 6f 20    No
+    equb &f2                                                          ; 9c40: f2          .
+
+; &9c41 referenced 2 times by &9c90, &babf
+.c9c41
+    brk                                                               ; 9c41: 00          .
+
+    equb &11                                                          ; 9c42: 11          .
+    equs "Escape"                                                     ; 9c43: 45 73 63... Esc
+    equb 0                                                            ; 9c49: 00          .
+
+; &9c4a referenced 2 times by &90fb, &b653
+.sub_c9c4a
+    jsr c8f92                                                         ; 9c4a: 20 92 8f     ..
+    cmp #&3d ; '='                                                    ; 9c4d: c9 3d       .=
+    bne c9c24                                                         ; 9c4f: d0 d3       ..
+    rts                                                               ; 9c51: 60          `
+
+; &9c52 referenced 1 time by &9c22
+.c9c52
+    jsr sub_c9dff                                                     ; 9c52: 20 ff 9d     ..
+; &9c55 referenced 3 times by &9132, &ba4a, &be7e
+.c9c55
+    txa                                                               ; 9c55: 8a          .
+    ldy l001b                                                         ; 9c56: a4 1b       ..
+    bra c9c74                                                         ; 9c58: 80 1a       ..
+; &9c5a referenced 9 times by &93b7, &97ba, &9819, &988f, &b315, &b336, &b354, &bef1, &bf04
+.sub_c9c5a
+    ldy l001b                                                         ; 9c5a: a4 1b       ..
+    bra c9c6c                                                         ; 9c5c: 80 0e       ..
+.sub_c9c5e
+    tsx                                                               ; 9c5e: ba          .
+    cpx #&fc                                                          ; 9c5f: e0 fc       ..
+    bcs c9c3b                                                         ; 9c61: b0 d8       ..
+    lda l01ff                                                         ; 9c63: ad ff 01    ...
+    cmp #&f2                                                          ; 9c66: c9 f2       ..
+    bne c9c3b                                                         ; 9c68: d0 d1       ..
+; &9c6a referenced 24 times by &8fc5, &8fd7, &8fea, &9042, &90c7, &9149, &93ec, &9430, &9703, &971b, &972e, &9737, &9827, &9831, &98af, &98b6, &98c3, &9c93, &b41e, &b70c, &b737, &b750, &b769, &b997
+.c9c6a
+    ldy l000a                                                         ; 9c6a: a4 0a       ..
+; &9c6c referenced 2 times by &8a79, &9c5c
+.c9c6c
+    dey                                                               ; 9c6c: 88          .
+; &9c6d referenced 1 time by &9c72
+.loop_c9c6d
+    iny                                                               ; 9c6d: c8          .
+    lda (l000b),y                                                     ; 9c6e: b1 0b       ..
+    cmp #&20 ; ' '                                                    ; 9c70: c9 20       .
+    beq loop_c9c6d                                                    ; 9c72: f0 f9       ..
+; &9c74 referenced 3 times by &9433, &9c58, &b428
+.c9c74
+    cmp #&3a ; ':'                                                    ; 9c74: c9 3a       .:
+    beq c9c80                                                         ; 9c76: f0 08       ..
+    cmp #&0d                                                          ; 9c78: c9 0d       ..
+    beq c9c80                                                         ; 9c7a: f0 04       ..
+    cmp #&8b                                                          ; 9c7c: c9 8b       ..
+    bne c9c2d                                                         ; 9c7e: d0 ad       ..
+; &9c80 referenced 10 times by &89e4, &9069, &907d, &9c76, &9c7a, &b02e, &b40d, &b451, &b77b, &ba8e
+.c9c80
+    clc                                                               ; 9c80: 18          .
+    tya                                                               ; 9c81: 98          .
+    adc l000b                                                         ; 9c82: 65 0b       e.
+    sta l000b                                                         ; 9c84: 85 0b       ..
+    bcc c9c8a                                                         ; 9c86: 90 02       ..
+    inc l000c                                                         ; 9c88: e6 0c       ..
+; &9c8a referenced 4 times by &9c86, &9cf5, &b5d9, &b7f4
+.c9c8a
+    ldy #1                                                            ; 9c8a: a0 01       ..
+    sty l000a                                                         ; 9c8c: 84 0a       ..
+; &9c8e referenced 1 time by &93fd
+.sub_c9c8e
+    bit l00ff                                                         ; 9c8e: 24 ff       $.
+    bmi c9c41                                                         ; 9c90: 30 af       0.
+; &9c92 referenced 1 time by &9c9a
+.loop_c9c92
+    rts                                                               ; 9c92: 60          `
+
+; &9c93 referenced 1 time by &b6bf
+.sub_c9c93
+    jsr c9c6a                                                         ; 9c93: 20 6a 9c     j.
+    lda (l000b)                                                       ; 9c96: b2 0b       ..
+    cmp #&3a ; ':'                                                    ; 9c98: c9 3a       .:
+    beq loop_c9c92                                                    ; 9c9a: f0 f6       ..
+    lda l000c                                                         ; 9c9c: a5 0c       ..
+    cmp #7                                                            ; 9c9e: c9 07       ..
+    beq c9cc6                                                         ; 9ca0: f0 24       .$
+; &9ca2 referenced 1 time by &8a8b
+.sub_c9ca2
+    ldy #1                                                            ; 9ca2: a0 01       ..
+    lda (l000b),y                                                     ; 9ca4: b1 0b       ..
+    bmi c9cc6                                                         ; 9ca6: 30 1e       0.
+    ldx l0020                                                         ; 9ca8: a6 20       .
+    beq c9cb6                                                         ; 9caa: f0 0a       ..
+    sta l002b                                                         ; 9cac: 85 2b       .+
+    iny                                                               ; 9cae: c8          .
+    lda (l000b),y                                                     ; 9caf: b1 0b       ..
+    sta l002a                                                         ; 9cb1: 85 2a       .*
+    jsr sub_c9d0f                                                     ; 9cb3: 20 0f 9d     ..
+; &9cb6 referenced 1 time by &9caa
+.c9cb6
+    lda #3                                                            ; 9cb6: a9 03       ..
+; &9cb8 referenced 1 time by &94d9
+.sub_c9cb8
+    clc                                                               ; 9cb8: 18          .
+    adc l000b                                                         ; 9cb9: 65 0b       e.
+    sta l000b                                                         ; 9cbb: 85 0b       ..
+    bcc c9cc1                                                         ; 9cbd: 90 02       ..
+    inc l000c                                                         ; 9cbf: e6 0c       ..
+; &9cc1 referenced 1 time by &9cbd
+.c9cc1
+    ldy #1                                                            ; 9cc1: a0 01       ..
+    sty l000a                                                         ; 9cc3: 84 0a       ..
+; &9cc5 referenced 1 time by &9d17
+.c9cc5
+    rts                                                               ; 9cc5: 60          `
+
+; &9cc6 referenced 2 times by &9ca0, &9ca6
+.c9cc6
+    jmp c904b                                                         ; 9cc6: 4c 4b 90    LK.
+
+; &9cc9 referenced 1 time by &9ccf
+.loop_c9cc9
+    jmp c9155                                                         ; 9cc9: 4c 55 91    LU.
+
+.sub_c9ccc
+    jsr sub_c9df3                                                     ; 9ccc: 20 f3 9d     ..
+    beq loop_c9cc9                                                    ; 9ccf: f0 f8       ..
+    bpl c9cd6                                                         ; 9cd1: 10 03       ..
+    jsr sub_c9788                                                     ; 9cd3: 20 88 97     ..
+; &9cd6 referenced 1 time by &9cd1
+.c9cd6
+    ldy l001b                                                         ; 9cd6: a4 1b       ..
+    sty l000a                                                         ; 9cd8: 84 0a       ..
+    lda l002a                                                         ; 9cda: a5 2a       .*
+    ora l002b                                                         ; 9cdc: 05 2b       .+
+    ora l002c                                                         ; 9cde: 05 2c       .,
+    ora l002d                                                         ; 9ce0: 05 2d       .-
+    beq c9cfb                                                         ; 9ce2: f0 17       ..
+    cpx #&8c                                                          ; 9ce4: e0 8c       ..
+    beq c9ceb                                                         ; 9ce6: f0 03       ..
+; &9ce8 referenced 1 time by &9cf0
+.loop_c9ce8
+    jmp c90d0                                                         ; 9ce8: 4c d0 90    L..
+
+; &9ceb referenced 1 time by &9ce6
+.c9ceb
+    inc l000a                                                         ; 9ceb: e6 0a       ..
+; &9ced referenced 2 times by &9d0a, &b849
+.c9ced
+    jsr sub_c9be2                                                     ; 9ced: 20 e2 9b     ..
+    bcc loop_c9ce8                                                    ; 9cf0: 90 f6       ..
+    jsr cb866                                                         ; 9cf2: 20 66 b8     f.
+    jsr c9c8a                                                         ; 9cf5: 20 8a 9c     ..
+    jmp cb753                                                         ; 9cf8: 4c 53 b7    LS.
+
+; &9cfb referenced 1 time by &9ce2
+.c9cfb
+    ldy l000a                                                         ; 9cfb: a4 0a       ..
+; &9cfd referenced 1 time by &9d06
+.loop_c9cfd
+    lda (l000b),y                                                     ; 9cfd: b1 0b       ..
+    cmp #&0d                                                          ; 9cff: c9 0d       ..
+    beq c9d0c                                                         ; 9d01: f0 09       ..
+    iny                                                               ; 9d03: c8          .
+    cmp #&8b                                                          ; 9d04: c9 8b       ..
+    bne loop_c9cfd                                                    ; 9d06: d0 f5       ..
+    sty l000a                                                         ; 9d08: 84 0a       ..
+    beq c9ced                                                         ; 9d0a: f0 e1       ..
+; &9d0c referenced 1 time by &9d01
+.c9d0c
+    jmp c907d                                                         ; 9d0c: 4c 7d 90    L}.
+
+; &9d0f referenced 3 times by &909d, &9cb3, &b757
+.sub_c9d0f
+    lda l002a                                                         ; 9d0f: a5 2a       .*
+    cmp l0021                                                         ; 9d11: c5 21       .!
+    lda l002b                                                         ; 9d13: a5 2b       .+
+    sbc l0022                                                         ; 9d15: e5 22       ."
+    bcs c9cc5                                                         ; 9d17: b0 ac       ..
+    lda #&5b ; '['                                                    ; 9d19: a9 5b       .[
+    jsr sub_cbdd8                                                     ; 9d1b: 20 d8 bd     ..
+    jsr sub_ca0e8                                                     ; 9d1e: 20 e8 a0     ..
+    lda #&5d ; ']'                                                    ; 9d21: a9 5d       .]
+    jsr sub_cbdd8                                                     ; 9d23: 20 d8 bd     ..
+    jmp cbdd2                                                         ; 9d26: 4c d2 bd    L..
+
+; &9d29 referenced 1 time by &9d84
+.c9d29
+    jsr cbc3a                                                         ; 9d29: 20 3a bc     :.
+    jsr sub_c9f07                                                     ; 9d2c: 20 07 9f     ..
+    tay                                                               ; 9d2f: a8          .
+    jsr sub_c97a2                                                     ; 9d30: 20 a2 97     ..
+    jsr sub_cbc24                                                     ; 9d33: 20 24 bc     $.
+; &9d36 referenced 1 time by &b614
+.sub_c9d36
+    jsr sub_ca514                                                     ; 9d36: 20 14 a5     ..
+    lda l002e                                                         ; 9d39: a5 2e       ..
+    eor l003b                                                         ; 9d3b: 45 3b       E;
+    bpl c9d57                                                         ; 9d3d: 10 18       ..
+    asl l002e                                                         ; 9d3f: 06 2e       ..
+    bra c9d79                                                         ; 9d41: 80 36       .6
+; &9d43 referenced 1 time by &9db8
+.c9d43
+    sty l002d                                                         ; 9d43: 84 2d       .-
+    pla                                                               ; 9d45: 68          h
+    sta l002c                                                         ; 9d46: 85 2c       .,
+    pla                                                               ; 9d48: 68          h
+    sta l002b                                                         ; 9d49: 85 2b       .+
+    pla                                                               ; 9d4b: 68          h
+    sta l002a                                                         ; 9d4c: 85 2a       .*
+    jsr sub_c828a                                                     ; 9d4e: 20 8a 82     ..
+    lda l003b                                                         ; 9d51: a5 3b       .;
+    eor #&80                                                          ; 9d53: 49 80       I.
+    sta l003b                                                         ; 9d55: 85 3b       .;
+; &9d57 referenced 1 time by &9d3d
+.c9d57
+    lda l003c                                                         ; 9d57: a5 3c       .<
+    cmp l0030                                                         ; 9d59: c5 30       .0
+    bne c9d75                                                         ; 9d5b: d0 18       ..
+    lda l003d                                                         ; 9d5d: a5 3d       .=
+    cmp l0031                                                         ; 9d5f: c5 31       .1
+    bne c9d75                                                         ; 9d61: d0 12       ..
+    lda l003e                                                         ; 9d63: a5 3e       .>
+    cmp l0032                                                         ; 9d65: c5 32       .2
+    bne c9d75                                                         ; 9d67: d0 0c       ..
+    lda l003f                                                         ; 9d69: a5 3f       .?
+    cmp l0033                                                         ; 9d6b: c5 33       .3
+    bne c9d75                                                         ; 9d6d: d0 06       ..
+    lda l0040                                                         ; 9d6f: a5 40       .@
+    sbc l0034                                                         ; 9d71: e5 34       .4
+    beq c9d7b                                                         ; 9d73: f0 06       ..
+; &9d75 referenced 4 times by &9d5b, &9d61, &9d67, &9d6d
+.c9d75
+    ror a                                                             ; 9d75: 6a          j
+    eor l003b                                                         ; 9d76: 45 3b       E;
+    rol a                                                             ; 9d78: 2a          *
+; &9d79 referenced 1 time by &9d41
+.c9d79
+    lda #&ff                                                          ; 9d79: a9 ff       ..
+; &9d7b referenced 1 time by &9d73
+.c9d7b
+    rts                                                               ; 9d7b: 60          `
+
+; &9d7c referenced 2 times by &9d98, &9dcb
+.c9d7c
+    jmp c9155                                                         ; 9d7c: 4c 55 91    LU.
+
+; &9d7f referenced 3 times by &9ea6, &9ead, &9ec2
+.sub_c9d7f
+    inc l001b                                                         ; 9d7f: e6 1b       ..
+; &9d81 referenced 2 times by &9e9d, &9ebb
+.sub_c9d81
+    txa                                                               ; 9d81: 8a          .
+; &9d82 referenced 1 time by &9e80
+.sub_c9d82
+    beq c9dc4                                                         ; 9d82: f0 40       .@
+    bmi c9d29                                                         ; 9d84: 30 a3       0.
+    lda l002a                                                         ; 9d86: a5 2a       .*
+    pha                                                               ; 9d88: 48          H
+    lda l002b                                                         ; 9d89: a5 2b       .+
+    pha                                                               ; 9d8b: 48          H
+    lda l002c                                                         ; 9d8c: a5 2c       .,
+    pha                                                               ; 9d8e: 48          H
+    lda l002d                                                         ; 9d8f: a5 2d       .-
+    pha                                                               ; 9d91: 48          H
+    jsr sub_c9f07                                                     ; 9d92: 20 07 9f     ..
+    tay                                                               ; 9d95: a8          .
+    bmi c9db4                                                         ; 9d96: 30 1c       0.
+    beq c9d7c                                                         ; 9d98: f0 e2       ..
+    pla                                                               ; 9d9a: 68          h
+    tay                                                               ; 9d9b: a8          .
+    eor l002d                                                         ; 9d9c: 45 2d       E-
+    bmi c9dba                                                         ; 9d9e: 30 1a       0.
+    cpy l002d                                                         ; 9da0: c4 2d       .-
+    bne c9dbe                                                         ; 9da2: d0 1a       ..
+    pla                                                               ; 9da4: 68          h
+    cmp l002c                                                         ; 9da5: c5 2c       .,
+    bne c9dbf                                                         ; 9da7: d0 16       ..
+    pla                                                               ; 9da9: 68          h
+    cmp l002b                                                         ; 9daa: c5 2b       .+
+    bne c9dc0                                                         ; 9dac: d0 12       ..
+    pla                                                               ; 9dae: 68          h
+    sbc l002a                                                         ; 9daf: e5 2a       .*
+    bne c9dc1                                                         ; 9db1: d0 0e       ..
+    rts                                                               ; 9db3: 60          `
+
+; &9db4 referenced 1 time by &9d96
+.c9db4
+    pla                                                               ; 9db4: 68          h
+    tay                                                               ; 9db5: a8          .
+    eor l002e                                                         ; 9db6: 45 2e       E.
+    bpl c9d43                                                         ; 9db8: 10 89       ..
+; &9dba referenced 1 time by &9d9e
+.c9dba
+    tya                                                               ; 9dba: 98          .
+    eor #&ff                                                          ; 9dbb: 49 ff       I.
+    asl a                                                             ; 9dbd: 0a          .
+; &9dbe referenced 1 time by &9da2
+.c9dbe
+    pla                                                               ; 9dbe: 68          h
+; &9dbf referenced 1 time by &9da7
+.c9dbf
+    pla                                                               ; 9dbf: 68          h
+; &9dc0 referenced 1 time by &9dac
+.c9dc0
+    pla                                                               ; 9dc0: 68          h
+; &9dc1 referenced 2 times by &9db1, &9dee
+.c9dc1
+    lda #&ff                                                          ; 9dc1: a9 ff       ..
+    rts                                                               ; 9dc3: 60          `
+
+; &9dc4 referenced 1 time by &9d82
+.c9dc4
+    jsr cbc91                                                         ; 9dc4: 20 91 bc     ..
+    jsr sub_c9f07                                                     ; 9dc7: 20 07 9f     ..
+    tay                                                               ; 9dca: a8          .
+    bne c9d7c                                                         ; 9dcb: d0 af       ..
+    lda (l0004)                                                       ; 9dcd: b2 04       ..
+    cmp l0036                                                         ; 9dcf: c5 36       .6
+    bcc c9dd5                                                         ; 9dd1: 90 02       ..
+    lda l0036                                                         ; 9dd3: a5 36       .6
+; &9dd5 referenced 1 time by &9dd1
+.c9dd5
+    sta l0037                                                         ; 9dd5: 85 37       .7
+; &9dd7 referenced 1 time by &9de1
+.loop_c9dd7
+    cpy l0037                                                         ; 9dd7: c4 37       .7
+    beq c9de5                                                         ; 9dd9: f0 0a       ..
+    iny                                                               ; 9ddb: c8          .
+    lda (l0004),y                                                     ; 9ddc: b1 04       ..
+    cmp l05ff,y                                                       ; 9dde: d9 ff 05    ...
+    beq loop_c9dd7                                                    ; 9de1: f0 f4       ..
+    bra c9de9                                                         ; 9de3: 80 04       ..
+; &9de5 referenced 1 time by &9dd9
+.c9de5
+    lda (l0004)                                                       ; 9de5: b2 04       ..
+    cmp l0036                                                         ; 9de7: c5 36       .6
+; &9de9 referenced 1 time by &9de3
+.c9de9
+    php                                                               ; 9de9: 08          .
+    jsr cbd21                                                         ; 9dea: 20 21 bd     !.
+    plp                                                               ; 9ded: 28          (
+    bne c9dc1                                                         ; 9dee: d0 d1       ..
+    lda #0                                                            ; 9df0: a9 00       ..
+    rts                                                               ; 9df2: 60          `
+
+; &9df3 referenced 8 times by &8d77, &912f, &9332, &9381, &9878, &9ccc, &ba47, &be76
+.sub_c9df3
+    lda l000b                                                         ; 9df3: a5 0b       ..
+    sta l0019                                                         ; 9df5: 85 19       ..
+    lda l000c                                                         ; 9df7: a5 0c       ..
+    sta l001a                                                         ; 9df9: 85 1a       ..
+    lda l000a                                                         ; 9dfb: a5 0a       ..
+    sta l001b                                                         ; 9dfd: 85 1b       ..
+; &9dff referenced 14 times by &920d, &92b7, &9774, &9c52, &ab8b, &ac7f, &ac8d, &adee, &aebd, &af0a, &b146, &b362, &b6d1, &b6ef
+.sub_c9dff
+    jsr sub_c9e45                                                     ; 9dff: 20 45 9e     E.
+; &9e02 referenced 1 time by &9e28
+.c9e02
+    cpx #&84                                                          ; 9e02: e0 84       ..
+    beq c9e10                                                         ; 9e04: f0 0a       ..
+    cpx #&82                                                          ; 9e06: e0 82       ..
+    beq c9e2a                                                         ; 9e08: f0 20       .
+    dec l001b                                                         ; 9e0a: c6 1b       ..
+    tay                                                               ; 9e0c: a8          .
+    sta l0027                                                         ; 9e0d: 85 27       .'
+    rts                                                               ; 9e0f: 60          `
+
+; &9e10 referenced 1 time by &9e04
+.c9e10
+    jsr sub_c9e3f                                                     ; 9e10: 20 3f 9e     ?.
+    jsr sub_c9783                                                     ; 9e13: 20 83 97     ..
+    ldy #3                                                            ; 9e16: a0 03       ..
+; &9e18 referenced 1 time by &9e21
+.loop_c9e18
+    lda (l0004),y                                                     ; 9e18: b1 04       ..
+    ora l002a,y                                                       ; 9e1a: 19 2a 00    .*.
+    sta l002a,y                                                       ; 9e1d: 99 2a 00    .*.
+    dey                                                               ; 9e20: 88          .
+    bpl loop_c9e18                                                    ; 9e21: 10 f5       ..
+; &9e23 referenced 1 time by &9e3d
+.loop_c9e23
+    jsr cbd3a                                                         ; 9e23: 20 3a bd     :.
+    lda #&40 ; '@'                                                    ; 9e26: a9 40       .@
+    bra c9e02                                                         ; 9e28: 80 d8       ..
+; &9e2a referenced 1 time by &9e08
+.c9e2a
+    jsr sub_c9e3f                                                     ; 9e2a: 20 3f 9e     ?.
+    jsr sub_c9783                                                     ; 9e2d: 20 83 97     ..
+    ldy #3                                                            ; 9e30: a0 03       ..
+; &9e32 referenced 1 time by &9e3b
+.loop_c9e32
+    lda (l0004),y                                                     ; 9e32: b1 04       ..
+    eor l002a,y                                                       ; 9e34: 59 2a 00    Y*.
+    sta l002a,y                                                       ; 9e37: 99 2a 00    .*.
+    dey                                                               ; 9e3a: 88          .
+    bpl loop_c9e32                                                    ; 9e3b: 10 f5       ..
+    bra loop_c9e23                                                    ; 9e3d: 80 e4       ..
+; &9e3f referenced 2 times by &9e10, &9e2a
+.sub_c9e3f
+    jsr sub_c9783                                                     ; 9e3f: 20 83 97     ..
+    jsr cbc66                                                         ; 9e42: 20 66 bc     f.
+; &9e45 referenced 1 time by &9dff
+.sub_c9e45
+    jsr sub_c9e6d                                                     ; 9e45: 20 6d 9e     m.
+; &9e48 referenced 1 time by &9e6b
+.c9e48
+    cpx #&80                                                          ; 9e48: e0 80       ..
+    beq c9e4d                                                         ; 9e4a: f0 01       ..
+    rts                                                               ; 9e4c: 60          `
+
+; &9e4d referenced 1 time by &9e4a
+.c9e4d
+    jsr sub_c9783                                                     ; 9e4d: 20 83 97     ..
+    jsr cbc66                                                         ; 9e50: 20 66 bc     f.
+    jsr sub_c9e6d                                                     ; 9e53: 20 6d 9e     m.
+    jsr sub_c9783                                                     ; 9e56: 20 83 97     ..
+    ldy #3                                                            ; 9e59: a0 03       ..
+; &9e5b referenced 1 time by &9e64
+.loop_c9e5b
+    lda (l0004),y                                                     ; 9e5b: b1 04       ..
+    and l002a,y                                                       ; 9e5d: 39 2a 00    9*.
+    sta l002a,y                                                       ; 9e60: 99 2a 00    .*.
+    dey                                                               ; 9e63: 88          .
+    bpl loop_c9e5b                                                    ; 9e64: 10 f5       ..
+    jsr cbd3a                                                         ; 9e66: 20 3a bd     :.
+    lda #&40 ; '@'                                                    ; 9e69: a9 40       .@
+    bra c9e48                                                         ; 9e6b: 80 db       ..
+; &9e6d referenced 2 times by &9e45, &9e53
+.sub_c9e6d
+    jsr sub_c9f07                                                     ; 9e6d: 20 07 9f     ..
+    cpx #&3f ; '?'                                                    ; 9e70: e0 3f       .?
+    bcs c9e78                                                         ; 9e72: b0 04       ..
+    cpx #&3c ; '<'                                                    ; 9e74: e0 3c       .<
+    bcs c9e79                                                         ; 9e76: b0 01       ..
+; &9e78 referenced 1 time by &9e72
+.c9e78
+    rts                                                               ; 9e78: 60          `
+
+; &9e79 referenced 1 time by &9e76
+.c9e79
+    beq c9e90                                                         ; 9e79: f0 15       ..
+    cpx #&3e ; '>'                                                    ; 9e7b: e0 3e       .>
+    beq c9eb2                                                         ; 9e7d: f0 33       .3
+    tax                                                               ; 9e7f: aa          .
+    jsr sub_c9d82                                                     ; 9e80: 20 82 9d     ..
+; &9e83 referenced 5 times by &9ea4, &9eab, &9ec0, &9ec5, &9ec7
+.c9e83
+    eor #&ff                                                          ; 9e83: 49 ff       I.
+; &9e85 referenced 6 times by &9ea0, &9ea2, &9ea9, &9eb0, &9ebe, &9ec9
+.c9e85
+    sta l002a                                                         ; 9e85: 85 2a       .*
+    sta l002b                                                         ; 9e87: 85 2b       .+
+    sta l002c                                                         ; 9e89: 85 2c       .,
+    sta l002d                                                         ; 9e8b: 85 2d       .-
+    lda #&40 ; '@'                                                    ; 9e8d: a9 40       .@
+    rts                                                               ; 9e8f: 60          `
+
+; &9e90 referenced 1 time by &9e79
+.c9e90
+    tax                                                               ; 9e90: aa          .
+    ldy l001b                                                         ; 9e91: a4 1b       ..
+    lda (l0019),y                                                     ; 9e93: b1 19       ..
+    cmp #&3d ; '='                                                    ; 9e95: c9 3d       .=
+    beq c9ea6                                                         ; 9e97: f0 0d       ..
+    cmp #&3e ; '>'                                                    ; 9e99: c9 3e       .>
+    beq c9ead                                                         ; 9e9b: f0 10       ..
+    jsr sub_c9d81                                                     ; 9e9d: 20 81 9d     ..
+    bcc c9e85                                                         ; 9ea0: 90 e3       ..
+    beq c9e85                                                         ; 9ea2: f0 e1       ..
+    bra c9e83                                                         ; 9ea4: 80 dd       ..
+; &9ea6 referenced 1 time by &9e97
+.c9ea6
+    jsr sub_c9d7f                                                     ; 9ea6: 20 7f 9d     ..
+    bcc c9e85                                                         ; 9ea9: 90 da       ..
+    bra c9e83                                                         ; 9eab: 80 d6       ..
+; &9ead referenced 1 time by &9e9b
+.c9ead
+    jsr sub_c9d7f                                                     ; 9ead: 20 7f 9d     ..
+    bra c9e85                                                         ; 9eb0: 80 d3       ..
+; &9eb2 referenced 1 time by &9e7d
+.c9eb2
+    tax                                                               ; 9eb2: aa          .
+    ldy l001b                                                         ; 9eb3: a4 1b       ..
+    lda (l0019),y                                                     ; 9eb5: b1 19       ..
+    cmp #&3d ; '='                                                    ; 9eb7: c9 3d       .=
+    beq c9ec2                                                         ; 9eb9: f0 07       ..
+    jsr sub_c9d81                                                     ; 9ebb: 20 81 9d     ..
+    bcs c9e85                                                         ; 9ebe: b0 c5       ..
+    bra c9e83                                                         ; 9ec0: 80 c1       ..
+; &9ec2 referenced 1 time by &9eb9
+.c9ec2
+    jsr sub_c9d7f                                                     ; 9ec2: 20 7f 9d     ..
+    bcc c9e83                                                         ; 9ec5: 90 bc       ..
+    beq c9e83                                                         ; 9ec7: f0 ba       ..
+    bra c9e85                                                         ; 9ec9: 80 ba       ..
+; &9ecb referenced 2 times by &9eec, &afbe
+.c9ecb
+    brk                                                               ; 9ecb: 00          .
+
+    equb &13                                                          ; 9ecc: 13          .
+    equs "String too long"                                            ; 9ecd: 53 74 72... Str
+    equb 0                                                            ; 9edc: 00          .
+
+; &9edd referenced 1 time by &9f16
+.c9edd
+    jsr cbc91                                                         ; 9edd: 20 91 bc     ..
+    jsr sub_ca06c                                                     ; 9ee0: 20 6c a0     l.
+    tay                                                               ; 9ee3: a8          .
+    bne c9f4c                                                         ; 9ee4: d0 66       .f
+    clc                                                               ; 9ee6: 18          .
+    phx                                                               ; 9ee7: da          .
+    lda (l0004)                                                       ; 9ee8: b2 04       ..
+    adc l0036                                                         ; 9eea: 65 36       e6
+    bcs c9ecb                                                         ; 9eec: b0 dd       ..
+    tax                                                               ; 9eee: aa          .
+    pha                                                               ; 9eef: 48          H
+    ldy l0036                                                         ; 9ef0: a4 36       .6
+; &9ef2 referenced 1 time by &9efa
+.loop_c9ef2
+    lda l05ff,y                                                       ; 9ef2: b9 ff 05    ...
+    sta l05ff,x                                                       ; 9ef5: 9d ff 05    ...
+    dex                                                               ; 9ef8: ca          .
+    dey                                                               ; 9ef9: 88          .
+    bne loop_c9ef2                                                    ; 9efa: d0 f6       ..
+    jsr sub_cbd12                                                     ; 9efc: 20 12 bd     ..
+    pla                                                               ; 9eff: 68          h
+    sta l0036                                                         ; 9f00: 85 36       .6
+    plx                                                               ; 9f02: fa          .
+    lda #0                                                            ; 9f03: a9 00       ..
+    bra c9f0a                                                         ; 9f05: 80 03       ..
+; &9f07 referenced 4 times by &9d2c, &9d92, &9dc7, &9e6d
+.sub_c9f07
+    jsr sub_ca026                                                     ; 9f07: 20 26 a0     &.
+; &9f0a referenced 4 times by &9f05, &9f46, &9f4a, &9f57
+.c9f0a
+    cpx #&2b ; '+'                                                    ; 9f0a: e0 2b       .+
+    beq c9f13                                                         ; 9f0c: f0 05       ..
+    cpx #&2d ; '-'                                                    ; 9f0e: e0 2d       .-
+    beq c9f70                                                         ; 9f10: f0 5e       .^
+    rts                                                               ; 9f12: 60          `
+
+; &9f13 referenced 1 time by &9f0c
+.c9f13
+    tay                                                               ; 9f13: a8          .
+    bmi c9f4f                                                         ; 9f14: 30 39       09
+    beq c9edd                                                         ; 9f16: f0 c5       ..
+    jsr sub_ca023                                                     ; 9f18: 20 23 a0     #.
+    tay                                                               ; 9f1b: a8          .
+    bmi c9f64                                                         ; 9f1c: 30 46       0F
+    beq c9f4c                                                         ; 9f1e: f0 2c       .,
+    clc                                                               ; 9f20: 18          .
+    lda (l0004)                                                       ; 9f21: b2 04       ..
+    adc l002a                                                         ; 9f23: 65 2a       e*
+    sta l002a                                                         ; 9f25: 85 2a       .*
+    ldy #1                                                            ; 9f27: a0 01       ..
+    lda (l0004),y                                                     ; 9f29: b1 04       ..
+    adc l002b                                                         ; 9f2b: 65 2b       e+
+    sta l002b                                                         ; 9f2d: 85 2b       .+
+    iny                                                               ; 9f2f: c8          .
+    lda (l0004),y                                                     ; 9f30: b1 04       ..
+    adc l002c                                                         ; 9f32: 65 2c       e,
+    sta l002c                                                         ; 9f34: 85 2c       .,
+    iny                                                               ; 9f36: c8          .
+    lda (l0004),y                                                     ; 9f37: b1 04       ..
+    adc l002d                                                         ; 9f39: 65 2d       e-
+; &9f3b referenced 1 time by &9f98
+.c9f3b
+    sta l002d                                                         ; 9f3b: 85 2d       .-
+    clc                                                               ; 9f3d: 18          .
+    lda l0004                                                         ; 9f3e: a5 04       ..
+    adc #4                                                            ; 9f40: 69 04       i.
+    sta l0004                                                         ; 9f42: 85 04       ..
+    lda #&40 ; '@'                                                    ; 9f44: a9 40       .@
+    bcc c9f0a                                                         ; 9f46: 90 c2       ..
+    inc l0005                                                         ; 9f48: e6 05       ..
+    bra c9f0a                                                         ; 9f4a: 80 be       ..
+; &9f4c referenced 5 times by &9ee4, &9f1e, &9f73, &9f7b, &9fbb
+.c9f4c
+    jmp c9155                                                         ; 9f4c: 4c 55 91    LU.
+
+; &9f4f referenced 1 time by &9f14
+.c9f4f
+    jsr sub_cbc18                                                     ; 9f4f: 20 18 bc     ..
+    jsr ca70a                                                         ; 9f52: 20 0a a7     ..
+; &9f55 referenced 2 times by &9f5f, &9f6e
+.c9f55
+    ldx l0027                                                         ; 9f55: a6 27       .'
+    bra c9f0a                                                         ; 9f57: 80 b1       ..
+; &9f59 referenced 1 time by &9f71
+.loop_c9f59
+    jsr sub_cbc18                                                     ; 9f59: 20 18 bc     ..
+    jsr ca704                                                         ; 9f5c: 20 04 a7     ..
+    bra c9f55                                                         ; 9f5f: 80 f4       ..
+; &9f61 referenced 1 time by &9f79
+.loop_c9f61
+    jsr cad10                                                         ; 9f61: 20 10 ad     ..
+; &9f64 referenced 1 time by &9f1c
+.c9f64
+    stx l0027                                                         ; 9f64: 86 27       .'
+    jsr sub_c8287                                                     ; 9f66: 20 87 82     ..
+    lda l003d                                                         ; 9f69: a5 3d       .=
+    jsr sub_ca70d                                                     ; 9f6b: 20 0d a7     ..
+    bra c9f55                                                         ; 9f6e: 80 e5       ..
+; &9f70 referenced 1 time by &9f10
+.c9f70
+    tay                                                               ; 9f70: a8          .
+    bmi loop_c9f59                                                    ; 9f71: 30 e6       0.
+    beq c9f4c                                                         ; 9f73: f0 d7       ..
+    jsr sub_ca023                                                     ; 9f75: 20 23 a0     #.
+    tay                                                               ; 9f78: a8          .
+    bmi loop_c9f61                                                    ; 9f79: 30 e6       0.
+    beq c9f4c                                                         ; 9f7b: f0 cf       ..
+    sec                                                               ; 9f7d: 38          8
+    lda (l0004)                                                       ; 9f7e: b2 04       ..
+    sbc l002a                                                         ; 9f80: e5 2a       .*
+    sta l002a                                                         ; 9f82: 85 2a       .*
+    ldy #1                                                            ; 9f84: a0 01       ..
+    lda (l0004),y                                                     ; 9f86: b1 04       ..
+    sbc l002b                                                         ; 9f88: e5 2b       .+
+    sta l002b                                                         ; 9f8a: 85 2b       .+
+    iny                                                               ; 9f8c: c8          .
+    lda (l0004),y                                                     ; 9f8d: b1 04       ..
+    sbc l002c                                                         ; 9f8f: e5 2c       .,
+    sta l002c                                                         ; 9f91: 85 2c       .,
+    iny                                                               ; 9f93: c8          .
+    lda (l0004),y                                                     ; 9f94: b1 04       ..
+    sbc l002d                                                         ; 9f96: e5 2d       .-
+    bra c9f3b                                                         ; 9f98: 80 a1       ..
+; &9f9a referenced 2 times by &9fdb, &9fdf
+.c9f9a
+    jsr c828d                                                         ; 9f9a: 20 8d 82     ..
+; &9f9d referenced 1 time by &9fce
+.c9f9d
+    jsr sub_c8287                                                     ; 9f9d: 20 87 82     ..
+    and l003d                                                         ; 9fa0: 25 3d       %=
+    jsr sub_ca6eb                                                     ; 9fa2: 20 eb a6     ..
+    bra c9fb6                                                         ; 9fa5: 80 0f       ..
+; &9fa7 referenced 2 times by &9fc4, &9fc8
+.c9fa7
+    jsr c828d                                                         ; 9fa7: 20 8d 82     ..
+; &9faa referenced 1 time by &9fb9
+.loop_c9faa
+    jsr cbc3a                                                         ; 9faa: 20 3a bc     :.
+    jsr sub_ca06c                                                     ; 9fad: 20 6c a0     l.
+    jsr sub_cbc20                                                     ; 9fb0: 20 20 bc      .
+    jsr ca6e4                                                         ; 9fb3: 20 e4 a6     ..
+; &9fb6 referenced 1 time by &9fa5
+.c9fb6
+    bra ca029                                                         ; 9fb6: 80 71       .q
+; &9fb8 referenced 1 time by &a02b
+.c9fb8
+    tay                                                               ; 9fb8: a8          .
+    bmi loop_c9faa                                                    ; 9fb9: 30 ef       0.
+; &9fbb referenced 1 time by &9fd0
+.loop_c9fbb
+    beq c9f4c                                                         ; 9fbb: f0 8f       ..
+    lda l002b                                                         ; 9fbd: a5 2b       .+
+    asl a                                                             ; 9fbf: 0a          .
+    lda l002c                                                         ; 9fc0: a5 2c       .,
+    adc #0                                                            ; 9fc2: 69 00       i.
+    bne c9fa7                                                         ; 9fc4: d0 e1       ..
+    adc l002d                                                         ; 9fc6: 65 2d       e-
+    bne c9fa7                                                         ; 9fc8: d0 dd       ..
+    jsr sub_ca069                                                     ; 9fca: 20 69 a0     i.
+    tay                                                               ; 9fcd: a8          .
+    bmi c9f9d                                                         ; 9fce: 30 cd       0.
+    beq loop_c9fbb                                                    ; 9fd0: f0 e9       ..
+    lda l002b                                                         ; 9fd2: a5 2b       .+
+    sta l0038                                                         ; 9fd4: 85 38       .8
+    asl a                                                             ; 9fd6: 0a          .
+    lda l002c                                                         ; 9fd7: a5 2c       .,
+    adc #0                                                            ; 9fd9: 69 00       i.
+    bne c9f9a                                                         ; 9fdb: d0 bd       ..
+    adc l002d                                                         ; 9fdd: 65 2d       e-
+    bne c9f9a                                                         ; 9fdf: d0 b9       ..
+    bcc c9fe6                                                         ; 9fe1: 90 03       ..
+    jsr cad20                                                         ; 9fe3: 20 20 ad      .
+; &9fe6 referenced 1 time by &9fe1
+.c9fe6
+    stx l0027                                                         ; 9fe6: 86 27       .'
+    ldx #&3d ; '='                                                    ; 9fe8: a2 3d       .=
+    jsr sub_cbe06                                                     ; 9fea: 20 06 be     ..
+    jsr sub_cbd26                                                     ; 9fed: 20 26 bd     &.
+    ldy #0                                                            ; 9ff0: a0 00       ..
+    ldx #0                                                            ; 9ff2: a2 00       ..
+; &9ff4 referenced 1 time by &a01b
+.c9ff4
+    lsr l003e                                                         ; 9ff4: 46 3e       F>
+    ror l003d                                                         ; 9ff6: 66 3d       f=
+    bcc ca00f                                                         ; 9ff8: 90 15       ..
+    clc                                                               ; 9ffa: 18          .
+    tya                                                               ; 9ffb: 98          .
+    adc l002a                                                         ; 9ffc: 65 2a       e*
+    tay                                                               ; 9ffe: a8          .
+    txa                                                               ; 9fff: 8a          .
+    adc l002b                                                         ; a000: 65 2b       e+
+    tax                                                               ; a002: aa          .
+    lda l003f                                                         ; a003: a5 3f       .?
+    adc l002c                                                         ; a005: 65 2c       e,
+    sta l003f                                                         ; a007: 85 3f       .?
+    lda l0040                                                         ; a009: a5 40       .@
+    adc l002d                                                         ; a00b: 65 2d       e-
+    sta l0040                                                         ; a00d: 85 40       .@
+; &a00f referenced 1 time by &9ff8
+.ca00f
+    asl l002a                                                         ; a00f: 06 2a       .*
+    rol l002b                                                         ; a011: 26 2b       &+
+    rol l002c                                                         ; a013: 26 2c       &,
+    rol l002d                                                         ; a015: 26 2d       &-
+    lda l003d                                                         ; a017: a5 3d       .=
+    ora l003e                                                         ; a019: 05 3e       .>
+    bne c9ff4                                                         ; a01b: d0 d7       ..
+    sty l003d                                                         ; a01d: 84 3d       .=
+    stx l003e                                                         ; a01f: 86 3e       .>
+    bra ca04d                                                         ; a021: 80 2a       .*
+; &a023 referenced 2 times by &9f18, &9f75
+.sub_ca023
+    jsr cbc66                                                         ; a023: 20 66 bc     f.
+; &a026 referenced 2 times by &9f07, &bc1b
+.sub_ca026
+    jsr sub_ca06c                                                     ; a026: 20 6c a0     l.
+; &a029 referenced 2 times by &9fb6, &a05d
+.ca029
+    cpx #&2a ; '*'                                                    ; a029: e0 2a       .*
+    beq c9fb8                                                         ; a02b: f0 8b       ..
+    cpx #&2f ; '/'                                                    ; a02d: e0 2f       ./
+    bcc ca03b                                                         ; a02f: 90 0a       ..
+    beq ca03c                                                         ; a031: f0 09       ..
+    cpx #&83                                                          ; a033: e0 83       ..
+    beq ca04a                                                         ; a035: f0 13       ..
+    cpx #&81                                                          ; a037: e0 81       ..
+    beq ca05f                                                         ; a039: f0 24       .$
+; &a03b referenced 1 time by &a02f
+.ca03b
+    rts                                                               ; a03b: 60          `
+
+; &a03c referenced 1 time by &a031
+.ca03c
+    jsr sub_cbc36                                                     ; a03c: 20 36 bc     6.
+    jsr sub_ca06c                                                     ; a03f: 20 6c a0     l.
+    jsr sub_cbc1e                                                     ; a042: 20 1e bc     ..
+    jsr ca634                                                         ; a045: 20 34 a6     4.
+    bra ca05b                                                         ; a048: 80 11       ..
+; &a04a referenced 1 time by &a035
+.ca04a
+    jsr sub_c81bd                                                     ; a04a: 20 bd 81     ..
+; &a04d referenced 1 time by &a021
+.ca04d
+    lda l0038                                                         ; a04d: a5 38       .8
+    php                                                               ; a04f: 08          .
+    ldx #&3d ; '='                                                    ; a050: a2 3d       .=
+; &a052 referenced 1 time by &a067
+.loop_ca052
+    jsr sub_caad8                                                     ; a052: 20 d8 aa     ..
+    plp                                                               ; a055: 28          (
+    bpl ca05b                                                         ; a056: 10 03       ..
+    jsr cad20                                                         ; a058: 20 20 ad      .
+; &a05b referenced 2 times by &a048, &a056
+.ca05b
+    ldx l0027                                                         ; a05b: a6 27       .'
+    bra ca029                                                         ; a05d: 80 ca       ..
+; &a05f referenced 1 time by &a039
+.ca05f
+    jsr sub_c81bd                                                     ; a05f: 20 bd 81     ..
+    bit l0037                                                         ; a062: 24 37       $7
+    php                                                               ; a064: 08          .
+    ldx #&39 ; '9'                                                    ; a065: a2 39       .9
+    bra loop_ca052                                                    ; a067: 80 e9       ..
+; &a069 referenced 2 times by &81c8, &9fca
+.sub_ca069
+    jsr cbc66                                                         ; a069: 20 66 bc     f.
+; &a06c referenced 4 times by &9ee0, &9fad, &a026, &a03f
+.sub_ca06c
+    jsr cad78                                                         ; a06c: 20 78 ad     x.
+; &a06f referenced 2 times by &a0cf, &a0e6
+.ca06f
+    pha                                                               ; a06f: 48          H
+; &a070 referenced 1 time by &a078
+.loop_ca070
+    ldy l001b                                                         ; a070: a4 1b       ..
+    inc l001b                                                         ; a072: e6 1b       ..
+    lda (l0019),y                                                     ; a074: b1 19       ..
+    cmp #&20 ; ' '                                                    ; a076: c9 20       .
+    beq loop_ca070                                                    ; a078: f0 f6       ..
+    tax                                                               ; a07a: aa          .
+    pla                                                               ; a07b: 68          h
+    cpx #&5e ; '^'                                                    ; a07c: e0 5e       .^
+    beq ca081                                                         ; a07e: f0 01       ..
+    rts                                                               ; a080: 60          `
+
+; &a081 referenced 2 times by &a07e, &a089
+.ca081
+    jsr sub_cbc36                                                     ; a081: 20 36 bc     6.
+    jsr cad78                                                         ; a084: 20 78 ad     x.
+    bmi ca09f                                                         ; a087: 30 16       0.
+    beq ca081                                                         ; a089: f0 f6       ..
+    lda l002a                                                         ; a08b: a5 2a       .*
+    asl a                                                             ; a08d: 0a          .
+    lda #0                                                            ; a08e: a9 00       ..
+    adc l002b                                                         ; a090: 65 2b       e+
+    bne ca09c                                                         ; a092: d0 08       ..
+    adc l002c                                                         ; a094: 65 2c       e,
+    bne ca09c                                                         ; a096: d0 04       ..
+    adc l002d                                                         ; a098: 65 2d       e-
+    beq ca0c7                                                         ; a09a: f0 2b       .+
+; &a09c referenced 2 times by &a092, &a096
+.ca09c
+    jsr c828d                                                         ; a09c: 20 8d 82     ..
+; &a09f referenced 1 time by &a087
+.ca09f
+    lda l0030                                                         ; a09f: a5 30       .0
+    beq ca0c5                                                         ; a0a1: f0 22       ."
+    cmp #&87                                                          ; a0a3: c9 87       ..
+    bcs ca0d1                                                         ; a0a5: b0 2a       .*
+    cmp #&81                                                          ; a0a7: c9 81       ..
+    bcc ca0d1                                                         ; a0a9: 90 26       .&
+    ora #&78 ; 'x'                                                    ; a0ab: 09 78       .x
+    tay                                                               ; a0ad: a8          .
+    lda l0032                                                         ; a0ae: a5 32       .2
+    ora l0033                                                         ; a0b0: 05 33       .3
+    ora l0034                                                         ; a0b2: 05 34       .4
+    bne ca0d1                                                         ; a0b4: d0 1b       ..
+    lda l0031                                                         ; a0b6: a5 31       .1
+; &a0b8 referenced 1 time by &a0bc
+.loop_ca0b8
+    lsr a                                                             ; a0b8: 4a          J
+    bcs ca0d1                                                         ; a0b9: b0 16       ..
+    iny                                                               ; a0bb: c8          .
+    bmi loop_ca0b8                                                    ; a0bc: 30 fa       0.
+    ldy l002e                                                         ; a0be: a4 2e       ..
+    bpl ca0c5                                                         ; a0c0: 10 03       ..
+    eor #&ff                                                          ; a0c2: 49 ff       I.
+    inc a                                                             ; a0c4: 1a          .
+; &a0c5 referenced 2 times by &a0a1, &a0c0
+.ca0c5
+    sta l002a                                                         ; a0c5: 85 2a       .*
+; &a0c7 referenced 1 time by &a09a
+.ca0c7
+    jsr sub_ca56d                                                     ; a0c7: 20 6d a5     m.
+    lda l002a                                                         ; a0ca: a5 2a       .*
+    jsr sub_ca5f9                                                     ; a0cc: 20 f9 a5     ..
+    bra ca06f                                                         ; a0cf: 80 9e       ..
+; &a0d1 referenced 4 times by &a0a5, &a0a9, &a0b4, &a0b9
+.ca0d1
+    lda #&71 ; 'q'                                                    ; a0d1: a9 71       .q
+    jsr ca547                                                         ; a0d3: 20 47 a5     G.
+    jsr sub_ca56d                                                     ; a0d6: 20 6d a5     m.
+    jsr sub_ca7af                                                     ; a0d9: 20 af a7     ..
+    lda #&71 ; 'q'                                                    ; a0dc: a9 71       .q
+    ldy #4                                                            ; a0de: a0 04       ..
+    jsr sub_ca9c3                                                     ; a0e0: 20 c3 a9     ..
+    jsr sub_caa1a                                                     ; a0e3: 20 1a aa     ..
+    bra ca06f                                                         ; a0e6: 80 87       ..
+; &a0e8 referenced 3 times by &9535, &9d1e, &b505
+.sub_ca0e8
+    lda #0                                                            ; a0e8: a9 00       ..
+    bra ca0ee                                                         ; a0ea: 80 02       ..
+; &a0ec referenced 2 times by &9558, &b4c6
+.sub_ca0ec
+    lda #5                                                            ; a0ec: a9 05       ..
+; &a0ee referenced 1 time by &a0ea
+.ca0ee
+    sta l0014                                                         ; a0ee: 85 14       ..
+    ldx #4                                                            ; a0f0: a2 04       ..
+; &a0f2 referenced 1 time by &a10b
+.loop_ca0f2
+    stz l003f,x                                                       ; a0f2: 74 3f       t?
+    sec                                                               ; a0f4: 38          8
+; &a0f5 referenced 1 time by &a108
+.loop_ca0f5
+    lda l002a                                                         ; a0f5: a5 2a       .*
+    sbc l80e2,x                                                       ; a0f7: fd e2 80    ...
+    tay                                                               ; a0fa: a8          .
+    lda l002b                                                         ; a0fb: a5 2b       .+
+    sbc l80dd,x                                                       ; a0fd: fd dd 80    ...
+    bcc ca10a                                                         ; a100: 90 08       ..
+    sta l002b                                                         ; a102: 85 2b       .+
+    sty l002a                                                         ; a104: 84 2a       .*
+    inc l003f,x                                                       ; a106: f6 3f       .?
+    bra loop_ca0f5                                                    ; a108: 80 eb       ..
+; &a10a referenced 1 time by &a100
+.ca10a
+    dex                                                               ; a10a: ca          .
+    bpl loop_ca0f2                                                    ; a10b: 10 e5       ..
+    ldx #5                                                            ; a10d: a2 05       ..
+; &a10f referenced 1 time by &a114
+.loop_ca10f
+    dex                                                               ; a10f: ca          .
+    beq ca116                                                         ; a110: f0 04       ..
+    lda l003f,x                                                       ; a112: b5 3f       .?
+    beq loop_ca10f                                                    ; a114: f0 f9       ..
+; &a116 referenced 1 time by &a110
+.ca116
+    stx l0037                                                         ; a116: 86 37       .7
+    lda l0014                                                         ; a118: a5 14       ..
+    beq ca126                                                         ; a11a: f0 0a       ..
+    sbc l0037                                                         ; a11c: e5 37       .7
+    beq ca126                                                         ; a11e: f0 06       ..
+    tax                                                               ; a120: aa          .
+    jsr cbdff                                                         ; a121: 20 ff bd     ..
+    ldx l0037                                                         ; a124: a6 37       .7
+; &a126 referenced 3 times by &a11a, &a11e, &a12e
+.ca126
+    lda l003f,x                                                       ; a126: b5 3f       .?
+    ora #&30 ; '0'                                                    ; a128: 09 30       .0
+    jsr cbdd4                                                         ; a12a: 20 d4 bd     ..
+    dex                                                               ; a12d: ca          .
+    bpl ca126                                                         ; a12e: 10 f6       ..
+    rts                                                               ; a130: 60          `
+
+; &a131 referenced 1 time by &a1a7
+.ca131
+    tya                                                               ; a131: 98          .
+    bpl ca137                                                         ; a132: 10 03       ..
+    jsr sub_c9788                                                     ; a134: 20 88 97     ..
+; &a137 referenced 1 time by &a132
+.ca137
+    ldx #0                                                            ; a137: a2 00       ..
+    ldy #0                                                            ; a139: a0 00       ..
+; &a13b referenced 1 time by &a14f
+.loop_ca13b
+    lda l002a,y                                                       ; a13b: b9 2a 00    .*.
+    pha                                                               ; a13e: 48          H
+    and #&0f                                                          ; a13f: 29 0f       ).
+    sta l003f,x                                                       ; a141: 95 3f       .?
+    pla                                                               ; a143: 68          h
+    lsr a                                                             ; a144: 4a          J
+    lsr a                                                             ; a145: 4a          J
+    lsr a                                                             ; a146: 4a          J
+    lsr a                                                             ; a147: 4a          J
+    inx                                                               ; a148: e8          .
+    sta l003f,x                                                       ; a149: 95 3f       .?
+    inx                                                               ; a14b: e8          .
+    iny                                                               ; a14c: c8          .
+    cpy #4                                                            ; a14d: c0 04       ..
+    bne loop_ca13b                                                    ; a14f: d0 ea       ..
+; &a151 referenced 1 time by &a156
+.loop_ca151
+    dex                                                               ; a151: ca          .
+    beq ca158                                                         ; a152: f0 04       ..
+    lda l003f,x                                                       ; a154: b5 3f       .?
+    beq loop_ca151                                                    ; a156: f0 f9       ..
+; &a158 referenced 2 times by &a152, &a166
+.ca158
+    lda l003f,x                                                       ; a158: b5 3f       .?
+    cmp #&0a                                                          ; a15a: c9 0a       ..
+    bcc ca160                                                         ; a15c: 90 02       ..
+    adc #6                                                            ; a15e: 69 06       i.
+; &a160 referenced 1 time by &a15c
+.ca160
+    adc #&30 ; '0'                                                    ; a160: 69 30       i0
+    jsr ca2cc                                                         ; a162: 20 cc a2     ..
+    dex                                                               ; a165: ca          .
+    bpl ca158                                                         ; a166: 10 f0       ..
+    rts                                                               ; a168: 60          `
+
+; &a169 referenced 1 time by &a1b1
+.ca169
+    lda l002e                                                         ; a169: a5 2e       ..
+    bpl ca174                                                         ; a16b: 10 07       ..
+    lda #&2d ; '-'                                                    ; a16d: a9 2d       .-
+    stz l002e                                                         ; a16f: 64 2e       d.
+    jsr ca2cc                                                         ; a171: 20 cc a2     ..
+; &a174 referenced 3 times by &a16b, &a17f, &a1d2
+.ca174
+    lda l0030                                                         ; a174: a5 30       .0
+    cmp #&81                                                          ; a176: c9 81       ..
+    bcs ca1c1                                                         ; a178: b0 47       .G
+    jsr sub_ca46b                                                     ; a17a: 20 6b a4     k.
+    dec l0048                                                         ; a17d: c6 48       .H
+    bra ca174                                                         ; a17f: 80 f3       ..
+; &a181 referenced 2 times by &92c7, &af83
+.sub_ca181
+    ldx l0402                                                         ; a181: ae 02 04    ...
+    cpx #3                                                            ; a184: e0 03       ..
+    bcc ca18a                                                         ; a186: 90 02       ..
+    ldx #0                                                            ; a188: a2 00       ..
+; &a18a referenced 1 time by &a186
+.ca18a
+    stx l0037                                                         ; a18a: 86 37       .7
+    lda l0401                                                         ; a18c: ad 01 04    ...
+    beq ca197                                                         ; a18f: f0 06       ..
+    cmp #&0a                                                          ; a191: c9 0a       ..
+    bcs ca19b                                                         ; a193: b0 06       ..
+    bra ca19d                                                         ; a195: 80 06       ..
+; &a197 referenced 1 time by &a18f
+.ca197
+    cpx #2                                                            ; a197: e0 02       ..
+    beq ca19d                                                         ; a199: f0 02       ..
+; &a19b referenced 2 times by &a193, &af7e
+.ca19b
+    lda #&0a                                                          ; a19b: a9 0a       ..
+; &a19d referenced 2 times by &a195, &a199
+.ca19d
+    sta l0038                                                         ; a19d: 85 38       .8
+    sta l004d                                                         ; a19f: 85 4d       .M
+    stz l0036                                                         ; a1a1: 64 36       d6
+    stz l0048                                                         ; a1a3: 64 48       dH
+    bit l0015                                                         ; a1a5: 24 15       $.
+    bmi ca131                                                         ; a1a7: 30 88       0.
+    tya                                                               ; a1a9: 98          .
+    bmi ca1af                                                         ; a1aa: 30 03       0.
+    jsr c828d                                                         ; a1ac: 20 8d 82     ..
+; &a1af referenced 1 time by &a1aa
+.ca1af
+    lda l0031                                                         ; a1af: a5 31       .1
+    bne ca169                                                         ; a1b1: d0 b6       ..
+    lda l0037                                                         ; a1b3: a5 37       .7
+    bne ca21c                                                         ; a1b5: d0 65       .e
+    lda #&30 ; '0'                                                    ; a1b7: a9 30       .0
+    jmp ca2cc                                                         ; a1b9: 4c cc a2    L..
+
+; &a1bc referenced 1 time by &a216
+.ca1bc
+    jsr ca622                                                         ; a1bc: 20 22 a6     ".
+    bra ca1d0                                                         ; a1bf: 80 0f       ..
+; &a1c1 referenced 1 time by &a178
+.ca1c1
+    cmp #&84                                                          ; a1c1: c9 84       ..
+    bcc ca1d4                                                         ; a1c3: 90 0f       ..
+    bne ca1cd                                                         ; a1c5: d0 06       ..
+    lda l0031                                                         ; a1c7: a5 31       .1
+    cmp #&a0                                                          ; a1c9: c9 a0       ..
+    bcc ca1d4                                                         ; a1cb: 90 07       ..
+; &a1cd referenced 1 time by &a1c5
+.ca1cd
+    jsr sub_ca4ba                                                     ; a1cd: 20 ba a4     ..
+; &a1d0 referenced 1 time by &a1bf
+.ca1d0
+    inc l0048                                                         ; a1d0: e6 48       .H
+    bra ca174                                                         ; a1d2: 80 a0       ..
+; &a1d4 referenced 2 times by &a1c3, &a1cb
+.ca1d4
+    jsr sub_ca3ed                                                     ; a1d4: 20 ed a3     ..
+    lda l004d                                                         ; a1d7: a5 4d       .M
+    sta l0038                                                         ; a1d9: 85 38       .8
+    ldx l0037                                                         ; a1db: a6 37       .7
+    cpx #2                                                            ; a1dd: e0 02       ..
+    bne ca1ef                                                         ; a1df: d0 0e       ..
+    adc l0048                                                         ; a1e1: 65 48       eH
+    bmi ca220                                                         ; a1e3: 30 3b       0;
+    cmp #&0b                                                          ; a1e5: c9 0b       ..
+    bcc ca1ed                                                         ; a1e7: 90 04       ..
+    lda #&0a                                                          ; a1e9: a9 0a       ..
+    stz l0037                                                         ; a1eb: 64 37       d7
+; &a1ed referenced 1 time by &a1e7
+.ca1ed
+    sta l0038                                                         ; a1ed: 85 38       .8
+; &a1ef referenced 1 time by &a1df
+.ca1ef
+    lda l0038                                                         ; a1ef: a5 38       .8
+    eor #&ff                                                          ; a1f1: 49 ff       I.
+    lsr a                                                             ; a1f3: 4a          J
+    php                                                               ; a1f4: 08          .
+    asl a                                                             ; a1f5: 0a          .
+    asl a                                                             ; a1f6: 0a          .
+    adc #&bc                                                          ; a1f7: 69 bc       i.
+    jsr sub_ca572                                                     ; a1f9: 20 72 a5     r.
+    dec l0030                                                         ; a1fc: c6 30       .0
+    plp                                                               ; a1fe: 28          (
+    bcc ca204                                                         ; a1ff: 90 03       ..
+    jsr sub_ca46b                                                     ; a201: 20 6b a4     k.
+; &a204 referenced 1 time by &a1ff
+.ca204
+    jsr sub_c8429                                                     ; a204: 20 29 84     ).
+; &a207 referenced 1 time by &a210
+.loop_ca207
+    lda l0030                                                         ; a207: a5 30       .0
+    cmp #&84                                                          ; a209: c9 84       ..
+    bcs ca212                                                         ; a20b: b0 05       ..
+    jsr ca4a9                                                         ; a20d: 20 a9 a4     ..
+    bne loop_ca207                                                    ; a210: d0 f5       ..
+; &a212 referenced 1 time by &a20b
+.ca212
+    lda l0031                                                         ; a212: a5 31       .1
+    cmp #&a0                                                          ; a214: c9 a0       ..
+    bcs ca1bc                                                         ; a216: b0 a4       ..
+    lda l0038                                                         ; a218: a5 38       .8
+    bne ca22a                                                         ; a21a: d0 0e       ..
+; &a21c referenced 1 time by &a1b5
+.ca21c
+    cmp #1                                                            ; a21c: c9 01       ..
+    beq ca261                                                         ; a21e: f0 41       .A
+; &a220 referenced 2 times by &89d0, &a1e3
+.ca220
+    jsr ca72b                                                         ; a220: 20 2b a7     +.
+    stz l0048                                                         ; a223: 64 48       dH
+    lda l004d                                                         ; a225: a5 4d       .M
+    inc a                                                             ; a227: 1a          .
+    sta l0038                                                         ; a228: 85 38       .8
+; &a22a referenced 1 time by &a21a
+.ca22a
+    lda #1                                                            ; a22a: a9 01       ..
+    cmp l0037                                                         ; a22c: c5 37       .7
+    beq ca261                                                         ; a22e: f0 31       .1
+    ldy l0048                                                         ; a230: a4 48       .H
+    bmi ca23e                                                         ; a232: 30 0a       0.
+    cpy l0038                                                         ; a234: c4 38       .8
+    bcs ca261                                                         ; a236: b0 29       .)
+    stz l0048                                                         ; a238: 64 48       dH
+    iny                                                               ; a23a: c8          .
+    tya                                                               ; a23b: 98          .
+    bne ca261                                                         ; a23c: d0 23       .#
+; &a23e referenced 1 time by &a232
+.ca23e
+    lda l0037                                                         ; a23e: a5 37       .7
+    cmp #2                                                            ; a240: c9 02       ..
+    beq ca24a                                                         ; a242: f0 06       ..
+    lda #1                                                            ; a244: a9 01       ..
+    cpy #&ff                                                          ; a246: c0 ff       ..
+    bne ca261                                                         ; a248: d0 17       ..
+; &a24a referenced 1 time by &a242
+.ca24a
+    lda #&30 ; '0'                                                    ; a24a: a9 30       .0
+    jsr ca2cc                                                         ; a24c: 20 cc a2     ..
+    lda #&2e ; '.'                                                    ; a24f: a9 2e       ..
+    jsr ca2cc                                                         ; a251: 20 cc a2     ..
+    lda #&30 ; '0'                                                    ; a254: a9 30       .0
+; &a256 referenced 1 time by &a25d
+.loop_ca256
+    inc l0048                                                         ; a256: e6 48       .H
+    beq ca25f                                                         ; a258: f0 05       ..
+    jsr ca2cc                                                         ; a25a: 20 cc a2     ..
+    bra loop_ca256                                                    ; a25d: 80 f7       ..
+; &a25f referenced 1 time by &a258
+.ca25f
+    lda #&80                                                          ; a25f: a9 80       ..
+; &a261 referenced 5 times by &a21e, &a22e, &a236, &a23c, &a248
+.ca261
+    sta l004d                                                         ; a261: 85 4d       .M
+; &a263 referenced 1 time by &a271
+.loop_ca263
+    jsr sub_ca40a                                                     ; a263: 20 0a a4     ..
+    dec l004d                                                         ; a266: c6 4d       .M
+    bne ca26f                                                         ; a268: d0 05       ..
+    lda #&2e ; '.'                                                    ; a26a: a9 2e       ..
+    jsr ca2cc                                                         ; a26c: 20 cc a2     ..
+; &a26f referenced 1 time by &a268
+.ca26f
+    dec l0038                                                         ; a26f: c6 38       .8
+    bne loop_ca263                                                    ; a271: d0 f0       ..
+    ldy l0037                                                         ; a273: a4 37       .7
+    dey                                                               ; a275: 88          .
+    beq ca290                                                         ; a276: f0 18       ..
+    dey                                                               ; a278: 88          .
+    beq ca28c                                                         ; a279: f0 11       ..
+    ldy l0036                                                         ; a27b: a4 36       .6
+; &a27d referenced 1 time by &a283
+.loop_ca27d
+    dey                                                               ; a27d: 88          .
+    lda l0600,y                                                       ; a27e: b9 00 06    ...
+    cmp #&30 ; '0'                                                    ; a281: c9 30       .0
+    beq loop_ca27d                                                    ; a283: f0 f8       ..
+    cmp #&2e ; '.'                                                    ; a285: c9 2e       ..
+    beq ca28a                                                         ; a287: f0 01       ..
+    iny                                                               ; a289: c8          .
+; &a28a referenced 1 time by &a287
+.ca28a
+    sty l0036                                                         ; a28a: 84 36       .6
+; &a28c referenced 1 time by &a279
+.ca28c
+    lda l0048                                                         ; a28c: a5 48       .H
+    beq ca2b7                                                         ; a28e: f0 27       .'
+; &a290 referenced 1 time by &a276
+.ca290
+    lda #&45 ; 'E'                                                    ; a290: a9 45       .E
+    jsr ca2cc                                                         ; a292: 20 cc a2     ..
+    lda l0048                                                         ; a295: a5 48       .H
+    bpl ca2a3                                                         ; a297: 10 0a       ..
+    lda #&2d ; '-'                                                    ; a299: a9 2d       .-
+    jsr ca2cc                                                         ; a29b: 20 cc a2     ..
+    sec                                                               ; a29e: 38          8
+    lda #0                                                            ; a29f: a9 00       ..
+    sbc l0048                                                         ; a2a1: e5 48       .H
+; &a2a3 referenced 1 time by &a297
+.ca2a3
+    jsr sub_ca2b8                                                     ; a2a3: 20 b8 a2     ..
+    lda l0037                                                         ; a2a6: a5 37       .7
+    beq ca2b7                                                         ; a2a8: f0 0d       ..
+    lda #&20 ; ' '                                                    ; a2aa: a9 20       .
+    ldy l0048                                                         ; a2ac: a4 48       .H
+    bmi ca2b3                                                         ; a2ae: 30 03       0.
+    jsr ca2cc                                                         ; a2b0: 20 cc a2     ..
+; &a2b3 referenced 1 time by &a2ae
+.ca2b3
+    cpx #0                                                            ; a2b3: e0 00       ..
+    beq ca2cc                                                         ; a2b5: f0 15       ..
+; &a2b7 referenced 2 times by &a28e, &a2a8
+.ca2b7
+    rts                                                               ; a2b7: 60          `
+
+; &a2b8 referenced 1 time by &a2a3
+.sub_ca2b8
+    ldx #&ff                                                          ; a2b8: a2 ff       ..
+    sec                                                               ; a2ba: 38          8
+; &a2bb referenced 1 time by &a2be
+.loop_ca2bb
+    inx                                                               ; a2bb: e8          .
+    sbc #&0a                                                          ; a2bc: e9 0a       ..
+    bcs loop_ca2bb                                                    ; a2be: b0 fb       ..
+    adc #&0a                                                          ; a2c0: 69 0a       i.
+    pha                                                               ; a2c2: 48          H
+    txa                                                               ; a2c3: 8a          .
+    beq ca2c9                                                         ; a2c4: f0 03       ..
+    jsr sub_ca2ca                                                     ; a2c6: 20 ca a2     ..
+; &a2c9 referenced 1 time by &a2c4
+.ca2c9
+    pla                                                               ; a2c9: 68          h
+; &a2ca referenced 2 times by &a2c6, &a410
+.sub_ca2ca
+    ora #&30 ; '0'                                                    ; a2ca: 09 30       .0
+; &a2cc referenced 11 times by &a162, &a171, &a1b9, &a24c, &a251, &a25a, &a26c, &a292, &a29b, &a2b0, &a2b5
+.ca2cc
+    phx                                                               ; a2cc: da          .
+    ldx l0036                                                         ; a2cd: a6 36       .6
+    sta l0600,x                                                       ; a2cf: 9d 00 06    ...
+    plx                                                               ; a2d2: fa          .
+    inc l0036                                                         ; a2d3: e6 36       .6
+    rts                                                               ; a2d5: 60          `
+
+; &a2d6 referenced 2 times by &a2f5, &a2f9
+.ca2d6
+    clc                                                               ; a2d6: 18          .
+    lda #&ff                                                          ; a2d7: a9 ff       ..
+    jmp c82dd                                                         ; a2d9: 4c dd 82    L..
+
+    equb &60                                                          ; a2dc: 60          `
+
+; &a2dd referenced 3 times by &abcb, &abd5, &adb6
+.sub_ca2dd
+    stz l0031                                                         ; a2dd: 64 31       d1
+    stz l0032                                                         ; a2df: 64 32       d2
+    stz l0033                                                         ; a2e1: 64 33       d3
+    stz l0034                                                         ; a2e3: 64 34       d4
+    stz l0035                                                         ; a2e5: 64 35       d5
+    stz l0047                                                         ; a2e7: 64 47       dG
+    stz l0048                                                         ; a2e9: 64 48       dH
+    ldx #&ff                                                          ; a2eb: a2 ff       ..
+    stx l0049                                                         ; a2ed: 86 49       .I
+    cmp #&2e ; '.'                                                    ; a2ef: c9 2e       ..
+    beq ca348                                                         ; a2f1: f0 55       .U
+    cmp #&3a ; ':'                                                    ; a2f3: c9 3a       .:
+    bcs ca2d6                                                         ; a2f5: b0 df       ..
+    sbc #&2f ; '/'                                                    ; a2f7: e9 2f       ./
+    bmi ca2d6                                                         ; a2f9: 30 db       0.
+; &a2fb referenced 4 times by &a31f, &a323, &a337, &a33c
+.ca2fb
+    sta l0035                                                         ; a2fb: 85 35       .5
+; &a2fd referenced 1 time by &a340
+.ca2fd
+    lda l0047                                                         ; a2fd: a5 47       .G
+    beq ca303                                                         ; a2ff: f0 02       ..
+    dec l0048                                                         ; a301: c6 48       .H
+; &a303 referenced 2 times by &a2ff, &a34a
+.ca303
+    iny                                                               ; a303: c8          .
+    lda (l0019),y                                                     ; a304: b1 19       ..
+    cmp #&3a ; ':'                                                    ; a306: c9 3a       .:
+    bcs ca34c                                                         ; a308: b0 42       .B
+    sbc #&2f ; '/'                                                    ; a30a: e9 2f       ./
+    bcc ca342                                                         ; a30c: 90 34       .4
+    sta l0042                                                         ; a30e: 85 42       .B
+    ldx l0049                                                         ; a310: a6 49       .I
+    bpl ca325                                                         ; a312: 10 11       ..
+    lda l0035                                                         ; a314: a5 35       .5
+    asl a                                                             ; a316: 0a          .
+    asl a                                                             ; a317: 0a          .
+    adc l0035                                                         ; a318: 65 35       e5
+    asl a                                                             ; a31a: 0a          .
+    adc l0042                                                         ; a31b: 65 42       eB
+    cmp #&19                                                          ; a31d: c9 19       ..
+    bcc ca2fb                                                         ; a31f: 90 da       ..
+    stz l0049                                                         ; a321: 64 49       dI
+    bra ca2fb                                                         ; a323: 80 d6       ..
+; &a325 referenced 1 time by &a312
+.ca325
+    cpx #2                                                            ; a325: e0 02       ..
+    bcs ca33e                                                         ; a327: b0 15       ..
+    jsr sub_ca419                                                     ; a329: 20 19 a4     ..
+    cmp #&19                                                          ; a32c: c9 19       ..
+    bcc ca333                                                         ; a32e: 90 03       ..
+    inc l0049                                                         ; a330: e6 49       .I
+    clc                                                               ; a332: 18          .
+; &a333 referenced 1 time by &a32e
+.ca333
+    lda l0042                                                         ; a333: a5 42       .B
+    adc l0035                                                         ; a335: 65 35       e5
+    bcc ca2fb                                                         ; a337: 90 c2       ..
+    jsr sub_ca503                                                     ; a339: 20 03 a5     ..
+    bra ca2fb                                                         ; a33c: 80 bd       ..
+; &a33e referenced 1 time by &a327
+.ca33e
+    inc l0048                                                         ; a33e: e6 48       .H
+    bra ca2fd                                                         ; a340: 80 bb       ..
+; &a342 referenced 1 time by &a30c
+.ca342
+    eor #&fe                                                          ; a342: 49 fe       I.
+    ora l0047                                                         ; a344: 05 47       .G
+    bne ca357                                                         ; a346: d0 0f       ..
+; &a348 referenced 1 time by &a2f1
+.ca348
+    inc l0047                                                         ; a348: e6 47       .G
+    bra ca303                                                         ; a34a: 80 b7       ..
+; &a34c referenced 1 time by &a308
+.ca34c
+    cmp #&45 ; 'E'                                                    ; a34c: c9 45       .E
+    bne ca357                                                         ; a34e: d0 07       ..
+    jsr sub_ca3b5                                                     ; a350: 20 b5 a3     ..
+    adc l0048                                                         ; a353: 65 48       eH
+    sta l0048                                                         ; a355: 85 48       .H
+; &a357 referenced 2 times by &a346, &a34e
+.ca357
+    sty l001b                                                         ; a357: 84 1b       ..
+    ldy l0031                                                         ; a359: a4 31       .1
+    bne ca385                                                         ; a35b: d0 28       .(
+    lda l0032                                                         ; a35d: a5 32       .2
+    bmi ca385                                                         ; a35f: 30 24       0$
+    sta l002d                                                         ; a361: 85 2d       .-
+    beq ca36b                                                         ; a363: f0 06       ..
+    lda l0048                                                         ; a365: a5 48       .H
+    ora l0047                                                         ; a367: 05 47       .G
+    bne ca385                                                         ; a369: d0 1a       ..
+; &a36b referenced 1 time by &a363
+.ca36b
+    lda l0035                                                         ; a36b: a5 35       .5
+    sta l002a                                                         ; a36d: 85 2a       .*
+    lda l0034                                                         ; a36f: a5 34       .4
+    sta l002b                                                         ; a371: 85 2b       .+
+    lda l0033                                                         ; a373: a5 33       .3
+    sta l002c                                                         ; a375: 85 2c       .,
+    lda l0048                                                         ; a377: a5 48       .H
+    bne ca37e                                                         ; a379: d0 03       ..
+    inc a                                                             ; a37b: 1a          .
+    sec                                                               ; a37c: 38          8
+    rts                                                               ; a37d: 60          `
+
+; &a37e referenced 1 time by &a379
+.ca37e
+    jsr c828d                                                         ; a37e: 20 8d 82     ..
+    bne ca393                                                         ; a381: d0 10       ..
+    bra ca3aa                                                         ; a383: 80 25       .%
+; &a385 referenced 3 times by &a35b, &a35f, &a369
+.ca385
+    lda #&a8                                                          ; a385: a9 a8       ..
+    sta l0030                                                         ; a387: 85 30       .0
+    stz l002e                                                         ; a389: 64 2e       d.
+    stz l002f                                                         ; a38b: 64 2f       d/
+    tya                                                               ; a38d: 98          .
+    sta l0031                                                         ; a38e: 85 31       .1
+    jsr c8304                                                         ; a390: 20 04 83     ..
+; &a393 referenced 1 time by &a381
+.ca393
+    ldy l0048                                                         ; a393: a4 48       .H
+    bmi ca3a1                                                         ; a395: 30 0a       0.
+    beq ca3a7                                                         ; a397: f0 0e       ..
+; &a399 referenced 1 time by &a39d
+.loop_ca399
+    jsr sub_ca46b                                                     ; a399: 20 6b a4     k.
+    dey                                                               ; a39c: 88          .
+    bne loop_ca399                                                    ; a39d: d0 fa       ..
+    bra ca3a7                                                         ; a39f: 80 06       ..
+; &a3a1 referenced 2 times by &a395, &a3a5
+.ca3a1
+    jsr sub_ca4ba                                                     ; a3a1: 20 ba a4     ..
+    iny                                                               ; a3a4: c8          .
+    bne ca3a1                                                         ; a3a5: d0 fa       ..
+; &a3a7 referenced 2 times by &a397, &a39f
+.ca3a7
+    jsr ca712                                                         ; a3a7: 20 12 a7     ..
+; &a3aa referenced 1 time by &a383
+.ca3aa
+    sec                                                               ; a3aa: 38          8
+    lda #&ff                                                          ; a3ab: a9 ff       ..
+    rts                                                               ; a3ad: 60          `
+
+; &a3ae referenced 1 time by &a3ba
+.loop_ca3ae
+    jsr sub_ca3c0                                                     ; a3ae: 20 c0 a3     ..
+    eor #&ff                                                          ; a3b1: 49 ff       I.
+    sec                                                               ; a3b3: 38          8
+    rts                                                               ; a3b4: 60          `
+
+; &a3b5 referenced 1 time by &a350
+.sub_ca3b5
+    iny                                                               ; a3b5: c8          .
+    lda (l0019),y                                                     ; a3b6: b1 19       ..
+    cmp #&2d ; '-'                                                    ; a3b8: c9 2d       .-
+    beq loop_ca3ae                                                    ; a3ba: f0 f2       ..
+    cmp #&2b ; '+'                                                    ; a3bc: c9 2b       .+
+    bne ca3c3                                                         ; a3be: d0 03       ..
+; &a3c0 referenced 1 time by &a3ae
+.sub_ca3c0
+    iny                                                               ; a3c0: c8          .
+    lda (l0019),y                                                     ; a3c1: b1 19       ..
+; &a3c3 referenced 1 time by &a3be
+.ca3c3
+    cmp #&3a ; ':'                                                    ; a3c3: c9 3a       .:
+    bcs ca3e9                                                         ; a3c5: b0 22       ."
+    sbc #&2f ; '/'                                                    ; a3c7: e9 2f       ./
+    bcc ca3e9                                                         ; a3c9: 90 1e       ..
+    sta l0049                                                         ; a3cb: 85 49       .I
+    iny                                                               ; a3cd: c8          .
+    lda (l0019),y                                                     ; a3ce: b1 19       ..
+    cmp #&3a ; ':'                                                    ; a3d0: c9 3a       .:
+    bcs ca3e5                                                         ; a3d2: b0 11       ..
+    sbc #&2f ; '/'                                                    ; a3d4: e9 2f       ./
+    bcc ca3e5                                                         ; a3d6: 90 0d       ..
+    iny                                                               ; a3d8: c8          .
+    sta l0042                                                         ; a3d9: 85 42       .B
+    lda l0049                                                         ; a3db: a5 49       .I
+    asl a                                                             ; a3dd: 0a          .
+    asl a                                                             ; a3de: 0a          .
+    adc l0049                                                         ; a3df: 65 49       eI
+    asl a                                                             ; a3e1: 0a          .
+    adc l0042                                                         ; a3e2: 65 42       eB
+    rts                                                               ; a3e4: 60          `
+
+; &a3e5 referenced 2 times by &a3d2, &a3d6
+.ca3e5
+    lda l0049                                                         ; a3e5: a5 49       .I
+    clc                                                               ; a3e7: 18          .
+    rts                                                               ; a3e8: 60          `
+
+; &a3e9 referenced 2 times by &a3c5, &a3c9
+.ca3e9
+    lda #0                                                            ; a3e9: a9 00       ..
+    clc                                                               ; a3eb: 18          .
+    rts                                                               ; a3ec: 60          `
+
+; &a3ed referenced 3 times by &828a, &a1d4, &a6ce
+.sub_ca3ed
+    lda l002e                                                         ; a3ed: a5 2e       ..
+    sta l003b                                                         ; a3ef: 85 3b       .;
+    lda l0030                                                         ; a3f1: a5 30       .0
+    sta l003c                                                         ; a3f3: 85 3c       .<
+    lda l0031                                                         ; a3f5: a5 31       .1
+    sta l003d                                                         ; a3f7: 85 3d       .=
+    lda l0032                                                         ; a3f9: a5 32       .2
+    sta l003e                                                         ; a3fb: 85 3e       .>
+    lda l0033                                                         ; a3fd: a5 33       .3
+    sta l003f                                                         ; a3ff: 85 3f       .?
+    lda l0034                                                         ; a401: a5 34       .4
+    sta l0040                                                         ; a403: 85 40       .@
+    lda l0035                                                         ; a405: a5 35       .5
+    sta l0041                                                         ; a407: 85 41       .A
+    rts                                                               ; a409: 60          `
+
+; &a40a referenced 1 time by &a263
+.sub_ca40a
+    lda l0031                                                         ; a40a: a5 31       .1
+    lsr a                                                             ; a40c: 4a          J
+    lsr a                                                             ; a40d: 4a          J
+    lsr a                                                             ; a40e: 4a          J
+    lsr a                                                             ; a40f: 4a          J
+    jsr sub_ca2ca                                                     ; a410: 20 ca a2     ..
+    lda #&f0                                                          ; a413: a9 f0       ..
+    trb l0031                                                         ; a415: 14 31       .1
+    ldx #1                                                            ; a417: a2 01       ..
+; &a419 referenced 1 time by &a329
+.sub_ca419
+    asl l0035                                                         ; a419: 06 35       .5
+    rol l0034                                                         ; a41b: 26 34       &4
+    rol l0033                                                         ; a41d: 26 33       &3
+    txa                                                               ; a41f: 8a          .
+    beq ca42c                                                         ; a420: f0 0a       ..
+    rol l0032                                                         ; a422: 26 32       &2
+    rol l0031                                                         ; a424: 26 31       &1
+; &a426 referenced 4 times by &a474, &a478, &a4c6, &a4ca
+.ca426
+    lda l0031                                                         ; a426: a5 31       .1
+    pha                                                               ; a428: 48          H
+    lda l0032                                                         ; a429: a5 32       .2
+    pha                                                               ; a42b: 48          H
+; &a42c referenced 1 time by &a420
+.ca42c
+    lda l0033                                                         ; a42c: a5 33       .3
+    pha                                                               ; a42e: 48          H
+    lda l0034                                                         ; a42f: a5 34       .4
+    pha                                                               ; a431: 48          H
+    lda l0035                                                         ; a432: a5 35       .5
+    cpx #0                                                            ; a434: e0 00       ..
+    bmi ca47a                                                         ; a436: 30 42       0B
+    bne ca446                                                         ; a438: d0 0c       ..
+    asl a                                                             ; a43a: 0a          .
+    rol l0034                                                         ; a43b: 26 34       &4
+    rol l0033                                                         ; a43d: 26 33       &3
+    asl a                                                             ; a43f: 0a          .
+    rol l0034                                                         ; a440: 26 34       &4
+    rol l0033                                                         ; a442: 26 33       &3
+    bra ca452                                                         ; a444: 80 0c       ..
+; &a446 referenced 2 times by &a438, &a450
+.ca446
+    asl a                                                             ; a446: 0a          .
+    rol l0034                                                         ; a447: 26 34       &4
+    rol l0033                                                         ; a449: 26 33       &3
+    rol l0032                                                         ; a44b: 26 32       &2
+    rol l0031                                                         ; a44d: 26 31       &1
+    dex                                                               ; a44f: ca          .
+    bpl ca446                                                         ; a450: 10 f4       ..
+; &a452 referenced 2 times by &a444, &a487
+.ca452
+    adc l0035                                                         ; a452: 65 35       e5
+    sta l0035                                                         ; a454: 85 35       .5
+    pla                                                               ; a456: 68          h
+    adc l0034                                                         ; a457: 65 34       e4
+    sta l0034                                                         ; a459: 85 34       .4
+    pla                                                               ; a45b: 68          h
+    adc l0033                                                         ; a45c: 65 33       e3
+    sta l0033                                                         ; a45e: 85 33       .3
+    inx                                                               ; a460: e8          .
+    bne ca4b9                                                         ; a461: d0 56       .V
+    pla                                                               ; a463: 68          h
+    adc l0032                                                         ; a464: 65 32       e2
+    sta l0032                                                         ; a466: 85 32       .2
+    pla                                                               ; a468: 68          h
+    bra ca4a3                                                         ; a469: 80 38       .8
+; &a46b referenced 3 times by &a17a, &a201, &a399
+.sub_ca46b
+    clc                                                               ; a46b: 18          .
+    lda l0030                                                         ; a46c: a5 30       .0
+    adc #3                                                            ; a46e: 69 03       i.
+    ldx #&fe                                                          ; a470: a2 fe       ..
+    sta l0030                                                         ; a472: 85 30       .0
+    bcc ca426                                                         ; a474: 90 b0       ..
+    inc l002f                                                         ; a476: e6 2f       ./
+    bra ca426                                                         ; a478: 80 ac       ..
+; &a47a referenced 2 times by &a436, &a484
+.ca47a
+    lsr l0031                                                         ; a47a: 46 31       F1
+    ror l0032                                                         ; a47c: 66 32       f2
+    ror l0033                                                         ; a47e: 66 33       f3
+    ror l0034                                                         ; a480: 66 34       f4
+    ror a                                                             ; a482: 6a          j
+    inx                                                               ; a483: e8          .
+    bne ca47a                                                         ; a484: d0 f4       ..
+    dex                                                               ; a486: ca          .
+    bra ca452                                                         ; a487: 80 c9       ..
+; &a489 referenced 1 time by &84aa
+.ca489
+    lda l0035                                                         ; a489: a5 35       .5
+    adc l0041                                                         ; a48b: 65 41       eA
+    sta l0035                                                         ; a48d: 85 35       .5
+    lda l0034                                                         ; a48f: a5 34       .4
+    adc l0040                                                         ; a491: 65 40       e@
+    sta l0034                                                         ; a493: 85 34       .4
+    lda l0033                                                         ; a495: a5 33       .3
+    adc l003f                                                         ; a497: 65 3f       e?
+    sta l0033                                                         ; a499: 85 33       .3
+    lda l0032                                                         ; a49b: a5 32       .2
+    adc l003e                                                         ; a49d: 65 3e       e>
+    sta l0032                                                         ; a49f: 85 32       .2
+    lda l003d                                                         ; a4a1: a5 3d       .=
+; &a4a3 referenced 1 time by &a469
+.ca4a3
+    adc l0031                                                         ; a4a3: 65 31       e1
+    sta l0031                                                         ; a4a5: 85 31       .1
+    bcc ca4b9                                                         ; a4a7: 90 10       ..
+; &a4a9 referenced 3 times by &a20d, &a4f2, &a511
+.ca4a9
+    ror l0031                                                         ; a4a9: 66 31       f1
+    ror l0032                                                         ; a4ab: 66 32       f2
+    ror l0033                                                         ; a4ad: 66 33       f3
+    ror l0034                                                         ; a4af: 66 34       f4
+    ror l0035                                                         ; a4b1: 66 35       f5
+    inc l0030                                                         ; a4b3: e6 30       .0
+    bne ca4b9                                                         ; a4b5: d0 02       ..
+    inc l002f                                                         ; a4b7: e6 2f       ./
+; &a4b9 referenced 3 times by &a461, &a4a7, &a4b5
+.ca4b9
+    rts                                                               ; a4b9: 60          `
+
+; &a4ba referenced 2 times by &a1cd, &a3a1
+.sub_ca4ba
+    clc                                                               ; a4ba: 18          .
+    lda #&fc                                                          ; a4bb: a9 fc       ..
+    tax                                                               ; a4bd: aa          .
+    adc l0030                                                         ; a4be: 65 30       e0
+    bcs ca4c4                                                         ; a4c0: b0 02       ..
+    dec l002f                                                         ; a4c2: c6 2f       ./
+; &a4c4 referenced 1 time by &a4c0
+.ca4c4
+    sta l0030                                                         ; a4c4: 85 30       .0
+    jsr ca426                                                         ; a4c6: 20 26 a4     &.
+    dex                                                               ; a4c9: ca          .
+    jsr ca426                                                         ; a4ca: 20 26 a4     &.
+    inx                                                               ; a4cd: e8          .
+; &a4ce referenced 1 time by &a4f6
+.ca4ce
+    lda l0034,x                                                       ; a4ce: b5 34       .4
+    rol a                                                             ; a4d0: 2a          *
+    lda l0033,x                                                       ; a4d1: b5 33       .3
+    adc l0035                                                         ; a4d3: 65 35       e5
+    sta l0035                                                         ; a4d5: 85 35       .5
+    lda l0032,x                                                       ; a4d7: b5 32       .2
+    adc l0034                                                         ; a4d9: 65 34       e4
+    sta l0034                                                         ; a4db: 85 34       .4
+    lda l0031,x                                                       ; a4dd: b5 31       .1
+    adc l0033                                                         ; a4df: 65 33       e3
+    sta l0033                                                         ; a4e1: 85 33       .3
+    txa                                                               ; a4e3: 8a          .
+    beq ca4e8                                                         ; a4e4: f0 02       ..
+    lda l0031                                                         ; a4e6: a5 31       .1
+; &a4e8 referenced 1 time by &a4e4
+.ca4e8
+    adc l0032                                                         ; a4e8: 65 32       e2
+    sta l0032                                                         ; a4ea: 85 32       .2
+    bcc ca4f5                                                         ; a4ec: 90 07       ..
+    inc l0031                                                         ; a4ee: e6 31       .1
+    bne ca4f5                                                         ; a4f0: d0 03       ..
+    jsr ca4a9                                                         ; a4f2: 20 a9 a4     ..
+; &a4f5 referenced 2 times by &a4ec, &a4f0
+.ca4f5
+    dex                                                               ; a4f5: ca          .
+    bpl ca4ce                                                         ; a4f6: 10 d6       ..
+    lda l0032                                                         ; a4f8: a5 32       .2
+    rol a                                                             ; a4fa: 2a          *
+    lda l0031                                                         ; a4fb: a5 31       .1
+    adc l0035                                                         ; a4fd: 65 35       e5
+    sta l0035                                                         ; a4ff: 85 35       .5
+    bcc ca513                                                         ; a501: 90 10       ..
+; &a503 referenced 1 time by &a339
+.sub_ca503
+    inc l0034                                                         ; a503: e6 34       .4
+    bne ca513                                                         ; a505: d0 0c       ..
+; &a507 referenced 1 time by &a722
+.sub_ca507
+    inc l0033                                                         ; a507: e6 33       .3
+    bne ca513                                                         ; a509: d0 08       ..
+; &a50b referenced 1 time by &a6df
+.sub_ca50b
+    inc l0032                                                         ; a50b: e6 32       .2
+    bne ca513                                                         ; a50d: d0 04       ..
+    inc l0031                                                         ; a50f: e6 31       .1
+    beq ca4a9                                                         ; a511: f0 96       ..
+; &a513 referenced 4 times by &a501, &a505, &a509, &a50d
+.ca513
+    rts                                                               ; a513: 60          `
+
+; &a514 referenced 5 times by &9d36, &a638, &a6e8, &a70a, &a9a3
+.sub_ca514
+    stz l0041                                                         ; a514: 64 41       dA
+    ldy #4                                                            ; a516: a0 04       ..
+    lda (l004a),y                                                     ; a518: b1 4a       .J
+    sta l0040                                                         ; a51a: 85 40       .@
+    dey                                                               ; a51c: 88          .
+    lda (l004a),y                                                     ; a51d: b1 4a       .J
+    sta l003f                                                         ; a51f: 85 3f       .?
+    dey                                                               ; a521: 88          .
+    lda (l004a),y                                                     ; a522: b1 4a       .J
+    sta l003e                                                         ; a524: 85 3e       .>
+    dey                                                               ; a526: 88          .
+    lda (l004a),y                                                     ; a527: b1 4a       .J
+    sta l003b                                                         ; a529: 85 3b       .;
+    tay                                                               ; a52b: a8          .
+    lda (l004a)                                                       ; a52c: b2 4a       .J
+    sta l003c                                                         ; a52e: 85 3c       .<
+    bne ca53b                                                         ; a530: d0 09       ..
+    tya                                                               ; a532: 98          .
+    ora l003e                                                         ; a533: 05 3e       .>
+    ora l003f                                                         ; a535: 05 3f       .?
+    ora l0040                                                         ; a537: 05 40       .@
+    beq ca53e                                                         ; a539: f0 03       ..
+; &a53b referenced 1 time by &a530
+.ca53b
+    tya                                                               ; a53b: 98          .
+    ora #&80                                                          ; a53c: 09 80       ..
+; &a53e referenced 1 time by &a539
+.ca53e
+    sta l003d                                                         ; a53e: 85 3d       .=
+    rts                                                               ; a540: 60          `
+
+; &a541 referenced 1 time by &a8db
+.sub_ca541
+    lda #&76 ; 'v'                                                    ; a541: a9 76       .v
+    bra ca547                                                         ; a543: 80 02       ..
+; &a545 referenced 8 times by &9210, &a5c4, &a5ec, &a6cb, &a7ef, &a97b, &a9e9, &a9f2
+.sub_ca545
+    lda #&6c ; 'l'                                                    ; a545: a9 6c       .l
+; &a547 referenced 2 times by &a0d3, &a543
+.ca547
+    sta l004a                                                         ; a547: 85 4a       .J
+    lda #4                                                            ; a549: a9 04       ..
+    sta l004b                                                         ; a54b: 85 4b       .K
+; &a54d referenced 2 times by &b6e2, &b704
+.sub_ca54d
+    lda l0030                                                         ; a54d: a5 30       .0
+    sta (l004a)                                                       ; a54f: 92 4a       .J
+    ldy #1                                                            ; a551: a0 01       ..
+    lda l002e                                                         ; a553: a5 2e       ..
+    eor l0031                                                         ; a555: 45 31       E1
+    and #&80                                                          ; a557: 29 80       ).
+    eor l0031                                                         ; a559: 45 31       E1
+    sta (l004a),y                                                     ; a55b: 91 4a       .J
+    lda l0032                                                         ; a55d: a5 32       .2
+    iny                                                               ; a55f: c8          .
+    sta (l004a),y                                                     ; a560: 91 4a       .J
+    lda l0033                                                         ; a562: a5 33       .3
+    iny                                                               ; a564: c8          .
+    sta (l004a),y                                                     ; a565: 91 4a       .J
+    lda l0034                                                         ; a567: a5 34       .4
+    iny                                                               ; a569: c8          .
+    sta (l004a),y                                                     ; a56a: 91 4a       .J
+    rts                                                               ; a56c: 60          `
+
+; &a56d referenced 2 times by &a0c7, &a0d6
+.sub_ca56d
+    jsr sub_cbc24                                                     ; a56d: 20 24 bc     $.
+    bra ca57e                                                         ; a570: 80 0c       ..
+; &a572 referenced 1 time by &a1f9
+.sub_ca572
+    ldy #&bf                                                          ; a572: a0 bf       ..
+    bra ca57a                                                         ; a574: 80 04       ..
+; &a576 referenced 1 time by &b8d7
+.sub_ca576
+    lda #&6c ; 'l'                                                    ; a576: a9 6c       .l
+    ldy #4                                                            ; a578: a0 04       ..
+; &a57a referenced 1 time by &a574
+.ca57a
+    sta l004a                                                         ; a57a: 85 4a       .J
+    sty l004b                                                         ; a57c: 84 4b       .K
+; &a57e referenced 2 times by &a570, &b19e
+.ca57e
+    stz l0035                                                         ; a57e: 64 35       d5
+    stz l002f                                                         ; a580: 64 2f       d/
+    ldy #4                                                            ; a582: a0 04       ..
+    lda (l004a),y                                                     ; a584: b1 4a       .J
+    sta l0034                                                         ; a586: 85 34       .4
+    dey                                                               ; a588: 88          .
+    lda (l004a),y                                                     ; a589: b1 4a       .J
+    sta l0033                                                         ; a58b: 85 33       .3
+    dey                                                               ; a58d: 88          .
+    lda (l004a),y                                                     ; a58e: b1 4a       .J
+    sta l0032                                                         ; a590: 85 32       .2
+    dey                                                               ; a592: 88          .
+    lda (l004a),y                                                     ; a593: b1 4a       .J
+    sta l002e                                                         ; a595: 85 2e       ..
+    tay                                                               ; a597: a8          .
+    lda (l004a)                                                       ; a598: b2 4a       .J
+    sta l0030                                                         ; a59a: 85 30       .0
+    bne ca5a7                                                         ; a59c: d0 09       ..
+    tya                                                               ; a59e: 98          .
+    ora l0032                                                         ; a59f: 05 32       .2
+    ora l0033                                                         ; a5a1: 05 33       .3
+    ora l0034                                                         ; a5a3: 05 34       .4
+    beq ca5aa                                                         ; a5a5: f0 03       ..
+; &a5a7 referenced 1 time by &a59c
+.ca5a7
+    tya                                                               ; a5a7: 98          .
+    ora #&80                                                          ; a5a8: 09 80       ..
+; &a5aa referenced 1 time by &a5a5
+.ca5aa
+    sta l0031                                                         ; a5aa: 85 31       .1
+    rts                                                               ; a5ac: 60          `
+
+; &a5ad referenced 3 times by &a8e0, &a8ee, &a9a0
+.sub_ca5ad
+    clc                                                               ; a5ad: 18          .
+    lda l004c                                                         ; a5ae: a5 4c       .L
+    adc #5                                                            ; a5b0: 69 05       i.
+; &a5b2 referenced 1 time by &aa50
+.sub_ca5b2
+    sta l004c                                                         ; a5b2: 85 4c       .L
+; &a5b4 referenced 3 times by &a631, &a701, &a7fc
+.sub_ca5b4
+    ldy #&bf                                                          ; a5b4: a0 bf       ..
+; &a5b6 referenced 1 time by &a5bf
+.loop_ca5b6
+    sta l004a                                                         ; a5b6: 85 4a       .J
+    sty l004b                                                         ; a5b8: 84 4b       .K
+; &a5ba referenced 1 time by &a5e8
+.ca5ba
+    rts                                                               ; a5ba: 60          `
+
+; &a5bb referenced 2 times by &a8f8, &a9af
+.sub_ca5bb
+    lda #&6c ; 'l'                                                    ; a5bb: a9 6c       .l
+; &a5bd referenced 1 time by &a8e8
+.sub_ca5bd
+    ldy #4                                                            ; a5bd: a0 04       ..
+    bra loop_ca5b6                                                    ; a5bf: 80 f5       ..
+; &a5c1 referenced 1 time by &aa41
+.sub_ca5c1
+    jsr cad10                                                         ; a5c1: 20 10 ad     ..
+; &a5c4 referenced 1 time by &a95d
+.sub_ca5c4
+    jsr sub_ca545                                                     ; a5c4: 20 45 a5     E.
+    jsr sub_ca5f4                                                     ; a5c7: 20 f4 a5     ..
+    inc l0030                                                         ; a5ca: e6 30       .0
+; &a5cc referenced 2 times by &a5e3, &a90a
+.sub_ca5cc
+    jsr cad10                                                         ; a5cc: 20 10 ad     ..
+; &a5cf referenced 2 times by &a5f4, &aa39
+.sub_ca5cf
+    stz l003b                                                         ; a5cf: 64 3b       d;
+; &a5d1 referenced 1 time by &a993
+.sub_ca5d1
+    ldy #&80                                                          ; a5d1: a0 80       ..
+    sty l003d                                                         ; a5d3: 84 3d       .=
+    iny                                                               ; a5d5: c8          .
+    sty l003c                                                         ; a5d6: 84 3c       .<
+    stz l003e                                                         ; a5d8: 64 3e       d>
+    stz l003f                                                         ; a5da: 64 3f       d?
+    stz l0040                                                         ; a5dc: 64 40       d@
+    stz l0041                                                         ; a5de: 64 41       dA
+    jmp ca70f                                                         ; a5e0: 4c 0f a7    L..
+
+; &a5e3 referenced 2 times by &a7de, &a929
+.sub_ca5e3
+    jsr sub_ca5cc                                                     ; a5e3: 20 cc a5     ..
+    ldx l0031                                                         ; a5e6: a6 31       .1
+    beq ca5ba                                                         ; a5e8: f0 d0       ..
+    dec l0030                                                         ; a5ea: c6 30       .0
+    jsr sub_ca545                                                     ; a5ec: 20 45 a5     E.
+    txa                                                               ; a5ef: 8a          .
+    eor l002e                                                         ; a5f0: 45 2e       E.
+; &a5f2 referenced 1 time by &a96e
+.sub_ca5f2
+    sta l002e                                                         ; a5f2: 85 2e       ..
+; &a5f4 referenced 2 times by &a5c7, &a962
+.sub_ca5f4
+    jsr sub_ca5cf                                                     ; a5f4: 20 cf a5     ..
+    bra ca634                                                         ; a5f7: 80 3b       .;
+; &a5f9 referenced 1 time by &a0cc
+.sub_ca5f9
+    ldx #0                                                            ; a5f9: a2 00       ..
+    tay                                                               ; a5fb: a8          .
+    beq ca622                                                         ; a5fc: f0 24       .$
+    bpl ca608                                                         ; a5fe: 10 08       ..
+    dec a                                                             ; a600: 3a          :
+    eor #&ff                                                          ; a601: 49 ff       I.
+    pha                                                               ; a603: 48          H
+    jsr sub_ca62f                                                     ; a604: 20 2f a6     /.
+; &a607 referenced 1 time by &a615
+.loop_ca607
+    pla                                                               ; a607: 68          h
+; &a608 referenced 1 time by &a5fe
+.ca608
+    lsr a                                                             ; a608: 4a          J
+    beq ca61d                                                         ; a609: f0 12       ..
+    pha                                                               ; a60b: 48          H
+    bcc ca612                                                         ; a60c: 90 04       ..
+    inx                                                               ; a60e: e8          .
+    jsr cbc3a                                                         ; a60f: 20 3a bc     :.
+; &a612 referenced 1 time by &a60c
+.ca612
+    jsr ca6ce                                                         ; a612: 20 ce a6     ..
+    bra loop_ca607                                                    ; a615: 80 f0       ..
+; &a617 referenced 1 time by &a61e
+.loop_ca617
+    jsr sub_cbc24                                                     ; a617: 20 24 bc     $.
+    jsr ca6e4                                                         ; a61a: 20 e4 a6     ..
+; &a61d referenced 1 time by &a609
+.ca61d
+    dex                                                               ; a61d: ca          .
+    bpl loop_ca617                                                    ; a61e: 10 f7       ..
+    txa                                                               ; a620: 8a          .
+    rts                                                               ; a621: 60          `
+
+; &a622 referenced 3 times by &a1bc, &a5fc, &b6e5
+.ca622
+    lda #&80                                                          ; a622: a9 80       ..
+    sta l0031                                                         ; a624: 85 31       .1
+    inc a                                                             ; a626: 1a          .
+    sta l0030                                                         ; a627: 85 30       .0
+    jmp ca72f                                                         ; a629: 4c 2f a7    L/.
+
+; &a62c referenced 1 time by &a636
+.loop_ca62c
+    jmp c81ea                                                         ; a62c: 4c ea 81    L..
+
+; &a62f referenced 3 times by &a604, &a92f, &a975
+.sub_ca62f
+    lda #&b9                                                          ; a62f: a9 b9       ..
+; &a631 referenced 1 time by &a8d8
+.sub_ca631
+    jsr sub_ca5b4                                                     ; a631: 20 b4 a5     ..
+; &a634 referenced 5 times by &a045, &a5f7, &a8e3, &a8fb, &a914
+.ca634
+    lda l0031                                                         ; a634: a5 31       .1
+    beq loop_ca62c                                                    ; a636: f0 f4       ..
+    jsr sub_ca514                                                     ; a638: 20 14 a5     ..
+    bne ca640                                                         ; a63b: d0 03       ..
+    jmp ca72b                                                         ; a63d: 4c 2b a7    L+.
+
+; &a640 referenced 1 time by &a63b
+.ca640
+    lda l003b                                                         ; a640: a5 3b       .;
+    eor l002e                                                         ; a642: 45 2e       E.
+    sta l002e                                                         ; a644: 85 2e       ..
+    sec                                                               ; a646: 38          8
+    lda l003c                                                         ; a647: a5 3c       .<
+    adc #&81                                                          ; a649: 69 81       i.
+    rol l002f                                                         ; a64b: 26 2f       &/
+    sbc l0030                                                         ; a64d: e5 30       .0
+    bcs ca653                                                         ; a64f: b0 02       ..
+    dec l002f                                                         ; a651: c6 2f       ./
+; &a653 referenced 1 time by &a64f
+.ca653
+    sta l0030                                                         ; a653: 85 30       .0
+    lda l003d                                                         ; a655: a5 3d       .=
+    clc                                                               ; a657: 18          .
+    ldy #4                                                            ; a658: a0 04       ..
+    sty l003c                                                         ; a65a: 84 3c       .<
+; &a65c referenced 1 time by &a69e
+.ca65c
+    ldx #8                                                            ; a65c: a2 08       ..
+; &a65e referenced 1 time by &a697
+.ca65e
+    bcs ca676                                                         ; a65e: b0 16       ..
+    cmp l0031                                                         ; a660: c5 31       .1
+    bne ca674                                                         ; a662: d0 10       ..
+    ldy l003e                                                         ; a664: a4 3e       .>
+    cpy l0032                                                         ; a666: c4 32       .2
+    bne ca674                                                         ; a668: d0 0a       ..
+    ldy l003f                                                         ; a66a: a4 3f       .?
+    cpy l0033                                                         ; a66c: c4 33       .3
+    bne ca674                                                         ; a66e: d0 04       ..
+    ldy l0040                                                         ; a670: a4 40       .@
+    cpy l0034                                                         ; a672: c4 34       .4
+; &a674 referenced 3 times by &a662, &a668, &a66e
+.ca674
+    bcc ca68d                                                         ; a674: 90 17       ..
+; &a676 referenced 1 time by &a65e
+.ca676
+    tay                                                               ; a676: a8          .
+    lda l0040                                                         ; a677: a5 40       .@
+    sbc l0034                                                         ; a679: e5 34       .4
+    sta l0040                                                         ; a67b: 85 40       .@
+    lda l003f                                                         ; a67d: a5 3f       .?
+    sbc l0033                                                         ; a67f: e5 33       .3
+    sta l003f                                                         ; a681: 85 3f       .?
+    lda l003e                                                         ; a683: a5 3e       .>
+    sbc l0032                                                         ; a685: e5 32       .2
+    sta l003e                                                         ; a687: 85 3e       .>
+    tya                                                               ; a689: 98          .
+    sbc l0031                                                         ; a68a: e5 31       .1
+    sec                                                               ; a68c: 38          8
+; &a68d referenced 1 time by &a674
+.ca68d
+    rol l003b                                                         ; a68d: 26 3b       &;
+    asl l0040                                                         ; a68f: 06 40       .@
+    rol l003f                                                         ; a691: 26 3f       &?
+    rol l003e                                                         ; a693: 26 3e       &>
+    rol a                                                             ; a695: 2a          *
+    dex                                                               ; a696: ca          .
+    bne ca65e                                                         ; a697: d0 c5       ..
+    ldx l003b                                                         ; a699: a6 3b       .;
+    phx                                                               ; a69b: da          .
+    dec l003c                                                         ; a69c: c6 3c       .<
+    bne ca65c                                                         ; a69e: d0 bc       ..
+    plx                                                               ; a6a0: fa          .
+    ror a                                                             ; a6a1: 6a          j
+; &a6a2 referenced 1 time by &a8b0
+.ca6a2
+    lsr l0031                                                         ; a6a2: 46 31       F1
+    stx l0034                                                         ; a6a4: 86 34       .4
+    ldx #3                                                            ; a6a6: a2 03       ..
+; &a6a8 referenced 1 time by &a6b1
+.loop_ca6a8
+    cmp l0031                                                         ; a6a8: c5 31       .1
+    bcc ca6ae                                                         ; a6aa: 90 02       ..
+    sbc l0031                                                         ; a6ac: e5 31       .1
+; &a6ae referenced 1 time by &a6aa
+.ca6ae
+    php                                                               ; a6ae: 08          .
+    asl a                                                             ; a6af: 0a          .
+    dex                                                               ; a6b0: ca          .
+    bne loop_ca6a8                                                    ; a6b1: d0 f5       ..
+    plp                                                               ; a6b3: 28          (
+    ror a                                                             ; a6b4: 6a          j
+    plp                                                               ; a6b5: 28          (
+    ror a                                                             ; a6b6: 6a          j
+    plp                                                               ; a6b7: 28          (
+    ror a                                                             ; a6b8: 6a          j
+    sta l0035                                                         ; a6b9: 85 35       .5
+    pla                                                               ; a6bb: 68          h
+    sta l0033                                                         ; a6bc: 85 33       .3
+    pla                                                               ; a6be: 68          h
+    sta l0032                                                         ; a6bf: 85 32       .2
+    pla                                                               ; a6c1: 68          h
+    sta l0031                                                         ; a6c2: 85 31       .1
+; &a6c4 referenced 1 time by &aa97
+.ca6c4
+    bmi ca712                                                         ; a6c4: 30 4c       0L
+    jsr c8306                                                         ; a6c6: 20 06 83     ..
+    bra ca712                                                         ; a6c9: 80 47       .G
+; &a6cb referenced 2 times by &a8bc, &a907
+.sub_ca6cb
+    jsr sub_ca545                                                     ; a6cb: 20 45 a5     E.
+; &a6ce referenced 2 times by &a612, &a9ef
+.ca6ce
+    jsr sub_ca3ed                                                     ; a6ce: 20 ed a3     ..
+    lda l0030                                                         ; a6d1: a5 30       .0
+    beq ca72b                                                         ; a6d3: f0 56       .V
+    stz l0034                                                         ; a6d5: 64 34       d4
+    asl l0040                                                         ; a6d7: 06 40       .@
+    bcc ca6ed                                                         ; a6d9: 90 12       ..
+    inc l0033                                                         ; a6db: e6 33       .3
+    bne ca6ed                                                         ; a6dd: d0 0e       ..
+    jsr sub_ca50b                                                     ; a6df: 20 0b a5     ..
+    bra ca6ed                                                         ; a6e2: 80 09       ..
+; &a6e4 referenced 3 times by &9fb3, &a61a, &a9c7
+.ca6e4
+    lda l0031                                                         ; a6e4: a5 31       .1
+    beq ca73b                                                         ; a6e6: f0 53       .S
+    jsr sub_ca514                                                     ; a6e8: 20 14 a5     ..
+; &a6eb referenced 1 time by &9fa2
+.sub_ca6eb
+    beq ca72b                                                         ; a6eb: f0 3e       .>
+; &a6ed referenced 3 times by &a6d9, &a6dd, &a6e2
+.ca6ed
+    jsr sub_ca73e                                                     ; a6ed: 20 3e a7     >.
+    bra ca712                                                         ; a6f0: 80 20       .
+; &a6f2 referenced 2 times by &8362, &a729
+.ca6f2
+    brk                                                               ; a6f2: 00          .
+
+    equb &14                                                          ; a6f3: 14          .
+    equs "Too big"                                                    ; a6f4: 54 6f 6f... Too
+    equb 0                                                            ; a6fb: 00          .
+
+.sub_ca6fc
+    jsr sub_ca901                                                     ; a6fc: 20 01 a9     ..
+; &a6ff referenced 3 times by &a940, &a948, &ab56
+.sub_ca6ff
+    lda #&90                                                          ; a6ff: a9 90       ..
+    jsr sub_ca5b4                                                     ; a701: 20 b4 a5     ..
+; &a704 referenced 2 times by &9f5c, &a9b2
+.ca704
+    lda l0031                                                         ; a704: a5 31       .1
+    eor l002e                                                         ; a706: 45 2e       E.
+    sta l002e                                                         ; a708: 85 2e       ..
+; &a70a referenced 5 times by &9f52, &a8eb, &a8f1, &a8fe, &b5fe
+.ca70a
+    jsr sub_ca514                                                     ; a70a: 20 14 a5     ..
+; &a70d referenced 1 time by &9f6b
+.sub_ca70d
+    beq ca73b                                                         ; a70d: f0 2c       .,
+; &a70f referenced 1 time by &a5e0
+.ca70f
+    jsr sub_c8429                                                     ; a70f: 20 29 84     ).
+; &a712 referenced 5 times by &a3a7, &a6c4, &a6c9, &a6f0, &a802
+.ca712
+    lda l0035                                                         ; a712: a5 35       .5
+    bpl ca725                                                         ; a714: 10 0f       ..
+    asl a                                                             ; a716: 0a          .
+    bne ca71e                                                         ; a717: d0 05       ..
+    rol a                                                             ; a719: 2a          *
+    and l0034                                                         ; a71a: 25 34       %4
+    bne ca725                                                         ; a71c: d0 07       ..
+; &a71e referenced 1 time by &a717
+.ca71e
+    inc l0034                                                         ; a71e: e6 34       .4
+    bne ca725                                                         ; a720: d0 03       ..
+    jsr sub_ca507                                                     ; a722: 20 07 a5     ..
+; &a725 referenced 3 times by &a714, &a71c, &a720
+.ca725
+    lda l002f                                                         ; a725: a5 2f       ./
+    beq ca739                                                         ; a727: f0 10       ..
+    bpl ca6f2                                                         ; a729: 10 c7       ..
+; &a72b referenced 7 times by &835b, &84cb, &a220, &a63d, &a6d3, &a6eb, &a9f5
+.ca72b
+    stz l0030                                                         ; a72b: 64 30       d0
+    stz l0031                                                         ; a72d: 64 31       d1
+; &a72f referenced 1 time by &a629
+.ca72f
+    stz l002e                                                         ; a72f: 64 2e       d.
+; &a731 referenced 1 time by &82e8
+.sub_ca731
+    stz l002f                                                         ; a731: 64 2f       d/
+    stz l0032                                                         ; a733: 64 32       d2
+    stz l0033                                                         ; a735: 64 33       d3
+    stz l0034                                                         ; a737: 64 34       d4
+; &a739 referenced 1 time by &a727
+.ca739
+    stz l0035                                                         ; a739: 64 35       d5
+; &a73b referenced 2 times by &a6e6, &a70d
+.ca73b
+    lda #&ff                                                          ; a73b: a9 ff       ..
+; &a73d referenced 1 time by &a7a7
+.ca73d
+    rts                                                               ; a73d: 60          `
+
+; &a73e referenced 3 times by &a6ed, &a9ac, &aab6
+.sub_ca73e
+    clc                                                               ; a73e: 18          .
+    lda l0030                                                         ; a73f: a5 30       .0
+    adc l003c                                                         ; a741: 65 3c       e<
+    rol l002f                                                         ; a743: 26 2f       &/
+    sbc #&7f                                                          ; a745: e9 7f       ..
+    sta l0030                                                         ; a747: 85 30       .0
+    bcs ca74d                                                         ; a749: b0 02       ..
+    dec l002f                                                         ; a74b: c6 2f       ./
+; &a74d referenced 1 time by &a749
+.ca74d
+    lda l002e                                                         ; a74d: a5 2e       ..
+    eor l003b                                                         ; a74f: 45 3b       E;
+    sta l002e                                                         ; a751: 85 2e       ..
+    phx                                                               ; a753: da          .
+    ldx #&f8                                                          ; a754: a2 f8       ..
+    ldy #4                                                            ; a756: a0 04       ..
+; &a758 referenced 1 time by &a761
+.loop_ca758
+    lda l0039,x                                                       ; a758: b5 39       .9
+    stz l0039,x                                                       ; a75a: 74 39       t9
+    sta l0041,y                                                       ; a75c: 99 41 00    .A.
+    inx                                                               ; a75f: e8          .
+    dey                                                               ; a760: 88          .
+    bne loop_ca758                                                    ; a761: d0 f5       ..
+    stz l003c                                                         ; a763: 64 3c       d<
+    stz l003b                                                         ; a765: 64 3b       d;
+    stz l003a                                                         ; a767: 64 3a       d:
+    bra ca79b                                                         ; a769: 80 30       .0
+; &a76b referenced 1 time by &a79d
+.ca76b
+    phx                                                               ; a76b: da          .
+    lsr l003d                                                         ; a76c: 46 3d       F=
+    ror l003e                                                         ; a76e: 66 3e       f>
+    ror l003f                                                         ; a770: 66 3f       f?
+    ror l0040                                                         ; a772: 66 40       f@
+    ror l0041                                                         ; a774: 66 41       fA
+; &a776 referenced 1 time by &a798
+.ca776
+    asl l0046,x                                                       ; a776: 16 46       .F
+    bcc ca797                                                         ; a778: 90 1d       ..
+    clc                                                               ; a77a: 18          .
+    tya                                                               ; a77b: 98          .
+    adc l0042,x                                                       ; a77c: 75 42       uB
+    tay                                                               ; a77e: a8          .
+    lda l0034                                                         ; a77f: a5 34       .4
+    adc l0041,x                                                       ; a781: 75 41       uA
+    sta l0034                                                         ; a783: 85 34       .4
+    lda l0033                                                         ; a785: a5 33       .3
+    adc l0040,x                                                       ; a787: 75 40       u@
+    sta l0033                                                         ; a789: 85 33       .3
+    lda l0032                                                         ; a78b: a5 32       .2
+    adc l003f,x                                                       ; a78d: 75 3f       u?
+    sta l0032                                                         ; a78f: 85 32       .2
+    lda l0031                                                         ; a791: a5 31       .1
+    adc l003e,x                                                       ; a793: 75 3e       u>
+    sta l0031                                                         ; a795: 85 31       .1
+; &a797 referenced 1 time by &a778
+.ca797
+    inx                                                               ; a797: e8          .
+    bmi ca776                                                         ; a798: 30 dc       0.
+    plx                                                               ; a79a: fa          .
+; &a79b referenced 2 times by &a769, &a7a0
+.ca79b
+    lda l0046,x                                                       ; a79b: b5 46       .F
+    bne ca76b                                                         ; a79d: d0 cc       ..
+    inx                                                               ; a79f: e8          .
+    bmi ca79b                                                         ; a7a0: 30 f9       0.
+    plx                                                               ; a7a2: fa          .
+    sty l0035                                                         ; a7a3: 84 35       .5
+    lda l0031                                                         ; a7a5: a5 31       .1
+    bmi ca73d                                                         ; a7a7: 30 94       0.
+    jmp c8306                                                         ; a7a9: 4c 06 83    L..
+
+; &a7ac referenced 1 time by &a9bc
+.sub_ca7ac
+    jsr sub_c979f                                                     ; a7ac: 20 9f 97     ..
+; &a7af referenced 1 time by &a0d9
+.sub_ca7af
+    lda l0031                                                         ; a7af: a5 31       .1
+    eor l002e                                                         ; a7b1: 45 2e       E.
+    bmi ca7cd                                                         ; a7b3: 30 18       0.
+    brk                                                               ; a7b5: 00          .
+
+    equb &16                                                          ; a7b6: 16          .
+    equs "Log range"                                                  ; a7b7: 4c 6f 67... Log
+
+; &a7c0 referenced 1 time by &a811
+.ca7c0
+    brk                                                               ; a7c0: 00          .
+
+    equb &15                                                          ; a7c1: 15          .
+    equs "-ve roo"                                                    ; a7c2: 2d 76 65... -ve
+; &a7c9 referenced 1 time by &a985
+.la7c9
+    equb &74,   0, &86, &8e                                           ; a7c9: 74 00 86... t..
+
+; &a7cd referenced 1 time by &a7b3
+.ca7cd
+    ldy #&80                                                          ; a7cd: a0 80       ..
+    ldx l0030                                                         ; a7cf: a6 30       .0
+    beq ca7db                                                         ; a7d1: f0 08       ..
+    lda l0031                                                         ; a7d3: a5 31       .1
+    cmp #&b5                                                          ; a7d5: c9 b5       ..
+    bcs ca7db                                                         ; a7d7: b0 02       ..
+    dex                                                               ; a7d9: ca          .
+    iny                                                               ; a7da: c8          .
+; &a7db referenced 2 times by &a7d1, &a7d7
+.ca7db
+    phx                                                               ; a7db: da          .
+    sty l0030                                                         ; a7dc: 84 30       .0
+    jsr sub_ca5e3                                                     ; a7de: 20 e3 a5     ..
+    lda l0030                                                         ; a7e1: a5 30       .0
+    beq ca7ef                                                         ; a7e3: f0 0a       ..
+    cmp #&6e ; 'n'                                                    ; a7e5: c9 6e       .n
+    bcc ca7ed                                                         ; a7e7: 90 04       ..
+    clc                                                               ; a7e9: 18          .
+    jsr sub_ca8b9                                                     ; a7ea: 20 b9 a8     ..
+; &a7ed referenced 1 time by &a7e7
+.ca7ed
+    inc l0030                                                         ; a7ed: e6 30       .0
+; &a7ef referenced 1 time by &a7e3
+.ca7ef
+    jsr sub_ca545                                                     ; a7ef: 20 45 a5     E.
+    pla                                                               ; a7f2: 68          h
+    eor #&80                                                          ; a7f3: 49 80       I.
+    beq ca805                                                         ; a7f5: f0 0e       ..
+    jsr sub_c82e6                                                     ; a7f7: 20 e6 82     ..
+    lda #&9f                                                          ; a7fa: a9 9f       ..
+    jsr sub_ca5b4                                                     ; a7fc: 20 b4 a5     ..
+    jsr sub_ca9a3                                                     ; a7ff: 20 a3 a9     ..
+    jsr ca712                                                         ; a802: 20 12 a7     ..
+; &a805 referenced 2 times by &a7f5, &a80d
+.ca805
+    jmp cad10                                                         ; a805: 4c 10 ad    L..
+
+.sub_ca808
+    jsr sub_c979f                                                     ; a808: 20 9f 97     ..
+; &a80b referenced 1 time by &a911
+.sub_ca80b
+    lda l0031                                                         ; a80b: a5 31       .1
+    beq ca805                                                         ; a80d: f0 f6       ..
+    lda l002e                                                         ; a80f: a5 2e       ..
+    bmi ca7c0                                                         ; a811: 30 ad       0.
+    lda l0030                                                         ; a813: a5 30       .0
+    lsr a                                                             ; a815: 4a          J
+    php                                                               ; a816: 08          .
+    adc #&41 ; 'A'                                                    ; a817: 69 41       iA
+    sta l0030                                                         ; a819: 85 30       .0
+    lda l0031                                                         ; a81b: a5 31       .1
+    plp                                                               ; a81d: 28          (
+    bcc ca829                                                         ; a81e: 90 09       ..
+    lsr a                                                             ; a820: 4a          J
+    ror l0032                                                         ; a821: 66 32       f2
+    ror l0033                                                         ; a823: 66 33       f3
+    ror l0034                                                         ; a825: 66 34       f4
+    ror l0035                                                         ; a827: 66 35       f5
+; &a829 referenced 1 time by &a81e
+.ca829
+    stz l003e                                                         ; a829: 64 3e       d>
+    stz l003f                                                         ; a82b: 64 3f       d?
+    ldx #&68 ; 'h'                                                    ; a82d: a2 68       .h
+    sec                                                               ; a82f: 38          8
+    sbc #&90                                                          ; a830: e9 90       ..
+    bcs ca838                                                         ; a832: b0 04       ..
+    adc #&50 ; 'P'                                                    ; a834: 69 50       iP
+    ldx #&48 ; 'H'                                                    ; a836: a2 48       .H
+; &a838 referenced 1 time by &a832
+.ca838
+    sta l0031                                                         ; a838: 85 31       .1
+    txa                                                               ; a83a: 8a          .
+    ldx #&fc                                                          ; a83b: a2 fc       ..
+    ldy #&0c                                                          ; a83d: a0 0c       ..
+; &a83f referenced 1 time by &a89e
+.ca83f
+    sta l0041,x                                                       ; a83f: 95 41       .A
+; &a841 referenced 1 time by &a87d
+.ca841
+    asl l0033                                                         ; a841: 06 33       .3
+    rol l0032                                                         ; a843: 26 32       &2
+    rol l0031                                                         ; a845: 26 31       &1
+    lda l0031                                                         ; a847: a5 31       .1
+    cmp l003d                                                         ; a849: c5 3d       .=
+    bne ca857                                                         ; a84b: d0 0a       ..
+    lda l0032                                                         ; a84d: a5 32       .2
+    cmp l003e                                                         ; a84f: c5 3e       .>
+    bne ca857                                                         ; a851: d0 04       ..
+    lda l0033                                                         ; a853: a5 33       .3
+    cmp l003f                                                         ; a855: c5 3f       .?
+; &a857 referenced 2 times by &a84b, &a851
+.ca857
+    bcc ca875                                                         ; a857: 90 1c       ..
+    lda l0033                                                         ; a859: a5 33       .3
+    sbc l003f                                                         ; a85b: e5 3f       .?
+    sta l0033                                                         ; a85d: 85 33       .3
+    lda l0032                                                         ; a85f: a5 32       .2
+    sbc l003e                                                         ; a861: e5 3e       .>
+    sta l0032                                                         ; a863: 85 32       .2
+    lda l0031                                                         ; a865: a5 31       .1
+    sbc l003d                                                         ; a867: e5 3d       .=
+    sta l0031                                                         ; a869: 85 31       .1
+    tya                                                               ; a86b: 98          .
+    clc                                                               ; a86c: 18          .
+    adc l0041,x                                                       ; a86d: 75 41       uA
+    bcc ca878                                                         ; a86f: 90 07       ..
+    inc l0040,x                                                       ; a871: f6 40       .@
+    bra ca878                                                         ; a873: 80 03       ..
+; &a875 referenced 1 time by &a857
+.ca875
+    tya                                                               ; a875: 98          .
+    eor l0041,x                                                       ; a876: 55 41       UA
+; &a878 referenced 2 times by &a86f, &a873
+.ca878
+    sta l0041,x                                                       ; a878: 95 41       .A
+    tya                                                               ; a87a: 98          .
+    lsr a                                                             ; a87b: 4a          J
+    tay                                                               ; a87c: a8          .
+    bne ca841                                                         ; a87d: d0 c2       ..
+    ldy l0040,x                                                       ; a87f: b4 40       .@
+    phy                                                               ; a881: 5a          Z
+    cpx #&fd                                                          ; a882: e0 fd       ..
+    bne ca88a                                                         ; a884: d0 04       ..
+    lda l0034                                                         ; a886: a5 34       .4
+    sta l0033                                                         ; a888: 85 33       .3
+; &a88a referenced 1 time by &a884
+.ca88a
+    bcs ca899                                                         ; a88a: b0 0d       ..
+    ply                                                               ; a88c: 7a          z
+    ldy #4                                                            ; a88d: a0 04       ..
+; &a88f referenced 1 time by &a895
+.loop_ca88f
+    asl l0035                                                         ; a88f: 06 35       .5
+    rol l0034                                                         ; a891: 26 34       &4
+    rol a                                                             ; a893: 2a          *
+    dey                                                               ; a894: 88          .
+    bne loop_ca88f                                                    ; a895: d0 f8       ..
+    tsb l0033                                                         ; a897: 04 33       .3
+; &a899 referenced 1 time by &a88a
+.ca899
+    lda #&80                                                          ; a899: a9 80       ..
+    ldy #&c0                                                          ; a89b: a0 c0       ..
+    inx                                                               ; a89d: e8          .
+    bne ca83f                                                         ; a89e: d0 9f       ..
+    ldx l003d                                                         ; a8a0: a6 3d       .=
+    lda l0031                                                         ; a8a2: a5 31       .1
+    stx l0031                                                         ; a8a4: 86 31       .1
+    ldx l0040                                                         ; a8a6: a6 40       .@
+    asl a                                                             ; a8a8: 0a          .
+    cmp l0031                                                         ; a8a9: c5 31       .1
+    bcc ca8b0                                                         ; a8ab: 90 03       ..
+    sbc l0031                                                         ; a8ad: e5 31       .1
+    inx                                                               ; a8af: e8          .
+; &a8b0 referenced 1 time by &a8ab
+.ca8b0
+    jmp ca6a2                                                         ; a8b0: 4c a2 a6    L..
+
+; &a8b3 referenced 2 times by &a9e6, &aa3e
+.sub_ca8b3
+    ldx #&ca                                                          ; a8b3: a2 ca       ..
+    dec l0030                                                         ; a8b5: c6 30       .0
+    bra ca8bb                                                         ; a8b7: 80 02       ..
+; &a8b9 referenced 2 times by &a7ea, &a938
+.sub_ca8b9
+    ldx #&e7                                                          ; a8b9: a2 e7       ..
+; &a8bb referenced 1 time by &a8b7
+.ca8bb
+    php                                                               ; a8bb: 08          .
+    jsr sub_ca6cb                                                     ; a8bc: 20 cb a6     ..
+    plp                                                               ; a8bf: 28          (
+    ror l002e                                                         ; a8c0: 66 2e       f.
+    txa                                                               ; a8c2: 8a          .
+    jsr sub_caa55                                                     ; a8c3: 20 55 aa     U.
+    dec a                                                             ; a8c6: 3a          :
+    dec a                                                             ; a8c7: 3a          :
+    sta l0047                                                         ; a8c8: 85 47       .G
+    txa                                                               ; a8ca: 8a          .
+    iny                                                               ; a8cb: c8          .
+    clc                                                               ; a8cc: 18          .
+; &a8cd referenced 1 time by &a8d0
+.loop_ca8cd
+    adc #&0a                                                          ; a8cd: 69 0a       i.
+    dey                                                               ; a8cf: 88          .
+    bpl loop_ca8cd                                                    ; a8d0: 10 fb       ..
+    adc #&f1                                                          ; a8d2: 69 f1       i.
+    sta l004c                                                         ; a8d4: 85 4c       .L
+    lda #&be                                                          ; a8d6: a9 be       ..
+    jsr sub_ca631                                                     ; a8d8: 20 31 a6     1.
+    jsr sub_ca541                                                     ; a8db: 20 41 a5     A.
+    bra ca8ee                                                         ; a8de: 80 0e       ..
+; &a8e0 referenced 1 time by &a8f6
+.loop_ca8e0
+    jsr sub_ca5ad                                                     ; a8e0: 20 ad a5     ..
+    jsr ca634                                                         ; a8e3: 20 34 a6     4.
+    lda #&76 ; 'v'                                                    ; a8e6: a9 76       .v
+    jsr sub_ca5bd                                                     ; a8e8: 20 bd a5     ..
+    jsr ca70a                                                         ; a8eb: 20 0a a7     ..
+; &a8ee referenced 1 time by &a8de
+.ca8ee
+    jsr sub_ca5ad                                                     ; a8ee: 20 ad a5     ..
+    jsr ca70a                                                         ; a8f1: 20 0a a7     ..
+    inc l0047                                                         ; a8f4: e6 47       .G
+    bmi loop_ca8e0                                                    ; a8f6: 30 e8       0.
+    jsr sub_ca5bb                                                     ; a8f8: 20 bb a5     ..
+    jsr ca634                                                         ; a8fb: 20 34 a6     4.
+    jmp ca70a                                                         ; a8fe: 4c 0a a7    L..
+
+; &a901 referenced 1 time by &a6fc
+.sub_ca901
+    jsr sub_c979f                                                     ; a901: 20 9f 97     ..
+    lda l002e                                                         ; a904: a5 2e       ..
+    pha                                                               ; a906: 48          H
+    jsr sub_ca6cb                                                     ; a907: 20 cb a6     ..
+    jsr sub_ca5cc                                                     ; a90a: 20 cc a5     ..
+    lda l0031                                                         ; a90d: a5 31       .1
+    beq ca948                                                         ; a90f: f0 37       .7
+    jsr sub_ca80b                                                     ; a911: 20 0b a8     ..
+    jsr ca634                                                         ; a914: 20 34 a6     4.
+    bra ca91f                                                         ; a917: 80 06       ..
+.sub_ca919
+    jsr sub_c979f                                                     ; a919: 20 9f 97     ..
+    lda l002e                                                         ; a91c: a5 2e       ..
+    pha                                                               ; a91e: 48          H
+; &a91f referenced 1 time by &a917
+.ca91f
+    stz l002e                                                         ; a91f: 64 2e       d.
+    lda #&c7                                                          ; a921: a9 c7       ..
+    jsr sub_caa55                                                     ; a923: 20 55 aa     U.
+    php                                                               ; a926: 08          .
+    bne ca92d                                                         ; a927: d0 04       ..
+    jsr sub_ca5e3                                                     ; a929: 20 e3 a5     ..
+    sec                                                               ; a92c: 38          8
+; &a92d referenced 1 time by &a927
+.ca92d
+    bcs ca932                                                         ; a92d: b0 03       ..
+    jsr sub_ca62f                                                     ; a92f: 20 2f a6     /.
+; &a932 referenced 1 time by &a92d
+.ca932
+    lda l0030                                                         ; a932: a5 30       .0
+    cmp #&6d ; 'm'                                                    ; a934: c9 6d       .m
+    bcc ca93b                                                         ; a936: 90 03       ..
+    jsr sub_ca8b9                                                     ; a938: 20 b9 a8     ..
+; &a93b referenced 1 time by &a936
+.ca93b
+    plp                                                               ; a93b: 28          (
+    bne ca946                                                         ; a93c: d0 08       ..
+    inc l0030                                                         ; a93e: e6 30       .0
+    jsr sub_ca6ff                                                     ; a940: 20 ff a6     ..
+    dec l0030                                                         ; a943: c6 30       .0
+    sec                                                               ; a945: 38          8
+; &a946 referenced 1 time by &a93c
+.ca946
+    bcs ca94b                                                         ; a946: b0 03       ..
+; &a948 referenced 1 time by &a90f
+.ca948
+    jsr sub_ca6ff                                                     ; a948: 20 ff a6     ..
+; &a94b referenced 1 time by &a946
+.ca94b
+    pla                                                               ; a94b: 68          h
+    jmp cad14                                                         ; a94c: 4c 14 ad    L..
+
+.sub_ca94f
+    jsr sub_ca9d1                                                     ; a94f: 20 d1 a9     ..
+    bra ca959                                                         ; a952: 80 05       ..
+.sub_ca954
+    jsr sub_ca9d1                                                     ; a954: 20 d1 a9     ..
+    inc l0049                                                         ; a957: e6 49       .I
+; &a959 referenced 1 time by &a952
+.ca959
+    lsr l0049                                                         ; a959: 46 49       FI
+    bcc ca962                                                         ; a95b: 90 05       ..
+    jsr sub_ca5c4                                                     ; a95d: 20 c4 a5     ..
+    bra ca965                                                         ; a960: 80 03       ..
+; &a962 referenced 1 time by &a95b
+.ca962
+    jsr sub_ca5f4                                                     ; a962: 20 f4 a5     ..
+; &a965 referenced 1 time by &a960
+.ca965
+    lsr l0049                                                         ; a965: 46 49       FI
+    bcs ca978                                                         ; a967: b0 0f       ..
+; &a969 referenced 1 time by &a973
+.loop_ca969
+    tay                                                               ; a969: a8          .
+    rts                                                               ; a96a: 60          `
+
+.sub_ca96b
+    jsr sub_ca9d1                                                     ; a96b: 20 d1 a9     ..
+    jsr sub_ca5f2                                                     ; a96e: 20 f2 a5     ..
+    lsr l0049                                                         ; a971: 46 49       FI
+    bcc loop_ca969                                                    ; a973: 90 f4       ..
+    jsr sub_ca62f                                                     ; a975: 20 2f a6     /.
+; &a978 referenced 1 time by &a967
+.ca978
+    jmp cad10                                                         ; a978: 4c 10 ad    L..
+
+; &a97b referenced 2 times by &a9dd, &aa30
+.sub_ca97b
+    jsr sub_ca545                                                     ; a97b: 20 45 a5     E.
+    lda l0030                                                         ; a97e: a5 30       .0
+    ldx #0                                                            ; a980: a2 00       ..
+; &a982 referenced 1 time by &a988
+.loop_ca982
+    dey                                                               ; a982: 88          .
+    stx l0031,y                                                       ; a983: 96 31       .1
+    cmp la7c9,y                                                       ; a985: d9 c9 a7    ...
+    bcc loop_ca982                                                    ; a988: 90 f8       ..
+    lda l004c                                                         ; a98a: a5 4c       .L
+    jsr ca9c1                                                         ; a98c: 20 c1 a9     ..
+    lda l002e                                                         ; a98f: a5 2e       ..
+    sta l003b                                                         ; a991: 85 3b       .;
+    jsr sub_ca5d1                                                     ; a993: 20 d1 a5     ..
+    dec l0030                                                         ; a996: c6 30       .0
+    jsr sub_c9788                                                     ; a998: 20 88 97     ..
+    sta l0049                                                         ; a99b: 85 49       .I
+    jsr c828d                                                         ; a99d: 20 8d 82     ..
+    jsr sub_ca5ad                                                     ; a9a0: 20 ad a5     ..
+; &a9a3 referenced 1 time by &a7ff
+.sub_ca9a3
+    jsr sub_ca514                                                     ; a9a3: 20 14 a5     ..
+    ldy #5                                                            ; a9a6: a0 05       ..
+    lda (l004a),y                                                     ; a9a8: b1 4a       .J
+    sta l0041                                                         ; a9aa: 85 41       .A
+    jsr sub_ca73e                                                     ; a9ac: 20 3e a7     >.
+    jsr sub_ca5bb                                                     ; a9af: 20 bb a5     ..
+    jmp ca704                                                         ; a9b2: 4c 04 a7    L..
+
+.sub_ca9b5
+    jsr sub_c979f                                                     ; a9b5: 20 9f 97     ..
+    lda #&ca                                                          ; a9b8: a9 ca       ..
+    bra ca9c1                                                         ; a9ba: 80 05       ..
+.sub_ca9bc
+    jsr sub_ca7ac                                                     ; a9bc: 20 ac a7     ..
+    lda #&82                                                          ; a9bf: a9 82       ..
+; &a9c1 referenced 3 times by &a98c, &a9ba, &a9cf
+.ca9c1
+    ldy #&bf                                                          ; a9c1: a0 bf       ..
+; &a9c3 referenced 1 time by &a0e0
+.sub_ca9c3
+    sty l004b                                                         ; a9c3: 84 4b       .K
+    sta l004a                                                         ; a9c5: 85 4a       .J
+    jmp ca6e4                                                         ; a9c7: 4c e4 a6    L..
+
+.sub_ca9ca
+    jsr sub_c979f                                                     ; a9ca: 20 9f 97     ..
+    lda #&cf                                                          ; a9cd: a9 cf       ..
+    bra ca9c1                                                         ; a9cf: 80 f0       ..
+; &a9d1 referenced 3 times by &a94f, &a954, &a96b
+.sub_ca9d1
+    jsr sub_c979f                                                     ; a9d1: 20 9f 97     ..
+    lda #&8b                                                          ; a9d4: a9 8b       ..
+    jsr sub_caa50                                                     ; a9d6: 20 50 aa     P.
+    bcc caa07                                                         ; a9d9: 90 2c       .,
+    bne ca9e0                                                         ; a9db: d0 03       ..
+    jsr sub_ca97b                                                     ; a9dd: 20 7b a9     {.
+; &a9e0 referenced 1 time by &a9db
+.ca9e0
+    lda #&6e ; 'n'                                                    ; a9e0: a9 6e       .n
+    cmp l0030                                                         ; a9e2: c5 30       .0
+    bcs ca9f2                                                         ; a9e4: b0 0c       ..
+    jsr sub_ca8b3                                                     ; a9e6: 20 b3 a8     ..
+    jsr sub_ca545                                                     ; a9e9: 20 45 a5     E.
+    inc l046c                                                         ; a9ec: ee 6c 04    .l.
+; &a9ef referenced 1 time by &aa4d
+.ca9ef
+    jmp ca6ce                                                         ; a9ef: 4c ce a6    L..
+
+; &a9f2 referenced 1 time by &a9e4
+.ca9f2
+    jsr sub_ca545                                                     ; a9f2: 20 45 a5     E.
+; &a9f5 referenced 1 time by &a9fa
+.loop_ca9f5
+    jmp ca72b                                                         ; a9f5: 4c 2b a7    L+.
+
+; &a9f8 referenced 1 time by &aa1f
+.ca9f8
+    lda l002e                                                         ; a9f8: a5 2e       ..
+    bmi loop_ca9f5                                                    ; a9fa: 30 f9       0.
+    brk                                                               ; a9fc: 00          .
+
+    equb &18                                                          ; a9fd: 18          .
+    equs "Exp range"                                                  ; a9fe: 45 78 70... Exp
+
+; &aa07 referenced 1 time by &a9d9
+.caa07
+    brk                                                               ; aa07: 00          .
+
+    equb &17                                                          ; aa08: 17          .
+    equs "Accuracy lost"                                              ; aa09: 41 63 63... Acc
+    equb 0                                                            ; aa16: 00          .
+
+.sub_caa17
+    jsr sub_c979f                                                     ; aa17: 20 9f 97     ..
+; &aa1a referenced 1 time by &a0e3
+.sub_caa1a
+    lda #&9a                                                          ; aa1a: a9 9a       ..
+    jsr sub_caa50                                                     ; aa1c: 20 50 aa     P.
+    bcc ca9f8                                                         ; aa1f: 90 d7       ..
+    bne caa2c                                                         ; aa21: d0 09       ..
+    lda l0030                                                         ; aa23: a5 30       .0
+    inc a                                                             ; aa25: 1a          .
+    and #8                                                            ; aa26: 29 08       ).
+    beq caa2c                                                         ; aa28: f0 02       ..
+    dec l0030                                                         ; aa2a: c6 30       .0
+; &aa2c referenced 2 times by &aa21, &aa28
+.caa2c
+    dec a                                                             ; aa2c: 3a          :
+    pha                                                               ; aa2d: 48          H
+    beq caa33                                                         ; aa2e: f0 03       ..
+    jsr sub_ca97b                                                     ; aa30: 20 7b a9     {.
+; &aa33 referenced 1 time by &aa2e
+.caa33
+    lda l0030                                                         ; aa33: a5 30       .0
+    cmp #&6a ; 'j'                                                    ; aa35: c9 6a       .j
+    bcs caa3e                                                         ; aa37: b0 05       ..
+    jsr sub_ca5cf                                                     ; aa39: 20 cf a5     ..
+    bra caa44                                                         ; aa3c: 80 06       ..
+; &aa3e referenced 1 time by &aa37
+.caa3e
+    jsr sub_ca8b3                                                     ; aa3e: 20 b3 a8     ..
+    jsr sub_ca5c1                                                     ; aa41: 20 c1 a5     ..
+; &aa44 referenced 1 time by &aa3c
+.caa44
+    clc                                                               ; aa44: 18          .
+    lda l0030                                                         ; aa45: a5 30       .0
+    adc l0049                                                         ; aa47: 65 49       eI
+    sta l0030                                                         ; aa49: 85 30       .0
+    pla                                                               ; aa4b: 68          h
+    dec a                                                             ; aa4c: 3a          :
+    bpl ca9ef                                                         ; aa4d: 10 a0       ..
+    rts                                                               ; aa4f: 60          `
+
+; &aa50 referenced 2 times by &a9d6, &aa1c
+.sub_caa50
+    jsr sub_ca5b2                                                     ; aa50: 20 b2 a5     ..
+    stz l0049                                                         ; aa53: 64 49       dI
+; &aa55 referenced 2 times by &a8c3, &a923
+.sub_caa55
+    phx                                                               ; aa55: da          .
+    tax                                                               ; aa56: aa          .
+    ldy #1                                                            ; aa57: a0 01       ..
+; &aa59 referenced 1 time by &aa69
+.loop_caa59
+    dex                                                               ; aa59: ca          .
+    lda cbf00,x                                                       ; aa5a: bd 00 bf    ...
+    cmp l0030                                                         ; aa5d: c5 30       .0
+    bne caa66                                                         ; aa5f: d0 05       ..
+    lda lbefe,x                                                       ; aa61: bd fe be    ...
+    cmp l0031                                                         ; aa64: c5 31       .1
+; &aa66 referenced 1 time by &aa5f
+.caa66
+    bcs caa6b                                                         ; aa66: b0 03       ..
+    dey                                                               ; aa68: 88          .
+    bpl loop_caa59                                                    ; aa69: 10 ee       ..
+; &aa6b referenced 1 time by &aa66
+.caa6b
+    plx                                                               ; aa6b: fa          .
+    tya                                                               ; aa6c: 98          .
+    rts                                                               ; aa6d: 60          `
+
+; &aa6e referenced 2 times by &ac12, &aefb
+.sub_caa6e
+    jsr sub_c9779                                                     ; aa6e: 20 79 97     y.
+    lda #osbyte_inkey                                                 ; aa71: a9 81       ..
+    ldx l002a                                                         ; aa73: a6 2a       .*
+    ldy l002b                                                         ; aa75: a4 2b       .+
+    jmp osbyte                                                        ; aa77: 4c f4 ff    L..
+
+; &aa7a referenced 2 times by &aaae, &aab0
+.caa7a
+    jsr sub_c83d3                                                     ; aa7a: 20 d3 83     ..
+; &aa7d referenced 1 time by &aaab
+.caa7d
+    stz l002e                                                         ; aa7d: 64 2e       d.
+    stz l002f                                                         ; aa7f: 64 2f       d/
+    stz l0035                                                         ; aa81: 64 35       d5
+    lda #&80                                                          ; aa83: a9 80       ..
+    sta l0030                                                         ; aa85: 85 30       .0
+    eor l000d                                                         ; aa87: 45 0d       E.
+    sta l0034                                                         ; aa89: 85 34       .4
+    eor l000e                                                         ; aa8b: 45 0e       E.
+    sta l0033                                                         ; aa8d: 85 33       .3
+    eor l000f                                                         ; aa8f: 45 0f       E.
+    sta l0032                                                         ; aa91: 85 32       .2
+    eor l0010                                                         ; aa93: 45 10       E.
+    sta l0031                                                         ; aa95: 85 31       .1
+    jmp ca6c4                                                         ; aa97: 4c c4 a6    L..
+
+; &aa9a referenced 1 time by &aad1
+.caa9a
+    inc l001b                                                         ; aa9a: e6 1b       ..
+    jsr sub_c976c                                                     ; aa9c: 20 6c 97     l.
+    lda l002d                                                         ; aa9f: a5 2d       .-
+    bmi caac1                                                         ; aaa1: 30 1e       0.
+    ora l002c                                                         ; aaa3: 05 2c       .,
+    ora l002b                                                         ; aaa5: 05 2b       .+
+    bne caab0                                                         ; aaa7: d0 07       ..
+    lda l002a                                                         ; aaa9: a5 2a       .*
+    beq caa7d                                                         ; aaab: f0 d0       ..
+    dec a                                                             ; aaad: 3a          :
+    beq caa7a                                                         ; aaae: f0 ca       ..
+; &aab0 referenced 1 time by &aaa7
+.caab0
+    jsr caa7a                                                         ; aab0: 20 7a aa     z.
+    jsr sub_c828a                                                     ; aab3: 20 8a 82     ..
+    jsr sub_ca73e                                                     ; aab6: 20 3e a7     >.
+    jsr sub_c9788                                                     ; aab9: 20 88 97     ..
+    jsr sub_cbf2f                                                     ; aabc: 20 2f bf     /.
+    bra caae8                                                         ; aabf: 80 27       .'
+; &aac1 referenced 1 time by &aaa1
+.caac1
+    ldx #&0d                                                          ; aac1: a2 0d       ..
+    jsr sub_cbe06                                                     ; aac3: 20 06 be     ..
+    lda #&40 ; '@'                                                    ; aac6: a9 40       .@
+    sta l0011                                                         ; aac8: 85 11       ..
+    rts                                                               ; aaca: 60          `
+
+.sub_caacb
+    ldy l001b                                                         ; aacb: a4 1b       ..
+    lda (l0019),y                                                     ; aacd: b1 19       ..
+    cmp #&28 ; '('                                                    ; aacf: c9 28       .(
+    beq caa9a                                                         ; aad1: f0 c7       ..
+    jsr sub_c83d3                                                     ; aad3: 20 d3 83     ..
+    ldx #&0d                                                          ; aad6: a2 0d       ..
+; &aad8 referenced 2 times by &a052, &b1d8
+.sub_caad8
+    lda l0000,x                                                       ; aad8: b5 00       ..
+    sta l002a                                                         ; aada: 85 2a       .*
+    lda l0001,x                                                       ; aadc: b5 01       ..
+    sta l002b                                                         ; aade: 85 2b       .+
+    lda l0002,x                                                       ; aae0: b5 02       ..
+    sta l002c                                                         ; aae2: 85 2c       .,
+    lda l0003,x                                                       ; aae4: b5 03       ..
+    sta l002d                                                         ; aae6: 85 2d       .-
+; &aae8 referenced 4 times by &aabf, &aaf9, &ab12, &ab2d
+.caae8
+    lda #&40 ; '@'                                                    ; aae8: a9 40       .@
+    rts                                                               ; aaea: 60          `
+
+.sub_caaeb
+    jsr sub_c9779                                                     ; aaeb: 20 79 97     y.
+    ldx #3                                                            ; aaee: a2 03       ..
+; &aaf0 referenced 1 time by &aaf7
+.loop_caaf0
+    lda l002a,x                                                       ; aaf0: b5 2a       .*
+    eor #&ff                                                          ; aaf2: 49 ff       I.
+    sta l002a,x                                                       ; aaf4: 95 2a       .*
+    dex                                                               ; aaf6: ca          .
+    bpl loop_caaf0                                                    ; aaf7: 10 f7       ..
+    bra caae8                                                         ; aaf9: 80 ed       ..
+.sub_caafb
+    jsr sub_cab14                                                     ; aafb: 20 14 ab     ..
+    stx l002a                                                         ; aafe: 86 2a       .*
+    rts                                                               ; ab00: 60          `
+
+.sub_cab01
+    jsr sub_c9779                                                     ; ab01: 20 79 97     y.
+    jsr sub_c93c7                                                     ; ab04: 20 c7 93     ..
+    sta l002a                                                         ; ab07: 85 2a       .*
+    stx l002b                                                         ; ab09: 86 2b       .+
+    sty l002c                                                         ; ab0b: 84 2c       .,
+    php                                                               ; ab0d: 08          .
+    pla                                                               ; ab0e: 68          h
+    sta l002d                                                         ; ab0f: 85 2d       .-
+    cld                                                               ; ab11: d8          .
+    bra caae8                                                         ; ab12: 80 d4       ..
+; &ab14 referenced 1 time by &aafb
+.sub_cab14
+    lda #osbyte_read_text_cursor_pos                                  ; ab14: a9 86       ..
+    jsr osbyte                                                        ; ab16: 20 f4 ff     ..
+    tya                                                               ; ab19: 98          .
+; &ab1a referenced 2 times by &ab35, &ab52
+.cab1a
+    jmp cae60                                                         ; ab1a: 4c 60 ae    L`.
+
+.sub_cab1d
+    lda #2                                                            ; ab1d: a9 02       ..
+    bra cab23                                                         ; ab1f: 80 02       ..
+.sub_cab21
+    lda #0                                                            ; ab21: a9 00       ..
+; &ab23 referenced 1 time by &ab1f
+.cab23
+    pha                                                               ; ab23: 48          H
+    jsr sub_cba7a                                                     ; ab24: 20 7a ba     z.
+    ldx #&2a ; '*'                                                    ; ab27: a2 2a       .*
+    pla                                                               ; ab29: 68          h
+    jsr osargs                                                        ; ab2a: 20 da ff     ..
+    bra caae8                                                         ; ab2d: 80 b9       ..
+.sub_cab2f
+    jsr sub_cba7a                                                     ; ab2f: 20 7a ba     z.
+    jsr osbget                                                        ; ab32: 20 d7 ff     ..
+    bra cab1a                                                         ; ab35: 80 e3       ..
+.sub_cab37
+    lda #&40 ; '@'                                                    ; ab37: a9 40       .@
+    bra cab41                                                         ; ab39: 80 06       ..
+.sub_cab3b
+    lda #&80                                                          ; ab3b: a9 80       ..
+    bra cab41                                                         ; ab3d: 80 02       ..
+.sub_cab3f
+    lda #&c0                                                          ; ab3f: a9 c0       ..
+; &ab41 referenced 2 times by &ab39, &ab3d
+.cab41
+    pha                                                               ; ab41: 48          H
+    jsr cad78                                                         ; ab42: 20 78 ad     x.
+    bne cab9d                                                         ; ab45: d0 56       .V
+    jsr sub_cbe6b                                                     ; ab47: 20 6b be     k.
+    ldx #0                                                            ; ab4a: a2 00       ..
+    ldy #6                                                            ; ab4c: a0 06       ..
+    pla                                                               ; ab4e: 68          h
+    jsr osfind                                                        ; ab4f: 20 ce ff     ..
+    bra cab1a                                                         ; ab52: 80 c6       ..
+.sub_cab54
+    stz l0031                                                         ; ab54: 64 31       d1
+    jsr sub_ca6ff                                                     ; ab56: 20 ff a6     ..
+    inc l0030                                                         ; ab59: e6 30       .0
+    rts                                                               ; ab5b: 60          `
+
+.sub_cab5c
+    jsr cad78                                                         ; ab5c: 20 78 ad     x.
+    bne cab9d                                                         ; ab5f: d0 3c       .<
+    inc l0036                                                         ; ab61: e6 36       .6
+    ldy l0036                                                         ; ab63: a4 36       .6
+    lda #&0d                                                          ; ab65: a9 0d       ..
+    sta l05ff,y                                                       ; ab67: 99 ff 05    ...
+    jsr cbc91                                                         ; ab6a: 20 91 bc     ..
+    lda l0019                                                         ; ab6d: a5 19       ..
+    pha                                                               ; ab6f: 48          H
+    lda l001a                                                         ; ab70: a5 1a       ..
+    pha                                                               ; ab72: 48          H
+    lda l001b                                                         ; ab73: a5 1b       ..
+    pha                                                               ; ab75: 48          H
+    ldy l0004                                                         ; ab76: a4 04       ..
+    ldx l0005                                                         ; ab78: a6 05       ..
+    iny                                                               ; ab7a: c8          .
+    sty l0019                                                         ; ab7b: 84 19       ..
+    sty l0037                                                         ; ab7d: 84 37       .7
+    bne cab82                                                         ; ab7f: d0 01       ..
+    inx                                                               ; ab81: e8          .
+; &ab82 referenced 1 time by &ab7f
+.cab82
+    stx l001a                                                         ; ab82: 86 1a       ..
+    stx l0038                                                         ; ab84: 86 38       .8
+    jsr c8edc                                                         ; ab86: 20 dc 8e     ..
+    stz l001b                                                         ; ab89: 64 1b       d.
+    jsr sub_c9dff                                                     ; ab8b: 20 ff 9d     ..
+    jsr cbd21                                                         ; ab8e: 20 21 bd     !.
+; &ab91 referenced 1 time by &abdf
+.cab91
+    pla                                                               ; ab91: 68          h
+    sta l001b                                                         ; ab92: 85 1b       ..
+    pla                                                               ; ab94: 68          h
+    sta l001a                                                         ; ab95: 85 1a       ..
+    pla                                                               ; ab97: 68          h
+    sta l0019                                                         ; ab98: 85 19       ..
+    lda l0027                                                         ; ab9a: a5 27       .'
+    rts                                                               ; ab9c: 60          `
+
+; &ab9d referenced 3 times by &ab45, &ab5f, &aba3
+.cab9d
+    jmp c9155                                                         ; ab9d: 4c 55 91    LU.
+
+.sub_caba0
+    jsr cad78                                                         ; aba0: 20 78 ad     x.
+    bne cab9d                                                         ; aba3: d0 f8       ..
+; &aba5 referenced 1 time by &b96e
+.sub_caba5
+    ldx l0036                                                         ; aba5: a6 36       .6
+    stz l0600,x                                                       ; aba7: 9e 00 06    ...
+    lda l0019                                                         ; abaa: a5 19       ..
+    pha                                                               ; abac: 48          H
+    lda l001a                                                         ; abad: a5 1a       ..
+    pha                                                               ; abaf: 48          H
+    lda l001b                                                         ; abb0: a5 1b       ..
+    pha                                                               ; abb2: 48          H
+    stz l001b                                                         ; abb3: 64 1b       d.
+    stz l0019                                                         ; abb5: 64 19       d.
+    lda #6                                                            ; abb7: a9 06       ..
+    sta l001a                                                         ; abb9: 85 1a       ..
+    jsr c8f92                                                         ; abbb: 20 92 8f     ..
+    cmp #&2d ; '-'                                                    ; abbe: c9 2d       .-
+    beq cabd0                                                         ; abc0: f0 0e       ..
+    cmp #&2b ; '+'                                                    ; abc2: c9 2b       .+
+    bne cabc9                                                         ; abc4: d0 03       ..
+    jsr c8f92                                                         ; abc6: 20 92 8f     ..
+; &abc9 referenced 1 time by &abc4
+.cabc9
+    dec l001b                                                         ; abc9: c6 1b       ..
+    jsr sub_ca2dd                                                     ; abcb: 20 dd a2     ..
+    bra cabdd                                                         ; abce: 80 0d       ..
+; &abd0 referenced 1 time by &abc0
+.cabd0
+    jsr c8f92                                                         ; abd0: 20 92 8f     ..
+    dec l001b                                                         ; abd3: c6 1b       ..
+    jsr sub_ca2dd                                                     ; abd5: 20 dd a2     ..
+    bcc cabdd                                                         ; abd8: 90 03       ..
+    jsr sub_cad1c                                                     ; abda: 20 1c ad     ..
+; &abdd referenced 2 times by &abce, &abd8
+.cabdd
+    sta l0027                                                         ; abdd: 85 27       .'
+    bra cab91                                                         ; abdf: 80 b0       ..
+.sub_cabe1
+    jsr cad78                                                         ; abe1: 20 78 ad     x.
+    beq cac1c                                                         ; abe4: f0 36       .6
+    bpl cac02                                                         ; abe6: 10 1a       ..
+    lda l002e                                                         ; abe8: a5 2e       ..
+    php                                                               ; abea: 08          .
+    stz l002e                                                         ; abeb: 64 2e       d.
+    jsr sub_c8349                                                     ; abed: 20 49 83     I.
+    plp                                                               ; abf0: 28          (
+    bpl cabfd                                                         ; abf1: 10 0a       ..
+    lda l003d                                                         ; abf3: a5 3d       .=
+    beq cabfa                                                         ; abf5: f0 03       ..
+    jsr sub_c83c2                                                     ; abf7: 20 c2 83     ..
+; &abfa referenced 1 time by &abf5
+.cabfa
+    jsr sub_c83aa                                                     ; abfa: 20 aa 83     ..
+; &abfd referenced 1 time by &abf1
+.cabfd
+    jsr sub_c978b                                                     ; abfd: 20 8b 97     ..
+    lda #&40 ; '@'                                                    ; ac00: a9 40       .@
+; &ac02 referenced 1 time by &abe6
+.cac02
+    rts                                                               ; ac02: 60          `
+
+.sub_cac03
+    jsr cad78                                                         ; ac03: 20 78 ad     x.
+    bne cac1c                                                         ; ac06: d0 14       ..
+    lda l0036                                                         ; ac08: a5 36       .6
+    beq cac2b                                                         ; ac0a: f0 1f       ..
+    lda l0600                                                         ; ac0c: ad 00 06    ...
+; &ac0f referenced 1 time by &ac5b
+.cac0f
+    jmp cae60                                                         ; ac0f: 4c 60 ae    L`.
+
+.sub_cac12
+    jsr sub_caa6e                                                     ; ac12: 20 6e aa     n.
+    tya                                                               ; ac15: 98          .
+    bne cac2b                                                         ; ac16: d0 13       ..
+    txa                                                               ; ac18: 8a          .
+    jmp cae62                                                         ; ac19: 4c 62 ae    Lb.
+
+; &ac1c referenced 5 times by &abe4, &ac06, &ac4b, &ac82, &ac90
+.cac1c
+    jmp c9155                                                         ; ac1c: 4c 55 91    LU.
+
+.sub_cac1f
+    jsr sub_cba7a                                                     ; ac1f: 20 7a ba     z.
+    tax                                                               ; ac22: aa          .
+    lda #osbyte_check_eof                                             ; ac23: a9 7f       ..
+    jsr osbyte                                                        ; ac25: 20 f4 ff     ..
+    txa                                                               ; ac28: 8a          .
+    beq cac2d                                                         ; ac29: f0 02       ..
+; &ac2b referenced 6 times by &ac0a, &ac16, &ac44, &ac4f, &ac7b, &b3dd
+.cac2b
+    ldx #&ff                                                          ; ac2b: a2 ff       ..
+; &ac2d referenced 2 times by &ac29, &ac3a
+.cac2d
+    stx l002a                                                         ; ac2d: 86 2a       .*
+    stx l002b                                                         ; ac2f: 86 2b       .+
+    stx l002c                                                         ; ac31: 86 2c       .,
+    stx l002d                                                         ; ac33: 86 2d       .-
+; &ac35 referenced 1 time by &ac57
+.cac35
+    lda #&40 ; '@'                                                    ; ac35: a9 40       .@
+    rts                                                               ; ac37: 60          `
+
+; &ac38 referenced 5 times by &97e6, &9ae1, &ac3e, &adf9, &b3d3
+.cac38
+    ldx #0                                                            ; ac38: a2 00       ..
+    bra cac2d                                                         ; ac3a: 80 f1       ..
+; &ac3c referenced 1 time by &ac49
+.loop_cac3c
+    lda l0031                                                         ; ac3c: a5 31       .1
+    beq cac38                                                         ; ac3e: f0 f8       ..
+    lda l002e                                                         ; ac40: a5 2e       ..
+    bpl cac59                                                         ; ac42: 10 15       ..
+    bra cac2b                                                         ; ac44: 80 e5       ..
+.sub_cac46
+    jsr cad78                                                         ; ac46: 20 78 ad     x.
+    bmi loop_cac3c                                                    ; ac49: 30 f1       0.
+    beq cac1c                                                         ; ac4b: f0 cf       ..
+    lda l002d                                                         ; ac4d: a5 2d       .-
+    bmi cac2b                                                         ; ac4f: 30 da       0.
+    ora l002c                                                         ; ac51: 05 2c       .,
+    ora l002b                                                         ; ac53: 05 2b       .+
+    ora l002a                                                         ; ac55: 05 2a       .*
+    beq cac35                                                         ; ac57: f0 dc       ..
+; &ac59 referenced 1 time by &ac42
+.cac59
+    lda #1                                                            ; ac59: a9 01       ..
+; &ac5b referenced 1 time by &ac7d
+.cac5b
+    bra cac0f                                                         ; ac5b: 80 b2       ..
+.sub_cac5d
+    jsr sub_c8fae                                                     ; ac5d: 20 ae 8f     ..
+    jsr sub_c976c                                                     ; ac60: 20 6c 97     l.
+    lda l002a                                                         ; ac63: a5 2a       .*
+    pha                                                               ; ac65: 48          H
+    ldx l002b                                                         ; ac66: a6 2b       .+
+    jsr sub_cbd26                                                     ; ac68: 20 26 bd     &.
+    stx l002d                                                         ; ac6b: 86 2d       .-
+    pla                                                               ; ac6d: 68          h
+    sta l002c                                                         ; ac6e: 85 2c       .,
+    ldy #>(l002a)                                                     ; ac70: a0 00       ..
+    ldx #<(l002a)                                                     ; ac72: a2 2a       .*
+    lda #osword_read_pixel                                            ; ac74: a9 09       ..
+    jsr osword                                                        ; ac76: 20 f1 ff     ..
+    lda l002e                                                         ; ac79: a5 2e       ..
+    bmi cac2b                                                         ; ac7b: 30 ae       0.
+    bra cac5b                                                         ; ac7d: 80 dc       ..
+.sub_cac7f
+    jsr sub_c9dff                                                     ; ac7f: 20 ff 9d     ..
+    bne cac1c                                                         ; ac82: d0 98       ..
+    cpx #&2c ; ','                                                    ; ac84: e0 2c       .,
+    bne caca0                                                         ; ac86: d0 18       ..
+    inc l001b                                                         ; ac88: e6 1b       ..
+    jsr cbc91                                                         ; ac8a: 20 91 bc     ..
+    jsr sub_c9dff                                                     ; ac8d: 20 ff 9d     ..
+    bne cac1c                                                         ; ac90: d0 8a       ..
+    lda #1                                                            ; ac92: a9 01       ..
+    sta l002a                                                         ; ac94: 85 2a       .*
+    inc l001b                                                         ; ac96: e6 1b       ..
+    cpx #&29 ; ')'                                                    ; ac98: e0 29       .)
+    beq caca9                                                         ; ac9a: f0 0d       ..
+    cpx #&2c ; ','                                                    ; ac9c: e0 2c       .,
+    beq caca3                                                         ; ac9e: f0 03       ..
+; &aca0 referenced 1 time by &ac86
+.caca0
+    jmp c8fbb                                                         ; aca0: 4c bb 8f    L..
+
+; &aca3 referenced 1 time by &ac9e
+.caca3
+    jsr sub_c9769                                                     ; aca3: 20 69 97     i.
+    jsr sub_cbd12                                                     ; aca6: 20 12 bd     ..
+; &aca9 referenced 1 time by &ac9a
+.caca9
+    ldx l002a                                                         ; aca9: a6 2a       .*
+    bne cacaf                                                         ; acab: d0 02       ..
+    ldx #1                                                            ; acad: a2 01       ..
+; &acaf referenced 1 time by &acab
+.cacaf
+    stx l002a                                                         ; acaf: 86 2a       .*
+    txa                                                               ; acb1: 8a          .
+    dex                                                               ; acb2: ca          .
+    stx l002d                                                         ; acb3: 86 2d       .-
+    clc                                                               ; acb5: 18          .
+    adc l0004                                                         ; acb6: 65 04       e.
+    sta l0037                                                         ; acb8: 85 37       .7
+    lda #0                                                            ; acba: a9 00       ..
+    adc l0005                                                         ; acbc: 65 05       e.
+    sta l0038                                                         ; acbe: 85 38       .8
+    lda (l0004)                                                       ; acc0: b2 04       ..
+    sec                                                               ; acc2: 38          8
+    sbc l002d                                                         ; acc3: e5 2d       .-
+    bcc cace8                                                         ; acc5: 90 21       .!
+    sbc l0036                                                         ; acc7: e5 36       .6
+    bcc cace8                                                         ; acc9: 90 1d       ..
+    adc #0                                                            ; accb: 69 00       i.
+    sta l002b                                                         ; accd: 85 2b       .+
+    jsr cbd21                                                         ; accf: 20 21 bd     !.
+; &acd2 referenced 2 times by &acf7, &acfb
+.cacd2
+    ldy #0                                                            ; acd2: a0 00       ..
+    ldx l0036                                                         ; acd4: a6 36       .6
+    beq cace3                                                         ; acd6: f0 0b       ..
+; &acd8 referenced 1 time by &ace1
+.loop_cacd8
+    lda (l0037),y                                                     ; acd8: b1 37       .7
+    cmp l0600,y                                                       ; acda: d9 00 06    ...
+    bne cacef                                                         ; acdd: d0 10       ..
+    iny                                                               ; acdf: c8          .
+    dex                                                               ; ace0: ca          .
+    bne loop_cacd8                                                    ; ace1: d0 f5       ..
+; &ace3 referenced 1 time by &acd6
+.cace3
+    lda l002a                                                         ; ace3: a5 2a       .*
+; &ace5 referenced 1 time by &aced
+.loop_cace5
+    jmp cae60                                                         ; ace5: 4c 60 ae    L`.
+
+; &ace8 referenced 2 times by &acc5, &acc9
+.cace8
+    jsr cbd21                                                         ; ace8: 20 21 bd     !.
+; &aceb referenced 1 time by &acf3
+.loop_caceb
+    lda #0                                                            ; aceb: a9 00       ..
+    bra loop_cace5                                                    ; aced: 80 f6       ..
+; &acef referenced 1 time by &acdd
+.cacef
+    inc l002a                                                         ; acef: e6 2a       .*
+    dec l002b                                                         ; acf1: c6 2b       .+
+    beq loop_caceb                                                    ; acf3: f0 f6       ..
+    inc l0037                                                         ; acf5: e6 37       .7
+    bne cacd2                                                         ; acf7: d0 d9       ..
+    inc l0038                                                         ; acf9: e6 38       .8
+    bra cacd2                                                         ; acfb: 80 d5       ..
+; &acfd referenced 2 times by &ad05, &ad1c
+.cacfd
+    jmp c9155                                                         ; acfd: 4c 55 91    LU.
+
+.sub_cad00
+    jsr cad78                                                         ; ad00: 20 78 ad     x.
+    bmi cad0d                                                         ; ad03: 30 08       0.
+    beq cacfd                                                         ; ad05: f0 f6       ..
+; &ad07 referenced 1 time by &81d7
+.sub_cad07
+    bit l002d                                                         ; ad07: 24 2d       $-
+    bmi cad20                                                         ; ad09: 30 15       0.
+    bra cad37                                                         ; ad0b: 80 2a       .*
+; &ad0d referenced 1 time by &ad03
+.cad0d
+    stz l002e                                                         ; ad0d: 64 2e       d.
+    rts                                                               ; ad0f: 60          `
+
+; &ad10 referenced 6 times by &9f61, &a5c1, &a5cc, &a805, &a978, &ad1e
+.cad10
+    lda l0031                                                         ; ad10: a5 31       .1
+    eor l002e                                                         ; ad12: 45 2e       E.
+; &ad14 referenced 1 time by &a94c
+.cad14
+    sta l002e                                                         ; ad14: 85 2e       ..
+    lda #&ff                                                          ; ad16: a9 ff       ..
+    rts                                                               ; ad18: 60          `
+
+; &ad19 referenced 1 time by &ad84
+.cad19
+    jsr sub_cad8e                                                     ; ad19: 20 8e ad     ..
+; &ad1c referenced 1 time by &abda
+.sub_cad1c
+    beq cacfd                                                         ; ad1c: f0 df       ..
+    bmi cad10                                                         ; ad1e: 30 f0       0.
+; &ad20 referenced 5 times by &81c5, &8295, &9fe3, &a058, &ad09
+.cad20
+    sec                                                               ; ad20: 38          8
+    lda #0                                                            ; ad21: a9 00       ..
+    tay                                                               ; ad23: a8          .
+    sbc l002a                                                         ; ad24: e5 2a       .*
+    sta l002a                                                         ; ad26: 85 2a       .*
+    tya                                                               ; ad28: 98          .
+    sbc l002b                                                         ; ad29: e5 2b       .+
+    sta l002b                                                         ; ad2b: 85 2b       .+
+    tya                                                               ; ad2d: 98          .
+    sbc l002c                                                         ; ad2e: e5 2c       .,
+    sta l002c                                                         ; ad30: 85 2c       .,
+    tya                                                               ; ad32: 98          .
+    sbc l002d                                                         ; ad33: e5 2d       .-
+    sta l002d                                                         ; ad35: 85 2d       .-
+; &ad37 referenced 1 time by &ad0b
+.cad37
+    lda #&40 ; '@'                                                    ; ad37: a9 40       .@
+    rts                                                               ; ad39: 60          `
+
+; &ad3a referenced 2 times by &b957, &b9c5
+.sub_cad3a
+    jsr c8f92                                                         ; ad3a: 20 92 8f     ..
+    cmp #&22 ; '"'                                                    ; ad3d: c9 22       ."
+    beq cad5b                                                         ; ad3f: f0 1a       ..
+    ldx #0                                                            ; ad41: a2 00       ..
+; &ad43 referenced 1 time by &ad50
+.loop_cad43
+    lda (l0019),y                                                     ; ad43: b1 19       ..
+    sta l0600,x                                                       ; ad45: 9d 00 06    ...
+    iny                                                               ; ad48: c8          .
+    inx                                                               ; ad49: e8          .
+    cmp #&0d                                                          ; ad4a: c9 0d       ..
+    beq cad52                                                         ; ad4c: f0 04       ..
+    cmp #&2c ; ','                                                    ; ad4e: c9 2c       .,
+    bne loop_cad43                                                    ; ad50: d0 f1       ..
+; &ad52 referenced 1 time by &ad4c
+.cad52
+    dey                                                               ; ad52: 88          .
+; &ad53 referenced 1 time by &ad73
+.cad53
+    dex                                                               ; ad53: ca          .
+    stx l0036                                                         ; ad54: 86 36       .6
+    sty l001b                                                         ; ad56: 84 1b       ..
+    lda #0                                                            ; ad58: a9 00       ..
+    rts                                                               ; ad5a: 60          `
+
+; &ad5b referenced 2 times by &ad3f, &ad88
+.cad5b
+    ldx #0                                                            ; ad5b: a2 00       ..
+; &ad5d referenced 1 time by &ad71
+.loop_cad5d
+    iny                                                               ; ad5d: c8          .
+; &ad5e referenced 1 time by &ad6b
+.loop_cad5e
+    lda (l0019),y                                                     ; ad5e: b1 19       ..
+    cmp #&0d                                                          ; ad60: c9 0d       ..
+    beq cad75                                                         ; ad62: f0 11       ..
+    sta l0600,x                                                       ; ad64: 9d 00 06    ...
+    iny                                                               ; ad67: c8          .
+    inx                                                               ; ad68: e8          .
+    cmp #&22 ; '"'                                                    ; ad69: c9 22       ."
+    bne loop_cad5e                                                    ; ad6b: d0 f1       ..
+    lda (l0019),y                                                     ; ad6d: b1 19       ..
+    cmp #&22 ; '"'                                                    ; ad6f: c9 22       ."
+    beq loop_cad5d                                                    ; ad71: f0 ea       ..
+    bne cad53                                                         ; ad73: d0 de       ..
+; &ad75 referenced 1 time by &ad62
+.cad75
+    jmp c9357                                                         ; ad75: 4c 57 93    LW.
+
+; &ad78 referenced 14 times by &9779, &979f, &a06c, &a084, &ab42, &ab5c, &aba0, &abe1, &ac03, &ac46, &ad00, &ad80, &ae59, &af6e
+.cad78
+    ldy l001b                                                         ; ad78: a4 1b       ..
+    inc l001b                                                         ; ad7a: e6 1b       ..
+    lda (l0019),y                                                     ; ad7c: b1 19       ..
+    cmp #&20 ; ' '                                                    ; ad7e: c9 20       .
+    beq cad78                                                         ; ad80: f0 f6       ..
+    cmp #&2d ; '-'                                                    ; ad82: c9 2d       .-
+    beq cad19                                                         ; ad84: f0 93       ..
+    cmp #&22 ; '"'                                                    ; ad86: c9 22       ."
+    beq cad5b                                                         ; ad88: f0 d1       ..
+    cmp #&2b ; '+'                                                    ; ad8a: c9 2b       .+
+    bne cad91                                                         ; ad8c: d0 03       ..
+; &ad8e referenced 1 time by &ad19
+.sub_cad8e
+    jsr c8f92                                                         ; ad8e: 20 92 8f     ..
+; &ad91 referenced 1 time by &ad8c
+.cad91
+    cmp #&8e                                                          ; ad91: c9 8e       ..
+    bcc cad9c                                                         ; ad93: 90 07       ..
+    cmp #&c6                                                          ; ad95: c9 c6       ..
+    bcs cadce                                                         ; ad97: b0 35       .5
+    jmp c90de                                                         ; ad99: 4c de 90    L..
+
+; &ad9c referenced 1 time by &ad93
+.cad9c
+    cmp #&3f ; '?'                                                    ; ad9c: c9 3f       .?
+    bcs cadac                                                         ; ad9e: b0 0c       ..
+    cmp #&2e ; '.'                                                    ; ada0: c9 2e       ..
+    bcs cadb6                                                         ; ada2: b0 12       ..
+    cmp #&26 ; '&'                                                    ; ada4: c9 26       .&
+    beq cadf9                                                         ; ada6: f0 51       .Q
+    cmp #&28 ; '('                                                    ; ada8: c9 28       .(
+    beq cadee                                                         ; adaa: f0 42       .B
+; &adac referenced 1 time by &ad9e
+.cadac
+    dec l001b                                                         ; adac: c6 1b       ..
+    jsr sub_c99d8                                                     ; adae: 20 d8 99     ..
+    beq cadbc                                                         ; adb1: f0 09       ..
+    jmp cb1de                                                         ; adb3: 4c de b1    L..
+
+; &adb6 referenced 1 time by &ada2
+.cadb6
+    jsr sub_ca2dd                                                     ; adb6: 20 dd a2     ..
+    bcc cadce                                                         ; adb9: 90 13       ..
+    rts                                                               ; adbb: 60          `
+
+; &adbc referenced 1 time by &adb1
+.cadbc
+    lda l0028                                                         ; adbc: a5 28       .(
+    and #2                                                            ; adbe: 29 02       ).
+    bne cadce                                                         ; adc0: d0 0c       ..
+    bcs cadce                                                         ; adc2: b0 0a       ..
+    stx l001b                                                         ; adc4: 86 1b       ..
+; &adc6 referenced 1 time by &8a9b
+.sub_cadc6
+    lda l0440                                                         ; adc6: ad 40 04    .@.
+    ldy l0441                                                         ; adc9: ac 41 04    .A.
+    bra cae3f                                                         ; adcc: 80 71       .q
+; &adce referenced 6 times by &93c4, &ad97, &adb9, &adc0, &adc2, &ae46
+.cadce
+    brk                                                               ; adce: 00          .
+
+    equb &1a                                                          ; adcf: 1a          .
+    equs "No such variable"                                           ; add0: 4e 6f 20... No
+
+; &ade0 referenced 1 time by &adf5
+.loop_cade0
+    brk                                                               ; ade0: 00          .
+
+    equb &1b, &8d, &29                                                ; ade1: 1b 8d 29    ..)
+
+; &ade4 referenced 1 time by &ae18
+.cade4
+    brk                                                               ; ade4: 00          .
+
+    equb &1c                                                          ; ade5: 1c          .
+    equs "Bad Hex"                                                    ; ade6: 42 61 64... Bad
+    equb 0                                                            ; aded: 00          .
+
+; &adee referenced 3 times by &976c, &adaa, &af8e
+.cadee
+    jsr sub_c9dff                                                     ; adee: 20 ff 9d     ..
+    inc l001b                                                         ; adf1: e6 1b       ..
+    cpx #&29 ; ')'                                                    ; adf3: e0 29       .)
+    bne loop_cade0                                                    ; adf5: d0 e9       ..
+    tay                                                               ; adf7: a8          .
+    rts                                                               ; adf8: 60          `
+
+; &adf9 referenced 1 time by &ada6
+.cadf9
+    jsr cac38                                                         ; adf9: 20 38 ac     8.
+    bra cae00                                                         ; adfc: 80 02       ..
+; &adfe referenced 1 time by &ae11
+.loop_cadfe
+    inx                                                               ; adfe: e8          .
+    pha                                                               ; adff: 48          H
+; &ae00 referenced 1 time by &adfc
+.cae00
+    iny                                                               ; ae00: c8          .
+    lda (l0019),y                                                     ; ae01: b1 19       ..
+    cmp #&41 ; 'A'                                                    ; ae03: c9 41       .A
+    bcc cae0d                                                         ; ae05: 90 06       ..
+    sbc #&37 ; '7'                                                    ; ae07: e9 37       .7
+    cmp #&10                                                          ; ae09: c9 10       ..
+    bra cae11                                                         ; ae0b: 80 04       ..
+; &ae0d referenced 1 time by &ae05
+.cae0d
+    sbc #&2f ; '/'                                                    ; ae0d: e9 2f       ./
+    cmp #&0a                                                          ; ae0f: c9 0a       ..
+; &ae11 referenced 1 time by &ae0b
+.cae11
+    bcc loop_cadfe                                                    ; ae11: 90 eb       ..
+    sty l001b                                                         ; ae13: 84 1b       ..
+    dex                                                               ; ae15: ca          .
+    cpx #8                                                            ; ae16: e0 08       ..
+    bcs cade4                                                         ; ae18: b0 ca       ..
+    txa                                                               ; ae1a: 8a          .
+    tay                                                               ; ae1b: a8          .
+    ldx #0                                                            ; ae1c: a2 00       ..
+; &ae1e referenced 1 time by &ae2f
+.loop_cae1e
+    pla                                                               ; ae1e: 68          h
+    sta l002a,x                                                       ; ae1f: 95 2a       .*
+    dey                                                               ; ae21: 88          .
+    bmi cae31                                                         ; ae22: 30 0d       0.
+    inx                                                               ; ae24: e8          .
+    pla                                                               ; ae25: 68          h
+    asl a                                                             ; ae26: 0a          .
+    asl a                                                             ; ae27: 0a          .
+    asl a                                                             ; ae28: 0a          .
+    asl a                                                             ; ae29: 0a          .
+    ora l0029,x                                                       ; ae2a: 15 29       .)
+    sta l0029,x                                                       ; ae2c: 95 29       .)
+    dey                                                               ; ae2e: 88          .
+    bpl loop_cae1e                                                    ; ae2f: 10 ed       ..
+; &ae31 referenced 1 time by &ae22
+.cae31
+    lda #&40 ; '@'                                                    ; ae31: a9 40       .@
+    rts                                                               ; ae33: 60          `
+
+.sub_cae34
+    jsr sub_c9779                                                     ; ae34: 20 79 97     y.
+    ldx l002a                                                         ; ae37: a6 2a       .*
+    lda #osbyte_read_adc_or_get_buffer_status                         ; ae39: a9 80       ..
+    jsr osbyte                                                        ; ae3b: 20 f4 ff     ..
+    txa                                                               ; ae3e: 8a          .
+; &ae3f referenced 1 time by &adcc
+.cae3f
+    bra cae62                                                         ; ae3f: 80 21       .!
+.sub_cae41
+    iny                                                               ; ae41: c8          .
+    lda (l0019),y                                                     ; ae42: b1 19       ..
+    cmp #&50 ; 'P'                                                    ; ae44: c9 50       .P
+    bne cadce                                                         ; ae46: d0 86       ..
+    inc l001b                                                         ; ae48: e6 1b       ..
+    lda l0012                                                         ; ae4a: a5 12       ..
+    ldy l0013                                                         ; ae4c: a4 13       ..
+    bra cae62                                                         ; ae4e: 80 12       ..
+.sub_cae50
+    ldy l0018                                                         ; ae50: a4 18       ..
+    lda #0                                                            ; ae52: a9 00       ..
+    bra cae62                                                         ; ae54: 80 0c       ..
+; &ae56 referenced 2 times by &ae5c, &aec0
+.cae56
+    jmp c9155                                                         ; ae56: 4c 55 91    LU.
+
+.sub_cae59
+    jsr cad78                                                         ; ae59: 20 78 ad     x.
+    bne cae56                                                         ; ae5c: d0 f8       ..
+    lda l0036                                                         ; ae5e: a5 36       .6
+; &ae60 referenced 11 times by &8ff4, &9412, &941d, &964b, &ab1a, &ac0f, &ace5, &ae6f, &ae85, &ae8a, &b698
+.cae60
+    ldy #0                                                            ; ae60: a0 00       ..
+; &ae62 referenced 8 times by &ac19, &ae3f, &ae4e, &ae54, &ae75, &ae7b, &ae81, &b202
+.cae62
+    sta l002a                                                         ; ae62: 85 2a       .*
+    sty l002b                                                         ; ae64: 84 2b       .+
+    stz l002c                                                         ; ae66: 64 2c       d,
+    stz l002d                                                         ; ae68: 64 2d       d-
+    lda #&40 ; '@'                                                    ; ae6a: a9 40       .@
+    rts                                                               ; ae6c: 60          `
+
+.sub_cae6d
+    lda l001e                                                         ; ae6d: a5 1e       ..
+    bra cae60                                                         ; ae6f: 80 ef       ..
+.sub_cae71
+    lda l0000                                                         ; ae71: a5 00       ..
+    ldy l0001                                                         ; ae73: a4 01       ..
+    bra cae62                                                         ; ae75: 80 eb       ..
+.sub_cae77
+    lda l0006                                                         ; ae77: a5 06       ..
+    ldy l0007                                                         ; ae79: a4 07       ..
+    bra cae62                                                         ; ae7b: 80 e5       ..
+.sub_cae7d
+    ldy l0009                                                         ; ae7d: a4 09       ..
+    lda l0008                                                         ; ae7f: a5 08       ..
+    bra cae62                                                         ; ae81: 80 df       ..
+.sub_cae83
+    lda (l00fd)                                                       ; ae83: b2 fd       ..
+    bra cae60                                                         ; ae85: 80 d9       ..
+.sub_cae87
+    jsr osrdch                                                        ; ae87: 20 e0 ff     ..
+    bra cae60                                                         ; ae8a: 80 d4       ..
+.sub_cae8c
+    iny                                                               ; ae8c: c8          .
+    lda (l0019),y                                                     ; ae8d: b1 19       ..
+    cmp #&24 ; '$'                                                    ; ae8f: c9 24       .$
+    beq cae9f                                                         ; ae91: f0 0c       ..
+    ldx #<(l002a)                                                     ; ae93: a2 2a       .*
+    ldy #>(l002a)                                                     ; ae95: a0 00       ..
+    lda #osword_read_clock                                            ; ae97: a9 01       ..
+    jsr osword                                                        ; ae99: 20 f1 ff     ..
+    lda #&40 ; '@'                                                    ; ae9c: a9 40       .@
+    rts                                                               ; ae9e: 60          `
+
+; &ae9f referenced 1 time by &ae91
+.cae9f
+    inc l001b                                                         ; ae9f: e6 1b       ..
+    lda #osword_read_cmos_clock                                       ; aea1: a9 0e       ..
+    ldx #<(l0600)                                                     ; aea3: a2 00       ..
+    ldy #>(l0600)                                                     ; aea5: a0 06       ..
+    stz l0600                                                         ; aea7: 9c 00 06    ...
+    jsr osword                                                        ; aeaa: 20 f1 ff     ..
+    lda #&18                                                          ; aead: a9 18       ..
+    bra caed7                                                         ; aeaf: 80 26       .&
+.sub_caeb1
+    jsr osrdch                                                        ; aeb1: 20 e0 ff     ..
+; &aeb4 referenced 2 times by &af01, &b26e
+.caeb4
+    sta l0600                                                         ; aeb4: 8d 00 06    ...
+    lda #1                                                            ; aeb7: a9 01       ..
+    bra caed7                                                         ; aeb9: 80 1c       ..
+.sub_caebb
+    clc                                                               ; aebb: 18          .
+.sub_caebc
+    php                                                               ; aebc: 08          .
+    jsr sub_c9dff                                                     ; aebd: 20 ff 9d     ..
+    bne cae56                                                         ; aec0: d0 94       ..
+    cpx #&2c ; ','                                                    ; aec2: e0 2c       .,
+    bne caf07                                                         ; aec4: d0 41       .A
+    inc l001b                                                         ; aec6: e6 1b       ..
+    jsr sub_c9769                                                     ; aec8: 20 69 97     i.
+    jsr sub_cbd12                                                     ; aecb: 20 12 bd     ..
+    plp                                                               ; aece: 28          (
+    bcs caedc                                                         ; aecf: b0 0b       ..
+    lda l002a                                                         ; aed1: a5 2a       .*
+    cmp l0036                                                         ; aed3: c5 36       .6
+    bcs caed9                                                         ; aed5: b0 02       ..
+; &aed7 referenced 3 times by &aeaf, &aeb9, &af05
+.caed7
+    sta l0036                                                         ; aed7: 85 36       .6
+; &aed9 referenced 3 times by &aed5, &aee0, &aef9
+.caed9
+    lda #0                                                            ; aed9: a9 00       ..
+; &aedb referenced 2 times by &aee2, &aee9
+.caedb
+    rts                                                               ; aedb: 60          `
+
+; &aedc referenced 1 time by &aecf
+.caedc
+    lda l0036                                                         ; aedc: a5 36       .6
+    sbc l002a                                                         ; aede: e5 2a       .*
+    bcc caed9                                                         ; aee0: 90 f7       ..
+    beq caedb                                                         ; aee2: f0 f7       ..
+    tax                                                               ; aee4: aa          .
+    lda l002a                                                         ; aee5: a5 2a       .*
+    sta l0036                                                         ; aee7: 85 36       .6
+    beq caedb                                                         ; aee9: f0 f0       ..
+    ldy #0                                                            ; aeeb: a0 00       ..
+; &aeed referenced 1 time by &aef7
+.loop_caeed
+    lda l0600,x                                                       ; aeed: bd 00 06    ...
+    sta l0600,y                                                       ; aef0: 99 00 06    ...
+    inx                                                               ; aef3: e8          .
+    iny                                                               ; aef4: c8          .
+    dec l002a                                                         ; aef5: c6 2a       .*
+    bne loop_caeed                                                    ; aef7: d0 f4       ..
+    bra caed9                                                         ; aef9: 80 de       ..
+.sub_caefb
+    jsr sub_caa6e                                                     ; aefb: 20 6e aa     n.
+    txa                                                               ; aefe: 8a          .
+    cpy #0                                                            ; aeff: c0 00       ..
+    beq caeb4                                                         ; af01: f0 b1       ..
+; &af03 referenced 2 times by &af39, &af4f
+.caf03
+    lda #0                                                            ; af03: a9 00       ..
+    bra caed7                                                         ; af05: 80 d0       ..
+; &af07 referenced 3 times by &aec4, &af11, &af2a
+.caf07
+    jmp c8fbb                                                         ; af07: 4c bb 8f    L..
+
+.sub_caf0a
+    jsr sub_c9dff                                                     ; af0a: 20 ff 9d     ..
+    bne caf88                                                         ; af0d: d0 79       .y
+    cpx #&2c ; ','                                                    ; af0f: e0 2c       .,
+    bne caf07                                                         ; af11: d0 f4       ..
+    jsr cbc91                                                         ; af13: 20 91 bc     ..
+    inc l001b                                                         ; af16: e6 1b       ..
+    jsr sub_c9774                                                     ; af18: 20 74 97     t.
+    lda l002a                                                         ; af1b: a5 2a       .*
+    pha                                                               ; af1d: 48          H
+    lda #&ff                                                          ; af1e: a9 ff       ..
+    sta l002a                                                         ; af20: 85 2a       .*
+    inc l001b                                                         ; af22: e6 1b       ..
+    cpx #&29 ; ')'                                                    ; af24: e0 29       .)
+    beq caf2f                                                         ; af26: f0 07       ..
+    cpx #&2c ; ','                                                    ; af28: e0 2c       .,
+    bne caf07                                                         ; af2a: d0 db       ..
+    jsr sub_c976c                                                     ; af2c: 20 6c 97     l.
+; &af2f referenced 1 time by &af26
+.caf2f
+    jsr sub_cbd12                                                     ; af2f: 20 12 bd     ..
+    pla                                                               ; af32: 68          h
+    tay                                                               ; af33: a8          .
+    clc                                                               ; af34: 18          .
+    beq caf3d                                                         ; af35: f0 06       ..
+    sbc l0036                                                         ; af37: e5 36       .6
+    bcs caf03                                                         ; af39: b0 c8       ..
+    dey                                                               ; af3b: 88          .
+    tya                                                               ; af3c: 98          .
+; &af3d referenced 1 time by &af35
+.caf3d
+    sta l002c                                                         ; af3d: 85 2c       .,
+    tax                                                               ; af3f: aa          .
+    ldy #0                                                            ; af40: a0 00       ..
+    lda l0036                                                         ; af42: a5 36       .6
+    sec                                                               ; af44: 38          8
+    sbc l002c                                                         ; af45: e5 2c       .,
+    cmp l002a                                                         ; af47: c5 2a       .*
+    bcs caf4d                                                         ; af49: b0 02       ..
+    sta l002a                                                         ; af4b: 85 2a       .*
+; &af4d referenced 1 time by &af49
+.caf4d
+    lda l002a                                                         ; af4d: a5 2a       .*
+    beq caf03                                                         ; af4f: f0 b2       ..
+; &af51 referenced 1 time by &af5b
+.loop_caf51
+    lda l0600,x                                                       ; af51: bd 00 06    ...
+    sta l0600,y                                                       ; af54: 99 00 06    ...
+    iny                                                               ; af57: c8          .
+    inx                                                               ; af58: e8          .
+    cpy l002a                                                         ; af59: c4 2a       .*
+    bne loop_caf51                                                    ; af5b: d0 f4       ..
+    sty l0036                                                         ; af5d: 84 36       .6
+    bra cafb8                                                         ; af5f: 80 57       .W
+.sub_caf61
+    jsr c8f92                                                         ; af61: 20 92 8f     ..
+    ldy #&ff                                                          ; af64: a0 ff       ..
+    cmp #&7e ; '~'                                                    ; af66: c9 7e       .~
+    beq caf6d                                                         ; af68: f0 03       ..
+    iny                                                               ; af6a: c8          .
+    dec l001b                                                         ; af6b: c6 1b       ..
+; &af6d referenced 1 time by &af68
+.caf6d
+    phy                                                               ; af6d: 5a          Z
+    jsr cad78                                                         ; af6e: 20 78 ad     x.
+    beq caf88                                                         ; af71: f0 15       ..
+    tay                                                               ; af73: a8          .
+    pla                                                               ; af74: 68          h
+    sta l0015                                                         ; af75: 85 15       ..
+    lda l0403                                                         ; af77: ad 03 04    ...
+    bne caf83                                                         ; af7a: d0 07       ..
+    sta l0037                                                         ; af7c: 85 37       .7
+    jsr ca19b                                                         ; af7e: 20 9b a1     ..
+    bra cafb8                                                         ; af81: 80 35       .5
+; &af83 referenced 1 time by &af7a
+.caf83
+    jsr sub_ca181                                                     ; af83: 20 81 a1     ..
+    bra cafb8                                                         ; af86: 80 30       .0
+; &af88 referenced 3 times by &af0d, &af71, &af91
+.caf88
+    jmp c9155                                                         ; af88: 4c 55 91    LU.
+
+.sub_caf8b
+    jsr sub_c8fae                                                     ; af8b: 20 ae 8f     ..
+    jsr cadee                                                         ; af8e: 20 ee ad     ..
+    bne caf88                                                         ; af91: d0 f5       ..
+    jsr sub_cbd26                                                     ; af93: 20 26 bd     &.
+    ldy l0036                                                         ; af96: a4 36       .6
+    beq cafb8                                                         ; af98: f0 1e       ..
+    lda l002a                                                         ; af9a: a5 2a       .*
+    beq cafbb                                                         ; af9c: f0 1d       ..
+    dec l002a                                                         ; af9e: c6 2a       .*
+    beq cafb8                                                         ; afa0: f0 16       ..
+; &afa2 referenced 1 time by &afb4
+.loop_cafa2
+    ldx #0                                                            ; afa2: a2 00       ..
+; &afa4 referenced 1 time by &afb0
+.loop_cafa4
+    lda l0600,x                                                       ; afa4: bd 00 06    ...
+    sta l0600,y                                                       ; afa7: 99 00 06    ...
+    inx                                                               ; afaa: e8          .
+    iny                                                               ; afab: c8          .
+    beq cafbe                                                         ; afac: f0 10       ..
+    cpx l0036                                                         ; afae: e4 36       .6
+    bcc loop_cafa4                                                    ; afb0: 90 f2       ..
+    dec l002a                                                         ; afb2: c6 2a       .*
+    bne loop_cafa2                                                    ; afb4: d0 ec       ..
+    sty l0036                                                         ; afb6: 84 36       .6
+; &afb8 referenced 5 times by &af5f, &af81, &af86, &af98, &afa0
+.cafb8
+    lda #0                                                            ; afb8: a9 00       ..
+    rts                                                               ; afba: 60          `
+
+; &afbb referenced 1 time by &af9c
+.cafbb
+    sta l0036                                                         ; afbb: 85 36       .6
+    rts                                                               ; afbd: 60          `
+
+; &afbe referenced 1 time by &afac
+.cafbe
+    jmp c9ecb                                                         ; afbe: 4c cb 9e    L..
+
+; &afc1 referenced 1 time by &afdf
+.loop_cafc1
+    pla                                                               ; afc1: 68          h
+    sta l000c                                                         ; afc2: 85 0c       ..
+    pla                                                               ; afc4: 68          h
+    sta l000b                                                         ; afc5: 85 0b       ..
+    brk                                                               ; afc7: 00          .
+
+    equb &1d                                                          ; afc8: 1d          .
+    equs "No such "                                                   ; afc9: 4e 6f 20... No
+    equb &a4, &2f, &f2,   0                                           ; afd1: a4 2f f2... ./.
+
+; &afd5 referenced 1 time by &b0a3
+.cafd5
+    lda l0018                                                         ; afd5: a5 18       ..
+    sta l000c                                                         ; afd7: 85 0c       ..
+    stz l000b                                                         ; afd9: 64 0b       d.
+; &afdb referenced 2 times by &aff7, &affb
+.cafdb
+    ldy #1                                                            ; afdb: a0 01       ..
+    lda (l000b),y                                                     ; afdd: b1 0b       ..
+    bmi loop_cafc1                                                    ; afdf: 30 e0       0.
+    ldy #3                                                            ; afe1: a0 03       ..
+; &afe3 referenced 1 time by &afe8
+.loop_cafe3
+    iny                                                               ; afe3: c8          .
+    lda (l000b),y                                                     ; afe4: b1 0b       ..
+    cmp #&20 ; ' '                                                    ; afe6: c9 20       .
+    beq loop_cafe3                                                    ; afe8: f0 f9       ..
+    cmp #&dd                                                          ; afea: c9 dd       ..
+    beq caffd                                                         ; afec: f0 0f       ..
+; &afee referenced 2 times by &b01e, &b02a
+.cafee
+    ldy #3                                                            ; afee: a0 03       ..
+    lda (l000b),y                                                     ; aff0: b1 0b       ..
+    clc                                                               ; aff2: 18          .
+    adc l000b                                                         ; aff3: 65 0b       e.
+    sta l000b                                                         ; aff5: 85 0b       ..
+    bcc cafdb                                                         ; aff7: 90 e2       ..
+    inc l000c                                                         ; aff9: e6 0c       ..
+    bra cafdb                                                         ; affb: 80 de       ..
+; &affd referenced 1 time by &afec
+.caffd
+    iny                                                               ; affd: c8          .
+    sty l000a                                                         ; affe: 84 0a       ..
+    jsr c8f9d                                                         ; b000: 20 9d 8f     ..
+    tya                                                               ; b003: 98          .
+    tax                                                               ; b004: aa          .
+    clc                                                               ; b005: 18          .
+    adc l000b                                                         ; b006: 65 0b       e.
+    ldy l000c                                                         ; b008: a4 0c       ..
+    bcc cb00e                                                         ; b00a: 90 02       ..
+    iny                                                               ; b00c: c8          .
+    clc                                                               ; b00d: 18          .
+; &b00e referenced 1 time by &b00a
+.cb00e
+    sbc #0                                                            ; b00e: e9 00       ..
+    sta l003c                                                         ; b010: 85 3c       .<
+    tya                                                               ; b012: 98          .
+    sbc #0                                                            ; b013: e9 00       ..
+    sta l003d                                                         ; b015: 85 3d       .=
+    ldy #1                                                            ; b017: a0 01       ..
+; &b019 referenced 1 time by &b023
+.loop_cb019
+    inx                                                               ; b019: e8          .
+    lda (l003c),y                                                     ; b01a: b1 3c       .<
+    cmp (l0037),y                                                     ; b01c: d1 37       .7
+    bne cafee                                                         ; b01e: d0 ce       ..
+    iny                                                               ; b020: c8          .
+    cpy l0039                                                         ; b021: c4 39       .9
+    bne loop_cb019                                                    ; b023: d0 f4       ..
+    lda (l003c),y                                                     ; b025: b1 3c       .<
+    jsr sub_c8e41                                                     ; b027: 20 41 8e     A.
+    bcs cafee                                                         ; b02a: b0 c2       ..
+    txa                                                               ; b02c: 8a          .
+    tay                                                               ; b02d: a8          .
+    jsr c9c80                                                         ; b02e: 20 80 9c     ..
+    jsr sub_c9914                                                     ; b031: 20 14 99     ..
+    ldx #1                                                            ; b034: a2 01       ..
+    jsr sub_c9952                                                     ; b036: 20 52 99     R.
+    lda l000b                                                         ; b039: a5 0b       ..
+    sta (l0002)                                                       ; b03b: 92 02       ..
+    ldy #1                                                            ; b03d: a0 01       ..
+    lda l000c                                                         ; b03f: a5 0c       ..
+    sta (l0002),y                                                     ; b041: 91 02       ..
+    iny                                                               ; b043: c8          .
+    jsr sub_c995a                                                     ; b044: 20 5a 99     Z.
+    jmp cb0b0                                                         ; b047: 4c b0 b0    L..
+
+; &b04a referenced 1 time by &b09a
+.cb04a
+    brk                                                               ; b04a: 00          .
+
+    equb &1e                                                          ; b04b: 1e          .
+    equs "Bad call"                                                   ; b04c: 42 61 64... Bad
+    equb 0                                                            ; b054: 00          .
+
+.sub_cb055
+    lda #&a4                                                          ; b055: a9 a4       ..
+; &b057 referenced 2 times by &97b7, &b83c
+.sub_cb057
+    sta l0027                                                         ; b057: 85 27       .'
+    tsx                                                               ; b059: ba          .
+    txa                                                               ; b05a: 8a          .
+    clc                                                               ; b05b: 18          .
+    adc l0004                                                         ; b05c: 65 04       e.
+    jsr sub_cbd5e                                                     ; b05e: 20 5e bd     ^.
+    txa                                                               ; b061: 8a          .
+    sta (l0004)                                                       ; b062: 92 04       ..
+    ldy #0                                                            ; b064: a0 00       ..
+; &b066 referenced 1 time by &b06f
+.loop_cb066
+    inx                                                               ; b066: e8          .
+    iny                                                               ; b067: c8          .
+    lda l0100,x                                                       ; b068: bd 00 01    ...
+    sta (l0004),y                                                     ; b06b: 91 04       ..
+    cpx #&ff                                                          ; b06d: e0 ff       ..
+    bne loop_cb066                                                    ; b06f: d0 f5       ..
+    txs                                                               ; b071: 9a          .
+    lda l0027                                                         ; b072: a5 27       .'
+    pha                                                               ; b074: 48          H
+    lda l000a                                                         ; b075: a5 0a       ..
+    pha                                                               ; b077: 48          H
+    lda l000b                                                         ; b078: a5 0b       ..
+    pha                                                               ; b07a: 48          H
+    lda l000c                                                         ; b07b: a5 0c       ..
+    pha                                                               ; b07d: 48          H
+    lda l001b                                                         ; b07e: a5 1b       ..
+    tax                                                               ; b080: aa          .
+    clc                                                               ; b081: 18          .
+    adc l0019                                                         ; b082: 65 19       e.
+    ldy l001a                                                         ; b084: a4 1a       ..
+    bcc cb08a                                                         ; b086: 90 02       ..
+    iny                                                               ; b088: c8          .
+    clc                                                               ; b089: 18          .
+; &b08a referenced 1 time by &b086
+.cb08a
+    sbc #1                                                            ; b08a: e9 01       ..
+    sta l0037                                                         ; b08c: 85 37       .7
+    tya                                                               ; b08e: 98          .
+    sbc #0                                                            ; b08f: e9 00       ..
+    sta l0038                                                         ; b091: 85 38       .8
+    ldy #2                                                            ; b093: a0 02       ..
+    jsr c9bbc                                                         ; b095: 20 bc 9b     ..
+    cpy #2                                                            ; b098: c0 02       ..
+    beq cb04a                                                         ; b09a: f0 ae       ..
+    stx l001b                                                         ; b09c: 86 1b       ..
+    jsr sub_c8139                                                     ; b09e: 20 39 81     9.
+    bne cb0a6                                                         ; b0a1: d0 03       ..
+    jmp cafd5                                                         ; b0a3: 4c d5 af    L..
+
+; &b0a6 referenced 1 time by &b0a1
+.cb0a6
+    lda (l002a)                                                       ; b0a6: b2 2a       .*
+    sta l000b                                                         ; b0a8: 85 0b       ..
+    ldy #1                                                            ; b0aa: a0 01       ..
+    lda (l002a),y                                                     ; b0ac: b1 2a       .*
+    sta l000c                                                         ; b0ae: 85 0c       ..
+; &b0b0 referenced 1 time by &b047
+.cb0b0
+    lda #0                                                            ; b0b0: a9 00       ..
+    pha                                                               ; b0b2: 48          H
+    stz l000a                                                         ; b0b3: 64 0a       d.
+    jsr c8f9d                                                         ; b0b5: 20 9d 8f     ..
+    cmp #&28 ; '('                                                    ; b0b8: c9 28       .(
+    beq cb109                                                         ; b0ba: f0 4d       .M
+    dec l000a                                                         ; b0bc: c6 0a       ..
+; &b0be referenced 1 time by &b1bc
+.cb0be
+    lda l001b                                                         ; b0be: a5 1b       ..
+    pha                                                               ; b0c0: 48          H
+    lda l0019                                                         ; b0c1: a5 19       ..
+    pha                                                               ; b0c3: 48          H
+    lda l001a                                                         ; b0c4: a5 1a       ..
+    pha                                                               ; b0c6: 48          H
+    jsr c90d0                                                         ; b0c7: 20 d0 90     ..
+    pla                                                               ; b0ca: 68          h
+    sta l001a                                                         ; b0cb: 85 1a       ..
+    pla                                                               ; b0cd: 68          h
+    sta l0019                                                         ; b0ce: 85 19       ..
+    pla                                                               ; b0d0: 68          h
+    sta l001b                                                         ; b0d1: 85 1b       ..
+    pla                                                               ; b0d3: 68          h
+    beq cb0e2                                                         ; b0d4: f0 0c       ..
+    sta l003f                                                         ; b0d6: 85 3f       .?
+; &b0d8 referenced 1 time by &b0e0
+.loop_cb0d8
+    jsr sub_cbd46                                                     ; b0d8: 20 46 bd     F.
+    jsr sub_cbcaa                                                     ; b0db: 20 aa bc     ..
+    dec l003f                                                         ; b0de: c6 3f       .?
+    bne loop_cb0d8                                                    ; b0e0: d0 f6       ..
+; &b0e2 referenced 1 time by &b0d4
+.cb0e2
+    pla                                                               ; b0e2: 68          h
+    sta l000c                                                         ; b0e3: 85 0c       ..
+    pla                                                               ; b0e5: 68          h
+    sta l000b                                                         ; b0e6: 85 0b       ..
+    pla                                                               ; b0e8: 68          h
+    sta l000a                                                         ; b0e9: 85 0a       ..
+    pla                                                               ; b0eb: 68          h
+    lda (l0004)                                                       ; b0ec: b2 04       ..
+    tax                                                               ; b0ee: aa          .
+    txs                                                               ; b0ef: 9a          .
+    ldy #0                                                            ; b0f0: a0 00       ..
+; &b0f2 referenced 1 time by &b0fb
+.loop_cb0f2
+    iny                                                               ; b0f2: c8          .
+    inx                                                               ; b0f3: e8          .
+    lda (l0004),y                                                     ; b0f4: b1 04       ..
+    sta l0100,x                                                       ; b0f6: 9d 00 01    ...
+    cpx #&ff                                                          ; b0f9: e0 ff       ..
+    bne loop_cb0f2                                                    ; b0fb: d0 f5       ..
+    tya                                                               ; b0fd: 98          .
+    adc l0004                                                         ; b0fe: 65 04       e.
+    sta l0004                                                         ; b100: 85 04       ..
+    bcc cb106                                                         ; b102: 90 02       ..
+    inc l0005                                                         ; b104: e6 05       ..
+; &b106 referenced 1 time by &b102
+.cb106
+    lda l0027                                                         ; b106: a5 27       .'
+    rts                                                               ; b108: 60          `
+
+; &b109 referenced 2 times by &b0ba, &b136
+.cb109
+    lda l001b                                                         ; b109: a5 1b       ..
+    pha                                                               ; b10b: 48          H
+    lda l0019                                                         ; b10c: a5 19       ..
+    pha                                                               ; b10e: 48          H
+    lda l001a                                                         ; b10f: a5 1a       ..
+    pha                                                               ; b111: 48          H
+    jsr sub_c997d                                                     ; b112: 20 7d 99     }.
+    beq cb169                                                         ; b115: f0 52       .R
+    lda l001b                                                         ; b117: a5 1b       ..
+    sta l000a                                                         ; b119: 85 0a       ..
+    pla                                                               ; b11b: 68          h
+    sta l001a                                                         ; b11c: 85 1a       ..
+    pla                                                               ; b11e: 68          h
+    sta l0019                                                         ; b11f: 85 19       ..
+    pla                                                               ; b121: 68          h
+    sta l001b                                                         ; b122: 85 1b       ..
+    plx                                                               ; b124: fa          .
+    lda l002c                                                         ; b125: a5 2c       .,
+    pha                                                               ; b127: 48          H
+    lda l002b                                                         ; b128: a5 2b       .+
+    pha                                                               ; b12a: 48          H
+    lda l002a                                                         ; b12b: a5 2a       .*
+    pha                                                               ; b12d: 48          H
+    inx                                                               ; b12e: e8          .
+    phx                                                               ; b12f: da          .
+    jsr sub_cb1bf                                                     ; b130: 20 bf b1     ..
+    jsr sub_c8da2                                                     ; b133: 20 a2 8d     ..
+    beq cb109                                                         ; b136: f0 d1       ..
+    cmp #&29 ; ')'                                                    ; b138: c9 29       .)
+    bne cb169                                                         ; b13a: d0 2d       .-
+    lda #0                                                            ; b13c: a9 00       ..
+    pha                                                               ; b13e: 48          H
+    jsr c8f92                                                         ; b13f: 20 92 8f     ..
+    cmp #&28 ; '('                                                    ; b142: c9 28       .(
+    bne cb169                                                         ; b144: d0 23       .#
+; &b146 referenced 1 time by &b159
+.loop_cb146
+    jsr sub_c9dff                                                     ; b146: 20 ff 9d     ..
+    jsr sub_cbc62                                                     ; b149: 20 62 bc     b.
+    lda l0027                                                         ; b14c: a5 27       .'
+    sta l002d                                                         ; b14e: 85 2d       .-
+    jsr cbc66                                                         ; b150: 20 66 bc     f.
+    plx                                                               ; b153: fa          .
+    inx                                                               ; b154: e8          .
+    phx                                                               ; b155: da          .
+    jsr sub_c8fa8                                                     ; b156: 20 a8 8f     ..
+    beq loop_cb146                                                    ; b159: f0 eb       ..
+    cmp #&29 ; ')'                                                    ; b15b: c9 29       .)
+    bne cb169                                                         ; b15d: d0 0a       ..
+    pla                                                               ; b15f: 68          h
+    pla                                                               ; b160: 68          h
+    sta l004c                                                         ; b161: 85 4c       .L
+    sta l004d                                                         ; b163: 85 4d       .M
+    cpx l004c                                                         ; b165: e4 4c       .L
+    beq cb17e                                                         ; b167: f0 15       ..
+; &b169 referenced 6 times by &b115, &b13a, &b144, &b15d, &b18e, &b1ad
+.cb169
+    ldx #&fb                                                          ; b169: a2 fb       ..
+    txs                                                               ; b16b: 9a          .
+    pla                                                               ; b16c: 68          h
+    sta l000c                                                         ; b16d: 85 0c       ..
+    pla                                                               ; b16f: 68          h
+    sta l000b                                                         ; b170: 85 0b       ..
+    brk                                                               ; b172: 00          .
+
+    equb &1f                                                          ; b173: 1f          .
+    equs "Arguments"                                                  ; b174: 41 72 67... Arg
+    equb 0                                                            ; b17d: 00          .
+
+; &b17e referenced 2 times by &b167, &b1b7
+.cb17e
+    jsr sub_cbd26                                                     ; b17e: 20 26 bd     &.
+    pla                                                               ; b181: 68          h
+    sta l002a                                                         ; b182: 85 2a       .*
+    pla                                                               ; b184: 68          h
+    sta l002b                                                         ; b185: 85 2b       .+
+    pla                                                               ; b187: 68          h
+    sta l002c                                                         ; b188: 85 2c       .,
+    bmi cb1ab                                                         ; b18a: 30 1f       0.
+    lda l002d                                                         ; b18c: a5 2d       .-
+    beq cb169                                                         ; b18e: f0 d9       ..
+    sta l0027                                                         ; b190: 85 27       .'
+    ldx #&37 ; '7'                                                    ; b192: a2 37       .7
+    jsr sub_cbe06                                                     ; b194: 20 06 be     ..
+    lda l0027                                                         ; b197: a5 27       .'
+    bpl cb1a3                                                         ; b199: 10 08       ..
+    jsr sub_cbc24                                                     ; b19b: 20 24 bc     $.
+    jsr ca57e                                                         ; b19e: 20 7e a5     ~.
+    bra cb1a6                                                         ; b1a1: 80 03       ..
+; &b1a3 referenced 1 time by &b199
+.cb1a3
+    jsr sub_cbd26                                                     ; b1a3: 20 26 bd     &.
+; &b1a6 referenced 1 time by &b1a1
+.cb1a6
+    jsr sub_cb372                                                     ; b1a6: 20 72 b3     r.
+    bra cb1b5                                                         ; b1a9: 80 0a       ..
+; &b1ab referenced 1 time by &b18a
+.cb1ab
+    lda l002d                                                         ; b1ab: a5 2d       .-
+    bne cb169                                                         ; b1ad: d0 ba       ..
+    jsr sub_cbd12                                                     ; b1af: 20 12 bd     ..
+    jsr sub_c9171                                                     ; b1b2: 20 71 91     q.
+; &b1b5 referenced 1 time by &b1a9
+.cb1b5
+    dec l004c                                                         ; b1b5: c6 4c       .L
+    bne cb17e                                                         ; b1b7: d0 c5       ..
+    lda l004d                                                         ; b1b9: a5 4d       .M
+    pha                                                               ; b1bb: 48          H
+    jmp cb0be                                                         ; b1bc: 4c be b0    L..
+
+; &b1bf referenced 2 times by &97dc, &b130
+.sub_cb1bf
+    ldy l002c                                                         ; b1bf: a4 2c       .,
+    cpy #5                                                            ; b1c1: c0 05       ..
+    bcs cb1ca                                                         ; b1c3: b0 05       ..
+    ldx #&37 ; '7'                                                    ; b1c5: a2 37       .7
+    jsr sub_cbe06                                                     ; b1c7: 20 06 be     ..
+; &b1ca referenced 1 time by &b1c3
+.cb1ca
+    jsr cb1de                                                         ; b1ca: 20 de b1     ..
+    php                                                               ; b1cd: 08          .
+    jsr sub_cbc62                                                     ; b1ce: 20 62 bc     b.
+    plp                                                               ; b1d1: 28          (
+    beq cb1db                                                         ; b1d2: f0 07       ..
+    bmi cb1db                                                         ; b1d4: 30 05       0.
+    ldx #&37 ; '7'                                                    ; b1d6: a2 37       .7
+    jsr sub_caad8                                                     ; b1d8: 20 d8 aa     ..
+; &b1db referenced 2 times by &b1d2, &b1d4
+.cb1db
+    jmp cbc66                                                         ; b1db: 4c 66 bc    Lf.
+
+; &b1de referenced 3 times by &9a7f, &adb3, &b1ca
+.cb1de
+    ldy l002c                                                         ; b1de: a4 2c       .,
+    bmi cb235                                                         ; b1e0: 30 53       0S
+    beq cb200                                                         ; b1e2: f0 1c       ..
+    cpy #5                                                            ; b1e4: c0 05       ..
+    beq cb205                                                         ; b1e6: f0 1d       ..
+    ldy #3                                                            ; b1e8: a0 03       ..
+    lda (l002a),y                                                     ; b1ea: b1 2a       .*
+    sta l002d                                                         ; b1ec: 85 2d       .-
+    dey                                                               ; b1ee: 88          .
+    lda (l002a),y                                                     ; b1ef: b1 2a       .*
+    sta l002c                                                         ; b1f1: 85 2c       .,
+    dey                                                               ; b1f3: 88          .
+    lda (l002a),y                                                     ; b1f4: b1 2a       .*
+    tax                                                               ; b1f6: aa          .
+    lda (l002a)                                                       ; b1f7: b2 2a       .*
+    sta l002a                                                         ; b1f9: 85 2a       .*
+    stx l002b                                                         ; b1fb: 86 2b       .+
+    lda #&40 ; '@'                                                    ; b1fd: a9 40       .@
+    rts                                                               ; b1ff: 60          `
+
+; &b200 referenced 1 time by &b1e2
+.cb200
+    lda (l002a),y                                                     ; b200: b1 2a       .*
+    jmp cae62                                                         ; b202: 4c 62 ae    Lb.
+
+; &b205 referenced 2 times by &b1e6, &b5f1
+.cb205
+    stz l0035                                                         ; b205: 64 35       d5
+    stz l002f                                                         ; b207: 64 2f       d/
+    dey                                                               ; b209: 88          .
+    lda (l002a),y                                                     ; b20a: b1 2a       .*
+    sta l0034                                                         ; b20c: 85 34       .4
+    dey                                                               ; b20e: 88          .
+    lda (l002a),y                                                     ; b20f: b1 2a       .*
+    sta l0033                                                         ; b211: 85 33       .3
+    dey                                                               ; b213: 88          .
+    lda (l002a),y                                                     ; b214: b1 2a       .*
+    sta l0032                                                         ; b216: 85 32       .2
+    dey                                                               ; b218: 88          .
+    lda (l002a),y                                                     ; b219: b1 2a       .*
+    sta l002e                                                         ; b21b: 85 2e       ..
+    tay                                                               ; b21d: a8          .
+    lda (l002a)                                                       ; b21e: b2 2a       .*
+    sta l0030                                                         ; b220: 85 30       .0
+    bne cb22d                                                         ; b222: d0 09       ..
+    tya                                                               ; b224: 98          .
+    ora l0032                                                         ; b225: 05 32       .2
+    ora l0033                                                         ; b227: 05 33       .3
+    ora l0034                                                         ; b229: 05 34       .4
+    beq cb230                                                         ; b22b: f0 03       ..
+; &b22d referenced 1 time by &b222
+.cb22d
+    tya                                                               ; b22d: 98          .
+    ora #&80                                                          ; b22e: 09 80       ..
+; &b230 referenced 1 time by &b22b
+.cb230
+    sta l0031                                                         ; b230: 85 31       .1
+    lda #&ff                                                          ; b232: a9 ff       ..
+    rts                                                               ; b234: 60          `
+
+; &b235 referenced 1 time by &b1e0
+.cb235
+    cpy #&80                                                          ; b235: c0 80       ..
+    beq cb257                                                         ; b237: f0 1e       ..
+    ldy #3                                                            ; b239: a0 03       ..
+    lda (l002a),y                                                     ; b23b: b1 2a       .*
+    sta l0036                                                         ; b23d: 85 36       .6
+    beq cb256                                                         ; b23f: f0 15       ..
+    ldy #1                                                            ; b241: a0 01       ..
+    lda (l002a),y                                                     ; b243: b1 2a       .*
+    sta l0038                                                         ; b245: 85 38       .8
+    lda (l002a)                                                       ; b247: b2 2a       .*
+    sta l0037                                                         ; b249: 85 37       .7
+    ldy l0036                                                         ; b24b: a4 36       .6
+; &b24d referenced 1 time by &b254
+.loop_cb24d
+    dey                                                               ; b24d: 88          .
+    lda (l0037),y                                                     ; b24e: b1 37       .7
+    sta l0600,y                                                       ; b250: 99 00 06    ...
+    tya                                                               ; b253: 98          .
+    bne loop_cb24d                                                    ; b254: d0 f7       ..
+; &b256 referenced 1 time by &b23f
+.cb256
+    rts                                                               ; b256: 60          `
+
+; &b257 referenced 1 time by &b237
+.cb257
+    ldy #0                                                            ; b257: a0 00       ..
+; &b259 referenced 1 time by &b263
+.loop_cb259
+    lda (l002a),y                                                     ; b259: b1 2a       .*
+    sta l0600,y                                                       ; b25b: 99 00 06    ...
+    eor #&0d                                                          ; b25e: 49 0d       I.
+    beq cb266                                                         ; b260: f0 04       ..
+    iny                                                               ; b262: c8          .
+    bne loop_cb259                                                    ; b263: d0 f4       ..
+    tya                                                               ; b265: 98          .
+; &b266 referenced 1 time by &b260
+.cb266
+    sty l0036                                                         ; b266: 84 36       .6
+    rts                                                               ; b268: 60          `
+
+.sub_cb269
+    jsr sub_c9779                                                     ; b269: 20 79 97     y.
+    lda l002a                                                         ; b26c: a5 2a       .*
+    jmp caeb4                                                         ; b26e: 4c b4 ae    L..
+
+    equb &a4, &0a, &f0,   1, &88, &20, &80, &9c, &64,   8, &64,   9   ; b271: a4 0a f0... ...
+    equb &a6, &18, &86                                                ; b27d: a6 18 86    ...
+    equs "8d7"                                                        ; b280: 38 64 37    8d7
+    equb &a4, &0c, &c0,   7, &f0, &28, &a6, &0b, &20, &5d, &8e, &c9   ; b283: a4 0c c0... ...
+    equb &0d, &d0, &18, &e4, &37, &98, &e5, &38, &90, &18, &20, &5d   ; b28f: 0d d0 18... ...
+    equb &8e,   9,   0, &30, &11, &85,   9, &20, &5d, &8e, &85,   8   ; b29b: 8e 09 00... ...
+    equb &20, &5d, &8e, &e4, &37, &98, &e5, &38, &b0, &da, &60, &a2   ; b2a7: 20 5d 8e...  ].
+    equb &ff, &86, &28, &9a, &e8, &a0,   0, &a9, &da, &20, &f4, &ff   ; b2b3: ff 86 28... ..(
+    equb &a9, &7e, &20, &f4, &ff, &20, &71, &b2, &64, &20, &b2, &fd   ; b2bf: a9 7e 20... .~
+    equb &d0,   3, &20, &e0, &b2, &a5, &16, &85, &0b, &a5, &17, &85   ; b2cb: d0 03 20... ..
+    equb &0c, &64, &0a, &20, &ff, &bb, &4c, &d0, &90                  ; b2d7: 0c 64 0a... .d.
+
+; &b2e0 referenced 3 times by &9051, &905f, &b76c
+.sub_cb2e0
+    lda #&e9                                                          ; b2e0: a9 e9       ..
+    sta l0016                                                         ; b2e2: 85 16       ..
+    lda #&b2                                                          ; b2e4: a9 b2       ..
+    sta l0017                                                         ; b2e6: 85 17       ..
+    rts                                                               ; b2e8: 60          `
+
+    equb &f6, &3a, &e7, &9e, &f1                                      ; b2e9: f6 3a e7... .:.
+    equs '"', " at line ", '"', ";"                                   ; b2ee: 22 20 61... " a
+    equb &9e, &3a, &e0, &8b, &f1, &3a, &e0, &0d                       ; b2fa: 9e 3a e0... .:.
+
+.sub_cb302
+    jsr sub_c9332                                                     ; b302: 20 32 93     2.
+    ldx #3                                                            ; b305: a2 03       ..
+; &b307 referenced 1 time by &b313
+.loop_cb307
+    lda l002a                                                         ; b307: a5 2a       .*
+    pha                                                               ; b309: 48          H
+    lda l002b                                                         ; b30a: a5 2b       .+
+    pha                                                               ; b30c: 48          H
+    phx                                                               ; b30d: da          .
+    jsr sub_c9771                                                     ; b30e: 20 71 97     q.
+    plx                                                               ; b311: fa          .
+    dex                                                               ; b312: ca          .
+    bne loop_cb307                                                    ; b313: d0 f2       ..
+    jsr sub_c9c5a                                                     ; b315: 20 5a 9c     Z.
+    lda l002a                                                         ; b318: a5 2a       .*
+    sta l003d                                                         ; b31a: 85 3d       .=
+    lda l002b                                                         ; b31c: a5 2b       .+
+    sta l003e                                                         ; b31e: 85 3e       .>
+    ldy #7                                                            ; b320: a0 07       ..
+    ldx #5                                                            ; b322: a2 05       ..
+    bra cb341                                                         ; b324: 80 1b       ..
+.sub_cb326
+    jsr sub_c9332                                                     ; b326: 20 32 93     2.
+    ldx #&0d                                                          ; b329: a2 0d       ..
+; &b32b referenced 1 time by &b334
+.loop_cb32b
+    lda l002a                                                         ; b32b: a5 2a       .*
+    pha                                                               ; b32d: 48          H
+    phx                                                               ; b32e: da          .
+    jsr sub_c9771                                                     ; b32f: 20 71 97     q.
+    plx                                                               ; b332: fa          .
+    dex                                                               ; b333: ca          .
+    bne loop_cb32b                                                    ; b334: d0 f5       ..
+    jsr sub_c9c5a                                                     ; b336: 20 5a 9c     Z.
+    lda l002a                                                         ; b339: a5 2a       .*
+    sta l0044                                                         ; b33b: 85 44       .D
+    ldx #&0c                                                          ; b33d: a2 0c       ..
+    ldy #8                                                            ; b33f: a0 08       ..
+; &b341 referenced 2 times by &b324, &b345
+.cb341
+    pla                                                               ; b341: 68          h
+    sta l0037,x                                                       ; b342: 95 37       .7
+    dex                                                               ; b344: ca          .
+    bpl cb341                                                         ; b345: 10 fa       ..
+    tya                                                               ; b347: 98          .
+    ldx #<(l0037)                                                     ; b348: a2 37       .7
+    ldy #>(l0037)                                                     ; b34a: a0 00       ..
+; &b34c referenced 1 time by &9750
+.cb34c
+    jsr osword                                                        ; b34c: 20 f1 ff     ..
+    bra cb35c                                                         ; b34f: 80 0b       ..
+.sub_cb351
+    jsr sub_c9332                                                     ; b351: 20 32 93     2.
+    jsr sub_c9c5a                                                     ; b354: 20 5a 9c     Z.
+    ldy l002a                                                         ; b357: a4 2a       .*
+    dey                                                               ; b359: 88          .
+    sty l0023                                                         ; b35a: 84 23       .#
+; &b35c referenced 1 time by &b34f
+.cb35c
+    jmp c90ca                                                         ; b35c: 4c ca 90    L..
+
+; &b35f referenced 1 time by &b377
+.loop_cb35f
+    jmp c9155                                                         ; b35f: 4c 55 91    LU.
+
+; &b362 referenced 2 times by &b656, &b9ba
+.sub_cb362
+    jsr sub_c9dff                                                     ; b362: 20 ff 9d     ..
+; &b365 referenced 5 times by &8aa0, &9141, &95b8, &97eb, &b971
+.sub_cb365
+    ply                                                               ; b365: 7a          z
+    plx                                                               ; b366: fa          .
+    pla                                                               ; b367: 68          h
+    sta l0039                                                         ; b368: 85 39       .9
+    pla                                                               ; b36a: 68          h
+    sta l0038                                                         ; b36b: 85 38       .8
+    pla                                                               ; b36d: 68          h
+    sta l0037                                                         ; b36e: 85 37       .7
+    phx                                                               ; b370: da          .
+    phy                                                               ; b371: 5a          Z
+; &b372 referenced 2 times by &b1a6, &b8dd
+.sub_cb372
+    lda l0039                                                         ; b372: a5 39       .9
+    lsr a                                                             ; b374: 4a          J
+    lda l0027                                                         ; b375: a5 27       .'
+    beq loop_cb35f                                                    ; b377: f0 e6       ..
+    bcs cb399                                                         ; b379: b0 1e       ..
+    bpl cb380                                                         ; b37b: 10 03       ..
+    jsr sub_c9788                                                     ; b37d: 20 88 97     ..
+; &b380 referenced 1 time by &b37b
+.cb380
+    lda l002a                                                         ; b380: a5 2a       .*
+    sta (l0037)                                                       ; b382: 92 37       .7
+    lda l0039                                                         ; b384: a5 39       .9
+    beq cb398                                                         ; b386: f0 10       ..
+    lda l002b                                                         ; b388: a5 2b       .+
+    ldy #1                                                            ; b38a: a0 01       ..
+    sta (l0037),y                                                     ; b38c: 91 37       .7
+    lda l002c                                                         ; b38e: a5 2c       .,
+    iny                                                               ; b390: c8          .
+    sta (l0037),y                                                     ; b391: 91 37       .7
+    lda l002d                                                         ; b393: a5 2d       .-
+    iny                                                               ; b395: c8          .
+    sta (l0037),y                                                     ; b396: 91 37       .7
+; &b398 referenced 1 time by &b386
+.cb398
+    rts                                                               ; b398: 60          `
+
+; &b399 referenced 1 time by &b379
+.cb399
+    bmi cb39e                                                         ; b399: 30 03       0.
+    jsr c828d                                                         ; b39b: 20 8d 82     ..
+; &b39e referenced 2 times by &b399, &b609
+.cb39e
+    lda l0030                                                         ; b39e: a5 30       .0
+    sta (l0037)                                                       ; b3a0: 92 37       .7
+    ldy #1                                                            ; b3a2: a0 01       ..
+    lda l002e                                                         ; b3a4: a5 2e       ..
+    eor l0031                                                         ; b3a6: 45 31       E1
+    and #&80                                                          ; b3a8: 29 80       ).
+    eor l0031                                                         ; b3aa: 45 31       E1
+    sta (l0037),y                                                     ; b3ac: 91 37       .7
+    iny                                                               ; b3ae: c8          .
+    lda l0032                                                         ; b3af: a5 32       .2
+    sta (l0037),y                                                     ; b3b1: 91 37       .7
+    iny                                                               ; b3b3: c8          .
+    lda l0033                                                         ; b3b4: a5 33       .3
+    sta (l0037),y                                                     ; b3b6: 91 37       .7
+    iny                                                               ; b3b8: c8          .
+    lda l0034                                                         ; b3b9: a5 34       .4
+    sta (l0037),y                                                     ; b3bb: 91 37       .7
+    rts                                                               ; b3bd: 60          `
+
+; &b3be referenced 1 time by &bf56
+.lb3be
+    equs "EDIT 12,2"                                                  ; b3be: 45 44 49... EDI
+    equb &0d                                                          ; b3c7: 0d          .
+
+.sub_cb3c8
+    jsr sub_cbbdc                                                     ; b3c8: 20 dc bb     ..
+    lda #&80                                                          ; b3cb: a9 80       ..
+    sta l001f                                                         ; b3cd: 85 1f       ..
+; &b3cf referenced 1 time by &b417
+.cb3cf
+    stz l003b                                                         ; b3cf: 64 3b       d;
+    stz l003c                                                         ; b3d1: 64 3c       d<
+    jsr cac38                                                         ; b3d3: 20 38 ac     8.
+    jsr sub_c9be2                                                     ; b3d6: 20 e2 9b     ..
+    php                                                               ; b3d9: 08          .
+    jsr cbc66                                                         ; b3da: 20 66 bc     f.
+    jsr cac2b                                                         ; b3dd: 20 2b ac     +.
+    lsr l002b                                                         ; b3e0: 46 2b       F+
+    plp                                                               ; b3e2: 28          (
+    bcc cb3f4                                                         ; b3e3: 90 0f       ..
+    jsr sub_c8da2                                                     ; b3e5: 20 a2 8d     ..
+    beq cb3fb                                                         ; b3e8: f0 11       ..
+    jsr sub_cbd26                                                     ; b3ea: 20 26 bd     &.
+    jsr cbc66                                                         ; b3ed: 20 66 bc     f.
+    dec l000a                                                         ; b3f0: c6 0a       ..
+    bra cb3fe                                                         ; b3f2: 80 0a       ..
+; &b3f4 referenced 1 time by &b3e3
+.cb3f4
+    jsr sub_c8da2                                                     ; b3f4: 20 a2 8d     ..
+    beq cb3fb                                                         ; b3f7: f0 02       ..
+    dec l000a                                                         ; b3f9: c6 0a       ..
+; &b3fb referenced 2 times by &b3e8, &b3f7
+.cb3fb
+    jsr sub_c9be2                                                     ; b3fb: 20 e2 9b     ..
+; &b3fe referenced 1 time by &b3f2
+.cb3fe
+    ldx #&31 ; '1'                                                    ; b3fe: a2 31       .1
+    jsr sub_cbe06                                                     ; b400: 20 06 be     ..
+    jsr c8f9d                                                         ; b403: 20 9d 8f     ..
+    cmp #&e7                                                          ; b406: c9 e7       ..
+    bne cb428                                                         ; b408: d0 1e       ..
+    jsr c8f9d                                                         ; b40a: 20 9d 8f     ..
+    jsr c9c80                                                         ; b40d: 20 80 9c     ..
+    bra cb42b                                                         ; b410: 80 19       ..
+.sub_cb412
+    iny                                                               ; b412: c8          .
+    lda (l000b),y                                                     ; b413: b1 0b       ..
+    cmp #&4f ; 'O'                                                    ; b415: c9 4f       .O
+    bne cb3cf                                                         ; b417: d0 b6       ..
+    inc l000a                                                         ; b419: e6 0a       ..
+    jsr sub_c9332                                                     ; b41b: 20 32 93     2.
+    jsr c9c6a                                                         ; b41e: 20 6a 9c     j.
+    lda l002a                                                         ; b421: a5 2a       .*
+    sta l001f                                                         ; b423: 85 1f       ..
+; &b425 referenced 1 time by &b46a
+.cb425
+    jmp c904b                                                         ; b425: 4c 4b 90    LK.
+
+; &b428 referenced 1 time by &b408
+.cb428
+    jsr c9c74                                                         ; b428: 20 74 9c     t.
+; &b42b referenced 1 time by &b410
+.cb42b
+    lda l000b                                                         ; b42b: a5 0b       ..
+    sta l0019                                                         ; b42d: 85 19       ..
+    jsr sub_cbe25                                                     ; b42f: 20 25 be     %.
+    jsr sub_cbd26                                                     ; b432: 20 26 bd     &.
+    jsr sub_c8191                                                     ; b435: 20 91 81     ..
+    lda l003d                                                         ; b438: a5 3d       .=
+    sta l000b                                                         ; b43a: 85 0b       ..
+    lda l003e                                                         ; b43c: a5 3e       .>
+    sta l000c                                                         ; b43e: 85 0c       ..
+    bcs cb45d                                                         ; b440: b0 1b       ..
+    dey                                                               ; b442: 88          .
+    bra cb454                                                         ; b443: 80 0f       ..
+; &b445 referenced 1 time by &b4b8
+.cb445
+    jsr cbdd4                                                         ; b445: 20 d4 bd     ..
+    bit l001f                                                         ; b448: 24 1f       $.
+    bmi cb451                                                         ; b44a: 30 05       0.
+    lda #&0a                                                          ; b44c: a9 0a       ..
+    jsr oswrch                                                        ; b44e: 20 ee ff     ..
+; &b451 referenced 2 times by &b44a, &b4c4
+.cb451
+    jsr c9c80                                                         ; b451: 20 80 9c     ..
+; &b454 referenced 1 time by &b443
+.cb454
+    lda (l000b),y                                                     ; b454: b1 0b       ..
+    sta l002b                                                         ; b456: 85 2b       .+
+    iny                                                               ; b458: c8          .
+    lda (l000b),y                                                     ; b459: b1 0b       ..
+    sta l002a                                                         ; b45b: 85 2a       .*
+; &b45d referenced 1 time by &b440
+.cb45d
+    lda l002a                                                         ; b45d: a5 2a       .*
+    clc                                                               ; b45f: 18          .
+    sbc l0031                                                         ; b460: e5 31       .1
+    lda l002b                                                         ; b462: a5 2b       .+
+    sbc l0032                                                         ; b464: e5 32       .2
+    bcc cb46f                                                         ; b466: 90 07       ..
+    bit l001f                                                         ; b468: 24 1f       $.
+    bpl cb425                                                         ; b46a: 10 b9       ..
+    jmp cbf54                                                         ; b46c: 4c 54 bf    LT.
+
+; &b46f referenced 1 time by &b466
+.cb46f
+    stz l004c                                                         ; b46f: 64 4c       dL
+    stz l004d                                                         ; b471: 64 4d       dM
+    ldy #4                                                            ; b473: a0 04       ..
+    sty l000a                                                         ; b475: 84 0a       ..
+    sty l001b                                                         ; b477: 84 1b       ..
+    bit l003b                                                         ; b479: 24 3b       $;
+    bpl cb47f                                                         ; b47b: 10 02       ..
+    stz l003b                                                         ; b47d: 64 3b       d;
+; &b47f referenced 1 time by &b47b
+.cb47f
+    bit l003c                                                         ; b47f: 24 3c       $<
+    bpl cb485                                                         ; b481: 10 02       ..
+    stz l003c                                                         ; b483: 64 3c       d<
+; &b485 referenced 2 times by &b481, &b4c0
+.cb485
+    lda (l000b),y                                                     ; b485: b1 0b       ..
+    cmp #&0d                                                          ; b487: c9 0d       ..
+    beq cb4c2                                                         ; b489: f0 37       .7
+    cmp #&f4                                                          ; b48b: c9 f4       ..
+    beq cb495                                                         ; b48d: f0 06       ..
+    cmp #&22 ; '"'                                                    ; b48f: c9 22       ."
+    bne cb497                                                         ; b491: d0 04       ..
+    eor l004c                                                         ; b493: 45 4c       EL
+; &b495 referenced 1 time by &b48d
+.cb495
+    sta l004c                                                         ; b495: 85 4c       .L
+; &b497 referenced 1 time by &b491
+.cb497
+    ldx l004c                                                         ; b497: a6 4c       .L
+    bne cb4a7                                                         ; b499: d0 0c       ..
+    cmp #&ed                                                          ; b49b: c9 ed       ..
+    bne cb4a1                                                         ; b49d: d0 02       ..
+    dec l003b                                                         ; b49f: c6 3b       .;
+; &b4a1 referenced 1 time by &b49d
+.cb4a1
+    cmp #&fd                                                          ; b4a1: c9 fd       ..
+    bne cb4a7                                                         ; b4a3: d0 02       ..
+    dec l003c                                                         ; b4a5: c6 3c       .<
+; &b4a7 referenced 2 times by &b499, &b4a3
+.cb4a7
+    ldx l0019                                                         ; b4a7: a6 19       ..
+; &b4a9 referenced 1 time by &b4b6
+.loop_cb4a9
+    lda l0700,x                                                       ; b4a9: bd 00 07    ...
+    cmp #&0d                                                          ; b4ac: c9 0d       ..
+    beq cb4ba                                                         ; b4ae: f0 0a       ..
+    cmp (l000b),y                                                     ; b4b0: d1 0b       ..
+    bne cb4bc                                                         ; b4b2: d0 08       ..
+    iny                                                               ; b4b4: c8          .
+    inx                                                               ; b4b5: e8          .
+    bra loop_cb4a9                                                    ; b4b6: 80 f1       ..
+; &b4b8 referenced 1 time by &b4e6
+.cb4b8
+    bra cb445                                                         ; b4b8: 80 8b       ..
+; &b4ba referenced 1 time by &b4ae
+.cb4ba
+    sta l004d                                                         ; b4ba: 85 4d       .M
+; &b4bc referenced 1 time by &b4b2
+.cb4bc
+    inc l001b                                                         ; b4bc: e6 1b       ..
+    ldy l001b                                                         ; b4be: a4 1b       ..
+    bra cb485                                                         ; b4c0: 80 c3       ..
+; &b4c2 referenced 1 time by &b489
+.cb4c2
+    lda l004d                                                         ; b4c2: a5 4d       .M
+    beq cb451                                                         ; b4c4: f0 8b       ..
+    jsr sub_ca0ec                                                     ; b4c6: 20 ec a0     ..
+    lda #1                                                            ; b4c9: a9 01       ..
+    inx                                                               ; b4cb: e8          .
+    sec                                                               ; b4cc: 38          8
+    jsr sub_cbdf4                                                     ; b4cd: 20 f4 bd     ..
+    ldx l003b                                                         ; b4d0: a6 3b       .;
+    lda #2                                                            ; b4d2: a9 02       ..
+    jsr sub_cbdf3                                                     ; b4d4: 20 f3 bd     ..
+    ldx l003c                                                         ; b4d7: a6 3c       .<
+    lda #4                                                            ; b4d9: a9 04       ..
+    jsr sub_cbdf3                                                     ; b4db: 20 f3 bd     ..
+    stz l004c                                                         ; b4de: 64 4c       dL
+; &b4e0 referenced 1 time by &b508
+.cb4e0
+    ldy l000a                                                         ; b4e0: a4 0a       ..
+; &b4e2 referenced 2 times by &b4f6, &b520
+.cb4e2
+    lda (l000b),y                                                     ; b4e2: b1 0b       ..
+    cmp #&0d                                                          ; b4e4: c9 0d       ..
+    beq cb4b8                                                         ; b4e6: f0 d0       ..
+    cmp #&22 ; '"'                                                    ; b4e8: c9 22       ."
+    bne cb4f8                                                         ; b4ea: d0 0c       ..
+    eor l004c                                                         ; b4ec: 45 4c       EL
+    sta l004c                                                         ; b4ee: 85 4c       .L
+    lda #&22 ; '"'                                                    ; b4f0: a9 22       ."
+; &b4f2 referenced 1 time by &b4fa
+.loop_cb4f2
+    jsr cbdd4                                                         ; b4f2: 20 d4 bd     ..
+    iny                                                               ; b4f5: c8          .
+    bra cb4e2                                                         ; b4f6: 80 ea       ..
+; &b4f8 referenced 1 time by &b4ea
+.cb4f8
+    ldx l004c                                                         ; b4f8: a6 4c       .L
+    bne loop_cb4f2                                                    ; b4fa: d0 f6       ..
+    cmp #&8d                                                          ; b4fc: c9 8d       ..
+    bne cb50a                                                         ; b4fe: d0 0a       ..
+    jsr sub_c9bee                                                     ; b500: 20 ee 9b     ..
+    sty l000a                                                         ; b503: 84 0a       ..
+    jsr sub_ca0e8                                                     ; b505: 20 e8 a0     ..
+    bra cb4e0                                                         ; b508: 80 d6       ..
+; &b50a referenced 1 time by &b4fe
+.cb50a
+    cmp #&e3                                                          ; b50a: c9 e3       ..
+    bne cb510                                                         ; b50c: d0 02       ..
+    inc l003b                                                         ; b50e: e6 3b       .;
+; &b510 referenced 1 time by &b50c
+.cb510
+    cmp #&f5                                                          ; b510: c9 f5       ..
+    bne cb516                                                         ; b512: d0 02       ..
+    inc l003c                                                         ; b514: e6 3c       .<
+; &b516 referenced 1 time by &b512
+.cb516
+    cmp #&f4                                                          ; b516: c9 f4       ..
+    bne cb51c                                                         ; b518: d0 02       ..
+    sta l004c                                                         ; b51a: 85 4c       .L
+; &b51c referenced 1 time by &b518
+.cb51c
+    jsr sub_cbd77                                                     ; b51c: 20 77 bd     w.
+    iny                                                               ; b51f: c8          .
+    bra cb4e2                                                         ; b520: 80 c0       ..
+; &b522 referenced 1 time by &b5ee
+.cb522
+    jsr sub_c99c4                                                     ; b522: 20 c4 99     ..
+    bne cb530                                                         ; b525: d0 09       ..
+    ldx l0026                                                         ; b527: a6 26       .&
+    beq cb563                                                         ; b529: f0 38       .8
+    bcs cb56a                                                         ; b52b: b0 3d       .=
+; &b52d referenced 1 time by &b530
+.loop_cb52d
+    jmp c9c2d                                                         ; b52d: 4c 2d 9c    L-.
+
+; &b530 referenced 1 time by &b525
+.cb530
+    bcs loop_cb52d                                                    ; b530: b0 fb       ..
+    ldx l0026                                                         ; b532: a6 26       .&
+    beq cb563                                                         ; b534: f0 2d       .-
+; &b536 referenced 1 time by &b552
+.loop_cb536
+    lda l002a                                                         ; b536: a5 2a       .*
+    cmp l0519,x                                                       ; b538: dd 19 05    ...
+    bne cb54b                                                         ; b53b: d0 0e       ..
+    lda l002b                                                         ; b53d: a5 2b       .+
+    cmp l051a,x                                                       ; b53f: dd 1a 05    ...
+    bne cb54b                                                         ; b542: d0 07       ..
+    lda l002c                                                         ; b544: a5 2c       .,
+    cmp l051b,x                                                       ; b546: dd 1b 05    ...
+    beq cb56a                                                         ; b549: f0 1f       ..
+; &b54b referenced 2 times by &b53b, &b542
+.cb54b
+    txa                                                               ; b54b: 8a          .
+    sec                                                               ; b54c: 38          8
+    sbc #&0f                                                          ; b54d: e9 0f       ..
+    tax                                                               ; b54f: aa          .
+    stx l0026                                                         ; b550: 86 26       .&
+    bne loop_cb536                                                    ; b552: d0 e2       ..
+    brk                                                               ; b554: 00          .
+
+    equs "!Can't match "                                              ; b555: 21 43 61... !Ca
+    equb &e3                                                          ; b562: e3          .
+
+; &b563 referenced 2 times by &b529, &b534
+.cb563
+    brk                                                               ; b563: 00          .
+
+    equs " No "                                                       ; b564: 20 4e 6f...  No
+    equb &e3,   0                                                     ; b568: e3 00       ..
+
+; &b56a referenced 2 times by &b52b, &b549
+.cb56a
+    lda l0519,x                                                       ; b56a: bd 19 05    ...
+    sta l002a                                                         ; b56d: 85 2a       .*
+    lda l051a,x                                                       ; b56f: bd 1a 05    ...
+    sta l002b                                                         ; b572: 85 2b       .+
+    ldy l051b,x                                                       ; b574: bc 1b 05    ...
+    cpy #5                                                            ; b577: c0 05       ..
+    beq cb5f1                                                         ; b579: f0 76       .v
+    lda (l002a)                                                       ; b57b: b2 2a       .*
+    adc l051c,x                                                       ; b57d: 7d 1c 05    }..
+    sta (l002a)                                                       ; b580: 92 2a       .*
+    sta l0037                                                         ; b582: 85 37       .7
+    ldy #1                                                            ; b584: a0 01       ..
+    lda (l002a),y                                                     ; b586: b1 2a       .*
+    adc l051d,x                                                       ; b588: 7d 1d 05    }..
+    sta (l002a),y                                                     ; b58b: 91 2a       .*
+    sta l0038                                                         ; b58d: 85 38       .8
+    iny                                                               ; b58f: c8          .
+    lda (l002a),y                                                     ; b590: b1 2a       .*
+    adc l051e,x                                                       ; b592: 7d 1e 05    }..
+    sta (l002a),y                                                     ; b595: 91 2a       .*
+    sta l0039                                                         ; b597: 85 39       .9
+    iny                                                               ; b599: c8          .
+    lda (l002a),y                                                     ; b59a: b1 2a       .*
+    adc l051f,x                                                       ; b59c: 7d 1f 05    }..
+    sta (l002a),y                                                     ; b59f: 91 2a       .*
+    tay                                                               ; b5a1: a8          .
+    lda l0037                                                         ; b5a2: a5 37       .7
+    sec                                                               ; b5a4: 38          8
+    sbc l0521,x                                                       ; b5a5: fd 21 05    .!.
+    sta l0037                                                         ; b5a8: 85 37       .7
+    lda l0038                                                         ; b5aa: a5 38       .8
+    sbc l0522,x                                                       ; b5ac: fd 22 05    .".
+    tsb l0037                                                         ; b5af: 04 37       .7
+    lda l0039                                                         ; b5b1: a5 39       .9
+    sbc l0523,x                                                       ; b5b3: fd 23 05    .#.
+    tsb l0037                                                         ; b5b6: 04 37       .7
+    tya                                                               ; b5b8: 98          .
+    sbc l0524,x                                                       ; b5b9: fd 24 05    .$.
+    ora l0037                                                         ; b5bc: 05 37       .7
+    beq cb5cf                                                         ; b5be: f0 0f       ..
+    tya                                                               ; b5c0: 98          .
+    eor l051f,x                                                       ; b5c1: 5d 1f 05    ]..
+    eor l0524,x                                                       ; b5c4: 5d 24 05    ]$.
+    bpl cb5cd                                                         ; b5c7: 10 04       ..
+    bcs cb5cf                                                         ; b5c9: b0 04       ..
+    bra cb5df                                                         ; b5cb: 80 12       ..
+; &b5cd referenced 1 time by &b5c7
+.cb5cd
+    bcs cb5df                                                         ; b5cd: b0 10       ..
+; &b5cf referenced 5 times by &b5be, &b5c9, &b617, &b61e, &b622
+.cb5cf
+    ldy l0526,x                                                       ; b5cf: bc 26 05    .&.
+    lda l0527,x                                                       ; b5d2: bd 27 05    .'.
+    sty l000b                                                         ; b5d5: 84 0b       ..
+    sta l000c                                                         ; b5d7: 85 0c       ..
+    jsr c9c8a                                                         ; b5d9: 20 8a 9c     ..
+    jmp c90d0                                                         ; b5dc: 4c d0 90    L..
+
+; &b5df referenced 4 times by &b5cb, &b5cd, &b620, &b624
+.cb5df
+    txa                                                               ; b5df: 8a          .
+    sec                                                               ; b5e0: 38          8
+    sbc #&0f                                                          ; b5e1: e9 0f       ..
+    sta l0026                                                         ; b5e3: 85 26       .&
+    ldy l001b                                                         ; b5e5: a4 1b       ..
+    sty l000a                                                         ; b5e7: 84 0a       ..
+    jsr sub_c8da2                                                     ; b5e9: 20 a2 8d     ..
+    bne cb626                                                         ; b5ec: d0 38       .8
+    jmp cb522                                                         ; b5ee: 4c 22 b5    L".
+
+; &b5f1 referenced 1 time by &b579
+.cb5f1
+    jsr cb205                                                         ; b5f1: 20 05 b2     ..
+    txa                                                               ; b5f4: 8a          .
+    clc                                                               ; b5f5: 18          .
+    adc #&1c                                                          ; b5f6: 69 1c       i.
+    sta l004a                                                         ; b5f8: 85 4a       .J
+    lda #5                                                            ; b5fa: a9 05       ..
+    sta l004b                                                         ; b5fc: 85 4b       .K
+    jsr ca70a                                                         ; b5fe: 20 0a a7     ..
+    lda l002a                                                         ; b601: a5 2a       .*
+    sta l0037                                                         ; b603: 85 37       .7
+    lda l002b                                                         ; b605: a5 2b       .+
+    sta l0038                                                         ; b607: 85 38       .8
+    jsr cb39e                                                         ; b609: 20 9e b3     ..
+    ldx l0026                                                         ; b60c: a6 26       .&
+    txa                                                               ; b60e: 8a          .
+    clc                                                               ; b60f: 18          .
+    adc #&21 ; '!'                                                    ; b610: 69 21       i!
+    sta l004a                                                         ; b612: 85 4a       .J
+    jsr sub_c9d36                                                     ; b614: 20 36 9d     6.
+    beq cb5cf                                                         ; b617: f0 b6       ..
+    lda l051d,x                                                       ; b619: bd 1d 05    ...
+    bmi cb622                                                         ; b61c: 30 04       0.
+    bcs cb5cf                                                         ; b61e: b0 af       ..
+    bra cb5df                                                         ; b620: 80 bd       ..
+; &b622 referenced 1 time by &b61c
+.cb622
+    bcc cb5cf                                                         ; b622: 90 ab       ..
+    bra cb5df                                                         ; b624: 80 b9       ..
+; &b626 referenced 1 time by &b5ec
+.cb626
+    jmp c90c5                                                         ; b626: 4c c5 90    L..
+
+; &b629 referenced 2 times by &b64c, &b64e
+.cb629
+    brk                                                               ; b629: 00          .
+
+    equb &22, &e3                                                     ; b62a: 22 e3       ".
+    equs " variable"                                                  ; b62c: 20 76 61...  va
+
+; &b635 referenced 1 time by &b664
+.cb635
+    brk                                                               ; b635: 00          .
+
+    equs "#Too many "                                                 ; b636: 23 54 6f... #To
+    equb &e3, &73                                                     ; b640: e3 73       .s
+
+; &b642 referenced 1 time by &b65e
+.loop_cb642
+    brk                                                               ; b642: 00          .
+
+    equs "$No "                                                       ; b643: 24 4e 6f... $No
+    equb &b8,   0                                                     ; b647: b8 00       ..
+
+.sub_cb649
+    jsr sub_c997d                                                     ; b649: 20 7d 99     }.
+    beq cb629                                                         ; b64c: f0 db       ..
+    bcs cb629                                                         ; b64e: b0 d9       ..
+    jsr sub_cbc83                                                     ; b650: 20 83 bc     ..
+    jsr sub_c9c4a                                                     ; b653: 20 4a 9c     J.
+    jsr sub_cb362                                                     ; b656: 20 62 b3     b.
+    jsr c8f92                                                         ; b659: 20 92 8f     ..
+    cmp #&b8                                                          ; b65c: c9 b8       ..
+    bne loop_cb642                                                    ; b65e: d0 e2       ..
+    ldy l0026                                                         ; b660: a4 26       .&
+    cpy #&96                                                          ; b662: c0 96       ..
+    bcs cb635                                                         ; b664: b0 cf       ..
+    tya                                                               ; b666: 98          .
+    adc #&0f                                                          ; b667: 69 0f       i.
+    sta l0026                                                         ; b669: 85 26       .&
+    lda l0037                                                         ; b66b: a5 37       .7
+    sta l0528,y                                                       ; b66d: 99 28 05    .(.
+    lda l0038                                                         ; b670: a5 38       .8
+    sta l0529,y                                                       ; b672: 99 29 05    .).
+    lda l0039                                                         ; b675: a5 39       .9
+    sta l052a,y                                                       ; b677: 99 2a 05    .*.
+    lsr a                                                             ; b67a: 4a          J
+    bcs cb6d1                                                         ; b67b: b0 54       .T
+    jsr sub_c9774                                                     ; b67d: 20 74 97     t.
+    ldy l0026                                                         ; b680: a4 26       .&
+    lda l002a                                                         ; b682: a5 2a       .*
+    sta l0521,y                                                       ; b684: 99 21 05    .!.
+    lda l002b                                                         ; b687: a5 2b       .+
+    sta l0522,y                                                       ; b689: 99 22 05    .".
+    lda l002c                                                         ; b68c: a5 2c       .,
+    sta l0523,y                                                       ; b68e: 99 23 05    .#.
+    lda l002d                                                         ; b691: a5 2d       .-
+    sta l0524,y                                                       ; b693: 99 24 05    .$.
+    lda #1                                                            ; b696: a9 01       ..
+    jsr cae60                                                         ; b698: 20 60 ae     `.
+    jsr c8f92                                                         ; b69b: 20 92 8f     ..
+    cmp #&88                                                          ; b69e: c9 88       ..
+    bne cb6a7                                                         ; b6a0: d0 05       ..
+    jsr sub_c9774                                                     ; b6a2: 20 74 97     t.
+    ldy l001b                                                         ; b6a5: a4 1b       ..
+; &b6a7 referenced 1 time by &b6a0
+.cb6a7
+    sty l000a                                                         ; b6a7: 84 0a       ..
+    ldy l0026                                                         ; b6a9: a4 26       .&
+    lda l002a                                                         ; b6ab: a5 2a       .*
+    sta l051c,y                                                       ; b6ad: 99 1c 05    ...
+    lda l002b                                                         ; b6b0: a5 2b       .+
+    sta l051d,y                                                       ; b6b2: 99 1d 05    ...
+    lda l002c                                                         ; b6b5: a5 2c       .,
+    sta l051e,y                                                       ; b6b7: 99 1e 05    ...
+    lda l002d                                                         ; b6ba: a5 2d       .-
+    sta l051f,y                                                       ; b6bc: 99 1f 05    ...
+; &b6bf referenced 1 time by &b707
+.cb6bf
+    jsr sub_c9c93                                                     ; b6bf: 20 93 9c     ..
+    ldy l0026                                                         ; b6c2: a4 26       .&
+    lda l000b                                                         ; b6c4: a5 0b       ..
+    sta l0526,y                                                       ; b6c6: 99 26 05    .&.
+    lda l000c                                                         ; b6c9: a5 0c       ..
+    sta l0527,y                                                       ; b6cb: 99 27 05    .'.
+    jmp c90d0                                                         ; b6ce: 4c d0 90    L..
+
+; &b6d1 referenced 1 time by &b67b
+.cb6d1
+    jsr sub_c9dff                                                     ; b6d1: 20 ff 9d     ..
+    jsr sub_c97a2                                                     ; b6d4: 20 a2 97     ..
+    lda l0026                                                         ; b6d7: a5 26       .&
+    clc                                                               ; b6d9: 18          .
+    adc #&21 ; '!'                                                    ; b6da: 69 21       i!
+    sta l004a                                                         ; b6dc: 85 4a       .J
+    lda #5                                                            ; b6de: a9 05       ..
+    sta l004b                                                         ; b6e0: 85 4b       .K
+    jsr sub_ca54d                                                     ; b6e2: 20 4d a5     M.
+    jsr ca622                                                         ; b6e5: 20 22 a6     ".
+    jsr c8f92                                                         ; b6e8: 20 92 8f     ..
+    cmp #&88                                                          ; b6eb: c9 88       ..
+    bne cb6f7                                                         ; b6ed: d0 08       ..
+    jsr sub_c9dff                                                     ; b6ef: 20 ff 9d     ..
+    jsr sub_c97a2                                                     ; b6f2: 20 a2 97     ..
+    ldy l001b                                                         ; b6f5: a4 1b       ..
+; &b6f7 referenced 1 time by &b6ed
+.cb6f7
+    sty l000a                                                         ; b6f7: 84 0a       ..
+    lda l0026                                                         ; b6f9: a5 26       .&
+    clc                                                               ; b6fb: 18          .
+    adc #&1c                                                          ; b6fc: 69 1c       i.
+    sta l004a                                                         ; b6fe: 85 4a       .J
+    lda #5                                                            ; b700: a9 05       ..
+    sta l004b                                                         ; b702: 85 4b       .K
+    jsr sub_ca54d                                                     ; b704: 20 4d a5     M.
+    bra cb6bf                                                         ; b707: 80 b6       ..
+.sub_cb709
+    jsr sub_cb85a                                                     ; b709: 20 5a b8     Z.
+; &b70c referenced 1 time by &b802
+.cb70c
+    jsr c9c6a                                                         ; b70c: 20 6a 9c     j.
+    ldy l0025                                                         ; b70f: a4 25       .%
+    cpy #&1a                                                          ; b711: c0 1a       ..
+    bcs cb723                                                         ; b713: b0 0e       ..
+    lda l000b                                                         ; b715: a5 0b       ..
+    sta l05cc,y                                                       ; b717: 99 cc 05    ...
+    lda l000c                                                         ; b71a: a5 0c       ..
+    sta l05e6,y                                                       ; b71c: 99 e6 05    ...
+    inc l0025                                                         ; b71f: e6 25       .%
+    bra cb753                                                         ; b721: 80 30       .0
+; &b723 referenced 1 time by &b713
+.cb723
+    brk                                                               ; b723: 00          .
+
+    equs "%Too many "                                                 ; b724: 25 54 6f... %To
+    equb &e4, &73                                                     ; b72e: e4 73       .s
+
+; &b730 referenced 1 time by &b73c
+.loop_cb730
+    brk                                                               ; b730: 00          .
+
+    equs "&No "                                                       ; b731: 26 4e 6f... &No
+    equb &e4,   0                                                     ; b735: e4 00       ..
+
+.sub_cb737
+    jsr c9c6a                                                         ; b737: 20 6a 9c     j.
+    ldx l0025                                                         ; b73a: a6 25       .%
+    beq loop_cb730                                                    ; b73c: f0 f2       ..
+    dec l0025                                                         ; b73e: c6 25       .%
+    ldy l05cb,x                                                       ; b740: bc cb 05    ...
+    lda l05e5,x                                                       ; b743: bd e5 05    ...
+    sty l000b                                                         ; b746: 84 0b       ..
+    sta l000c                                                         ; b748: 85 0c       ..
+; &b74a referenced 1 time by &b76f
+.cb74a
+    jmp c90ca                                                         ; b74a: 4c ca 90    L..
+
+.sub_cb74d
+    jsr sub_cb85a                                                     ; b74d: 20 5a b8     Z.
+    jsr c9c6a                                                         ; b750: 20 6a 9c     j.
+; &b753 referenced 3 times by &9cf8, &b721, &b7f7
+.cb753
+    lda l0020                                                         ; b753: a5 20       .
+    beq cb75a                                                         ; b755: f0 03       ..
+    jsr sub_c9d0f                                                     ; b757: 20 0f 9d     ..
+; &b75a referenced 1 time by &b755
+.cb75a
+    ldy #4                                                            ; b75a: a0 04       ..
+    sty l000a                                                         ; b75c: 84 0a       ..
+    ldy l003d                                                         ; b75e: a4 3d       .=
+    lda l003e                                                         ; b760: a5 3e       .>
+; &b762 referenced 1 time by &ba69
+.cb762
+    sty l000b                                                         ; b762: 84 0b       ..
+    sta l000c                                                         ; b764: 85 0c       ..
+    jmp c90d0                                                         ; b766: 4c d0 90    L..
+
+; &b769 referenced 1 time by &b776
+.loop_cb769
+    jsr c9c6a                                                         ; b769: 20 6a 9c     j.
+    jsr sub_cb2e0                                                     ; b76c: 20 e0 b2     ..
+    bra cb74a                                                         ; b76f: 80 d9       ..
+; &b771 referenced 1 time by &b790
+.loop_cb771
+    jsr c8f9d                                                         ; b771: 20 9d 8f     ..
+    cmp #&87                                                          ; b774: c9 87       ..
+    beq loop_cb769                                                    ; b776: f0 f1       ..
+    ldy l000a                                                         ; b778: a4 0a       ..
+    dey                                                               ; b77a: 88          .
+    jsr c9c80                                                         ; b77b: 20 80 9c     ..
+    stz l000a                                                         ; b77e: 64 0a       d.
+    lda l000b                                                         ; b780: a5 0b       ..
+    sta l0016                                                         ; b782: 85 16       ..
+    lda l000c                                                         ; b784: a5 0c       ..
+    sta l0017                                                         ; b786: 85 17       ..
+    jmp c9073                                                         ; b788: 4c 73 90    Ls.
+
+.sub_cb78b
+    jsr c8f9d                                                         ; b78b: 20 9d 8f     ..
+    cmp #&85                                                          ; b78e: c9 85       ..
+    beq loop_cb771                                                    ; b790: f0 df       ..
+    dec l000a                                                         ; b792: c6 0a       ..
+    jsr sub_c9332                                                     ; b794: 20 32 93     2.
+    cpx #&f2                                                          ; b797: e0 f2       ..
+    beq cb7a4                                                         ; b799: f0 09       ..
+    iny                                                               ; b79b: c8          .
+    cpx #&e5                                                          ; b79c: e0 e5       ..
+    beq cb7a4                                                         ; b79e: f0 04       ..
+    cpx #&e4                                                          ; b7a0: e0 e4       ..
+    bne cb81a                                                         ; b7a2: d0 76       .v
+; &b7a4 referenced 2 times by &b799, &b79e
+.cb7a4
+    phx                                                               ; b7a4: da          .
+    lda l002b                                                         ; b7a5: a5 2b       .+
+    ora l002c                                                         ; b7a7: 05 2c       .,
+    ora l002d                                                         ; b7a9: 05 2d       .-
+    bne cb805                                                         ; b7ab: d0 58       .X
+    dec l002a                                                         ; b7ad: c6 2a       .*
+    beq cb7e6                                                         ; b7af: f0 35       .5
+    bmi cb805                                                         ; b7b1: 30 52       0R
+; &b7b3 referenced 4 times by &b7cc, &b7dc, &b7e0, &b7e4
+.cb7b3
+    lda (l000b),y                                                     ; b7b3: b1 0b       ..
+    cmp #&0d                                                          ; b7b5: c9 0d       ..
+    beq cb805                                                         ; b7b7: f0 4c       .L
+    cmp #&3a ; ':'                                                    ; b7b9: c9 3a       .:
+    beq cb805                                                         ; b7bb: f0 48       .H
+    cmp #&8b                                                          ; b7bd: c9 8b       ..
+    beq cb805                                                         ; b7bf: f0 44       .D
+    iny                                                               ; b7c1: c8          .
+    cmp #&22 ; '"'                                                    ; b7c2: c9 22       ."
+    bne cb7ca                                                         ; b7c4: d0 04       ..
+    eor l002b                                                         ; b7c6: 45 2b       E+
+    sta l002b                                                         ; b7c8: 85 2b       .+
+; &b7ca referenced 1 time by &b7c4
+.cb7ca
+    ldx l002b                                                         ; b7ca: a6 2b       .+
+    bne cb7b3                                                         ; b7cc: d0 e5       ..
+    cmp #&29 ; ')'                                                    ; b7ce: c9 29       .)
+    bne cb7d4                                                         ; b7d0: d0 02       ..
+    dec l002c                                                         ; b7d2: c6 2c       .,
+; &b7d4 referenced 1 time by &b7d0
+.cb7d4
+    cmp #&28 ; '('                                                    ; b7d4: c9 28       .(
+    bne cb7da                                                         ; b7d6: d0 02       ..
+    inc l002c                                                         ; b7d8: e6 2c       .,
+; &b7da referenced 1 time by &b7d6
+.cb7da
+    cmp #&2c ; ','                                                    ; b7da: c9 2c       .,
+    bne cb7b3                                                         ; b7dc: d0 d5       ..
+    ldx l002c                                                         ; b7de: a6 2c       .,
+    bne cb7b3                                                         ; b7e0: d0 d1       ..
+    dec l002a                                                         ; b7e2: c6 2a       .*
+    bne cb7b3                                                         ; b7e4: d0 cd       ..
+; &b7e6 referenced 1 time by &b7af
+.cb7e6
+    pla                                                               ; b7e6: 68          h
+    cmp #&f2                                                          ; b7e7: c9 f2       ..
+    beq cb833                                                         ; b7e9: f0 48       .H
+    sty l000a                                                         ; b7eb: 84 0a       ..
+    cmp #&e4                                                          ; b7ed: c9 e4       ..
+    beq cb7fa                                                         ; b7ef: f0 09       ..
+    jsr sub_cb85a                                                     ; b7f1: 20 5a b8     Z.
+    jsr c9c8a                                                         ; b7f4: 20 8a 9c     ..
+    jmp cb753                                                         ; b7f7: 4c 53 b7    LS.
+
+; &b7fa referenced 1 time by &b7ef
+.cb7fa
+    jsr sub_cb85a                                                     ; b7fa: 20 5a b8     Z.
+    ldy l000a                                                         ; b7fd: a4 0a       ..
+    jsr sub_cb84d                                                     ; b7ff: 20 4d b8     M.
+    jmp cb70c                                                         ; b802: 4c 0c b7    L..
+
+; &b805 referenced 5 times by &b7ab, &b7b1, &b7b7, &b7bb, &b7bf
+.cb805
+    pla                                                               ; b805: 68          h
+; &b806 referenced 1 time by &b80f
+.loop_cb806
+    lda (l000b),y                                                     ; b806: b1 0b       ..
+    iny                                                               ; b808: c8          .
+    cmp #&8b                                                          ; b809: c9 8b       ..
+    beq cb847                                                         ; b80b: f0 3a       .:
+    cmp #&0d                                                          ; b80d: c9 0d       ..
+    bne loop_cb806                                                    ; b80f: d0 f5       ..
+    brk                                                               ; b811: 00          .
+
+    equb &28, &ee                                                     ; b812: 28 ee       (.
+    equs " range"                                                     ; b814: 20 72 61...  ra
+
+; &b81a referenced 2 times by &b7a2, &b83a
+.cb81a
+    brk                                                               ; b81a: 00          .
+
+    equb &27, &ee                                                     ; b81b: 27 ee       '.
+    equs " syntax"                                                    ; b81d: 20 73 79...  sy
+
+; &b824 referenced 1 time by &b869
+.cb824
+    brk                                                               ; b824: 00          .
+
+    equs ")No such line"                                              ; b825: 29 4e 6f... )No
+    equb 0                                                            ; b832: 00          .
+
+; &b833 referenced 1 time by &b7e9
+.cb833
+    sty l001b                                                         ; b833: 84 1b       ..
+    jsr c8f92                                                         ; b835: 20 92 8f     ..
+    cmp #&f2                                                          ; b838: c9 f2       ..
+    bne cb81a                                                         ; b83a: d0 de       ..
+    jsr sub_cb057                                                     ; b83c: 20 57 b0     W.
+    ldy l001b                                                         ; b83f: a4 1b       ..
+    jsr sub_cb84d                                                     ; b841: 20 4d b8     M.
+    jmp c90c7                                                         ; b844: 4c c7 90    L..
+
+; &b847 referenced 1 time by &b80b
+.cb847
+    sty l000a                                                         ; b847: 84 0a       ..
+    jmp c9ced                                                         ; b849: 4c ed 9c    L..
+
+; &b84c referenced 1 time by &b855
+.loop_cb84c
+    iny                                                               ; b84c: c8          .
+; &b84d referenced 2 times by &b7ff, &b841
+.sub_cb84d
+    lda (l000b),y                                                     ; b84d: b1 0b       ..
+    cmp #&0d                                                          ; b84f: c9 0d       ..
+    beq cb857                                                         ; b851: f0 04       ..
+    cmp #&3a ; ':'                                                    ; b853: c9 3a       .:
+    bne loop_cb84c                                                    ; b855: d0 f5       ..
+; &b857 referenced 1 time by &b851
+.cb857
+    sty l000a                                                         ; b857: 84 0a       ..
+    rts                                                               ; b859: 60          `
+
+; &b85a referenced 5 times by &b709, &b74d, &b7f1, &b7fa, &b994
+.sub_cb85a
+    jsr sub_c9be2                                                     ; b85a: 20 e2 9b     ..
+    bcs cb866                                                         ; b85d: b0 07       ..
+    jsr sub_c9332                                                     ; b85f: 20 32 93     2.
+    lda #&80                                                          ; b862: a9 80       ..
+    trb l002b                                                         ; b864: 14 2b       .+
+; &b866 referenced 2 times by &9cf2, &b85d
+.cb866
+    jsr sub_c8191                                                     ; b866: 20 91 81     ..
+    bcc cb824                                                         ; b869: 90 b9       ..
+    rts                                                               ; b86b: 60          `
+
+; &b86c referenced 2 times by &b8a2, &b8bc
+.cb86c
+    jmp c9155                                                         ; b86c: 4c 55 91    LU.
+
+; &b86f referenced 1 time by &b88a
+.loop_cb86f
+    jmp c9c2d                                                         ; b86f: 4c 2d 9c    L-.
+
+; &b872 referenced 1 time by &b882
+.loop_cb872
+    sty l000a                                                         ; b872: 84 0a       ..
+; &b874 referenced 1 time by &b8e4
+.cb874
+    jmp c90c7                                                         ; b874: 4c c7 90    L..
+
+; &b877 referenced 1 time by &b8e9
+.cb877
+    jsr sub_cba6c                                                     ; b877: 20 6c ba     l.
+    sty l004c                                                         ; b87a: 84 4c       .L
+    jsr c9338                                                         ; b87c: 20 38 93     8.
+; &b87f referenced 2 times by &b8b8, &b8e0
+.cb87f
+    jsr sub_c8da2                                                     ; b87f: 20 a2 8d     ..
+    bne loop_cb872                                                    ; b882: d0 ee       ..
+    lda l004c                                                         ; b884: a5 4c       .L
+    pha                                                               ; b886: 48          H
+    jsr sub_c997d                                                     ; b887: 20 7d 99     }.
+    beq loop_cb86f                                                    ; b88a: f0 e3       ..
+    jsr c9338                                                         ; b88c: 20 38 93     8.
+    pla                                                               ; b88f: 68          h
+    sta l004c                                                         ; b890: 85 4c       .L
+    php                                                               ; b892: 08          .
+    jsr cbc66                                                         ; b893: 20 66 bc     f.
+.sub_cb896
+    ldy l004c                                                         ; b896: a4 4c       .L
+    jsr osbget                                                        ; b898: 20 d7 ff     ..
+    sta l0027                                                         ; b89b: 85 27       .'
+    plp                                                               ; b89d: 28          (
+    bcc cb8ba                                                         ; b89e: 90 1a       ..
+    lda l0027                                                         ; b8a0: a5 27       .'
+    bne cb86c                                                         ; b8a2: d0 c8       ..
+    jsr osbget                                                        ; b8a4: 20 d7 ff     ..
+    sta l0036                                                         ; b8a7: 85 36       .6
+    tax                                                               ; b8a9: aa          .
+    beq cb8b5                                                         ; b8aa: f0 09       ..
+; &b8ac referenced 1 time by &b8b3
+.loop_cb8ac
+    jsr osbget                                                        ; b8ac: 20 d7 ff     ..
+    sta l05ff,x                                                       ; b8af: 9d ff 05    ...
+    dex                                                               ; b8b2: ca          .
+    bne loop_cb8ac                                                    ; b8b3: d0 f7       ..
+; &b8b5 referenced 1 time by &b8aa
+.cb8b5
+    jsr sub_c916e                                                     ; b8b5: 20 6e 91     n.
+    bra cb87f                                                         ; b8b8: 80 c5       ..
+; &b8ba referenced 1 time by &b89e
+.cb8ba
+    lda l0027                                                         ; b8ba: a5 27       .'
+    beq cb86c                                                         ; b8bc: f0 ae       ..
+    bmi cb8cc                                                         ; b8be: 30 0c       0.
+    ldx #3                                                            ; b8c0: a2 03       ..
+; &b8c2 referenced 1 time by &b8c8
+.loop_cb8c2
+    jsr osbget                                                        ; b8c2: 20 d7 ff     ..
+    sta l002a,x                                                       ; b8c5: 95 2a       .*
+    dex                                                               ; b8c7: ca          .
+    bpl loop_cb8c2                                                    ; b8c8: 10 f8       ..
+    bra cb8da                                                         ; b8ca: 80 0e       ..
+; &b8cc referenced 1 time by &b8be
+.cb8cc
+    ldx #4                                                            ; b8cc: a2 04       ..
+; &b8ce referenced 1 time by &b8d5
+.loop_cb8ce
+    jsr osbget                                                        ; b8ce: 20 d7 ff     ..
+    sta l046c,x                                                       ; b8d1: 9d 6c 04    .l.
+    dex                                                               ; b8d4: ca          .
+    bpl loop_cb8ce                                                    ; b8d5: 10 f7       ..
+    jsr sub_ca576                                                     ; b8d7: 20 76 a5     v.
+; &b8da referenced 1 time by &b8ca
+.cb8da
+    jsr sub_cbd46                                                     ; b8da: 20 46 bd     F.
+    jsr sub_cb372                                                     ; b8dd: 20 72 b3     r.
+    bra cb87f                                                         ; b8e0: 80 9d       ..
+; &b8e2 referenced 1 time by &b922
+.cb8e2
+    pla                                                               ; b8e2: 68          h
+    pla                                                               ; b8e3: 68          h
+    bra cb874                                                         ; b8e4: 80 8e       ..
+.sub_cb8e6
+    jsr sub_c8d9c                                                     ; b8e6: 20 9c 8d     ..
+    beq cb877                                                         ; b8e9: f0 8c       ..
+    cmp #&86                                                          ; b8eb: c9 86       ..
+    beq cb8f2                                                         ; b8ed: f0 03       ..
+    dec l000a                                                         ; b8ef: c6 0a       ..
+    clc                                                               ; b8f1: 18          .
+; &b8f2 referenced 1 time by &b8ed
+.cb8f2
+    ror l004c                                                         ; b8f2: 66 4c       fL
+    lsr l004c                                                         ; b8f4: 46 4c       FL
+    lda #&ff                                                          ; b8f6: a9 ff       ..
+    sta l004d                                                         ; b8f8: 85 4d       .M
+; &b8fa referenced 3 times by &b911, &b915, &b974
+.cb8fa
+    jsr sub_c935c                                                     ; b8fa: 20 5c 93     \.
+    bcs cb909                                                         ; b8fd: b0 0a       ..
+; &b8ff referenced 1 time by &b902
+.loop_cb8ff
+    jsr sub_c935c                                                     ; b8ff: 20 5c 93     \.
+    bcc loop_cb8ff                                                    ; b902: 90 fb       ..
+    ldx #&ff                                                          ; b904: a2 ff       ..
+    stx l004d                                                         ; b906: 86 4d       .M
+    clc                                                               ; b908: 18          .
+; &b909 referenced 1 time by &b8fd
+.cb909
+    php                                                               ; b909: 08          .
+    asl l004c                                                         ; b90a: 06 4c       .L
+    plp                                                               ; b90c: 28          (
+    ror l004c                                                         ; b90d: 66 4c       fL
+    cmp #&2c ; ','                                                    ; b90f: c9 2c       .,
+    beq cb8fa                                                         ; b911: f0 e7       ..
+    cmp #&3b ; ';'                                                    ; b913: c9 3b       .;
+    beq cb8fa                                                         ; b915: f0 e3       ..
+    dec l000a                                                         ; b917: c6 0a       ..
+    lda l004c                                                         ; b919: a5 4c       .L
+    pha                                                               ; b91b: 48          H
+    lda l004d                                                         ; b91c: a5 4d       .M
+    pha                                                               ; b91e: 48          H
+    jsr sub_c997d                                                     ; b91f: 20 7d 99     }.
+    beq cb8e2                                                         ; b922: f0 be       ..
+    pla                                                               ; b924: 68          h
+    sta l004d                                                         ; b925: 85 4d       .M
+    pla                                                               ; b927: 68          h
+    sta l004c                                                         ; b928: 85 4c       .L
+    jsr c9338                                                         ; b92a: 20 38 93     8.
+    php                                                               ; b92d: 08          .
+    bit l004c                                                         ; b92e: 24 4c       $L
+    bvs cb938                                                         ; b930: 70 06       p.
+    lda l004d                                                         ; b932: a5 4d       .M
+    cmp #&ff                                                          ; b934: c9 ff       ..
+    bne cb94f                                                         ; b936: d0 17       ..
+; &b938 referenced 1 time by &b930
+.cb938
+    bit l004c                                                         ; b938: 24 4c       $L
+    bpl cb941                                                         ; b93a: 10 05       ..
+    lda #&3f ; '?'                                                    ; b93c: a9 3f       .?
+    jsr oswrch                                                        ; b93e: 20 ee ff     ..
+; &b941 referenced 1 time by &b93a
+.cb941
+    jsr sub_cbaa0                                                     ; b941: 20 a0 ba     ..
+    sty l0036                                                         ; b944: 84 36       .6
+    asl l004c                                                         ; b946: 06 4c       .L
+    clc                                                               ; b948: 18          .
+    ror l004c                                                         ; b949: 66 4c       fL
+    bit l004c                                                         ; b94b: 24 4c       $L
+    bvs cb968                                                         ; b94d: 70 19       p.
+; &b94f referenced 1 time by &b936
+.cb94f
+    sta l001b                                                         ; b94f: 85 1b       ..
+    stz l0019                                                         ; b951: 64 19       d.
+    lda #6                                                            ; b953: a9 06       ..
+    sta l001a                                                         ; b955: 85 1a       ..
+    jsr sub_cad3a                                                     ; b957: 20 3a ad     :.
+; &b95a referenced 1 time by &b961
+.loop_cb95a
+    jsr sub_c8fa8                                                     ; b95a: 20 a8 8f     ..
+    beq cb965                                                         ; b95d: f0 06       ..
+    cmp #&0d                                                          ; b95f: c9 0d       ..
+    bne loop_cb95a                                                    ; b961: d0 f7       ..
+    ldy #&fe                                                          ; b963: a0 fe       ..
+; &b965 referenced 1 time by &b95d
+.cb965
+    iny                                                               ; b965: c8          .
+    sty l004d                                                         ; b966: 84 4d       .M
+; &b968 referenced 1 time by &b94d
+.cb968
+    plp                                                               ; b968: 28          (
+    bcs cb976                                                         ; b969: b0 0b       ..
+    jsr sub_cbc83                                                     ; b96b: 20 83 bc     ..
+    jsr sub_caba5                                                     ; b96e: 20 a5 ab     ..
+    jsr sub_cb365                                                     ; b971: 20 65 b3     e.
+; &b974 referenced 1 time by &b97b
+.loop_cb974
+    bra cb8fa                                                         ; b974: 80 84       ..
+; &b976 referenced 1 time by &b969
+.cb976
+    stz l0027                                                         ; b976: 64 27       d'
+    jsr sub_c9171                                                     ; b978: 20 71 91     q.
+    bra loop_cb974                                                    ; b97b: 80 f7       ..
+.sub_cb97d
+    stz l003d                                                         ; b97d: 64 3d       d=
+    ldy l0018                                                         ; b97f: a4 18       ..
+    sty l003e                                                         ; b981: 84 3e       .>
+    jsr c8f9d                                                         ; b983: 20 9d 8f     ..
+    dec l000a                                                         ; b986: c6 0a       ..
+    cmp #&3a ; ':'                                                    ; b988: c9 3a       .:
+    beq cb997                                                         ; b98a: f0 0b       ..
+    cmp #&0d                                                          ; b98c: c9 0d       ..
+    beq cb997                                                         ; b98e: f0 07       ..
+    cmp #&8b                                                          ; b990: c9 8b       ..
+    beq cb997                                                         ; b992: f0 03       ..
+    jsr sub_cb85a                                                     ; b994: 20 5a b8     Z.
+; &b997 referenced 3 times by &b98a, &b98e, &b992
+.cb997
+    jsr c9c6a                                                         ; b997: 20 6a 9c     j.
+    lda l003d                                                         ; b99a: a5 3d       .=
+    sta l001c                                                         ; b99c: 85 1c       ..
+    lda l003e                                                         ; b99e: a5 3e       .>
+    sta l001d                                                         ; b9a0: 85 1d       ..
+    jmp c90ca                                                         ; b9a2: 4c ca 90    L..
+
+; &b9a5 referenced 2 times by &b9b0, &b9da
+.cb9a5
+    jsr sub_c8da2                                                     ; b9a5: 20 a2 8d     ..
+    beq cb9ad                                                         ; b9a8: f0 03       ..
+    jmp c90c5                                                         ; b9aa: 4c c5 90    L..
+
+; &b9ad referenced 1 time by &b9a8
+.cb9ad
+    jsr sub_c997d                                                     ; b9ad: 20 7d 99     }.
+    beq cb9a5                                                         ; b9b0: f0 f3       ..
+    bcs cb9bf                                                         ; b9b2: b0 0b       ..
+    jsr sub_cb9dc                                                     ; b9b4: 20 dc b9     ..
+    jsr sub_cbc83                                                     ; b9b7: 20 83 bc     ..
+    jsr sub_cb362                                                     ; b9ba: 20 62 b3     b.
+    bra cb9cd                                                         ; b9bd: 80 0e       ..
+; &b9bf referenced 1 time by &b9b2
+.cb9bf
+    jsr sub_cb9dc                                                     ; b9bf: 20 dc b9     ..
+    jsr cbc66                                                         ; b9c2: 20 66 bc     f.
+    jsr sub_cad3a                                                     ; b9c5: 20 3a ad     :.
+    sta l0027                                                         ; b9c8: 85 27       .'
+    jsr sub_c916e                                                     ; b9ca: 20 6e 91     n.
+; &b9cd referenced 1 time by &b9bd
+.cb9cd
+    clc                                                               ; b9cd: 18          .
+    lda l001b                                                         ; b9ce: a5 1b       ..
+    adc l0019                                                         ; b9d0: 65 19       e.
+    sta l001c                                                         ; b9d2: 85 1c       ..
+    lda l001a                                                         ; b9d4: a5 1a       ..
+    adc #0                                                            ; b9d6: 69 00       i.
+    sta l001d                                                         ; b9d8: 85 1d       ..
+    bra cb9a5                                                         ; b9da: 80 c9       ..
+; &b9dc referenced 2 times by &b9b4, &b9bf
+.sub_cb9dc
+    jsr c9338                                                         ; b9dc: 20 38 93     8.
+    lda l001c                                                         ; b9df: a5 1c       ..
+    sta l0019                                                         ; b9e1: 85 19       ..
+    lda l001d                                                         ; b9e3: a5 1d       ..
+    sta l001a                                                         ; b9e5: 85 1a       ..
+    stz l001b                                                         ; b9e7: 64 1b       d.
+    jsr sub_c8fa8                                                     ; b9e9: 20 a8 8f     ..
+    beq cba46                                                         ; b9ec: f0 58       .X
+    cmp #&dc                                                          ; b9ee: c9 dc       ..
+    beq cba46                                                         ; b9f0: f0 54       .T
+    cmp #&0d                                                          ; b9f2: c9 0d       ..
+    beq cb9ff                                                         ; b9f4: f0 09       ..
+; &b9f6 referenced 1 time by &b9fd
+.loop_cb9f6
+    jsr sub_c8fa8                                                     ; b9f6: 20 a8 8f     ..
+    beq cba46                                                         ; b9f9: f0 4b       .K
+    cmp #&0d                                                          ; b9fb: c9 0d       ..
+    bne loop_cb9f6                                                    ; b9fd: d0 f7       ..
+; &b9ff referenced 3 times by &b9f4, &ba1b, &ba1f
+.cb9ff
+    ldy l001b                                                         ; b9ff: a4 1b       ..
+    lda (l0019),y                                                     ; ba01: b1 19       ..
+    bmi cba21                                                         ; ba03: 30 1c       0.
+    iny                                                               ; ba05: c8          .
+    iny                                                               ; ba06: c8          .
+    lda (l0019),y                                                     ; ba07: b1 19       ..
+    tax                                                               ; ba09: aa          .
+; &ba0a referenced 1 time by &ba0f
+.loop_cba0a
+    iny                                                               ; ba0a: c8          .
+    lda (l0019),y                                                     ; ba0b: b1 19       ..
+    cmp #&20 ; ' '                                                    ; ba0d: c9 20       .
+    beq loop_cba0a                                                    ; ba0f: f0 f9       ..
+    cmp #&dc                                                          ; ba11: c9 dc       ..
+    beq cba43                                                         ; ba13: f0 2e       ..
+    txa                                                               ; ba15: 8a          .
+    clc                                                               ; ba16: 18          .
+    adc l0019                                                         ; ba17: 65 19       e.
+    sta l0019                                                         ; ba19: 85 19       ..
+    bcc cb9ff                                                         ; ba1b: 90 e2       ..
+    inc l001a                                                         ; ba1d: e6 1a       ..
+    bra cb9ff                                                         ; ba1f: 80 de       ..
+; &ba21 referenced 1 time by &ba03
+.cba21
+    brk                                                               ; ba21: 00          .
+
+    equs "*Out of "                                                   ; ba22: 2a 4f 75... *Ou
+    equb &dc                                                          ; ba2a: dc          .
+
+; &ba2b referenced 1 time by &ba52
+.cba2b
+    brk                                                               ; ba2b: 00          .
+
+    equs "+No "                                                       ; ba2c: 2b 4e 6f... +No
+    equb &f5                                                          ; ba30: f5          .
+
+; &ba31 referenced 1 time by &ba7f
+.cba31
+    brk                                                               ; ba31: 00          .
+
+    equb &2d, &8d, &23                                                ; ba32: 2d 8d 23    -.#
+
+; &ba35 referenced 1 time by &ba8c
+.cba35
+    brk                                                               ; ba35: 00          .
+
+    equs ",Too many "                                                 ; ba36: 2c 54 6f... ,To
+    equb &f5, &73,   0                                                ; ba40: f5 73 00    .s.
+
+; &ba43 referenced 1 time by &ba13
+.cba43
+    iny                                                               ; ba43: c8          .
+    sty l001b                                                         ; ba44: 84 1b       ..
+; &ba46 referenced 3 times by &b9ec, &b9f0, &b9f9
+.cba46
+    rts                                                               ; ba46: 60          `
+
+.sub_cba47
+    jsr sub_c9df3                                                     ; ba47: 20 f3 9d     ..
+    jsr c9c55                                                         ; ba4a: 20 55 9c     U.
+    jsr sub_c9781                                                     ; ba4d: 20 81 97     ..
+    ldx l0024                                                         ; ba50: a6 24       .$
+    beq cba2b                                                         ; ba52: f0 d7       ..
+    lda l002a                                                         ; ba54: a5 2a       .*
+    ora l002b                                                         ; ba56: 05 2b       .+
+    ora l002c                                                         ; ba58: 05 2c       .,
+    ora l002d                                                         ; ba5a: 05 2d       .-
+    beq cba63                                                         ; ba5c: f0 05       ..
+    dec l0024                                                         ; ba5e: c6 24       .$
+    jmp c90ca                                                         ; ba60: 4c ca 90    L..
+
+; &ba63 referenced 1 time by &ba5c
+.cba63
+    ldy l04ff,x                                                       ; ba63: bc ff 04    ...
+    lda l0513,x                                                       ; ba66: bd 13 05    ...
+    jmp cb762                                                         ; ba69: 4c 62 b7    Lb.
+
+; &ba6c referenced 2 times by &9204, &b877
+.sub_cba6c
+    dec l000a                                                         ; ba6c: c6 0a       ..
+; &ba6e referenced 3 times by &beda, &beee, &befd
+.sub_cba6e
+    lda l000a                                                         ; ba6e: a5 0a       ..
+    sta l001b                                                         ; ba70: 85 1b       ..
+    lda l000b                                                         ; ba72: a5 0b       ..
+    sta l0019                                                         ; ba74: 85 19       ..
+    lda l000c                                                         ; ba76: a5 0c       ..
+    sta l001a                                                         ; ba78: 85 1a       ..
+; &ba7a referenced 3 times by &ab24, &ab2f, &ac1f
+.sub_cba7a
+    jsr c8f92                                                         ; ba7a: 20 92 8f     ..
+    cmp #&23 ; '#'                                                    ; ba7d: c9 23       .#
+    bne cba31                                                         ; ba7f: d0 b0       ..
+    jsr sub_c9779                                                     ; ba81: 20 79 97     y.
+    ldy l002a                                                         ; ba84: a4 2a       .*
+    tya                                                               ; ba86: 98          .
+    rts                                                               ; ba87: 60          `
+
+.sub_cba88
+    ldx l0024                                                         ; ba88: a6 24       .$
+    cpx #&14                                                          ; ba8a: e0 14       ..
+    bcs cba35                                                         ; ba8c: b0 a7       ..
+    jsr c9c80                                                         ; ba8e: 20 80 9c     ..
+    lda l000b                                                         ; ba91: a5 0b       ..
+    sta l0500,x                                                       ; ba93: 9d 00 05    ...
+    lda l000c                                                         ; ba96: a5 0c       ..
+    sta l0514,x                                                       ; ba98: 9d 14 05    ...
+    inc l0024                                                         ; ba9b: e6 24       .$
+    jmp c90d0                                                         ; ba9d: 4c d0 90    L..
+
+; &baa0 referenced 1 time by &b941
+.sub_cbaa0
+    lda #6                                                            ; baa0: a9 06       ..
+    bra cbaa6                                                         ; baa2: 80 02       ..
+; &baa4 referenced 2 times by &9059, &955b
+.sub_cbaa4
+    lda #7                                                            ; baa4: a9 07       ..
+; &baa6 referenced 1 time by &baa2
+.cbaa6
+    stz l0037                                                         ; baa6: 64 37       d7
+    sta l0038                                                         ; baa8: 85 38       .8
+    lda #&ee                                                          ; baaa: a9 ee       ..
+    sta l0039                                                         ; baac: 85 39       .9
+    lda #&20 ; ' '                                                    ; baae: a9 20       .
+    sta l003a                                                         ; bab0: 85 3a       .:
+    ldy #&ff                                                          ; bab2: a0 ff       ..
+    sty l003b                                                         ; bab4: 84 3b       .;
+    iny                                                               ; bab6: c8          .
+    ldx #&37 ; '7'                                                    ; bab7: a2 37       .7
+    tya                                                               ; bab9: 98          .
+    jsr osword                                                        ; baba: 20 f1 ff     ..
+    bcc cbac5                                                         ; babd: 90 06       ..
+    jmp c9c41                                                         ; babf: 4c 41 9c    LA.
+
+; &bac2 referenced 8 times by &8a14, &8a68, &9285, &9319, &932a, &9538, &98c6, &bdc6
+.sub_cbac2
+    jsr osnewl                                                        ; bac2: 20 e7 ff     ..
+; &bac5 referenced 2 times by &babd, &bddf
+.cbac5
+    stz l001e                                                         ; bac5: 64 1e       d.
+    rts                                                               ; bac7: 60          `
+
+; &bac8 referenced 2 times by &93fa, &bb47
+.sub_cbac8
+    jsr sub_c8191                                                     ; bac8: 20 91 81     ..
+    bcc cbb1a                                                         ; bacb: 90 4d       .M
+    lda l003d                                                         ; bacd: a5 3d       .=
+    sta l0037                                                         ; bacf: 85 37       .7
+    sta l0012                                                         ; bad1: 85 12       ..
+    lda l003e                                                         ; bad3: a5 3e       .>
+    sta l0038                                                         ; bad5: 85 38       .8
+    sta l0013                                                         ; bad7: 85 13       ..
+    ldy #3                                                            ; bad9: a0 03       ..
+    lda (l0037),y                                                     ; badb: b1 37       .7
+    clc                                                               ; badd: 18          .
+    adc l0037                                                         ; bade: 65 37       e7
+    sta l0037                                                         ; bae0: 85 37       .7
+    bcc cbae6                                                         ; bae2: 90 02       ..
+    inc l0038                                                         ; bae4: e6 38       .8
+; &bae6 referenced 1 time by &bae2
+.cbae6
+    ldy #0                                                            ; bae6: a0 00       ..
+; &bae8 referenced 2 times by &bb04, &bb0a
+.cbae8
+    lda (l0037),y                                                     ; bae8: b1 37       .7
+    sta (l0012),y                                                     ; baea: 91 12       ..
+    cmp #&0d                                                          ; baec: c9 0d       ..
+    bne cbb03                                                         ; baee: d0 13       ..
+    iny                                                               ; baf0: c8          .
+    bne cbaf7                                                         ; baf1: d0 04       ..
+    inc l0038                                                         ; baf3: e6 38       .8
+    inc l0013                                                         ; baf5: e6 13       ..
+; &baf7 referenced 1 time by &baf1
+.cbaf7
+    lda (l0037),y                                                     ; baf7: b1 37       .7
+    sta (l0012),y                                                     ; baf9: 91 12       ..
+    bmi cbb0c                                                         ; bafb: 30 0f       0.
+    jsr sub_cbb0f                                                     ; bafd: 20 0f bb     ..
+    jsr sub_cbb0f                                                     ; bb00: 20 0f bb     ..
+; &bb03 referenced 1 time by &baee
+.cbb03
+    iny                                                               ; bb03: c8          .
+    bne cbae8                                                         ; bb04: d0 e2       ..
+    inc l0038                                                         ; bb06: e6 38       .8
+    inc l0013                                                         ; bb08: e6 13       ..
+    bra cbae8                                                         ; bb0a: 80 dc       ..
+; &bb0c referenced 1 time by &bafb
+.cbb0c
+    jmp cbe45                                                         ; bb0c: 4c 45 be    LE.
+
+; &bb0f referenced 2 times by &bafd, &bb00
+.sub_cbb0f
+    iny                                                               ; bb0f: c8          .
+    bne cbb16                                                         ; bb10: d0 04       ..
+    inc l0013                                                         ; bb12: e6 13       ..
+    inc l0038                                                         ; bb14: e6 38       .8
+; &bb16 referenced 1 time by &bb10
+.cbb16
+    lda (l0037),y                                                     ; bb16: b1 37       .7
+    sta (l0012),y                                                     ; bb18: 91 12       ..
+; &bb1a referenced 3 times by &bacb, &bb36, &bb54
+.cbb1a
+    rts                                                               ; bb1a: 60          `
+
+; &bb1b referenced 2 times by &903d, &9062
+.sub_cbb1b
+    ldx #&ff                                                          ; bb1b: a2 ff       ..
+    stx l0028                                                         ; bb1d: 86 28       .(
+    stx l003c                                                         ; bb1f: 86 3c       .<
+    jsr sub_cbbff                                                     ; bb21: 20 ff bb     ..
+    lda l000b                                                         ; bb24: a5 0b       ..
+    sta l0037                                                         ; bb26: 85 37       .7
+    lda l000c                                                         ; bb28: a5 0c       ..
+    sta l0038                                                         ; bb2a: 85 38       .8
+    stz l003b                                                         ; bb2c: 64 3b       d;
+    stz l000a                                                         ; bb2e: 64 0a       d.
+    jsr c8e6f                                                         ; bb30: 20 6f 8e     o.
+    jsr sub_c9be2                                                     ; bb33: 20 e2 9b     ..
+    bcc cbb1a                                                         ; bb36: 90 e2       ..
+; &bb38 referenced 1 time by &9566
+.sub_cbb38
+    lda l001f                                                         ; bb38: a5 1f       ..
+    beq cbb45                                                         ; bb3a: f0 09       ..
+; &bb3c referenced 1 time by &bb42
+.loop_cbb3c
+    lda l0700,y                                                       ; bb3c: b9 00 07    ...
+    iny                                                               ; bb3f: c8          .
+    cmp #&20 ; ' '                                                    ; bb40: c9 20       .
+    beq loop_cbb3c                                                    ; bb42: f0 f8       ..
+    dey                                                               ; bb44: 88          .
+; &bb45 referenced 1 time by &bb3a
+.cbb45
+    sty l003b                                                         ; bb45: 84 3b       .;
+    jsr sub_cbac8                                                     ; bb47: 20 c8 ba     ..
+    ldy #7                                                            ; bb4a: a0 07       ..
+    sty l003c                                                         ; bb4c: 84 3c       .<
+    ldy #0                                                            ; bb4e: a0 00       ..
+    lda #&0d                                                          ; bb50: a9 0d       ..
+    cmp (l003b)                                                       ; bb52: d2 3b       .;
+    beq cbb1a                                                         ; bb54: f0 c4       ..
+; &bb56 referenced 1 time by &bb59
+.loop_cbb56
+    iny                                                               ; bb56: c8          .
+    cmp (l003b),y                                                     ; bb57: d1 3b       .;
+    bne loop_cbb56                                                    ; bb59: d0 fb       ..
+    lda #&20 ; ' '                                                    ; bb5b: a9 20       .
+; &bb5d referenced 1 time by &bb62
+.loop_cbb5d
+    dey                                                               ; bb5d: 88          .
+    beq cbb64                                                         ; bb5e: f0 04       ..
+    cmp (l003b),y                                                     ; bb60: d1 3b       .;
+    beq loop_cbb5d                                                    ; bb62: f0 f9       ..
+; &bb64 referenced 1 time by &bb5e
+.cbb64
+    iny                                                               ; bb64: c8          .
+    lda #&0d                                                          ; bb65: a9 0d       ..
+    sta (l003b),y                                                     ; bb67: 91 3b       .;
+    iny                                                               ; bb69: c8          .
+    iny                                                               ; bb6a: c8          .
+    iny                                                               ; bb6b: c8          .
+    iny                                                               ; bb6c: c8          .
+    sty l003f                                                         ; bb6d: 84 3f       .?
+    lda l0012                                                         ; bb6f: a5 12       ..
+    sta l0039                                                         ; bb71: 85 39       .9
+    lda l0013                                                         ; bb73: a5 13       ..
+    sta l003a                                                         ; bb75: 85 3a       .:
+    jsr sub_cbe44                                                     ; bb77: 20 44 be     D.
+    sta l0037                                                         ; bb7a: 85 37       .7
+    lda l0013                                                         ; bb7c: a5 13       ..
+    sta l0038                                                         ; bb7e: 85 38       .8
+    dey                                                               ; bb80: 88          .
+    lda l0006                                                         ; bb81: a5 06       ..
+    cmp l0012                                                         ; bb83: c5 12       ..
+    lda l0007                                                         ; bb85: a5 07       ..
+    sbc l0013                                                         ; bb87: e5 13       ..
+    bcs cbb9b                                                         ; bb89: b0 10       ..
+    jsr sub_cbe25                                                     ; bb8b: 20 25 be     %.
+    jsr sub_cbbdc                                                     ; bb8e: 20 dc bb     ..
+    brk                                                               ; bb91: 00          .
+
+    equb   0, &86                                                     ; bb92: 00 86       ..
+    equs " space"                                                     ; bb94: 20 73 70...  sp
+    equb 0                                                            ; bb9a: 00          .
+
+; &bb9b referenced 2 times by &bb89, &bbb4
+.cbb9b
+    lda (l0039),y                                                     ; bb9b: b1 39       .9
+    sta (l0037),y                                                     ; bb9d: 91 37       .7
+    tya                                                               ; bb9f: 98          .
+    bne cbba6                                                         ; bba0: d0 04       ..
+    dec l003a                                                         ; bba2: c6 3a       .:
+    dec l0038                                                         ; bba4: c6 38       .8
+; &bba6 referenced 1 time by &bba0
+.cbba6
+    dey                                                               ; bba6: 88          .
+    tya                                                               ; bba7: 98          .
+    adc l0039                                                         ; bba8: 65 39       e9
+    ldx l003a                                                         ; bbaa: a6 3a       .:
+    bcc cbbaf                                                         ; bbac: 90 01       ..
+    inx                                                               ; bbae: e8          .
+; &bbaf referenced 1 time by &bbac
+.cbbaf
+    cmp l003d                                                         ; bbaf: c5 3d       .=
+    txa                                                               ; bbb1: 8a          .
+    sbc l003e                                                         ; bbb2: e5 3e       .>
+    bcs cbb9b                                                         ; bbb4: b0 e5       ..
+    ldy #1                                                            ; bbb6: a0 01       ..
+    lda l002b                                                         ; bbb8: a5 2b       .+
+    sta (l003d),y                                                     ; bbba: 91 3d       .=
+    iny                                                               ; bbbc: c8          .
+    lda l002a                                                         ; bbbd: a5 2a       .*
+    sta (l003d),y                                                     ; bbbf: 91 3d       .=
+    iny                                                               ; bbc1: c8          .
+    lda l003f                                                         ; bbc2: a5 3f       .?
+    sta (l003d),y                                                     ; bbc4: 91 3d       .=
+    sec                                                               ; bbc6: 38          8
+    tya                                                               ; bbc7: 98          .
+    adc l003d                                                         ; bbc8: 65 3d       e=
+    sta l003d                                                         ; bbca: 85 3d       .=
+    bcc cbbd0                                                         ; bbcc: 90 02       ..
+    inc l003e                                                         ; bbce: e6 3e       .>
+; &bbd0 referenced 1 time by &bbcc
+.cbbd0
+    ldy #&ff                                                          ; bbd0: a0 ff       ..
+; &bbd2 referenced 1 time by &bbd9
+.loop_cbbd2
+    iny                                                               ; bbd2: c8          .
+    lda (l003b),y                                                     ; bbd3: b1 3b       .;
+    sta (l003d),y                                                     ; bbd5: 91 3d       .=
+    cmp #&0d                                                          ; bbd7: c9 0d       ..
+    bne loop_cbbd2                                                    ; bbd9: d0 f7       ..
+    rts                                                               ; bbdb: 60          `
+
+; &bbdc referenced 7 times by &8fda, &9048, &9569, &9706, &b3c8, &bb8e, &bd71
+.sub_cbbdc
+    lda l0012                                                         ; bbdc: a5 12       ..
+    sta l0000                                                         ; bbde: 85 00       ..
+    sta l0002                                                         ; bbe0: 85 02       ..
+    lda l0013                                                         ; bbe2: a5 13       ..
+    sta l0001                                                         ; bbe4: 85 01       ..
+    sta l0003                                                         ; bbe6: 85 03       ..
+    jsr sub_cbbff                                                     ; bbe8: 20 ff bb     ..
+; &bbeb referenced 1 time by &96f4
+.sub_cbbeb
+    ldx #&10                                                          ; bbeb: a2 10       ..
+; &bbed referenced 1 time by &bbf4
+.loop_cbbed
+    lda lbf71,x                                                       ; bbed: bd 71 bf    .q.
+    sta l07ef,x                                                       ; bbf0: 9d ef 07    ...
+    dex                                                               ; bbf3: ca          .
+    bne loop_cbbed                                                    ; bbf4: d0 f7       ..
+    ldx #&80                                                          ; bbf6: a2 80       ..
+; &bbf8 referenced 1 time by &bbfc
+.loop_cbbf8
+    stz l047f,x                                                       ; bbf8: 9e 7f 04    ...
+    dex                                                               ; bbfb: ca          .
+    bne loop_cbbf8                                                    ; bbfc: d0 fa       ..
+    rts                                                               ; bbfe: 60          `
+
+; &bbff referenced 2 times by &bb21, &bbe8
+.sub_cbbff
+    lda l0018                                                         ; bbff: a5 18       ..
+    sta l001d                                                         ; bc01: 85 1d       ..
+    lda l0006                                                         ; bc03: a5 06       ..
+    sta l0004                                                         ; bc05: 85 04       ..
+    lda l0007                                                         ; bc07: a5 07       ..
+    sta l0005                                                         ; bc09: 85 05       ..
+    lda #&80                                                          ; bc0b: a9 80       ..
+    trb l001f                                                         ; bc0d: 14 1f       ..
+    stz l0024                                                         ; bc0f: 64 24       d$
+    stz l0026                                                         ; bc11: 64 26       d&
+    stz l0025                                                         ; bc13: 64 25       d%
+    stz l001c                                                         ; bc15: 64 1c       d.
+    rts                                                               ; bc17: 60          `
+
+; &bc18 referenced 2 times by &9f4f, &9f59
+.sub_cbc18
+    jsr cbc3a                                                         ; bc18: 20 3a bc     :.
+    jsr sub_ca026                                                     ; bc1b: 20 26 a0     &.
+; &bc1e referenced 1 time by &a042
+.sub_cbc1e
+    stx l0027                                                         ; bc1e: 86 27       .'
+; &bc20 referenced 1 time by &9fb0
+.sub_cbc20
+    tay                                                               ; bc20: a8          .
+    jsr sub_c97a2                                                     ; bc21: 20 a2 97     ..
+; &bc24 referenced 4 times by &9d33, &a56d, &a617, &b19b
+.sub_cbc24
+    lda l0004                                                         ; bc24: a5 04       ..
+    clc                                                               ; bc26: 18          .
+    sta l004a                                                         ; bc27: 85 4a       .J
+    adc #5                                                            ; bc29: 69 05       i.
+    sta l0004                                                         ; bc2b: 85 04       ..
+    lda l0005                                                         ; bc2d: a5 05       ..
+    sta l004b                                                         ; bc2f: 85 4b       .K
+    adc #0                                                            ; bc31: 69 00       i.
+    sta l0005                                                         ; bc33: 85 05       ..
+    rts                                                               ; bc35: 60          `
+
+; &bc36 referenced 2 times by &a03c, &a081
+.sub_cbc36
+    tay                                                               ; bc36: a8          .
+    jsr sub_c97a2                                                     ; bc37: 20 a2 97     ..
+; &bc3a referenced 5 times by &9d29, &9faa, &a60f, &bc18, &bc64
+.cbc3a
+    lda l0004                                                         ; bc3a: a5 04       ..
+    sec                                                               ; bc3c: 38          8
+    sbc #5                                                            ; bc3d: e9 05       ..
+    jsr sub_cbd5e                                                     ; bc3f: 20 5e bd     ^.
+    lda l0030                                                         ; bc42: a5 30       .0
+    sta (l0004)                                                       ; bc44: 92 04       ..
+    ldy #1                                                            ; bc46: a0 01       ..
+    lda l002e                                                         ; bc48: a5 2e       ..
+    eor l0031                                                         ; bc4a: 45 31       E1
+    and #&80                                                          ; bc4c: 29 80       ).
+    eor l0031                                                         ; bc4e: 45 31       E1
+    sta (l0004),y                                                     ; bc50: 91 04       ..
+    iny                                                               ; bc52: c8          .
+    lda l0032                                                         ; bc53: a5 32       .2
+    sta (l0004),y                                                     ; bc55: 91 04       ..
+    iny                                                               ; bc57: c8          .
+    lda l0033                                                         ; bc58: a5 33       .3
+    sta (l0004),y                                                     ; bc5a: 91 04       ..
+    iny                                                               ; bc5c: c8          .
+    lda l0034                                                         ; bc5d: a5 34       .4
+    sta (l0004),y                                                     ; bc5f: 91 04       ..
+    rts                                                               ; bc61: 60          `
+
+; &bc62 referenced 2 times by &b149, &b1ce
+.sub_cbc62
+    beq cbc91                                                         ; bc62: f0 2d       .-
+    bmi cbc3a                                                         ; bc64: 30 d4       0.
+; &bc66 referenced 20 times by &8fb1, &9114, &9387, &93df, &9418, &9555, &964e, &9889, &9ae6, &9b27, &9e42, &9e50, &a023, &a069, &b150, &b1db, &b3da, &b3ed, &b893, &b9c2
+.cbc66
+    lda l0004                                                         ; bc66: a5 04       ..
+    sec                                                               ; bc68: 38          8
+    sbc #4                                                            ; bc69: e9 04       ..
+    jsr sub_cbd5e                                                     ; bc6b: 20 5e bd     ^.
+    ldy #3                                                            ; bc6e: a0 03       ..
+    lda l002d                                                         ; bc70: a5 2d       .-
+    sta (l0004),y                                                     ; bc72: 91 04       ..
+    dey                                                               ; bc74: 88          .
+    lda l002c                                                         ; bc75: a5 2c       .,
+    sta (l0004),y                                                     ; bc77: 91 04       ..
+    dey                                                               ; bc79: 88          .
+    lda l002b                                                         ; bc7a: a5 2b       .+
+    sta (l0004),y                                                     ; bc7c: 91 04       ..
+    lda l002a                                                         ; bc7e: a5 2a       .*
+    sta (l0004)                                                       ; bc80: 92 04       ..
+    rts                                                               ; bc82: 60          `
+
+; &bc83 referenced 6 times by &8a98, &9588, &97e3, &b650, &b96b, &b9b7
+.sub_cbc83
+    ply                                                               ; bc83: 7a          z
+    plx                                                               ; bc84: fa          .
+    lda l002a                                                         ; bc85: a5 2a       .*
+    pha                                                               ; bc87: 48          H
+    lda l002b                                                         ; bc88: a5 2b       .+
+    pha                                                               ; bc8a: 48          H
+    lda l002c                                                         ; bc8b: a5 2c       .,
+    pha                                                               ; bc8d: 48          H
+    phx                                                               ; bc8e: da          .
+    phy                                                               ; bc8f: 5a          Z
+    rts                                                               ; bc90: 60          `
+
+; &bc91 referenced 7 times by &9769, &9dc4, &9edd, &ab6a, &ac8a, &af13, &bc62
+.cbc91
+    clc                                                               ; bc91: 18          .
+    lda l0004                                                         ; bc92: a5 04       ..
+    sbc l0036                                                         ; bc94: e5 36       .6
+    jsr sub_cbd5e                                                     ; bc96: 20 5e bd     ^.
+    ldy l0036                                                         ; bc99: a4 36       .6
+    beq cbca5                                                         ; bc9b: f0 08       ..
+; &bc9d referenced 1 time by &bca3
+.loop_cbc9d
+    lda l05ff,y                                                       ; bc9d: b9 ff 05    ...
+    sta (l0004),y                                                     ; bca0: 91 04       ..
+    dey                                                               ; bca2: 88          .
+    bne loop_cbc9d                                                    ; bca3: d0 f8       ..
+; &bca5 referenced 1 time by &bc9b
+.cbca5
+    lda l0036                                                         ; bca5: a5 36       .6
+    sta (l0004)                                                       ; bca7: 92 04       ..
+    rts                                                               ; bca9: 60          `
+
+; &bcaa referenced 1 time by &b0db
+.sub_cbcaa
+    lda l0039                                                         ; bcaa: a5 39       .9
+    cmp #&80                                                          ; bcac: c9 80       ..
+    beq cbcd5                                                         ; bcae: f0 25       .%
+    bcc cbcea                                                         ; bcb0: 90 38       .8
+    lda (l0004)                                                       ; bcb2: b2 04       ..
+    tax                                                               ; bcb4: aa          .
+    beq cbccd                                                         ; bcb5: f0 16       ..
+    lda (l0037)                                                       ; bcb7: b2 37       .7
+    sbc #1                                                            ; bcb9: e9 01       ..
+    sta l0039                                                         ; bcbb: 85 39       .9
+    ldy #1                                                            ; bcbd: a0 01       ..
+    lda (l0037),y                                                     ; bcbf: b1 37       .7
+    sbc #0                                                            ; bcc1: e9 00       ..
+    sta l003a                                                         ; bcc3: 85 3a       .:
+; &bcc5 referenced 1 time by &bccb
+.loop_cbcc5
+    lda (l0004),y                                                     ; bcc5: b1 04       ..
+    sta (l0039),y                                                     ; bcc7: 91 39       .9
+    iny                                                               ; bcc9: c8          .
+    dex                                                               ; bcca: ca          .
+    bne loop_cbcc5                                                    ; bccb: d0 f8       ..
+; &bccd referenced 1 time by &bcb5
+.cbccd
+    lda (l0004)                                                       ; bccd: b2 04       ..
+    ldy #3                                                            ; bccf: a0 03       ..
+; &bcd1 referenced 1 time by &bce8
+.loop_cbcd1
+    sta (l0037),y                                                     ; bcd1: 91 37       .7
+    bra cbd21                                                         ; bcd3: 80 4c       .L
+; &bcd5 referenced 1 time by &bcae
+.cbcd5
+    lda (l0004)                                                       ; bcd5: b2 04       ..
+    ldy #0                                                            ; bcd7: a0 00       ..
+    tax                                                               ; bcd9: aa          .
+    beq cbce6                                                         ; bcda: f0 0a       ..
+; &bcdc referenced 1 time by &bce4
+.loop_cbcdc
+    iny                                                               ; bcdc: c8          .
+    lda (l0004),y                                                     ; bcdd: b1 04       ..
+    dey                                                               ; bcdf: 88          .
+    sta (l0037),y                                                     ; bce0: 91 37       .7
+    iny                                                               ; bce2: c8          .
+    dex                                                               ; bce3: ca          .
+    bne loop_cbcdc                                                    ; bce4: d0 f6       ..
+; &bce6 referenced 1 time by &bcda
+.cbce6
+    lda #&0d                                                          ; bce6: a9 0d       ..
+    bne loop_cbcd1                                                    ; bce8: d0 e7       ..
+; &bcea referenced 1 time by &bcb0
+.cbcea
+    lda (l0004)                                                       ; bcea: b2 04       ..
+    sta (l0037)                                                       ; bcec: 92 37       .7
+    ldy #4                                                            ; bcee: a0 04       ..
+    lda l0039                                                         ; bcf0: a5 39       .9
+    beq cbd0e                                                         ; bcf2: f0 1a       ..
+    ldy #1                                                            ; bcf4: a0 01       ..
+    lda (l0004),y                                                     ; bcf6: b1 04       ..
+    sta (l0037),y                                                     ; bcf8: 91 37       .7
+    iny                                                               ; bcfa: c8          .
+    lda (l0004),y                                                     ; bcfb: b1 04       ..
+    sta (l0037),y                                                     ; bcfd: 91 37       .7
+    iny                                                               ; bcff: c8          .
+    lda (l0004),y                                                     ; bd00: b1 04       ..
+    sta (l0037),y                                                     ; bd02: 91 37       .7
+    iny                                                               ; bd04: c8          .
+    cpy l0039                                                         ; bd05: c4 39       .9
+    bcs cbd0e                                                         ; bd07: b0 05       ..
+    lda (l0004),y                                                     ; bd09: b1 04       ..
+    sta (l0037),y                                                     ; bd0b: 91 37       .7
+    iny                                                               ; bd0d: c8          .
+; &bd0e referenced 2 times by &bcf2, &bd07
+.cbd0e
+    tya                                                               ; bd0e: 98          .
+    clc                                                               ; bd0f: 18          .
+    bra cbd3d                                                         ; bd10: 80 2b       .+
+; &bd12 referenced 5 times by &9efc, &aca6, &aecb, &af2f, &b1af
+.sub_cbd12
+    lda (l0004)                                                       ; bd12: b2 04       ..
+    sta l0036                                                         ; bd14: 85 36       .6
+    beq cbd23                                                         ; bd16: f0 0b       ..
+    tay                                                               ; bd18: a8          .
+; &bd19 referenced 1 time by &bd1f
+.loop_cbd19
+    lda (l0004),y                                                     ; bd19: b1 04       ..
+    sta l05ff,y                                                       ; bd1b: 99 ff 05    ...
+    dey                                                               ; bd1e: 88          .
+    bne loop_cbd19                                                    ; bd1f: d0 f8       ..
+; &bd21 referenced 5 times by &9dea, &ab8e, &accf, &ace8, &bcd3
+.cbd21
+    lda (l0004)                                                       ; bd21: b2 04       ..
+; &bd23 referenced 1 time by &bd16
+.cbd23
+    sec                                                               ; bd23: 38          8
+    bra cbd3d                                                         ; bd24: 80 17       ..
+; &bd26 referenced 13 times by &8287, &916e, &93ba, &93f7, &9552, &955e, &9fed, &ac68, &af93, &b17e, &b1a3, &b3ea, &b432
+.sub_cbd26
+    ldy #3                                                            ; bd26: a0 03       ..
+    lda (l0004),y                                                     ; bd28: b1 04       ..
+    sta l002d                                                         ; bd2a: 85 2d       .-
+    dey                                                               ; bd2c: 88          .
+    lda (l0004),y                                                     ; bd2d: b1 04       ..
+    sta l002c                                                         ; bd2f: 85 2c       .,
+    dey                                                               ; bd31: 88          .
+    lda (l0004),y                                                     ; bd32: b1 04       ..
+    sta l002b                                                         ; bd34: 85 2b       .+
+    lda (l0004)                                                       ; bd36: b2 04       ..
+    sta l002a                                                         ; bd38: 85 2a       .*
+; &bd3a referenced 3 times by &9e23, &9e66, &bd5c
+.cbd3a
+    clc                                                               ; bd3a: 18          .
+    lda #4                                                            ; bd3b: a9 04       ..
+; &bd3d referenced 2 times by &bd10, &bd24
+.cbd3d
+    adc l0004                                                         ; bd3d: 65 04       e.
+    sta l0004                                                         ; bd3f: 85 04       ..
+    bcc cbd45                                                         ; bd41: 90 02       ..
+    inc l0005                                                         ; bd43: e6 05       ..
+; &bd45 referenced 1 time by &bd41
+.cbd45
+    rts                                                               ; bd45: 60          `
+
+; &bd46 referenced 3 times by &989b, &b0d8, &b8da
+.sub_cbd46
+    ldx #&37 ; '7'                                                    ; bd46: a2 37       .7
+; &bd48 referenced 5 times by &81dc, &944c, &95c8, &9af4, &9b35
+.sub_cbd48
+    ldy #3                                                            ; bd48: a0 03       ..
+    lda (l0004),y                                                     ; bd4a: b1 04       ..
+    sta l0003,x                                                       ; bd4c: 95 03       ..
+    dey                                                               ; bd4e: 88          .
+    lda (l0004),y                                                     ; bd4f: b1 04       ..
+    sta l0002,x                                                       ; bd51: 95 02       ..
+    dey                                                               ; bd53: 88          .
+    lda (l0004),y                                                     ; bd54: b1 04       ..
+    sta l0001,x                                                       ; bd56: 95 01       ..
+    lda (l0004)                                                       ; bd58: b2 04       ..
+    sta l0000,x                                                       ; bd5a: 95 00       ..
+    bra cbd3a                                                         ; bd5c: 80 dc       ..
+; &bd5e referenced 4 times by &b05e, &bc3f, &bc6b, &bc96
+.sub_cbd5e
+    sta l0004                                                         ; bd5e: 85 04       ..
+    bcs cbd64                                                         ; bd60: b0 02       ..
+    dec l0005                                                         ; bd62: c6 05       ..
+; &bd64 referenced 1 time by &bd60
+.cbd64
+    ldy l0005                                                         ; bd64: a4 05       ..
+    cpy l0003                                                         ; bd66: c4 03       ..
+    bcc cbd74                                                         ; bd68: 90 0a       ..
+    bne cbd70                                                         ; bd6a: d0 04       ..
+    cmp l0002                                                         ; bd6c: c5 02       ..
+    bcc cbd74                                                         ; bd6e: 90 04       ..
+; &bd70 referenced 1 time by &bd6a
+.cbd70
+    rts                                                               ; bd70: 60          `
+
+; &bd71 referenced 1 time by &bdef
+.cbd71
+    jsr sub_cbbdc                                                     ; bd71: 20 dc bb     ..
+; &bd74 referenced 2 times by &bd68, &bd6e
+.cbd74
+    jmp c9164                                                         ; bd74: 4c 64 91    Ld.
+
+; &bd77 referenced 4 times by &8a3c, &8a5e, &98cf, &b51c
+.sub_cbd77
+    sta l0037                                                         ; bd77: 85 37       .7
+    cmp #&80                                                          ; bd79: c9 80       ..
+    bcc cbdd4                                                         ; bd7b: 90 57       .W
+    lda #&13                                                          ; bd7d: a9 13       ..
+    sta l0038                                                         ; bd7f: 85 38       .8
+    lda #&85                                                          ; bd81: a9 85       ..
+    sta l0039                                                         ; bd83: 85 39       .9
+    phy                                                               ; bd85: 5a          Z
+; &bd86 referenced 2 times by &bd98, &bd9c
+.cbd86
+    ldy #0                                                            ; bd86: a0 00       ..
+; &bd88 referenced 1 time by &bd8b
+.loop_cbd88
+    iny                                                               ; bd88: c8          .
+    lda (l0038),y                                                     ; bd89: b1 38       .8
+    bpl loop_cbd88                                                    ; bd8b: 10 fb       ..
+    cmp l0037                                                         ; bd8d: c5 37       .7
+    beq cbd9e                                                         ; bd8f: f0 0d       ..
+    iny                                                               ; bd91: c8          .
+    tya                                                               ; bd92: 98          .
+    sec                                                               ; bd93: 38          8
+    adc l0038                                                         ; bd94: 65 38       e8
+    sta l0038                                                         ; bd96: 85 38       .8
+    bcc cbd86                                                         ; bd98: 90 ec       ..
+    inc l0039                                                         ; bd9a: e6 39       .9
+    bra cbd86                                                         ; bd9c: 80 e8       ..
+; &bd9e referenced 1 time by &bd8f
+.cbd9e
+    ldy #0                                                            ; bd9e: a0 00       ..
+; &bda0 referenced 1 time by &bda8
+.loop_cbda0
+    lda (l0038),y                                                     ; bda0: b1 38       .8
+    bmi cbdaa                                                         ; bda2: 30 06       0.
+    jsr cbdd4                                                         ; bda4: 20 d4 bd     ..
+    iny                                                               ; bda7: c8          .
+    bne loop_cbda0                                                    ; bda8: d0 f6       ..
+; &bdaa referenced 1 time by &bda2
+.cbdaa
+    ply                                                               ; bdaa: 7a          z
+    rts                                                               ; bdab: 60          `
+
+; &bdac referenced 2 times by &89fb, &bdcf
+.sub_cbdac
+    pha                                                               ; bdac: 48          H
+    lsr a                                                             ; bdad: 4a          J
+    lsr a                                                             ; bdae: 4a          J
+    lsr a                                                             ; bdaf: 4a          J
+    lsr a                                                             ; bdb0: 4a          J
+    jsr sub_cbdb7                                                     ; bdb1: 20 b7 bd     ..
+    pla                                                               ; bdb4: 68          h
+    and #&0f                                                          ; bdb5: 29 0f       ).
+; &bdb7 referenced 1 time by &bdb1
+.sub_cbdb7
+    cmp #&0a                                                          ; bdb7: c9 0a       ..
+    bcc cbdbd                                                         ; bdb9: 90 02       ..
+    adc #6                                                            ; bdbb: 69 06       i.
+; &bdbd referenced 1 time by &bdb9
+.cbdbd
+    adc #&30 ; '0'                                                    ; bdbd: 69 30       i0
+; &bdbf referenced 1 time by &bdda
+.loop_cbdbf
+    pha                                                               ; bdbf: 48          H
+    lda l0023                                                         ; bdc0: a5 23       .#
+    cmp l001e                                                         ; bdc2: c5 1e       ..
+    bcs cbdc9                                                         ; bdc4: b0 03       ..
+    jsr sub_cbac2                                                     ; bdc6: 20 c2 ba     ..
+; &bdc9 referenced 1 time by &bdc4
+.cbdc9
+    pla                                                               ; bdc9: 68          h
+    inc l001e                                                         ; bdca: e6 1e       ..
+    jmp (wrchv)                                                       ; bdcc: 6c 0e 02    l..
+
+; &bdcf referenced 2 times by &8a00, &8a20
+.sub_cbdcf
+    jsr sub_cbdac                                                     ; bdcf: 20 ac bd     ..
+; &bdd2 referenced 4 times by &9268, &92d4, &9d26, &bdff
+.cbdd2
+    lda #&20 ; ' '                                                    ; bdd2: a9 20       .
+; &bdd4 referenced 5 times by &a12a, &b445, &b4f2, &bd7b, &bda4
+.cbdd4
+    bit l001f                                                         ; bdd4: 24 1f       $.
+    bmi cbde2                                                         ; bdd6: 30 0a       0.
+; &bdd8 referenced 4 times by &92e3, &937c, &9d1b, &9d23
+.sub_cbdd8
+    cmp #&0d                                                          ; bdd8: c9 0d       ..
+    bne loop_cbdbf                                                    ; bdda: d0 e3       ..
+    jsr oswrch                                                        ; bddc: 20 ee ff     ..
+    jmp cbac5                                                         ; bddf: 4c c5 ba    L..
+
+; &bde2 referenced 1 time by &bdd6
+.cbde2
+    sta (l0002)                                                       ; bde2: 92 02       ..
+    inc l0002                                                         ; bde4: e6 02       ..
+    bne cbe05                                                         ; bde6: d0 1d       ..
+    inc l0003                                                         ; bde8: e6 03       ..
+    pha                                                               ; bdea: 48          H
+    lda l0003                                                         ; bdeb: a5 03       ..
+    eor l0007                                                         ; bded: 45 07       E.
+    beq cbd71                                                         ; bdef: f0 80       ..
+    pla                                                               ; bdf1: 68          h
+    rts                                                               ; bdf2: 60          `
+
+; &bdf3 referenced 2 times by &b4d4, &b4db
+.sub_cbdf3
+    clc                                                               ; bdf3: 18          .
+; &bdf4 referenced 1 time by &b4cd
+.sub_cbdf4
+    and l001f                                                         ; bdf4: 25 1f       %.
+    beq cbe05                                                         ; bdf6: f0 0d       ..
+    txa                                                               ; bdf8: 8a          .
+    bmi cbe05                                                         ; bdf9: 30 0a       0.
+    rol a                                                             ; bdfb: 2a          *
+    tax                                                               ; bdfc: aa          .
+    beq cbe05                                                         ; bdfd: f0 06       ..
+; &bdff referenced 6 times by &8a19, &8a2f, &8a4b, &9325, &a121, &be03
+.cbdff
+    jsr cbdd2                                                         ; bdff: 20 d2 bd     ..
+    dex                                                               ; be02: ca          .
+    bne cbdff                                                         ; be03: d0 fa       ..
+; &be05 referenced 4 times by &bde6, &bdf6, &bdf9, &bdfd
+.cbe05
+    rts                                                               ; be05: 60          `
+
+; &be06 referenced 6 times by &8d6a, &9fea, &aac3, &b194, &b1c7, &b400
+.sub_cbe06
+    lda l002a                                                         ; be06: a5 2a       .*
+    sta l0000,x                                                       ; be08: 95 00       ..
+    lda l002b                                                         ; be0a: a5 2b       .+
+    sta l0001,x                                                       ; be0c: 95 01       ..
+    lda l002c                                                         ; be0e: a5 2c       .,
+    sta l0002,x                                                       ; be10: 95 02       ..
+    lda l002d                                                         ; be12: a5 2d       .-
+    sta l0003,x                                                       ; be14: 95 03       ..
+    rts                                                               ; be16: 60          `
+
+; &be17 referenced 2 times by &8fc0, &8fe5
+.sub_cbe17
+    jsr sub_cbe81                                                     ; be17: 20 81 be     ..
+    stz l003d                                                         ; be1a: 64 3d       d=
+    ldy #>(l0037)                                                     ; be1c: a0 00       ..
+    lda #osfile_load                                                  ; be1e: a9 ff       ..
+    ldx #<(l0037)                                                     ; be20: a2 37       .7
+    jsr osfile                                                        ; be22: 20 dd ff     ..
+; &be25 referenced 6 times by &8fd2, &8fed, &944f, &b42f, &bb8b, &be95
+.sub_cbe25
+    lda l0018                                                         ; be25: a5 18       ..
+    sta l0013                                                         ; be27: 85 13       ..
+    stz l0012                                                         ; be29: 64 12       d.
+    ldy #1                                                            ; be2b: a0 01       ..
+; &be2d referenced 1 time by &be41
+.loop_cbe2d
+    lda (l0012)                                                       ; be2d: b2 12       ..
+    cmp #&0d                                                          ; be2f: c9 0d       ..
+    bne cbe51                                                         ; be31: d0 1e       ..
+    lda (l0012),y                                                     ; be33: b1 12       ..
+    bmi cbe43                                                         ; be35: 30 0c       0.
+    ldy #3                                                            ; be37: a0 03       ..
+    lda (l0012),y                                                     ; be39: b1 12       ..
+    beq cbe51                                                         ; be3b: f0 14       ..
+    clc                                                               ; be3d: 18          .
+    jsr sub_cbe46                                                     ; be3e: 20 46 be     F.
+    bra loop_cbe2d                                                    ; be41: 80 ea       ..
+; &be43 referenced 1 time by &be35
+.cbe43
+    iny                                                               ; be43: c8          .
+; &be44 referenced 1 time by &bb77
+.sub_cbe44
+    clc                                                               ; be44: 18          .
+; &be45 referenced 1 time by &bb0c
+.cbe45
+    tya                                                               ; be45: 98          .
+; &be46 referenced 1 time by &be3e
+.sub_cbe46
+    adc l0012                                                         ; be46: 65 12       e.
+    sta l0012                                                         ; be48: 85 12       ..
+    bcc cbe4e                                                         ; be4a: 90 02       ..
+    inc l0013                                                         ; be4c: e6 13       ..
+; &be4e referenced 1 time by &be4a
+.cbe4e
+    ldy #1                                                            ; be4e: a0 01       ..
+    rts                                                               ; be50: 60          `
+
+; &be51 referenced 2 times by &be31, &be3b
+.cbe51
+    jsr sub_cbf0f                                                     ; be51: 20 0f bf     ..
+    ora l6142                                                         ; be54: 0d 42 61    .Ba
+    stz l0020                                                         ; be57: 64 20       d
+    bvs lbecd                                                         ; be59: 70 72       pr
+    equs "ogram"                                                      ; be5b: 6f 67 72... ogr
+    equb &0d, &ea, &4c, &4b, &90                                      ; be60: 0d ea 4c... ..L
+
+; &be65 referenced 1 time by &be7b
+.sub_cbe65
+    stz l0037                                                         ; be65: 64 37       d7
+    lda #6                                                            ; be67: a9 06       ..
+    sta l0038                                                         ; be69: 85 38       .8
+; &be6b referenced 2 times by &91ef, &ab47
+.sub_cbe6b
+    ldy l0036                                                         ; be6b: a4 36       .6
+    lda #&0d                                                          ; be6d: a9 0d       ..
+    sta l0600,y                                                       ; be6f: 99 00 06    ...
+    rts                                                               ; be72: 60          `
+
+; &be73 referenced 1 time by &be79
+.loop_cbe73
+    jmp c9155                                                         ; be73: 4c 55 91    LU.
+
+; &be76 referenced 2 times by &be81, &bec7
+.sub_cbe76
+    jsr sub_c9df3                                                     ; be76: 20 f3 9d     ..
+    bne loop_cbe73                                                    ; be79: d0 f8       ..
+    jsr sub_cbe65                                                     ; be7b: 20 65 be     e.
+    jmp c9c55                                                         ; be7e: 4c 55 9c    LU.
+
+; &be81 referenced 2 times by &be17, &be98
+.sub_cbe81
+    jsr sub_cbe76                                                     ; be81: 20 76 be     v.
+    dey                                                               ; be84: 88          .
+    sty l0039                                                         ; be85: 84 39       .9
+    lda l0018                                                         ; be87: a5 18       ..
+    sta l003a                                                         ; be89: 85 3a       .:
+; &be8b referenced 1 time by &9834
+.sub_cbe8b
+    lda #osbyte_read_high_order_address                               ; be8b: a9 82       ..
+    jsr osbyte                                                        ; be8d: 20 f4 ff     ..
+    stx l003b                                                         ; be90: 86 3b       .;
+    sty l003c                                                         ; be92: 84 3c       .<
+    rts                                                               ; be94: 60          `
+
+.sub_cbe95
+    jsr sub_cbe25                                                     ; be95: 20 25 be     %.
+    jsr sub_cbe81                                                     ; be98: 20 81 be     ..
+    stx l003f                                                         ; be9b: 86 3f       .?
+    sty l0040                                                         ; be9d: 84 40       .@
+    stx l0043                                                         ; be9f: 86 43       .C
+    sty l0044                                                         ; bea1: 84 44       .D
+    stx l0047                                                         ; bea3: 86 47       .G
+    sty l0048                                                         ; bea5: 84 48       .H
+    stz l0041                                                         ; bea7: 64 41       dA
+    ldx l0012                                                         ; bea9: a6 12       ..
+    stx l0045                                                         ; beab: 86 45       .E
+    ldx l0013                                                         ; bead: a6 13       ..
+    stx l0046                                                         ; beaf: 86 46       .F
+    ldx #&e7                                                          ; beb1: a2 e7       ..
+    stx l003d                                                         ; beb3: 86 3d       .=
+    ldx #&80                                                          ; beb5: a2 80       ..
+    stx l003e                                                         ; beb7: 86 3e       .>
+    ldx l0018                                                         ; beb9: a6 18       ..
+    stx l0042                                                         ; bebb: 86 42       .B
+    lda #osfile_save                                                  ; bebd: a9 00       ..
+    tay                                                               ; bebf: a8          .
+    ldx #<(l0037)                                                     ; bec0: a2 37       .7
+    jsr osfile                                                        ; bec2: 20 dd ff     ..
+    bra cbeeb                                                         ; bec5: 80 24       .$
+.sub_cbec7
+    jsr sub_cbe76                                                     ; bec7: 20 76 be     v.
+    ldx #<(l0600)                                                     ; beca: a2 00       ..
+.sub_cbecc
+lbecd = sub_cbecc+1
+    ldy #>(l0600)                                                     ; becc: a0 06       ..
+; overlapping: asl l0020                                              ; becd: 06 20       .
+; &becd referenced 1 time by &be59
+    jsr oscli                                                         ; bece: 20 f7 ff     ..
+    bra cbeeb                                                         ; bed1: 80 18       ..
+; &bed3 referenced 1 time by &90ad
+.cbed3
+    lda #3                                                            ; bed3: a9 03       ..
+    bra cbed9                                                         ; bed5: 80 02       ..
+.sub_cbed7
+    lda #1                                                            ; bed7: a9 01       ..
+; &bed9 referenced 1 time by &bed5
+.cbed9
+    pha                                                               ; bed9: 48          H
+    jsr sub_cba6e                                                     ; beda: 20 6e ba     n.
+    phy                                                               ; bedd: 5a          Z
+    jsr c9c16                                                         ; bede: 20 16 9c     ..
+    jsr sub_c9781                                                     ; bee1: 20 81 97     ..
+    ply                                                               ; bee4: 7a          z
+    ldx #&2a ; '*'                                                    ; bee5: a2 2a       .*
+    pla                                                               ; bee7: 68          h
+    jsr osargs                                                        ; bee8: 20 da ff     ..
+; &beeb referenced 4 times by &bec5, &bed1, &befb, &bf0d
+.cbeeb
+    jmp c90ca                                                         ; beeb: 4c ca 90    L..
+
+.sub_cbeee
+    jsr sub_cba6e                                                     ; beee: 20 6e ba     n.
+    jsr sub_c9c5a                                                     ; bef1: 20 5a 9c     Z.
+    ldy l002a                                                         ; bef4: a4 2a       .*
+    lda #0                                                            ; bef6: a9 00       ..
+    jsr osfind                                                        ; bef8: 20 ce ff     ..
+    bra cbeeb                                                         ; befb: 80 ee       ..
+.sub_cbefd
+lbefe = sub_cbefd+1
+    jsr sub_cba6e                                                     ; befd: 20 6e ba     n.
+; &befe referenced 1 time by &aa61
+; &bf00 referenced 1 time by &aa5a
+.cbf00
+    pha                                                               ; bf00: 48          H
+    jsr sub_c9771                                                     ; bf01: 20 71 97     q.
+    jsr sub_c9c5a                                                     ; bf04: 20 5a 9c     Z.
+    ply                                                               ; bf07: 7a          z
+    lda l002a                                                         ; bf08: a5 2a       .*
+    jsr osbput                                                        ; bf0a: 20 d4 ff     ..
+    bra cbeeb                                                         ; bf0d: 80 dc       ..
+; &bf0f referenced 2 times by &951f, &be51
+.sub_cbf0f
+    pla                                                               ; bf0f: 68          h
+    sta l0037                                                         ; bf10: 85 37       .7
+    pla                                                               ; bf12: 68          h
+    sta l0038                                                         ; bf13: 85 38       .8
+    bra cbf1a                                                         ; bf15: 80 03       ..
+; &bf17 referenced 1 time by &bf1d
+.loop_cbf17
+    jsr osasci                                                        ; bf17: 20 e3 ff     ..
+; &bf1a referenced 1 time by &bf15
+.cbf1a
+    jsr sub_c8e66                                                     ; bf1a: 20 66 8e     f.
+    bpl loop_cbf17                                                    ; bf1d: 10 f8       ..
+    jmp (l0037)                                                       ; bf1f: 6c 37 00    l7.
+
+; &bf22 referenced 4 times by &8ff7, &8ffb, &9007, &9012
+.sub_cbf22
+    lda #osword_read_io_memory                                        ; bf22: a9 05       ..
+    phx                                                               ; bf24: da          .
+    ldx #<(l002a)                                                     ; bf25: a2 2a       .*
+    ldy #>(l002a)                                                     ; bf27: a0 00       ..
+    jsr osword                                                        ; bf29: 20 f1 ff     ..
+    plx                                                               ; bf2c: fa          .
+    lda l002e                                                         ; bf2d: a5 2e       ..
+; &bf2f referenced 4 times by &9400, &958e, &965e, &aabc
+.sub_cbf2f
+    inc l002a                                                         ; bf2f: e6 2a       .*
+    bne cbf3d                                                         ; bf31: d0 0a       ..
+    inc l002b                                                         ; bf33: e6 2b       .+
+    bne cbf3d                                                         ; bf35: d0 06       ..
+    inc l002c                                                         ; bf37: e6 2c       .,
+    bne cbf3d                                                         ; bf39: d0 02       ..
+    inc l002d                                                         ; bf3b: e6 2d       .-
+; &bf3d referenced 3 times by &bf31, &bf35, &bf39
+.cbf3d
+    rts                                                               ; bf3d: 60          `
+
+; &bf3e referenced 2 times by &9019, &9045
+.sub_cbf3e
+    lda #&0d                                                          ; bf3e: a9 0d       ..
+    ldy l0018                                                         ; bf40: a4 18       ..
+    sty l0013                                                         ; bf42: 84 13       ..
+    stz l0012                                                         ; bf44: 64 12       d.
+    stz l0020                                                         ; bf46: 64 20       d
+    sta (l0012)                                                       ; bf48: 92 12       ..
+    lda #&ff                                                          ; bf4a: a9 ff       ..
+    ldy #1                                                            ; bf4c: a0 01       ..
+    sta (l0012),y                                                     ; bf4e: 91 12       ..
+    iny                                                               ; bf50: c8          .
+    sty l0012                                                         ; bf51: 84 12       ..
+    rts                                                               ; bf53: 60          `
+
+; &bf54 referenced 1 time by &b46c
+.cbf54
+    ldy #9                                                            ; bf54: a0 09       ..
+; &bf56 referenced 1 time by &bf5d
+.loop_cbf56
+    lda lb3be,y                                                       ; bf56: b9 be b3    ...
+    sta l0600,y                                                       ; bf59: 99 00 06    ...
+    dey                                                               ; bf5c: 88          .
+    bpl loop_cbf56                                                    ; bf5d: 10 f7       ..
+    ldx #<(l0600)                                                     ; bf5f: a2 00       ..
+    ldy #>(l0600)                                                     ; bf61: a0 06       ..
+    jmp oscli                                                         ; bf63: 4c f7 ff    L..
+
+; &bf66 referenced 1 time by &80ac
+.sub_cbf66
+    lda #osbyte_read_tube_presence                                    ; bf66: a9 ea       ..
+    ldx #0                                                            ; bf68: a2 00       ..
+    ldy #&ff                                                          ; bf6a: a0 ff       ..
+    jsr osbyte                                                        ; bf6c: 20 f4 ff     ..
+    txa                                                               ; bf6f: 8a          .
+    rts                                                               ; bf70: 60          `
+
+; &bf71 referenced 1 time by &bbed
+.lbf71
+    equb &52, &0b, &a8, &34, &a6, &e4, &a6, &0a, &a7, &10, &ad, &7e   ; bf71: 52 0b a8... R..
+    equb &a5, &4d, &a5, &4a, &2e, &7f, &5e, &5b, &d8, &aa,   0, &ca   ; bf7d: a5 4d a5... .M.
+    equb &98, &80, &81, &22, &f9, &83, &6e, &81, &49, &0f, &da, &a2   ; bf89: 98 80 81... ...
+    equb &21, &b3, &b2, &87, &80, &82, &38, &aa, &3b, &29, &80, &31   ; bf95: 21 b3 b2... !..
+    equb &72, &17, &f7, &d1, &5f, &5b, &e6, &ff, &66, &2b, &cc, &77   ; bfa1: 72 17 f7... r..
+    equb &6d,   6, &37, &bd, &73, &51, &b7, &17, &7a, &23, &d7, &0a   ; bfad: 6d 06 37... m.7
+    equb &81,   0,   0,   0,   0, &82, &40,   0,   0,   0, &9a, &d4   ; bfb9: 81 00 00... ...
+    equb &82, &7f, &b9, &ff, &78, &7b, &0e, &fa, &35, &12, &86, &65   ; bfc5: 82 7f b9... ...
+    equb &2e, &e0, &d3, &7e, &88, &88, &88, &89, &7b, &8c             ; bfd1: 2e e0 d3... ...
+    equs "o-Y"                                                        ; bfdb: 6f 2d 59    o-Y
+    equb &81, &99, &99, &99, &9a, &f3, &9e, &7b, &77, &81, &c0,   0   ; bfde: 81 99 99... ...
+    equb   0,   0, &80, &93, &e6, &90,   0, &81, &c4                  ; bfea: 00 00 80... ...
+    equs "DDD"                                                        ; bff3: 44 44 44    DDD
+    equb &80, &9d, &fd, &13,   4, &81, &e6                            ; bff6: 80 9d fd... ...
+    equs "fff"                                                        ; bffd: 66 66 66    fff
+.pydis_end
+
+; Label references by decreasing frequency:
+;     l002a:              206
+;     l0037:              133
+;     l002b:              119
+;     l0031:               88
+;     l000b:               82
+;     l001b:               82
+;     l000a:               81
+;     l003d:               78
+;     l0004:               75
+;     l002c:               75
+;     l0033:               66
+;     l0032:               65
+;     l0034:               63
+;     l0039:               59
+;     l0038:               58
+;     l0030:               57
+;     l002d:               56
+;     l0019:               52
+;     l003f:               52
+;     l0036:               51
+;     l003b:               49
+;     l002e:               48
+;     l003e:               48
+;     l0035:               42
+;     l000c:               37
+;     l003c:               36
+;     l0040:               34
+;     l004c:               31
+;     l0002:               29
+;     l003a:               29
+;     l0600:               29
+;     c8f9d:               29
+;     l0027:               28
+;     l004a:               25
+;     c9c6a:               24
+;     sub_c9332:           23
+;     l0003:               22
+;     l001a:               22
+;     l0012:               21
+;     l0041:               21
+;     l0048:               21
+;     cbc66:               20
+;     sub_c8da2:           18
+;     l0005:               17
+;     l002f:               17
+;     l004d:               16
+;     c8f92:               16
+;     l0013:               15
+;     l0018:               15
+;     l0049:               15
+;     oswrch:              15
+;     c9155:               14
+;     sub_c9dff:           14
+;     cad78:               14
+;     l0026:               13
+;     sub_cbd26:           13
+;     l0029:               12
+;     c90ca:               11
+;     ca2cc:               11
+;     cae60:               11
+;     osbyte:              11
+;     l0007:               10
+;     l000d:               10
+;     l0028:               10
+;     l0042:               10
+;     sub_c9779:           10
+;     sub_c9be2:           10
+;     c9c80:               10
+;     l000f:                9
+;     l001f:                9
+;     l05ff:                9
+;     sub_c8e5f:            9
+;     sub_c997d:            9
+;     sub_c9c5a:            9
+;     l0000:                8
+;     l0001:                8
+;     l0006:                8
+;     l001e:                8
+;     l0047:                8
+;     l004b:                8
+;     c828d:                8
+;     sub_c8d86:            8
+;     c90d0:                8
+;     c9338:                8
+;     c95f1:                8
+;     sub_c979f:            8
+;     sub_c9df3:            8
+;     sub_ca545:            8
+;     cae62:                8
+;     sub_cbac2:            8
+;     l0014:                7
+;     sub_c8fa8:            7
+;     c9048:                7
+;     sub_c9774:            7
+;     sub_c9783:            7
+;     c9c2d:                7
+;     ca72b:                7
+;     sub_cbbdc:            7
+;     cbc91:                7
+;     l000e:                6
+;     l0015:                6
+;     l0020:                6
+;     romsel_copy:          6
+;     c8b1b:                6
+;     c8bf9:                6
+;     sub_c8d9c:            6
+;     sub_c8e41:            6
+;     c8e6c:                6
+;     c904b:                6
+;     c90c5:                6
+;     sub_c976c:            6
+;     sub_c9771:            6
+;     c9e85:                6
+;     cac2b:                6
+;     cad10:                6
+;     cadce:                6
+;     cb169:                6
+;     sub_cbc83:            6
+;     cbdff:                6
+;     sub_cbe06:            6
+;     sub_cbe25:            6
+;     osbput:               6
+;     osbget:               6
+;     osword:               6
+;     l0010:                5
+;     l0024:                5
+;     l0025:                5
+;     os_text_ptr:          5
+;     l0400:                5
+;     c84ce:                5
+;     sub_c8d94:            5
+;     c932d:                5
+;     c9784:                5
+;     sub_c9788:            5
+;     sub_c97a2:            5
+;     c9a46:                5
+;     c9e83:                5
+;     c9f4c:                5
+;     ca261:                5
+;     sub_ca514:            5
+;     ca634:                5
+;     ca70a:                5
+;     ca712:                5
+;     cac1c:                5
+;     cac38:                5
+;     cad20:                5
+;     cafb8:                5
+;     sub_cb365:            5
+;     cb5cf:                5
+;     cb805:                5
+;     sub_cb85a:            5
+;     cbc3a:                5
+;     sub_cbd12:            5
+;     cbd21:                5
+;     sub_cbd48:            5
+;     cbdd4:                5
+;     l0011:                4
+;     l001c:                4
+;     l001d:                4
+;     l0046:                4
+;     l0100:                4
+;     l0440:                4
+;     l0441:                4
+;     sub_c8149:            4
+;     c815d:                4
+;     c820f:                4
+;     c84a3:                4
+;     c8af2:                4
+;     c8ce3:                4
+;     c8dfc:                4
+;     c8e51:                4
+;     c8ee7:                4
+;     c9045:                4
+;     c90c7:                4
+;     c9207:                4
+;     c9700:                4
+;     sub_c977e:            4
+;     sub_c9781:            4
+;     c9808:                4
+;     sub_c9952:            4
+;     c9c16:                4
+;     c9c8a:                4
+;     c9d75:                4
+;     sub_c9f07:            4
+;     c9f0a:                4
+;     sub_ca06c:            4
+;     ca0d1:                4
+;     ca2fb:                4
+;     ca426:                4
+;     ca513:                4
+;     caae8:                4
+;     cb5df:                4
+;     cb7b3:                4
+;     sub_cbc24:            4
+;     sub_cbd5e:            4
+;     sub_cbd77:            4
+;     cbdd2:                4
+;     sub_cbdd8:            4
+;     cbe05:                4
+;     cbeeb:                4
+;     sub_cbf22:            4
+;     sub_cbf2f:            4
+;     l0016:                3
+;     l0023:                3
+;     l00fd:                3
+;     l0401:                3
+;     l046c:                3
+;     l051d:                3
+;     l051f:                3
+;     l0524:                3
+;     c806a:                3
+;     sub_c80d8:            3
+;     c8190:                3
+;     sub_c8191:            3
+;     c827c:                3
+;     c82dd:                3
+;     c8304:                3
+;     c83d2:                3
+;     c8b10:                3
+;     c8bb2:                3
+;     c8c1b:                3
+;     c8c1e:                3
+;     c8cbb:                3
+;     c8d64:                3
+;     sub_c8d89:            3
+;     sub_c8d8c:            3
+;     c8e3f:                3
+;     sub_c8e66:            3
+;     c8e6f:                3
+;     c8e9c:                3
+;     c8ed0:                3
+;     c8edc:                3
+;     c8fbb:                3
+;     c9164:                3
+;     sub_c916e:            3
+;     c926e:                3
+;     c9276:                3
+;     c9288:                3
+;     c92da:                3
+;     sub_c9330:            3
+;     c93d7:                3
+;     sub_c953d:            3
+;     c96b8:                3
+;     c96ca:                3
+;     c979c:                3
+;     c98bd:                3
+;     c990c:                3
+;     sub_c990f:            3
+;     sub_c9923:            3
+;     c9a14:                3
+;     c9a28:                3
+;     sub_c9b97:            3
+;     c9bda:                3
+;     c9c55:                3
+;     c9c74:                3
+;     sub_c9d0f:            3
+;     sub_c9d7f:            3
+;     sub_ca0e8:            3
+;     ca126:                3
+;     ca174:                3
+;     sub_ca2dd:            3
+;     ca385:                3
+;     sub_ca3ed:            3
+;     sub_ca46b:            3
+;     ca4a9:                3
+;     ca4b9:                3
+;     sub_ca5ad:            3
+;     sub_ca5b4:            3
+;     ca622:                3
+;     sub_ca62f:            3
+;     ca674:                3
+;     ca6e4:                3
+;     ca6ed:                3
+;     sub_ca6ff:            3
+;     ca725:                3
+;     sub_ca73e:            3
+;     ca9c1:                3
+;     sub_ca9d1:            3
+;     cab9d:                3
+;     cadee:                3
+;     caed7:                3
+;     caed9:                3
+;     caf07:                3
+;     caf88:                3
+;     cb1de:                3
+;     sub_cb2e0:            3
+;     cb753:                3
+;     cb8fa:                3
+;     cb997:                3
+;     cb9ff:                3
+;     cba46:                3
+;     sub_cba6e:            3
+;     sub_cba7a:            3
+;     cbb1a:                3
+;     cbd3a:                3
+;     sub_cbd46:            3
+;     cbf3d:                3
+;     osnewl:               3
+;     oscli:                3
+;     l0017:                2
+;     l0021:                2
+;     l0022:                2
+;     l0044:                2
+;     l004e:                2
+;     l01ff:                2
+;     wrchv:                2
+;     l0402:                2
+;     l0403:                2
+;     l043c:                2
+;     l043d:                2
+;     l0519:                2
+;     l051a:                2
+;     l051b:                2
+;     l051c:                2
+;     l051e:                2
+;     l0521:                2
+;     l0522:                2
+;     l0523:                2
+;     l0526:                2
+;     l0527:                2
+;     l0700:                2
+;     c8067:                2
+;     c808f:                2
+;     c80a8:                2
+;     c80cc:                2
+;     c8151:                2
+;     c8197:                2
+;     c81b9:                2
+;     sub_c81bd:            2
+;     sub_c8287:            2
+;     sub_c828a:            2
+;     c82ae:                2
+;     c82f4:                2
+;     c82fb:                2
+;     c8306:                2
+;     sub_c83d3:            2
+;     c840a:                2
+;     sub_c8429:            2
+;     c89dd:                2
+;     c8b40:                2
+;     c8b5f:                2
+;     c8b62:                2
+;     c8b83:                2
+;     c8c31:                2
+;     c8c99:                2
+;     c8ca4:                2
+;     c8cbd:                2
+;     c8d34:                2
+;     c8d6e:                2
+;     sub_c8da8:            2
+;     c8dc9:                2
+;     c8e57:                2
+;     c8e7d:                2
+;     c8eb6:                2
+;     c8f1a:                2
+;     c8f26:                2
+;     c8f41:                2
+;     c8f5d:                2
+;     sub_c8fae:            2
+;     c9073:                2
+;     c90de:                2
+;     c914f:                2
+;     sub_c9171:            2
+;     c9193:                2
+;     c91ad:                2
+;     c91d1:                2
+;     c9285:                2
+;     sub_c933d:            2
+;     c9357:                2
+;     sub_c935c:            2
+;     sub_c93c7:            2
+;     sub_c9410:            2
+;     sub_c9436:            2
+;     c947f:                2
+;     c94ba:                2
+;     c94e4:                2
+;     c950d:                2
+;     c9555:                2
+;     sub_c95cb:            2
+;     c9635:                2
+;     sub_c9769:            2
+;     c979b:                2
+;     c97ee:                2
+;     c9866:                2
+;     c986a:                2
+;     c98c0:                2
+;     c98dc:                2
+;     c9928:                2
+;     c9977:                2
+;     c997a:                2
+;     c999f:                2
+;     sub_c99c4:            2
+;     c99fa:                2
+;     c9a3a:                2
+;     c9a75:                2
+;     c9ac1:                2
+;     sub_c9ac9:            2
+;     c9bae:                2
+;     c9bbc:                2
+;     c9bce:                2
+;     sub_c9bee:            2
+;     sub_c9c0a:            2
+;     c9c3b:                2
+;     c9c41:                2
+;     sub_c9c4a:            2
+;     c9c6c:                2
+;     c9cc6:                2
+;     c9ced:                2
+;     c9d7c:                2
+;     sub_c9d81:            2
+;     c9dc1:                2
+;     sub_c9e3f:            2
+;     sub_c9e6d:            2
+;     c9ecb:                2
+;     c9f55:                2
+;     c9f9a:                2
+;     c9fa7:                2
+;     sub_ca023:            2
+;     sub_ca026:            2
+;     ca029:                2
+;     ca05b:                2
+;     sub_ca069:            2
+;     ca06f:                2
+;     ca081:                2
+;     ca09c:                2
+;     ca0c5:                2
+;     sub_ca0ec:            2
+;     ca158:                2
+;     sub_ca181:            2
+;     ca19b:                2
+;     ca19d:                2
+;     ca1d4:                2
+;     ca220:                2
+;     ca2b7:                2
+;     sub_ca2ca:            2
+;     ca2d6:                2
+;     ca303:                2
+;     ca357:                2
+;     ca3a1:                2
+;     ca3a7:                2
+;     ca3e5:                2
+;     ca3e9:                2
+;     ca446:                2
+;     ca452:                2
+;     ca47a:                2
+;     sub_ca4ba:            2
+;     ca4f5:                2
+;     ca547:                2
+;     sub_ca54d:            2
+;     sub_ca56d:            2
+;     ca57e:                2
+;     sub_ca5bb:            2
+;     sub_ca5cc:            2
+;     sub_ca5cf:            2
+;     sub_ca5e3:            2
+;     sub_ca5f4:            2
+;     sub_ca6cb:            2
+;     ca6ce:                2
+;     ca6f2:                2
+;     ca704:                2
+;     ca73b:                2
+;     ca79b:                2
+;     ca7db:                2
+;     ca805:                2
+;     ca857:                2
+;     ca878:                2
+;     sub_ca8b3:            2
+;     sub_ca8b9:            2
+;     sub_ca97b:            2
+;     caa2c:                2
+;     sub_caa50:            2
+;     sub_caa55:            2
+;     sub_caa6e:            2
+;     caa7a:                2
+;     sub_caad8:            2
+;     cab1a:                2
+;     cab41:                2
+;     cabdd:                2
+;     cac2d:                2
+;     cacd2:                2
+;     cace8:                2
+;     cacfd:                2
+;     sub_cad3a:            2
+;     cad5b:                2
+;     cae56:                2
+;     caeb4:                2
+;     caedb:                2
+;     caf03:                2
+;     cafdb:                2
+;     cafee:                2
+;     sub_cb057:            2
+;     cb109:                2
+;     cb17e:                2
+;     sub_cb1bf:            2
+;     cb1db:                2
+;     cb205:                2
+;     cb341:                2
+;     sub_cb362:            2
+;     sub_cb372:            2
+;     cb39e:                2
+;     cb3fb:                2
+;     cb451:                2
+;     cb485:                2
+;     cb4a7:                2
+;     cb4e2:                2
+;     cb54b:                2
+;     cb563:                2
+;     cb56a:                2
+;     cb629:                2
+;     cb7a4:                2
+;     cb81a:                2
+;     sub_cb84d:            2
+;     cb866:                2
+;     cb86c:                2
+;     cb87f:                2
+;     cb9a5:                2
+;     sub_cb9dc:            2
+;     sub_cba6c:            2
+;     sub_cbaa4:            2
+;     cbac5:                2
+;     sub_cbac8:            2
+;     cbae8:                2
+;     sub_cbb0f:            2
+;     sub_cbb1b:            2
+;     cbb9b:                2
+;     sub_cbbff:            2
+;     sub_cbc18:            2
+;     sub_cbc36:            2
+;     sub_cbc62:            2
+;     cbd0e:                2
+;     cbd3d:                2
+;     cbd74:                2
+;     cbd86:                2
+;     sub_cbdac:            2
+;     sub_cbdcf:            2
+;     sub_cbdf3:            2
+;     sub_cbe17:            2
+;     cbe51:                2
+;     sub_cbe6b:            2
+;     sub_cbe76:            2
+;     sub_cbe81:            2
+;     sub_cbf0f:            2
+;     sub_cbf3e:            2
+;     osfind:               2
+;     osargs:               2
+;     osfile:               2
+;     osrdch:               2
+;     osasci:               2
+;     l0008:                1
+;     l0009:                1
+;     l0043:                1
+;     l0045:                1
+;     l0061:                1
+;     l0064:                1
+;     l0066:                1
+;     l00c1:                1
+;     l00e1:                1
+;     l00e6:                1
+;     l00fe:                1
+;     l00ff:                1
+;     l0106:                1
+;     brkv:                 1
+;     brkv+1:               1
+;     l0404:                1
+;     l040c:                1
+;     l0460:                1
+;     l0464:                1
+;     l0469:                1
+;     l047f:                1
+;     l04ff:                1
+;     l0500:                1
+;     l0513:                1
+;     l0514:                1
+;     l0528:                1
+;     l0529:                1
+;     l052a:                1
+;     l05cb:                1
+;     l05cc:                1
+;     l05e5:                1
+;     l05e6:                1
+;     l07ef:                1
+;     l0bb1:                1
+;     l0e4e:                1
+;     l4e4e:                1
+;     l5252:                1
+;     l6142:                1
+;     l7461:                1
+;     l7f0e:                1
+;     l7f13:                1
+;     service_handler:      1
+;     c8040:                1
+;     c804c:                1
+;     loop_c8057:           1
+;     c805e:                1
+;     c8070:                1
+;     loop_c8091:           1
+;     copy_to_stack_loop:   1
+;     l80c2:                1
+;     l80dd:                1
+;     l80e2:                1
+;     language_handler:     1
+;     c80ff:                1
+;     sub_c8139:            1
+;     c8168:                1
+;     loop_c8176:           1
+;     c817a:                1
+;     c8187:                1
+;     loop_c819f:           1
+;     c81ad:                1
+;     c81c8:                1
+;     loop_c81e1:           1
+;     c81ea:                1
+;     c81fd:                1
+;     loop_c8206:           1
+;     c8210:                1
+;     c8230:                1
+;     loop_c8235:           1
+;     c823f:                1
+;     c8242:                1
+;     c8246:                1
+;     loop_c8252:           1
+;     c825b:                1
+;     c829a:                1
+;     loop_c82b2:           1
+;     c82be:                1
+;     c82c8:                1
+;     c82d8:                1
+;     sub_c82e6:            1
+;     loop_c82f7:           1
+;     loop_c8314:           1
+;     c832f:                1
+;     loop_c8331:           1
+;     c833b:                1
+;     c8345:                1
+;     c8346:                1
+;     sub_c8349:            1
+;     sub_c834f:            1
+;     c8353:                1
+;     c835e:                1
+;     c8362:                1
+;     loop_c8365:           1
+;     c8371:                1
+;     c8372:                1
+;     c8392:                1
+;     loop_c839e:           1
+;     c83a6:                1
+;     sub_c83aa:            1
+;     c83c1:                1
+;     sub_c83c2:            1
+;     c83d5:                1
+;     loop_c8428:           1
+;     loop_c8440:           1
+;     c8456:                1
+;     loop_c845b:           1
+;     c846a:                1
+;     loop_c847b:           1
+;     c8491:                1
+;     loop_c8496:           1
+;     c84ad:                1
+;     c84f4:                1
+;     l880a:                1
+;     l8909:                1
+;     l894e:                1
+;     l8993:                1
+;     c89bf:                1
+;     loop_c89d7:           1
+;     c89f4:                1
+;     c8a0b:                1
+;     loop_c8a11:           1
+;     c8a1e:                1
+;     c8a28:                1
+;     loop_c8a2a:           1
+;     c8a34:                1
+;     loop_c8a3c:           1
+;     c8a44:                1
+;     c8a4b:                1
+;     loop_c8a4f:           1
+;     loop_c8a54:           1
+;     loop_c8a5e:           1
+;     c8a64:                1
+;     c8a68:                1
+;     c8a6b:                1
+;     loop_c8a6e:           1
+;     c8a79:                1
+;     c8a8b:                1
+;     c8a8e:                1
+;     c8a91:                1
+;     sub_c8aa8:            1
+;     loop_c8ac3:           1
+;     loop_c8ad4:           1
+;     c8adf:                1
+;     loop_c8ae3:           1
+;     c8aef:                1
+;     c8af5:                1
+;     c8b33:                1
+;     c8b4b:                1
+;     c8b55:                1
+;     c8b63:                1
+;     c8b98:                1
+;     c8b9b:                1
+;     c8b9c:                1
+;     loop_c8b9e:           1
+;     c8ba3:                1
+;     c8baf:                1
+;     c8bb4:                1
+;     c8bb6:                1
+;     c8bbd:                1
+;     c8bc4:                1
+;     c8bde:                1
+;     c8be9:                1
+;     c8c01:                1
+;     loop_c8c15:           1
+;     c8c24:                1
+;     c8c41:                1
+;     c8c43:                1
+;     c8c55:                1
+;     c8c57:                1
+;     c8c5e:                1
+;     c8c74:                1
+;     c8c84:                1
+;     c8c87:                1
+;     c8c96:                1
+;     loop_c8c9b:           1
+;     c8ca7:                1
+;     c8cb8:                1
+;     c8cc0:                1
+;     c8ce6:                1
+;     c8cfd:                1
+;     c8d16:                1
+;     c8d37:                1
+;     c8d44:                1
+;     loop_c8d71:           1
+;     c8d74:                1
+;     loop_c8db7:           1
+;     sub_c8dc1:            1
+;     c8dff:                1
+;     loop_c8e16:           1
+;     sub_c8e1f:            1
+;     sub_c8e58:            1
+;     c8e8d:                1
+;     loop_c8e91:           1
+;     c8e9d:                1
+;     sub_c8ea4:            1
+;     c8ea6:                1
+;     c8eaa:                1
+;     c8ebe:                1
+;     loop_c8ee2:           1
+;     c8ef3:                1
+;     c8f03:                1
+;     loop_c8f0b:           1
+;     c8f25:                1
+;     c8f32:                1
+;     c8f3d:                1
+;     c8f52:                1
+;     c8f6d:                1
+;     c8f74:                1
+;     loop_c8f7a:           1
+;     c8f86:                1
+;     c8f87:                1
+;     c8f8c:                1
+;     c8f9c:                1
+;     loop_c8fa7:           1
+;     sub_c8fb4:            1
+;     c8fda:                1
+;     c8ff2:                1
+;     loop_c9004:           1
+;     c901c:                1
+;     loop_c9024:           1
+;     c9033:                1
+;     c905c:                1
+;     c9069:                1
+;     loop_c9078:           1
+;     c907d:                1
+;     c9082:                1
+;     c9086:                1
+;     c90a0:                1
+;     loop_c90a6:           1
+;     loop_c90ad:           1
+;     c90b0:                1
+;     c90d2:                1
+;     c90e3:                1
+;     c90ea:                1
+;     c9108:                1
+;     c9112:                1
+;     c9123:                1
+;     c9135:                1
+;     c9146:                1
+;     loop_c91e4:           1
+;     c91ee:                1
+;     c91ef:                1
+;     loop_c91f6:           1
+;     c9201:                1
+;     c9204:                1
+;     loop_c9220:           1
+;     c922a:                1
+;     loop_c922c:           1
+;     c9237:                1
+;     loop_c923f:           1
+;     c924a:                1
+;     c9259:                1
+;     loop_c9260:           1
+;     loop_c9268:           1
+;     c9274:                1
+;     loop_c928b:           1
+;     c929e:                1
+;     loop_c92d4:           1
+;     loop_c92e0:           1
+;     c92ed:                1
+;     loop_c92f0:           1
+;     c9304:                1
+;     c931e:                1
+;     c9321:                1
+;     c9325:                1
+;     c932a:                1
+;     loop_c9355:           1
+;     loop_c9356:           1
+;     loop_c9368:           1
+;     c937c:                1
+;     c938f:                1
+;     c93b4:                1
+;     c93c4:                1
+;     loop_c93fa:           1
+;     c9433:                1
+;     sub_c943e:            1
+;     loop_c9455:           1
+;     c9469:                1
+;     c9476:                1
+;     c9487:                1
+;     loop_c948a:           1
+;     c94aa:                1
+;     c94b0:                1
+;     c94c8:                1
+;     c94d1:                1
+;     c94d5:                1
+;     c94de:                1
+;     c9509:                1
+;     c951d:                1
+;     c951f:                1
+;     c954b:                1
+;     c9579:                1
+;     c957c:                1
+;     c957f:                1
+;     c95be:                1
+;     sub_c95c6:            1
+;     loop_c95cf:           1
+;     c95e0:                1
+;     c95f9:                1
+;     c9606:                1
+;     c9628:                1
+;     c9632:                1
+;     c963b:                1
+;     c964e:                1
+;     c968d:                1
+;     c96bf:                1
+;     c971b:                1
+;     loop_c9724:           1
+;     loop_c9728:           1
+;     c972c:                1
+;     c9735:                1
+;     loop_c9750:           1
+;     c9753:                1
+;     sub_c978b:            1
+;     loop_c97c0:           1
+;     loop_c97c6:           1
+;     c97d2:                1
+;     c97fe:                1
+;     c9801:                1
+;     c9877:                1
+;     c9889:                1
+;     loop_c98cb:           1
+;     c98d7:                1
+;     loop_c98df:           1
+;     loop_c9904:           1
+;     sub_c9914:            1
+;     loop_c992a:           1
+;     c9937:                1
+;     loop_c9948:           1
+;     loop_c9954:           1
+;     sub_c995a:            1
+;     c9962:                1
+;     c996e:                1
+;     c9979:                1
+;     c9990:                1
+;     c99a0:                1
+;     c99a2:                1
+;     c99ab:                1
+;     c99ba:                1
+;     loop_c99cf:           1
+;     sub_c99d0:            1
+;     sub_c99d6:            1
+;     sub_c99d8:            1
+;     c9a0e:                1
+;     c9a58:                1
+;     c9a63:                1
+;     c9a67:                1
+;     c9a76:                1
+;     c9a79:                1
+;     c9a7b:                1
+;     c9a99:                1
+;     c9aa0:                1
+;     c9aa5:                1
+;     loop_c9ab6:           1
+;     c9abc:                1
+;     c9ae6:                1
+;     c9b4c:                1
+;     c9b5a:                1
+;     c9b78:                1
+;     c9b80:                1
+;     c9b8a:                1
+;     sub_c9bba:            1
+;     c9bd2:                1
+;     c9bdb:                1
+;     loop_c9be0:           1
+;     c9c08:                1
+;     c9c24:                1
+;     c9c52:                1
+;     loop_c9c6d:           1
+;     sub_c9c8e:            1
+;     loop_c9c92:           1
+;     sub_c9c93:            1
+;     sub_c9ca2:            1
+;     c9cb6:                1
+;     sub_c9cb8:            1
+;     c9cc1:                1
+;     c9cc5:                1
+;     loop_c9cc9:           1
+;     c9cd6:                1
+;     loop_c9ce8:           1
+;     c9ceb:                1
+;     c9cfb:                1
+;     loop_c9cfd:           1
+;     c9d0c:                1
+;     c9d29:                1
+;     sub_c9d36:            1
+;     c9d43:                1
+;     c9d57:                1
+;     c9d79:                1
+;     c9d7b:                1
+;     sub_c9d82:            1
+;     c9db4:                1
+;     c9dba:                1
+;     c9dbe:                1
+;     c9dbf:                1
+;     c9dc0:                1
+;     c9dc4:                1
+;     c9dd5:                1
+;     loop_c9dd7:           1
+;     c9de5:                1
+;     c9de9:                1
+;     c9e02:                1
+;     c9e10:                1
+;     loop_c9e18:           1
+;     loop_c9e23:           1
+;     c9e2a:                1
+;     loop_c9e32:           1
+;     sub_c9e45:            1
+;     c9e48:                1
+;     c9e4d:                1
+;     loop_c9e5b:           1
+;     c9e78:                1
+;     c9e79:                1
+;     c9e90:                1
+;     c9ea6:                1
+;     c9ead:                1
+;     c9eb2:                1
+;     c9ec2:                1
+;     c9edd:                1
+;     loop_c9ef2:           1
+;     c9f13:                1
+;     c9f3b:                1
+;     c9f4f:                1
+;     loop_c9f59:           1
+;     loop_c9f61:           1
+;     c9f64:                1
+;     c9f70:                1
+;     c9f9d:                1
+;     loop_c9faa:           1
+;     c9fb6:                1
+;     c9fb8:                1
+;     loop_c9fbb:           1
+;     c9fe6:                1
+;     c9ff4:                1
+;     ca00f:                1
+;     ca03b:                1
+;     ca03c:                1
+;     ca04a:                1
+;     ca04d:                1
+;     loop_ca052:           1
+;     ca05f:                1
+;     loop_ca070:           1
+;     ca09f:                1
+;     loop_ca0b8:           1
+;     ca0c7:                1
+;     ca0ee:                1
+;     loop_ca0f2:           1
+;     loop_ca0f5:           1
+;     ca10a:                1
+;     loop_ca10f:           1
+;     ca116:                1
+;     ca131:                1
+;     ca137:                1
+;     loop_ca13b:           1
+;     loop_ca151:           1
+;     ca160:                1
+;     ca169:                1
+;     ca18a:                1
+;     ca197:                1
+;     ca1af:                1
+;     ca1bc:                1
+;     ca1c1:                1
+;     ca1cd:                1
+;     ca1d0:                1
+;     ca1ed:                1
+;     ca1ef:                1
+;     ca204:                1
+;     loop_ca207:           1
+;     ca212:                1
+;     ca21c:                1
+;     ca22a:                1
+;     ca23e:                1
+;     ca24a:                1
+;     loop_ca256:           1
+;     ca25f:                1
+;     loop_ca263:           1
+;     ca26f:                1
+;     loop_ca27d:           1
+;     ca28a:                1
+;     ca28c:                1
+;     ca290:                1
+;     ca2a3:                1
+;     ca2b3:                1
+;     sub_ca2b8:            1
+;     loop_ca2bb:           1
+;     ca2c9:                1
+;     ca2fd:                1
+;     ca325:                1
+;     ca333:                1
+;     ca33e:                1
+;     ca342:                1
+;     ca348:                1
+;     ca34c:                1
+;     ca36b:                1
+;     ca37e:                1
+;     ca393:                1
+;     loop_ca399:           1
+;     ca3aa:                1
+;     loop_ca3ae:           1
+;     sub_ca3b5:            1
+;     sub_ca3c0:            1
+;     ca3c3:                1
+;     sub_ca40a:            1
+;     sub_ca419:            1
+;     ca42c:                1
+;     ca489:                1
+;     ca4a3:                1
+;     ca4c4:                1
+;     ca4ce:                1
+;     ca4e8:                1
+;     sub_ca503:            1
+;     sub_ca507:            1
+;     sub_ca50b:            1
+;     ca53b:                1
+;     ca53e:                1
+;     sub_ca541:            1
+;     sub_ca572:            1
+;     sub_ca576:            1
+;     ca57a:                1
+;     ca5a7:                1
+;     ca5aa:                1
+;     sub_ca5b2:            1
+;     loop_ca5b6:           1
+;     ca5ba:                1
+;     sub_ca5bd:            1
+;     sub_ca5c1:            1
+;     sub_ca5c4:            1
+;     sub_ca5d1:            1
+;     sub_ca5f2:            1
+;     sub_ca5f9:            1
+;     loop_ca607:           1
+;     ca608:                1
+;     ca612:                1
+;     loop_ca617:           1
+;     ca61d:                1
+;     loop_ca62c:           1
+;     sub_ca631:            1
+;     ca640:                1
+;     ca653:                1
+;     ca65c:                1
+;     ca65e:                1
+;     ca676:                1
+;     ca68d:                1
+;     ca6a2:                1
+;     loop_ca6a8:           1
+;     ca6ae:                1
+;     ca6c4:                1
+;     sub_ca6eb:            1
+;     sub_ca70d:            1
+;     ca70f:                1
+;     ca71e:                1
+;     ca72f:                1
+;     sub_ca731:            1
+;     ca739:                1
+;     ca73d:                1
+;     ca74d:                1
+;     loop_ca758:           1
+;     ca76b:                1
+;     ca776:                1
+;     ca797:                1
+;     sub_ca7ac:            1
+;     sub_ca7af:            1
+;     ca7c0:                1
+;     la7c9:                1
+;     ca7cd:                1
+;     ca7ed:                1
+;     ca7ef:                1
+;     sub_ca80b:            1
+;     ca829:                1
+;     ca838:                1
+;     ca83f:                1
+;     ca841:                1
+;     ca875:                1
+;     ca88a:                1
+;     loop_ca88f:           1
+;     ca899:                1
+;     ca8b0:                1
+;     ca8bb:                1
+;     loop_ca8cd:           1
+;     loop_ca8e0:           1
+;     ca8ee:                1
+;     sub_ca901:            1
+;     ca91f:                1
+;     ca92d:                1
+;     ca932:                1
+;     ca93b:                1
+;     ca946:                1
+;     ca948:                1
+;     ca94b:                1
+;     ca959:                1
+;     ca962:                1
+;     ca965:                1
+;     loop_ca969:           1
+;     ca978:                1
+;     loop_ca982:           1
+;     sub_ca9a3:            1
+;     sub_ca9c3:            1
+;     ca9e0:                1
+;     ca9ef:                1
+;     ca9f2:                1
+;     loop_ca9f5:           1
+;     ca9f8:                1
+;     caa07:                1
+;     sub_caa1a:            1
+;     caa33:                1
+;     caa3e:                1
+;     caa44:                1
+;     loop_caa59:           1
+;     caa66:                1
+;     caa6b:                1
+;     caa7d:                1
+;     caa9a:                1
+;     caab0:                1
+;     caac1:                1
+;     loop_caaf0:           1
+;     sub_cab14:            1
+;     cab23:                1
+;     cab82:                1
+;     cab91:                1
+;     sub_caba5:            1
+;     cabc9:                1
+;     cabd0:                1
+;     cabfa:                1
+;     cabfd:                1
+;     cac02:                1
+;     cac0f:                1
+;     cac35:                1
+;     loop_cac3c:           1
+;     cac59:                1
+;     cac5b:                1
+;     caca0:                1
+;     caca3:                1
+;     caca9:                1
+;     cacaf:                1
+;     loop_cacd8:           1
+;     cace3:                1
+;     loop_cace5:           1
+;     loop_caceb:           1
+;     cacef:                1
+;     sub_cad07:            1
+;     cad0d:                1
+;     cad14:                1
+;     cad19:                1
+;     sub_cad1c:            1
+;     cad37:                1
+;     loop_cad43:           1
+;     cad52:                1
+;     cad53:                1
+;     loop_cad5d:           1
+;     loop_cad5e:           1
+;     cad75:                1
+;     sub_cad8e:            1
+;     cad91:                1
+;     cad9c:                1
+;     cadac:                1
+;     cadb6:                1
+;     cadbc:                1
+;     sub_cadc6:            1
+;     loop_cade0:           1
+;     cade4:                1
+;     cadf9:                1
+;     loop_cadfe:           1
+;     cae00:                1
+;     cae0d:                1
+;     cae11:                1
+;     loop_cae1e:           1
+;     cae31:                1
+;     cae3f:                1
+;     cae9f:                1
+;     caedc:                1
+;     loop_caeed:           1
+;     caf2f:                1
+;     caf3d:                1
+;     caf4d:                1
+;     loop_caf51:           1
+;     caf6d:                1
+;     caf83:                1
+;     loop_cafa2:           1
+;     loop_cafa4:           1
+;     cafbb:                1
+;     cafbe:                1
+;     loop_cafc1:           1
+;     cafd5:                1
+;     loop_cafe3:           1
+;     caffd:                1
+;     cb00e:                1
+;     loop_cb019:           1
+;     cb04a:                1
+;     loop_cb066:           1
+;     cb08a:                1
+;     cb0a6:                1
+;     cb0b0:                1
+;     cb0be:                1
+;     loop_cb0d8:           1
+;     cb0e2:                1
+;     loop_cb0f2:           1
+;     cb106:                1
+;     loop_cb146:           1
+;     cb1a3:                1
+;     cb1a6:                1
+;     cb1ab:                1
+;     cb1b5:                1
+;     cb1ca:                1
+;     cb200:                1
+;     cb22d:                1
+;     cb230:                1
+;     cb235:                1
+;     loop_cb24d:           1
+;     cb256:                1
+;     cb257:                1
+;     loop_cb259:           1
+;     cb266:                1
+;     loop_cb307:           1
+;     loop_cb32b:           1
+;     cb34c:                1
+;     cb35c:                1
+;     loop_cb35f:           1
+;     cb380:                1
+;     cb398:                1
+;     cb399:                1
+;     lb3be:                1
+;     cb3cf:                1
+;     cb3f4:                1
+;     cb3fe:                1
+;     cb425:                1
+;     cb428:                1
+;     cb42b:                1
+;     cb445:                1
+;     cb454:                1
+;     cb45d:                1
+;     cb46f:                1
+;     cb47f:                1
+;     cb495:                1
+;     cb497:                1
+;     cb4a1:                1
+;     loop_cb4a9:           1
+;     cb4b8:                1
+;     cb4ba:                1
+;     cb4bc:                1
+;     cb4c2:                1
+;     cb4e0:                1
+;     loop_cb4f2:           1
+;     cb4f8:                1
+;     cb50a:                1
+;     cb510:                1
+;     cb516:                1
+;     cb51c:                1
+;     cb522:                1
+;     loop_cb52d:           1
+;     cb530:                1
+;     loop_cb536:           1
+;     cb5cd:                1
+;     cb5f1:                1
+;     cb622:                1
+;     cb626:                1
+;     cb635:                1
+;     loop_cb642:           1
+;     cb6a7:                1
+;     cb6bf:                1
+;     cb6d1:                1
+;     cb6f7:                1
+;     cb70c:                1
+;     cb723:                1
+;     loop_cb730:           1
+;     cb74a:                1
+;     cb75a:                1
+;     cb762:                1
+;     loop_cb769:           1
+;     loop_cb771:           1
+;     cb7ca:                1
+;     cb7d4:                1
+;     cb7da:                1
+;     cb7e6:                1
+;     cb7fa:                1
+;     loop_cb806:           1
+;     cb824:                1
+;     cb833:                1
+;     cb847:                1
+;     loop_cb84c:           1
+;     cb857:                1
+;     loop_cb86f:           1
+;     loop_cb872:           1
+;     cb874:                1
+;     cb877:                1
+;     loop_cb8ac:           1
+;     cb8b5:                1
+;     cb8ba:                1
+;     loop_cb8c2:           1
+;     cb8cc:                1
+;     loop_cb8ce:           1
+;     cb8da:                1
+;     cb8e2:                1
+;     cb8f2:                1
+;     loop_cb8ff:           1
+;     cb909:                1
+;     cb938:                1
+;     cb941:                1
+;     cb94f:                1
+;     loop_cb95a:           1
+;     cb965:                1
+;     cb968:                1
+;     loop_cb974:           1
+;     cb976:                1
+;     cb9ad:                1
+;     cb9bf:                1
+;     cb9cd:                1
+;     loop_cb9f6:           1
+;     loop_cba0a:           1
+;     cba21:                1
+;     cba2b:                1
+;     cba31:                1
+;     cba35:                1
+;     cba43:                1
+;     cba63:                1
+;     sub_cbaa0:            1
+;     cbaa6:                1
+;     cbae6:                1
+;     cbaf7:                1
+;     cbb03:                1
+;     cbb0c:                1
+;     cbb16:                1
+;     sub_cbb38:            1
+;     loop_cbb3c:           1
+;     cbb45:                1
+;     loop_cbb56:           1
+;     loop_cbb5d:           1
+;     cbb64:                1
+;     cbba6:                1
+;     cbbaf:                1
+;     cbbd0:                1
+;     loop_cbbd2:           1
+;     sub_cbbeb:            1
+;     loop_cbbed:           1
+;     loop_cbbf8:           1
+;     sub_cbc1e:            1
+;     sub_cbc20:            1
+;     loop_cbc9d:           1
+;     cbca5:                1
+;     sub_cbcaa:            1
+;     loop_cbcc5:           1
+;     cbccd:                1
+;     loop_cbcd1:           1
+;     cbcd5:                1
+;     loop_cbcdc:           1
+;     cbce6:                1
+;     cbcea:                1
+;     loop_cbd19:           1
+;     cbd23:                1
+;     cbd45:                1
+;     cbd64:                1
+;     cbd70:                1
+;     cbd71:                1
+;     loop_cbd88:           1
+;     cbd9e:                1
+;     loop_cbda0:           1
+;     cbdaa:                1
+;     sub_cbdb7:            1
+;     cbdbd:                1
+;     loop_cbdbf:           1
+;     cbdc9:                1
+;     cbde2:                1
+;     sub_cbdf4:            1
+;     loop_cbe2d:           1
+;     cbe43:                1
+;     sub_cbe44:            1
+;     cbe45:                1
+;     sub_cbe46:            1
+;     cbe4e:                1
+;     sub_cbe65:            1
+;     loop_cbe73:           1
+;     sub_cbe8b:            1
+;     lbecd:                1
+;     cbed3:                1
+;     cbed9:                1
+;     lbefe:                1
+;     cbf00:                1
+;     loop_cbf17:           1
+;     cbf1a:                1
+;     cbf54:                1
+;     loop_cbf56:           1
+;     sub_cbf66:            1
+;     lbf71:                1
+;     le09c:                1
+
+; Automatically generated labels:
+;     c8040
+;     c804c
+;     c805e
+;     c8067
+;     c806a
+;     c8070
+;     c808f
+;     c80a8
+;     c80cc
+;     c80ff
+;     c8151
+;     c815d
+;     c8168
+;     c817a
+;     c8187
+;     c8190
+;     c8197
+;     c81ad
+;     c81b9
+;     c81c8
+;     c81ea
+;     c81fd
+;     c820f
+;     c8210
+;     c8230
+;     c823f
+;     c8242
+;     c8246
+;     c825b
+;     c827c
+;     c828d
+;     c829a
+;     c82ae
+;     c82be
+;     c82c8
+;     c82d8
+;     c82dd
+;     c82f4
+;     c82fb
+;     c8304
+;     c8306
+;     c832f
+;     c833b
+;     c8345
+;     c8346
+;     c8353
+;     c835e
+;     c8362
+;     c8371
+;     c8372
+;     c8392
+;     c83a6
+;     c83c1
+;     c83d2
+;     c83d5
+;     c840a
+;     c8456
+;     c846a
+;     c8491
+;     c84a3
+;     c84ad
+;     c84ce
+;     c84f4
+;     c89bf
+;     c89dd
+;     c89f4
+;     c8a0b
+;     c8a1e
+;     c8a28
+;     c8a34
+;     c8a44
+;     c8a4b
+;     c8a64
+;     c8a68
+;     c8a6b
+;     c8a79
+;     c8a8b
+;     c8a8e
+;     c8a91
+;     c8adf
+;     c8aef
+;     c8af2
+;     c8af5
+;     c8b10
+;     c8b1b
+;     c8b33
+;     c8b40
+;     c8b4b
+;     c8b55
+;     c8b5f
+;     c8b62
+;     c8b63
+;     c8b83
+;     c8b98
+;     c8b9b
+;     c8b9c
+;     c8ba3
+;     c8baf
+;     c8bb2
+;     c8bb4
+;     c8bb6
+;     c8bbd
+;     c8bc4
+;     c8bde
+;     c8be9
+;     c8bf9
+;     c8c01
+;     c8c1b
+;     c8c1e
+;     c8c24
+;     c8c31
+;     c8c41
+;     c8c43
+;     c8c55
+;     c8c57
+;     c8c5e
+;     c8c74
+;     c8c84
+;     c8c87
+;     c8c96
+;     c8c99
+;     c8ca4
+;     c8ca7
+;     c8cb8
+;     c8cbb
+;     c8cbd
+;     c8cc0
+;     c8ce3
+;     c8ce6
+;     c8cfd
+;     c8d16
+;     c8d34
+;     c8d37
+;     c8d44
+;     c8d64
+;     c8d6e
+;     c8d74
+;     c8dc9
+;     c8dfc
+;     c8dff
+;     c8e3f
+;     c8e51
+;     c8e57
+;     c8e6c
+;     c8e6f
+;     c8e7d
+;     c8e8d
+;     c8e9c
+;     c8e9d
+;     c8ea6
+;     c8eaa
+;     c8eb6
+;     c8ebe
+;     c8ed0
+;     c8edc
+;     c8ee7
+;     c8ef3
+;     c8f03
+;     c8f1a
+;     c8f25
+;     c8f26
+;     c8f32
+;     c8f3d
+;     c8f41
+;     c8f52
+;     c8f5d
+;     c8f6d
+;     c8f74
+;     c8f86
+;     c8f87
+;     c8f8c
+;     c8f92
+;     c8f9c
+;     c8f9d
+;     c8fbb
+;     c8fda
+;     c8ff2
+;     c901c
+;     c9033
+;     c9045
+;     c9048
+;     c904b
+;     c905c
+;     c9069
+;     c9073
+;     c907d
+;     c9082
+;     c9086
+;     c90a0
+;     c90b0
+;     c90c5
+;     c90c7
+;     c90ca
+;     c90d0
+;     c90d2
+;     c90de
+;     c90e3
+;     c90ea
+;     c9108
+;     c9112
+;     c9123
+;     c9135
+;     c9146
+;     c914f
+;     c9155
+;     c9164
+;     c9193
+;     c91ad
+;     c91d1
+;     c91ee
+;     c91ef
+;     c9201
+;     c9204
+;     c9207
+;     c922a
+;     c9237
+;     c924a
+;     c9259
+;     c926e
+;     c9274
+;     c9276
+;     c9285
+;     c9288
+;     c929e
+;     c92da
+;     c92ed
+;     c9304
+;     c931e
+;     c9321
+;     c9325
+;     c932a
+;     c932d
+;     c9338
+;     c9357
+;     c937c
+;     c938f
+;     c93b4
+;     c93c4
+;     c93d7
+;     c9433
+;     c9469
+;     c9476
+;     c947f
+;     c9487
+;     c94aa
+;     c94b0
+;     c94ba
+;     c94c8
+;     c94d1
+;     c94d5
+;     c94de
+;     c94e4
+;     c9509
+;     c950d
+;     c951d
+;     c951f
+;     c954b
+;     c9555
+;     c9579
+;     c957c
+;     c957f
+;     c95be
+;     c95e0
+;     c95f1
+;     c95f9
+;     c9606
+;     c9628
+;     c9632
+;     c9635
+;     c963b
+;     c964e
+;     c968d
+;     c96b8
+;     c96bf
+;     c96ca
+;     c9700
+;     c971b
+;     c972c
+;     c9735
+;     c9753
+;     c9784
+;     c979b
+;     c979c
+;     c97d2
+;     c97ee
+;     c97fe
+;     c9801
+;     c9808
+;     c9866
+;     c986a
+;     c9877
+;     c9889
+;     c98bd
+;     c98c0
+;     c98d7
+;     c98dc
+;     c990c
+;     c9928
+;     c9937
+;     c9962
+;     c996e
+;     c9977
+;     c9979
+;     c997a
+;     c9990
+;     c999f
+;     c99a0
+;     c99a2
+;     c99ab
+;     c99ba
+;     c99fa
+;     c9a0e
+;     c9a14
+;     c9a28
+;     c9a3a
+;     c9a46
+;     c9a58
+;     c9a63
+;     c9a67
+;     c9a75
+;     c9a76
+;     c9a79
+;     c9a7b
+;     c9a99
+;     c9aa0
+;     c9aa5
+;     c9abc
+;     c9ac1
+;     c9ae6
+;     c9b4c
+;     c9b5a
+;     c9b78
+;     c9b80
+;     c9b8a
+;     c9bae
+;     c9bbc
+;     c9bce
+;     c9bd2
+;     c9bda
+;     c9bdb
+;     c9c08
+;     c9c16
+;     c9c24
+;     c9c2d
+;     c9c3b
+;     c9c41
+;     c9c52
+;     c9c55
+;     c9c6a
+;     c9c6c
+;     c9c74
+;     c9c80
+;     c9c8a
+;     c9cb6
+;     c9cc1
+;     c9cc5
+;     c9cc6
+;     c9cd6
+;     c9ceb
+;     c9ced
+;     c9cfb
+;     c9d0c
+;     c9d29
+;     c9d43
+;     c9d57
+;     c9d75
+;     c9d79
+;     c9d7b
+;     c9d7c
+;     c9db4
+;     c9dba
+;     c9dbe
+;     c9dbf
+;     c9dc0
+;     c9dc1
+;     c9dc4
+;     c9dd5
+;     c9de5
+;     c9de9
+;     c9e02
+;     c9e10
+;     c9e2a
+;     c9e48
+;     c9e4d
+;     c9e78
+;     c9e79
+;     c9e83
+;     c9e85
+;     c9e90
+;     c9ea6
+;     c9ead
+;     c9eb2
+;     c9ec2
+;     c9ecb
+;     c9edd
+;     c9f0a
+;     c9f13
+;     c9f3b
+;     c9f4c
+;     c9f4f
+;     c9f55
+;     c9f64
+;     c9f70
+;     c9f9a
+;     c9f9d
+;     c9fa7
+;     c9fb6
+;     c9fb8
+;     c9fe6
+;     c9ff4
+;     ca00f
+;     ca029
+;     ca03b
+;     ca03c
+;     ca04a
+;     ca04d
+;     ca05b
+;     ca05f
+;     ca06f
+;     ca081
+;     ca09c
+;     ca09f
+;     ca0c5
+;     ca0c7
+;     ca0d1
+;     ca0ee
+;     ca10a
+;     ca116
+;     ca126
+;     ca131
+;     ca137
+;     ca158
+;     ca160
+;     ca169
+;     ca174
+;     ca18a
+;     ca197
+;     ca19b
+;     ca19d
+;     ca1af
+;     ca1bc
+;     ca1c1
+;     ca1cd
+;     ca1d0
+;     ca1d4
+;     ca1ed
+;     ca1ef
+;     ca204
+;     ca212
+;     ca21c
+;     ca220
+;     ca22a
+;     ca23e
+;     ca24a
+;     ca25f
+;     ca261
+;     ca26f
+;     ca28a
+;     ca28c
+;     ca290
+;     ca2a3
+;     ca2b3
+;     ca2b7
+;     ca2c9
+;     ca2cc
+;     ca2d6
+;     ca2fb
+;     ca2fd
+;     ca303
+;     ca325
+;     ca333
+;     ca33e
+;     ca342
+;     ca348
+;     ca34c
+;     ca357
+;     ca36b
+;     ca37e
+;     ca385
+;     ca393
+;     ca3a1
+;     ca3a7
+;     ca3aa
+;     ca3c3
+;     ca3e5
+;     ca3e9
+;     ca426
+;     ca42c
+;     ca446
+;     ca452
+;     ca47a
+;     ca489
+;     ca4a3
+;     ca4a9
+;     ca4b9
+;     ca4c4
+;     ca4ce
+;     ca4e8
+;     ca4f5
+;     ca513
+;     ca53b
+;     ca53e
+;     ca547
+;     ca57a
+;     ca57e
+;     ca5a7
+;     ca5aa
+;     ca5ba
+;     ca608
+;     ca612
+;     ca61d
+;     ca622
+;     ca634
+;     ca640
+;     ca653
+;     ca65c
+;     ca65e
+;     ca674
+;     ca676
+;     ca68d
+;     ca6a2
+;     ca6ae
+;     ca6c4
+;     ca6ce
+;     ca6e4
+;     ca6ed
+;     ca6f2
+;     ca704
+;     ca70a
+;     ca70f
+;     ca712
+;     ca71e
+;     ca725
+;     ca72b
+;     ca72f
+;     ca739
+;     ca73b
+;     ca73d
+;     ca74d
+;     ca76b
+;     ca776
+;     ca797
+;     ca79b
+;     ca7c0
+;     ca7cd
+;     ca7db
+;     ca7ed
+;     ca7ef
+;     ca805
+;     ca829
+;     ca838
+;     ca83f
+;     ca841
+;     ca857
+;     ca875
+;     ca878
+;     ca88a
+;     ca899
+;     ca8b0
+;     ca8bb
+;     ca8ee
+;     ca91f
+;     ca92d
+;     ca932
+;     ca93b
+;     ca946
+;     ca948
+;     ca94b
+;     ca959
+;     ca962
+;     ca965
+;     ca978
+;     ca9c1
+;     ca9e0
+;     ca9ef
+;     ca9f2
+;     ca9f8
+;     caa07
+;     caa2c
+;     caa33
+;     caa3e
+;     caa44
+;     caa66
+;     caa6b
+;     caa7a
+;     caa7d
+;     caa9a
+;     caab0
+;     caac1
+;     caae8
+;     cab1a
+;     cab23
+;     cab41
+;     cab82
+;     cab91
+;     cab9d
+;     cabc9
+;     cabd0
+;     cabdd
+;     cabfa
+;     cabfd
+;     cac02
+;     cac0f
+;     cac1c
+;     cac2b
+;     cac2d
+;     cac35
+;     cac38
+;     cac59
+;     cac5b
+;     caca0
+;     caca3
+;     caca9
+;     cacaf
+;     cacd2
+;     cace3
+;     cace8
+;     cacef
+;     cacfd
+;     cad0d
+;     cad10
+;     cad14
+;     cad19
+;     cad20
+;     cad37
+;     cad52
+;     cad53
+;     cad5b
+;     cad75
+;     cad78
+;     cad91
+;     cad9c
+;     cadac
+;     cadb6
+;     cadbc
+;     cadce
+;     cade4
+;     cadee
+;     cadf9
+;     cae00
+;     cae0d
+;     cae11
+;     cae31
+;     cae3f
+;     cae56
+;     cae60
+;     cae62
+;     cae9f
+;     caeb4
+;     caed7
+;     caed9
+;     caedb
+;     caedc
+;     caf03
+;     caf07
+;     caf2f
+;     caf3d
+;     caf4d
+;     caf6d
+;     caf83
+;     caf88
+;     cafb8
+;     cafbb
+;     cafbe
+;     cafd5
+;     cafdb
+;     cafee
+;     caffd
+;     cb00e
+;     cb04a
+;     cb08a
+;     cb0a6
+;     cb0b0
+;     cb0be
+;     cb0e2
+;     cb106
+;     cb109
+;     cb169
+;     cb17e
+;     cb1a3
+;     cb1a6
+;     cb1ab
+;     cb1b5
+;     cb1ca
+;     cb1db
+;     cb1de
+;     cb200
+;     cb205
+;     cb22d
+;     cb230
+;     cb235
+;     cb256
+;     cb257
+;     cb266
+;     cb341
+;     cb34c
+;     cb35c
+;     cb380
+;     cb398
+;     cb399
+;     cb39e
+;     cb3cf
+;     cb3f4
+;     cb3fb
+;     cb3fe
+;     cb425
+;     cb428
+;     cb42b
+;     cb445
+;     cb451
+;     cb454
+;     cb45d
+;     cb46f
+;     cb47f
+;     cb485
+;     cb495
+;     cb497
+;     cb4a1
+;     cb4a7
+;     cb4b8
+;     cb4ba
+;     cb4bc
+;     cb4c2
+;     cb4e0
+;     cb4e2
+;     cb4f8
+;     cb50a
+;     cb510
+;     cb516
+;     cb51c
+;     cb522
+;     cb530
+;     cb54b
+;     cb563
+;     cb56a
+;     cb5cd
+;     cb5cf
+;     cb5df
+;     cb5f1
+;     cb622
+;     cb626
+;     cb629
+;     cb635
+;     cb6a7
+;     cb6bf
+;     cb6d1
+;     cb6f7
+;     cb70c
+;     cb723
+;     cb74a
+;     cb753
+;     cb75a
+;     cb762
+;     cb7a4
+;     cb7b3
+;     cb7ca
+;     cb7d4
+;     cb7da
+;     cb7e6
+;     cb7fa
+;     cb805
+;     cb81a
+;     cb824
+;     cb833
+;     cb847
+;     cb857
+;     cb866
+;     cb86c
+;     cb874
+;     cb877
+;     cb87f
+;     cb8b5
+;     cb8ba
+;     cb8cc
+;     cb8da
+;     cb8e2
+;     cb8f2
+;     cb8fa
+;     cb909
+;     cb938
+;     cb941
+;     cb94f
+;     cb965
+;     cb968
+;     cb976
+;     cb997
+;     cb9a5
+;     cb9ad
+;     cb9bf
+;     cb9cd
+;     cb9ff
+;     cba21
+;     cba2b
+;     cba31
+;     cba35
+;     cba43
+;     cba46
+;     cba63
+;     cbaa6
+;     cbac5
+;     cbae6
+;     cbae8
+;     cbaf7
+;     cbb03
+;     cbb0c
+;     cbb16
+;     cbb1a
+;     cbb45
+;     cbb64
+;     cbb9b
+;     cbba6
+;     cbbaf
+;     cbbd0
+;     cbc3a
+;     cbc66
+;     cbc91
+;     cbca5
+;     cbccd
+;     cbcd5
+;     cbce6
+;     cbcea
+;     cbd0e
+;     cbd21
+;     cbd23
+;     cbd3a
+;     cbd3d
+;     cbd45
+;     cbd64
+;     cbd70
+;     cbd71
+;     cbd74
+;     cbd86
+;     cbd9e
+;     cbdaa
+;     cbdbd
+;     cbdc9
+;     cbdd2
+;     cbdd4
+;     cbde2
+;     cbdff
+;     cbe05
+;     cbe43
+;     cbe45
+;     cbe4e
+;     cbe51
+;     cbed3
+;     cbed9
+;     cbeeb
+;     cbf00
+;     cbf1a
+;     cbf3d
+;     cbf54
+;     l0000
+;     l0001
+;     l0002
+;     l0003
+;     l0004
+;     l0005
+;     l0006
+;     l0007
+;     l0008
+;     l0009
+;     l000a
+;     l000b
+;     l000c
+;     l000d
+;     l000e
+;     l000f
+;     l0010
+;     l0011
+;     l0012
+;     l0013
+;     l0014
+;     l0015
+;     l0016
+;     l0017
+;     l0018
+;     l0019
+;     l001a
+;     l001b
+;     l001c
+;     l001d
+;     l001e
+;     l001f
+;     l0020
+;     l0021
+;     l0022
+;     l0023
+;     l0024
+;     l0025
+;     l0026
+;     l0027
+;     l0028
+;     l0029
+;     l002a
+;     l002b
+;     l002c
+;     l002d
+;     l002e
+;     l002f
+;     l0030
+;     l0031
+;     l0032
+;     l0033
+;     l0034
+;     l0035
+;     l0036
+;     l0037
+;     l0038
+;     l0039
+;     l003a
+;     l003b
+;     l003c
+;     l003d
+;     l003e
+;     l003f
+;     l0040
+;     l0041
+;     l0042
+;     l0043
+;     l0044
+;     l0045
+;     l0046
+;     l0047
+;     l0048
+;     l0049
+;     l004a
+;     l004b
+;     l004c
+;     l004d
+;     l004e
+;     l0061
+;     l0064
+;     l0066
+;     l00c1
+;     l00e1
+;     l00e6
+;     l00fd
+;     l00fe
+;     l00ff
+;     l0100
+;     l0106
+;     l01ff
+;     l0400
+;     l0401
+;     l0402
+;     l0403
+;     l0404
+;     l040c
+;     l043c
+;     l043d
+;     l0440
+;     l0441
+;     l0460
+;     l0464
+;     l0469
+;     l046c
+;     l047f
+;     l04ff
+;     l0500
+;     l0513
+;     l0514
+;     l0519
+;     l051a
+;     l051b
+;     l051c
+;     l051d
+;     l051e
+;     l051f
+;     l0521
+;     l0522
+;     l0523
+;     l0524
+;     l0526
+;     l0527
+;     l0528
+;     l0529
+;     l052a
+;     l05cb
+;     l05cc
+;     l05e5
+;     l05e6
+;     l05ff
+;     l0600
+;     l0700
+;     l07ef
+;     l0bb1
+;     l0e4e
+;     l4e4e
+;     l5252
+;     l6142
+;     l7461
+;     l7f0e
+;     l7f13
+;     l80c2
+;     l80dd
+;     l80e2
+;     l880a
+;     l8826
+;     l8909
+;     l894e
+;     l8993
+;     la7c9
+;     lb3be
+;     lbecd
+;     lbefe
+;     lbf71
+;     le09c
+;     loop_c8057
+;     loop_c8091
+;     loop_c8176
+;     loop_c819f
+;     loop_c81e1
+;     loop_c8206
+;     loop_c8235
+;     loop_c8252
+;     loop_c82b2
+;     loop_c82f7
+;     loop_c8314
+;     loop_c8331
+;     loop_c8365
+;     loop_c839e
+;     loop_c8428
+;     loop_c8440
+;     loop_c845b
+;     loop_c847b
+;     loop_c8496
+;     loop_c89d7
+;     loop_c8a11
+;     loop_c8a2a
+;     loop_c8a3c
+;     loop_c8a4f
+;     loop_c8a54
+;     loop_c8a5e
+;     loop_c8a6e
+;     loop_c8ac3
+;     loop_c8ad4
+;     loop_c8ae3
+;     loop_c8b9e
+;     loop_c8c15
+;     loop_c8c9b
+;     loop_c8d71
+;     loop_c8db7
+;     loop_c8e16
+;     loop_c8e91
+;     loop_c8ee2
+;     loop_c8f0b
+;     loop_c8f7a
+;     loop_c8fa7
+;     loop_c9004
+;     loop_c9024
+;     loop_c9078
+;     loop_c90a6
+;     loop_c90ad
+;     loop_c91e4
+;     loop_c91f6
+;     loop_c9220
+;     loop_c922c
+;     loop_c923f
+;     loop_c9260
+;     loop_c9268
+;     loop_c928b
+;     loop_c92d4
+;     loop_c92e0
+;     loop_c92f0
+;     loop_c9355
+;     loop_c9356
+;     loop_c9368
+;     loop_c93fa
+;     loop_c9455
+;     loop_c948a
+;     loop_c95cf
+;     loop_c9724
+;     loop_c9728
+;     loop_c9750
+;     loop_c97c0
+;     loop_c97c6
+;     loop_c98cb
+;     loop_c98df
+;     loop_c9904
+;     loop_c992a
+;     loop_c9948
+;     loop_c9954
+;     loop_c99cf
+;     loop_c9ab6
+;     loop_c9be0
+;     loop_c9c6d
+;     loop_c9c92
+;     loop_c9cc9
+;     loop_c9ce8
+;     loop_c9cfd
+;     loop_c9dd7
+;     loop_c9e18
+;     loop_c9e23
+;     loop_c9e32
+;     loop_c9e5b
+;     loop_c9ef2
+;     loop_c9f59
+;     loop_c9f61
+;     loop_c9faa
+;     loop_c9fbb
+;     loop_ca052
+;     loop_ca070
+;     loop_ca0b8
+;     loop_ca0f2
+;     loop_ca0f5
+;     loop_ca10f
+;     loop_ca13b
+;     loop_ca151
+;     loop_ca207
+;     loop_ca256
+;     loop_ca263
+;     loop_ca27d
+;     loop_ca2bb
+;     loop_ca399
+;     loop_ca3ae
+;     loop_ca5b6
+;     loop_ca607
+;     loop_ca617
+;     loop_ca62c
+;     loop_ca6a8
+;     loop_ca758
+;     loop_ca88f
+;     loop_ca8cd
+;     loop_ca8e0
+;     loop_ca969
+;     loop_ca982
+;     loop_ca9f5
+;     loop_caa59
+;     loop_caaf0
+;     loop_cac3c
+;     loop_cacd8
+;     loop_cace5
+;     loop_caceb
+;     loop_cad43
+;     loop_cad5d
+;     loop_cad5e
+;     loop_cade0
+;     loop_cadfe
+;     loop_cae1e
+;     loop_caeed
+;     loop_caf51
+;     loop_cafa2
+;     loop_cafa4
+;     loop_cafc1
+;     loop_cafe3
+;     loop_cb019
+;     loop_cb066
+;     loop_cb0d8
+;     loop_cb0f2
+;     loop_cb146
+;     loop_cb24d
+;     loop_cb259
+;     loop_cb307
+;     loop_cb32b
+;     loop_cb35f
+;     loop_cb4a9
+;     loop_cb4f2
+;     loop_cb52d
+;     loop_cb536
+;     loop_cb642
+;     loop_cb730
+;     loop_cb769
+;     loop_cb771
+;     loop_cb806
+;     loop_cb84c
+;     loop_cb86f
+;     loop_cb872
+;     loop_cb8ac
+;     loop_cb8c2
+;     loop_cb8ce
+;     loop_cb8ff
+;     loop_cb95a
+;     loop_cb974
+;     loop_cb9f6
+;     loop_cba0a
+;     loop_cbb3c
+;     loop_cbb56
+;     loop_cbb5d
+;     loop_cbbd2
+;     loop_cbbed
+;     loop_cbbf8
+;     loop_cbc9d
+;     loop_cbcc5
+;     loop_cbcd1
+;     loop_cbcdc
+;     loop_cbd19
+;     loop_cbd88
+;     loop_cbda0
+;     loop_cbdbf
+;     loop_cbe2d
+;     loop_cbe73
+;     loop_cbf17
+;     loop_cbf56
+;     sub_c80d8
+;     sub_c8139
+;     sub_c8149
+;     sub_c8191
+;     sub_c81bd
+;     sub_c8287
+;     sub_c828a
+;     sub_c82e6
+;     sub_c8349
+;     sub_c834b
+;     sub_c834f
+;     sub_c83aa
+;     sub_c83c2
+;     sub_c83d3
+;     sub_c8429
+;     sub_c8984
+;     sub_c8992
+;     sub_c8aa8
+;     sub_c8d86
+;     sub_c8d89
+;     sub_c8d8c
+;     sub_c8d94
+;     sub_c8d9c
+;     sub_c8da2
+;     sub_c8da8
+;     sub_c8dc1
+;     sub_c8e1f
+;     sub_c8e41
+;     sub_c8e58
+;     sub_c8e5f
+;     sub_c8e66
+;     sub_c8ea4
+;     sub_c8fa8
+;     sub_c8fae
+;     sub_c8fb4
+;     sub_c8fc0
+;     sub_c8fc5
+;     sub_c8fd7
+;     sub_c8fe5
+;     sub_c8fea
+;     sub_c9042
+;     sub_c910d
+;     sub_c9149
+;     sub_c916e
+;     sub_c9171
+;     sub_c9250
+;     sub_c9330
+;     sub_c9332
+;     sub_c933d
+;     sub_c935c
+;     sub_c9381
+;     sub_c93c7
+;     sub_c93da
+;     sub_c9410
+;     sub_c9436
+;     sub_c943e
+;     sub_c9447
+;     sub_c953d
+;     sub_c954c
+;     sub_c95c6
+;     sub_c95cb
+;     sub_c96d4
+;     sub_c96e5
+;     sub_c96f9
+;     sub_c9703
+;     sub_c970b
+;     sub_c973e
+;     sub_c9769
+;     sub_c976c
+;     sub_c9771
+;     sub_c9774
+;     sub_c9779
+;     sub_c977e
+;     sub_c9781
+;     sub_c9783
+;     sub_c9788
+;     sub_c978b
+;     sub_c979f
+;     sub_c97a2
+;     sub_c97a9
+;     sub_c9810
+;     sub_c9824
+;     sub_c982e
+;     sub_c9871
+;     sub_c9875
+;     sub_c9880
+;     sub_c98af
+;     sub_c98b6
+;     sub_c98c3
+;     sub_c990f
+;     sub_c9914
+;     sub_c9923
+;     sub_c9952
+;     sub_c995a
+;     sub_c997d
+;     sub_c99c4
+;     sub_c99d0
+;     sub_c99d6
+;     sub_c99d8
+;     sub_c9ac9
+;     sub_c9b97
+;     sub_c9bba
+;     sub_c9be2
+;     sub_c9bee
+;     sub_c9c0a
+;     sub_c9c4a
+;     sub_c9c5a
+;     sub_c9c5e
+;     sub_c9c8e
+;     sub_c9c93
+;     sub_c9ca2
+;     sub_c9cb8
+;     sub_c9ccc
+;     sub_c9d0f
+;     sub_c9d36
+;     sub_c9d7f
+;     sub_c9d81
+;     sub_c9d82
+;     sub_c9df3
+;     sub_c9dff
+;     sub_c9e3f
+;     sub_c9e45
+;     sub_c9e6d
+;     sub_c9f07
+;     sub_ca023
+;     sub_ca026
+;     sub_ca069
+;     sub_ca06c
+;     sub_ca0e8
+;     sub_ca0ec
+;     sub_ca181
+;     sub_ca2b8
+;     sub_ca2ca
+;     sub_ca2dd
+;     sub_ca3b5
+;     sub_ca3c0
+;     sub_ca3ed
+;     sub_ca40a
+;     sub_ca419
+;     sub_ca46b
+;     sub_ca4ba
+;     sub_ca503
+;     sub_ca507
+;     sub_ca50b
+;     sub_ca514
+;     sub_ca541
+;     sub_ca545
+;     sub_ca54d
+;     sub_ca56d
+;     sub_ca572
+;     sub_ca576
+;     sub_ca5ad
+;     sub_ca5b2
+;     sub_ca5b4
+;     sub_ca5bb
+;     sub_ca5bd
+;     sub_ca5c1
+;     sub_ca5c4
+;     sub_ca5cc
+;     sub_ca5cf
+;     sub_ca5d1
+;     sub_ca5e3
+;     sub_ca5f2
+;     sub_ca5f4
+;     sub_ca5f9
+;     sub_ca62f
+;     sub_ca631
+;     sub_ca6cb
+;     sub_ca6eb
+;     sub_ca6fc
+;     sub_ca6ff
+;     sub_ca70d
+;     sub_ca731
+;     sub_ca73e
+;     sub_ca7ac
+;     sub_ca7af
+;     sub_ca808
+;     sub_ca80b
+;     sub_ca8b3
+;     sub_ca8b9
+;     sub_ca901
+;     sub_ca919
+;     sub_ca94f
+;     sub_ca954
+;     sub_ca96b
+;     sub_ca97b
+;     sub_ca9a3
+;     sub_ca9b5
+;     sub_ca9bc
+;     sub_ca9c3
+;     sub_ca9ca
+;     sub_ca9d1
+;     sub_caa17
+;     sub_caa1a
+;     sub_caa50
+;     sub_caa55
+;     sub_caa6e
+;     sub_caacb
+;     sub_caad8
+;     sub_caaeb
+;     sub_caafb
+;     sub_cab01
+;     sub_cab14
+;     sub_cab1d
+;     sub_cab21
+;     sub_cab2f
+;     sub_cab37
+;     sub_cab3b
+;     sub_cab3f
+;     sub_cab54
+;     sub_cab5c
+;     sub_caba0
+;     sub_caba5
+;     sub_cabe1
+;     sub_cac03
+;     sub_cac12
+;     sub_cac1f
+;     sub_cac46
+;     sub_cac5d
+;     sub_cac7f
+;     sub_cad00
+;     sub_cad07
+;     sub_cad1c
+;     sub_cad3a
+;     sub_cad8e
+;     sub_cadc6
+;     sub_cae34
+;     sub_cae41
+;     sub_cae50
+;     sub_cae59
+;     sub_cae6d
+;     sub_cae71
+;     sub_cae77
+;     sub_cae7d
+;     sub_cae83
+;     sub_cae87
+;     sub_cae8c
+;     sub_caeb1
+;     sub_caebb
+;     sub_caebc
+;     sub_caefb
+;     sub_caf0a
+;     sub_caf61
+;     sub_caf8b
+;     sub_cb055
+;     sub_cb057
+;     sub_cb1bf
+;     sub_cb269
+;     sub_cb2e0
+;     sub_cb302
+;     sub_cb326
+;     sub_cb351
+;     sub_cb362
+;     sub_cb365
+;     sub_cb372
+;     sub_cb3c8
+;     sub_cb412
+;     sub_cb649
+;     sub_cb709
+;     sub_cb737
+;     sub_cb74d
+;     sub_cb78b
+;     sub_cb84d
+;     sub_cb85a
+;     sub_cb896
+;     sub_cb8e6
+;     sub_cb97d
+;     sub_cb9dc
+;     sub_cba47
+;     sub_cba6c
+;     sub_cba6e
+;     sub_cba7a
+;     sub_cba88
+;     sub_cbaa0
+;     sub_cbaa4
+;     sub_cbac2
+;     sub_cbac8
+;     sub_cbb0f
+;     sub_cbb1b
+;     sub_cbb38
+;     sub_cbbdc
+;     sub_cbbeb
+;     sub_cbbff
+;     sub_cbc18
+;     sub_cbc1e
+;     sub_cbc20
+;     sub_cbc24
+;     sub_cbc36
+;     sub_cbc62
+;     sub_cbc83
+;     sub_cbcaa
+;     sub_cbd12
+;     sub_cbd26
+;     sub_cbd46
+;     sub_cbd48
+;     sub_cbd5e
+;     sub_cbd77
+;     sub_cbdac
+;     sub_cbdb7
+;     sub_cbdcf
+;     sub_cbdd8
+;     sub_cbdf3
+;     sub_cbdf4
+;     sub_cbe06
+;     sub_cbe17
+;     sub_cbe25
+;     sub_cbe44
+;     sub_cbe46
+;     sub_cbe65
+;     sub_cbe6b
+;     sub_cbe76
+;     sub_cbe81
+;     sub_cbe8b
+;     sub_cbe95
+;     sub_cbec7
+;     sub_cbecc
+;     sub_cbed7
+;     sub_cbeee
+;     sub_cbefd
+;     sub_cbf0f
+;     sub_cbf22
+;     sub_cbf2f
+;     sub_cbf3e
+;     sub_cbf66
+    assert <(l002a) == &2a
+    assert <(l002a) == &2a
+    assert <(l002a) == &2a
+    assert <(l0037) == &37
+    assert <(l0037) == &37
+    assert <(l0037) == &37
+    assert <(l0600) == &00
+    assert <(l0600) == &00
+    assert <(l0600) == &00
+    assert >(l002a) == &00
+    assert >(l002a) == &00
+    assert >(l002a) == &00
+    assert >(l0037) == &00
+    assert >(l0037) == &00
+    assert >(l0600) == &06
+    assert >(l0600) == &06
+    assert >(l0600) == &06
+    assert c9073 == &9073
+    assert c9073 == &9073
+    assert c9073 == &9073
+    assert c95f9 == &95f9
+    assert c97d2 == &97d2
+    assert c98dc == &98dc
+    assert cac2b == &ac2b
+    assert cac38 == &ac38
+    assert cb522 == &b522
+    assert cb9ad == &b9ad
+    assert copyright - rom_header == &13
+    assert osbyte_check_eof == &7f
+    assert osbyte_enter_language == &8e
+    assert osbyte_inkey == &81
+    assert osbyte_read_adc_or_get_buffer_status == &80
+    assert osbyte_read_high_order_address == &82
+    assert osbyte_read_himem == &84
+    assert osbyte_read_himem_for_mode == &85
+    assert osbyte_read_text_cursor_pos == &86
+    assert osbyte_read_tube_presence == &ea
+    assert osbyte_read_write_basic_rom_bank == &bb
+    assert osfile_load == &ff
+    assert osfile_save == &00
+    assert osword_read_clock == &01
+    assert osword_read_cmos_clock == &0e
+    assert osword_read_io_memory == &05
+    assert osword_read_pixel == &09
+    assert sub_c834b == &834b
+    assert sub_c8984 == &8984
+    assert sub_c8fc0 == &8fc0
+    assert sub_c8fc5 == &8fc5
+    assert sub_c8fd7 == &8fd7
+    assert sub_c8fe5 == &8fe5
+    assert sub_c8fea == &8fea
+    assert sub_c9042 == &9042
+    assert sub_c910d == &910d
+    assert sub_c9149 == &9149
+    assert sub_c9250 == &9250
+    assert sub_c9381 == &9381
+    assert sub_c93da == &93da
+    assert sub_c9447 == &9447
+    assert sub_c954c == &954c
+    assert sub_c96d4 == &96d4
+    assert sub_c96e5 == &96e5
+    assert sub_c96f9 == &96f9
+    assert sub_c9703 == &9703
+    assert sub_c970b == &970b
+    assert sub_c973e == &973e
+    assert sub_c97a9 == &97a9
+    assert sub_c9810 == &9810
+    assert sub_c9824 == &9824
+    assert sub_c982e == &982e
+    assert sub_c9871 == &9871
+    assert sub_c9875 == &9875
+    assert sub_c9880 == &9880
+    assert sub_c98af == &98af
+    assert sub_c98b6 == &98b6
+    assert sub_c98c3 == &98c3
+    assert sub_c9c5e == &9c5e
+    assert sub_c9ccc == &9ccc
+    assert sub_ca6fc == &a6fc
+    assert sub_ca7ac == &a7ac
+    assert sub_ca808 == &a808
+    assert sub_ca901 == &a901
+    assert sub_ca919 == &a919
+    assert sub_ca94f == &a94f
+    assert sub_ca954 == &a954
+    assert sub_ca96b == &a96b
+    assert sub_ca9b5 == &a9b5
+    assert sub_ca9bc == &a9bc
+    assert sub_ca9ca == &a9ca
+    assert sub_caa17 == &aa17
+    assert sub_caacb == &aacb
+    assert sub_caaeb == &aaeb
+    assert sub_caafb == &aafb
+    assert sub_cab01 == &ab01
+    assert sub_cab14 == &ab14
+    assert sub_cab1d == &ab1d
+    assert sub_cab21 == &ab21
+    assert sub_cab2f == &ab2f
+    assert sub_cab37 == &ab37
+    assert sub_cab3b == &ab3b
+    assert sub_cab3f == &ab3f
+    assert sub_cab54 == &ab54
+    assert sub_cab5c == &ab5c
+    assert sub_caba0 == &aba0
+    assert sub_cabe1 == &abe1
+    assert sub_cac03 == &ac03
+    assert sub_cac12 == &ac12
+    assert sub_cac1f == &ac1f
+    assert sub_cac46 == &ac46
+    assert sub_cac5d == &ac5d
+    assert sub_cac7f == &ac7f
+    assert sub_cad00 == &ad00
+    assert sub_cae34 == &ae34
+    assert sub_cae41 == &ae41
+    assert sub_cae50 == &ae50
+    assert sub_cae59 == &ae59
+    assert sub_cae6d == &ae6d
+    assert sub_cae71 == &ae71
+    assert sub_cae77 == &ae77
+    assert sub_cae7d == &ae7d
+    assert sub_cae83 == &ae83
+    assert sub_cae87 == &ae87
+    assert sub_cae8c == &ae8c
+    assert sub_caeb1 == &aeb1
+    assert sub_caebb == &aebb
+    assert sub_caebc == &aebc
+    assert sub_caefb == &aefb
+    assert sub_caf0a == &af0a
+    assert sub_caf61 == &af61
+    assert sub_caf8b == &af8b
+    assert sub_cb055 == &b055
+    assert sub_cb269 == &b269
+    assert sub_cb302 == &b302
+    assert sub_cb326 == &b326
+    assert sub_cb351 == &b351
+    assert sub_cb3c8 == &b3c8
+    assert sub_cb412 == &b412
+    assert sub_cb649 == &b649
+    assert sub_cb709 == &b709
+    assert sub_cb737 == &b737
+    assert sub_cb74d == &b74d
+    assert sub_cb78b == &b78b
+    assert sub_cb896 == &b896
+    assert sub_cb8e6 == &b8e6
+    assert sub_cb97d == &b97d
+    assert sub_cba47 == &ba47
+    assert sub_cba88 == &ba88
+    assert sub_cbe95 == &be95
+    assert sub_cbec7 == &bec7
+    assert sub_cbed7 == &bed7
+    assert sub_cbeee == &beee
+    assert sub_cbefd == &befd
+
+save pydis_start, pydis_end

--- a/examples/known_good/basic4_xa.asm
+++ b/examples/known_good/basic4_xa.asm
@@ -1,0 +1,13894 @@
+// Constants
+osbyte_check_eof                       = 127
+osbyte_enter_language                  = 142
+osbyte_inkey                           = 129
+osbyte_read_adc_or_get_buffer_status   = 128
+osbyte_read_high_order_address         = 130
+osbyte_read_himem                      = 132
+osbyte_read_himem_for_mode             = 133
+osbyte_read_text_cursor_pos            = 134
+osbyte_read_tube_presence              = 234
+osbyte_read_write_basic_rom_bank       = 187
+osfile_load                            = 255
+osfile_save                            = 0
+osword_read_clock                      = 1
+osword_read_cmos_clock                 = 14
+osword_read_io_memory                  = 5
+osword_read_pixel                      = 9
+
+// Memory locations
+l0000       = $0000
+l0001       = $0001
+l0002       = $0002
+l0003       = $0003
+l0004       = $0004
+l0005       = $0005
+l0006       = $0006
+l0007       = $0007
+l0008       = $0008
+l0009       = $0009
+l000a       = $000a
+l000b       = $000b
+l000c       = $000c
+l000d       = $000d
+l000e       = $000e
+l000f       = $000f
+l0010       = $0010
+l0011       = $0011
+l0012       = $0012
+l0013       = $0013
+l0014       = $0014
+l0015       = $0015
+l0016       = $0016
+l0017       = $0017
+l0018       = $0018
+l0019       = $0019
+l001a       = $001a
+l001b       = $001b
+l001c       = $001c
+l001d       = $001d
+l001e       = $001e
+l001f       = $001f
+l0020       = $0020
+l0021       = $0021
+l0022       = $0022
+l0023       = $0023
+l0024       = $0024
+l0025       = $0025
+l0026       = $0026
+l0027       = $0027
+l0028       = $0028
+l0029       = $0029
+l002a       = $002a
+l002b       = $002b
+l002c       = $002c
+l002d       = $002d
+l002e       = $002e
+l002f       = $002f
+l0030       = $0030
+l0031       = $0031
+l0032       = $0032
+l0033       = $0033
+l0034       = $0034
+l0035       = $0035
+l0036       = $0036
+l0037       = $0037
+l0038       = $0038
+l0039       = $0039
+l003a       = $003a
+l003b       = $003b
+l003c       = $003c
+l003d       = $003d
+l003e       = $003e
+l003f       = $003f
+l0040       = $0040
+l0041       = $0041
+l0042       = $0042
+l0043       = $0043
+l0044       = $0044
+l0045       = $0045
+l0046       = $0046
+l0047       = $0047
+l0048       = $0048
+l0049       = $0049
+l004a       = $004a
+l004b       = $004b
+l004c       = $004c
+l004d       = $004d
+l004e       = $004e
+l0061       = $0061
+l0064       = $0064
+l0066       = $0066
+l00c1       = $00c1
+l00e1       = $00e1
+l00e6       = $00e6
+os_text_ptr = $00f2
+romsel_copy = $00f4
+l00fd       = $00fd
+l00fe       = $00fe
+l00ff       = $00ff
+l0100       = $0100
+l0106       = $0106
+l01ff       = $01ff
+brkv        = $0202
+wrchv       = $020e
+l0400       = $0400
+l0401       = $0401
+l0402       = $0402
+l0403       = $0403
+l0404       = $0404
+l040c       = $040c
+l043c       = $043c
+l043d       = $043d
+l0440       = $0440
+l0441       = $0441
+l0460       = $0460
+l0464       = $0464
+l0469       = $0469
+l046c       = $046c
+l047f       = $047f
+l04ff       = $04ff
+l0500       = $0500
+l0513       = $0513
+l0514       = $0514
+l0519       = $0519
+l051a       = $051a
+l051b       = $051b
+l051c       = $051c
+l051d       = $051d
+l051e       = $051e
+l051f       = $051f
+l0521       = $0521
+l0522       = $0522
+l0523       = $0523
+l0524       = $0524
+l0526       = $0526
+l0527       = $0527
+l0528       = $0528
+l0529       = $0529
+l052a       = $052a
+l05cb       = $05cb
+l05cc       = $05cc
+l05e5       = $05e5
+l05e6       = $05e6
+l05ff       = $05ff
+l0600       = $0600
+l0700       = $0700
+l07ef       = $07ef
+l0bb1       = $0bb1
+l0e4e       = $0e4e
+l4e4e       = $4e4e
+l5252       = $5252
+l6142       = $6142
+l7461       = $7461
+l7f0e       = $7f0e
+l7f13       = $7f13
+le09c       = $e09c
+osfind      = $ffce
+osbput      = $ffd4
+osbget      = $ffd7
+osargs      = $ffda
+osfile      = $ffdd
+osrdch      = $ffe0
+osasci      = $ffe3
+osnewl      = $ffe7
+oswrch      = $ffee
+osword      = $fff1
+osbyte      = $fff4
+oscli       = $fff7
+
+    * = $8000
+
+// Sideways ROM header
+rom_header
+language_entry
+pydis_start
+    jmp language_handler                                              // 8000: 4c e7 80    L..
+
+service_entry
+    jmp service_handler                                               // 8003: 4c 2c 80    L,.
+
+rom_type
+    .byt $e2                                                          // 8006: e2          .
+copyright_offset
+    .byt copyright - rom_header                                       // 8007: 13          .
+binary_version
+    .byt 7                                                            // 8008: 07          .
+title
+    .asc "BASIC"                                                      // 8009: 42 41 53... BAS
+version
+    .byt 0                                                            // 800e: 00          .
+    .asc "4r32"                                                       // 800f: 34 72 33... 4r3
+copyright
+    .byt 0                                                            // 8013: 00          .
+    .asc "(C)1988 Acorn", $0a, $0d, 0                                 // 8014: 28 43 29... (C)
+    .byt   0, $b8, $28, $80,   0, $c0, $82,   0                       // 8024: 00 b8 28... ..(
+
+// $802c referenced 1 time by $8003
+service_handler
+    pha                                                               // 802c: 48          H
+    tax                                                               // 802d: aa          .
+    tya                                                               // 802e: 98          .
+    pha                                                               // 802f: 48          H
+    cpx #9                                                            // 8030: e0 09       ..
+    beq c804c                                                         // 8032: f0 18       ..
+    cpx #4                                                            // 8034: e0 04       ..
+    beq c8070                                                         // 8036: f0 38       .8
+    cpx #2                                                            // 8038: e0 02       ..
+    beq c8040                                                         // 803a: f0 04       ..
+    cpx #$27 // '''                                                   // 803c: e0 27       .'
+    bne c806a                                                         // 803e: d0 2a       .*
+// $8040 referenced 1 time by $803a
+c8040
+    lda #osbyte_read_write_basic_rom_bank                             // 8040: a9 bb       ..
+    ldx romsel_copy                                                   // 8042: a6 f4       ..
+    ldy #0                                                            // 8044: a0 00       ..
+    jsr osbyte                                                        // 8046: 20 f4 ff     ..
+    jmp c806a                                                         // 8049: 4c 6a 80    Lj.
+
+// $804c referenced 1 time by $8032
+c804c
+    lda (os_text_ptr),y                                               // 804c: b1 f2       ..
+    cmp #$0d                                                          // 804e: c9 0d       ..
+    bne c806a                                                         // 8050: d0 18       ..
+    jsr osnewl                                                        // 8052: 20 e7 ff     ..
+    ldx #$f6                                                          // 8055: a2 f6       ..
+// $8057 referenced 1 time by $8062
+loop_c8057
+    lda l7f13,x                                                       // 8057: bd 13 7f    ...
+    bne c805e                                                         // 805a: d0 02       ..
+    lda #$20 // ' '                                                   // 805c: a9 20       .
+// $805e referenced 1 time by $805a
+c805e
+    jsr osasci                                                        // 805e: 20 e3 ff     ..
+    inx                                                               // 8061: e8          .
+    bne loop_c8057                                                    // 8062: d0 f3       ..
+    jsr osnewl                                                        // 8064: 20 e7 ff     ..
+// $8067 referenced 2 times by $809c, $80a6
+c8067
+    jsr sub_c80d8                                                     // 8067: 20 d8 80     ..
+// $806a referenced 3 times by $803e, $8049, $8050
+c806a
+    pla                                                               // 806a: 68          h
+    tay                                                               // 806b: a8          .
+    ldx romsel_copy                                                   // 806c: a6 f4       ..
+    pla                                                               // 806e: 68          h
+    rts                                                               // 806f: 60          `
+
+// $8070 referenced 1 time by $8036
+c8070
+    lda (os_text_ptr),y                                               // 8070: b1 f2       ..
+    and #$df                                                          // 8072: 29 df       ).
+    cmp #$48 // 'H'                                                   // 8074: c9 48       .H
+    bne c808f                                                         // 8076: d0 17       ..
+    iny                                                               // 8078: c8          .
+    lda #$40 // '@'                                                   // 8079: a9 40       .@
+    tsb romsel_copy                                                   // 807b: 04 f4       ..
+    lda (os_text_ptr),y                                               // 807d: b1 f2       ..
+    iny                                                               // 807f: c8          .
+    cmp #$2e // '.'                                                   // 8080: c9 2e       ..
+    beq c80a8                                                         // 8082: f0 24       .$
+    and #$df                                                          // 8084: 29 df       ).
+    cmp #$49 // 'I'                                                   // 8086: c9 49       .I
+    beq c808f                                                         // 8088: f0 05       ..
+    jsr sub_c80d8                                                     // 808a: 20 d8 80     ..
+    dey                                                               // 808d: 88          .
+    dey                                                               // 808e: 88          .
+// $808f referenced 2 times by $8076, $8088
+c808f
+    ldx #$fb                                                          // 808f: a2 fb       ..
+// $8091 referenced 1 time by $80a0
+loop_c8091
+    lda (os_text_ptr),y                                               // 8091: b1 f2       ..
+    cmp #$2e // '.'                                                   // 8093: c9 2e       ..
+    beq c80a8                                                         // 8095: f0 11       ..
+    and #$df                                                          // 8097: 29 df       ).
+    cmp l7f0e,x                                                       // 8099: dd 0e 7f    ...
+    bne c8067                                                         // 809c: d0 c9       ..
+    iny                                                               // 809e: c8          .
+    inx                                                               // 809f: e8          .
+    bne loop_c8091                                                    // 80a0: d0 ef       ..
+    lda (os_text_ptr),y                                               // 80a2: b1 f2       ..
+    cmp #$21 // '!'                                                   // 80a4: c9 21       .!
+    bcs c8067                                                         // 80a6: b0 bf       ..
+// $80a8 referenced 2 times by $8082, $8095
+c80a8
+    bit romsel_copy                                                   // 80a8: 24 f4       $.
+    bvc c80cc                                                         // 80aa: 50 20       P
+    jsr sub_cbf66                                                     // 80ac: 20 66 bf     f.
+    bne c80cc                                                         // 80af: d0 1b       ..
+    jsr sub_c80d8                                                     // 80b1: 20 d8 80     ..
+    ldx #$0a                                                          // 80b4: a2 0a       ..
+// $80b6 referenced 1 time by $80bd
+copy_to_stack_loop
+    lda l80c2,x                                                       // 80b6: bd c2 80    ...
+    sta l0100,x                                                       // 80b9: 9d 00 01    ...
+    dex                                                               // 80bc: ca          .
+    bpl copy_to_stack_loop                                            // 80bd: 10 f7       ..
+    jmp l0100                                                         // 80bf: 4c 00 01    L..
+
+// $80c2 referenced 1 time by $80b6
+l80c2
+    .byt 0, 0                                                         // 80c2: 00 00       ..
+    .asc "No TUBE"                                                    // 80c4: 4e 6f 20... No
+    .byt 0                                                            // 80cb: 00          .
+
+// $80cc referenced 2 times by $80aa, $80af
+c80cc
+    lda romsel_copy                                                   // 80cc: a5 f4       ..
+    eor #$40 // '@'                                                   // 80ce: 49 40       I@
+    tax                                                               // 80d0: aa          .
+    lda #osbyte_enter_language                                        // 80d1: a9 8e       ..
+    ldy #0                                                            // 80d3: a0 00       ..
+    jmp osbyte                                                        // 80d5: 4c f4 ff    L..
+
+// $80d8 referenced 3 times by $8067, $808a, $80b1
+sub_c80d8
+    lda #$40 // '@'                                                   // 80d8: a9 40       .@
+    trb romsel_copy                                                   // 80da: 14 f4       ..
+    rts                                                               // 80dc: 60          `
+
+// $80dd referenced 1 time by $a0fd
+l80dd
+    .byt   0,   0,   0,   3, $27                                      // 80dd: 00 00 00... ...
+// $80e2 referenced 1 time by $a0f7
+l80e2
+    .byt   1, $0a, $64, $e8, $10                                      // 80e2: 01 0a 64... ..d
+
+// $80e7 referenced 1 time by $8000
+language_handler
+    and l0011                                                         // 80e7: 25 11       %.
+    ora l000d                                                         // 80e9: 05 0d       ..
+    ora l000e                                                         // 80eb: 05 0e       ..
+    ora l000f                                                         // 80ed: 05 0f       ..
+    ora l0010                                                         // 80ef: 05 10       ..
+    bne c80ff                                                         // 80f1: d0 0c       ..
+    lda #$41 // 'A'                                                   // 80f3: a9 41       .A
+    sta l000d                                                         // 80f5: 85 0d       ..
+    eor #$13                                                          // 80f7: 49 13       I.
+    sta l000e                                                         // 80f9: 85 0e       ..
+    eor #5                                                            // 80fb: 49 05       I.
+    sta l000f                                                         // 80fd: 85 0f       ..
+// $80ff referenced 1 time by $80f1
+c80ff
+    lda #osbyte_read_himem                                            // 80ff: a9 84       ..
+    jsr osbyte                                                        // 8101: 20 f4 ff     ..
+    stx l0006                                                         // 8104: 86 06       ..
+    sty l0007                                                         // 8106: 84 07       ..
+    dec                                                               // 8108: 3a          :
+    jsr osbyte                                                        // 8109: 20 f4 ff     ..
+    sty l0018                                                         // 810c: 84 18       ..
+    ldx #$13                                                          // 810e: a2 13       ..
+    stx l00fd                                                         // 8110: 86 fd       ..
+    ldx #$80                                                          // 8112: a2 80       ..
+    stx l00fe                                                         // 8114: 86 fe       ..
+    stz l001f                                                         // 8116: 64 1f       d.
+    stz l0402                                                         // 8118: 9c 02 04    ...
+    stz l0403                                                         // 811b: 9c 03 04    ...
+    ldx #$ff                                                          // 811e: a2 ff       ..
+    stx l0023                                                         // 8120: 86 23       .#
+    ldx #$0a                                                          // 8122: a2 0a       ..
+    stx l0400                                                         // 8124: 8e 00 04    ...
+    dex                                                               // 8127: ca          .
+    stx l0401                                                         // 8128: 8e 01 04    ...
+    lda #$b2                                                          // 812b: a9 b2       ..
+    sta brkv                                                          // 812d: 8d 02 02    ...
+    lda #$b2                                                          // 8130: a9 b2       ..
+    sta brkv+1                                                        // 8132: 8d 03 02    ...
+    cli                                                               // 8135: 58          X
+    jmp c8ff2                                                         // 8136: 4c f2 8f    L..
+
+// $8139 referenced 1 time by $b09e
+sub_c8139
+    sty l0039                                                         // 8139: 84 39       .9
+    ldy #1                                                            // 813b: a0 01       ..
+    lda (l0037),y                                                     // 813d: b1 37       .7
+    ldy #$f6                                                          // 813f: a0 f6       ..
+    cmp #$f2                                                          // 8141: c9 f2       ..
+    beq c8151                                                         // 8143: f0 0c       ..
+    ldy #$f8                                                          // 8145: a0 f8       ..
+    bra c8151                                                         // 8147: 80 08       ..
+// $8149 referenced 4 times by $9638, $9a5c, $9aaf, $9acb
+sub_c8149
+    sty l0039                                                         // 8149: 84 39       .9
+    ldy #1                                                            // 814b: a0 01       ..
+    lda (l0037),y                                                     // 814d: b1 37       .7
+    asl                                                               // 814f: 0a          .
+    tay                                                               // 8150: a8          .
+// $8151 referenced 2 times by $8143, $8147
+c8151
+    lda l0401,y                                                       // 8151: b9 01 04    ...
+    beq c8190                                                         // 8154: f0 3a       .:
+    sta l002b                                                         // 8156: 85 2b       .+
+    lda l0400,y                                                       // 8158: b9 00 04    ...
+    bra c8168                                                         // 815b: 80 0b       ..
+// $815d referenced 4 times by $8172, $8178, $817c, $8185
+c815d
+    ldy #1                                                            // 815d: a0 01       ..
+    lda (l002a),y                                                     // 815f: b1 2a       .*
+    beq c8190                                                         // 8161: f0 2d       .-
+    tay                                                               // 8163: a8          .
+    lda (l002a)                                                       // 8164: b2 2a       .*
+    sty l002b                                                         // 8166: 84 2b       .+
+// $8168 referenced 1 time by $815b
+c8168
+    sta l002a                                                         // 8168: 85 2a       .*
+    ldy #2                                                            // 816a: a0 02       ..
+    lda (l002a),y                                                     // 816c: b1 2a       .*
+    bne c817a                                                         // 816e: d0 0a       ..
+    cpy l0039                                                         // 8170: c4 39       .9
+    bne c815d                                                         // 8172: d0 e9       ..
+    bra c8187                                                         // 8174: 80 11       ..
+// $8176 referenced 1 time by $8181
+loop_c8176
+    lda (l002a),y                                                     // 8176: b1 2a       .*
+    beq c815d                                                         // 8178: f0 e3       ..
+// $817a referenced 1 time by $816e
+c817a
+    cmp (l0037),y                                                     // 817a: d1 37       .7
+    bne c815d                                                         // 817c: d0 df       ..
+    iny                                                               // 817e: c8          .
+    cpy l0039                                                         // 817f: c4 39       .9
+    bne loop_c8176                                                    // 8181: d0 f3       ..
+    lda (l002a),y                                                     // 8183: b1 2a       .*
+    bne c815d                                                         // 8185: d0 d6       ..
+// $8187 referenced 1 time by $8174
+c8187
+    tya                                                               // 8187: 98          .
+    adc l002a                                                         // 8188: 65 2a       e*
+    sta l002a                                                         // 818a: 85 2a       .*
+    bcc c8190                                                         // 818c: 90 02       ..
+    inc l002b                                                         // 818e: e6 2b       .+
+// $8190 referenced 3 times by $8154, $8161, $818c
+c8190
+    rts                                                               // 8190: 60          `
+
+// $8191 referenced 3 times by $b435, $b866, $bac8
+sub_c8191
+    stz l003d                                                         // 8191: 64 3d       d=
+    lda l0018                                                         // 8193: a5 18       ..
+    sta l003e                                                         // 8195: 85 3e       .>
+// $8197 referenced 2 times by $81a7, $81ab
+c8197
+    ldy #1                                                            // 8197: a0 01       ..
+    lda (l003d),y                                                     // 8199: b1 3d       .=
+    cmp l002b                                                         // 819b: c5 2b       .+
+    bcs c81ad                                                         // 819d: b0 0e       ..
+// $819f referenced 1 time by $81b4
+loop_c819f
+    ldy #3                                                            // 819f: a0 03       ..
+    lda (l003d),y                                                     // 81a1: b1 3d       .=
+    adc l003d                                                         // 81a3: 65 3d       e=
+    sta l003d                                                         // 81a5: 85 3d       .=
+    bcc c8197                                                         // 81a7: 90 ee       ..
+    inc l003e                                                         // 81a9: e6 3e       .>
+    bra c8197                                                         // 81ab: 80 ea       ..
+// $81ad referenced 1 time by $819d
+c81ad
+    bne c81b9                                                         // 81ad: d0 0a       ..
+    iny                                                               // 81af: c8          .
+    lda (l003d),y                                                     // 81b0: b1 3d       .=
+    cmp l002a                                                         // 81b2: c5 2a       .*
+    bcc loop_c819f                                                    // 81b4: 90 e9       ..
+    bne c81b9                                                         // 81b6: d0 01       ..
+    rts                                                               // 81b8: 60          `
+
+// $81b9 referenced 2 times by $81ad, $81b6
+c81b9
+    ldy #2                                                            // 81b9: a0 02       ..
+    clc                                                               // 81bb: 18          .
+    rts                                                               // 81bc: 60          `
+
+// $81bd referenced 2 times by $a04a, $a05f
+sub_c81bd
+    jsr sub_c9783                                                     // 81bd: 20 83 97     ..
+    lda l002d                                                         // 81c0: a5 2d       .-
+    pha                                                               // 81c2: 48          H
+    bpl c81c8                                                         // 81c3: 10 03       ..
+    jsr cad20                                                         // 81c5: 20 20 ad      .
+// $81c8 referenced 1 time by $81c3
+c81c8
+    jsr sub_ca069                                                     // 81c8: 20 69 a0     i.
+    stx l0027                                                         // 81cb: 86 27       .'
+    jsr sub_c9783                                                     // 81cd: 20 83 97     ..
+    pla                                                               // 81d0: 68          h
+    sta l0038                                                         // 81d1: 85 38       .8
+    eor l002d                                                         // 81d3: 45 2d       E-
+    sta l0037                                                         // 81d5: 85 37       .7
+    jsr sub_cad07                                                     // 81d7: 20 07 ad     ..
+    ldx #$39 // '9'                                                   // 81da: a2 39       .9
+    jsr sub_cbd48                                                     // 81dc: 20 48 bd     H.
+    ldx #3                                                            // 81df: a2 03       ..
+// $81e1 referenced 1 time by $81e8
+loop_c81e1
+    stz l003d,x                                                       // 81e1: 74 3d       t=
+    lda l002a,x                                                       // 81e3: b5 2a       .*
+    bne c81fd                                                         // 81e5: d0 16       ..
+    dex                                                               // 81e7: ca          .
+    bpl loop_c81e1                                                    // 81e8: 10 f7       ..
+// $81ea referenced 1 time by $a62c
+c81ea
+    brk                                                               // 81ea: 00          .
+
+    .byt $12                                                          // 81eb: 12          .
+    .asc "Division by zero"                                           // 81ec: 44 69 76... Div
+    .byt 0                                                            // 81fc: 00          .
+
+// $81fd referenced 1 time by $81e5
+c81fd
+    rol                                                               // 81fd: 2a          *
+    txa                                                               // 81fe: 8a          .
+    tay                                                               // 81ff: a8          .
+    adc #0                                                            // 8200: 69 00       i.
+    sta l0042                                                         // 8202: 85 42       .B
+    ldx #3                                                            // 8204: a2 03       ..
+// $8206 referenced 1 time by $820d
+loop_c8206
+    lda l0039,x                                                       // 8206: b5 39       .9
+    stz l003d,x                                                       // 8208: 74 3d       t=
+    bne c8230                                                         // 820a: d0 24       .$
+    dex                                                               // 820c: ca          .
+    bpl loop_c8206                                                    // 820d: 10 f7       ..
+// $820f referenced 4 times by $8211, $8225, $822a, $822e
+c820f
+    rts                                                               // 820f: 60          `
+
+// $8210 referenced 1 time by $823d
+c8210
+    tya                                                               // 8210: 98          .
+    beq c820f                                                         // 8211: f0 fc       ..
+    lda l003d,y                                                       // 8213: b9 3d 00    .=.
+    sta l003d                                                         // 8216: 85 3d       .=
+    lda l003e,y                                                       // 8218: b9 3e 00    .>.
+    sta l003e                                                         // 821b: 85 3e       .>
+    lda l003f,y                                                       // 821d: b9 3f 00    .?.
+    sta l003f                                                         // 8220: 85 3f       .?
+    stz l0040                                                         // 8222: 64 40       d@
+    dey                                                               // 8224: 88          .
+    beq c820f                                                         // 8225: f0 e8       ..
+    stz l003f                                                         // 8227: 64 3f       d?
+    dey                                                               // 8229: 88          .
+    beq c820f                                                         // 822a: f0 e3       ..
+    stz l003e                                                         // 822c: 64 3e       d>
+    bra c820f                                                         // 822e: 80 df       ..
+// $8230 referenced 1 time by $820a
+c8230
+    cmp l002a,y                                                       // 8230: d9 2a 00    .*.
+    bcs c823f                                                         // 8233: b0 0a       ..
+// $8235 referenced 1 time by $8240
+loop_c8235
+    lda l0039,x                                                       // 8235: b5 39       .9
+    sta l003d,y                                                       // 8237: 99 3d 00    .=.
+    stz l0039,x                                                       // 823a: 74 39       t9
+    dex                                                               // 823c: ca          .
+    bmi c8210                                                         // 823d: 30 d1       0.
+// $823f referenced 1 time by $8233
+c823f
+    dey                                                               // 823f: 88          .
+    bpl loop_c8235                                                    // 8240: 10 f3       ..
+// $8242 referenced 1 time by $8284
+c8242
+    ldy #8                                                            // 8242: a0 08       ..
+    stx l0041                                                         // 8244: 86 41       .A
+// $8246 referenced 1 time by $827f
+c8246
+    rol l0039,x                                                       // 8246: 36 39       69
+    rol l003d                                                         // 8248: 26 3d       &=
+    rol l003e                                                         // 824a: 26 3e       &>
+    rol l003f                                                         // 824c: 26 3f       &?
+    rol l0040                                                         // 824e: 26 40       &@
+    ldx l0042                                                         // 8250: a6 42       .B
+// $8252 referenced 1 time by $8259
+loop_c8252
+    lda l003d,x                                                       // 8252: b5 3d       .=
+    cmp l002a,x                                                       // 8254: d5 2a       .*
+    bne c825b                                                         // 8256: d0 03       ..
+    dex                                                               // 8258: ca          .
+    bpl loop_c8252                                                    // 8259: 10 f7       ..
+// $825b referenced 1 time by $8256
+c825b
+    bcc c827c                                                         // 825b: 90 1f       ..
+    lda l003d                                                         // 825d: a5 3d       .=
+    sbc l002a                                                         // 825f: e5 2a       .*
+    sta l003d                                                         // 8261: 85 3d       .=
+    ldx l0042                                                         // 8263: a6 42       .B
+    beq c827c                                                         // 8265: f0 15       ..
+    lda l003e                                                         // 8267: a5 3e       .>
+    sbc l002b                                                         // 8269: e5 2b       .+
+    sta l003e                                                         // 826b: 85 3e       .>
+    dex                                                               // 826d: ca          .
+    beq c827c                                                         // 826e: f0 0c       ..
+    lda l003f                                                         // 8270: a5 3f       .?
+    sbc l002c                                                         // 8272: e5 2c       .,
+    sta l003f                                                         // 8274: 85 3f       .?
+    lda l0040                                                         // 8276: a5 40       .@
+    sbc l002d                                                         // 8278: e5 2d       .-
+    sta l0040                                                         // 827a: 85 40       .@
+// $827c referenced 3 times by $825b, $8265, $826e
+c827c
+    ldx l0041                                                         // 827c: a6 41       .A
+    dey                                                               // 827e: 88          .
+    bne c8246                                                         // 827f: d0 c5       ..
+    rol l0039,x                                                       // 8281: 36 39       69
+    dex                                                               // 8283: ca          .
+    bpl c8242                                                         // 8284: 10 bc       ..
+    rts                                                               // 8286: 60          `
+
+// $8287 referenced 2 times by $9f66, $9f9d
+sub_c8287
+    jsr sub_cbd26                                                     // 8287: 20 26 bd     &.
+// $828a referenced 2 times by $9d4e, $aab3
+sub_c828a
+    jsr sub_ca3ed                                                     // 828a: 20 ed a3     ..
+// $828d referenced 8 times by $97a6, $9f9a, $9fa7, $a09c, $a1ac, $a37e, $a99d, $b39b
+c828d
+    stz l0035                                                         // 828d: 64 35       d5
+    lda l002d                                                         // 828f: a5 2d       .-
+    sta l002e                                                         // 8291: 85 2e       ..
+    bpl c829a                                                         // 8293: 10 05       ..
+    jsr cad20                                                         // 8295: 20 20 ad      .
+    lda l002d                                                         // 8298: a5 2d       .-
+// $829a referenced 1 time by $8293
+c829a
+    bne c82c8                                                         // 829a: d0 2c       .,
+    stz l0034                                                         // 829c: 64 34       d4
+    ldy l002a                                                         // 829e: a4 2a       .*
+    lda l002c                                                         // 82a0: a5 2c       .,
+    bne c82be                                                         // 82a2: d0 1a       ..
+    stz l0033                                                         // 82a4: 64 33       d3
+    lda l002b                                                         // 82a6: a5 2b       .+
+    beq c82d8                                                         // 82a8: f0 2e       ..
+    sty l0032                                                         // 82aa: 84 32       .2
+    ldy #$90                                                          // 82ac: a0 90       ..
+// $82ae referenced 2 times by $82c6, $82d6
+c82ae
+    ora #0                                                            // 82ae: 09 00       ..
+    bmi c82fb                                                         // 82b0: 30 49       0I
+// $82b2 referenced 1 time by $82ba
+loop_c82b2
+    dey                                                               // 82b2: 88          .
+    asl l0034                                                         // 82b3: 06 34       .4
+    rol l0033                                                         // 82b5: 26 33       &3
+    rol l0032                                                         // 82b7: 26 32       &2
+    rol                                                               // 82b9: 2a          *
+    bpl loop_c82b2                                                    // 82ba: 10 f6       ..
+    bra c82fb                                                         // 82bc: 80 3d       .=
+// $82be referenced 1 time by $82a2
+c82be
+    sty l0033                                                         // 82be: 84 33       .3
+    ldy l002b                                                         // 82c0: a4 2b       .+
+    sty l0032                                                         // 82c2: 84 32       .2
+    ldy #$98                                                          // 82c4: a0 98       ..
+    bra c82ae                                                         // 82c6: 80 e6       ..
+// $82c8 referenced 1 time by $829a
+c82c8
+    ldy l002c                                                         // 82c8: a4 2c       .,
+    sty l0032                                                         // 82ca: 84 32       .2
+    ldy l002b                                                         // 82cc: a4 2b       .+
+    sty l0033                                                         // 82ce: 84 33       .3
+    ldy l002a                                                         // 82d0: a4 2a       .*
+    sty l0034                                                         // 82d2: 84 34       .4
+    ldy #$a0                                                          // 82d4: a0 a0       ..
+    bra c82ae                                                         // 82d6: 80 d6       ..
+// $82d8 referenced 1 time by $82a8
+c82d8
+    stz l0032                                                         // 82d8: 64 32       d2
+    tya                                                               // 82da: 98          .
+    bne c82f4                                                         // 82db: d0 17       ..
+// $82dd referenced 3 times by $82ed, $8310, $a2d9
+c82dd
+    stz l0031                                                         // 82dd: 64 31       d1
+    stz l002e                                                         // 82df: 64 2e       d.
+    stz l0030                                                         // 82e1: 64 30       d0
+    stz l002f                                                         // 82e3: 64 2f       d/
+    rts                                                               // 82e5: 60          `
+
+// $82e6 referenced 1 time by $a7f7
+sub_c82e6
+    sta l002e                                                         // 82e6: 85 2e       ..
+    jsr sub_ca731                                                     // 82e8: 20 31 a7     1.
+    lda l002e                                                         // 82eb: a5 2e       ..
+    beq c82dd                                                         // 82ed: f0 ee       ..
+    bpl c82f4                                                         // 82ef: 10 03       ..
+    eor #$ff                                                          // 82f1: 49 ff       I.
+    inc                                                               // 82f3: 1a          .
+// $82f4 referenced 2 times by $82db, $82ef
+c82f4
+    ldy #$89                                                          // 82f4: a0 89       ..
+    lsr                                                               // 82f6: 4a          J
+// $82f7 referenced 1 time by $82f9
+loop_c82f7
+    dey                                                               // 82f7: 88          .
+    rol                                                               // 82f8: 2a          *
+    bpl loop_c82f7                                                    // 82f9: 10 fc       ..
+// $82fb referenced 2 times by $82b0, $82bc
+c82fb
+    sty l0030                                                         // 82fb: 84 30       .0
+    stz l002f                                                         // 82fd: 64 2f       d/
+    sta l0031                                                         // 82ff: 85 31       .1
+    rts                                                               // 8301: 60          `
+
+    .byt $a5, $31                                                     // 8302: a5 31       .1
+
+// $8304 referenced 3 times by $84f1, $8510, $a390
+c8304
+    bmi c8346                                                         // 8304: 30 40       0@
+// $8306 referenced 2 times by $a6c6, $a7a9
+c8306
+    bne c832f                                                         // 8306: d0 27       .'
+    ora l0032                                                         // 8308: 05 32       .2
+    ora l0033                                                         // 830a: 05 33       .3
+    ora l0034                                                         // 830c: 05 34       .4
+    ora l0035                                                         // 830e: 05 35       .5
+    beq c82dd                                                         // 8310: f0 cb       ..
+    ldy l0030                                                         // 8312: a4 30       .0
+// $8314 referenced 1 time by $832b
+loop_c8314
+    lda l0032                                                         // 8314: a5 32       .2
+    pha                                                               // 8316: 48          H
+    lda l0033                                                         // 8317: a5 33       .3
+    sta l0032                                                         // 8319: 85 32       .2
+    lda l0034                                                         // 831b: a5 34       .4
+    sta l0033                                                         // 831d: 85 33       .3
+    lda l0035                                                         // 831f: a5 35       .5
+    sta l0034                                                         // 8321: 85 34       .4
+    stz l0035                                                         // 8323: 64 35       d5
+    tya                                                               // 8325: 98          .
+    sec                                                               // 8326: 38          8
+    sbc #8                                                            // 8327: e9 08       ..
+    tay                                                               // 8329: a8          .
+    pla                                                               // 832a: 68          h
+    beq loop_c8314                                                    // 832b: f0 e7       ..
+    bra c833b                                                         // 832d: 80 0c       ..
+// $832f referenced 1 time by $8306
+c832f
+    ldy l0030                                                         // 832f: a4 30       .0
+// $8331 referenced 1 time by $833b
+loop_c8331
+    dey                                                               // 8331: 88          .
+    asl l0035                                                         // 8332: 06 35       .5
+    rol l0034                                                         // 8334: 26 34       &4
+    rol l0033                                                         // 8336: 26 33       &3
+    rol l0032                                                         // 8338: 26 32       &2
+    rol                                                               // 833a: 2a          *
+// $833b referenced 1 time by $832d
+c833b
+    bpl loop_c8331                                                    // 833b: 10 f4       ..
+    cpy l0030                                                         // 833d: c4 30       .0
+    sty l0030                                                         // 833f: 84 30       .0
+    bcc c8345                                                         // 8341: 90 02       ..
+    dec l002f                                                         // 8343: c6 2f       ./
+// $8345 referenced 1 time by $8341
+c8345
+    tay                                                               // 8345: a8          .
+// $8346 referenced 1 time by $8304
+c8346
+    sta l0031                                                         // 8346: 85 31       .1
+    rts                                                               // 8348: 60          `
+
+// $8349 referenced 1 time by $abed
+sub_c8349
+    stz l003d                                                         // 8349: 64 3d       d=
+sub_c834b
+    ldy l0031                                                         // 834b: a4 31       .1
+    bra c8353                                                         // 834d: 80 04       ..
+// $834f referenced 1 time by $9788
+sub_c834f
+    ldy l0031                                                         // 834f: a4 31       .1
+    sty l003d                                                         // 8351: 84 3d       .=
+// $8353 referenced 1 time by $834d
+c8353
+    lda l0030                                                         // 8353: a5 30       .0
+    cmp #$81                                                          // 8355: c9 81       ..
+    bcs c835e                                                         // 8357: b0 05       ..
+    sty l003d                                                         // 8359: 84 3d       .=
+    jmp ca72b                                                         // 835b: 4c 2b a7    L+.
+
+// $835e referenced 1 time by $8357
+c835e
+    cmp #$a0                                                          // 835e: c9 a0       ..
+    bcc c8372                                                         // 8360: 90 10       ..
+// $8362 referenced 1 time by $83d0
+c8362
+    jmp ca6f2                                                         // 8362: 4c f2 a6    L..
+
+// $8365 referenced 1 time by $8374
+loop_c8365
+    lsr l0031                                                         // 8365: 46 31       F1
+    ror l0032                                                         // 8367: 66 32       f2
+    ror l0033                                                         // 8369: 66 33       f3
+    ror l0034                                                         // 836b: 66 34       f4
+    bcc c8371                                                         // 836d: 90 02       ..
+    sta l003d                                                         // 836f: 85 3d       .=
+// $8371 referenced 1 time by $836d
+c8371
+    inc                                                               // 8371: 1a          .
+// $8372 referenced 1 time by $8360
+c8372
+    bit #7                                                            // 8372: 89 07       ..
+    bne loop_c8365                                                    // 8374: d0 ef       ..
+    and #$18                                                          // 8376: 29 18       ).
+    beq c83a6                                                         // 8378: f0 2c       .,
+    lsr                                                               // 837a: 4a          J
+    lsr                                                               // 837b: 4a          J
+    lsr                                                               // 837c: 4a          J
+    tay                                                               // 837d: a8          .
+    phx                                                               // 837e: da          .
+    eor #3                                                            // 837f: 49 03       I.
+    tax                                                               // 8381: aa          .
+    lda l003d                                                         // 8382: a5 3d       .=
+    bne c8392                                                         // 8384: d0 0c       ..
+    stz l0035                                                         // 8386: 64 35       d5
+    lda l0034                                                         // 8388: a5 34       .4
+    ora l0031,y                                                       // 838a: 19 31 00    .1.
+    ora l0032,y                                                       // 838d: 19 32 00    .2.
+    sta l003d                                                         // 8390: 85 3d       .=
+// $8392 referenced 1 time by $8384
+c8392
+    lda l0033                                                         // 8392: a5 33       .3
+    sta l0034                                                         // 8394: 85 34       .4
+    lda l0032                                                         // 8396: a5 32       .2
+    sta l0033,x                                                       // 8398: 95 33       .3
+    lda l0031                                                         // 839a: a5 31       .1
+    sta l0032,x                                                       // 839c: 95 32       .2
+// $839e referenced 1 time by $83a1
+loop_c839e
+    stz l0031,x                                                       // 839e: 74 31       t1
+    dex                                                               // 83a0: ca          .
+    bpl loop_c839e                                                    // 83a1: 10 fb       ..
+    plx                                                               // 83a3: fa          .
+    stz l0035                                                         // 83a4: 64 35       d5
+// $83a6 referenced 1 time by $8378
+c83a6
+    lda l002e                                                         // 83a6: a5 2e       ..
+    bpl c83c1                                                         // 83a8: 10 17       ..
+// $83aa referenced 1 time by $abfa
+sub_c83aa
+    sec                                                               // 83aa: 38          8
+    ldy #0                                                            // 83ab: a0 00       ..
+    tya                                                               // 83ad: 98          .
+    sbc l0034                                                         // 83ae: e5 34       .4
+    sta l0034                                                         // 83b0: 85 34       .4
+    tya                                                               // 83b2: 98          .
+    sbc l0033                                                         // 83b3: e5 33       .3
+    sta l0033                                                         // 83b5: 85 33       .3
+    tya                                                               // 83b7: 98          .
+    sbc l0032                                                         // 83b8: e5 32       .2
+    sta l0032                                                         // 83ba: 85 32       .2
+    tya                                                               // 83bc: 98          .
+    sbc l0031                                                         // 83bd: e5 31       .1
+    sta l0031                                                         // 83bf: 85 31       .1
+// $83c1 referenced 1 time by $83a8
+c83c1
+    rts                                                               // 83c1: 60          `
+
+// $83c2 referenced 1 time by $abf7
+sub_c83c2
+    inc l0034                                                         // 83c2: e6 34       .4
+    bne c83d2                                                         // 83c4: d0 0c       ..
+    inc l0033                                                         // 83c6: e6 33       .3
+    bne c83d2                                                         // 83c8: d0 08       ..
+    inc l0032                                                         // 83ca: e6 32       .2
+    bne c83d2                                                         // 83cc: d0 04       ..
+    inc l0031                                                         // 83ce: e6 31       .1
+    beq c8362                                                         // 83d0: f0 90       ..
+// $83d2 referenced 3 times by $83c4, $83c8, $83cc
+c83d2
+    rts                                                               // 83d2: 60          `
+
+// $83d3 referenced 2 times by $aa7a, $aad3
+sub_c83d3
+    ldy #2                                                            // 83d3: a0 02       ..
+// $83d5 referenced 1 time by $8407
+c83d5
+    ror l0011                                                         // 83d5: 66 11       f.
+    ror l0010                                                         // 83d7: 66 10       f.
+    lda l000f                                                         // 83d9: a5 0f       ..
+    sta l0011                                                         // 83db: 85 11       ..
+    ror                                                               // 83dd: 6a          j
+    pha                                                               // 83de: 48          H
+    lda l000e                                                         // 83df: a5 0e       ..
+    ldx l000d                                                         // 83e1: a6 0d       ..
+    lsr l000f                                                         // 83e3: 46 0f       F.
+    ror                                                               // 83e5: 6a          j
+    ror l000d                                                         // 83e6: 66 0d       f.
+    lsr l000f                                                         // 83e8: 46 0f       F.
+    ror                                                               // 83ea: 6a          j
+    ror l000d                                                         // 83eb: 66 0d       f.
+    lsr l000f                                                         // 83ed: 46 0f       F.
+    ror                                                               // 83ef: 6a          j
+    ror l000d                                                         // 83f0: 66 0d       f.
+    lsr l000f                                                         // 83f2: 46 0f       F.
+    ror                                                               // 83f4: 6a          j
+    ror l000d                                                         // 83f5: 66 0d       f.
+    eor l0010                                                         // 83f7: 45 10       E.
+    stx l000f                                                         // 83f9: 86 0f       ..
+    ldx l000e                                                         // 83fb: a6 0e       ..
+    stx l0010                                                         // 83fd: 86 10       ..
+    sta l000e                                                         // 83ff: 85 0e       ..
+    pla                                                               // 8401: 68          h
+    eor l000d                                                         // 8402: 45 0d       E.
+    sta l000d                                                         // 8404: 85 0d       ..
+    dey                                                               // 8406: 88          .
+    bne c83d5                                                         // 8407: d0 cc       ..
+    rts                                                               // 8409: 60          `
+
+// $840a referenced 2 times by $842b, $846f
+c840a
+    lda l003b                                                         // 840a: a5 3b       .;
+    sta l002e                                                         // 840c: 85 2e       ..
+    stz l002f                                                         // 840e: 64 2f       d/
+    lda l003c                                                         // 8410: a5 3c       .<
+    sta l0030                                                         // 8412: 85 30       .0
+    lda l003d                                                         // 8414: a5 3d       .=
+    sta l0031                                                         // 8416: 85 31       .1
+    lda l003e                                                         // 8418: a5 3e       .>
+    sta l0032                                                         // 841a: 85 32       .2
+    lda l003f                                                         // 841c: a5 3f       .?
+    sta l0033                                                         // 841e: 85 33       .3
+    lda l0040                                                         // 8420: a5 40       .@
+    sta l0034                                                         // 8422: 85 34       .4
+    lda l0041                                                         // 8424: a5 41       .A
+    sta l0035                                                         // 8426: 85 35       .5
+// $8428 referenced 1 time by $8438
+loop_c8428
+    rts                                                               // 8428: 60          `
+
+// $8429 referenced 2 times by $a204, $a70f
+sub_c8429
+    lda l0031                                                         // 8429: a5 31       .1
+    beq c840a                                                         // 842b: f0 dd       ..
+    sec                                                               // 842d: 38          8
+    lda l0030                                                         // 842e: a5 30       .0
+    sbc l003c                                                         // 8430: e5 3c       .<
+    beq c84a3                                                         // 8432: f0 6f       .o
+    bcc c846a                                                         // 8434: 90 34       .4
+    cmp #$25 // '%'                                                   // 8436: c9 25       .%
+    bcs loop_c8428                                                    // 8438: b0 ee       ..
+    tay                                                               // 843a: a8          .
+    and #$38 // '8'                                                   // 843b: 29 38       )8
+    beq c8456                                                         // 843d: f0 17       ..
+    sec                                                               // 843f: 38          8
+// $8440 referenced 1 time by $8454
+loop_c8440
+    ldx l0040                                                         // 8440: a6 40       .@
+    stx l0041                                                         // 8442: 86 41       .A
+    ldx l003f                                                         // 8444: a6 3f       .?
+    stx l0040                                                         // 8446: 86 40       .@
+    ldx l003e                                                         // 8448: a6 3e       .>
+    stx l003f                                                         // 844a: 86 3f       .?
+    ldx l003d                                                         // 844c: a6 3d       .=
+    stx l003e                                                         // 844e: 86 3e       .>
+    stz l003d                                                         // 8450: 64 3d       d=
+    sbc #8                                                            // 8452: e9 08       ..
+    bne loop_c8440                                                    // 8454: d0 ea       ..
+// $8456 referenced 1 time by $843d
+c8456
+    tya                                                               // 8456: 98          .
+    and #7                                                            // 8457: 29 07       ).
+    beq c84a3                                                         // 8459: f0 48       .H
+// $845b referenced 1 time by $8466
+loop_c845b
+    lsr l003d                                                         // 845b: 46 3d       F=
+    ror l003e                                                         // 845d: 66 3e       f>
+    ror l003f                                                         // 845f: 66 3f       f?
+    ror l0040                                                         // 8461: 66 40       f@
+    ror l0041                                                         // 8463: 66 41       fA
+    dec                                                               // 8465: 3a          :
+    bne loop_c845b                                                    // 8466: d0 f3       ..
+    bra c84a3                                                         // 8468: 80 39       .9
+// $846a referenced 1 time by $8434
+c846a
+    eor #$ff                                                          // 846a: 49 ff       I.
+    inc                                                               // 846c: 1a          .
+    cmp #$25 // '%'                                                   // 846d: c9 25       .%
+    bcs c840a                                                         // 846f: b0 99       ..
+    ldy l003c                                                         // 8471: a4 3c       .<
+    sty l0030                                                         // 8473: 84 30       .0
+    tay                                                               // 8475: a8          .
+    and #$38 // '8'                                                   // 8476: 29 38       )8
+    beq c8491                                                         // 8478: f0 17       ..
+    sec                                                               // 847a: 38          8
+// $847b referenced 1 time by $848f
+loop_c847b
+    ldx l0034                                                         // 847b: a6 34       .4
+    stx l0035                                                         // 847d: 86 35       .5
+    ldx l0033                                                         // 847f: a6 33       .3
+    stx l0034                                                         // 8481: 86 34       .4
+    ldx l0032                                                         // 8483: a6 32       .2
+    stx l0033                                                         // 8485: 86 33       .3
+    ldx l0031                                                         // 8487: a6 31       .1
+    stx l0032                                                         // 8489: 86 32       .2
+    stz l0031                                                         // 848b: 64 31       d1
+    sbc #8                                                            // 848d: e9 08       ..
+    bne loop_c847b                                                    // 848f: d0 ea       ..
+// $8491 referenced 1 time by $8478
+c8491
+    tya                                                               // 8491: 98          .
+    and #7                                                            // 8492: 29 07       ).
+    beq c84a3                                                         // 8494: f0 0d       ..
+// $8496 referenced 1 time by $84a1
+loop_c8496
+    lsr l0031                                                         // 8496: 46 31       F1
+    ror l0032                                                         // 8498: 66 32       f2
+    ror l0033                                                         // 849a: 66 33       f3
+    ror l0034                                                         // 849c: 66 34       f4
+    ror l0035                                                         // 849e: 66 35       f5
+    dec                                                               // 84a0: 3a          :
+    bne loop_c8496                                                    // 84a1: d0 f3       ..
+// $84a3 referenced 4 times by $8432, $8459, $8468, $8494
+c84a3
+    lda l002e                                                         // 84a3: a5 2e       ..
+    eor l003b                                                         // 84a5: 45 3b       E;
+    bmi c84ad                                                         // 84a7: 30 04       0.
+    clc                                                               // 84a9: 18          .
+    jmp ca489                                                         // 84aa: 4c 89 a4    L..
+
+// $84ad referenced 1 time by $84a7
+c84ad
+    lda l0031                                                         // 84ad: a5 31       .1
+    cmp l003d                                                         // 84af: c5 3d       .=
+    bne c84ce                                                         // 84b1: d0 1b       ..
+    lda l0032                                                         // 84b3: a5 32       .2
+    cmp l003e                                                         // 84b5: c5 3e       .>
+    bne c84ce                                                         // 84b7: d0 15       ..
+    lda l0033                                                         // 84b9: a5 33       .3
+    cmp l003f                                                         // 84bb: c5 3f       .?
+    bne c84ce                                                         // 84bd: d0 0f       ..
+    lda l0034                                                         // 84bf: a5 34       .4
+    cmp l0040                                                         // 84c1: c5 40       .@
+    bne c84ce                                                         // 84c3: d0 09       ..
+    lda l0035                                                         // 84c5: a5 35       .5
+    cmp l0041                                                         // 84c7: c5 41       .A
+    bne c84ce                                                         // 84c9: d0 03       ..
+    jmp ca72b                                                         // 84cb: 4c 2b a7    L+.
+
+// $84ce referenced 5 times by $84b1, $84b7, $84bd, $84c3, $84c9
+c84ce
+    bcs c84f4                                                         // 84ce: b0 24       .$
+    lda l003b                                                         // 84d0: a5 3b       .;
+    sta l002e                                                         // 84d2: 85 2e       ..
+    sec                                                               // 84d4: 38          8
+    lda l0041                                                         // 84d5: a5 41       .A
+    sbc l0035                                                         // 84d7: e5 35       .5
+    sta l0035                                                         // 84d9: 85 35       .5
+    lda l0040                                                         // 84db: a5 40       .@
+    sbc l0034                                                         // 84dd: e5 34       .4
+    sta l0034                                                         // 84df: 85 34       .4
+    lda l003f                                                         // 84e1: a5 3f       .?
+    sbc l0033                                                         // 84e3: e5 33       .3
+    sta l0033                                                         // 84e5: 85 33       .3
+    lda l003e                                                         // 84e7: a5 3e       .>
+    sbc l0032                                                         // 84e9: e5 32       .2
+    sta l0032                                                         // 84eb: 85 32       .2
+    lda l003d                                                         // 84ed: a5 3d       .=
+    sbc l0031                                                         // 84ef: e5 31       .1
+    jmp c8304                                                         // 84f1: 4c 04 83    L..
+
+// $84f4 referenced 1 time by $84ce
+c84f4
+    lda l0035                                                         // 84f4: a5 35       .5
+    sbc l0041                                                         // 84f6: e5 41       .A
+    sta l0035                                                         // 84f8: 85 35       .5
+    lda l0034                                                         // 84fa: a5 34       .4
+    sbc l0040                                                         // 84fc: e5 40       .@
+    sta l0034                                                         // 84fe: 85 34       .4
+    lda l0033                                                         // 8500: a5 33       .3
+    sbc l003f                                                         // 8502: e5 3f       .?
+    sta l0033                                                         // 8504: 85 33       .3
+    lda l0032                                                         // 8506: a5 32       .2
+    sbc l003e                                                         // 8508: e5 3e       .>
+    sta l0032                                                         // 850a: 85 32       .2
+    lda l0031                                                         // 850c: a5 31       .1
+    sbc l003d                                                         // 850e: e5 3d       .=
+    jmp c8304                                                         // 8510: 4c 04 83    L..
+
+    .asc "AND"                                                        // 8513: 41 4e 44    AND
+    .byt $80,   0                                                     // 8516: 80 00       ..
+    .asc "ABS"                                                        // 8518: 41 42 53    ABS
+    .byt $94,   0                                                     // 851b: 94 00       ..
+    .asc "ACS"                                                        // 851d: 41 43 53    ACS
+    .byt $95,   0                                                     // 8520: 95 00       ..
+    .asc "ADVAL"                                                      // 8522: 41 44 56... ADV
+    .byt $96,   0                                                     // 8527: 96 00       ..
+    .asc "ASC"                                                        // 8529: 41 53 43    ASC
+    .byt $97,   0                                                     // 852c: 97 00       ..
+    .asc "ASN"                                                        // 852e: 41 53 4e    ASN
+    .byt $98,   0                                                     // 8531: 98 00       ..
+    .asc "ATN"                                                        // 8533: 41 54 4e    ATN
+    .byt $99,   0                                                     // 8536: 99 00       ..
+    .asc "AUTO"                                                       // 8538: 41 55 54... AUT
+    .byt $c6, $10                                                     // 853c: c6 10       ..
+    .asc "BGET"                                                       // 853e: 42 47 45... BGE
+    .byt $9a,   1                                                     // 8542: 9a 01       ..
+    .asc "BPUT"                                                       // 8544: 42 50 55... BPU
+    .byt $d5,   3                                                     // 8548: d5 03       ..
+    .asc "COLOUR"                                                     // 854a: 43 4f 4c... COL
+    .byt $fb,   2                                                     // 8550: fb 02       ..
+    .asc "CALL"                                                       // 8552: 43 41 4c... CAL
+    .byt $d6,   2                                                     // 8556: d6 02       ..
+    .asc "CHAIN"                                                      // 8558: 43 48 41... CHA
+    .byt $d7,   2                                                     // 855d: d7 02       ..
+    .asc "CHR$"                                                       // 855f: 43 48 52... CHR
+    .byt $bd,   0                                                     // 8563: bd 00       ..
+    .asc "CLEAR"                                                      // 8565: 43 4c 45... CLE
+    .byt $d8,   1                                                     // 856a: d8 01       ..
+    .asc "CLOSE"                                                      // 856c: 43 4c 4f... CLO
+    .byt $d9,   3                                                     // 8571: d9 03       ..
+    .asc "CLG"                                                        // 8573: 43 4c 47    CLG
+    .byt $da,   1                                                     // 8576: da 01       ..
+    .asc "CLS"                                                        // 8578: 43 4c 53    CLS
+    .byt $db,   1                                                     // 857b: db 01       ..
+    .asc "COS"                                                        // 857d: 43 4f 53    COS
+    .byt $9b,   0                                                     // 8580: 9b 00       ..
+    .asc "COUNT"                                                      // 8582: 43 4f 55... COU
+    .byt $9c,   1                                                     // 8587: 9c 01       ..
+    .asc "COLOR"                                                      // 8589: 43 4f 4c... COL
+    .byt $fb,   2                                                     // 858e: fb 02       ..
+    .asc "DATA"                                                       // 8590: 44 41 54... DAT
+    .byt $dc                                                          // 8594: dc          .
+    .asc " DEG"                                                       // 8595: 20 44 45...  DE
+    .byt $9d,   0                                                     // 8599: 9d 00       ..
+    .asc "DEF"                                                        // 859b: 44 45 46    DEF
+    .byt $dd,   0                                                     // 859e: dd 00       ..
+    .asc "DELETE"                                                     // 85a0: 44 45 4c... DEL
+    .byt $c7, $10                                                     // 85a6: c7 10       ..
+    .asc "DIV"                                                        // 85a8: 44 49 56    DIV
+    .byt $81,   0                                                     // 85ab: 81 00       ..
+    .asc "DIM"                                                        // 85ad: 44 49 4d    DIM
+    .byt $de,   2                                                     // 85b0: de 02       ..
+    .asc "DRAW"                                                       // 85b2: 44 52 41... DRA
+    .byt $df,   2                                                     // 85b6: df 02       ..
+    .asc "ENDPROC"                                                    // 85b8: 45 4e 44... END
+    .byt $e1,   1                                                     // 85bf: e1 01       ..
+    .asc "END"                                                        // 85c1: 45 4e 44    END
+    .byt $e0,   1                                                     // 85c4: e0 01       ..
+    .asc "ENVELOPE"                                                   // 85c6: 45 4e 56... ENV
+    .byt $e2,   2                                                     // 85ce: e2 02       ..
+    .asc "ELSE"                                                       // 85d0: 45 4c 53... ELS
+    .byt $8b, $14                                                     // 85d4: 8b 14       ..
+    .asc "EVAL"                                                       // 85d6: 45 56 41... EVA
+    .byt $a0,   0                                                     // 85da: a0 00       ..
+    .asc "ERL"                                                        // 85dc: 45 52 4c    ERL
+    .byt $9e,   1                                                     // 85df: 9e 01       ..
+    .asc "ERROR"                                                      // 85e1: 45 52 52... ERR
+    .byt $85,   4                                                     // 85e6: 85 04       ..
+    .asc "EOF"                                                        // 85e8: 45 4f 46    EOF
+    .byt $c5,   1                                                     // 85eb: c5 01       ..
+    .asc "EOR"                                                        // 85ed: 45 4f 52    EOR
+    .byt $82,   0                                                     // 85f0: 82 00       ..
+    .asc "ERR"                                                        // 85f2: 45 52 52    ERR
+    .byt $9f,   1                                                     // 85f5: 9f 01       ..
+    .asc "EXP"                                                        // 85f7: 45 58 50    EXP
+    .byt $a1,   0                                                     // 85fa: a1 00       ..
+    .asc "EXT"                                                        // 85fc: 45 58 54    EXT
+    .byt $a2,   1                                                     // 85ff: a2 01       ..
+    .asc "EDIT"                                                       // 8601: 45 44 49... EDI
+    .byt $ce, $10                                                     // 8605: ce 10       ..
+    .asc "FOR"                                                        // 8607: 46 4f 52    FOR
+    .byt $e3,   2                                                     // 860a: e3 02       ..
+    .asc "FALSE"                                                      // 860c: 46 41 4c... FAL
+    .byt $a3,   1, $46, $4e, $a4,   8                                 // 8611: a3 01 46... ..F
+    .asc "GOTO"                                                       // 8617: 47 4f 54... GOT
+    .byt $e5, $12                                                     // 861b: e5 12       ..
+    .asc "GET$"                                                       // 861d: 47 45 54... GET
+    .byt $be,   0                                                     // 8621: be 00       ..
+    .asc "GET"                                                        // 8623: 47 45 54    GET
+    .byt $a5,   0                                                     // 8626: a5 00       ..
+    .asc "GOSUB"                                                      // 8628: 47 4f 53... GOS
+    .byt $e4, $12                                                     // 862d: e4 12       ..
+    .asc "GCOL"                                                       // 862f: 47 43 4f... GCO
+    .byt $e6,   2                                                     // 8633: e6 02       ..
+    .asc "HIMEM"                                                      // 8635: 48 49 4d... HIM
+    .byt $93                                                          // 863a: 93          .
+    .asc "CINPUT"                                                     // 863b: 43 49 4e... CIN
+    .byt $e8,   2, $49, $46, $e7,   2                                 // 8641: e8 02 49... ..I
+    .asc "INKEY$"                                                     // 8647: 49 4e 4b... INK
+    .byt $bf,   0                                                     // 864d: bf 00       ..
+    .asc "INKEY"                                                      // 864f: 49 4e 4b... INK
+    .byt $a6,   0                                                     // 8654: a6 00       ..
+    .asc "INT"                                                        // 8656: 49 4e 54    INT
+    .byt $a8,   0                                                     // 8659: a8 00       ..
+    .asc "INSTR("                                                     // 865b: 49 4e 53... INS
+    .byt $a7,   0                                                     // 8661: a7 00       ..
+    .asc "LIST"                                                       // 8663: 4c 49 53... LIS
+    .byt $c9, $10                                                     // 8667: c9 10       ..
+    .asc "LINE"                                                       // 8669: 4c 49 4e... LIN
+    .byt $86,   0                                                     // 866d: 86 00       ..
+    .asc "LOAD"                                                       // 866f: 4c 4f 41... LOA
+    .byt $c8,   2                                                     // 8673: c8 02       ..
+    .asc "LOMEM"                                                      // 8675: 4c 4f 4d... LOM
+    .byt $92                                                          // 867a: 92          .
+    .asc "CLOCAL"                                                     // 867b: 43 4c 4f... CLO
+    .byt $ea,   2                                                     // 8681: ea 02       ..
+    .asc "LEFT$("                                                     // 8683: 4c 45 46... LEF
+    .byt $c0,   0                                                     // 8689: c0 00       ..
+    .asc "LEN"                                                        // 868b: 4c 45 4e    LEN
+    .byt $a9,   0                                                     // 868e: a9 00       ..
+    .asc "LET"                                                        // 8690: 4c 45 54    LET
+    .byt $e9,   4                                                     // 8693: e9 04       ..
+    .asc "LOG"                                                        // 8695: 4c 4f 47    LOG
+    .byt $ab,   0, $4c, $4e, $aa,   0                                 // 8698: ab 00 4c... ..L
+    .asc "MID$("                                                      // 869e: 4d 49 44... MID
+    .byt $c1,   0                                                     // 86a3: c1 00       ..
+    .asc "MODE"                                                       // 86a5: 4d 4f 44... MOD
+    .byt $eb,   2                                                     // 86a9: eb 02       ..
+    .asc "MOD"                                                        // 86ab: 4d 4f 44    MOD
+    .byt $83,   0                                                     // 86ae: 83 00       ..
+    .asc "MOVE"                                                       // 86b0: 4d 4f 56... MOV
+    .byt $ec,   2                                                     // 86b4: ec 02       ..
+    .asc "NEXT"                                                       // 86b6: 4e 45 58... NEX
+    .byt $ed,   2                                                     // 86ba: ed 02       ..
+    .asc "NEW"                                                        // 86bc: 4e 45 57    NEW
+    .byt $ca,   1                                                     // 86bf: ca 01       ..
+    .asc "NOT"                                                        // 86c1: 4e 4f 54    NOT
+    .byt $ac,   0                                                     // 86c4: ac 00       ..
+    .asc "OLD"                                                        // 86c6: 4f 4c 44    OLD
+    .byt $cb,   1, $4f, $4e, $ee,   2                                 // 86c9: cb 01 4f... ..O
+    .asc "OFF"                                                        // 86cf: 4f 46 46    OFF
+    .byt $87,   0, $4f, $52, $84,   0                                 // 86d2: 87 00 4f... ..O
+    .asc "OPENIN"                                                     // 86d8: 4f 50 45... OPE
+    .byt $8e,   0                                                     // 86de: 8e 00       ..
+    .asc "OPENOUT"                                                    // 86e0: 4f 50 45... OPE
+    .byt $ae,   0                                                     // 86e7: ae 00       ..
+    .asc "OPENUP"                                                     // 86e9: 4f 50 45... OPE
+    .byt $ad,   0                                                     // 86ef: ad 00       ..
+    .asc "OSCLI"                                                      // 86f1: 4f 53 43... OSC
+    .byt $ff,   2                                                     // 86f6: ff 02       ..
+    .asc "PRINT"                                                      // 86f8: 50 52 49... PRI
+    .byt $f1,   2                                                     // 86fd: f1 02       ..
+    .asc "PAGE"                                                       // 86ff: 50 41 47... PAG
+    .byt $90                                                          // 8703: 90          .
+    .asc "CPTR"                                                       // 8704: 43 50 54... CPT
+    .byt $8f                                                          // 8708: 8f          .
+    .asc "CPI"                                                        // 8709: 43 50 49    CPI
+    .byt $af,   1                                                     // 870c: af 01       ..
+    .asc "PLOT"                                                       // 870e: 50 4c 4f... PLO
+    .byt $f0,   2                                                     // 8712: f0 02       ..
+    .asc "POINT("                                                     // 8714: 50 4f 49... POI
+    .byt $b0,   0                                                     // 871a: b0 00       ..
+    .asc "PROC"                                                       // 871c: 50 52 4f... PRO
+    .byt $f2, $0a                                                     // 8720: f2 0a       ..
+    .asc "POS"                                                        // 8722: 50 4f 53    POS
+    .byt $b1,   1                                                     // 8725: b1 01       ..
+    .asc "RETURN"                                                     // 8727: 52 45 54... RET
+    .byt $f8,   1                                                     // 872d: f8 01       ..
+    .asc "REPEAT"                                                     // 872f: 52 45 50... REP
+    .byt $f5,   0                                                     // 8735: f5 00       ..
+    .asc "REPORT"                                                     // 8737: 52 45 50... REP
+    .byt $f6,   1                                                     // 873d: f6 01       ..
+    .asc "READ"                                                       // 873f: 52 45 41... REA
+    .byt $f3,   2                                                     // 8743: f3 02       ..
+    .asc "REM"                                                        // 8745: 52 45 4d    REM
+    .byt $f4                                                          // 8748: f4          .
+    .asc " RUN"                                                       // 8749: 20 52 55...  RU
+    .byt $f9,   1                                                     // 874d: f9 01       ..
+    .asc "RAD"                                                        // 874f: 52 41 44    RAD
+    .byt $b2,   0                                                     // 8752: b2 00       ..
+    .asc "RESTORE"                                                    // 8754: 52 45 53... RES
+    .byt $f7, $12                                                     // 875b: f7 12       ..
+    .asc "RIGHT$("                                                    // 875d: 52 49 47... RIG
+    .byt $c2,   0                                                     // 8764: c2 00       ..
+    .asc "RND"                                                        // 8766: 52 4e 44    RND
+    .byt $b3,   1                                                     // 8769: b3 01       ..
+    .asc "RENUMBER"                                                   // 876b: 52 45 4e... REN
+    .byt $cc, $10                                                     // 8773: cc 10       ..
+    .asc "STEP"                                                       // 8775: 53 54 45... STE
+    .byt $88,   0                                                     // 8779: 88 00       ..
+    .asc "SAVE"                                                       // 877b: 53 41 56... SAV
+    .byt $cd,   2                                                     // 877f: cd 02       ..
+    .asc "SGN"                                                        // 8781: 53 47 4e    SGN
+    .byt $b4,   0                                                     // 8784: b4 00       ..
+    .asc "SIN"                                                        // 8786: 53 49 4e    SIN
+    .byt $b5,   0                                                     // 8789: b5 00       ..
+    .asc "SQR"                                                        // 878b: 53 51 52    SQR
+    .byt $b6,   0                                                     // 878e: b6 00       ..
+    .asc "SPC"                                                        // 8790: 53 50 43    SPC
+    .byt $89,   0                                                     // 8793: 89 00       ..
+    .asc "STR$"                                                       // 8795: 53 54 52... STR
+    .byt $c3,   0                                                     // 8799: c3 00       ..
+    .asc "STRING$("                                                   // 879b: 53 54 52... STR
+    .byt $c4,   0                                                     // 87a3: c4 00       ..
+    .asc "SOUND"                                                      // 87a5: 53 4f 55... SOU
+    .byt $d4,   2                                                     // 87aa: d4 02       ..
+    .asc "STOP"                                                       // 87ac: 53 54 4f... STO
+    .byt $fa,   1                                                     // 87b0: fa 01       ..
+    .asc "TAN"                                                        // 87b2: 54 41 4e    TAN
+    .byt $b7,   0                                                     // 87b5: b7 00       ..
+    .asc "THEN"                                                       // 87b7: 54 48 45... THE
+    .byt $8c, $14, $54, $4f, $b8,   0                                 // 87bb: 8c 14 54... ..T
+    .asc "TAB("                                                       // 87c1: 54 41 42... TAB
+    .byt $8a,   0                                                     // 87c5: 8a 00       ..
+    .asc "TRACE"                                                      // 87c7: 54 52 41... TRA
+    .byt $fc, $12                                                     // 87cc: fc 12       ..
+    .asc "TIME"                                                       // 87ce: 54 49 4d... TIM
+    .byt $91                                                          // 87d2: 91          .
+    .asc "CTRUE"                                                      // 87d3: 43 54 52... CTR
+    .byt $b9,   1                                                     // 87d8: b9 01       ..
+    .asc "UNTIL"                                                      // 87da: 55 4e 54... UNT
+    .byt $fd,   2                                                     // 87df: fd 02       ..
+    .asc "USR"                                                        // 87e1: 55 53 52    USR
+    .byt $ba,   0                                                     // 87e4: ba 00       ..
+    .asc "VDU"                                                        // 87e6: 56 44 55    VDU
+    .byt $ef,   2                                                     // 87e9: ef 02       ..
+    .asc "VAL"                                                        // 87eb: 56 41 4c    VAL
+    .byt $bb,   0                                                     // 87ee: bb 00       ..
+    .asc "VPOS"                                                       // 87f0: 56 50 4f... VPO
+    .byt $bc,   1                                                     // 87f4: bc 01       ..
+    .asc "WIDTH"                                                      // 87f6: 57 49 44... WID
+    .byt $fe,   2                                                     // 87fb: fe 02       ..
+    .asc "PAGE"                                                       // 87fd: 50 41 47... PAG
+    .byt $d0,   0                                                     // 8801: d0 00       ..
+    .asc "PTR"                                                        // 8803: 50 54 52    PTR
+    .byt $cf,   0, $54, $49                                           // 8806: cf 00 54... ..T
+// $880a referenced 1 time by $90e0
+l880a
+    .byt $4d, $45, $d1,   0                                           // 880a: 4d 45 d1... ME.
+    .asc "LOMEM"                                                      // 880e: 4c 4f 4d... LOM
+    .byt $d2,   0                                                     // 8813: d2 00       ..
+    .asc "HIMEM"                                                      // 8815: 48 49 4d... HIM
+    .byt $d3,   0                                                     // 881a: d3 00       ..
+    .asc "Missing "                                                   // 881c: 4d 69 73... Mis
+    .byt $8d,   0                                                     // 8824: 8d 00       ..
+l8826
+l8909 = l8826+227
+    .word sub_cab37, sub_cab21, sub_cae50, sub_cae8c, sub_cae71       // 8826: 37 ab 21... 7.!
+    .word sub_cae77, sub_cad00, sub_ca6fc, sub_cae34, sub_cac03       // 8830: 77 ae 00... w..
+    .word sub_ca901, sub_ca919, sub_cab2f, sub_ca954, sub_cae6d       // 883a: 01 a9 19... ...
+    .word sub_ca9ca, sub_cae7d, sub_cae83, sub_cab5c, sub_caa17       // 8844: ca a9 7d... ..}
+    .word sub_cab1d,     cac38, sub_cb055, sub_cae87, sub_cac12       // 884e: 1d ab 38... ..8
+    .word sub_cac7f, sub_cabe1, sub_cae59, sub_ca7ac, sub_ca9bc       // 8858: 7f ac e1... ...
+    .word sub_caaeb, sub_cab3f, sub_cab3b, sub_cab54, sub_cac5d       // 8862: eb aa 3f... ..?
+    .word sub_caafb, sub_ca9b5, sub_caacb, sub_cac46, sub_ca94f       // 886c: fb aa b5... ...
+    .word sub_ca808, sub_ca96b, sub_cae41,     cac2b, sub_cab01       // 8876: 08 a8 6b... ..k
+    .word sub_caba0, sub_cab14, sub_cb269, sub_caeb1, sub_caefb       // 8880: a0 ab 14... ...
+    .word sub_caebb, sub_caf0a, sub_caebc, sub_caf61, sub_caf8b       // 888a: bb ae 0a... ...
+    .word sub_cac1f, sub_c954c, sub_c93da, sub_c8fe5, sub_cb412       // 8894: 1f ac 4c... ..L
+    .word sub_c9042, sub_c8fc5, sub_c9447, sub_cbe95, sub_cb3c8       // 889e: 42 90 c5... B..
+    .word sub_cbed7, sub_c96f9, sub_c973e, sub_c96e5, sub_c96d4       // 88a8: d7 be f9... ...
+    .word sub_cb302, sub_cbefd, sub_c9381, sub_c8fc0, sub_c9703       // 88b2: 02 b3 fd... ...
+    .word sub_cbeee, sub_c98af, sub_c98b6,     c9073,     c9073       // 88bc: ee be af... ...
+    .word     c95f9, sub_c9875, sub_c8fea, sub_c9c5e, sub_cb326       // 88c6: f9 95 75... ..u
+    .word sub_cb649, sub_cb709, sub_cb74d, sub_c9810, sub_c9ccc       // 88d0: 49 b6 09... I..
+    .word sub_cb8e6, sub_c910d,     c97d2, sub_c982e, sub_c9871       // 88da: e6 b8 0d... ...
+    .word     cb522, sub_cb78b,     c98dc, sub_c9880, sub_c9250       // 88e4: 22 b5 8b... "..
+    .word sub_c97a9,     cb9ad,     c9073, sub_cba88, sub_c98c3       // 88ee: a9 97 ad... ...
+    .word sub_cb97d, sub_cb737, sub_c8fd7, sub_c9149, sub_c9824       // 88f8: 7d b9 37... }.7
+    .word sub_c970b, sub_cba47, sub_cb351, sub_cbec7, sub_c834b       // 8902: 0b 97 47... ..G
+    .word sub_c8984, sub_cb896                                        // 890c: 84 89 96... ...
+// $8909 referenced 1 time by $8ae3
+    .byt $b9, $d8, $d9, $f0,   1, $10, $81, $90, $89, $93, $a3, $a4   // 8910: b9 d8 d9... ...
+    .byt $a9                                                          // 891c: a9          .
+    .asc "89x"                                                        // 891d: 38 39 78    89x
+    .byt   1, $13, $21, $a1, $c1, $19, $18, $99, $98, $63, $73, $b1   // 8920: 01 13 21... ..!
+    .byt $a9, $c5, $0c, $c3, $d3, $41, $c4, $f2, $41, $83, $b0, $81   // 892c: a9 c5 0c... ...
+    .asc "Clr"                                                        // 8938: 43 6c 72    Clr
+    .byt $ec, $f2, $a3, $c3, $92, $9a, $18, $19                       // 893b: ec f2 a3... ...
+    .asc "bB4"                                                        // 8943: 62 42 34    bB4
+    .byt $b0, $72, $98, $99, $81, $98, $99, $14                       // 8946: b0 72 98... .r.
+// $894e referenced 1 time by $8ae8
+l894e
+    .byt $35, $0a, $0d, $0d, $0d, $0d, $10, $10                       // 894e: 35 0a 0d... 5..
+    .asc "%%9AAAAJJLLLPPRSSS"                                         // 8956: 25 25 39... %%9
+    .byt $10                                                          // 8968: 10          .
+    .asc "%AAAA"                                                      // 8969: 25 41 41... %AA
+    .byt   8,   8,   8,   9,   9, $0a, $0a, $0a, $0a,   5, $15, $3e   // 896e: 08 08 08... ...
+    .byt   4, $0d, $30, $4c,   6                                      // 897a: 04 0d 30... ..0
+    .asc "2II"                                                        // 897f: 32 49 49    2II
+    .byt $10, $25                                                     // 8982: 10 25       .%
+
+sub_c8984
+    ora l0e4e                                                         // 8984: 0d 4e 0e    .N.
+    asl l5252                                                         // 8987: 0e 52 52    .RR
+    ora #$29 // ')'                                                   // 898a: 09 29       .)
+    rol                                                               // 898c: 2a          *
+    bmi c89bf                                                         // 898d: 30 30       00
+    lsr l4e4e                                                         // 898f: 4e 4e 4e    NNN
+sub_c8992
+l8993 = sub_c8992+1
+    rol !l0016,x                                                      // 8992: 3e 16 00    >..
+// $8993 referenced 1 time by $8b10
+    clc                                                               // 8995: 18          .
+    cld                                                               // 8996: d8          .
+    cli                                                               // 8997: 58          X
+    clv                                                               // 8998: b8          .
+    dex                                                               // 8999: ca          .
+    dey                                                               // 899a: 88          .
+    inx                                                               // 899b: e8          .
+    iny                                                               // 899c: c8          .
+    nop                                                               // 899d: ea          .
+    pha                                                               // 899e: 48          H
+    php                                                               // 899f: 08          .
+    pla                                                               // 89a0: 68          h
+    plp                                                               // 89a1: 28          (
+    rti                                                               // 89a2: 40          @
+
+    .byt $60, $38, $f8, $78, $aa, $a8, $ba, $8a, $9a, $98, $3a, $1a   // 89a3: 60 38 f8... `8.
+    .byt $5a, $da, $7a, $fa, $90, $b0, $f0, $30, $d0, $10, $50, $70   // 89af: 5a da 7a... Z.z
+    .byt $80, $21, $41,   1                                           // 89bb: 80 21 41... .!A
+
+// $89bf referenced 1 time by $898d
+c89bf
+    adc (l00c1,x)                                                     // 89bf: 61 c1       a.
+    lda (l00e1,x)                                                     // 89c1: a1 e1       ..
+    asl l0046                                                         // 89c3: 06 46       .F
+    rol l0066                                                         // 89c5: 26 66       &f
+    dec l00e6                                                         // 89c7: c6 e6       ..
+    stz le09c                                                         // 89c9: 9c 9c e0    ...
+    cpy #0                                                            // 89cc: c0 00       ..
+    bpl c89f4                                                         // 89ce: 10 24       .$
+    jmp ca220                                                         // 89d0: 4c 20 a2    L .
+
+    .byt $a0, $81, $86, $84                                           // 89d3: a0 81 86... ...
+
+// $89d7 referenced 1 time by $89e2
+loop_c89d7
+    dec                                                               // 89d7: 3a          :
+    sta l0028                                                         // 89d8: 85 28       .(
+    jmp c90d0                                                         // 89da: 4c d0 90    L..
+
+// $89dd referenced 2 times by $8a8e, $90aa
+c89dd
+    jsr c8f9d                                                         // 89dd: 20 9d 8f     ..
+    eor #$5d // ']'                                                   // 89e0: 49 5d       I]
+    beq loop_c89d7                                                    // 89e2: f0 f3       ..
+    jsr c9c80                                                         // 89e4: 20 80 9c     ..
+    dec l000a                                                         // 89e7: c6 0a       ..
+    jsr sub_c8aa8                                                     // 89e9: 20 a8 8a     ..
+    dec l000a                                                         // 89ec: c6 0a       ..
+    lda l0028                                                         // 89ee: a5 28       .(
+    lsr                                                               // 89f0: 4a          J
+    bcc c8a6b                                                         // 89f1: 90 78       .x
+// overlapping: lda l001e                                             // 89f3: a5 1e       ..
+    .byt $a5                                                          // 89f3: a5          .
+
+// $89f4 referenced 1 time by $89ce
+c89f4
+    asl l0469,x                                                       // 89f4: 1e 69 04    .i.
+// overlapping: adc #4                                                // 89f5: 69 04       i.
+    sta l003f                                                         // 89f7: 85 3f       .?
+    lda l0038                                                         // 89f9: a5 38       .8
+    jsr sub_cbdac                                                     // 89fb: 20 ac bd     ..
+    lda l0037                                                         // 89fe: a5 37       .7
+    jsr sub_cbdcf                                                     // 8a00: 20 cf bd     ..
+    ldx #$fc                                                          // 8a03: a2 fc       ..
+    ldy l0039                                                         // 8a05: a4 39       .9
+    bpl c8a0b                                                         // 8a07: 10 02       ..
+    ldy l0036                                                         // 8a09: a4 36       .6
+// $8a0b referenced 1 time by $8a07
+c8a0b
+    sty l0038                                                         // 8a0b: 84 38       .8
+    beq c8a28                                                         // 8a0d: f0 19       ..
+    ldy #0                                                            // 8a0f: a0 00       ..
+// $8a11 referenced 1 time by $8a26
+loop_c8a11
+    inx                                                               // 8a11: e8          .
+    bne c8a1e                                                         // 8a12: d0 0a       ..
+    jsr sub_cbac2                                                     // 8a14: 20 c2 ba     ..
+    ldx l003f                                                         // 8a17: a6 3f       .?
+    jsr cbdff                                                         // 8a19: 20 ff bd     ..
+    ldx #$fd                                                          // 8a1c: a2 fd       ..
+// $8a1e referenced 1 time by $8a12
+c8a1e
+    lda (l003a),y                                                     // 8a1e: b1 3a       .:
+    jsr sub_cbdcf                                                     // 8a20: 20 cf bd     ..
+    iny                                                               // 8a23: c8          .
+    dec l0038                                                         // 8a24: c6 38       .8
+    bne loop_c8a11                                                    // 8a26: d0 e9       ..
+// $8a28 referenced 1 time by $8a0d
+c8a28
+    txa                                                               // 8a28: 8a          .
+    tay                                                               // 8a29: a8          .
+// $8a2a referenced 1 time by $8a32
+loop_c8a2a
+    iny                                                               // 8a2a: c8          .
+    beq c8a34                                                         // 8a2b: f0 07       ..
+    ldx #3                                                            // 8a2d: a2 03       ..
+    jsr cbdff                                                         // 8a2f: 20 ff bd     ..
+    bra loop_c8a2a                                                    // 8a32: 80 f6       ..
+// $8a34 referenced 1 time by $8a2b
+c8a34
+    ldx #$0a                                                          // 8a34: a2 0a       ..
+    lda (l000b)                                                       // 8a36: b2 0b       ..
+    cmp #$2e // '.'                                                   // 8a38: c9 2e       ..
+    bne c8a4b                                                         // 8a3a: d0 0f       ..
+// $8a3c referenced 1 time by $8a49
+loop_c8a3c
+    jsr sub_cbd77                                                     // 8a3c: 20 77 bd     w.
+    dex                                                               // 8a3f: ca          .
+    bne c8a44                                                         // 8a40: d0 02       ..
+    ldx #1                                                            // 8a42: a2 01       ..
+// $8a44 referenced 1 time by $8a40
+c8a44
+    iny                                                               // 8a44: c8          .
+    lda (l000b),y                                                     // 8a45: b1 0b       ..
+    cpy l004e                                                         // 8a47: c4 4e       .N
+    bne loop_c8a3c                                                    // 8a49: d0 f1       ..
+// $8a4b referenced 1 time by $8a3a
+c8a4b
+    jsr cbdff                                                         // 8a4b: 20 ff bd     ..
+    dey                                                               // 8a4e: 88          .
+// $8a4f referenced 1 time by $8a52
+loop_c8a4f
+    iny                                                               // 8a4f: c8          .
+    cmp (l000b),y                                                     // 8a50: d1 0b       ..
+    beq loop_c8a4f                                                    // 8a52: f0 fb       ..
+// $8a54 referenced 1 time by $8a62
+loop_c8a54
+    lda (l000b),y                                                     // 8a54: b1 0b       ..
+    cmp #$3a // ':'                                                   // 8a56: c9 3a       .:
+    beq c8a64                                                         // 8a58: f0 0a       ..
+    cmp #$0d                                                          // 8a5a: c9 0d       ..
+    beq c8a68                                                         // 8a5c: f0 0a       ..
+// $8a5e referenced 1 time by $8a66
+loop_c8a5e
+    jsr sub_cbd77                                                     // 8a5e: 20 77 bd     w.
+    iny                                                               // 8a61: c8          .
+    bra loop_c8a54                                                    // 8a62: 80 f0       ..
+// $8a64 referenced 1 time by $8a58
+c8a64
+    cpy l000a                                                         // 8a64: c4 0a       ..
+    bcc loop_c8a5e                                                    // 8a66: 90 f6       ..
+// $8a68 referenced 1 time by $8a5c
+c8a68
+    jsr sub_cbac2                                                     // 8a68: 20 c2 ba     ..
+// $8a6b referenced 1 time by $89f1
+c8a6b
+    ldy l000a                                                         // 8a6b: a4 0a       ..
+    dey                                                               // 8a6d: 88          .
+// $8a6e referenced 1 time by $8a77
+loop_c8a6e
+    iny                                                               // 8a6e: c8          .
+    lda (l000b),y                                                     // 8a6f: b1 0b       ..
+    cmp #$3a // ':'                                                   // 8a71: c9 3a       .:
+    beq c8a79                                                         // 8a73: f0 04       ..
+    cmp #$0d                                                          // 8a75: c9 0d       ..
+    bne loop_c8a6e                                                    // 8a77: d0 f5       ..
+// $8a79 referenced 1 time by $8a73
+c8a79
+    jsr c9c6c                                                         // 8a79: 20 6c 9c     l.
+    lda (l000b)                                                       // 8a7c: b2 0b       ..
+    cmp #$3a // ':'                                                   // 8a7e: c9 3a       .:
+    beq c8a8e                                                         // 8a80: f0 0c       ..
+    lda l000c                                                         // 8a82: a5 0c       ..
+    cmp #7                                                            // 8a84: c9 07       ..
+    bne c8a8b                                                         // 8a86: d0 03       ..
+    jmp c904b                                                         // 8a88: 4c 4b 90    LK.
+
+// $8a8b referenced 1 time by $8a86
+c8a8b
+    jsr sub_c9ca2                                                     // 8a8b: 20 a2 9c     ..
+// $8a8e referenced 1 time by $8a80
+c8a8e
+    jmp c89dd                                                         // 8a8e: 4c dd 89    L..
+
+// $8a91 referenced 1 time by $8abd
+c8a91
+    jsr sub_c997d                                                     // 8a91: 20 7d 99     }.
+    beq c8af2                                                         // 8a94: f0 5c       .\ 
+    bcs c8af2                                                         // 8a96: b0 5a       .Z
+    jsr sub_cbc83                                                     // 8a98: 20 83 bc     ..
+    jsr sub_cadc6                                                     // 8a9b: 20 c6 ad     ..
+    sta l0027                                                         // 8a9e: 85 27       .'
+    jsr sub_cb365                                                     // 8aa0: 20 65 b3     e.
+    jsr c9338                                                         // 8aa3: 20 38 93     8.
+    sty l004e                                                         // 8aa6: 84 4e       .N
+// $8aa8 referenced 1 time by $89e9
+sub_c8aa8
+    jsr c8f9d                                                         // 8aa8: 20 9d 8f     ..
+    ldy #0                                                            // 8aab: a0 00       ..
+    stz l003d                                                         // 8aad: 64 3d       d=
+    cmp #$3a // ':'                                                   // 8aaf: c9 3a       .:
+    beq c8b1b                                                         // 8ab1: f0 68       .h
+    cmp #$0d                                                          // 8ab3: c9 0d       ..
+    beq c8b1b                                                         // 8ab5: f0 64       .d
+    cmp #$5c // '\'                                                   // 8ab7: c9 5c       .\ 
+    beq c8b1b                                                         // 8ab9: f0 60       .`
+    cmp #$2e // '.'                                                   // 8abb: c9 2e       ..
+    beq c8a91                                                         // 8abd: f0 d2       ..
+    dec l000a                                                         // 8abf: c6 0a       ..
+    ldx #3                                                            // 8ac1: a2 03       ..
+// $8ac3 referenced 1 time by $8add
+loop_c8ac3
+    ldy l000a                                                         // 8ac3: a4 0a       ..
+    inc l000a                                                         // 8ac5: e6 0a       ..
+    lda (l000b),y                                                     // 8ac7: b1 0b       ..
+    bmi c8af5                                                         // 8ac9: 30 2a       0*
+    cmp #$20 // ' '                                                   // 8acb: c9 20       .
+    beq c8adf                                                         // 8acd: f0 10       ..
+    ldy #5                                                            // 8acf: a0 05       ..
+    asl                                                               // 8ad1: 0a          .
+    asl                                                               // 8ad2: 0a          .
+    asl                                                               // 8ad3: 0a          .
+// $8ad4 referenced 1 time by $8ada
+loop_c8ad4
+    asl                                                               // 8ad4: 0a          .
+    rol l003d                                                         // 8ad5: 26 3d       &=
+    rol l003e                                                         // 8ad7: 26 3e       &>
+    dey                                                               // 8ad9: 88          .
+    bne loop_c8ad4                                                    // 8ada: d0 f8       ..
+    dex                                                               // 8adc: ca          .
+    bne loop_c8ac3                                                    // 8add: d0 e4       ..
+// $8adf referenced 1 time by $8acd
+c8adf
+    ldx #$45 // 'E'                                                   // 8adf: a2 45       .E
+    lda l003d                                                         // 8ae1: a5 3d       .=
+// $8ae3 referenced 1 time by $8af0
+loop_c8ae3
+    cmp l8909,x                                                       // 8ae3: dd 09 89    ...
+    bne c8aef                                                         // 8ae6: d0 07       ..
+    ldy l894e,x                                                       // 8ae8: bc 4e 89    .N.
+    cpy l003e                                                         // 8aeb: c4 3e       .>
+    beq c8b10                                                         // 8aed: f0 21       .!
+// $8aef referenced 1 time by $8ae6
+c8aef
+    dex                                                               // 8aef: ca          .
+    bne loop_c8ae3                                                    // 8af0: d0 f1       ..
+// $8af2 referenced 4 times by $8a94, $8a96, $8b03, $8b0e
+c8af2
+    jmp c9c2d                                                         // 8af2: 4c 2d 9c    L-.
+
+// $8af5 referenced 1 time by $8ac9
+c8af5
+    ldx #$29 // ')'                                                   // 8af5: a2 29       .)
+    cmp #$80                                                          // 8af7: c9 80       ..
+    beq c8b10                                                         // 8af9: f0 15       ..
+    inx                                                               // 8afb: e8          .
+    cmp #$82                                                          // 8afc: c9 82       ..
+    beq c8b10                                                         // 8afe: f0 10       ..
+    inx                                                               // 8b00: e8          .
+    cmp #$84                                                          // 8b01: c9 84       ..
+    bne c8af2                                                         // 8b03: d0 ed       ..
+    inc l000a                                                         // 8b05: e6 0a       ..
+    iny                                                               // 8b07: c8          .
+    lda (l000b),y                                                     // 8b08: b1 0b       ..
+    and #$df                                                          // 8b0a: 29 df       ).
+    cmp #$41 // 'A'                                                   // 8b0c: c9 41       .A
+    bne c8af2                                                         // 8b0e: d0 e2       ..
+// $8b10 referenced 3 times by $8aed, $8af9, $8afe
+c8b10
+    lda l8993,x                                                       // 8b10: bd 93 89    ...
+    sta l0029                                                         // 8b13: 85 29       .)
+    ldy #1                                                            // 8b15: a0 01       ..
+    cpx #$20 // ' '                                                   // 8b17: e0 20       .
+    bcs c8b63                                                         // 8b19: b0 48       .H
+// $8b1b referenced 6 times by $8ab1, $8ab5, $8ab9, $8ba0, $8cbd, $8d6e
+c8b1b
+    lda l0440                                                         // 8b1b: ad 40 04    .@.
+    sta l0037                                                         // 8b1e: 85 37       .7
+    sty l0039                                                         // 8b20: 84 39       .9
+    ldx l0028                                                         // 8b22: a6 28       .(
+    cpx #4                                                            // 8b24: e0 04       ..
+    ldx l0441                                                         // 8b26: ae 41 04    .A.
+    stx l0038                                                         // 8b29: 86 38       .8
+    bcc c8b33                                                         // 8b2b: 90 06       ..
+    lda l043c                                                         // 8b2d: ad 3c 04    .<.
+    ldx l043d                                                         // 8b30: ae 3d 04    .=.
+// $8b33 referenced 1 time by $8b2b
+c8b33
+    sta l003a                                                         // 8b33: 85 3a       .:
+    stx l003b                                                         // 8b35: 86 3b       .;
+    tya                                                               // 8b37: 98          .
+    beq c8b62                                                         // 8b38: f0 28       .(
+    bpl c8b40                                                         // 8b3a: 10 04       ..
+    ldy l0036                                                         // 8b3c: a4 36       .6
+    beq c8b62                                                         // 8b3e: f0 22       ."
+// $8b40 referenced 2 times by $8b3a, $8b60
+c8b40
+    dey                                                               // 8b40: 88          .
+    lda l0029,y                                                       // 8b41: b9 29 00    .).
+    bit l0039                                                         // 8b44: 24 39       $9
+    bpl c8b4b                                                         // 8b46: 10 03       ..
+    lda l0600,y                                                       // 8b48: b9 00 06    ...
+// $8b4b referenced 1 time by $8b46
+c8b4b
+    sta (l003a),y                                                     // 8b4b: 91 3a       .:
+    inc l0440                                                         // 8b4d: ee 40 04    .@.
+    bne c8b55                                                         // 8b50: d0 03       ..
+    inc l0441                                                         // 8b52: ee 41 04    .A.
+// $8b55 referenced 1 time by $8b50
+c8b55
+    bcc c8b5f                                                         // 8b55: 90 08       ..
+    inc l043c                                                         // 8b57: ee 3c 04    .<.
+    bne c8b5f                                                         // 8b5a: d0 03       ..
+    inc l043d                                                         // 8b5c: ee 3d 04    .=.
+// $8b5f referenced 2 times by $8b55, $8b5a
+c8b5f
+    tya                                                               // 8b5f: 98          .
+    bne c8b40                                                         // 8b60: d0 de       ..
+// $8b62 referenced 2 times by $8b38, $8b3e
+c8b62
+    rts                                                               // 8b62: 60          `
+
+// $8b63 referenced 1 time by $8b19
+c8b63
+    cpx #$29 // ')'                                                   // 8b63: e0 29       .)
+    bcs c8ba3                                                         // 8b65: b0 3c       .<
+    jsr sub_c9332                                                     // 8b67: 20 32 93     2.
+    clc                                                               // 8b6a: 18          .
+    lda l002a                                                         // 8b6b: a5 2a       .*
+    sbc l0440                                                         // 8b6d: ed 40 04    .@.
+    tay                                                               // 8b70: a8          .
+    lda l002b                                                         // 8b71: a5 2b       .+
+    sbc l0441                                                         // 8b73: ed 41 04    .A.
+    cpy #1                                                            // 8b76: c0 01       ..
+    dey                                                               // 8b78: 88          .
+    sbc #0                                                            // 8b79: e9 00       ..
+    beq c8b98                                                         // 8b7b: f0 1b       ..
+    inc                                                               // 8b7d: 1a          .
+    bne c8b83                                                         // 8b7e: d0 03       ..
+    tya                                                               // 8b80: 98          .
+    bmi c8b9c                                                         // 8b81: 30 19       0.
+// $8b83 referenced 2 times by $8b7e, $8b99
+c8b83
+    lda l0028                                                         // 8b83: a5 28       .(
+    and #2                                                            // 8b85: 29 02       ).
+    beq c8b9b                                                         // 8b87: f0 12       ..
+    brk                                                               // 8b89: 00          .
+
+    .byt 1                                                            // 8b8a: 01          .
+    .asc "Out of range"                                               // 8b8b: 4f 75 74... Out
+    .byt 0                                                            // 8b97: 00          .
+
+// $8b98 referenced 1 time by $8b7b
+c8b98
+    tya                                                               // 8b98: 98          .
+    bmi c8b83                                                         // 8b99: 30 e8       0.
+// $8b9b referenced 1 time by $8b87
+c8b9b
+    tay                                                               // 8b9b: a8          .
+// $8b9c referenced 1 time by $8b81
+c8b9c
+    sty l002a                                                         // 8b9c: 84 2a       .*
+// $8b9e referenced 1 time by $8bb4
+loop_c8b9e
+    ldy #2                                                            // 8b9e: a0 02       ..
+    jmp c8b1b                                                         // 8ba0: 4c 1b 8b    L..
+
+// $8ba3 referenced 1 time by $8b65
+c8ba3
+    cpx #$30 // '0'                                                   // 8ba3: e0 30       .0
+    bcs c8bbd                                                         // 8ba5: b0 16       ..
+    jsr sub_c8d9c                                                     // 8ba7: 20 9c 8d     ..
+    bne c8bc4                                                         // 8baa: d0 18       ..
+    jsr sub_c8d89                                                     // 8bac: 20 89 8d     ..
+// $8baf referenced 1 time by $8ca4
+c8baf
+    jsr sub_c9332                                                     // 8baf: 20 32 93     2.
+// $8bb2 referenced 3 times by $8bdc, $8be5, $8bf7
+c8bb2
+    lda l002b                                                         // 8bb2: a5 2b       .+
+// $8bb4 referenced 1 time by $8c22
+c8bb4
+    beq loop_c8b9e                                                    // 8bb4: f0 e8       ..
+// $8bb6 referenced 1 time by $8d31
+c8bb6
+    brk                                                               // 8bb6: 00          .
+
+    .byt 2                                                            // 8bb7: 02          .
+    .asc "Byte"                                                       // 8bb8: 42 79 74... Byt
+    .byt 0                                                            // 8bbc: 00          .
+
+// $8bbd referenced 1 time by $8ba5
+c8bbd
+    cpx #$41 // 'A'                                                   // 8bbd: e0 41       .A
+    bne c8c24                                                         // 8bbf: d0 63       .c
+    jsr c8f9d                                                         // 8bc1: 20 9d 8f     ..
+// $8bc4 referenced 1 time by $8baa
+c8bc4
+    cmp #$28 // '('                                                   // 8bc4: c9 28       .(
+    bne c8c01                                                         // 8bc6: d0 39       .9
+    jsr sub_c9332                                                     // 8bc8: 20 32 93     2.
+    jsr c8f9d                                                         // 8bcb: 20 9d 8f     ..
+    cmp #$29 // ')'                                                   // 8bce: c9 29       .)
+    bne c8be9                                                         // 8bd0: d0 17       ..
+    jsr sub_c8d86                                                     // 8bd2: 20 86 8d     ..
+    jsr sub_c8da2                                                     // 8bd5: 20 a2 8d     ..
+    beq c8bde                                                         // 8bd8: f0 04       ..
+    inc l0029                                                         // 8bda: e6 29       .)
+    bra c8bb2                                                         // 8bdc: 80 d4       ..
+// $8bde referenced 1 time by $8bd8
+c8bde
+    jsr c8f9d                                                         // 8bde: 20 9d 8f     ..
+    and #$df                                                          // 8be1: 29 df       ).
+    cmp #$59 // 'Y'                                                   // 8be3: c9 59       .Y
+    beq c8bb2                                                         // 8be5: f0 cb       ..
+    bra c8bf9                                                         // 8be7: 80 10       ..
+// $8be9 referenced 1 time by $8bd0
+c8be9
+    cmp #$2c // ','                                                   // 8be9: c9 2c       .,
+    bne c8bf9                                                         // 8beb: d0 0c       ..
+    jsr sub_c8d94                                                     // 8bed: 20 94 8d     ..
+    bne c8bf9                                                         // 8bf0: d0 07       ..
+    jsr c8f9d                                                         // 8bf2: 20 9d 8f     ..
+    cmp #$29 // ')'                                                   // 8bf5: c9 29       .)
+    beq c8bb2                                                         // 8bf7: f0 b9       ..
+// $8bf9 referenced 6 times by $8be7, $8beb, $8bf0, $8c13, $8c41, $8ce3
+c8bf9
+    brk                                                               // 8bf9: 00          .
+
+    .byt 3                                                            // 8bfa: 03          .
+    .asc "Index"                                                      // 8bfb: 49 6e 64... Ind
+    .byt 0                                                            // 8c00: 00          .
+
+// $8c01 referenced 1 time by $8bc6
+c8c01
+    jsr sub_c9330                                                     // 8c01: 20 30 93     0.
+    jsr sub_c8da2                                                     // 8c04: 20 a2 8d     ..
+    bne c8c1b                                                         // 8c07: d0 12       ..
+    jsr sub_c8d86                                                     // 8c09: 20 86 8d     ..
+    jsr sub_c8d94                                                     // 8c0c: 20 94 8d     ..
+    beq c8c1b                                                         // 8c0f: f0 0a       ..
+    cmp #$59 // 'Y'                                                   // 8c11: c9 59       .Y
+    bne c8bf9                                                         // 8c13: d0 e4       ..
+// $8c15 referenced 1 time by $8c20
+loop_c8c15
+    jsr sub_c8d89                                                     // 8c15: 20 89 8d     ..
+    jmp c8cbb                                                         // 8c18: 4c bb 8c    L..
+
+// $8c1b referenced 3 times by $8c07, $8c0f, $8c99
+c8c1b
+    jsr sub_c8d8c                                                     // 8c1b: 20 8c 8d     ..
+// $8c1e referenced 3 times by $8c37, $8c3f, $8d34
+c8c1e
+    lda l002b                                                         // 8c1e: a5 2b       .+
+    bne loop_c8c15                                                    // 8c20: d0 f3       ..
+    bra c8bb4                                                         // 8c22: 80 90       ..
+// $8c24 referenced 1 time by $8bbf
+c8c24
+    cpx #$36 // '6'                                                   // 8c24: e0 36       .6
+    bcs c8c5e                                                         // 8c26: b0 36       .6
+    jsr c8f9d                                                         // 8c28: 20 9d 8f     ..
+    and #$df                                                          // 8c2b: 29 df       ).
+    cmp #$41 // 'A'                                                   // 8c2d: c9 41       .A
+    beq c8c43                                                         // 8c2f: f0 12       ..
+// $8c31 referenced 2 times by $8c49, $8c9e
+c8c31
+    jsr sub_c9330                                                     // 8c31: 20 30 93     0.
+    jsr sub_c8da2                                                     // 8c34: 20 a2 8d     ..
+    bne c8c1e                                                         // 8c37: d0 e5       ..
+    jsr sub_c8d86                                                     // 8c39: 20 86 8d     ..
+    jsr sub_c8d94                                                     // 8c3c: 20 94 8d     ..
+    beq c8c1e                                                         // 8c3f: f0 dd       ..
+// $8c41 referenced 1 time by $8c7d
+c8c41
+    bra c8bf9                                                         // 8c41: 80 b6       ..
+// $8c43 referenced 1 time by $8c2f
+c8c43
+    iny                                                               // 8c43: c8          .
+    lda (l000b),y                                                     // 8c44: b1 0b       ..
+    jsr sub_c8e41                                                     // 8c46: 20 41 8e     A.
+    bcs c8c31                                                         // 8c49: b0 e6       ..
+    ldy #$16                                                          // 8c4b: a0 16       ..
+    cpx #$34 // '4'                                                   // 8c4d: e0 34       .4
+    bcc c8c57                                                         // 8c4f: 90 06       ..
+    bne c8c55                                                         // 8c51: d0 02       ..
+    ldy #$36 // '6'                                                   // 8c53: a0 36       .6
+// $8c55 referenced 1 time by $8c51
+c8c55
+    sty l0029                                                         // 8c55: 84 29       .)
+// $8c57 referenced 1 time by $8c4f
+c8c57
+    jsr sub_c8d8c                                                     // 8c57: 20 8c 8d     ..
+    ldy #1                                                            // 8c5a: a0 01       ..
+    bra c8cbd                                                         // 8c5c: 80 5f       ._
+// $8c5e referenced 1 time by $8c26
+c8c5e
+    cpx #$38 // '8'                                                   // 8c5e: e0 38       .8
+    bcs c8c87                                                         // 8c60: b0 25       .%
+    jsr sub_c9332                                                     // 8c62: 20 32 93     2.
+    ldy #3                                                            // 8c65: a0 03       ..
+    ldx #1                                                            // 8c67: a2 01       ..
+    lda l002b                                                         // 8c69: a5 2b       .+
+    bne c8c74                                                         // 8c6b: d0 07       ..
+    ldx #$0f                                                          // 8c6d: a2 0f       ..
+    lda #$64 // 'd'                                                   // 8c6f: a9 64       .d
+    sta l0029                                                         // 8c71: 85 29       .)
+    dey                                                               // 8c73: 88          .
+// $8c74 referenced 1 time by $8c6b
+c8c74
+    phy                                                               // 8c74: 5a          Z
+    jsr sub_c8da2                                                     // 8c75: 20 a2 8d     ..
+    bne c8c84                                                         // 8c78: d0 0a       ..
+    jsr sub_c8d94                                                     // 8c7a: 20 94 8d     ..
+    bne c8c41                                                         // 8c7d: d0 c2       ..
+    txa                                                               // 8c7f: 8a          .
+    adc l0029                                                         // 8c80: 65 29       e)
+    sta l0029                                                         // 8c82: 85 29       .)
+// $8c84 referenced 1 time by $8c78
+c8c84
+    ply                                                               // 8c84: 7a          z
+    bra c8cbd                                                         // 8c85: 80 36       .6
+// $8c87 referenced 1 time by $8c60
+c8c87
+    cpx #$3c // '<'                                                   // 8c87: e0 3c       .<
+    bcs c8ca7                                                         // 8c89: b0 1c       ..
+    cpx #$3a // ':'                                                   // 8c8b: e0 3a       .:
+    bcs c8c96                                                         // 8c8d: b0 07       ..
+    jsr sub_c8d9c                                                     // 8c8f: 20 9c 8d     ..
+    beq c8ca4                                                         // 8c92: f0 10       ..
+    dec l000a                                                         // 8c94: c6 0a       ..
+// $8c96 referenced 1 time by $8c8d
+c8c96
+    jsr sub_c9332                                                     // 8c96: 20 32 93     2.
+// $8c99 referenced 2 times by $8d06, $8d14
+c8c99
+    bra c8c1b                                                         // 8c99: 80 80       ..
+// $8c9b referenced 1 time by $8ca7
+loop_c8c9b
+    jsr sub_c8d9c                                                     // 8c9b: 20 9c 8d     ..
+    bne c8c31                                                         // 8c9e: d0 91       ..
+    ldy #$89                                                          // 8ca0: a0 89       ..
+    sty l0029                                                         // 8ca2: 84 29       .)
+// $8ca4 referenced 2 times by $8c92, $8cfb
+c8ca4
+    jmp c8baf                                                         // 8ca4: 4c af 8b    L..
+
+// $8ca7 referenced 1 time by $8c89
+c8ca7
+    beq loop_c8c9b                                                    // 8ca7: f0 f2       ..
+    cpx #$3e // '>'                                                   // 8ca9: e0 3e       .>
+    beq c8cb8                                                         // 8cab: f0 0b       ..
+    bcs c8ce6                                                         // 8cad: b0 37       .7
+    jsr c8f9d                                                         // 8caf: 20 9d 8f     ..
+    cmp #$28 // '('                                                   // 8cb2: c9 28       .(
+    beq c8cc0                                                         // 8cb4: f0 0a       ..
+    dec l000a                                                         // 8cb6: c6 0a       ..
+// $8cb8 referenced 1 time by $8cab
+c8cb8
+    jsr sub_c9332                                                     // 8cb8: 20 32 93     2.
+// $8cbb referenced 3 times by $8c18, $8cce, $8ce1
+c8cbb
+    ldy #3                                                            // 8cbb: a0 03       ..
+// $8cbd referenced 2 times by $8c5c, $8c85
+c8cbd
+    jmp c8b1b                                                         // 8cbd: 4c 1b 8b    L..
+
+// $8cc0 referenced 1 time by $8cb4
+c8cc0
+    jsr sub_c8d86                                                     // 8cc0: 20 86 8d     ..
+    jsr sub_c8d86                                                     // 8cc3: 20 86 8d     ..
+    jsr sub_c9332                                                     // 8cc6: 20 32 93     2.
+    jsr c8f9d                                                         // 8cc9: 20 9d 8f     ..
+    cmp #$29 // ')'                                                   // 8ccc: c9 29       .)
+    beq c8cbb                                                         // 8cce: f0 eb       ..
+    cmp #$2c // ','                                                   // 8cd0: c9 2c       .,
+    bne c8ce3                                                         // 8cd2: d0 0f       ..
+    jsr sub_c8d86                                                     // 8cd4: 20 86 8d     ..
+    jsr sub_c8d94                                                     // 8cd7: 20 94 8d     ..
+    bne c8ce3                                                         // 8cda: d0 07       ..
+    jsr c8f9d                                                         // 8cdc: 20 9d 8f     ..
+    cmp #$29 // ')'                                                   // 8cdf: c9 29       .)
+    beq c8cbb                                                         // 8ce1: f0 d8       ..
+// $8ce3 referenced 4 times by $8cd2, $8cda, $8d0f, $8d28
+c8ce3
+    jmp c8bf9                                                         // 8ce3: 4c f9 8b    L..
+
+// $8ce6 referenced 1 time by $8cad
+c8ce6
+    cpx #$44 // 'D'                                                   // 8ce6: e0 44       .D
+    bcs c8d37                                                         // 8ce8: b0 4d       .M
+    lda l003d                                                         // 8cea: a5 3d       .=
+    eor #1                                                            // 8cec: 49 01       I.
+    and #$1f                                                          // 8cee: 29 1f       ).
+    pha                                                               // 8cf0: 48          H
+    cpx #$41 // 'A'                                                   // 8cf1: e0 41       .A
+    bcs c8d16                                                         // 8cf3: b0 21       .!
+    jsr sub_c8d9c                                                     // 8cf5: 20 9c 8d     ..
+    bne c8cfd                                                         // 8cf8: d0 03       ..
+    pla                                                               // 8cfa: 68          h
+    bra c8ca4                                                         // 8cfb: 80 a7       ..
+// $8cfd referenced 1 time by $8cf8
+c8cfd
+    jsr sub_c9330                                                     // 8cfd: 20 30 93     0.
+    pla                                                               // 8d00: 68          h
+    sta l0037                                                         // 8d01: 85 37       .7
+    jsr sub_c8da2                                                     // 8d03: 20 a2 8d     ..
+    bne c8c99                                                         // 8d06: d0 91       ..
+    jsr c8f9d                                                         // 8d08: 20 9d 8f     ..
+    and #$1f                                                          // 8d0b: 29 1f       ).
+    cmp l0037                                                         // 8d0d: c5 37       .7
+    bne c8ce3                                                         // 8d0f: d0 d2       ..
+    jsr sub_c8d86                                                     // 8d11: 20 86 8d     ..
+    bra c8c99                                                         // 8d14: 80 83       ..
+// $8d16 referenced 1 time by $8cf3
+c8d16
+    jsr sub_c9332                                                     // 8d16: 20 32 93     2.
+    pla                                                               // 8d19: 68          h
+    sta l0037                                                         // 8d1a: 85 37       .7
+    jsr sub_c8da2                                                     // 8d1c: 20 a2 8d     ..
+    bne c8d34                                                         // 8d1f: d0 13       ..
+    jsr c8f9d                                                         // 8d21: 20 9d 8f     ..
+    and #$1f                                                          // 8d24: 29 1f       ).
+    cmp l0037                                                         // 8d26: c5 37       .7
+    bne c8ce3                                                         // 8d28: d0 b9       ..
+    jsr sub_c8d86                                                     // 8d2a: 20 86 8d     ..
+    lda l002b                                                         // 8d2d: a5 2b       .+
+    beq c8d34                                                         // 8d2f: f0 03       ..
+    jmp c8bb6                                                         // 8d31: 4c b6 8b    L..
+
+// $8d34 referenced 2 times by $8d1f, $8d2f
+c8d34
+    jmp c8c1e                                                         // 8d34: 4c 1e 8c    L..
+
+// $8d37 referenced 1 time by $8ce8
+c8d37
+    bne c8d44                                                         // 8d37: d0 0b       ..
+    jsr sub_c9332                                                     // 8d39: 20 32 93     2.
+    lda l002a                                                         // 8d3c: a5 2a       .*
+    sta l0028                                                         // 8d3e: 85 28       .(
+    ldy #0                                                            // 8d40: a0 00       ..
+    bra c8d6e                                                         // 8d42: 80 2a       .*
+// $8d44 referenced 1 time by $8d37
+c8d44
+    ldx #1                                                            // 8d44: a2 01       ..
+    ldy l000a                                                         // 8d46: a4 0a       ..
+    inc l000a                                                         // 8d48: e6 0a       ..
+    lda (l000b),y                                                     // 8d4a: b1 0b       ..
+    and #$df                                                          // 8d4c: 29 df       ).
+    cmp #$42 // 'B'                                                   // 8d4e: c9 42       .B
+    beq c8d64                                                         // 8d50: f0 12       ..
+    inx                                                               // 8d52: e8          .
+    cmp #$57 // 'W'                                                   // 8d53: c9 57       .W
+    beq c8d64                                                         // 8d55: f0 0d       ..
+    ldx #4                                                            // 8d57: a2 04       ..
+    cmp #$44 // 'D'                                                   // 8d59: c9 44       .D
+    beq c8d64                                                         // 8d5b: f0 07       ..
+    cmp #$53 // 'S'                                                   // 8d5d: c9 53       .S
+    beq c8d74                                                         // 8d5f: f0 13       ..
+    jmp c9c2d                                                         // 8d61: 4c 2d 9c    L-.
+
+// $8d64 referenced 3 times by $8d50, $8d55, $8d5b
+c8d64
+    phx                                                               // 8d64: da          .
+    jsr sub_c9332                                                     // 8d65: 20 32 93     2.
+    ldx #$29 // ')'                                                   // 8d68: a2 29       .)
+    jsr sub_cbe06                                                     // 8d6a: 20 06 be     ..
+    ply                                                               // 8d6d: 7a          z
+// $8d6e referenced 2 times by $8d42, $8d84
+c8d6e
+    jmp c8b1b                                                         // 8d6e: 4c 1b 8b    L..
+
+// $8d71 referenced 1 time by $8d7a
+loop_c8d71
+    jmp c9155                                                         // 8d71: 4c 55 91    LU.
+
+// $8d74 referenced 1 time by $8d5f
+c8d74
+    lda l0028                                                         // 8d74: a5 28       .(
+    pha                                                               // 8d76: 48          H
+    jsr sub_c9df3                                                     // 8d77: 20 f3 9d     ..
+    bne loop_c8d71                                                    // 8d7a: d0 f5       ..
+    pla                                                               // 8d7c: 68          h
+    sta l0028                                                         // 8d7d: 85 28       .(
+    jsr c9338                                                         // 8d7f: 20 38 93     8.
+    ldy #$ff                                                          // 8d82: a0 ff       ..
+    bra c8d6e                                                         // 8d84: 80 e8       ..
+// $8d86 referenced 8 times by $8bd2, $8c09, $8c39, $8cc0, $8cc3, $8cd4, $8d11, $8d2a
+sub_c8d86
+    jsr sub_c8d89                                                     // 8d86: 20 89 8d     ..
+// $8d89 referenced 3 times by $8bac, $8c15, $8d86
+sub_c8d89
+    jsr sub_c8d8c                                                     // 8d89: 20 8c 8d     ..
+// $8d8c referenced 3 times by $8c1b, $8c57, $8d89
+sub_c8d8c
+    lda l0029                                                         // 8d8c: a5 29       .)
+    clc                                                               // 8d8e: 18          .
+    adc #4                                                            // 8d8f: 69 04       i.
+    sta l0029                                                         // 8d91: 85 29       .)
+    rts                                                               // 8d93: 60          `
+
+// $8d94 referenced 5 times by $8bed, $8c0c, $8c3c, $8c7a, $8cd7
+sub_c8d94
+    jsr c8f9d                                                         // 8d94: 20 9d 8f     ..
+    and #$df                                                          // 8d97: 29 df       ).
+    cmp #$58 // 'X'                                                   // 8d99: c9 58       .X
+    rts                                                               // 8d9b: 60          `
+
+// $8d9c referenced 6 times by $8ba7, $8c8f, $8c9b, $8cf5, $9250, $b8e6
+sub_c8d9c
+    jsr c8f9d                                                         // 8d9c: 20 9d 8f     ..
+    cmp #$23 // '#'                                                   // 8d9f: c9 23       .#
+    rts                                                               // 8da1: 60          `
+
+// $8da2 referenced 18 times by $8bd5, $8c04, $8c34, $8c75, $8d03, $8d1c, $93e2, $9420, $95be, $9670, $97f6, $98f3, $b133, $b3e5, $b3f4, $b5e9, $b87f, $b9a5
+sub_c8da2
+    jsr c8f9d                                                         // 8da2: 20 9d 8f     ..
+    cmp #$2c // ','                                                   // 8da5: c9 2c       .,
+    rts                                                               // 8da7: 60          `
+
+// $8da8 referenced 2 times by $8e02, $8f5e
+sub_c8da8
+    sta (l0037)                                                       // 8da8: 92 37       .7
+    clc                                                               // 8daa: 18          .
+    tya                                                               // 8dab: 98          .
+    adc l0037                                                         // 8dac: 65 37       e7
+    sta l0039                                                         // 8dae: 85 39       .9
+    ldy #0                                                            // 8db0: a0 00       ..
+    tya                                                               // 8db2: 98          .
+    adc l0038                                                         // 8db3: 65 38       e8
+    sta l003a                                                         // 8db5: 85 3a       .:
+// $8db7 referenced 1 time by $8dbe
+loop_c8db7
+    iny                                                               // 8db7: c8          .
+    lda (l0039),y                                                     // 8db8: b1 39       .9
+    sta (l0037),y                                                     // 8dba: 91 37       .7
+    cmp #$0d                                                          // 8dbc: c9 0d       ..
+    bne loop_c8db7                                                    // 8dbe: d0 f7       ..
+    rts                                                               // 8dc0: 60          `
+
+// $8dc1 referenced 1 time by $8ecb
+sub_c8dc1
+    and #$0f                                                          // 8dc1: 29 0f       ).
+    sta l003d                                                         // 8dc3: 85 3d       .=
+    ldx #0                                                            // 8dc5: a2 00       ..
+    ldy #0                                                            // 8dc7: a0 00       ..
+// $8dc9 referenced 2 times by $8df6, $8df9
+c8dc9
+    iny                                                               // 8dc9: c8          .
+    lda (l0037),y                                                     // 8dca: b1 37       .7
+    jsr c8e51                                                         // 8dcc: 20 51 8e     Q.
+    bcc c8dff                                                         // 8dcf: 90 2e       ..
+    and #$0f                                                          // 8dd1: 29 0f       ).
+    pha                                                               // 8dd3: 48          H
+    stx l003e                                                         // 8dd4: 86 3e       .>
+    lda l003d                                                         // 8dd6: a5 3d       .=
+    asl                                                               // 8dd8: 0a          .
+    rol l003e                                                         // 8dd9: 26 3e       &>
+    bmi c8dfc                                                         // 8ddb: 30 1f       0.
+    asl                                                               // 8ddd: 0a          .
+    rol l003e                                                         // 8dde: 26 3e       &>
+    bmi c8dfc                                                         // 8de0: 30 1a       0.
+    adc l003d                                                         // 8de2: 65 3d       e=
+    sta l003d                                                         // 8de4: 85 3d       .=
+    txa                                                               // 8de6: 8a          .
+    adc l003e                                                         // 8de7: 65 3e       e>
+    asl l003d                                                         // 8de9: 06 3d       .=
+    rol                                                               // 8deb: 2a          *
+    bmi c8dfc                                                         // 8dec: 30 0e       0.
+    bcs c8dfc                                                         // 8dee: b0 0c       ..
+    tax                                                               // 8df0: aa          .
+    pla                                                               // 8df1: 68          h
+    adc l003d                                                         // 8df2: 65 3d       e=
+    sta l003d                                                         // 8df4: 85 3d       .=
+    bcc c8dc9                                                         // 8df6: 90 d1       ..
+    inx                                                               // 8df8: e8          .
+    bpl c8dc9                                                         // 8df9: 10 ce       ..
+    pha                                                               // 8dfb: 48          H
+// $8dfc referenced 4 times by $8ddb, $8de0, $8dec, $8dee
+c8dfc
+    pla                                                               // 8dfc: 68          h
+    sec                                                               // 8dfd: 38          8
+    rts                                                               // 8dfe: 60          `
+
+// $8dff referenced 1 time by $8dcf
+c8dff
+    dey                                                               // 8dff: 88          .
+    lda #$8d                                                          // 8e00: a9 8d       ..
+    jsr sub_c8da8                                                     // 8e02: 20 a8 8d     ..
+    lda l0037                                                         // 8e05: a5 37       .7
+    sta l0039                                                         // 8e07: 85 39       .9
+    lda l0038                                                         // 8e09: a5 38       .8
+    sta l003a                                                         // 8e0b: 85 3a       .:
+    jsr sub_c8e5f                                                     // 8e0d: 20 5f 8e     _.
+    jsr sub_c8e5f                                                     // 8e10: 20 5f 8e     _.
+    jsr sub_c8e5f                                                     // 8e13: 20 5f 8e     _.
+// $8e16 referenced 1 time by $8e1b
+loop_c8e16
+    lda (l0039),y                                                     // 8e16: b1 39       .9
+    sta (l0037),y                                                     // 8e18: 91 37       .7
+    dey                                                               // 8e1a: 88          .
+    bne loop_c8e16                                                    // 8e1b: d0 f9       ..
+    ldy #3                                                            // 8e1d: a0 03       ..
+// $8e1f referenced 1 time by $9506
+sub_c8e1f
+    txa                                                               // 8e1f: 8a          .
+    ora #$40 // '@'                                                   // 8e20: 09 40       .@
+    sta (l0039),y                                                     // 8e22: 91 39       .9
+    dey                                                               // 8e24: 88          .
+    lda l003d                                                         // 8e25: a5 3d       .=
+    and #$3f // '?'                                                   // 8e27: 29 3f       )?
+    ora #$40 // '@'                                                   // 8e29: 09 40       .@
+    sta (l0039),y                                                     // 8e2b: 91 39       .9
+    dey                                                               // 8e2d: 88          .
+    lda #$3f // '?'                                                   // 8e2e: a9 3f       .?
+    trb l003d                                                         // 8e30: 14 3d       .=
+    txa                                                               // 8e32: 8a          .
+    and #$c0                                                          // 8e33: 29 c0       ).
+    lsr                                                               // 8e35: 4a          J
+    lsr                                                               // 8e36: 4a          J
+    ora l003d                                                         // 8e37: 05 3d       .=
+    lsr                                                               // 8e39: 4a          J
+    lsr                                                               // 8e3a: 4a          J
+    eor #$54 // 'T'                                                   // 8e3b: 49 54       IT
+    sta (l0039),y                                                     // 8e3d: 91 39       .9
+// $8e3f referenced 3 times by $8e43, $8e4b, $8e53
+c8e3f
+    clc                                                               // 8e3f: 18          .
+    rts                                                               // 8e40: 60          `
+
+// $8e41 referenced 6 times by $8c46, $8ee2, $8ee9, $8f4d, $8f7c, $b027
+sub_c8e41
+    cmp #$7b // '{'                                                   // 8e41: c9 7b       .{
+    bcs c8e3f                                                         // 8e43: b0 fa       ..
+    cmp #$5f // '_'                                                   // 8e45: c9 5f       ._
+    bcs c8e57                                                         // 8e47: b0 0e       ..
+    cmp #$5b // '['                                                   // 8e49: c9 5b       .[
+    bcs c8e3f                                                         // 8e4b: b0 f2       ..
+    cmp #$41 // 'A'                                                   // 8e4d: c9 41       .A
+    bcs c8e57                                                         // 8e4f: b0 06       ..
+// $8e51 referenced 4 times by $8dcc, $8e5a, $8e80, $8ec2
+c8e51
+    cmp #$3a // ':'                                                   // 8e51: c9 3a       .:
+    bcs c8e3f                                                         // 8e53: b0 ea       ..
+    cmp #$30 // '0'                                                   // 8e55: c9 30       .0
+// $8e57 referenced 2 times by $8e47, $8e4f
+c8e57
+    rts                                                               // 8e57: 60          `
+
+// $8e58 referenced 1 time by $8ed2
+sub_c8e58
+    cmp #$2e // '.'                                                   // 8e58: c9 2e       ..
+    bne c8e51                                                         // 8e5a: d0 f5       ..
+    rts                                                               // 8e5c: 60          `
+
+    .byt $b2, $37                                                     // 8e5d: b2 37       .7
+
+// $8e5f referenced 9 times by $8e0d, $8e10, $8e13, $8e66, $8e6c, $8ea1, $8ed7, $8eee, $8f81
+sub_c8e5f
+    inc l0037                                                         // 8e5f: e6 37       .7
+    bne c8e9c                                                         // 8e61: d0 39       .9
+    inc l0038                                                         // 8e63: e6 38       .8
+    rts                                                               // 8e65: 60          `
+
+// $8e66 referenced 3 times by $8e7d, $8e91, $bf1a
+sub_c8e66
+    jsr sub_c8e5f                                                     // 8e66: 20 5f 8e     _.
+    lda (l0037)                                                       // 8e69: b2 37       .7
+    rts                                                               // 8e6b: 60          `
+
+// $8e6c referenced 6 times by $8e77, $8e96, $8eac, $8ebc, $8ece, $8f8f
+c8e6c
+    jsr sub_c8e5f                                                     // 8e6c: 20 5f 8e     _.
+// $8e6f referenced 3 times by $8e87, $8ea8, $bb30
+c8e6f
+    lda (l0037)                                                       // 8e6f: b2 37       .7
+    cmp #$0d                                                          // 8e71: c9 0d       ..
+    beq c8e9c                                                         // 8e73: f0 27       .'
+    cmp #$20 // ' '                                                   // 8e75: c9 20       .
+    beq c8e6c                                                         // 8e77: f0 f3       ..
+    cmp #$26 // '&'                                                   // 8e79: c9 26       .&
+    bne c8e8d                                                         // 8e7b: d0 10       ..
+// $8e7d referenced 2 times by $8e83, $8e8b
+c8e7d
+    jsr sub_c8e66                                                     // 8e7d: 20 66 8e     f.
+    jsr c8e51                                                         // 8e80: 20 51 8e     Q.
+    bcs c8e7d                                                         // 8e83: b0 f8       ..
+    cmp #$41 // 'A'                                                   // 8e85: c9 41       .A
+    bcc c8e6f                                                         // 8e87: 90 e6       ..
+    cmp #$47 // 'G'                                                   // 8e89: c9 47       .G
+    bcc c8e7d                                                         // 8e8b: 90 f0       ..
+// $8e8d referenced 1 time by $8e7b
+c8e8d
+    cmp #$22 // '"'                                                   // 8e8d: c9 22       ."
+    bne c8e9d                                                         // 8e8f: d0 0c       ..
+// $8e91 referenced 1 time by $8e9a
+loop_c8e91
+    jsr sub_c8e66                                                     // 8e91: 20 66 8e     f.
+    cmp #$22 // '"'                                                   // 8e94: c9 22       ."
+    beq c8e6c                                                         // 8e96: f0 d4       ..
+    cmp #$0d                                                          // 8e98: c9 0d       ..
+    bne loop_c8e91                                                    // 8e9a: d0 f5       ..
+// $8e9c referenced 3 times by $8e61, $8e73, $8eb4
+c8e9c
+    rts                                                               // 8e9c: 60          `
+
+// $8e9d referenced 1 time by $8e8f
+c8e9d
+    cmp #$3a // ':'                                                   // 8e9d: c9 3a       .:
+    bne c8eaa                                                         // 8e9f: d0 09       ..
+    jsr sub_c8e5f                                                     // 8ea1: 20 5f 8e     _.
+// $8ea4 referenced 1 time by $9561
+sub_c8ea4
+    stz l003b                                                         // 8ea4: 64 3b       d;
+// $8ea6 referenced 1 time by $8ee0
+c8ea6
+    stz l003c                                                         // 8ea6: 64 3c       d<
+    bra c8e6f                                                         // 8ea8: 80 c5       ..
+// $8eaa referenced 1 time by $8e9f
+c8eaa
+    cmp #$2c // ','                                                   // 8eaa: c9 2c       .,
+    beq c8e6c                                                         // 8eac: f0 be       ..
+    cmp #$2a // '*'                                                   // 8eae: c9 2a       .*
+    bne c8ebe                                                         // 8eb0: d0 0c       ..
+    lda l003b                                                         // 8eb2: a5 3b       .;
+    beq c8e9c                                                         // 8eb4: f0 e6       ..
+// $8eb6 referenced 2 times by $8ee5, $8ef5
+c8eb6
+    ldx #$ff                                                          // 8eb6: a2 ff       ..
+    stx l003b                                                         // 8eb8: 86 3b       .;
+    stz l003c                                                         // 8eba: 64 3c       d<
+    bra c8e6c                                                         // 8ebc: 80 ae       ..
+// $8ebe referenced 1 time by $8eb0
+c8ebe
+    cmp #$2e // '.'                                                   // 8ebe: c9 2e       ..
+    beq c8ed0                                                         // 8ec0: f0 0e       ..
+    jsr c8e51                                                         // 8ec2: 20 51 8e     Q.
+    bcc c8ef3                                                         // 8ec5: 90 2c       .,
+    ldx l003c                                                         // 8ec7: a6 3c       .<
+    beq c8ed0                                                         // 8ec9: f0 05       ..
+    jsr sub_c8dc1                                                     // 8ecb: 20 c1 8d     ..
+    bcc c8e6c                                                         // 8ece: 90 9c       ..
+// $8ed0 referenced 3 times by $8ec0, $8ec9, $8eda
+c8ed0
+    lda (l0037)                                                       // 8ed0: b2 37       .7
+    jsr sub_c8e58                                                     // 8ed2: 20 58 8e     X.
+    bcc c8edc                                                         // 8ed5: 90 05       ..
+    jsr sub_c8e5f                                                     // 8ed7: 20 5f 8e     _.
+    bra c8ed0                                                         // 8eda: 80 f4       ..
+// $8edc referenced 3 times by $8ed5, $8eec, $ab86
+c8edc
+    ldx #$ff                                                          // 8edc: a2 ff       ..
+    stx l003b                                                         // 8ede: 86 3b       .;
+    bra c8ea6                                                         // 8ee0: 80 c4       ..
+// $8ee2 referenced 1 time by $8ef9
+loop_c8ee2
+    jsr sub_c8e41                                                     // 8ee2: 20 41 8e     A.
+    bcc c8eb6                                                         // 8ee5: 90 cf       ..
+// $8ee7 referenced 4 times by $8ef1, $8f07, $8f23, $8f50
+c8ee7
+    lda (l0037)                                                       // 8ee7: b2 37       .7
+    jsr sub_c8e41                                                     // 8ee9: 20 41 8e     A.
+    bcc c8edc                                                         // 8eec: 90 ee       ..
+    jsr sub_c8e5f                                                     // 8eee: 20 5f 8e     _.
+    bra c8ee7                                                         // 8ef1: 80 f4       ..
+// $8ef3 referenced 1 time by $8ec5
+c8ef3
+    cmp #$41 // 'A'                                                   // 8ef3: c9 41       .A
+    bcc c8eb6                                                         // 8ef5: 90 bf       ..
+    cmp #$58 // 'X'                                                   // 8ef7: c9 58       .X
+    bcs loop_c8ee2                                                    // 8ef9: b0 e7       ..
+    ldx #$13                                                          // 8efb: a2 13       ..
+    stx l0039                                                         // 8efd: 86 39       .9
+    ldx #$85                                                          // 8eff: a2 85       ..
+    stx l003a                                                         // 8f01: 86 3a       .:
+// $8f03 referenced 1 time by $8f3f
+c8f03
+    ldy #0                                                            // 8f03: a0 00       ..
+    cmp (l0039)                                                       // 8f05: d2 39       .9
+    bcc c8ee7                                                         // 8f07: 90 de       ..
+    bne c8f1a                                                         // 8f09: d0 0f       ..
+// $8f0b referenced 1 time by $8f12
+loop_c8f0b
+    iny                                                               // 8f0b: c8          .
+    lda (l0039),y                                                     // 8f0c: b1 39       .9
+    bmi c8f41                                                         // 8f0e: 30 31       01
+    cmp (l0037),y                                                     // 8f10: d1 37       .7
+    beq loop_c8f0b                                                    // 8f12: f0 f7       ..
+    lda (l0037),y                                                     // 8f14: b1 37       .7
+    cmp #$2e // '.'                                                   // 8f16: c9 2e       ..
+    beq c8f25                                                         // 8f18: f0 0b       ..
+// $8f1a referenced 2 times by $8f09, $8f1d
+c8f1a
+    iny                                                               // 8f1a: c8          .
+    lda (l0039),y                                                     // 8f1b: b1 39       .9
+    bpl c8f1a                                                         // 8f1d: 10 fb       ..
+    cmp #$fe                                                          // 8f1f: c9 fe       ..
+    bne c8f32                                                         // 8f21: d0 0f       ..
+    bcs c8ee7                                                         // 8f23: b0 c2       ..
+// $8f25 referenced 1 time by $8f18
+c8f25
+    iny                                                               // 8f25: c8          .
+// $8f26 referenced 2 times by $8f2c, $8f30
+c8f26
+    lda (l0039),y                                                     // 8f26: b1 39       .9
+    bmi c8f41                                                         // 8f28: 30 17       0.
+    inc l0039                                                         // 8f2a: e6 39       .9
+    bne c8f26                                                         // 8f2c: d0 f8       ..
+    inc l003a                                                         // 8f2e: e6 3a       .:
+    bra c8f26                                                         // 8f30: 80 f4       ..
+// $8f32 referenced 1 time by $8f21
+c8f32
+    sec                                                               // 8f32: 38          8
+    iny                                                               // 8f33: c8          .
+    tya                                                               // 8f34: 98          .
+    adc l0039                                                         // 8f35: 65 39       e9
+    sta l0039                                                         // 8f37: 85 39       .9
+    bcc c8f3d                                                         // 8f39: 90 02       ..
+    inc l003a                                                         // 8f3b: e6 3a       .:
+// $8f3d referenced 1 time by $8f39
+c8f3d
+    lda (l0037)                                                       // 8f3d: b2 37       .7
+    bra c8f03                                                         // 8f3f: 80 c2       ..
+// $8f41 referenced 2 times by $8f0e, $8f28
+c8f41
+    tax                                                               // 8f41: aa          .
+    iny                                                               // 8f42: c8          .
+    lda (l0039),y                                                     // 8f43: b1 39       .9
+    sta l003d                                                         // 8f45: 85 3d       .=
+    dey                                                               // 8f47: 88          .
+    lsr                                                               // 8f48: 4a          J
+    bcc c8f52                                                         // 8f49: 90 07       ..
+    lda (l0037),y                                                     // 8f4b: b1 37       .7
+    jsr sub_c8e41                                                     // 8f4d: 20 41 8e     A.
+    bcs c8ee7                                                         // 8f50: b0 95       ..
+// $8f52 referenced 1 time by $8f49
+c8f52
+    txa                                                               // 8f52: 8a          .
+    bit l003d                                                         // 8f53: 24 3d       $=
+    bvc c8f5d                                                         // 8f55: 50 06       P.
+    ldx l003b                                                         // 8f57: a6 3b       .;
+    bne c8f5d                                                         // 8f59: d0 02       ..
+    adc #$40 // '@'                                                   // 8f5b: 69 40       i@
+// $8f5d referenced 2 times by $8f55, $8f59
+c8f5d
+    dey                                                               // 8f5d: 88          .
+    jsr sub_c8da8                                                     // 8f5e: 20 a8 8d     ..
+    ldx #$ff                                                          // 8f61: a2 ff       ..
+    lda l003d                                                         // 8f63: a5 3d       .=
+    lsr                                                               // 8f65: 4a          J
+    lsr                                                               // 8f66: 4a          J
+    bcc c8f6d                                                         // 8f67: 90 04       ..
+    stx l003b                                                         // 8f69: 86 3b       .;
+    stz l003c                                                         // 8f6b: 64 3c       d<
+// $8f6d referenced 1 time by $8f67
+c8f6d
+    lsr                                                               // 8f6d: 4a          J
+    bcc c8f74                                                         // 8f6e: 90 04       ..
+    stz l003b                                                         // 8f70: 64 3b       d;
+    stz l003c                                                         // 8f72: 64 3c       d<
+// $8f74 referenced 1 time by $8f6e
+c8f74
+    lsr                                                               // 8f74: 4a          J
+    bcc c8f87                                                         // 8f75: 90 10       ..
+    pha                                                               // 8f77: 48          H
+    ldy #1                                                            // 8f78: a0 01       ..
+// $8f7a referenced 1 time by $8f84
+loop_c8f7a
+    lda (l0037),y                                                     // 8f7a: b1 37       .7
+    jsr sub_c8e41                                                     // 8f7c: 20 41 8e     A.
+    bcc c8f86                                                         // 8f7f: 90 05       ..
+    jsr sub_c8e5f                                                     // 8f81: 20 5f 8e     _.
+    bra loop_c8f7a                                                    // 8f84: 80 f4       ..
+// $8f86 referenced 1 time by $8f7f
+c8f86
+    pla                                                               // 8f86: 68          h
+// $8f87 referenced 1 time by $8f75
+c8f87
+    lsr                                                               // 8f87: 4a          J
+    bcc c8f8c                                                         // 8f88: 90 02       ..
+    stx l003c                                                         // 8f8a: 86 3c       .<
+// $8f8c referenced 1 time by $8f88
+c8f8c
+    lsr                                                               // 8f8c: 4a          J
+    bcs c8f9c                                                         // 8f8d: b0 0d       ..
+    jmp c8e6c                                                         // 8f8f: 4c 6c 8e    Ll.
+
+// $8f92 referenced 16 times by $8f9a, $8fa8, $8fb4, $9c4a, $abbb, $abc6, $abd0, $ad3a, $ad8e, $af61, $b13f, $b659, $b69b, $b6e8, $b835, $ba7a
+c8f92
+    ldy l001b                                                         // 8f92: a4 1b       ..
+    inc l001b                                                         // 8f94: e6 1b       ..
+    lda (l0019),y                                                     // 8f96: b1 19       ..
+    cmp #$20 // ' '                                                   // 8f98: c9 20       .
+    beq c8f92                                                         // 8f9a: f0 f6       ..
+// $8f9c referenced 1 time by $8f8d
+c8f9c
+    rts                                                               // 8f9c: 60          `
+
+// $8f9d referenced 29 times by $89dd, $8aa8, $8bc1, $8bcb, $8bde, $8bf2, $8c28, $8caf, $8cc9, $8cdc, $8d08, $8d21, $8d94, $8d9c, $8da2, $8fa5, $90e3, $9276, $928f, $935c, $95f9, $98dc, $b000, $b0b5, $b403, $b40a, $b771, $b78b, $b983
+c8f9d
+    ldy l000a                                                         // 8f9d: a4 0a       ..
+    inc l000a                                                         // 8f9f: e6 0a       ..
+    lda (l000b),y                                                     // 8fa1: b1 0b       ..
+    cmp #$20 // ' '                                                   // 8fa3: c9 20       .
+    beq c8f9d                                                         // 8fa5: f0 f6       ..
+// $8fa7 referenced 1 time by $8fb9
+loop_c8fa7
+    rts                                                               // 8fa7: 60          `
+
+// $8fa8 referenced 7 times by $9208, $9307, $9390, $b156, $b95a, $b9e9, $b9f6
+sub_c8fa8
+    jsr c8f92                                                         // 8fa8: 20 92 8f     ..
+    cmp #$2c // ','                                                   // 8fab: c9 2c       .,
+    rts                                                               // 8fad: 60          `
+
+// $8fae referenced 2 times by $ac5d, $af8b
+sub_c8fae
+    jsr sub_c9774                                                     // 8fae: 20 74 97     t.
+    jsr cbc66                                                         // 8fb1: 20 66 bc     f.
+// $8fb4 referenced 1 time by $9771
+sub_c8fb4
+    jsr c8f92                                                         // 8fb4: 20 92 8f     ..
+    cmp #$2c // ','                                                   // 8fb7: c9 2c       .,
+    beq loop_c8fa7                                                    // 8fb9: f0 ec       ..
+// $8fbb referenced 3 times by $92ed, $aca0, $af07
+c8fbb
+    brk                                                               // 8fbb: 00          .
+
+    .byt   5, $8d, $2c,   0                                           // 8fbc: 05 8d 2c... ..,
+
+sub_c8fc0
+    jsr sub_cbe17                                                     // 8fc0: 20 17 be     ..
+    bra c8fda                                                         // 8fc3: 80 15       ..
+sub_c8fc5
+    jsr c9c6a                                                         // 8fc5: 20 6a 9c     j.
+    lda l0018                                                         // 8fc8: a5 18       ..
+    sta l0038                                                         // 8fca: 85 38       .8
+    stz l0037                                                         // 8fcc: 64 37       d7
+    lda #0                                                            // 8fce: a9 00       ..
+    sta (l0037),y                                                     // 8fd0: 91 37       .7
+    jsr sub_cbe25                                                     // 8fd2: 20 25 be     %.
+    bra c9048                                                         // 8fd5: 80 71       .q
+sub_c8fd7
+    jsr c9c6a                                                         // 8fd7: 20 6a 9c     j.
+// $8fda referenced 1 time by $8fc3
+c8fda
+    jsr sub_cbbdc                                                     // 8fda: 20 dc bb     ..
+    lda l0018                                                         // 8fdd: a5 18       ..
+    sta l000c                                                         // 8fdf: 85 0c       ..
+    stz l000b                                                         // 8fe1: 64 0b       d.
+    bra c905c                                                         // 8fe3: 80 77       .w
+sub_c8fe5
+    jsr sub_cbe17                                                     // 8fe5: 20 17 be     ..
+    bra c9048                                                         // 8fe8: 80 5e       .^
+sub_c8fea
+    jsr c9c6a                                                         // 8fea: 20 6a 9c     j.
+    jsr sub_cbe25                                                     // 8fed: 20 25 be     %.
+    bra c904b                                                         // 8ff0: 80 59       .Y
+// $8ff2 referenced 1 time by $8136
+c8ff2
+    lda #$f2                                                          // 8ff2: a9 f2       ..
+    jsr cae60                                                         // 8ff4: 20 60 ae     `.
+    jsr sub_cbf22                                                     // 8ff7: 20 22 bf     ".
+    tax                                                               // 8ffa: aa          .
+    jsr sub_cbf22                                                     // 8ffb: 20 22 bf     ".
+    sta l002b                                                         // 8ffe: 85 2b       .+
+    stx l002a                                                         // 9000: 86 2a       .*
+    ldx #$14                                                          // 9002: a2 14       ..
+// $9004 referenced 1 time by $9010
+loop_c9004
+    dex                                                               // 9004: ca          .
+    beq c9045                                                         // 9005: f0 3e       .>
+    jsr sub_cbf22                                                     // 9007: 20 22 bf     ".
+    cmp #$0d                                                          // 900a: c9 0d       ..
+    beq c9045                                                         // 900c: f0 37       .7
+    cmp #$40 // '@'                                                   // 900e: c9 40       .@
+    bne loop_c9004                                                    // 9010: d0 f2       ..
+    jsr sub_cbf22                                                     // 9012: 20 22 bf     ".
+    cmp #$0d                                                          // 9015: c9 0d       ..
+    bne c9045                                                         // 9017: d0 2c       .,
+    jsr sub_cbf3e                                                     // 9019: 20 3e bf     >.
+// $901c referenced 1 time by $9040
+c901c
+    ldy #0                                                            // 901c: a0 00       ..
+    stz l000b                                                         // 901e: 64 0b       d.
+    lda #7                                                            // 9020: a9 07       ..
+    sta l000c                                                         // 9022: 85 0c       ..
+// $9024 referenced 1 time by $9035
+loop_c9024
+    lda (l0000)                                                       // 9024: b2 00       ..
+    beq c9048                                                         // 9026: f0 20       .
+    sta (l000b),y                                                     // 9028: 91 0b       ..
+    iny                                                               // 902a: c8          .
+    beq c9045                                                         // 902b: f0 18       ..
+    inc l0000                                                         // 902d: e6 00       ..
+    bne c9033                                                         // 902f: d0 02       ..
+    inc l0001                                                         // 9031: e6 01       ..
+// $9033 referenced 1 time by $902f
+c9033
+    cmp #$0d                                                          // 9033: c9 0d       ..
+    bne loop_c9024                                                    // 9035: d0 ed       ..
+    lda l0001                                                         // 9037: a5 01       ..
+    cmp l0007                                                         // 9039: c5 07       ..
+    bcs c9048                                                         // 903b: b0 0b       ..
+    jsr sub_cbb1b                                                     // 903d: 20 1b bb     ..
+    bra c901c                                                         // 9040: 80 da       ..
+sub_c9042
+    jsr c9c6a                                                         // 9042: 20 6a 9c     j.
+// $9045 referenced 4 times by $9005, $900c, $9017, $902b
+c9045
+    jsr sub_cbf3e                                                     // 9045: 20 3e bf     >.
+// $9048 referenced 7 times by $8fd5, $8fe8, $9026, $903b, $9065, $940d, $9579
+c9048
+    jsr sub_cbbdc                                                     // 9048: 20 dc bb     ..
+// $904b referenced 6 times by $8a88, $8ff0, $908a, $9090, $9cc6, $b425
+c904b
+    ldy #7                                                            // 904b: a0 07       ..
+    sty l000c                                                         // 904d: 84 0c       ..
+    stz l000b                                                         // 904f: 64 0b       d.
+    jsr sub_cb2e0                                                     // 9051: 20 e0 b2     ..
+    lda #$3e // '>'                                                   // 9054: a9 3e       .>
+    jsr oswrch                                                        // 9056: 20 ee ff     ..
+    jsr sub_cbaa4                                                     // 9059: 20 a4 ba     ..
+// $905c referenced 1 time by $8fe3
+c905c
+    ldx #$ff                                                          // 905c: a2 ff       ..
+    txs                                                               // 905e: 9a          .
+    jsr sub_cb2e0                                                     // 905f: 20 e0 b2     ..
+    jsr sub_cbb1b                                                     // 9062: 20 1b bb     ..
+    bcs c9048                                                         // 9065: b0 e1       ..
+    bra c90e3                                                         // 9067: 80 7a       .z
+// $9069 referenced 1 time by $90b7
+c9069
+    jsr c9c80                                                         // 9069: 20 80 9c     ..
+    ldx l000b                                                         // 906c: a6 0b       ..
+    ldy l000c                                                         // 906e: a4 0c       ..
+    jsr oscli                                                         // 9070: 20 f7 ff     ..
+// $9073 referenced 2 times by $9084, $b788
+c9073
+    lda #$0d                                                          // 9073: a9 0d       ..
+    ldy l000a                                                         // 9075: a4 0a       ..
+    dey                                                               // 9077: 88          .
+// $9078 referenced 1 time by $907b
+loop_c9078
+    iny                                                               // 9078: c8          .
+    cmp (l000b),y                                                     // 9079: d1 0b       ..
+    bne loop_c9078                                                    // 907b: d0 fb       ..
+// $907d referenced 1 time by $9d0c
+c907d
+    jsr c9c80                                                         // 907d: 20 80 9c     ..
+    bra c9086                                                         // 9080: 80 04       ..
+// $9082 referenced 1 time by $90ce
+c9082
+    cmp #$0d                                                          // 9082: c9 0d       ..
+    bne c9073                                                         // 9084: d0 ed       ..
+// $9086 referenced 1 time by $9080
+c9086
+    lda l000c                                                         // 9086: a5 0c       ..
+    cmp #7                                                            // 9088: c9 07       ..
+    beq c904b                                                         // 908a: f0 bf       ..
+    ldy #1                                                            // 908c: a0 01       ..
+    lda (l000b),y                                                     // 908e: b1 0b       ..
+    bmi c904b                                                         // 9090: 30 b9       0.
+    ldx l0020                                                         // 9092: a6 20       .
+    beq c90a0                                                         // 9094: f0 0a       ..
+    sta l002b                                                         // 9096: 85 2b       .+
+    iny                                                               // 9098: c8          .
+    lda (l000b),y                                                     // 9099: b1 0b       ..
+    sta l002a                                                         // 909b: 85 2a       .*
+    jsr sub_c9d0f                                                     // 909d: 20 0f 9d     ..
+// $90a0 referenced 1 time by $9094
+c90a0
+    ldy #4                                                            // 90a0: a0 04       ..
+    sty l000a                                                         // 90a2: 84 0a       ..
+    bra c90d2                                                         // 90a4: 80 2c       .,
+// $90a6 referenced 1 time by $90bb
+loop_c90a6
+    lda #3                                                            // 90a6: a9 03       ..
+    sta l0028                                                         // 90a8: 85 28       .(
+    jmp c89dd                                                         // 90aa: 4c dd 89    L..
+
+// $90ad referenced 1 time by $90bf
+loop_c90ad
+    jmp cbed3                                                         // 90ad: 4c d3 be    L..
+
+// $90b0 referenced 1 time by $90f7
+c90b0
+    ldy l000a                                                         // 90b0: a4 0a       ..
+    dey                                                               // 90b2: 88          .
+    lda (l000b),y                                                     // 90b3: b1 0b       ..
+    cmp #$2a // '*'                                                   // 90b5: c9 2a       .*
+    beq c9069                                                         // 90b7: f0 b0       ..
+    cmp #$5b // '['                                                   // 90b9: c9 5b       .[
+    beq loop_c90a6                                                    // 90bb: f0 e9       ..
+    cmp #$a2                                                          // 90bd: c9 a2       ..
+    beq loop_c90ad                                                    // 90bf: f0 ec       ..
+    cmp #$3d // '='                                                   // 90c1: c9 3d       .=
+    beq c9123                                                         // 90c3: f0 5e       .^
+// $90c5 referenced 6 times by $9288, $95c3, $97fb, $990c, $b626, $b9aa
+c90c5
+    dec l000a                                                         // 90c5: c6 0a       ..
+// $90c7 referenced 4 times by $924d, $97fe, $b844, $b874
+c90c7
+    jsr c9c6a                                                         // 90c7: 20 6a 9c     j.
+// $90ca referenced 11 times by $9121, $9144, $93c1, $9700, $97bd, $98c0, $b35c, $b74a, $b9a2, $ba60, $beeb
+c90ca
+    lda (l000b)                                                       // 90ca: b2 0b       ..
+    cmp #$3a // ':'                                                   // 90cc: c9 3a       .:
+    bne c9082                                                         // 90ce: d0 b2       ..
+// $90d0 referenced 8 times by $89da, $90d8, $9ce8, $b0c7, $b5dc, $b6ce, $b766, $ba9d
+c90d0
+    ldy l000a                                                         // 90d0: a4 0a       ..
+// $90d2 referenced 1 time by $90a4
+c90d2
+    inc l000a                                                         // 90d2: e6 0a       ..
+    lda (l000b),y                                                     // 90d4: b1 0b       ..
+    cmp #$20 // ' '                                                   // 90d6: c9 20       .
+    beq c90d0                                                         // 90d8: f0 f6       ..
+    cmp #$cf                                                          // 90da: c9 cf       ..
+    bcc c90ea                                                         // 90dc: 90 0c       ..
+// $90de referenced 2 times by $90e8, $ad99
+c90de
+    asl                                                               // 90de: 0a          .
+    tax                                                               // 90df: aa          .
+    jmp (l880a,x)                                                     // 90e0: 7c 0a 88    |..
+
+// $90e3 referenced 1 time by $9067
+c90e3
+    jsr c8f9d                                                         // 90e3: 20 9d 8f     ..
+    cmp #$c6                                                          // 90e6: c9 c6       ..
+    bcs c90de                                                         // 90e8: b0 f4       ..
+// $90ea referenced 1 time by $90dc
+c90ea
+    ldx l000b                                                         // 90ea: a6 0b       ..
+    stx l0019                                                         // 90ec: 86 19       ..
+    ldx l000c                                                         // 90ee: a6 0c       ..
+    stx l001a                                                         // 90f0: 86 1a       ..
+    jsr sub_c99d6                                                     // 90f2: 20 d6 99     ..
+    bne c9112                                                         // 90f5: d0 1b       ..
+    bcs c90b0                                                         // 90f7: b0 b7       ..
+    stx l001b                                                         // 90f9: 86 1b       ..
+    jsr sub_c9c4a                                                     // 90fb: 20 4a 9c     J.
+    jsr sub_c9923                                                     // 90fe: 20 23 99     #.
+    ldx #5                                                            // 9101: a2 05       ..
+    cpx l002c                                                         // 9103: e4 2c       .,
+    bne c9108                                                         // 9105: d0 01       ..
+    inx                                                               // 9107: e8          .
+// $9108 referenced 1 time by $9105
+c9108
+    jsr sub_c9952                                                     // 9108: 20 52 99     R.
+    dec l000a                                                         // 910b: c6 0a       ..
+sub_c910d
+    jsr sub_c997d                                                     // 910d: 20 7d 99     }.
+    beq c9146                                                         // 9110: f0 34       .4
+// $9112 referenced 1 time by $90f5
+c9112
+    bcc c9135                                                         // 9112: 90 21       .!
+    jsr cbc66                                                         // 9114: 20 66 bc     f.
+    jsr c9c16                                                         // 9117: 20 16 9c     ..
+    lda l0027                                                         // 911a: a5 27       .'
+    bne c9155                                                         // 911c: d0 37       .7
+    jsr sub_c916e                                                     // 911e: 20 6e 91     n.
+    bra c90ca                                                         // 9121: 80 a7       ..
+// $9123 referenced 1 time by $90c3
+c9123
+    tsx                                                               // 9123: ba          .
+    cpx #$fc                                                          // 9124: e0 fc       ..
+    bcs c914f                                                         // 9126: b0 27       .'
+    lda l01ff                                                         // 9128: ad ff 01    ...
+    cmp #$a4                                                          // 912b: c9 a4       ..
+    bne c914f                                                         // 912d: d0 20       .
+    jsr sub_c9df3                                                     // 912f: 20 f3 9d     ..
+    jmp c9c55                                                         // 9132: 4c 55 9c    LU.
+
+// $9135 referenced 1 time by $9112
+c9135
+    lda l002a                                                         // 9135: a5 2a       .*
+    pha                                                               // 9137: 48          H
+    lda l002b                                                         // 9138: a5 2b       .+
+    pha                                                               // 913a: 48          H
+    lda l002c                                                         // 913b: a5 2c       .,
+    pha                                                               // 913d: 48          H
+    jsr c9c16                                                         // 913e: 20 16 9c     ..
+    jsr sub_cb365                                                     // 9141: 20 65 b3     e.
+    bra c90ca                                                         // 9144: 80 84       ..
+// $9146 referenced 1 time by $9110
+c9146
+    jmp c9c2d                                                         // 9146: 4c 2d 9c    L-.
+
+sub_c9149
+    jsr c9c6a                                                         // 9149: 20 6a 9c     j.
+    brk                                                               // 914c: 00          .
+
+    .byt   0, $fa                                                     // 914d: 00 fa       ..
+
+// $914f referenced 2 times by $9126, $912d
+c914f
+    brk                                                               // 914f: 00          .
+
+    .byt 7                                                            // 9150: 07          .
+    .asc "No "                                                        // 9151: 4e 6f 20    No
+    .byt $a4                                                          // 9154: a4          .
+
+// $9155 referenced 14 times by $8d71, $911c, $979c, $9cc9, $9d7c, $9f4c, $ab9d, $ac1c, $acfd, $ae56, $af88, $b35f, $b86c, $be73
+c9155
+    brk                                                               // 9155: 00          .
+
+    .byt 6                                                            // 9156: 06          .
+    .asc "Type mismatch"                                              // 9157: 54 79 70... Typ
+
+// $9164 referenced 3 times by $91bb, $9974, $bd74
+c9164
+    brk                                                               // 9164: 00          .
+
+    .byt 0                                                            // 9165: 00          .
+    .asc "No room"                                                    // 9166: 4e 6f 20... No
+    .byt 0                                                            // 916d: 00          .
+
+// $916e referenced 3 times by $911e, $b8b5, $b9ca
+sub_c916e
+    jsr sub_cbd26                                                     // 916e: 20 26 bd     &.
+// $9171 referenced 2 times by $b1b2, $b978
+sub_c9171
+    lda l002c                                                         // 9171: a5 2c       .,
+    cmp #$80                                                          // 9173: c9 80       ..
+    beq c91ef                                                         // 9175: f0 78       .x
+    ldy #2                                                            // 9177: a0 02       ..
+    lda (l002a),y                                                     // 9179: b1 2a       .*
+    cmp l0036                                                         // 917b: c5 36       .6
+    bcs c91d1                                                         // 917d: b0 52       .R
+    lda l0002                                                         // 917f: a5 02       ..
+    sta l002c                                                         // 9181: 85 2c       .,
+    lda l0003                                                         // 9183: a5 03       ..
+    sta l002d                                                         // 9185: 85 2d       .-
+    lda l0036                                                         // 9187: a5 36       .6
+    cmp #8                                                            // 9189: c9 08       ..
+    bcc c9193                                                         // 918b: 90 06       ..
+    adc #7                                                            // 918d: 69 07       i.
+    bcc c9193                                                         // 918f: 90 02       ..
+    lda #$ff                                                          // 9191: a9 ff       ..
+// $9193 referenced 2 times by $918b, $918f
+c9193
+    clc                                                               // 9193: 18          .
+    pha                                                               // 9194: 48          H
+    tax                                                               // 9195: aa          .
+    lda (l002a),y                                                     // 9196: b1 2a       .*
+    adc (l002a)                                                       // 9198: 72 2a       r*
+    eor l0002                                                         // 919a: 45 02       E.
+    bne c91ad                                                         // 919c: d0 0f       ..
+    dey                                                               // 919e: 88          .
+    adc (l002a),y                                                     // 919f: 71 2a       q*
+    eor l0003                                                         // 91a1: 45 03       E.
+    bne c91ad                                                         // 91a3: d0 08       ..
+    sta l002d                                                         // 91a5: 85 2d       .-
+    txa                                                               // 91a7: 8a          .
+    iny                                                               // 91a8: c8          .
+    sec                                                               // 91a9: 38          8
+    sbc (l002a),y                                                     // 91aa: f1 2a       .*
+    tax                                                               // 91ac: aa          .
+// $91ad referenced 2 times by $919c, $91a3
+c91ad
+    txa                                                               // 91ad: 8a          .
+    clc                                                               // 91ae: 18          .
+    adc l0002                                                         // 91af: 65 02       e.
+    tay                                                               // 91b1: a8          .
+    lda l0003                                                         // 91b2: a5 03       ..
+    adc #0                                                            // 91b4: 69 00       i.
+    tax                                                               // 91b6: aa          .
+    cpy l0004                                                         // 91b7: c4 04       ..
+    sbc l0005                                                         // 91b9: e5 05       ..
+    bcs c9164                                                         // 91bb: b0 a7       ..
+    sty l0002                                                         // 91bd: 84 02       ..
+    stx l0003                                                         // 91bf: 86 03       ..
+    pla                                                               // 91c1: 68          h
+    ldy #2                                                            // 91c2: a0 02       ..
+    sta (l002a),y                                                     // 91c4: 91 2a       .*
+    dey                                                               // 91c6: 88          .
+    lda l002d                                                         // 91c7: a5 2d       .-
+    beq c91d1                                                         // 91c9: f0 06       ..
+    sta (l002a),y                                                     // 91cb: 91 2a       .*
+    lda l002c                                                         // 91cd: a5 2c       .,
+    sta (l002a)                                                       // 91cf: 92 2a       .*
+// $91d1 referenced 2 times by $917d, $91c9
+c91d1
+    ldy #3                                                            // 91d1: a0 03       ..
+    lda l0036                                                         // 91d3: a5 36       .6
+    sta (l002a),y                                                     // 91d5: 91 2a       .*
+    beq c91ee                                                         // 91d7: f0 15       ..
+    ldy #1                                                            // 91d9: a0 01       ..
+    lda (l002a),y                                                     // 91db: b1 2a       .*
+    sta l002d                                                         // 91dd: 85 2d       .-
+    lda (l002a)                                                       // 91df: b2 2a       .*
+    sta l002c                                                         // 91e1: 85 2c       .,
+    dey                                                               // 91e3: 88          .
+// $91e4 referenced 1 time by $91ec
+loop_c91e4
+    lda l0600,y                                                       // 91e4: b9 00 06    ...
+    sta (l002c),y                                                     // 91e7: 91 2c       .,
+    iny                                                               // 91e9: c8          .
+    cpy l0036                                                         // 91ea: c4 36       .6
+    bne loop_c91e4                                                    // 91ec: d0 f6       ..
+// $91ee referenced 1 time by $91d7
+c91ee
+    rts                                                               // 91ee: 60          `
+
+// $91ef referenced 1 time by $9175
+c91ef
+    jsr sub_cbe6b                                                     // 91ef: 20 6b be     k.
+    cpy #0                                                            // 91f2: c0 00       ..
+    beq c9201                                                         // 91f4: f0 0b       ..
+// $91f6 referenced 1 time by $91fc
+loop_c91f6
+    lda l0600,y                                                       // 91f6: b9 00 06    ...
+    sta (l002a),y                                                     // 91f9: 91 2a       .*
+    dey                                                               // 91fb: 88          .
+    bne loop_c91f6                                                    // 91fc: d0 f8       ..
+    lda l0600                                                         // 91fe: ad 00 06    ...
+// $9201 referenced 1 time by $91f4
+c9201
+    sta (l002a)                                                       // 9201: 92 2a       .*
+    rts                                                               // 9203: 60          `
+
+// $9204 referenced 1 time by $9253
+c9204
+    jsr sub_cba6c                                                     // 9204: 20 6c ba     l.
+// $9207 referenced 4 times by $9228, $9235, $923d, $9248
+c9207
+    phy                                                               // 9207: 5a          Z
+    jsr sub_c8fa8                                                     // 9208: 20 a8 8f     ..
+    bne c924a                                                         // 920b: d0 3d       .=
+    jsr sub_c9dff                                                     // 920d: 20 ff 9d     ..
+    jsr sub_ca545                                                     // 9210: 20 45 a5     E.
+    ply                                                               // 9213: 7a          z
+    lda l0027                                                         // 9214: a5 27       .'
+    jsr osbput                                                        // 9216: 20 d4 ff     ..
+    tax                                                               // 9219: aa          .
+    beq c9237                                                         // 921a: f0 1b       ..
+    bmi c922a                                                         // 921c: 30 0c       0.
+    ldx #3                                                            // 921e: a2 03       ..
+// $9220 referenced 1 time by $9226
+loop_c9220
+    lda l002a,x                                                       // 9220: b5 2a       .*
+    jsr osbput                                                        // 9222: 20 d4 ff     ..
+    dex                                                               // 9225: ca          .
+    bpl loop_c9220                                                    // 9226: 10 f8       ..
+    bra c9207                                                         // 9228: 80 dd       ..
+// $922a referenced 1 time by $921c
+c922a
+    ldx #4                                                            // 922a: a2 04       ..
+// $922c referenced 1 time by $9233
+loop_c922c
+    lda l046c,x                                                       // 922c: bd 6c 04    .l.
+    jsr osbput                                                        // 922f: 20 d4 ff     ..
+    dex                                                               // 9232: ca          .
+    bpl loop_c922c                                                    // 9233: 10 f7       ..
+    bra c9207                                                         // 9235: 80 d0       ..
+// $9237 referenced 1 time by $921a
+c9237
+    lda l0036                                                         // 9237: a5 36       .6
+    jsr osbput                                                        // 9239: 20 d4 ff     ..
+    tax                                                               // 923c: aa          .
+    beq c9207                                                         // 923d: f0 c8       ..
+// $923f referenced 1 time by $9246
+loop_c923f
+    lda l05ff,x                                                       // 923f: bd ff 05    ...
+    jsr osbput                                                        // 9242: 20 d4 ff     ..
+    dex                                                               // 9245: ca          .
+    bne loop_c923f                                                    // 9246: d0 f7       ..
+    bra c9207                                                         // 9248: 80 bd       ..
+// $924a referenced 1 time by $920b
+c924a
+    pla                                                               // 924a: 68          h
+    sty l000a                                                         // 924b: 84 0a       ..
+    jmp c90c7                                                         // 924d: 4c c7 90    L..
+
+sub_c9250
+    jsr sub_c8d9c                                                     // 9250: 20 9c 8d     ..
+    beq c9204                                                         // 9253: f0 af       ..
+    dec l000a                                                         // 9255: c6 0a       ..
+    bra c926e                                                         // 9257: 80 15       ..
+// $9259 referenced 1 time by $92a4
+c9259
+    lda l0400                                                         // 9259: ad 00 04    ...
+    beq c926e                                                         // 925c: f0 10       ..
+    lda l001e                                                         // 925e: a5 1e       ..
+// $9260 referenced 1 time by $9265
+loop_c9260
+    beq c926e                                                         // 9260: f0 0c       ..
+    sbc l0400                                                         // 9262: ed 00 04    ...
+    bcs loop_c9260                                                    // 9265: b0 f9       ..
+    tay                                                               // 9267: a8          .
+// $9268 referenced 1 time by $926c
+loop_c9268
+    jsr cbdd2                                                         // 9268: 20 d2 bd     ..
+    iny                                                               // 926b: c8          .
+    bne loop_c9268                                                    // 926c: d0 fa       ..
+// $926e referenced 3 times by $9257, $925c, $9260
+c926e
+    clc                                                               // 926e: 18          .
+    lda l0400                                                         // 926f: ad 00 04    ...
+    sta l0014                                                         // 9272: 85 14       ..
+// $9274 referenced 1 time by $92a0
+c9274
+    ror l0015                                                         // 9274: 66 15       f.
+// $9276 referenced 3 times by $92ad, $92dc, $92eb
+c9276
+    jsr c8f9d                                                         // 9276: 20 9d 8f     ..
+    cmp #$3a // ':'                                                   // 9279: c9 3a       .:
+    beq c9285                                                         // 927b: f0 08       ..
+    cmp #$0d                                                          // 927d: c9 0d       ..
+    beq c9285                                                         // 927f: f0 04       ..
+    cmp #$8b                                                          // 9281: c9 8b       ..
+    bne c929e                                                         // 9283: d0 19       ..
+// $9285 referenced 2 times by $927b, $927f
+c9285
+    jsr sub_cbac2                                                     // 9285: 20 c2 ba     ..
+// $9288 referenced 3 times by $9294, $9298, $929c
+c9288
+    jmp c90c5                                                         // 9288: 4c c5 90    L..
+
+// $928b referenced 1 time by $92a8
+loop_c928b
+    stz l0014                                                         // 928b: 64 14       d.
+    stz l0015                                                         // 928d: 64 15       d.
+    jsr c8f9d                                                         // 928f: 20 9d 8f     ..
+    cmp #$3a // ':'                                                   // 9292: c9 3a       .:
+    beq c9288                                                         // 9294: f0 f2       ..
+    cmp #$0d                                                          // 9296: c9 0d       ..
+    beq c9288                                                         // 9298: f0 ee       ..
+    cmp #$8b                                                          // 929a: c9 8b       ..
+    beq c9288                                                         // 929c: f0 ea       ..
+// $929e referenced 1 time by $9283
+c929e
+    cmp #$7e // '~'                                                   // 929e: c9 7e       .~
+    beq c9274                                                         // 92a0: f0 d2       ..
+    cmp #$2c // ','                                                   // 92a2: c9 2c       .,
+    beq c9259                                                         // 92a4: f0 b3       ..
+    cmp #$3b // ';'                                                   // 92a6: c9 3b       .;
+    beq loop_c928b                                                    // 92a8: f0 e1       ..
+    jsr sub_c933d                                                     // 92aa: 20 3d 93     =.
+    bcc c9276                                                         // 92ad: 90 c7       ..
+    lda l0014                                                         // 92af: a5 14       ..
+    pha                                                               // 92b1: 48          H
+    lda l0015                                                         // 92b2: a5 15       ..
+    pha                                                               // 92b4: 48          H
+    dec l001b                                                         // 92b5: c6 1b       ..
+    jsr sub_c9dff                                                     // 92b7: 20 ff 9d     ..
+    pla                                                               // 92ba: 68          h
+    sta l0015                                                         // 92bb: 85 15       ..
+    pla                                                               // 92bd: 68          h
+    sta l0014                                                         // 92be: 85 14       ..
+    lda l001b                                                         // 92c0: a5 1b       ..
+    sta l000a                                                         // 92c2: 85 0a       ..
+    tya                                                               // 92c4: 98          .
+    beq c92da                                                         // 92c5: f0 13       ..
+    jsr sub_ca181                                                     // 92c7: 20 81 a1     ..
+    lda l0014                                                         // 92ca: a5 14       ..
+    sec                                                               // 92cc: 38          8
+    sbc l0036                                                         // 92cd: e5 36       .6
+    bcc c92da                                                         // 92cf: 90 09       ..
+    beq c92da                                                         // 92d1: f0 07       ..
+    tay                                                               // 92d3: a8          .
+// $92d4 referenced 1 time by $92d8
+loop_c92d4
+    jsr cbdd2                                                         // 92d4: 20 d2 bd     ..
+    dey                                                               // 92d7: 88          .
+    bne loop_c92d4                                                    // 92d8: d0 fa       ..
+// $92da referenced 3 times by $92c5, $92cf, $92d1
+c92da
+    lda l0036                                                         // 92da: a5 36       .6
+    beq c9276                                                         // 92dc: f0 98       ..
+    ldy #0                                                            // 92de: a0 00       ..
+// $92e0 referenced 1 time by $92e9
+loop_c92e0
+    lda l0600,y                                                       // 92e0: b9 00 06    ...
+    jsr sub_cbdd8                                                     // 92e3: 20 d8 bd     ..
+    iny                                                               // 92e6: c8          .
+    cpy l0036                                                         // 92e7: c4 36       .6
+    bne loop_c92e0                                                    // 92e9: d0 f5       ..
+    bra c9276                                                         // 92eb: 80 89       ..
+// $92ed referenced 1 time by $930e
+c92ed
+    jmp c8fbb                                                         // 92ed: 4c bb 8f    L..
+
+// $92f0 referenced 1 time by $930a
+loop_c92f0
+    lda l002a                                                         // 92f0: a5 2a       .*
+    pha                                                               // 92f2: 48          H
+    jsr sub_c976c                                                     // 92f3: 20 6c 97     l.
+    lda #$1f                                                          // 92f6: a9 1f       ..
+    jsr oswrch                                                        // 92f8: 20 ee ff     ..
+    pla                                                               // 92fb: 68          h
+    jsr oswrch                                                        // 92fc: 20 ee ff     ..
+    jsr sub_c990f                                                     // 92ff: 20 0f 99     ..
+    bra c932d                                                         // 9302: 80 29       .)
+// $9304 referenced 1 time by $934f
+c9304
+    jsr sub_c9774                                                     // 9304: 20 74 97     t.
+    jsr sub_c8fa8                                                     // 9307: 20 a8 8f     ..
+    beq loop_c92f0                                                    // 930a: f0 e4       ..
+    cmp #$29 // ')'                                                   // 930c: c9 29       .)
+    bne c92ed                                                         // 930e: d0 dd       ..
+    lda l002a                                                         // 9310: a5 2a       .*
+    sbc l001e                                                         // 9312: e5 1e       ..
+    beq c932d                                                         // 9314: f0 17       ..
+    tax                                                               // 9316: aa          .
+    bcs c9325                                                         // 9317: b0 0c       ..
+    jsr sub_cbac2                                                     // 9319: 20 c2 ba     ..
+    bra c9321                                                         // 931c: 80 03       ..
+// $931e referenced 1 time by $9353
+c931e
+    jsr sub_c9779                                                     // 931e: 20 79 97     y.
+// $9321 referenced 1 time by $931c
+c9321
+    ldx l002a                                                         // 9321: a6 2a       .*
+    beq c932d                                                         // 9323: f0 08       ..
+// $9325 referenced 1 time by $9317
+c9325
+    jsr cbdff                                                         // 9325: 20 ff bd     ..
+    bra c932d                                                         // 9328: 80 03       ..
+// $932a referenced 1 time by $934b
+c932a
+    jsr sub_cbac2                                                     // 932a: 20 c2 ba     ..
+// $932d referenced 5 times by $9302, $9314, $9323, $9328, $937a
+c932d
+    clc                                                               // 932d: 18          .
+    bra c9338                                                         // 932e: 80 08       ..
+// $9330 referenced 3 times by $8c01, $8c31, $8cfd
+sub_c9330
+    dec l000a                                                         // 9330: c6 0a       ..
+// $9332 referenced 23 times by $8b67, $8baf, $8bc8, $8c62, $8c96, $8cb8, $8cc6, $8d16, $8d39, $8d65, $9651, $9718, $9810, $9824, $982e, $9880, $98ed, $b302, $b326, $b351, $b41b, $b794, $b85f
+sub_c9332
+    jsr sub_c9df3                                                     // 9332: 20 f3 9d     ..
+    jsr c9784                                                         // 9335: 20 84 97     ..
+// $9338 referenced 8 times by $8aa3, $8d7f, $932e, $95bb, $b87c, $b88c, $b92a, $b9dc
+c9338
+    ldy l001b                                                         // 9338: a4 1b       ..
+    sty l000a                                                         // 933a: 84 0a       ..
+    rts                                                               // 933c: 60          `
+
+// $933d referenced 2 times by $92aa, $935f
+sub_c933d
+    ldx l000b                                                         // 933d: a6 0b       ..
+    stx l0019                                                         // 933f: 86 19       ..
+    ldx l000c                                                         // 9341: a6 0c       ..
+    stx l001a                                                         // 9343: 86 1a       ..
+    ldx l000a                                                         // 9345: a6 0a       ..
+    stx l001b                                                         // 9347: 86 1b       ..
+    cmp #$27 // '''                                                   // 9349: c9 27       .'
+    beq c932a                                                         // 934b: f0 dd       ..
+    cmp #$8a                                                          // 934d: c9 8a       ..
+    beq c9304                                                         // 934f: f0 b3       ..
+    cmp #$89                                                          // 9351: c9 89       ..
+    beq c931e                                                         // 9353: f0 c9       ..
+// $9355 referenced 1 time by $9366
+loop_c9355
+    sec                                                               // 9355: 38          8
+// $9356 referenced 1 time by $9362
+loop_c9356
+    rts                                                               // 9356: 60          `
+
+// $9357 referenced 2 times by $936d, $ad75
+c9357
+    brk                                                               // 9357: 00          .
+
+    .byt   9, $8d, $22,   0                                           // 9358: 09 8d 22... .."
+
+// $935c referenced 2 times by $b8fa, $b8ff
+sub_c935c
+    jsr c8f9d                                                         // 935c: 20 9d 8f     ..
+    jsr sub_c933d                                                     // 935f: 20 3d 93     =.
+    bcc loop_c9356                                                    // 9362: 90 f2       ..
+    cmp #$22 // '"'                                                   // 9364: c9 22       ."
+    bne loop_c9355                                                    // 9366: d0 ed       ..
+// $9368 referenced 1 time by $937f
+loop_c9368
+    iny                                                               // 9368: c8          .
+    lda (l0019),y                                                     // 9369: b1 19       ..
+    cmp #$0d                                                          // 936b: c9 0d       ..
+    beq c9357                                                         // 936d: f0 e8       ..
+    cmp #$22 // '"'                                                   // 936f: c9 22       ."
+    bne c937c                                                         // 9371: d0 09       ..
+    iny                                                               // 9373: c8          .
+    sty l001b                                                         // 9374: 84 1b       ..
+    lda (l0019),y                                                     // 9376: b1 19       ..
+    cmp #$22 // '"'                                                   // 9378: c9 22       ."
+    bne c932d                                                         // 937a: d0 b1       ..
+// $937c referenced 1 time by $9371
+c937c
+    jsr sub_cbdd8                                                     // 937c: 20 d8 bd     ..
+    bra loop_c9368                                                    // 937f: 80 e7       ..
+sub_c9381
+    jsr sub_c9df3                                                     // 9381: 20 f3 9d     ..
+    jsr sub_c9781                                                     // 9384: 20 81 97     ..
+    jsr cbc66                                                         // 9387: 20 66 bc     f.
+    stz l0600                                                         // 938a: 9c 00 06    ...
+    ldy #0                                                            // 938d: a0 00       ..
+// $938f referenced 1 time by $93b2
+c938f
+    phy                                                               // 938f: 5a          Z
+    jsr sub_c8fa8                                                     // 9390: 20 a8 8f     ..
+    bne c93b4                                                         // 9393: d0 1f       ..
+    ldy l001b                                                         // 9395: a4 1b       ..
+    jsr sub_c99d0                                                     // 9397: 20 d0 99     ..
+    beq c93c4                                                         // 939a: f0 28       .(
+    ply                                                               // 939c: 7a          z
+    iny                                                               // 939d: c8          .
+    lda l002a                                                         // 939e: a5 2a       .*
+    sta l0600,y                                                       // 93a0: 99 00 06    ...
+    iny                                                               // 93a3: c8          .
+    lda l002b                                                         // 93a4: a5 2b       .+
+    sta l0600,y                                                       // 93a6: 99 00 06    ...
+    iny                                                               // 93a9: c8          .
+    lda l002c                                                         // 93aa: a5 2c       .,
+    sta l0600,y                                                       // 93ac: 99 00 06    ...
+    inc l0600                                                         // 93af: ee 00 06    ...
+    bra c938f                                                         // 93b2: 80 db       ..
+// $93b4 referenced 1 time by $9393
+c93b4
+    ply                                                               // 93b4: 7a          z
+    dec l001b                                                         // 93b5: c6 1b       ..
+    jsr sub_c9c5a                                                     // 93b7: 20 5a 9c     Z.
+    jsr sub_cbd26                                                     // 93ba: 20 26 bd     &.
+    jsr sub_c93c7                                                     // 93bd: 20 c7 93     ..
+    cld                                                               // 93c0: d8          .
+    jmp c90ca                                                         // 93c1: 4c ca 90    L..
+
+// $93c4 referenced 1 time by $939a
+c93c4
+    jmp cadce                                                         // 93c4: 4c ce ad    L..
+
+// $93c7 referenced 2 times by $93bd, $ab04
+sub_c93c7
+    lda l040c                                                         // 93c7: ad 0c 04    ...
+    lsr                                                               // 93ca: 4a          J
+    lda l0404                                                         // 93cb: ad 04 04    ...
+    ldx l0460                                                         // 93ce: ae 60 04    .`.
+    ldy l0464                                                         // 93d1: ac 64 04    .d.
+    jmp (l002a)                                                       // 93d4: 6c 2a 00    l*.
+
+// $93d7 referenced 3 times by $93dd, $93e5, $93ea
+c93d7
+    jmp c9c2d                                                         // 93d7: 4c 2d 9c    L-.
+
+sub_c93da
+    jsr sub_c9be2                                                     // 93da: 20 e2 9b     ..
+    bcc c93d7                                                         // 93dd: 90 f8       ..
+    jsr cbc66                                                         // 93df: 20 66 bc     f.
+    jsr sub_c8da2                                                     // 93e2: 20 a2 8d     ..
+    bne c93d7                                                         // 93e5: d0 f0       ..
+    jsr sub_c9be2                                                     // 93e7: 20 e2 9b     ..
+    bcc c93d7                                                         // 93ea: 90 eb       ..
+    jsr c9c6a                                                         // 93ec: 20 6a 9c     j.
+    lda l002a                                                         // 93ef: a5 2a       .*
+    sta l0039                                                         // 93f1: 85 39       .9
+    lda l002b                                                         // 93f3: a5 2b       .+
+    sta l003a                                                         // 93f5: 85 3a       .:
+    jsr sub_cbd26                                                     // 93f7: 20 26 bd     &.
+// $93fa referenced 1 time by $940b
+loop_c93fa
+    jsr sub_cbac8                                                     // 93fa: 20 c8 ba     ..
+    jsr sub_c9c8e                                                     // 93fd: 20 8e 9c     ..
+    jsr sub_cbf2f                                                     // 9400: 20 2f bf     /.
+    lda l0039                                                         // 9403: a5 39       .9
+    cmp l002a                                                         // 9405: c5 2a       .*
+    lda l003a                                                         // 9407: a5 3a       .:
+    sbc l002b                                                         // 9409: e5 2b       .+
+    bcs loop_c93fa                                                    // 940b: b0 ed       ..
+    jmp c9048                                                         // 940d: 4c 48 90    LH.
+
+// $9410 referenced 2 times by $9447, $954c
+sub_c9410
+    lda #$0a                                                          // 9410: a9 0a       ..
+    jsr cae60                                                         // 9412: 20 60 ae     `.
+    jsr sub_c9be2                                                     // 9415: 20 e2 9b     ..
+    jsr cbc66                                                         // 9418: 20 66 bc     f.
+    lda #$0a                                                          // 941b: a9 0a       ..
+    jsr cae60                                                         // 941d: 20 60 ae     `.
+    jsr sub_c8da2                                                     // 9420: 20 a2 8d     ..
+    bne c9433                                                         // 9423: d0 0e       ..
+    jsr sub_c9be2                                                     // 9425: 20 e2 9b     ..
+    lda l002b                                                         // 9428: a5 2b       .+
+    bne c947f                                                         // 942a: d0 53       .S
+    lda l002a                                                         // 942c: a5 2a       .*
+    beq c947f                                                         // 942e: f0 4f       .O
+    jmp c9c6a                                                         // 9430: 4c 6a 9c    Lj.
+
+// $9433 referenced 1 time by $9423
+c9433
+    jmp c9c74                                                         // 9433: 4c 74 9c    Lt.
+
+// $9436 referenced 2 times by $9452, $94e1
+sub_c9436
+    lda l0012                                                         // 9436: a5 12       ..
+    sta l003b                                                         // 9438: 85 3b       .;
+    lda l0013                                                         // 943a: a5 13       ..
+    sta l003c                                                         // 943c: 85 3c       .<
+// $943e referenced 1 time by $9487
+sub_c943e
+    lda l0018                                                         // 943e: a5 18       ..
+    sta l0038                                                         // 9440: 85 38       .8
+    ldy #1                                                            // 9442: a0 01       ..
+    sty l0037                                                         // 9444: 84 37       .7
+    rts                                                               // 9446: 60          `
+
+sub_c9447
+    jsr sub_c9410                                                     // 9447: 20 10 94     ..
+    ldx #$39 // '9'                                                   // 944a: a2 39       .9
+    jsr sub_cbd48                                                     // 944c: 20 48 bd     H.
+    jsr sub_cbe25                                                     // 944f: 20 25 be     %.
+    jsr sub_c9436                                                     // 9452: 20 36 94     6.
+// $9455 referenced 1 time by $9474
+loop_c9455
+    lda (l0037)                                                       // 9455: b2 37       .7
+    bmi c9487                                                         // 9457: 30 2e       0.
+    sta (l003b)                                                       // 9459: 92 3b       .;
+    lda (l0037),y                                                     // 945b: b1 37       .7
+    sta (l003b),y                                                     // 945d: 91 3b       .;
+    sec                                                               // 945f: 38          8
+    tya                                                               // 9460: 98          .
+    adc l003b                                                         // 9461: 65 3b       e;
+    sta l003b                                                         // 9463: 85 3b       .;
+    bcc c9469                                                         // 9465: 90 02       ..
+    inc l003c                                                         // 9467: e6 3c       .<
+// $9469 referenced 1 time by $9465
+c9469
+    cmp l0006                                                         // 9469: c5 06       ..
+    lda l003c                                                         // 946b: a5 3c       .<
+    sbc l0007                                                         // 946d: e5 07       ..
+    bcs c9476                                                         // 946f: b0 05       ..
+    jsr sub_c953d                                                     // 9471: 20 3d 95     =.
+    bra loop_c9455                                                    // 9474: 80 df       ..
+// $9476 referenced 1 time by $946f
+c9476
+    brk                                                               // 9476: 00          .
+
+    .byt   0, $cc                                                     // 9477: 00 cc       ..
+    .asc " space"                                                     // 9479: 20 73 70...  sp
+
+// $947f referenced 2 times by $942a, $942e
+c947f
+    brk                                                               // 947f: 00          .
+
+    .byt 0                                                            // 9480: 00          .
+    .asc "Silly"                                                      // 9481: 53 69 6c... Sil
+    .byt 0                                                            // 9486: 00          .
+
+// $9487 referenced 1 time by $9457
+c9487
+    jsr sub_c943e                                                     // 9487: 20 3e 94     >.
+// $948a referenced 1 time by $94a8
+loop_c948a
+    lda (l0037)                                                       // 948a: b2 37       .7
+    bmi c94aa                                                         // 948c: 30 1c       0.
+    lda l003a                                                         // 948e: a5 3a       .:
+    sta (l0037)                                                       // 9490: 92 37       .7
+    lda l0039                                                         // 9492: a5 39       .9
+    sta (l0037),y                                                     // 9494: 91 37       .7
+    clc                                                               // 9496: 18          .
+    lda l0039                                                         // 9497: a5 39       .9
+    adc l002a                                                         // 9499: 65 2a       e*
+    sta l0039                                                         // 949b: 85 39       .9
+    lda #0                                                            // 949d: a9 00       ..
+    adc l003a                                                         // 949f: 65 3a       e:
+    and #$7f                                                          // 94a1: 29 7f       ).
+    sta l003a                                                         // 94a3: 85 3a       .:
+    jsr sub_c953d                                                     // 94a5: 20 3d 95     =.
+    bra loop_c948a                                                    // 94a8: 80 e0       ..
+// $94aa referenced 1 time by $948c
+c94aa
+    lda l0018                                                         // 94aa: a5 18       ..
+    sta l000c                                                         // 94ac: 85 0c       ..
+    stz l000b                                                         // 94ae: 64 0b       d.
+// $94b0 referenced 1 time by $94dc
+c94b0
+    ldy #1                                                            // 94b0: a0 01       ..
+    lda (l000b),y                                                     // 94b2: b1 0b       ..
+    bmi c951d                                                         // 94b4: 30 67       0g
+    ldy #4                                                            // 94b6: a0 04       ..
+    stz l002c                                                         // 94b8: 64 2c       d,
+// $94ba referenced 2 times by $94d3, $950b
+c94ba
+    lda (l000b),y                                                     // 94ba: b1 0b       ..
+    ldx l002c                                                         // 94bc: a6 2c       .,
+    bne c94c8                                                         // 94be: d0 08       ..
+    cmp #$8d                                                          // 94c0: c9 8d       ..
+    beq c94de                                                         // 94c2: f0 1a       ..
+    cmp #$f4                                                          // 94c4: c9 f4       ..
+    beq c94d5                                                         // 94c6: f0 0d       ..
+// $94c8 referenced 1 time by $94be
+c94c8
+    iny                                                               // 94c8: c8          .
+    cmp #$22 // '"'                                                   // 94c9: c9 22       ."
+    bne c94d1                                                         // 94cb: d0 04       ..
+    eor l002c                                                         // 94cd: 45 2c       E,
+    sta l002c                                                         // 94cf: 85 2c       .,
+// $94d1 referenced 1 time by $94cb
+c94d1
+    cmp #$0d                                                          // 94d1: c9 0d       ..
+    bne c94ba                                                         // 94d3: d0 e5       ..
+// $94d5 referenced 1 time by $94c6
+c94d5
+    ldy #3                                                            // 94d5: a0 03       ..
+    lda (l000b),y                                                     // 94d7: b1 0b       ..
+    jsr sub_c9cb8                                                     // 94d9: 20 b8 9c     ..
+    bra c94b0                                                         // 94dc: 80 d2       ..
+// $94de referenced 1 time by $94c2
+c94de
+    jsr sub_c9bee                                                     // 94de: 20 ee 9b     ..
+    jsr sub_c9436                                                     // 94e1: 20 36 94     6.
+// $94e4 referenced 2 times by $9517, $951b
+c94e4
+    lda (l0037)                                                       // 94e4: b2 37       .7
+    bmi c951f                                                         // 94e6: 30 37       07
+    lda (l003b)                                                       // 94e8: b2 3b       .;
+    cmp l002b                                                         // 94ea: c5 2b       .+
+    bne c950d                                                         // 94ec: d0 1f       ..
+    lda (l003b),y                                                     // 94ee: b1 3b       .;
+    cmp l002a                                                         // 94f0: c5 2a       .*
+    bne c950d                                                         // 94f2: d0 19       ..
+    lda (l0037),y                                                     // 94f4: b1 37       .7
+    sta l003d                                                         // 94f6: 85 3d       .=
+    lda (l0037)                                                       // 94f8: b2 37       .7
+    tax                                                               // 94fa: aa          .
+    ldy l000a                                                         // 94fb: a4 0a       ..
+    dey                                                               // 94fd: 88          .
+    lda l000b                                                         // 94fe: a5 0b       ..
+    sta l0039                                                         // 9500: 85 39       .9
+    lda l000c                                                         // 9502: a5 0c       ..
+    sta l003a                                                         // 9504: 85 3a       .:
+    jsr sub_c8e1f                                                     // 9506: 20 1f 8e     ..
+// $9509 referenced 1 time by $953b
+c9509
+    ldy l000a                                                         // 9509: a4 0a       ..
+    bra c94ba                                                         // 950b: 80 ad       ..
+// $950d referenced 2 times by $94ec, $94f2
+c950d
+    clc                                                               // 950d: 18          .
+    jsr sub_c953d                                                     // 950e: 20 3d 95     =.
+    lda l003b                                                         // 9511: a5 3b       .;
+    adc #2                                                            // 9513: 69 02       i.
+    sta l003b                                                         // 9515: 85 3b       .;
+    bcc c94e4                                                         // 9517: 90 cb       ..
+    inc l003c                                                         // 9519: e6 3c       .<
+    bra c94e4                                                         // 951b: 80 c7       ..
+// $951d referenced 1 time by $94b4
+c951d
+    bra c9579                                                         // 951d: 80 5a       .Z
+// $951f referenced 1 time by $94e6
+c951f
+    jsr sub_cbf0f                                                     // 951f: 20 0f bf     ..
+    lsr l0061                                                         // 9522: 46 61       Fa
+    adc #$6c // 'l'                                                   // 9524: 69 6c       il
+    adc l0064                                                         // 9526: 65 64       ed
+    jsr l7461                                                         // 9528: 20 61 74     at
+    jsr l0bb1                                                         // 952b: 20 b1 0b     ..
+    sta l002b                                                         // 952e: 85 2b       .+
+    iny                                                               // 9530: c8          .
+    lda (l000b),y                                                     // 9531: b1 0b       ..
+    sta l002a                                                         // 9533: 85 2a       .*
+    jsr sub_ca0e8                                                     // 9535: 20 e8 a0     ..
+    jsr sub_cbac2                                                     // 9538: 20 c2 ba     ..
+    bra c9509                                                         // 953b: 80 cc       ..
+// $953d referenced 3 times by $9471, $94a5, $950e
+sub_c953d
+    iny                                                               // 953d: c8          .
+    lda (l0037),y                                                     // 953e: b1 37       .7
+    ldy #1                                                            // 9540: a0 01       ..
+    adc l0037                                                         // 9542: 65 37       e7
+    sta l0037                                                         // 9544: 85 37       .7
+    bcc c954b                                                         // 9546: 90 03       ..
+    inc l0038                                                         // 9548: e6 38       .8
+    clc                                                               // 954a: 18          .
+// $954b referenced 1 time by $9546
+c954b
+    rts                                                               // 954b: 60          `
+
+sub_c954c
+    jsr sub_c9410                                                     // 954c: 20 10 94     ..
+    lda l002a                                                         // 954f: a5 2a       .*
+    pha                                                               // 9551: 48          H
+    jsr sub_cbd26                                                     // 9552: 20 26 bd     &.
+// $9555 referenced 2 times by $9573, $9577
+c9555
+    jsr cbc66                                                         // 9555: 20 66 bc     f.
+    jsr sub_ca0ec                                                     // 9558: 20 ec a0     ..
+    jsr sub_cbaa4                                                     // 955b: 20 a4 ba     ..
+    jsr sub_cbd26                                                     // 955e: 20 26 bd     &.
+    jsr sub_c8ea4                                                     // 9561: 20 a4 8e     ..
+    ldy #0                                                            // 9564: a0 00       ..
+    jsr sub_cbb38                                                     // 9566: 20 38 bb     8.
+    jsr sub_cbbdc                                                     // 9569: 20 dc bb     ..
+    pla                                                               // 956c: 68          h
+    pha                                                               // 956d: 48          H
+    clc                                                               // 956e: 18          .
+    adc l002a                                                         // 956f: 65 2a       e*
+    sta l002a                                                         // 9571: 85 2a       .*
+    bcc c9555                                                         // 9573: 90 e0       ..
+    inc l002b                                                         // 9575: e6 2b       .+
+    bpl c9555                                                         // 9577: 10 dc       ..
+// $9579 referenced 1 time by $951d
+c9579
+    jmp c9048                                                         // 9579: 4c 48 90    LH.
+
+// $957c referenced 1 time by $95a6
+c957c
+    jmp c96ca                                                         // 957c: 4c ca 96    L..
+
+// $957f referenced 1 time by $9632
+c957f
+    dec l000a                                                         // 957f: c6 0a       ..
+    jsr sub_c997d                                                     // 9581: 20 7d 99     }.
+    beq c95f1                                                         // 9584: f0 6b       .k
+    bcs c95f1                                                         // 9586: b0 69       .i
+    jsr sub_cbc83                                                     // 9588: 20 83 bc     ..
+    jsr sub_c9774                                                     // 958b: 20 74 97     t.
+    jsr sub_cbf2f                                                     // 958e: 20 2f bf     /.
+    lda l002d                                                         // 9591: a5 2d       .-
+    ora l002c                                                         // 9593: 05 2c       .,
+    bne c95f1                                                         // 9595: d0 5a       .Z
+    clc                                                               // 9597: 18          .
+    lda l002a                                                         // 9598: a5 2a       .*
+    adc l0002                                                         // 959a: 65 02       e.
+    tay                                                               // 959c: a8          .
+    lda l002b                                                         // 959d: a5 2b       .+
+    adc l0003                                                         // 959f: 65 03       e.
+    tax                                                               // 95a1: aa          .
+    cpy l0004                                                         // 95a2: c4 04       ..
+    sbc l0005                                                         // 95a4: e5 05       ..
+    bcs c957c                                                         // 95a6: b0 d4       ..
+    lda l0002                                                         // 95a8: a5 02       ..
+    sta l002a                                                         // 95aa: 85 2a       .*
+    lda l0003                                                         // 95ac: a5 03       ..
+    sta l002b                                                         // 95ae: 85 2b       .+
+    sty l0002                                                         // 95b0: 84 02       ..
+    stx l0003                                                         // 95b2: 86 03       ..
+    lda #$40 // '@'                                                   // 95b4: a9 40       .@
+    sta l0027                                                         // 95b6: 85 27       .'
+    jsr sub_cb365                                                     // 95b8: 20 65 b3     e.
+    jsr c9338                                                         // 95bb: 20 38 93     8.
+// $95be referenced 1 time by $96c7
+c95be
+    jsr sub_c8da2                                                     // 95be: 20 a2 8d     ..
+    beq c95f9                                                         // 95c1: f0 36       .6
+    jmp c90c5                                                         // 95c3: 4c c5 90    L..
+
+// $95c6 referenced 1 time by $966d
+sub_c95c6
+    ldx #$3f // '?'                                                   // 95c6: a2 3f       .?
+    jsr sub_cbd48                                                     // 95c8: 20 48 bd     H.
+// $95cb referenced 2 times by $9680, $9b1b
+sub_c95cb
+    ldx #0                                                            // 95cb: a2 00       ..
+    ldy #0                                                            // 95cd: a0 00       ..
+// $95cf referenced 1 time by $95ea
+loop_c95cf
+    lsr l0040                                                         // 95cf: 46 40       F@
+    ror l003f                                                         // 95d1: 66 3f       f?
+    bcc c95e0                                                         // 95d3: 90 0b       ..
+    clc                                                               // 95d5: 18          .
+    tya                                                               // 95d6: 98          .
+    adc l002a                                                         // 95d7: 65 2a       e*
+    tay                                                               // 95d9: a8          .
+    txa                                                               // 95da: 8a          .
+    adc l002b                                                         // 95db: 65 2b       e+
+    tax                                                               // 95dd: aa          .
+    bcs c95f1                                                         // 95de: b0 11       ..
+// $95e0 referenced 1 time by $95d3
+c95e0
+    asl l002a                                                         // 95e0: 06 2a       .*
+    rol l002b                                                         // 95e2: 26 2b       &+
+    bcs c95f1                                                         // 95e4: b0 0b       ..
+    lda l003f                                                         // 95e6: a5 3f       .?
+    ora l0040                                                         // 95e8: 05 40       .@
+    bne loop_c95cf                                                    // 95ea: d0 e3       ..
+    sty l002a                                                         // 95ec: 84 2a       .*
+    stx l002b                                                         // 95ee: 86 2b       .+
+    rts                                                               // 95f0: 60          `
+
+// $95f1 referenced 8 times by $9584, $9586, $9595, $95de, $95e4, $961a, $963b, $965c
+c95f1
+    brk                                                               // 95f1: 00          .
+
+    .byt $0a                                                          // 95f2: 0a          .
+    .asc "Bad "                                                       // 95f3: 42 61 64... Bad
+    .byt $de,   0                                                     // 95f7: de 00       ..
+
+// $95f9 referenced 1 time by $95c1
+c95f9
+    jsr c8f9d                                                         // 95f9: 20 9d 8f     ..
+    tya                                                               // 95fc: 98          .
+    clc                                                               // 95fd: 18          .
+    adc l000b                                                         // 95fe: 65 0b       e.
+    ldx l000c                                                         // 9600: a6 0c       ..
+    bcc c9606                                                         // 9602: 90 02       ..
+    inx                                                               // 9604: e8          .
+    clc                                                               // 9605: 18          .
+// $9606 referenced 1 time by $9602
+c9606
+    sbc #0                                                            // 9606: e9 00       ..
+    sta l0037                                                         // 9608: 85 37       .7
+    txa                                                               // 960a: 8a          .
+    sbc #0                                                            // 960b: e9 00       ..
+    sta l0038                                                         // 960d: 85 38       .8
+    ldx #5                                                            // 960f: a2 05       ..
+    stx l003f                                                         // 9611: 86 3f       .?
+    ldx l000a                                                         // 9613: a6 0a       ..
+    jsr sub_c9bba                                                     // 9615: 20 ba 9b     ..
+    cpy #1                                                            // 9618: c0 01       ..
+    beq c95f1                                                         // 961a: f0 d5       ..
+    cmp #$28 // '('                                                   // 961c: c9 28       .(
+    beq c9635                                                         // 961e: f0 15       ..
+    cmp #$24 // '$'                                                   // 9620: c9 24       .$
+    beq c9628                                                         // 9622: f0 04       ..
+    cmp #$25 // '%'                                                   // 9624: c9 25       .%
+    bne c9632                                                         // 9626: d0 0a       ..
+// $9628 referenced 1 time by $9622
+c9628
+    dec l003f                                                         // 9628: c6 3f       .?
+    iny                                                               // 962a: c8          .
+    inx                                                               // 962b: e8          .
+    lda (l0037),y                                                     // 962c: b1 37       .7
+    cmp #$28 // '('                                                   // 962e: c9 28       .(
+    beq c9635                                                         // 9630: f0 03       ..
+// $9632 referenced 1 time by $9626
+c9632
+    jmp c957f                                                         // 9632: 4c 7f 95    L..
+
+// $9635 referenced 2 times by $961e, $9630
+c9635
+    iny                                                               // 9635: c8          .
+    stx l000a                                                         // 9636: 86 0a       ..
+    jsr sub_c8149                                                     // 9638: 20 49 81     I.
+// $963b referenced 1 time by $9677
+c963b
+    bne c95f1                                                         // 963b: d0 b4       ..
+    jsr sub_c9923                                                     // 963d: 20 23 99     #.
+    ldx #1                                                            // 9640: a2 01       ..
+    jsr sub_c9952                                                     // 9642: 20 52 99     R.
+    lda l003f                                                         // 9645: a5 3f       .?
+    pha                                                               // 9647: 48          H
+    lda #1                                                            // 9648: a9 01       ..
+    pha                                                               // 964a: 48          H
+    jsr cae60                                                         // 964b: 20 60 ae     `.
+// $964e referenced 1 time by $9673
+c964e
+    jsr cbc66                                                         // 964e: 20 66 bc     f.
+    jsr sub_c9332                                                     // 9651: 20 32 93     2.
+    lda l002b                                                         // 9654: a5 2b       .+
+    and #$c0                                                          // 9656: 29 c0       ).
+    ora l002c                                                         // 9658: 05 2c       .,
+    ora l002d                                                         // 965a: 05 2d       .-
+    bne c95f1                                                         // 965c: d0 93       ..
+    jsr sub_cbf2f                                                     // 965e: 20 2f bf     /.
+    ply                                                               // 9661: 7a          z
+    lda l002a                                                         // 9662: a5 2a       .*
+    sta (l0002),y                                                     // 9664: 91 02       ..
+    iny                                                               // 9666: c8          .
+    lda l002b                                                         // 9667: a5 2b       .+
+    sta (l0002),y                                                     // 9669: 91 02       ..
+    iny                                                               // 966b: c8          .
+    phy                                                               // 966c: 5a          Z
+    jsr sub_c95c6                                                     // 966d: 20 c6 95     ..
+    jsr sub_c8da2                                                     // 9670: 20 a2 8d     ..
+    beq c964e                                                         // 9673: f0 d9       ..
+    cmp #$29 // ')'                                                   // 9675: c9 29       .)
+    bne c963b                                                         // 9677: d0 c2       ..
+    plx                                                               // 9679: fa          .
+    pla                                                               // 967a: 68          h
+    phx                                                               // 967b: da          .
+    sta l003f                                                         // 967c: 85 3f       .?
+    stz l0040                                                         // 967e: 64 40       d@
+    jsr sub_c95cb                                                     // 9680: 20 cb 95     ..
+    pla                                                               // 9683: 68          h
+    pha                                                               // 9684: 48          H
+    adc l002a                                                         // 9685: 65 2a       e*
+    sta l002a                                                         // 9687: 85 2a       .*
+    bcc c968d                                                         // 9689: 90 02       ..
+    inc l002b                                                         // 968b: e6 2b       .+
+// $968d referenced 1 time by $9689
+c968d
+    lda l0003                                                         // 968d: a5 03       ..
+    sta l0038                                                         // 968f: 85 38       .8
+    lda l0002                                                         // 9691: a5 02       ..
+    sta l0037                                                         // 9693: 85 37       .7
+    clc                                                               // 9695: 18          .
+    adc l002a                                                         // 9696: 65 2a       e*
+    tay                                                               // 9698: a8          .
+    lda l002b                                                         // 9699: a5 2b       .+
+    adc l0003                                                         // 969b: 65 03       e.
+    bcs c96ca                                                         // 969d: b0 2b       .+
+    tax                                                               // 969f: aa          .
+    cpy l0004                                                         // 96a0: c4 04       ..
+    sbc l0005                                                         // 96a2: e5 05       ..
+    bcs c96ca                                                         // 96a4: b0 24       .$
+    sty l0002                                                         // 96a6: 84 02       ..
+    stx l0003                                                         // 96a8: 86 03       ..
+    pla                                                               // 96aa: 68          h
+    sta (l0037)                                                       // 96ab: 92 37       .7
+    adc l0037                                                         // 96ad: 65 37       e7
+    tay                                                               // 96af: a8          .
+    lda #0                                                            // 96b0: a9 00       ..
+    stz l0037                                                         // 96b2: 64 37       d7
+    bcc c96b8                                                         // 96b4: 90 02       ..
+    inc l0038                                                         // 96b6: e6 38       .8
+// $96b8 referenced 3 times by $96b4, $96c1, $96c5
+c96b8
+    sta (l0037),y                                                     // 96b8: 91 37       .7
+    iny                                                               // 96ba: c8          .
+    bne c96bf                                                         // 96bb: d0 02       ..
+    inc l0038                                                         // 96bd: e6 38       .8
+// $96bf referenced 1 time by $96bb
+c96bf
+    cpy l0002                                                         // 96bf: c4 02       ..
+    bne c96b8                                                         // 96c1: d0 f5       ..
+    cpx l0038                                                         // 96c3: e4 38       .8
+    bne c96b8                                                         // 96c5: d0 f1       ..
+    jmp c95be                                                         // 96c7: 4c be 95    L..
+
+// $96ca referenced 3 times by $957c, $969d, $96a4
+c96ca
+    brk                                                               // 96ca: 00          .
+
+    .byt $0b, $de                                                     // 96cb: 0b de       ..
+    .asc " space"                                                     // 96cd: 20 73 70...  sp
+    .byt 0                                                            // 96d3: 00          .
+
+sub_c96d4
+    jsr sub_c977e                                                     // 96d4: 20 7e 97     ~.
+    lda l002a                                                         // 96d7: a5 2a       .*
+    sta l0006                                                         // 96d9: 85 06       ..
+    sta l0004                                                         // 96db: 85 04       ..
+    lda l002b                                                         // 96dd: a5 2b       .+
+    sta l0007                                                         // 96df: 85 07       ..
+    sta l0005                                                         // 96e1: 85 05       ..
+    bra c9700                                                         // 96e3: 80 1b       ..
+sub_c96e5
+    jsr sub_c977e                                                     // 96e5: 20 7e 97     ~.
+    lda l002a                                                         // 96e8: a5 2a       .*
+    sta l0000                                                         // 96ea: 85 00       ..
+    sta l0002                                                         // 96ec: 85 02       ..
+    lda l002b                                                         // 96ee: a5 2b       .+
+    sta l0001                                                         // 96f0: 85 01       ..
+    sta l0003                                                         // 96f2: 85 03       ..
+    jsr sub_cbbeb                                                     // 96f4: 20 eb bb     ..
+    bra c9700                                                         // 96f7: 80 07       ..
+sub_c96f9
+    jsr sub_c977e                                                     // 96f9: 20 7e 97     ~.
+    lda l002b                                                         // 96fc: a5 2b       .+
+    sta l0018                                                         // 96fe: 85 18       ..
+// $9700 referenced 4 times by $96e3, $96f7, $9709, $972a
+c9700
+    jmp c90ca                                                         // 9700: 4c ca 90    L..
+
+sub_c9703
+    jsr c9c6a                                                         // 9703: 20 6a 9c     j.
+    jsr sub_cbbdc                                                     // 9706: 20 dc bb     ..
+    bra c9700                                                         // 9709: 80 f5       ..
+sub_c970b
+    jsr sub_c9be2                                                     // 970b: 20 e2 9b     ..
+    bcs c971b                                                         // 970e: b0 0b       ..
+    cmp #$ee                                                          // 9710: c9 ee       ..
+    beq c972c                                                         // 9712: f0 18       ..
+    cmp #$87                                                          // 9714: c9 87       ..
+    beq c9735                                                         // 9716: f0 1d       ..
+    jsr sub_c9332                                                     // 9718: 20 32 93     2.
+// $971b referenced 1 time by $970e
+c971b
+    jsr c9c6a                                                         // 971b: 20 6a 9c     j.
+    lda l002a                                                         // 971e: a5 2a       .*
+    sta l0021                                                         // 9720: 85 21       .!
+    lda l002b                                                         // 9722: a5 2b       .+
+// $9724 referenced 1 time by $9733
+loop_c9724
+    sta l0022                                                         // 9724: 85 22       ."
+    lda #$ff                                                          // 9726: a9 ff       ..
+// $9728 referenced 1 time by $973c
+loop_c9728
+    sta l0020                                                         // 9728: 85 20       .
+    bra c9700                                                         // 972a: 80 d4       ..
+// $972c referenced 1 time by $9712
+c972c
+    inc l000a                                                         // 972c: e6 0a       ..
+    jsr c9c6a                                                         // 972e: 20 6a 9c     j.
+    lda #$ff                                                          // 9731: a9 ff       ..
+    bne loop_c9724                                                    // 9733: d0 ef       ..
+// $9735 referenced 1 time by $9716
+c9735
+    inc l000a                                                         // 9735: e6 0a       ..
+    jsr c9c6a                                                         // 9737: 20 6a 9c     j.
+    lda #0                                                            // 973a: a9 00       ..
+    bra loop_c9728                                                    // 973c: 80 ea       ..
+sub_c973e
+    iny                                                               // 973e: c8          .
+    lda (l000b),y                                                     // 973f: b1 0b       ..
+    cmp #$24 // '$'                                                   // 9741: c9 24       .$
+    beq c9753                                                         // 9743: f0 0e       ..
+    jsr sub_c977e                                                     // 9745: 20 7e 97     ~.
+    stz l002e                                                         // 9748: 64 2e       d.
+    ldx #$2a // '*'                                                   // 974a: a2 2a       .*
+    ldy #0                                                            // 974c: a0 00       ..
+    lda #2                                                            // 974e: a9 02       ..
+// $9750 referenced 1 time by $9767
+loop_c9750
+    jmp cb34c                                                         // 9750: 4c 4c b3    LL.
+
+// $9753 referenced 1 time by $9743
+c9753
+    inc l000a                                                         // 9753: e6 0a       ..
+    jsr sub_c9c0a                                                     // 9755: 20 0a 9c     ..
+    lda l0027                                                         // 9758: a5 27       .'
+    bne c979c                                                         // 975a: d0 40       .@
+    lda #$0f                                                          // 975c: a9 0f       ..
+    ldy l0036                                                         // 975e: a4 36       .6
+    sty l05ff                                                         // 9760: 8c ff 05    ...
+    ldx #$ff                                                          // 9763: a2 ff       ..
+    ldy #5                                                            // 9765: a0 05       ..
+    bra loop_c9750                                                    // 9767: 80 e7       ..
+// $9769 referenced 2 times by $aca3, $aec8
+sub_c9769
+    jsr cbc91                                                         // 9769: 20 91 bc     ..
+// $976c referenced 6 times by $92f3, $9b2a, $9b4c, $aa9c, $ac60, $af2c
+sub_c976c
+    jsr cadee                                                         // 976c: 20 ee ad     ..
+    bra c9784                                                         // 976f: 80 13       ..
+// $9771 referenced 6 times by $9816, $9886, $988c, $b30e, $b32f, $bf01
+sub_c9771
+    jsr sub_c8fb4                                                     // 9771: 20 b4 8f     ..
+// $9774 referenced 7 times by $8fae, $9304, $958b, $9ae9, $af18, $b67d, $b6a2
+sub_c9774
+    jsr sub_c9dff                                                     // 9774: 20 ff 9d     ..
+    bra c9784                                                         // 9777: 80 0b       ..
+// $9779 referenced 10 times by $931e, $99a5, $99ad, $9a8b, $aa6e, $aaeb, $ab01, $ae34, $b269, $ba81
+sub_c9779
+    jsr cad78                                                         // 9779: 20 78 ad     x.
+    bra c9784                                                         // 977c: 80 06       ..
+// $977e referenced 4 times by $96d4, $96e5, $96f9, $9745
+sub_c977e
+    jsr sub_c9c0a                                                     // 977e: 20 0a 9c     ..
+// $9781 referenced 4 times by $9384, $987b, $ba4d, $bee1
+sub_c9781
+    lda l0027                                                         // 9781: a5 27       .'
+// $9783 referenced 7 times by $81bd, $81cd, $9e13, $9e2d, $9e3f, $9e4d, $9e56
+sub_c9783
+    tay                                                               // 9783: a8          .
+// $9784 referenced 5 times by $9335, $976f, $9777, $977c, $9a82
+c9784
+    beq c979c                                                         // 9784: f0 16       ..
+    bpl c979b                                                         // 9786: 10 13       ..
+// $9788 referenced 5 times by $9cd3, $a134, $a998, $aab9, $b37d
+sub_c9788
+    jsr sub_c834f                                                     // 9788: 20 4f 83     O.
+// $978b referenced 1 time by $abfd
+sub_c978b
+    lda l0031                                                         // 978b: a5 31       .1
+    sta l002d                                                         // 978d: 85 2d       .-
+    lda l0032                                                         // 978f: a5 32       .2
+    sta l002c                                                         // 9791: 85 2c       .,
+    lda l0033                                                         // 9793: a5 33       .3
+    sta l002b                                                         // 9795: 85 2b       .+
+    lda l0034                                                         // 9797: a5 34       .4
+    sta l002a                                                         // 9799: 85 2a       .*
+// $979b referenced 2 times by $9786, $97a4
+c979b
+    rts                                                               // 979b: 60          `
+
+// $979c referenced 3 times by $975a, $9784, $97a2
+c979c
+    jmp c9155                                                         // 979c: 4c 55 91    LU.
+
+// $979f referenced 8 times by $a7ac, $a808, $a901, $a919, $a9b5, $a9ca, $a9d1, $aa17
+sub_c979f
+    jsr cad78                                                         // 979f: 20 78 ad     x.
+// $97a2 referenced 5 times by $9d30, $b6d4, $b6f2, $bc21, $bc37
+sub_c97a2
+    beq c979c                                                         // 97a2: f0 f8       ..
+    bmi c979b                                                         // 97a4: 30 f5       0.
+    jmp c828d                                                         // 97a6: 4c 8d 82    L..
+
+sub_c97a9
+    lda l000b                                                         // 97a9: a5 0b       ..
+    sta l0019                                                         // 97ab: 85 19       ..
+    lda l000c                                                         // 97ad: a5 0c       ..
+    sta l001a                                                         // 97af: 85 1a       ..
+    lda l000a                                                         // 97b1: a5 0a       ..
+    sta l001b                                                         // 97b3: 85 1b       ..
+    lda #$f2                                                          // 97b5: a9 f2       ..
+    jsr sub_cb057                                                     // 97b7: 20 57 b0     W.
+    jsr sub_c9c5a                                                     // 97ba: 20 5a 9c     Z.
+    jmp c90ca                                                         // 97bd: 4c ca 90    L..
+
+// $97c0 referenced 1 time by $97c8
+loop_c97c0
+    lda #$0d                                                          // 97c0: a9 0d       ..
+    sta (l002a)                                                       // 97c2: 92 2a       .*
+    bra c97ee                                                         // 97c4: 80 28       .(
+// $97c6 referenced 1 time by $97e1
+loop_c97c6
+    cpy #$80                                                          // 97c6: c0 80       ..
+    beq loop_c97c0                                                    // 97c8: f0 f6       ..
+    ldy #3                                                            // 97ca: a0 03       ..
+    lda #0                                                            // 97cc: a9 00       ..
+    sta (l002a),y                                                     // 97ce: 91 2a       .*
+    beq c97ee                                                         // 97d0: f0 1c       ..
+// $97d2 referenced 1 time by $97f9
+c97d2
+    tsx                                                               // 97d2: ba          .
+    cpx #$fc                                                          // 97d3: e0 fc       ..
+    bcs c9801                                                         // 97d5: b0 2a       .*
+    jsr sub_c997d                                                     // 97d7: 20 7d 99     }.
+    beq c97fe                                                         // 97da: f0 22       ."
+    jsr sub_cb1bf                                                     // 97dc: 20 bf b1     ..
+    ldy l002c                                                         // 97df: a4 2c       .,
+    bmi loop_c97c6                                                    // 97e1: 30 e3       0.
+    jsr sub_cbc83                                                     // 97e3: 20 83 bc     ..
+    jsr cac38                                                         // 97e6: 20 38 ac     8.
+    sta l0027                                                         // 97e9: 85 27       .'
+    jsr sub_cb365                                                     // 97eb: 20 65 b3     e.
+// $97ee referenced 2 times by $97c4, $97d0
+c97ee
+    tsx                                                               // 97ee: ba          .
+    inc l0106,x                                                       // 97ef: fe 06 01    ...
+    ldy l001b                                                         // 97f2: a4 1b       ..
+    sty l000a                                                         // 97f4: 84 0a       ..
+    jsr sub_c8da2                                                     // 97f6: 20 a2 8d     ..
+    beq c97d2                                                         // 97f9: f0 d7       ..
+    jmp c90c5                                                         // 97fb: 4c c5 90    L..
+
+// $97fe referenced 1 time by $97da
+c97fe
+    jmp c90c7                                                         // 97fe: 4c c7 90    L..
+
+// $9801 referenced 1 time by $97d5
+c9801
+    brk                                                               // 9801: 00          .
+
+    .byt $0c                                                          // 9802: 0c          .
+    .asc "Not "                                                       // 9803: 4e 6f 74... Not
+    .byt $ea                                                          // 9807: ea          .
+
+// $9808 referenced 4 times by $9841, $9847, $9855, $985c
+c9808
+    brk                                                               // 9808: 00          .
+
+    .byt $19                                                          // 9809: 19          .
+    .asc "Bad "                                                       // 980a: 42 61 64... Bad
+    .byt $eb,   0                                                     // 980e: eb 00       ..
+
+sub_c9810
+    jsr sub_c9332                                                     // 9810: 20 32 93     2.
+    lda l002a                                                         // 9813: a5 2a       .*
+    pha                                                               // 9815: 48          H
+    jsr sub_c9771                                                     // 9816: 20 71 97     q.
+    jsr sub_c9c5a                                                     // 9819: 20 5a 9c     Z.
+    lda #$12                                                          // 981c: a9 12       ..
+    jsr oswrch                                                        // 981e: 20 ee ff     ..
+    pla                                                               // 9821: 68          h
+    bra c986a                                                         // 9822: 80 46       .F
+sub_c9824
+    jsr sub_c9332                                                     // 9824: 20 32 93     2.
+    jsr c9c6a                                                         // 9827: 20 6a 9c     j.
+    lda #$11                                                          // 982a: a9 11       ..
+    bra c986a                                                         // 982c: 80 3c       .<
+sub_c982e
+    jsr sub_c9332                                                     // 982e: 20 32 93     2.
+    jsr c9c6a                                                         // 9831: 20 6a 9c     j.
+    jsr sub_cbe8b                                                     // 9834: 20 8b be     ..
+    inx                                                               // 9837: e8          .
+    bne c9866                                                         // 9838: d0 2c       .,
+    iny                                                               // 983a: c8          .
+    bne c9866                                                         // 983b: d0 29       .)
+    lda l0004                                                         // 983d: a5 04       ..
+    cmp l0006                                                         // 983f: c5 06       ..
+    bne c9808                                                         // 9841: d0 c5       ..
+    lda l0005                                                         // 9843: a5 05       ..
+    cmp l0007                                                         // 9845: c5 07       ..
+    bne c9808                                                         // 9847: d0 bf       ..
+    ldx l002a                                                         // 9849: a6 2a       .*
+    lda #osbyte_read_himem_for_mode                                   // 984b: a9 85       ..
+    jsr osbyte                                                        // 984d: 20 f4 ff     ..
+    cpx l0002                                                         // 9850: e4 02       ..
+    tya                                                               // 9852: 98          .
+    sbc l0003                                                         // 9853: e5 03       ..
+    bcc c9808                                                         // 9855: 90 b1       ..
+    cpx l0012                                                         // 9857: e4 12       ..
+    tya                                                               // 9859: 98          .
+    sbc l0013                                                         // 985a: e5 13       ..
+    bcc c9808                                                         // 985c: 90 aa       ..
+    stx l0006                                                         // 985e: 86 06       ..
+    stx l0004                                                         // 9860: 86 04       ..
+    sty l0007                                                         // 9862: 84 07       ..
+    sty l0005                                                         // 9864: 84 05       ..
+// $9866 referenced 2 times by $9838, $983b
+c9866
+    stz l001e                                                         // 9866: 64 1e       d.
+    lda #$16                                                          // 9868: a9 16       ..
+// $986a referenced 2 times by $9822, $982c
+c986a
+    jsr oswrch                                                        // 986a: 20 ee ff     ..
+    lda l002a                                                         // 986d: a5 2a       .*
+    bra c98bd                                                         // 986f: 80 4c       .L
+sub_c9871
+    lda #4                                                            // 9871: a9 04       ..
+    bra c9877                                                         // 9873: 80 02       ..
+sub_c9875
+    lda #5                                                            // 9875: a9 05       ..
+// $9877 referenced 1 time by $9873
+c9877
+    pha                                                               // 9877: 48          H
+    jsr sub_c9df3                                                     // 9878: 20 f3 9d     ..
+    jsr sub_c9781                                                     // 987b: 20 81 97     ..
+    bra c9889                                                         // 987e: 80 09       ..
+sub_c9880
+    jsr sub_c9332                                                     // 9880: 20 32 93     2.
+    lda l002a                                                         // 9883: a5 2a       .*
+    pha                                                               // 9885: 48          H
+    jsr sub_c9771                                                     // 9886: 20 71 97     q.
+// $9889 referenced 1 time by $987e
+c9889
+    jsr cbc66                                                         // 9889: 20 66 bc     f.
+    jsr sub_c9771                                                     // 988c: 20 71 97     q.
+    jsr sub_c9c5a                                                     // 988f: 20 5a 9c     Z.
+    lda #$19                                                          // 9892: a9 19       ..
+    jsr oswrch                                                        // 9894: 20 ee ff     ..
+    pla                                                               // 9897: 68          h
+    jsr oswrch                                                        // 9898: 20 ee ff     ..
+    jsr sub_cbd46                                                     // 989b: 20 46 bd     F.
+    lda l0037                                                         // 989e: a5 37       .7
+    jsr oswrch                                                        // 98a0: 20 ee ff     ..
+    lda l0038                                                         // 98a3: a5 38       .8
+    jsr oswrch                                                        // 98a5: 20 ee ff     ..
+    jsr sub_c990f                                                     // 98a8: 20 0f 99     ..
+    lda l002b                                                         // 98ab: a5 2b       .+
+    bra c98bd                                                         // 98ad: 80 0e       ..
+sub_c98af
+    jsr c9c6a                                                         // 98af: 20 6a 9c     j.
+    lda #$10                                                          // 98b2: a9 10       ..
+    bra c98bd                                                         // 98b4: 80 07       ..
+sub_c98b6
+    jsr c9c6a                                                         // 98b6: 20 6a 9c     j.
+    stz l001e                                                         // 98b9: 64 1e       d.
+    lda #$0c                                                          // 98bb: a9 0c       ..
+// $98bd referenced 3 times by $986f, $98ad, $98b4
+c98bd
+    jsr oswrch                                                        // 98bd: 20 ee ff     ..
+// $98c0 referenced 2 times by $98cd, $98d5
+c98c0
+    jmp c90ca                                                         // 98c0: 4c ca 90    L..
+
+sub_c98c3
+    jsr c9c6a                                                         // 98c3: 20 6a 9c     j.
+    jsr sub_cbac2                                                     // 98c6: 20 c2 ba     ..
+    ldy #1                                                            // 98c9: a0 01       ..
+// $98cb referenced 1 time by $98d3
+loop_c98cb
+    lda (l00fd),y                                                     // 98cb: b1 fd       ..
+    beq c98c0                                                         // 98cd: f0 f1       ..
+    jsr sub_cbd77                                                     // 98cf: 20 77 bd     w.
+    iny                                                               // 98d2: c8          .
+    bne loop_c98cb                                                    // 98d3: d0 f6       ..
+    bra c98c0                                                         // 98d5: 80 e9       ..
+// $98d7 referenced 1 time by $98fa
+c98d7
+    lda l002b                                                         // 98d7: a5 2b       .+
+    jsr oswrch                                                        // 98d9: 20 ee ff     ..
+// $98dc referenced 2 times by $98f6, $990a
+c98dc
+    jsr c8f9d                                                         // 98dc: 20 9d 8f     ..
+// $98df referenced 1 time by $98fe
+loop_c98df
+    cmp #$3a // ':'                                                   // 98df: c9 3a       .:
+    beq c990c                                                         // 98e1: f0 29       .)
+    cmp #$0d                                                          // 98e3: c9 0d       ..
+    beq c990c                                                         // 98e5: f0 25       .%
+    cmp #$8b                                                          // 98e7: c9 8b       ..
+    beq c990c                                                         // 98e9: f0 21       .!
+    dec l000a                                                         // 98eb: c6 0a       ..
+    jsr sub_c9332                                                     // 98ed: 20 32 93     2.
+    jsr sub_c990f                                                     // 98f0: 20 0f 99     ..
+    jsr sub_c8da2                                                     // 98f3: 20 a2 8d     ..
+    beq c98dc                                                         // 98f6: f0 e4       ..
+    cmp #$3b // ';'                                                   // 98f8: c9 3b       .;
+    beq c98d7                                                         // 98fa: f0 db       ..
+    cmp #$7c // '|'                                                   // 98fc: c9 7c       .|
+    bne loop_c98df                                                    // 98fe: d0 df       ..
+    lda #0                                                            // 9900: a9 00       ..
+    ldy #9                                                            // 9902: a0 09       ..
+// $9904 referenced 1 time by $9908
+loop_c9904
+    jsr oswrch                                                        // 9904: 20 ee ff     ..
+    dey                                                               // 9907: 88          .
+    bne loop_c9904                                                    // 9908: d0 fa       ..
+    bra c98dc                                                         // 990a: 80 d0       ..
+// $990c referenced 3 times by $98e1, $98e5, $98e9
+c990c
+    jmp c90c5                                                         // 990c: 4c c5 90    L..
+
+// $990f referenced 3 times by $92ff, $98a8, $98f0
+sub_c990f
+    lda l002a                                                         // 990f: a5 2a       .*
+    jmp (wrchv)                                                       // 9911: 6c 0e 02    l..
+
+// $9914 referenced 1 time by $b031
+sub_c9914
+    ldy #1                                                            // 9914: a0 01       ..
+    lda (l0037),y                                                     // 9916: b1 37       .7
+    tax                                                               // 9918: aa          .
+    lda #$f6                                                          // 9919: a9 f6       ..
+    cpx #$f2                                                          // 991b: e0 f2       ..
+    beq c9928                                                         // 991d: f0 09       ..
+    lda #$f8                                                          // 991f: a9 f8       ..
+    bra c9928                                                         // 9921: 80 05       ..
+// $9923 referenced 3 times by $90fe, $963d, $9984
+sub_c9923
+    ldy #1                                                            // 9923: a0 01       ..
+    lda (l0037),y                                                     // 9925: b1 37       .7
+    asl                                                               // 9927: 0a          .
+// $9928 referenced 2 times by $991d, $9921
+c9928
+    ldx #4                                                            // 9928: a2 04       ..
+// $992a referenced 1 time by $9935
+loop_c992a
+    sta l003a                                                         // 992a: 85 3a       .:
+    stx l003b                                                         // 992c: 86 3b       .;
+    lda (l003a),y                                                     // 992e: b1 3a       .:
+    beq c9937                                                         // 9930: f0 05       ..
+    tax                                                               // 9932: aa          .
+    lda (l003a)                                                       // 9933: b2 3a       .:
+    bra loop_c992a                                                    // 9935: 80 f3       ..
+// $9937 referenced 1 time by $9930
+c9937
+    lda l0003                                                         // 9937: a5 03       ..
+    sta (l003a),y                                                     // 9939: 91 3a       .:
+    lda l0002                                                         // 993b: a5 02       ..
+    sta (l003a)                                                       // 993d: 92 3a       .:
+    lda #0                                                            // 993f: a9 00       ..
+    sta (l0002),y                                                     // 9941: 91 02       ..
+    iny                                                               // 9943: c8          .
+    cpy l0039                                                         // 9944: c4 39       .9
+    beq c9979                                                         // 9946: f0 31       .1
+// $9948 referenced 1 time by $994f
+loop_c9948
+    lda (l0037),y                                                     // 9948: b1 37       .7
+    sta (l0002),y                                                     // 994a: 91 02       ..
+    iny                                                               // 994c: c8          .
+    cpy l0039                                                         // 994d: c4 39       .9
+    bne loop_c9948                                                    // 994f: d0 f7       ..
+    rts                                                               // 9951: 60          `
+
+// $9952 referenced 4 times by $9108, $9642, $997a, $b036
+sub_c9952
+    lda #0                                                            // 9952: a9 00       ..
+// $9954 referenced 1 time by $9958
+loop_c9954
+    sta (l0002),y                                                     // 9954: 91 02       ..
+    iny                                                               // 9956: c8          .
+    dex                                                               // 9957: ca          .
+    bne loop_c9954                                                    // 9958: d0 fa       ..
+// $995a referenced 1 time by $b044
+sub_c995a
+    clc                                                               // 995a: 18          .
+    tya                                                               // 995b: 98          .
+    adc l0002                                                         // 995c: 65 02       e.
+    bcc c9962                                                         // 995e: 90 02       ..
+    inc l0003                                                         // 9960: e6 03       ..
+// $9962 referenced 1 time by $995e
+c9962
+    ldy l0003                                                         // 9962: a4 03       ..
+    cpy l0005                                                         // 9964: c4 05       ..
+    bcc c9977                                                         // 9966: 90 0f       ..
+    bne c996e                                                         // 9968: d0 04       ..
+    cmp l0004                                                         // 996a: c5 04       ..
+    bcc c9977                                                         // 996c: 90 09       ..
+// $996e referenced 1 time by $9968
+c996e
+    lda #0                                                            // 996e: a9 00       ..
+    ldy #1                                                            // 9970: a0 01       ..
+    sta (l003a),y                                                     // 9972: 91 3a       .:
+    jmp c9164                                                         // 9974: 4c 64 91    Ld.
+
+// $9977 referenced 2 times by $9966, $996c
+c9977
+    sta l0002                                                         // 9977: 85 02       ..
+// $9979 referenced 1 time by $9946
+c9979
+    rts                                                               // 9979: 60          `
+
+// $997a referenced 2 times by $998b, $998e
+c997a
+    jsr sub_c9952                                                     // 997a: 20 52 99     R.
+// $997d referenced 9 times by $8a91, $910d, $9581, $97d7, $b112, $b649, $b887, $b91f, $b9ad
+sub_c997d
+    jsr sub_c99c4                                                     // 997d: 20 c4 99     ..
+    bne c999f                                                         // 9980: d0 1d       ..
+    bcs c999f                                                         // 9982: b0 1b       ..
+    jsr sub_c9923                                                     // 9984: 20 23 99     #.
+    ldx #5                                                            // 9987: a2 05       ..
+    cpx l002c                                                         // 9989: e4 2c       .,
+    bne c997a                                                         // 998b: d0 ed       ..
+    inx                                                               // 998d: e8          .
+    bra c997a                                                         // 998e: 80 ea       ..
+// $9990 referenced 1 time by $99da
+c9990
+    cmp #$21 // '!'                                                   // 9990: c9 21       .!
+    beq c99a0                                                         // 9992: f0 0c       ..
+    cmp #$24 // '$'                                                   // 9994: c9 24       .$
+    beq c99ab                                                         // 9996: f0 13       ..
+    eor #$3f // '?'                                                   // 9998: 49 3f       I?
+    beq c99a2                                                         // 999a: f0 06       ..
+    lda #0                                                            // 999c: a9 00       ..
+    sec                                                               // 999e: 38          8
+// $999f referenced 2 times by $9980, $9982
+c999f
+    rts                                                               // 999f: 60          `
+
+// $99a0 referenced 1 time by $9992
+c99a0
+    lda #4                                                            // 99a0: a9 04       ..
+// $99a2 referenced 1 time by $999a
+c99a2
+    pha                                                               // 99a2: 48          H
+    inc l001b                                                         // 99a3: e6 1b       ..
+    jsr sub_c9779                                                     // 99a5: 20 79 97     y.
+    jmp c9a99                                                         // 99a8: 4c 99 9a    L..
+
+// $99ab referenced 1 time by $9996
+c99ab
+    inc l001b                                                         // 99ab: e6 1b       ..
+    jsr sub_c9779                                                     // 99ad: 20 79 97     y.
+    lda l002b                                                         // 99b0: a5 2b       .+
+    beq c99ba                                                         // 99b2: f0 06       ..
+    lda #$80                                                          // 99b4: a9 80       ..
+    sta l002c                                                         // 99b6: 85 2c       .,
+    sec                                                               // 99b8: 38          8
+    rts                                                               // 99b9: 60          `
+
+// $99ba referenced 1 time by $99b2
+c99ba
+    brk                                                               // 99ba: 00          .
+
+    .byt 8                                                            // 99bb: 08          .
+    .asc "$ range"                                                    // 99bc: 24 20 72... $ r
+    .byt 0                                                            // 99c3: 00          .
+
+// $99c4 referenced 2 times by $997d, $b522
+sub_c99c4
+    lda l000b                                                         // 99c4: a5 0b       ..
+    sta l0019                                                         // 99c6: 85 19       ..
+    lda l000c                                                         // 99c8: a5 0c       ..
+    sta l001a                                                         // 99ca: 85 1a       ..
+    ldy l000a                                                         // 99cc: a4 0a       ..
+    dey                                                               // 99ce: 88          .
+// $99cf referenced 1 time by $99d4
+loop_c99cf
+    iny                                                               // 99cf: c8          .
+// $99d0 referenced 1 time by $9397
+sub_c99d0
+    lda (l0019),y                                                     // 99d0: b1 19       ..
+    cmp #$20 // ' '                                                   // 99d2: c9 20       .
+    beq loop_c99cf                                                    // 99d4: f0 f9       ..
+// $99d6 referenced 1 time by $90f2
+sub_c99d6
+    sty l001b                                                         // 99d6: 84 1b       ..
+// $99d8 referenced 1 time by $adae
+sub_c99d8
+    cmp #$40 // '@'                                                   // 99d8: c9 40       .@
+    bcc c9990                                                         // 99da: 90 b4       ..
+    cmp #$5b // '['                                                   // 99dc: c9 5b       .[
+    bcs c99fa                                                         // 99de: b0 1a       ..
+    asl                                                               // 99e0: 0a          .
+    asl                                                               // 99e1: 0a          .
+    sta l002a                                                         // 99e2: 85 2a       .*
+    iny                                                               // 99e4: c8          .
+    lda (l0019),y                                                     // 99e5: b1 19       ..
+    cmp #$25 // '%'                                                   // 99e7: c9 25       .%
+    bne c99fa                                                         // 99e9: d0 0f       ..
+    lda #4                                                            // 99eb: a9 04       ..
+    sta l002b                                                         // 99ed: 85 2b       .+
+    ldx #4                                                            // 99ef: a2 04       ..
+    stx l002c                                                         // 99f1: 86 2c       .,
+    iny                                                               // 99f3: c8          .
+    lda (l0019),y                                                     // 99f4: b1 19       ..
+    cmp #$28 // '('                                                   // 99f6: c9 28       .(
+    bne c9a67                                                         // 99f8: d0 6d       .m
+// $99fa referenced 2 times by $99de, $99e9
+c99fa
+    ldx #5                                                            // 99fa: a2 05       ..
+    stx l002c                                                         // 99fc: 86 2c       .,
+    clc                                                               // 99fe: 18          .
+    ldy l001a                                                         // 99ff: a4 1a       ..
+    lda l001b                                                         // 9a01: a5 1b       ..
+    tax                                                               // 9a03: aa          .
+    bne c9a0e                                                         // 9a04: d0 08       ..
+    dec                                                               // 9a06: 3a          :
+    adc l0019                                                         // 9a07: 65 19       e.
+    bcs c9a14                                                         // 9a09: b0 09       ..
+    dey                                                               // 9a0b: 88          .
+    bra c9a14                                                         // 9a0c: 80 06       ..
+// $9a0e referenced 1 time by $9a04
+c9a0e
+    dec                                                               // 9a0e: 3a          :
+    adc l0019                                                         // 9a0f: 65 19       e.
+    bcc c9a14                                                         // 9a11: 90 01       ..
+    iny                                                               // 9a13: c8          .
+// $9a14 referenced 3 times by $9a09, $9a0c, $9a11
+c9a14
+    sta l0037                                                         // 9a14: 85 37       .7
+    sty l0038                                                         // 9a16: 84 38       .8
+    ldy #1                                                            // 9a18: a0 01       ..
+    lda (l0037),y                                                     // 9a1a: b1 37       .7
+    cmp #$41 // 'A'                                                   // 9a1c: c9 41       .A
+    bcs c9a3a                                                         // 9a1e: b0 1a       ..
+    cmp #$30 // '0'                                                   // 9a20: c9 30       .0
+    bcc c9a46                                                         // 9a22: 90 22       ."
+    cmp #$3a // ':'                                                   // 9a24: c9 3a       .:
+    bcs c9a46                                                         // 9a26: b0 1e       ..
+// $9a28 referenced 3 times by $9a36, $9a3c, $9a44
+c9a28
+    inx                                                               // 9a28: e8          .
+    iny                                                               // 9a29: c8          .
+    lda (l0037),y                                                     // 9a2a: b1 37       .7
+    cmp #$41 // 'A'                                                   // 9a2c: c9 41       .A
+    bcs c9a3a                                                         // 9a2e: b0 0a       ..
+    cmp #$30 // '0'                                                   // 9a30: c9 30       .0
+    bcc c9a46                                                         // 9a32: 90 12       ..
+    cmp #$3a // ':'                                                   // 9a34: c9 3a       .:
+    bcc c9a28                                                         // 9a36: 90 f0       ..
+    bra c9a46                                                         // 9a38: 80 0c       ..
+// $9a3a referenced 2 times by $9a1e, $9a2e
+c9a3a
+    cmp #$5b // '['                                                   // 9a3a: c9 5b       .[
+    bcc c9a28                                                         // 9a3c: 90 ea       ..
+    cmp #$5f // '_'                                                   // 9a3e: c9 5f       ._
+    bcc c9a46                                                         // 9a40: 90 04       ..
+    cmp #$7b // '{'                                                   // 9a42: c9 7b       .{
+    bcc c9a28                                                         // 9a44: 90 e2       ..
+// $9a46 referenced 5 times by $9a22, $9a26, $9a32, $9a38, $9a40
+c9a46
+    cpy #1                                                            // 9a46: c0 01       ..
+    beq c9a76                                                         // 9a48: f0 2c       .,
+    cmp #$24 // '$'                                                   // 9a4a: c9 24       .$
+    beq c9aa5                                                         // 9a4c: f0 57       .W
+    cmp #$25 // '%'                                                   // 9a4e: c9 25       .%
+    bne c9a58                                                         // 9a50: d0 06       ..
+    dec l002c                                                         // 9a52: c6 2c       .,
+    inx                                                               // 9a54: e8          .
+    iny                                                               // 9a55: c8          .
+    lda (l0037),y                                                     // 9a56: b1 37       .7
+// $9a58 referenced 1 time by $9a50
+c9a58
+    cmp #$28 // '('                                                   // 9a58: c9 28       .(
+    beq c9aa0                                                         // 9a5a: f0 44       .D
+    jsr sub_c8149                                                     // 9a5c: 20 49 81     I.
+    beq c9a75                                                         // 9a5f: f0 14       ..
+    stx l001b                                                         // 9a61: 86 1b       ..
+// $9a63 referenced 1 time by $9aa3
+c9a63
+    ldy l001b                                                         // 9a63: a4 1b       ..
+    lda (l0019),y                                                     // 9a65: b1 19       ..
+// $9a67 referenced 1 time by $99f8
+c9a67
+    cmp #$21 // '!'                                                   // 9a67: c9 21       .!
+    beq c9a79                                                         // 9a69: f0 0e       ..
+    eor #$3f // '?'                                                   // 9a6b: 49 3f       I?
+    beq c9a7b                                                         // 9a6d: f0 0c       ..
+    clc                                                               // 9a6f: 18          .
+    sty l001b                                                         // 9a70: 84 1b       ..
+    lda #$ff                                                          // 9a72: a9 ff       ..
+    rts                                                               // 9a74: 60          `
+
+// $9a75 referenced 2 times by $9a5f, $9ab2
+c9a75
+    clc                                                               // 9a75: 18          .
+// $9a76 referenced 1 time by $9a48
+c9a76
+    lda #0                                                            // 9a76: a9 00       ..
+    rts                                                               // 9a78: 60          `
+
+// $9a79 referenced 1 time by $9a69
+c9a79
+    lda #4                                                            // 9a79: a9 04       ..
+// $9a7b referenced 1 time by $9a6d
+c9a7b
+    pha                                                               // 9a7b: 48          H
+    iny                                                               // 9a7c: c8          .
+    sty l001b                                                         // 9a7d: 84 1b       ..
+    jsr cb1de                                                         // 9a7f: 20 de b1     ..
+    jsr c9784                                                         // 9a82: 20 84 97     ..
+    lda l002b                                                         // 9a85: a5 2b       .+
+    pha                                                               // 9a87: 48          H
+    lda l002a                                                         // 9a88: a5 2a       .*
+    pha                                                               // 9a8a: 48          H
+    jsr sub_c9779                                                     // 9a8b: 20 79 97     y.
+    clc                                                               // 9a8e: 18          .
+    pla                                                               // 9a8f: 68          h
+    adc l002a                                                         // 9a90: 65 2a       e*
+    sta l002a                                                         // 9a92: 85 2a       .*
+    pla                                                               // 9a94: 68          h
+    adc l002b                                                         // 9a95: 65 2b       e+
+    sta l002b                                                         // 9a97: 85 2b       .+
+// $9a99 referenced 1 time by $99a8
+c9a99
+    pla                                                               // 9a99: 68          h
+    sta l002c                                                         // 9a9a: 85 2c       .,
+    clc                                                               // 9a9c: 18          .
+    lda #$ff                                                          // 9a9d: a9 ff       ..
+    rts                                                               // 9a9f: 60          `
+
+// $9aa0 referenced 1 time by $9a5a
+c9aa0
+    jsr sub_c9ac9                                                     // 9aa0: 20 c9 9a     ..
+    bra c9a63                                                         // 9aa3: 80 be       ..
+// $9aa5 referenced 1 time by $9a4c
+c9aa5
+    dec l002c                                                         // 9aa5: c6 2c       .,
+    inx                                                               // 9aa7: e8          .
+    iny                                                               // 9aa8: c8          .
+    lda (l0037),y                                                     // 9aa9: b1 37       .7
+    cmp #$28 // '('                                                   // 9aab: c9 28       .(
+    beq c9abc                                                         // 9aad: f0 0d       ..
+    jsr sub_c8149                                                     // 9aaf: 20 49 81     I.
+    beq c9a75                                                         // 9ab2: f0 c1       ..
+    stx l001b                                                         // 9ab4: 86 1b       ..
+// $9ab6 referenced 1 time by $9abf
+loop_c9ab6
+    lda #$81                                                          // 9ab6: a9 81       ..
+    sta l002c                                                         // 9ab8: 85 2c       .,
+    sec                                                               // 9aba: 38          8
+    rts                                                               // 9abb: 60          `
+
+// $9abc referenced 1 time by $9aad
+c9abc
+    jsr sub_c9ac9                                                     // 9abc: 20 c9 9a     ..
+    bra loop_c9ab6                                                    // 9abf: 80 f5       ..
+// $9ac1 referenced 2 times by $9ace, $9af0
+c9ac1
+    brk                                                               // 9ac1: 00          .
+
+    .byt $0e                                                          // 9ac2: 0e          .
+    .asc "Array"                                                      // 9ac3: 41 72 72... Arr
+    .byt 0                                                            // 9ac8: 00          .
+
+// $9ac9 referenced 2 times by $9aa0, $9abc
+sub_c9ac9
+    inx                                                               // 9ac9: e8          .
+    iny                                                               // 9aca: c8          .
+    jsr sub_c8149                                                     // 9acb: 20 49 81     I.
+    beq c9ac1                                                         // 9ace: f0 f1       ..
+    stx l001b                                                         // 9ad0: 86 1b       ..
+    lda l002c                                                         // 9ad2: a5 2c       .,
+    pha                                                               // 9ad4: 48          H
+    lda l002a                                                         // 9ad5: a5 2a       .*
+    pha                                                               // 9ad7: 48          H
+    lda l002b                                                         // 9ad8: a5 2b       .+
+    pha                                                               // 9ada: 48          H
+    lda (l002a)                                                       // 9adb: b2 2a       .*
+    cmp #4                                                            // 9add: c9 04       ..
+    bcc c9b4c                                                         // 9adf: 90 6b       .k
+    jsr cac38                                                         // 9ae1: 20 38 ac     8.
+    inc l002d                                                         // 9ae4: e6 2d       .-
+// $9ae6 referenced 1 time by $9b25
+c9ae6
+    jsr cbc66                                                         // 9ae6: 20 66 bc     f.
+    jsr sub_c9774                                                     // 9ae9: 20 74 97     t.
+    inc l001b                                                         // 9aec: e6 1b       ..
+    cpx #$2c // ','                                                   // 9aee: e0 2c       .,
+    bne c9ac1                                                         // 9af0: d0 cf       ..
+    ldx #$39 // '9'                                                   // 9af2: a2 39       .9
+    jsr sub_cbd48                                                     // 9af4: 20 48 bd     H.
+    pla                                                               // 9af7: 68          h
+    sta l0038                                                         // 9af8: 85 38       .8
+    ply                                                               // 9afa: 7a          z
+    sty l0037                                                         // 9afb: 84 37       .7
+    phy                                                               // 9afd: 5a          Z
+    pha                                                               // 9afe: 48          H
+    ldy l003c                                                         // 9aff: a4 3c       .<
+    jsr sub_c9b97                                                     // 9b01: 20 97 9b     ..
+    sty l002d                                                         // 9b04: 84 2d       .-
+    lda (l0037),y                                                     // 9b06: b1 37       .7
+    sta l003f                                                         // 9b08: 85 3f       .?
+    iny                                                               // 9b0a: c8          .
+    lda (l0037),y                                                     // 9b0b: b1 37       .7
+    sta l0040                                                         // 9b0d: 85 40       .@
+    lda l002a                                                         // 9b0f: a5 2a       .*
+    adc l0039                                                         // 9b11: 65 39       e9
+    sta l002a                                                         // 9b13: 85 2a       .*
+    lda l002b                                                         // 9b15: a5 2b       .+
+    adc l003a                                                         // 9b17: 65 3a       e:
+    sta l002b                                                         // 9b19: 85 2b       .+
+    jsr sub_c95cb                                                     // 9b1b: 20 cb 95     ..
+    sec                                                               // 9b1e: 38          8
+    lda (l0037)                                                       // 9b1f: b2 37       .7
+    sbc l002d                                                         // 9b21: e5 2d       .-
+    cmp #3                                                            // 9b23: c9 03       ..
+    bcs c9ae6                                                         // 9b25: b0 bf       ..
+    jsr cbc66                                                         // 9b27: 20 66 bc     f.
+    jsr sub_c976c                                                     // 9b2a: 20 6c 97     l.
+    pla                                                               // 9b2d: 68          h
+    sta l0038                                                         // 9b2e: 85 38       .8
+    pla                                                               // 9b30: 68          h
+    sta l0037                                                         // 9b31: 85 37       .7
+    ldx #$39 // '9'                                                   // 9b33: a2 39       .9
+    jsr sub_cbd48                                                     // 9b35: 20 48 bd     H.
+    ldy l003c                                                         // 9b38: a4 3c       .<
+    jsr sub_c9b97                                                     // 9b3a: 20 97 9b     ..
+    clc                                                               // 9b3d: 18          .
+    lda l0039                                                         // 9b3e: a5 39       .9
+    adc l002a                                                         // 9b40: 65 2a       e*
+    sta l002a                                                         // 9b42: 85 2a       .*
+    lda l003a                                                         // 9b44: a5 3a       .:
+    adc l002b                                                         // 9b46: 65 2b       e+
+    sta l002b                                                         // 9b48: 85 2b       .+
+    bcc c9b5a                                                         // 9b4a: 90 0e       ..
+// $9b4c referenced 1 time by $9adf
+c9b4c
+    jsr sub_c976c                                                     // 9b4c: 20 6c 97     l.
+    pla                                                               // 9b4f: 68          h
+    sta l0038                                                         // 9b50: 85 38       .8
+    pla                                                               // 9b52: 68          h
+    sta l0037                                                         // 9b53: 85 37       .7
+    ldy #1                                                            // 9b55: a0 01       ..
+    jsr sub_c9b97                                                     // 9b57: 20 97 9b     ..
+// $9b5a referenced 1 time by $9b4a
+c9b5a
+    pla                                                               // 9b5a: 68          h
+    sta l002c                                                         // 9b5b: 85 2c       .,
+    cmp #5                                                            // 9b5d: c9 05       ..
+    bne c9b78                                                         // 9b5f: d0 17       ..
+    ldx l002b                                                         // 9b61: a6 2b       .+
+    lda l002a                                                         // 9b63: a5 2a       .*
+    asl l002a                                                         // 9b65: 06 2a       .*
+    rol l002b                                                         // 9b67: 26 2b       &+
+    asl l002a                                                         // 9b69: 06 2a       .*
+    rol l002b                                                         // 9b6b: 26 2b       &+
+    adc l002a                                                         // 9b6d: 65 2a       e*
+    sta l002a                                                         // 9b6f: 85 2a       .*
+    txa                                                               // 9b71: 8a          .
+    adc l002b                                                         // 9b72: 65 2b       e+
+    sta l002b                                                         // 9b74: 85 2b       .+
+    bra c9b80                                                         // 9b76: 80 08       ..
+// $9b78 referenced 1 time by $9b5f
+c9b78
+    asl l002a                                                         // 9b78: 06 2a       .*
+    rol l002b                                                         // 9b7a: 26 2b       &+
+    asl l002a                                                         // 9b7c: 06 2a       .*
+    rol l002b                                                         // 9b7e: 26 2b       &+
+// $9b80 referenced 1 time by $9b76
+c9b80
+    tya                                                               // 9b80: 98          .
+    adc l002a                                                         // 9b81: 65 2a       e*
+    sta l002a                                                         // 9b83: 85 2a       .*
+    bcc c9b8a                                                         // 9b85: 90 03       ..
+    inc l002b                                                         // 9b87: e6 2b       .+
+    clc                                                               // 9b89: 18          .
+// $9b8a referenced 1 time by $9b85
+c9b8a
+    lda l0037                                                         // 9b8a: a5 37       .7
+    adc l002a                                                         // 9b8c: 65 2a       e*
+    sta l002a                                                         // 9b8e: 85 2a       .*
+    lda l0038                                                         // 9b90: a5 38       .8
+    adc l002b                                                         // 9b92: 65 2b       e+
+    sta l002b                                                         // 9b94: 85 2b       .+
+    rts                                                               // 9b96: 60          `
+
+// $9b97 referenced 3 times by $9b01, $9b3a, $9b57
+sub_c9b97
+    lda l002b                                                         // 9b97: a5 2b       .+
+    and #$c0                                                          // 9b99: 29 c0       ).
+    ora l002c                                                         // 9b9b: 05 2c       .,
+    ora l002d                                                         // 9b9d: 05 2d       .-
+    bne c9bae                                                         // 9b9f: d0 0d       ..
+    lda l002a                                                         // 9ba1: a5 2a       .*
+    cmp (l0037),y                                                     // 9ba3: d1 37       .7
+    iny                                                               // 9ba5: c8          .
+    lda l002b                                                         // 9ba6: a5 2b       .+
+    sbc (l0037),y                                                     // 9ba8: f1 37       .7
+    bcs c9bae                                                         // 9baa: b0 02       ..
+    iny                                                               // 9bac: c8          .
+    rts                                                               // 9bad: 60          `
+
+// $9bae referenced 2 times by $9b9f, $9baa
+c9bae
+    brk                                                               // 9bae: 00          .
+
+    .byt $0f                                                          // 9baf: 0f          .
+    .asc "Subscript"                                                  // 9bb0: 53 75 62... Sub
+    .byt 0                                                            // 9bb9: 00          .
+
+// $9bba referenced 1 time by $9615
+sub_c9bba
+    ldy #1                                                            // 9bba: a0 01       ..
+// $9bbc referenced 2 times by $9bd0, $b095
+c9bbc
+    lda (l0037),y                                                     // 9bbc: b1 37       .7
+    cmp #$30 // '0'                                                   // 9bbe: c9 30       .0
+    bcc c9bda                                                         // 9bc0: 90 18       ..
+    cmp #$40 // '@'                                                   // 9bc2: c9 40       .@
+    bcs c9bd2                                                         // 9bc4: b0 0c       ..
+    cmp #$3a // ':'                                                   // 9bc6: c9 3a       .:
+    bcs c9bda                                                         // 9bc8: b0 10       ..
+    cpy #1                                                            // 9bca: c0 01       ..
+    beq c9bda                                                         // 9bcc: f0 0c       ..
+// $9bce referenced 2 times by $9bd8, $9bdd
+c9bce
+    inx                                                               // 9bce: e8          .
+    iny                                                               // 9bcf: c8          .
+    bne c9bbc                                                         // 9bd0: d0 ea       ..
+// $9bd2 referenced 1 time by $9bc4
+c9bd2
+    cmp #$5f // '_'                                                   // 9bd2: c9 5f       ._
+    bcs c9bdb                                                         // 9bd4: b0 05       ..
+    cmp #$5b // '['                                                   // 9bd6: c9 5b       .[
+    bcc c9bce                                                         // 9bd8: 90 f4       ..
+// $9bda referenced 3 times by $9bc0, $9bc8, $9bcc
+c9bda
+    rts                                                               // 9bda: 60          `
+
+// $9bdb referenced 1 time by $9bd4
+c9bdb
+    cmp #$7b // '{'                                                   // 9bdb: c9 7b       .{
+    bcc c9bce                                                         // 9bdd: 90 ef       ..
+    rts                                                               // 9bdf: 60          `
+
+// $9be0 referenced 1 time by $9be8
+loop_c9be0
+    inc l000a                                                         // 9be0: e6 0a       ..
+// $9be2 referenced 10 times by $93da, $93e7, $9415, $9425, $970b, $9ced, $b3d6, $b3fb, $b85a, $bb33
+sub_c9be2
+    ldy l000a                                                         // 9be2: a4 0a       ..
+    lda (l000b),y                                                     // 9be4: b1 0b       ..
+    cmp #$20 // ' '                                                   // 9be6: c9 20       .
+    beq loop_c9be0                                                    // 9be8: f0 f6       ..
+    cmp #$8d                                                          // 9bea: c9 8d       ..
+    bne c9c08                                                         // 9bec: d0 1a       ..
+// $9bee referenced 2 times by $94de, $b500
+sub_c9bee
+    iny                                                               // 9bee: c8          .
+    lda (l000b),y                                                     // 9bef: b1 0b       ..
+    asl                                                               // 9bf1: 0a          .
+    asl                                                               // 9bf2: 0a          .
+    tax                                                               // 9bf3: aa          .
+    and #$c0                                                          // 9bf4: 29 c0       ).
+    iny                                                               // 9bf6: c8          .
+    eor (l000b),y                                                     // 9bf7: 51 0b       Q.
+    sta l002a                                                         // 9bf9: 85 2a       .*
+    txa                                                               // 9bfb: 8a          .
+    asl                                                               // 9bfc: 0a          .
+    asl                                                               // 9bfd: 0a          .
+    iny                                                               // 9bfe: c8          .
+    eor (l000b),y                                                     // 9bff: 51 0b       Q.
+    sta l002b                                                         // 9c01: 85 2b       .+
+    iny                                                               // 9c03: c8          .
+    sty l000a                                                         // 9c04: 84 0a       ..
+    sec                                                               // 9c06: 38          8
+    rts                                                               // 9c07: 60          `
+
+// $9c08 referenced 1 time by $9bec
+c9c08
+    clc                                                               // 9c08: 18          .
+    rts                                                               // 9c09: 60          `
+
+// $9c0a referenced 2 times by $9755, $977e
+sub_c9c0a
+    lda l000b                                                         // 9c0a: a5 0b       ..
+    sta l0019                                                         // 9c0c: 85 19       ..
+    lda l000c                                                         // 9c0e: a5 0c       ..
+    sta l001a                                                         // 9c10: 85 1a       ..
+    lda l000a                                                         // 9c12: a5 0a       ..
+    sta l001b                                                         // 9c14: 85 1b       ..
+// $9c16 referenced 4 times by $9117, $913e, $9c1e, $bede
+c9c16
+    ldy l001b                                                         // 9c16: a4 1b       ..
+    inc l001b                                                         // 9c18: e6 1b       ..
+    lda (l0019),y                                                     // 9c1a: b1 19       ..
+    cmp #$20 // ' '                                                   // 9c1c: c9 20       .
+    beq c9c16                                                         // 9c1e: f0 f6       ..
+    cmp #$3d // '='                                                   // 9c20: c9 3d       .=
+    beq c9c52                                                         // 9c22: f0 2e       ..
+// $9c24 referenced 1 time by $9c4f
+c9c24
+    brk                                                               // 9c24: 00          .
+
+    .byt 4                                                            // 9c25: 04          .
+    .asc "Mistake"                                                    // 9c26: 4d 69 73... Mis
+
+// $9c2d referenced 7 times by $8af2, $8d61, $9146, $93d7, $9c7e, $b52d, $b86f
+c9c2d
+    brk                                                               // 9c2d: 00          .
+
+    .byt $10                                                          // 9c2e: 10          .
+    .asc "Syntax error"                                               // 9c2f: 53 79 6e... Syn
+
+// $9c3b referenced 2 times by $9c61, $9c68
+c9c3b
+    brk                                                               // 9c3b: 00          .
+
+    .byt $0d                                                          // 9c3c: 0d          .
+    .asc "No "                                                        // 9c3d: 4e 6f 20    No
+    .byt $f2                                                          // 9c40: f2          .
+
+// $9c41 referenced 2 times by $9c90, $babf
+c9c41
+    brk                                                               // 9c41: 00          .
+
+    .byt $11                                                          // 9c42: 11          .
+    .asc "Escape"                                                     // 9c43: 45 73 63... Esc
+    .byt 0                                                            // 9c49: 00          .
+
+// $9c4a referenced 2 times by $90fb, $b653
+sub_c9c4a
+    jsr c8f92                                                         // 9c4a: 20 92 8f     ..
+    cmp #$3d // '='                                                   // 9c4d: c9 3d       .=
+    bne c9c24                                                         // 9c4f: d0 d3       ..
+    rts                                                               // 9c51: 60          `
+
+// $9c52 referenced 1 time by $9c22
+c9c52
+    jsr sub_c9dff                                                     // 9c52: 20 ff 9d     ..
+// $9c55 referenced 3 times by $9132, $ba4a, $be7e
+c9c55
+    txa                                                               // 9c55: 8a          .
+    ldy l001b                                                         // 9c56: a4 1b       ..
+    bra c9c74                                                         // 9c58: 80 1a       ..
+// $9c5a referenced 9 times by $93b7, $97ba, $9819, $988f, $b315, $b336, $b354, $bef1, $bf04
+sub_c9c5a
+    ldy l001b                                                         // 9c5a: a4 1b       ..
+    bra c9c6c                                                         // 9c5c: 80 0e       ..
+sub_c9c5e
+    tsx                                                               // 9c5e: ba          .
+    cpx #$fc                                                          // 9c5f: e0 fc       ..
+    bcs c9c3b                                                         // 9c61: b0 d8       ..
+    lda l01ff                                                         // 9c63: ad ff 01    ...
+    cmp #$f2                                                          // 9c66: c9 f2       ..
+    bne c9c3b                                                         // 9c68: d0 d1       ..
+// $9c6a referenced 24 times by $8fc5, $8fd7, $8fea, $9042, $90c7, $9149, $93ec, $9430, $9703, $971b, $972e, $9737, $9827, $9831, $98af, $98b6, $98c3, $9c93, $b41e, $b70c, $b737, $b750, $b769, $b997
+c9c6a
+    ldy l000a                                                         // 9c6a: a4 0a       ..
+// $9c6c referenced 2 times by $8a79, $9c5c
+c9c6c
+    dey                                                               // 9c6c: 88          .
+// $9c6d referenced 1 time by $9c72
+loop_c9c6d
+    iny                                                               // 9c6d: c8          .
+    lda (l000b),y                                                     // 9c6e: b1 0b       ..
+    cmp #$20 // ' '                                                   // 9c70: c9 20       .
+    beq loop_c9c6d                                                    // 9c72: f0 f9       ..
+// $9c74 referenced 3 times by $9433, $9c58, $b428
+c9c74
+    cmp #$3a // ':'                                                   // 9c74: c9 3a       .:
+    beq c9c80                                                         // 9c76: f0 08       ..
+    cmp #$0d                                                          // 9c78: c9 0d       ..
+    beq c9c80                                                         // 9c7a: f0 04       ..
+    cmp #$8b                                                          // 9c7c: c9 8b       ..
+    bne c9c2d                                                         // 9c7e: d0 ad       ..
+// $9c80 referenced 10 times by $89e4, $9069, $907d, $9c76, $9c7a, $b02e, $b40d, $b451, $b77b, $ba8e
+c9c80
+    clc                                                               // 9c80: 18          .
+    tya                                                               // 9c81: 98          .
+    adc l000b                                                         // 9c82: 65 0b       e.
+    sta l000b                                                         // 9c84: 85 0b       ..
+    bcc c9c8a                                                         // 9c86: 90 02       ..
+    inc l000c                                                         // 9c88: e6 0c       ..
+// $9c8a referenced 4 times by $9c86, $9cf5, $b5d9, $b7f4
+c9c8a
+    ldy #1                                                            // 9c8a: a0 01       ..
+    sty l000a                                                         // 9c8c: 84 0a       ..
+// $9c8e referenced 1 time by $93fd
+sub_c9c8e
+    bit l00ff                                                         // 9c8e: 24 ff       $.
+    bmi c9c41                                                         // 9c90: 30 af       0.
+// $9c92 referenced 1 time by $9c9a
+loop_c9c92
+    rts                                                               // 9c92: 60          `
+
+// $9c93 referenced 1 time by $b6bf
+sub_c9c93
+    jsr c9c6a                                                         // 9c93: 20 6a 9c     j.
+    lda (l000b)                                                       // 9c96: b2 0b       ..
+    cmp #$3a // ':'                                                   // 9c98: c9 3a       .:
+    beq loop_c9c92                                                    // 9c9a: f0 f6       ..
+    lda l000c                                                         // 9c9c: a5 0c       ..
+    cmp #7                                                            // 9c9e: c9 07       ..
+    beq c9cc6                                                         // 9ca0: f0 24       .$
+// $9ca2 referenced 1 time by $8a8b
+sub_c9ca2
+    ldy #1                                                            // 9ca2: a0 01       ..
+    lda (l000b),y                                                     // 9ca4: b1 0b       ..
+    bmi c9cc6                                                         // 9ca6: 30 1e       0.
+    ldx l0020                                                         // 9ca8: a6 20       .
+    beq c9cb6                                                         // 9caa: f0 0a       ..
+    sta l002b                                                         // 9cac: 85 2b       .+
+    iny                                                               // 9cae: c8          .
+    lda (l000b),y                                                     // 9caf: b1 0b       ..
+    sta l002a                                                         // 9cb1: 85 2a       .*
+    jsr sub_c9d0f                                                     // 9cb3: 20 0f 9d     ..
+// $9cb6 referenced 1 time by $9caa
+c9cb6
+    lda #3                                                            // 9cb6: a9 03       ..
+// $9cb8 referenced 1 time by $94d9
+sub_c9cb8
+    clc                                                               // 9cb8: 18          .
+    adc l000b                                                         // 9cb9: 65 0b       e.
+    sta l000b                                                         // 9cbb: 85 0b       ..
+    bcc c9cc1                                                         // 9cbd: 90 02       ..
+    inc l000c                                                         // 9cbf: e6 0c       ..
+// $9cc1 referenced 1 time by $9cbd
+c9cc1
+    ldy #1                                                            // 9cc1: a0 01       ..
+    sty l000a                                                         // 9cc3: 84 0a       ..
+// $9cc5 referenced 1 time by $9d17
+c9cc5
+    rts                                                               // 9cc5: 60          `
+
+// $9cc6 referenced 2 times by $9ca0, $9ca6
+c9cc6
+    jmp c904b                                                         // 9cc6: 4c 4b 90    LK.
+
+// $9cc9 referenced 1 time by $9ccf
+loop_c9cc9
+    jmp c9155                                                         // 9cc9: 4c 55 91    LU.
+
+sub_c9ccc
+    jsr sub_c9df3                                                     // 9ccc: 20 f3 9d     ..
+    beq loop_c9cc9                                                    // 9ccf: f0 f8       ..
+    bpl c9cd6                                                         // 9cd1: 10 03       ..
+    jsr sub_c9788                                                     // 9cd3: 20 88 97     ..
+// $9cd6 referenced 1 time by $9cd1
+c9cd6
+    ldy l001b                                                         // 9cd6: a4 1b       ..
+    sty l000a                                                         // 9cd8: 84 0a       ..
+    lda l002a                                                         // 9cda: a5 2a       .*
+    ora l002b                                                         // 9cdc: 05 2b       .+
+    ora l002c                                                         // 9cde: 05 2c       .,
+    ora l002d                                                         // 9ce0: 05 2d       .-
+    beq c9cfb                                                         // 9ce2: f0 17       ..
+    cpx #$8c                                                          // 9ce4: e0 8c       ..
+    beq c9ceb                                                         // 9ce6: f0 03       ..
+// $9ce8 referenced 1 time by $9cf0
+loop_c9ce8
+    jmp c90d0                                                         // 9ce8: 4c d0 90    L..
+
+// $9ceb referenced 1 time by $9ce6
+c9ceb
+    inc l000a                                                         // 9ceb: e6 0a       ..
+// $9ced referenced 2 times by $9d0a, $b849
+c9ced
+    jsr sub_c9be2                                                     // 9ced: 20 e2 9b     ..
+    bcc loop_c9ce8                                                    // 9cf0: 90 f6       ..
+    jsr cb866                                                         // 9cf2: 20 66 b8     f.
+    jsr c9c8a                                                         // 9cf5: 20 8a 9c     ..
+    jmp cb753                                                         // 9cf8: 4c 53 b7    LS.
+
+// $9cfb referenced 1 time by $9ce2
+c9cfb
+    ldy l000a                                                         // 9cfb: a4 0a       ..
+// $9cfd referenced 1 time by $9d06
+loop_c9cfd
+    lda (l000b),y                                                     // 9cfd: b1 0b       ..
+    cmp #$0d                                                          // 9cff: c9 0d       ..
+    beq c9d0c                                                         // 9d01: f0 09       ..
+    iny                                                               // 9d03: c8          .
+    cmp #$8b                                                          // 9d04: c9 8b       ..
+    bne loop_c9cfd                                                    // 9d06: d0 f5       ..
+    sty l000a                                                         // 9d08: 84 0a       ..
+    beq c9ced                                                         // 9d0a: f0 e1       ..
+// $9d0c referenced 1 time by $9d01
+c9d0c
+    jmp c907d                                                         // 9d0c: 4c 7d 90    L}.
+
+// $9d0f referenced 3 times by $909d, $9cb3, $b757
+sub_c9d0f
+    lda l002a                                                         // 9d0f: a5 2a       .*
+    cmp l0021                                                         // 9d11: c5 21       .!
+    lda l002b                                                         // 9d13: a5 2b       .+
+    sbc l0022                                                         // 9d15: e5 22       ."
+    bcs c9cc5                                                         // 9d17: b0 ac       ..
+    lda #$5b // '['                                                   // 9d19: a9 5b       .[
+    jsr sub_cbdd8                                                     // 9d1b: 20 d8 bd     ..
+    jsr sub_ca0e8                                                     // 9d1e: 20 e8 a0     ..
+    lda #$5d // ']'                                                   // 9d21: a9 5d       .]
+    jsr sub_cbdd8                                                     // 9d23: 20 d8 bd     ..
+    jmp cbdd2                                                         // 9d26: 4c d2 bd    L..
+
+// $9d29 referenced 1 time by $9d84
+c9d29
+    jsr cbc3a                                                         // 9d29: 20 3a bc     :.
+    jsr sub_c9f07                                                     // 9d2c: 20 07 9f     ..
+    tay                                                               // 9d2f: a8          .
+    jsr sub_c97a2                                                     // 9d30: 20 a2 97     ..
+    jsr sub_cbc24                                                     // 9d33: 20 24 bc     $.
+// $9d36 referenced 1 time by $b614
+sub_c9d36
+    jsr sub_ca514                                                     // 9d36: 20 14 a5     ..
+    lda l002e                                                         // 9d39: a5 2e       ..
+    eor l003b                                                         // 9d3b: 45 3b       E;
+    bpl c9d57                                                         // 9d3d: 10 18       ..
+    asl l002e                                                         // 9d3f: 06 2e       ..
+    bra c9d79                                                         // 9d41: 80 36       .6
+// $9d43 referenced 1 time by $9db8
+c9d43
+    sty l002d                                                         // 9d43: 84 2d       .-
+    pla                                                               // 9d45: 68          h
+    sta l002c                                                         // 9d46: 85 2c       .,
+    pla                                                               // 9d48: 68          h
+    sta l002b                                                         // 9d49: 85 2b       .+
+    pla                                                               // 9d4b: 68          h
+    sta l002a                                                         // 9d4c: 85 2a       .*
+    jsr sub_c828a                                                     // 9d4e: 20 8a 82     ..
+    lda l003b                                                         // 9d51: a5 3b       .;
+    eor #$80                                                          // 9d53: 49 80       I.
+    sta l003b                                                         // 9d55: 85 3b       .;
+// $9d57 referenced 1 time by $9d3d
+c9d57
+    lda l003c                                                         // 9d57: a5 3c       .<
+    cmp l0030                                                         // 9d59: c5 30       .0
+    bne c9d75                                                         // 9d5b: d0 18       ..
+    lda l003d                                                         // 9d5d: a5 3d       .=
+    cmp l0031                                                         // 9d5f: c5 31       .1
+    bne c9d75                                                         // 9d61: d0 12       ..
+    lda l003e                                                         // 9d63: a5 3e       .>
+    cmp l0032                                                         // 9d65: c5 32       .2
+    bne c9d75                                                         // 9d67: d0 0c       ..
+    lda l003f                                                         // 9d69: a5 3f       .?
+    cmp l0033                                                         // 9d6b: c5 33       .3
+    bne c9d75                                                         // 9d6d: d0 06       ..
+    lda l0040                                                         // 9d6f: a5 40       .@
+    sbc l0034                                                         // 9d71: e5 34       .4
+    beq c9d7b                                                         // 9d73: f0 06       ..
+// $9d75 referenced 4 times by $9d5b, $9d61, $9d67, $9d6d
+c9d75
+    ror                                                               // 9d75: 6a          j
+    eor l003b                                                         // 9d76: 45 3b       E;
+    rol                                                               // 9d78: 2a          *
+// $9d79 referenced 1 time by $9d41
+c9d79
+    lda #$ff                                                          // 9d79: a9 ff       ..
+// $9d7b referenced 1 time by $9d73
+c9d7b
+    rts                                                               // 9d7b: 60          `
+
+// $9d7c referenced 2 times by $9d98, $9dcb
+c9d7c
+    jmp c9155                                                         // 9d7c: 4c 55 91    LU.
+
+// $9d7f referenced 3 times by $9ea6, $9ead, $9ec2
+sub_c9d7f
+    inc l001b                                                         // 9d7f: e6 1b       ..
+// $9d81 referenced 2 times by $9e9d, $9ebb
+sub_c9d81
+    txa                                                               // 9d81: 8a          .
+// $9d82 referenced 1 time by $9e80
+sub_c9d82
+    beq c9dc4                                                         // 9d82: f0 40       .@
+    bmi c9d29                                                         // 9d84: 30 a3       0.
+    lda l002a                                                         // 9d86: a5 2a       .*
+    pha                                                               // 9d88: 48          H
+    lda l002b                                                         // 9d89: a5 2b       .+
+    pha                                                               // 9d8b: 48          H
+    lda l002c                                                         // 9d8c: a5 2c       .,
+    pha                                                               // 9d8e: 48          H
+    lda l002d                                                         // 9d8f: a5 2d       .-
+    pha                                                               // 9d91: 48          H
+    jsr sub_c9f07                                                     // 9d92: 20 07 9f     ..
+    tay                                                               // 9d95: a8          .
+    bmi c9db4                                                         // 9d96: 30 1c       0.
+    beq c9d7c                                                         // 9d98: f0 e2       ..
+    pla                                                               // 9d9a: 68          h
+    tay                                                               // 9d9b: a8          .
+    eor l002d                                                         // 9d9c: 45 2d       E-
+    bmi c9dba                                                         // 9d9e: 30 1a       0.
+    cpy l002d                                                         // 9da0: c4 2d       .-
+    bne c9dbe                                                         // 9da2: d0 1a       ..
+    pla                                                               // 9da4: 68          h
+    cmp l002c                                                         // 9da5: c5 2c       .,
+    bne c9dbf                                                         // 9da7: d0 16       ..
+    pla                                                               // 9da9: 68          h
+    cmp l002b                                                         // 9daa: c5 2b       .+
+    bne c9dc0                                                         // 9dac: d0 12       ..
+    pla                                                               // 9dae: 68          h
+    sbc l002a                                                         // 9daf: e5 2a       .*
+    bne c9dc1                                                         // 9db1: d0 0e       ..
+    rts                                                               // 9db3: 60          `
+
+// $9db4 referenced 1 time by $9d96
+c9db4
+    pla                                                               // 9db4: 68          h
+    tay                                                               // 9db5: a8          .
+    eor l002e                                                         // 9db6: 45 2e       E.
+    bpl c9d43                                                         // 9db8: 10 89       ..
+// $9dba referenced 1 time by $9d9e
+c9dba
+    tya                                                               // 9dba: 98          .
+    eor #$ff                                                          // 9dbb: 49 ff       I.
+    asl                                                               // 9dbd: 0a          .
+// $9dbe referenced 1 time by $9da2
+c9dbe
+    pla                                                               // 9dbe: 68          h
+// $9dbf referenced 1 time by $9da7
+c9dbf
+    pla                                                               // 9dbf: 68          h
+// $9dc0 referenced 1 time by $9dac
+c9dc0
+    pla                                                               // 9dc0: 68          h
+// $9dc1 referenced 2 times by $9db1, $9dee
+c9dc1
+    lda #$ff                                                          // 9dc1: a9 ff       ..
+    rts                                                               // 9dc3: 60          `
+
+// $9dc4 referenced 1 time by $9d82
+c9dc4
+    jsr cbc91                                                         // 9dc4: 20 91 bc     ..
+    jsr sub_c9f07                                                     // 9dc7: 20 07 9f     ..
+    tay                                                               // 9dca: a8          .
+    bne c9d7c                                                         // 9dcb: d0 af       ..
+    lda (l0004)                                                       // 9dcd: b2 04       ..
+    cmp l0036                                                         // 9dcf: c5 36       .6
+    bcc c9dd5                                                         // 9dd1: 90 02       ..
+    lda l0036                                                         // 9dd3: a5 36       .6
+// $9dd5 referenced 1 time by $9dd1
+c9dd5
+    sta l0037                                                         // 9dd5: 85 37       .7
+// $9dd7 referenced 1 time by $9de1
+loop_c9dd7
+    cpy l0037                                                         // 9dd7: c4 37       .7
+    beq c9de5                                                         // 9dd9: f0 0a       ..
+    iny                                                               // 9ddb: c8          .
+    lda (l0004),y                                                     // 9ddc: b1 04       ..
+    cmp l05ff,y                                                       // 9dde: d9 ff 05    ...
+    beq loop_c9dd7                                                    // 9de1: f0 f4       ..
+    bra c9de9                                                         // 9de3: 80 04       ..
+// $9de5 referenced 1 time by $9dd9
+c9de5
+    lda (l0004)                                                       // 9de5: b2 04       ..
+    cmp l0036                                                         // 9de7: c5 36       .6
+// $9de9 referenced 1 time by $9de3
+c9de9
+    php                                                               // 9de9: 08          .
+    jsr cbd21                                                         // 9dea: 20 21 bd     !.
+    plp                                                               // 9ded: 28          (
+    bne c9dc1                                                         // 9dee: d0 d1       ..
+    lda #0                                                            // 9df0: a9 00       ..
+    rts                                                               // 9df2: 60          `
+
+// $9df3 referenced 8 times by $8d77, $912f, $9332, $9381, $9878, $9ccc, $ba47, $be76
+sub_c9df3
+    lda l000b                                                         // 9df3: a5 0b       ..
+    sta l0019                                                         // 9df5: 85 19       ..
+    lda l000c                                                         // 9df7: a5 0c       ..
+    sta l001a                                                         // 9df9: 85 1a       ..
+    lda l000a                                                         // 9dfb: a5 0a       ..
+    sta l001b                                                         // 9dfd: 85 1b       ..
+// $9dff referenced 14 times by $920d, $92b7, $9774, $9c52, $ab8b, $ac7f, $ac8d, $adee, $aebd, $af0a, $b146, $b362, $b6d1, $b6ef
+sub_c9dff
+    jsr sub_c9e45                                                     // 9dff: 20 45 9e     E.
+// $9e02 referenced 1 time by $9e28
+c9e02
+    cpx #$84                                                          // 9e02: e0 84       ..
+    beq c9e10                                                         // 9e04: f0 0a       ..
+    cpx #$82                                                          // 9e06: e0 82       ..
+    beq c9e2a                                                         // 9e08: f0 20       .
+    dec l001b                                                         // 9e0a: c6 1b       ..
+    tay                                                               // 9e0c: a8          .
+    sta l0027                                                         // 9e0d: 85 27       .'
+    rts                                                               // 9e0f: 60          `
+
+// $9e10 referenced 1 time by $9e04
+c9e10
+    jsr sub_c9e3f                                                     // 9e10: 20 3f 9e     ?.
+    jsr sub_c9783                                                     // 9e13: 20 83 97     ..
+    ldy #3                                                            // 9e16: a0 03       ..
+// $9e18 referenced 1 time by $9e21
+loop_c9e18
+    lda (l0004),y                                                     // 9e18: b1 04       ..
+    ora l002a,y                                                       // 9e1a: 19 2a 00    .*.
+    sta l002a,y                                                       // 9e1d: 99 2a 00    .*.
+    dey                                                               // 9e20: 88          .
+    bpl loop_c9e18                                                    // 9e21: 10 f5       ..
+// $9e23 referenced 1 time by $9e3d
+loop_c9e23
+    jsr cbd3a                                                         // 9e23: 20 3a bd     :.
+    lda #$40 // '@'                                                   // 9e26: a9 40       .@
+    bra c9e02                                                         // 9e28: 80 d8       ..
+// $9e2a referenced 1 time by $9e08
+c9e2a
+    jsr sub_c9e3f                                                     // 9e2a: 20 3f 9e     ?.
+    jsr sub_c9783                                                     // 9e2d: 20 83 97     ..
+    ldy #3                                                            // 9e30: a0 03       ..
+// $9e32 referenced 1 time by $9e3b
+loop_c9e32
+    lda (l0004),y                                                     // 9e32: b1 04       ..
+    eor l002a,y                                                       // 9e34: 59 2a 00    Y*.
+    sta l002a,y                                                       // 9e37: 99 2a 00    .*.
+    dey                                                               // 9e3a: 88          .
+    bpl loop_c9e32                                                    // 9e3b: 10 f5       ..
+    bra loop_c9e23                                                    // 9e3d: 80 e4       ..
+// $9e3f referenced 2 times by $9e10, $9e2a
+sub_c9e3f
+    jsr sub_c9783                                                     // 9e3f: 20 83 97     ..
+    jsr cbc66                                                         // 9e42: 20 66 bc     f.
+// $9e45 referenced 1 time by $9dff
+sub_c9e45
+    jsr sub_c9e6d                                                     // 9e45: 20 6d 9e     m.
+// $9e48 referenced 1 time by $9e6b
+c9e48
+    cpx #$80                                                          // 9e48: e0 80       ..
+    beq c9e4d                                                         // 9e4a: f0 01       ..
+    rts                                                               // 9e4c: 60          `
+
+// $9e4d referenced 1 time by $9e4a
+c9e4d
+    jsr sub_c9783                                                     // 9e4d: 20 83 97     ..
+    jsr cbc66                                                         // 9e50: 20 66 bc     f.
+    jsr sub_c9e6d                                                     // 9e53: 20 6d 9e     m.
+    jsr sub_c9783                                                     // 9e56: 20 83 97     ..
+    ldy #3                                                            // 9e59: a0 03       ..
+// $9e5b referenced 1 time by $9e64
+loop_c9e5b
+    lda (l0004),y                                                     // 9e5b: b1 04       ..
+    and l002a,y                                                       // 9e5d: 39 2a 00    9*.
+    sta l002a,y                                                       // 9e60: 99 2a 00    .*.
+    dey                                                               // 9e63: 88          .
+    bpl loop_c9e5b                                                    // 9e64: 10 f5       ..
+    jsr cbd3a                                                         // 9e66: 20 3a bd     :.
+    lda #$40 // '@'                                                   // 9e69: a9 40       .@
+    bra c9e48                                                         // 9e6b: 80 db       ..
+// $9e6d referenced 2 times by $9e45, $9e53
+sub_c9e6d
+    jsr sub_c9f07                                                     // 9e6d: 20 07 9f     ..
+    cpx #$3f // '?'                                                   // 9e70: e0 3f       .?
+    bcs c9e78                                                         // 9e72: b0 04       ..
+    cpx #$3c // '<'                                                   // 9e74: e0 3c       .<
+    bcs c9e79                                                         // 9e76: b0 01       ..
+// $9e78 referenced 1 time by $9e72
+c9e78
+    rts                                                               // 9e78: 60          `
+
+// $9e79 referenced 1 time by $9e76
+c9e79
+    beq c9e90                                                         // 9e79: f0 15       ..
+    cpx #$3e // '>'                                                   // 9e7b: e0 3e       .>
+    beq c9eb2                                                         // 9e7d: f0 33       .3
+    tax                                                               // 9e7f: aa          .
+    jsr sub_c9d82                                                     // 9e80: 20 82 9d     ..
+// $9e83 referenced 5 times by $9ea4, $9eab, $9ec0, $9ec5, $9ec7
+c9e83
+    eor #$ff                                                          // 9e83: 49 ff       I.
+// $9e85 referenced 6 times by $9ea0, $9ea2, $9ea9, $9eb0, $9ebe, $9ec9
+c9e85
+    sta l002a                                                         // 9e85: 85 2a       .*
+    sta l002b                                                         // 9e87: 85 2b       .+
+    sta l002c                                                         // 9e89: 85 2c       .,
+    sta l002d                                                         // 9e8b: 85 2d       .-
+    lda #$40 // '@'                                                   // 9e8d: a9 40       .@
+    rts                                                               // 9e8f: 60          `
+
+// $9e90 referenced 1 time by $9e79
+c9e90
+    tax                                                               // 9e90: aa          .
+    ldy l001b                                                         // 9e91: a4 1b       ..
+    lda (l0019),y                                                     // 9e93: b1 19       ..
+    cmp #$3d // '='                                                   // 9e95: c9 3d       .=
+    beq c9ea6                                                         // 9e97: f0 0d       ..
+    cmp #$3e // '>'                                                   // 9e99: c9 3e       .>
+    beq c9ead                                                         // 9e9b: f0 10       ..
+    jsr sub_c9d81                                                     // 9e9d: 20 81 9d     ..
+    bcc c9e85                                                         // 9ea0: 90 e3       ..
+    beq c9e85                                                         // 9ea2: f0 e1       ..
+    bra c9e83                                                         // 9ea4: 80 dd       ..
+// $9ea6 referenced 1 time by $9e97
+c9ea6
+    jsr sub_c9d7f                                                     // 9ea6: 20 7f 9d     ..
+    bcc c9e85                                                         // 9ea9: 90 da       ..
+    bra c9e83                                                         // 9eab: 80 d6       ..
+// $9ead referenced 1 time by $9e9b
+c9ead
+    jsr sub_c9d7f                                                     // 9ead: 20 7f 9d     ..
+    bra c9e85                                                         // 9eb0: 80 d3       ..
+// $9eb2 referenced 1 time by $9e7d
+c9eb2
+    tax                                                               // 9eb2: aa          .
+    ldy l001b                                                         // 9eb3: a4 1b       ..
+    lda (l0019),y                                                     // 9eb5: b1 19       ..
+    cmp #$3d // '='                                                   // 9eb7: c9 3d       .=
+    beq c9ec2                                                         // 9eb9: f0 07       ..
+    jsr sub_c9d81                                                     // 9ebb: 20 81 9d     ..
+    bcs c9e85                                                         // 9ebe: b0 c5       ..
+    bra c9e83                                                         // 9ec0: 80 c1       ..
+// $9ec2 referenced 1 time by $9eb9
+c9ec2
+    jsr sub_c9d7f                                                     // 9ec2: 20 7f 9d     ..
+    bcc c9e83                                                         // 9ec5: 90 bc       ..
+    beq c9e83                                                         // 9ec7: f0 ba       ..
+    bra c9e85                                                         // 9ec9: 80 ba       ..
+// $9ecb referenced 2 times by $9eec, $afbe
+c9ecb
+    brk                                                               // 9ecb: 00          .
+
+    .byt $13                                                          // 9ecc: 13          .
+    .asc "String too long"                                            // 9ecd: 53 74 72... Str
+    .byt 0                                                            // 9edc: 00          .
+
+// $9edd referenced 1 time by $9f16
+c9edd
+    jsr cbc91                                                         // 9edd: 20 91 bc     ..
+    jsr sub_ca06c                                                     // 9ee0: 20 6c a0     l.
+    tay                                                               // 9ee3: a8          .
+    bne c9f4c                                                         // 9ee4: d0 66       .f
+    clc                                                               // 9ee6: 18          .
+    phx                                                               // 9ee7: da          .
+    lda (l0004)                                                       // 9ee8: b2 04       ..
+    adc l0036                                                         // 9eea: 65 36       e6
+    bcs c9ecb                                                         // 9eec: b0 dd       ..
+    tax                                                               // 9eee: aa          .
+    pha                                                               // 9eef: 48          H
+    ldy l0036                                                         // 9ef0: a4 36       .6
+// $9ef2 referenced 1 time by $9efa
+loop_c9ef2
+    lda l05ff,y                                                       // 9ef2: b9 ff 05    ...
+    sta l05ff,x                                                       // 9ef5: 9d ff 05    ...
+    dex                                                               // 9ef8: ca          .
+    dey                                                               // 9ef9: 88          .
+    bne loop_c9ef2                                                    // 9efa: d0 f6       ..
+    jsr sub_cbd12                                                     // 9efc: 20 12 bd     ..
+    pla                                                               // 9eff: 68          h
+    sta l0036                                                         // 9f00: 85 36       .6
+    plx                                                               // 9f02: fa          .
+    lda #0                                                            // 9f03: a9 00       ..
+    bra c9f0a                                                         // 9f05: 80 03       ..
+// $9f07 referenced 4 times by $9d2c, $9d92, $9dc7, $9e6d
+sub_c9f07
+    jsr sub_ca026                                                     // 9f07: 20 26 a0     &.
+// $9f0a referenced 4 times by $9f05, $9f46, $9f4a, $9f57
+c9f0a
+    cpx #$2b // '+'                                                   // 9f0a: e0 2b       .+
+    beq c9f13                                                         // 9f0c: f0 05       ..
+    cpx #$2d // '-'                                                   // 9f0e: e0 2d       .-
+    beq c9f70                                                         // 9f10: f0 5e       .^
+    rts                                                               // 9f12: 60          `
+
+// $9f13 referenced 1 time by $9f0c
+c9f13
+    tay                                                               // 9f13: a8          .
+    bmi c9f4f                                                         // 9f14: 30 39       09
+    beq c9edd                                                         // 9f16: f0 c5       ..
+    jsr sub_ca023                                                     // 9f18: 20 23 a0     #.
+    tay                                                               // 9f1b: a8          .
+    bmi c9f64                                                         // 9f1c: 30 46       0F
+    beq c9f4c                                                         // 9f1e: f0 2c       .,
+    clc                                                               // 9f20: 18          .
+    lda (l0004)                                                       // 9f21: b2 04       ..
+    adc l002a                                                         // 9f23: 65 2a       e*
+    sta l002a                                                         // 9f25: 85 2a       .*
+    ldy #1                                                            // 9f27: a0 01       ..
+    lda (l0004),y                                                     // 9f29: b1 04       ..
+    adc l002b                                                         // 9f2b: 65 2b       e+
+    sta l002b                                                         // 9f2d: 85 2b       .+
+    iny                                                               // 9f2f: c8          .
+    lda (l0004),y                                                     // 9f30: b1 04       ..
+    adc l002c                                                         // 9f32: 65 2c       e,
+    sta l002c                                                         // 9f34: 85 2c       .,
+    iny                                                               // 9f36: c8          .
+    lda (l0004),y                                                     // 9f37: b1 04       ..
+    adc l002d                                                         // 9f39: 65 2d       e-
+// $9f3b referenced 1 time by $9f98
+c9f3b
+    sta l002d                                                         // 9f3b: 85 2d       .-
+    clc                                                               // 9f3d: 18          .
+    lda l0004                                                         // 9f3e: a5 04       ..
+    adc #4                                                            // 9f40: 69 04       i.
+    sta l0004                                                         // 9f42: 85 04       ..
+    lda #$40 // '@'                                                   // 9f44: a9 40       .@
+    bcc c9f0a                                                         // 9f46: 90 c2       ..
+    inc l0005                                                         // 9f48: e6 05       ..
+    bra c9f0a                                                         // 9f4a: 80 be       ..
+// $9f4c referenced 5 times by $9ee4, $9f1e, $9f73, $9f7b, $9fbb
+c9f4c
+    jmp c9155                                                         // 9f4c: 4c 55 91    LU.
+
+// $9f4f referenced 1 time by $9f14
+c9f4f
+    jsr sub_cbc18                                                     // 9f4f: 20 18 bc     ..
+    jsr ca70a                                                         // 9f52: 20 0a a7     ..
+// $9f55 referenced 2 times by $9f5f, $9f6e
+c9f55
+    ldx l0027                                                         // 9f55: a6 27       .'
+    bra c9f0a                                                         // 9f57: 80 b1       ..
+// $9f59 referenced 1 time by $9f71
+loop_c9f59
+    jsr sub_cbc18                                                     // 9f59: 20 18 bc     ..
+    jsr ca704                                                         // 9f5c: 20 04 a7     ..
+    bra c9f55                                                         // 9f5f: 80 f4       ..
+// $9f61 referenced 1 time by $9f79
+loop_c9f61
+    jsr cad10                                                         // 9f61: 20 10 ad     ..
+// $9f64 referenced 1 time by $9f1c
+c9f64
+    stx l0027                                                         // 9f64: 86 27       .'
+    jsr sub_c8287                                                     // 9f66: 20 87 82     ..
+    lda l003d                                                         // 9f69: a5 3d       .=
+    jsr sub_ca70d                                                     // 9f6b: 20 0d a7     ..
+    bra c9f55                                                         // 9f6e: 80 e5       ..
+// $9f70 referenced 1 time by $9f10
+c9f70
+    tay                                                               // 9f70: a8          .
+    bmi loop_c9f59                                                    // 9f71: 30 e6       0.
+    beq c9f4c                                                         // 9f73: f0 d7       ..
+    jsr sub_ca023                                                     // 9f75: 20 23 a0     #.
+    tay                                                               // 9f78: a8          .
+    bmi loop_c9f61                                                    // 9f79: 30 e6       0.
+    beq c9f4c                                                         // 9f7b: f0 cf       ..
+    sec                                                               // 9f7d: 38          8
+    lda (l0004)                                                       // 9f7e: b2 04       ..
+    sbc l002a                                                         // 9f80: e5 2a       .*
+    sta l002a                                                         // 9f82: 85 2a       .*
+    ldy #1                                                            // 9f84: a0 01       ..
+    lda (l0004),y                                                     // 9f86: b1 04       ..
+    sbc l002b                                                         // 9f88: e5 2b       .+
+    sta l002b                                                         // 9f8a: 85 2b       .+
+    iny                                                               // 9f8c: c8          .
+    lda (l0004),y                                                     // 9f8d: b1 04       ..
+    sbc l002c                                                         // 9f8f: e5 2c       .,
+    sta l002c                                                         // 9f91: 85 2c       .,
+    iny                                                               // 9f93: c8          .
+    lda (l0004),y                                                     // 9f94: b1 04       ..
+    sbc l002d                                                         // 9f96: e5 2d       .-
+    bra c9f3b                                                         // 9f98: 80 a1       ..
+// $9f9a referenced 2 times by $9fdb, $9fdf
+c9f9a
+    jsr c828d                                                         // 9f9a: 20 8d 82     ..
+// $9f9d referenced 1 time by $9fce
+c9f9d
+    jsr sub_c8287                                                     // 9f9d: 20 87 82     ..
+    and l003d                                                         // 9fa0: 25 3d       %=
+    jsr sub_ca6eb                                                     // 9fa2: 20 eb a6     ..
+    bra c9fb6                                                         // 9fa5: 80 0f       ..
+// $9fa7 referenced 2 times by $9fc4, $9fc8
+c9fa7
+    jsr c828d                                                         // 9fa7: 20 8d 82     ..
+// $9faa referenced 1 time by $9fb9
+loop_c9faa
+    jsr cbc3a                                                         // 9faa: 20 3a bc     :.
+    jsr sub_ca06c                                                     // 9fad: 20 6c a0     l.
+    jsr sub_cbc20                                                     // 9fb0: 20 20 bc      .
+    jsr ca6e4                                                         // 9fb3: 20 e4 a6     ..
+// $9fb6 referenced 1 time by $9fa5
+c9fb6
+    bra ca029                                                         // 9fb6: 80 71       .q
+// $9fb8 referenced 1 time by $a02b
+c9fb8
+    tay                                                               // 9fb8: a8          .
+    bmi loop_c9faa                                                    // 9fb9: 30 ef       0.
+// $9fbb referenced 1 time by $9fd0
+loop_c9fbb
+    beq c9f4c                                                         // 9fbb: f0 8f       ..
+    lda l002b                                                         // 9fbd: a5 2b       .+
+    asl                                                               // 9fbf: 0a          .
+    lda l002c                                                         // 9fc0: a5 2c       .,
+    adc #0                                                            // 9fc2: 69 00       i.
+    bne c9fa7                                                         // 9fc4: d0 e1       ..
+    adc l002d                                                         // 9fc6: 65 2d       e-
+    bne c9fa7                                                         // 9fc8: d0 dd       ..
+    jsr sub_ca069                                                     // 9fca: 20 69 a0     i.
+    tay                                                               // 9fcd: a8          .
+    bmi c9f9d                                                         // 9fce: 30 cd       0.
+    beq loop_c9fbb                                                    // 9fd0: f0 e9       ..
+    lda l002b                                                         // 9fd2: a5 2b       .+
+    sta l0038                                                         // 9fd4: 85 38       .8
+    asl                                                               // 9fd6: 0a          .
+    lda l002c                                                         // 9fd7: a5 2c       .,
+    adc #0                                                            // 9fd9: 69 00       i.
+    bne c9f9a                                                         // 9fdb: d0 bd       ..
+    adc l002d                                                         // 9fdd: 65 2d       e-
+    bne c9f9a                                                         // 9fdf: d0 b9       ..
+    bcc c9fe6                                                         // 9fe1: 90 03       ..
+    jsr cad20                                                         // 9fe3: 20 20 ad      .
+// $9fe6 referenced 1 time by $9fe1
+c9fe6
+    stx l0027                                                         // 9fe6: 86 27       .'
+    ldx #$3d // '='                                                   // 9fe8: a2 3d       .=
+    jsr sub_cbe06                                                     // 9fea: 20 06 be     ..
+    jsr sub_cbd26                                                     // 9fed: 20 26 bd     &.
+    ldy #0                                                            // 9ff0: a0 00       ..
+    ldx #0                                                            // 9ff2: a2 00       ..
+// $9ff4 referenced 1 time by $a01b
+c9ff4
+    lsr l003e                                                         // 9ff4: 46 3e       F>
+    ror l003d                                                         // 9ff6: 66 3d       f=
+    bcc ca00f                                                         // 9ff8: 90 15       ..
+    clc                                                               // 9ffa: 18          .
+    tya                                                               // 9ffb: 98          .
+    adc l002a                                                         // 9ffc: 65 2a       e*
+    tay                                                               // 9ffe: a8          .
+    txa                                                               // 9fff: 8a          .
+    adc l002b                                                         // a000: 65 2b       e+
+    tax                                                               // a002: aa          .
+    lda l003f                                                         // a003: a5 3f       .?
+    adc l002c                                                         // a005: 65 2c       e,
+    sta l003f                                                         // a007: 85 3f       .?
+    lda l0040                                                         // a009: a5 40       .@
+    adc l002d                                                         // a00b: 65 2d       e-
+    sta l0040                                                         // a00d: 85 40       .@
+// $a00f referenced 1 time by $9ff8
+ca00f
+    asl l002a                                                         // a00f: 06 2a       .*
+    rol l002b                                                         // a011: 26 2b       &+
+    rol l002c                                                         // a013: 26 2c       &,
+    rol l002d                                                         // a015: 26 2d       &-
+    lda l003d                                                         // a017: a5 3d       .=
+    ora l003e                                                         // a019: 05 3e       .>
+    bne c9ff4                                                         // a01b: d0 d7       ..
+    sty l003d                                                         // a01d: 84 3d       .=
+    stx l003e                                                         // a01f: 86 3e       .>
+    bra ca04d                                                         // a021: 80 2a       .*
+// $a023 referenced 2 times by $9f18, $9f75
+sub_ca023
+    jsr cbc66                                                         // a023: 20 66 bc     f.
+// $a026 referenced 2 times by $9f07, $bc1b
+sub_ca026
+    jsr sub_ca06c                                                     // a026: 20 6c a0     l.
+// $a029 referenced 2 times by $9fb6, $a05d
+ca029
+    cpx #$2a // '*'                                                   // a029: e0 2a       .*
+    beq c9fb8                                                         // a02b: f0 8b       ..
+    cpx #$2f // '/'                                                   // a02d: e0 2f       ./
+    bcc ca03b                                                         // a02f: 90 0a       ..
+    beq ca03c                                                         // a031: f0 09       ..
+    cpx #$83                                                          // a033: e0 83       ..
+    beq ca04a                                                         // a035: f0 13       ..
+    cpx #$81                                                          // a037: e0 81       ..
+    beq ca05f                                                         // a039: f0 24       .$
+// $a03b referenced 1 time by $a02f
+ca03b
+    rts                                                               // a03b: 60          `
+
+// $a03c referenced 1 time by $a031
+ca03c
+    jsr sub_cbc36                                                     // a03c: 20 36 bc     6.
+    jsr sub_ca06c                                                     // a03f: 20 6c a0     l.
+    jsr sub_cbc1e                                                     // a042: 20 1e bc     ..
+    jsr ca634                                                         // a045: 20 34 a6     4.
+    bra ca05b                                                         // a048: 80 11       ..
+// $a04a referenced 1 time by $a035
+ca04a
+    jsr sub_c81bd                                                     // a04a: 20 bd 81     ..
+// $a04d referenced 1 time by $a021
+ca04d
+    lda l0038                                                         // a04d: a5 38       .8
+    php                                                               // a04f: 08          .
+    ldx #$3d // '='                                                   // a050: a2 3d       .=
+// $a052 referenced 1 time by $a067
+loop_ca052
+    jsr sub_caad8                                                     // a052: 20 d8 aa     ..
+    plp                                                               // a055: 28          (
+    bpl ca05b                                                         // a056: 10 03       ..
+    jsr cad20                                                         // a058: 20 20 ad      .
+// $a05b referenced 2 times by $a048, $a056
+ca05b
+    ldx l0027                                                         // a05b: a6 27       .'
+    bra ca029                                                         // a05d: 80 ca       ..
+// $a05f referenced 1 time by $a039
+ca05f
+    jsr sub_c81bd                                                     // a05f: 20 bd 81     ..
+    bit l0037                                                         // a062: 24 37       $7
+    php                                                               // a064: 08          .
+    ldx #$39 // '9'                                                   // a065: a2 39       .9
+    bra loop_ca052                                                    // a067: 80 e9       ..
+// $a069 referenced 2 times by $81c8, $9fca
+sub_ca069
+    jsr cbc66                                                         // a069: 20 66 bc     f.
+// $a06c referenced 4 times by $9ee0, $9fad, $a026, $a03f
+sub_ca06c
+    jsr cad78                                                         // a06c: 20 78 ad     x.
+// $a06f referenced 2 times by $a0cf, $a0e6
+ca06f
+    pha                                                               // a06f: 48          H
+// $a070 referenced 1 time by $a078
+loop_ca070
+    ldy l001b                                                         // a070: a4 1b       ..
+    inc l001b                                                         // a072: e6 1b       ..
+    lda (l0019),y                                                     // a074: b1 19       ..
+    cmp #$20 // ' '                                                   // a076: c9 20       .
+    beq loop_ca070                                                    // a078: f0 f6       ..
+    tax                                                               // a07a: aa          .
+    pla                                                               // a07b: 68          h
+    cpx #$5e // '^'                                                   // a07c: e0 5e       .^
+    beq ca081                                                         // a07e: f0 01       ..
+    rts                                                               // a080: 60          `
+
+// $a081 referenced 2 times by $a07e, $a089
+ca081
+    jsr sub_cbc36                                                     // a081: 20 36 bc     6.
+    jsr cad78                                                         // a084: 20 78 ad     x.
+    bmi ca09f                                                         // a087: 30 16       0.
+    beq ca081                                                         // a089: f0 f6       ..
+    lda l002a                                                         // a08b: a5 2a       .*
+    asl                                                               // a08d: 0a          .
+    lda #0                                                            // a08e: a9 00       ..
+    adc l002b                                                         // a090: 65 2b       e+
+    bne ca09c                                                         // a092: d0 08       ..
+    adc l002c                                                         // a094: 65 2c       e,
+    bne ca09c                                                         // a096: d0 04       ..
+    adc l002d                                                         // a098: 65 2d       e-
+    beq ca0c7                                                         // a09a: f0 2b       .+
+// $a09c referenced 2 times by $a092, $a096
+ca09c
+    jsr c828d                                                         // a09c: 20 8d 82     ..
+// $a09f referenced 1 time by $a087
+ca09f
+    lda l0030                                                         // a09f: a5 30       .0
+    beq ca0c5                                                         // a0a1: f0 22       ."
+    cmp #$87                                                          // a0a3: c9 87       ..
+    bcs ca0d1                                                         // a0a5: b0 2a       .*
+    cmp #$81                                                          // a0a7: c9 81       ..
+    bcc ca0d1                                                         // a0a9: 90 26       .&
+    ora #$78 // 'x'                                                   // a0ab: 09 78       .x
+    tay                                                               // a0ad: a8          .
+    lda l0032                                                         // a0ae: a5 32       .2
+    ora l0033                                                         // a0b0: 05 33       .3
+    ora l0034                                                         // a0b2: 05 34       .4
+    bne ca0d1                                                         // a0b4: d0 1b       ..
+    lda l0031                                                         // a0b6: a5 31       .1
+// $a0b8 referenced 1 time by $a0bc
+loop_ca0b8
+    lsr                                                               // a0b8: 4a          J
+    bcs ca0d1                                                         // a0b9: b0 16       ..
+    iny                                                               // a0bb: c8          .
+    bmi loop_ca0b8                                                    // a0bc: 30 fa       0.
+    ldy l002e                                                         // a0be: a4 2e       ..
+    bpl ca0c5                                                         // a0c0: 10 03       ..
+    eor #$ff                                                          // a0c2: 49 ff       I.
+    inc                                                               // a0c4: 1a          .
+// $a0c5 referenced 2 times by $a0a1, $a0c0
+ca0c5
+    sta l002a                                                         // a0c5: 85 2a       .*
+// $a0c7 referenced 1 time by $a09a
+ca0c7
+    jsr sub_ca56d                                                     // a0c7: 20 6d a5     m.
+    lda l002a                                                         // a0ca: a5 2a       .*
+    jsr sub_ca5f9                                                     // a0cc: 20 f9 a5     ..
+    bra ca06f                                                         // a0cf: 80 9e       ..
+// $a0d1 referenced 4 times by $a0a5, $a0a9, $a0b4, $a0b9
+ca0d1
+    lda #$71 // 'q'                                                   // a0d1: a9 71       .q
+    jsr ca547                                                         // a0d3: 20 47 a5     G.
+    jsr sub_ca56d                                                     // a0d6: 20 6d a5     m.
+    jsr sub_ca7af                                                     // a0d9: 20 af a7     ..
+    lda #$71 // 'q'                                                   // a0dc: a9 71       .q
+    ldy #4                                                            // a0de: a0 04       ..
+    jsr sub_ca9c3                                                     // a0e0: 20 c3 a9     ..
+    jsr sub_caa1a                                                     // a0e3: 20 1a aa     ..
+    bra ca06f                                                         // a0e6: 80 87       ..
+// $a0e8 referenced 3 times by $9535, $9d1e, $b505
+sub_ca0e8
+    lda #0                                                            // a0e8: a9 00       ..
+    bra ca0ee                                                         // a0ea: 80 02       ..
+// $a0ec referenced 2 times by $9558, $b4c6
+sub_ca0ec
+    lda #5                                                            // a0ec: a9 05       ..
+// $a0ee referenced 1 time by $a0ea
+ca0ee
+    sta l0014                                                         // a0ee: 85 14       ..
+    ldx #4                                                            // a0f0: a2 04       ..
+// $a0f2 referenced 1 time by $a10b
+loop_ca0f2
+    stz l003f,x                                                       // a0f2: 74 3f       t?
+    sec                                                               // a0f4: 38          8
+// $a0f5 referenced 1 time by $a108
+loop_ca0f5
+    lda l002a                                                         // a0f5: a5 2a       .*
+    sbc l80e2,x                                                       // a0f7: fd e2 80    ...
+    tay                                                               // a0fa: a8          .
+    lda l002b                                                         // a0fb: a5 2b       .+
+    sbc l80dd,x                                                       // a0fd: fd dd 80    ...
+    bcc ca10a                                                         // a100: 90 08       ..
+    sta l002b                                                         // a102: 85 2b       .+
+    sty l002a                                                         // a104: 84 2a       .*
+    inc l003f,x                                                       // a106: f6 3f       .?
+    bra loop_ca0f5                                                    // a108: 80 eb       ..
+// $a10a referenced 1 time by $a100
+ca10a
+    dex                                                               // a10a: ca          .
+    bpl loop_ca0f2                                                    // a10b: 10 e5       ..
+    ldx #5                                                            // a10d: a2 05       ..
+// $a10f referenced 1 time by $a114
+loop_ca10f
+    dex                                                               // a10f: ca          .
+    beq ca116                                                         // a110: f0 04       ..
+    lda l003f,x                                                       // a112: b5 3f       .?
+    beq loop_ca10f                                                    // a114: f0 f9       ..
+// $a116 referenced 1 time by $a110
+ca116
+    stx l0037                                                         // a116: 86 37       .7
+    lda l0014                                                         // a118: a5 14       ..
+    beq ca126                                                         // a11a: f0 0a       ..
+    sbc l0037                                                         // a11c: e5 37       .7
+    beq ca126                                                         // a11e: f0 06       ..
+    tax                                                               // a120: aa          .
+    jsr cbdff                                                         // a121: 20 ff bd     ..
+    ldx l0037                                                         // a124: a6 37       .7
+// $a126 referenced 3 times by $a11a, $a11e, $a12e
+ca126
+    lda l003f,x                                                       // a126: b5 3f       .?
+    ora #$30 // '0'                                                   // a128: 09 30       .0
+    jsr cbdd4                                                         // a12a: 20 d4 bd     ..
+    dex                                                               // a12d: ca          .
+    bpl ca126                                                         // a12e: 10 f6       ..
+    rts                                                               // a130: 60          `
+
+// $a131 referenced 1 time by $a1a7
+ca131
+    tya                                                               // a131: 98          .
+    bpl ca137                                                         // a132: 10 03       ..
+    jsr sub_c9788                                                     // a134: 20 88 97     ..
+// $a137 referenced 1 time by $a132
+ca137
+    ldx #0                                                            // a137: a2 00       ..
+    ldy #0                                                            // a139: a0 00       ..
+// $a13b referenced 1 time by $a14f
+loop_ca13b
+    lda l002a,y                                                       // a13b: b9 2a 00    .*.
+    pha                                                               // a13e: 48          H
+    and #$0f                                                          // a13f: 29 0f       ).
+    sta l003f,x                                                       // a141: 95 3f       .?
+    pla                                                               // a143: 68          h
+    lsr                                                               // a144: 4a          J
+    lsr                                                               // a145: 4a          J
+    lsr                                                               // a146: 4a          J
+    lsr                                                               // a147: 4a          J
+    inx                                                               // a148: e8          .
+    sta l003f,x                                                       // a149: 95 3f       .?
+    inx                                                               // a14b: e8          .
+    iny                                                               // a14c: c8          .
+    cpy #4                                                            // a14d: c0 04       ..
+    bne loop_ca13b                                                    // a14f: d0 ea       ..
+// $a151 referenced 1 time by $a156
+loop_ca151
+    dex                                                               // a151: ca          .
+    beq ca158                                                         // a152: f0 04       ..
+    lda l003f,x                                                       // a154: b5 3f       .?
+    beq loop_ca151                                                    // a156: f0 f9       ..
+// $a158 referenced 2 times by $a152, $a166
+ca158
+    lda l003f,x                                                       // a158: b5 3f       .?
+    cmp #$0a                                                          // a15a: c9 0a       ..
+    bcc ca160                                                         // a15c: 90 02       ..
+    adc #6                                                            // a15e: 69 06       i.
+// $a160 referenced 1 time by $a15c
+ca160
+    adc #$30 // '0'                                                   // a160: 69 30       i0
+    jsr ca2cc                                                         // a162: 20 cc a2     ..
+    dex                                                               // a165: ca          .
+    bpl ca158                                                         // a166: 10 f0       ..
+    rts                                                               // a168: 60          `
+
+// $a169 referenced 1 time by $a1b1
+ca169
+    lda l002e                                                         // a169: a5 2e       ..
+    bpl ca174                                                         // a16b: 10 07       ..
+    lda #$2d // '-'                                                   // a16d: a9 2d       .-
+    stz l002e                                                         // a16f: 64 2e       d.
+    jsr ca2cc                                                         // a171: 20 cc a2     ..
+// $a174 referenced 3 times by $a16b, $a17f, $a1d2
+ca174
+    lda l0030                                                         // a174: a5 30       .0
+    cmp #$81                                                          // a176: c9 81       ..
+    bcs ca1c1                                                         // a178: b0 47       .G
+    jsr sub_ca46b                                                     // a17a: 20 6b a4     k.
+    dec l0048                                                         // a17d: c6 48       .H
+    bra ca174                                                         // a17f: 80 f3       ..
+// $a181 referenced 2 times by $92c7, $af83
+sub_ca181
+    ldx l0402                                                         // a181: ae 02 04    ...
+    cpx #3                                                            // a184: e0 03       ..
+    bcc ca18a                                                         // a186: 90 02       ..
+    ldx #0                                                            // a188: a2 00       ..
+// $a18a referenced 1 time by $a186
+ca18a
+    stx l0037                                                         // a18a: 86 37       .7
+    lda l0401                                                         // a18c: ad 01 04    ...
+    beq ca197                                                         // a18f: f0 06       ..
+    cmp #$0a                                                          // a191: c9 0a       ..
+    bcs ca19b                                                         // a193: b0 06       ..
+    bra ca19d                                                         // a195: 80 06       ..
+// $a197 referenced 1 time by $a18f
+ca197
+    cpx #2                                                            // a197: e0 02       ..
+    beq ca19d                                                         // a199: f0 02       ..
+// $a19b referenced 2 times by $a193, $af7e
+ca19b
+    lda #$0a                                                          // a19b: a9 0a       ..
+// $a19d referenced 2 times by $a195, $a199
+ca19d
+    sta l0038                                                         // a19d: 85 38       .8
+    sta l004d                                                         // a19f: 85 4d       .M
+    stz l0036                                                         // a1a1: 64 36       d6
+    stz l0048                                                         // a1a3: 64 48       dH
+    bit l0015                                                         // a1a5: 24 15       $.
+    bmi ca131                                                         // a1a7: 30 88       0.
+    tya                                                               // a1a9: 98          .
+    bmi ca1af                                                         // a1aa: 30 03       0.
+    jsr c828d                                                         // a1ac: 20 8d 82     ..
+// $a1af referenced 1 time by $a1aa
+ca1af
+    lda l0031                                                         // a1af: a5 31       .1
+    bne ca169                                                         // a1b1: d0 b6       ..
+    lda l0037                                                         // a1b3: a5 37       .7
+    bne ca21c                                                         // a1b5: d0 65       .e
+    lda #$30 // '0'                                                   // a1b7: a9 30       .0
+    jmp ca2cc                                                         // a1b9: 4c cc a2    L..
+
+// $a1bc referenced 1 time by $a216
+ca1bc
+    jsr ca622                                                         // a1bc: 20 22 a6     ".
+    bra ca1d0                                                         // a1bf: 80 0f       ..
+// $a1c1 referenced 1 time by $a178
+ca1c1
+    cmp #$84                                                          // a1c1: c9 84       ..
+    bcc ca1d4                                                         // a1c3: 90 0f       ..
+    bne ca1cd                                                         // a1c5: d0 06       ..
+    lda l0031                                                         // a1c7: a5 31       .1
+    cmp #$a0                                                          // a1c9: c9 a0       ..
+    bcc ca1d4                                                         // a1cb: 90 07       ..
+// $a1cd referenced 1 time by $a1c5
+ca1cd
+    jsr sub_ca4ba                                                     // a1cd: 20 ba a4     ..
+// $a1d0 referenced 1 time by $a1bf
+ca1d0
+    inc l0048                                                         // a1d0: e6 48       .H
+    bra ca174                                                         // a1d2: 80 a0       ..
+// $a1d4 referenced 2 times by $a1c3, $a1cb
+ca1d4
+    jsr sub_ca3ed                                                     // a1d4: 20 ed a3     ..
+    lda l004d                                                         // a1d7: a5 4d       .M
+    sta l0038                                                         // a1d9: 85 38       .8
+    ldx l0037                                                         // a1db: a6 37       .7
+    cpx #2                                                            // a1dd: e0 02       ..
+    bne ca1ef                                                         // a1df: d0 0e       ..
+    adc l0048                                                         // a1e1: 65 48       eH
+    bmi ca220                                                         // a1e3: 30 3b       0;
+    cmp #$0b                                                          // a1e5: c9 0b       ..
+    bcc ca1ed                                                         // a1e7: 90 04       ..
+    lda #$0a                                                          // a1e9: a9 0a       ..
+    stz l0037                                                         // a1eb: 64 37       d7
+// $a1ed referenced 1 time by $a1e7
+ca1ed
+    sta l0038                                                         // a1ed: 85 38       .8
+// $a1ef referenced 1 time by $a1df
+ca1ef
+    lda l0038                                                         // a1ef: a5 38       .8
+    eor #$ff                                                          // a1f1: 49 ff       I.
+    lsr                                                               // a1f3: 4a          J
+    php                                                               // a1f4: 08          .
+    asl                                                               // a1f5: 0a          .
+    asl                                                               // a1f6: 0a          .
+    adc #$bc                                                          // a1f7: 69 bc       i.
+    jsr sub_ca572                                                     // a1f9: 20 72 a5     r.
+    dec l0030                                                         // a1fc: c6 30       .0
+    plp                                                               // a1fe: 28          (
+    bcc ca204                                                         // a1ff: 90 03       ..
+    jsr sub_ca46b                                                     // a201: 20 6b a4     k.
+// $a204 referenced 1 time by $a1ff
+ca204
+    jsr sub_c8429                                                     // a204: 20 29 84     ).
+// $a207 referenced 1 time by $a210
+loop_ca207
+    lda l0030                                                         // a207: a5 30       .0
+    cmp #$84                                                          // a209: c9 84       ..
+    bcs ca212                                                         // a20b: b0 05       ..
+    jsr ca4a9                                                         // a20d: 20 a9 a4     ..
+    bne loop_ca207                                                    // a210: d0 f5       ..
+// $a212 referenced 1 time by $a20b
+ca212
+    lda l0031                                                         // a212: a5 31       .1
+    cmp #$a0                                                          // a214: c9 a0       ..
+    bcs ca1bc                                                         // a216: b0 a4       ..
+    lda l0038                                                         // a218: a5 38       .8
+    bne ca22a                                                         // a21a: d0 0e       ..
+// $a21c referenced 1 time by $a1b5
+ca21c
+    cmp #1                                                            // a21c: c9 01       ..
+    beq ca261                                                         // a21e: f0 41       .A
+// $a220 referenced 2 times by $89d0, $a1e3
+ca220
+    jsr ca72b                                                         // a220: 20 2b a7     +.
+    stz l0048                                                         // a223: 64 48       dH
+    lda l004d                                                         // a225: a5 4d       .M
+    inc                                                               // a227: 1a          .
+    sta l0038                                                         // a228: 85 38       .8
+// $a22a referenced 1 time by $a21a
+ca22a
+    lda #1                                                            // a22a: a9 01       ..
+    cmp l0037                                                         // a22c: c5 37       .7
+    beq ca261                                                         // a22e: f0 31       .1
+    ldy l0048                                                         // a230: a4 48       .H
+    bmi ca23e                                                         // a232: 30 0a       0.
+    cpy l0038                                                         // a234: c4 38       .8
+    bcs ca261                                                         // a236: b0 29       .)
+    stz l0048                                                         // a238: 64 48       dH
+    iny                                                               // a23a: c8          .
+    tya                                                               // a23b: 98          .
+    bne ca261                                                         // a23c: d0 23       .#
+// $a23e referenced 1 time by $a232
+ca23e
+    lda l0037                                                         // a23e: a5 37       .7
+    cmp #2                                                            // a240: c9 02       ..
+    beq ca24a                                                         // a242: f0 06       ..
+    lda #1                                                            // a244: a9 01       ..
+    cpy #$ff                                                          // a246: c0 ff       ..
+    bne ca261                                                         // a248: d0 17       ..
+// $a24a referenced 1 time by $a242
+ca24a
+    lda #$30 // '0'                                                   // a24a: a9 30       .0
+    jsr ca2cc                                                         // a24c: 20 cc a2     ..
+    lda #$2e // '.'                                                   // a24f: a9 2e       ..
+    jsr ca2cc                                                         // a251: 20 cc a2     ..
+    lda #$30 // '0'                                                   // a254: a9 30       .0
+// $a256 referenced 1 time by $a25d
+loop_ca256
+    inc l0048                                                         // a256: e6 48       .H
+    beq ca25f                                                         // a258: f0 05       ..
+    jsr ca2cc                                                         // a25a: 20 cc a2     ..
+    bra loop_ca256                                                    // a25d: 80 f7       ..
+// $a25f referenced 1 time by $a258
+ca25f
+    lda #$80                                                          // a25f: a9 80       ..
+// $a261 referenced 5 times by $a21e, $a22e, $a236, $a23c, $a248
+ca261
+    sta l004d                                                         // a261: 85 4d       .M
+// $a263 referenced 1 time by $a271
+loop_ca263
+    jsr sub_ca40a                                                     // a263: 20 0a a4     ..
+    dec l004d                                                         // a266: c6 4d       .M
+    bne ca26f                                                         // a268: d0 05       ..
+    lda #$2e // '.'                                                   // a26a: a9 2e       ..
+    jsr ca2cc                                                         // a26c: 20 cc a2     ..
+// $a26f referenced 1 time by $a268
+ca26f
+    dec l0038                                                         // a26f: c6 38       .8
+    bne loop_ca263                                                    // a271: d0 f0       ..
+    ldy l0037                                                         // a273: a4 37       .7
+    dey                                                               // a275: 88          .
+    beq ca290                                                         // a276: f0 18       ..
+    dey                                                               // a278: 88          .
+    beq ca28c                                                         // a279: f0 11       ..
+    ldy l0036                                                         // a27b: a4 36       .6
+// $a27d referenced 1 time by $a283
+loop_ca27d
+    dey                                                               // a27d: 88          .
+    lda l0600,y                                                       // a27e: b9 00 06    ...
+    cmp #$30 // '0'                                                   // a281: c9 30       .0
+    beq loop_ca27d                                                    // a283: f0 f8       ..
+    cmp #$2e // '.'                                                   // a285: c9 2e       ..
+    beq ca28a                                                         // a287: f0 01       ..
+    iny                                                               // a289: c8          .
+// $a28a referenced 1 time by $a287
+ca28a
+    sty l0036                                                         // a28a: 84 36       .6
+// $a28c referenced 1 time by $a279
+ca28c
+    lda l0048                                                         // a28c: a5 48       .H
+    beq ca2b7                                                         // a28e: f0 27       .'
+// $a290 referenced 1 time by $a276
+ca290
+    lda #$45 // 'E'                                                   // a290: a9 45       .E
+    jsr ca2cc                                                         // a292: 20 cc a2     ..
+    lda l0048                                                         // a295: a5 48       .H
+    bpl ca2a3                                                         // a297: 10 0a       ..
+    lda #$2d // '-'                                                   // a299: a9 2d       .-
+    jsr ca2cc                                                         // a29b: 20 cc a2     ..
+    sec                                                               // a29e: 38          8
+    lda #0                                                            // a29f: a9 00       ..
+    sbc l0048                                                         // a2a1: e5 48       .H
+// $a2a3 referenced 1 time by $a297
+ca2a3
+    jsr sub_ca2b8                                                     // a2a3: 20 b8 a2     ..
+    lda l0037                                                         // a2a6: a5 37       .7
+    beq ca2b7                                                         // a2a8: f0 0d       ..
+    lda #$20 // ' '                                                   // a2aa: a9 20       .
+    ldy l0048                                                         // a2ac: a4 48       .H
+    bmi ca2b3                                                         // a2ae: 30 03       0.
+    jsr ca2cc                                                         // a2b0: 20 cc a2     ..
+// $a2b3 referenced 1 time by $a2ae
+ca2b3
+    cpx #0                                                            // a2b3: e0 00       ..
+    beq ca2cc                                                         // a2b5: f0 15       ..
+// $a2b7 referenced 2 times by $a28e, $a2a8
+ca2b7
+    rts                                                               // a2b7: 60          `
+
+// $a2b8 referenced 1 time by $a2a3
+sub_ca2b8
+    ldx #$ff                                                          // a2b8: a2 ff       ..
+    sec                                                               // a2ba: 38          8
+// $a2bb referenced 1 time by $a2be
+loop_ca2bb
+    inx                                                               // a2bb: e8          .
+    sbc #$0a                                                          // a2bc: e9 0a       ..
+    bcs loop_ca2bb                                                    // a2be: b0 fb       ..
+    adc #$0a                                                          // a2c0: 69 0a       i.
+    pha                                                               // a2c2: 48          H
+    txa                                                               // a2c3: 8a          .
+    beq ca2c9                                                         // a2c4: f0 03       ..
+    jsr sub_ca2ca                                                     // a2c6: 20 ca a2     ..
+// $a2c9 referenced 1 time by $a2c4
+ca2c9
+    pla                                                               // a2c9: 68          h
+// $a2ca referenced 2 times by $a2c6, $a410
+sub_ca2ca
+    ora #$30 // '0'                                                   // a2ca: 09 30       .0
+// $a2cc referenced 11 times by $a162, $a171, $a1b9, $a24c, $a251, $a25a, $a26c, $a292, $a29b, $a2b0, $a2b5
+ca2cc
+    phx                                                               // a2cc: da          .
+    ldx l0036                                                         // a2cd: a6 36       .6
+    sta l0600,x                                                       // a2cf: 9d 00 06    ...
+    plx                                                               // a2d2: fa          .
+    inc l0036                                                         // a2d3: e6 36       .6
+    rts                                                               // a2d5: 60          `
+
+// $a2d6 referenced 2 times by $a2f5, $a2f9
+ca2d6
+    clc                                                               // a2d6: 18          .
+    lda #$ff                                                          // a2d7: a9 ff       ..
+    jmp c82dd                                                         // a2d9: 4c dd 82    L..
+
+    .byt $60                                                          // a2dc: 60          `
+
+// $a2dd referenced 3 times by $abcb, $abd5, $adb6
+sub_ca2dd
+    stz l0031                                                         // a2dd: 64 31       d1
+    stz l0032                                                         // a2df: 64 32       d2
+    stz l0033                                                         // a2e1: 64 33       d3
+    stz l0034                                                         // a2e3: 64 34       d4
+    stz l0035                                                         // a2e5: 64 35       d5
+    stz l0047                                                         // a2e7: 64 47       dG
+    stz l0048                                                         // a2e9: 64 48       dH
+    ldx #$ff                                                          // a2eb: a2 ff       ..
+    stx l0049                                                         // a2ed: 86 49       .I
+    cmp #$2e // '.'                                                   // a2ef: c9 2e       ..
+    beq ca348                                                         // a2f1: f0 55       .U
+    cmp #$3a // ':'                                                   // a2f3: c9 3a       .:
+    bcs ca2d6                                                         // a2f5: b0 df       ..
+    sbc #$2f // '/'                                                   // a2f7: e9 2f       ./
+    bmi ca2d6                                                         // a2f9: 30 db       0.
+// $a2fb referenced 4 times by $a31f, $a323, $a337, $a33c
+ca2fb
+    sta l0035                                                         // a2fb: 85 35       .5
+// $a2fd referenced 1 time by $a340
+ca2fd
+    lda l0047                                                         // a2fd: a5 47       .G
+    beq ca303                                                         // a2ff: f0 02       ..
+    dec l0048                                                         // a301: c6 48       .H
+// $a303 referenced 2 times by $a2ff, $a34a
+ca303
+    iny                                                               // a303: c8          .
+    lda (l0019),y                                                     // a304: b1 19       ..
+    cmp #$3a // ':'                                                   // a306: c9 3a       .:
+    bcs ca34c                                                         // a308: b0 42       .B
+    sbc #$2f // '/'                                                   // a30a: e9 2f       ./
+    bcc ca342                                                         // a30c: 90 34       .4
+    sta l0042                                                         // a30e: 85 42       .B
+    ldx l0049                                                         // a310: a6 49       .I
+    bpl ca325                                                         // a312: 10 11       ..
+    lda l0035                                                         // a314: a5 35       .5
+    asl                                                               // a316: 0a          .
+    asl                                                               // a317: 0a          .
+    adc l0035                                                         // a318: 65 35       e5
+    asl                                                               // a31a: 0a          .
+    adc l0042                                                         // a31b: 65 42       eB
+    cmp #$19                                                          // a31d: c9 19       ..
+    bcc ca2fb                                                         // a31f: 90 da       ..
+    stz l0049                                                         // a321: 64 49       dI
+    bra ca2fb                                                         // a323: 80 d6       ..
+// $a325 referenced 1 time by $a312
+ca325
+    cpx #2                                                            // a325: e0 02       ..
+    bcs ca33e                                                         // a327: b0 15       ..
+    jsr sub_ca419                                                     // a329: 20 19 a4     ..
+    cmp #$19                                                          // a32c: c9 19       ..
+    bcc ca333                                                         // a32e: 90 03       ..
+    inc l0049                                                         // a330: e6 49       .I
+    clc                                                               // a332: 18          .
+// $a333 referenced 1 time by $a32e
+ca333
+    lda l0042                                                         // a333: a5 42       .B
+    adc l0035                                                         // a335: 65 35       e5
+    bcc ca2fb                                                         // a337: 90 c2       ..
+    jsr sub_ca503                                                     // a339: 20 03 a5     ..
+    bra ca2fb                                                         // a33c: 80 bd       ..
+// $a33e referenced 1 time by $a327
+ca33e
+    inc l0048                                                         // a33e: e6 48       .H
+    bra ca2fd                                                         // a340: 80 bb       ..
+// $a342 referenced 1 time by $a30c
+ca342
+    eor #$fe                                                          // a342: 49 fe       I.
+    ora l0047                                                         // a344: 05 47       .G
+    bne ca357                                                         // a346: d0 0f       ..
+// $a348 referenced 1 time by $a2f1
+ca348
+    inc l0047                                                         // a348: e6 47       .G
+    bra ca303                                                         // a34a: 80 b7       ..
+// $a34c referenced 1 time by $a308
+ca34c
+    cmp #$45 // 'E'                                                   // a34c: c9 45       .E
+    bne ca357                                                         // a34e: d0 07       ..
+    jsr sub_ca3b5                                                     // a350: 20 b5 a3     ..
+    adc l0048                                                         // a353: 65 48       eH
+    sta l0048                                                         // a355: 85 48       .H
+// $a357 referenced 2 times by $a346, $a34e
+ca357
+    sty l001b                                                         // a357: 84 1b       ..
+    ldy l0031                                                         // a359: a4 31       .1
+    bne ca385                                                         // a35b: d0 28       .(
+    lda l0032                                                         // a35d: a5 32       .2
+    bmi ca385                                                         // a35f: 30 24       0$
+    sta l002d                                                         // a361: 85 2d       .-
+    beq ca36b                                                         // a363: f0 06       ..
+    lda l0048                                                         // a365: a5 48       .H
+    ora l0047                                                         // a367: 05 47       .G
+    bne ca385                                                         // a369: d0 1a       ..
+// $a36b referenced 1 time by $a363
+ca36b
+    lda l0035                                                         // a36b: a5 35       .5
+    sta l002a                                                         // a36d: 85 2a       .*
+    lda l0034                                                         // a36f: a5 34       .4
+    sta l002b                                                         // a371: 85 2b       .+
+    lda l0033                                                         // a373: a5 33       .3
+    sta l002c                                                         // a375: 85 2c       .,
+    lda l0048                                                         // a377: a5 48       .H
+    bne ca37e                                                         // a379: d0 03       ..
+    inc                                                               // a37b: 1a          .
+    sec                                                               // a37c: 38          8
+    rts                                                               // a37d: 60          `
+
+// $a37e referenced 1 time by $a379
+ca37e
+    jsr c828d                                                         // a37e: 20 8d 82     ..
+    bne ca393                                                         // a381: d0 10       ..
+    bra ca3aa                                                         // a383: 80 25       .%
+// $a385 referenced 3 times by $a35b, $a35f, $a369
+ca385
+    lda #$a8                                                          // a385: a9 a8       ..
+    sta l0030                                                         // a387: 85 30       .0
+    stz l002e                                                         // a389: 64 2e       d.
+    stz l002f                                                         // a38b: 64 2f       d/
+    tya                                                               // a38d: 98          .
+    sta l0031                                                         // a38e: 85 31       .1
+    jsr c8304                                                         // a390: 20 04 83     ..
+// $a393 referenced 1 time by $a381
+ca393
+    ldy l0048                                                         // a393: a4 48       .H
+    bmi ca3a1                                                         // a395: 30 0a       0.
+    beq ca3a7                                                         // a397: f0 0e       ..
+// $a399 referenced 1 time by $a39d
+loop_ca399
+    jsr sub_ca46b                                                     // a399: 20 6b a4     k.
+    dey                                                               // a39c: 88          .
+    bne loop_ca399                                                    // a39d: d0 fa       ..
+    bra ca3a7                                                         // a39f: 80 06       ..
+// $a3a1 referenced 2 times by $a395, $a3a5
+ca3a1
+    jsr sub_ca4ba                                                     // a3a1: 20 ba a4     ..
+    iny                                                               // a3a4: c8          .
+    bne ca3a1                                                         // a3a5: d0 fa       ..
+// $a3a7 referenced 2 times by $a397, $a39f
+ca3a7
+    jsr ca712                                                         // a3a7: 20 12 a7     ..
+// $a3aa referenced 1 time by $a383
+ca3aa
+    sec                                                               // a3aa: 38          8
+    lda #$ff                                                          // a3ab: a9 ff       ..
+    rts                                                               // a3ad: 60          `
+
+// $a3ae referenced 1 time by $a3ba
+loop_ca3ae
+    jsr sub_ca3c0                                                     // a3ae: 20 c0 a3     ..
+    eor #$ff                                                          // a3b1: 49 ff       I.
+    sec                                                               // a3b3: 38          8
+    rts                                                               // a3b4: 60          `
+
+// $a3b5 referenced 1 time by $a350
+sub_ca3b5
+    iny                                                               // a3b5: c8          .
+    lda (l0019),y                                                     // a3b6: b1 19       ..
+    cmp #$2d // '-'                                                   // a3b8: c9 2d       .-
+    beq loop_ca3ae                                                    // a3ba: f0 f2       ..
+    cmp #$2b // '+'                                                   // a3bc: c9 2b       .+
+    bne ca3c3                                                         // a3be: d0 03       ..
+// $a3c0 referenced 1 time by $a3ae
+sub_ca3c0
+    iny                                                               // a3c0: c8          .
+    lda (l0019),y                                                     // a3c1: b1 19       ..
+// $a3c3 referenced 1 time by $a3be
+ca3c3
+    cmp #$3a // ':'                                                   // a3c3: c9 3a       .:
+    bcs ca3e9                                                         // a3c5: b0 22       ."
+    sbc #$2f // '/'                                                   // a3c7: e9 2f       ./
+    bcc ca3e9                                                         // a3c9: 90 1e       ..
+    sta l0049                                                         // a3cb: 85 49       .I
+    iny                                                               // a3cd: c8          .
+    lda (l0019),y                                                     // a3ce: b1 19       ..
+    cmp #$3a // ':'                                                   // a3d0: c9 3a       .:
+    bcs ca3e5                                                         // a3d2: b0 11       ..
+    sbc #$2f // '/'                                                   // a3d4: e9 2f       ./
+    bcc ca3e5                                                         // a3d6: 90 0d       ..
+    iny                                                               // a3d8: c8          .
+    sta l0042                                                         // a3d9: 85 42       .B
+    lda l0049                                                         // a3db: a5 49       .I
+    asl                                                               // a3dd: 0a          .
+    asl                                                               // a3de: 0a          .
+    adc l0049                                                         // a3df: 65 49       eI
+    asl                                                               // a3e1: 0a          .
+    adc l0042                                                         // a3e2: 65 42       eB
+    rts                                                               // a3e4: 60          `
+
+// $a3e5 referenced 2 times by $a3d2, $a3d6
+ca3e5
+    lda l0049                                                         // a3e5: a5 49       .I
+    clc                                                               // a3e7: 18          .
+    rts                                                               // a3e8: 60          `
+
+// $a3e9 referenced 2 times by $a3c5, $a3c9
+ca3e9
+    lda #0                                                            // a3e9: a9 00       ..
+    clc                                                               // a3eb: 18          .
+    rts                                                               // a3ec: 60          `
+
+// $a3ed referenced 3 times by $828a, $a1d4, $a6ce
+sub_ca3ed
+    lda l002e                                                         // a3ed: a5 2e       ..
+    sta l003b                                                         // a3ef: 85 3b       .;
+    lda l0030                                                         // a3f1: a5 30       .0
+    sta l003c                                                         // a3f3: 85 3c       .<
+    lda l0031                                                         // a3f5: a5 31       .1
+    sta l003d                                                         // a3f7: 85 3d       .=
+    lda l0032                                                         // a3f9: a5 32       .2
+    sta l003e                                                         // a3fb: 85 3e       .>
+    lda l0033                                                         // a3fd: a5 33       .3
+    sta l003f                                                         // a3ff: 85 3f       .?
+    lda l0034                                                         // a401: a5 34       .4
+    sta l0040                                                         // a403: 85 40       .@
+    lda l0035                                                         // a405: a5 35       .5
+    sta l0041                                                         // a407: 85 41       .A
+    rts                                                               // a409: 60          `
+
+// $a40a referenced 1 time by $a263
+sub_ca40a
+    lda l0031                                                         // a40a: a5 31       .1
+    lsr                                                               // a40c: 4a          J
+    lsr                                                               // a40d: 4a          J
+    lsr                                                               // a40e: 4a          J
+    lsr                                                               // a40f: 4a          J
+    jsr sub_ca2ca                                                     // a410: 20 ca a2     ..
+    lda #$f0                                                          // a413: a9 f0       ..
+    trb l0031                                                         // a415: 14 31       .1
+    ldx #1                                                            // a417: a2 01       ..
+// $a419 referenced 1 time by $a329
+sub_ca419
+    asl l0035                                                         // a419: 06 35       .5
+    rol l0034                                                         // a41b: 26 34       &4
+    rol l0033                                                         // a41d: 26 33       &3
+    txa                                                               // a41f: 8a          .
+    beq ca42c                                                         // a420: f0 0a       ..
+    rol l0032                                                         // a422: 26 32       &2
+    rol l0031                                                         // a424: 26 31       &1
+// $a426 referenced 4 times by $a474, $a478, $a4c6, $a4ca
+ca426
+    lda l0031                                                         // a426: a5 31       .1
+    pha                                                               // a428: 48          H
+    lda l0032                                                         // a429: a5 32       .2
+    pha                                                               // a42b: 48          H
+// $a42c referenced 1 time by $a420
+ca42c
+    lda l0033                                                         // a42c: a5 33       .3
+    pha                                                               // a42e: 48          H
+    lda l0034                                                         // a42f: a5 34       .4
+    pha                                                               // a431: 48          H
+    lda l0035                                                         // a432: a5 35       .5
+    cpx #0                                                            // a434: e0 00       ..
+    bmi ca47a                                                         // a436: 30 42       0B
+    bne ca446                                                         // a438: d0 0c       ..
+    asl                                                               // a43a: 0a          .
+    rol l0034                                                         // a43b: 26 34       &4
+    rol l0033                                                         // a43d: 26 33       &3
+    asl                                                               // a43f: 0a          .
+    rol l0034                                                         // a440: 26 34       &4
+    rol l0033                                                         // a442: 26 33       &3
+    bra ca452                                                         // a444: 80 0c       ..
+// $a446 referenced 2 times by $a438, $a450
+ca446
+    asl                                                               // a446: 0a          .
+    rol l0034                                                         // a447: 26 34       &4
+    rol l0033                                                         // a449: 26 33       &3
+    rol l0032                                                         // a44b: 26 32       &2
+    rol l0031                                                         // a44d: 26 31       &1
+    dex                                                               // a44f: ca          .
+    bpl ca446                                                         // a450: 10 f4       ..
+// $a452 referenced 2 times by $a444, $a487
+ca452
+    adc l0035                                                         // a452: 65 35       e5
+    sta l0035                                                         // a454: 85 35       .5
+    pla                                                               // a456: 68          h
+    adc l0034                                                         // a457: 65 34       e4
+    sta l0034                                                         // a459: 85 34       .4
+    pla                                                               // a45b: 68          h
+    adc l0033                                                         // a45c: 65 33       e3
+    sta l0033                                                         // a45e: 85 33       .3
+    inx                                                               // a460: e8          .
+    bne ca4b9                                                         // a461: d0 56       .V
+    pla                                                               // a463: 68          h
+    adc l0032                                                         // a464: 65 32       e2
+    sta l0032                                                         // a466: 85 32       .2
+    pla                                                               // a468: 68          h
+    bra ca4a3                                                         // a469: 80 38       .8
+// $a46b referenced 3 times by $a17a, $a201, $a399
+sub_ca46b
+    clc                                                               // a46b: 18          .
+    lda l0030                                                         // a46c: a5 30       .0
+    adc #3                                                            // a46e: 69 03       i.
+    ldx #$fe                                                          // a470: a2 fe       ..
+    sta l0030                                                         // a472: 85 30       .0
+    bcc ca426                                                         // a474: 90 b0       ..
+    inc l002f                                                         // a476: e6 2f       ./
+    bra ca426                                                         // a478: 80 ac       ..
+// $a47a referenced 2 times by $a436, $a484
+ca47a
+    lsr l0031                                                         // a47a: 46 31       F1
+    ror l0032                                                         // a47c: 66 32       f2
+    ror l0033                                                         // a47e: 66 33       f3
+    ror l0034                                                         // a480: 66 34       f4
+    ror                                                               // a482: 6a          j
+    inx                                                               // a483: e8          .
+    bne ca47a                                                         // a484: d0 f4       ..
+    dex                                                               // a486: ca          .
+    bra ca452                                                         // a487: 80 c9       ..
+// $a489 referenced 1 time by $84aa
+ca489
+    lda l0035                                                         // a489: a5 35       .5
+    adc l0041                                                         // a48b: 65 41       eA
+    sta l0035                                                         // a48d: 85 35       .5
+    lda l0034                                                         // a48f: a5 34       .4
+    adc l0040                                                         // a491: 65 40       e@
+    sta l0034                                                         // a493: 85 34       .4
+    lda l0033                                                         // a495: a5 33       .3
+    adc l003f                                                         // a497: 65 3f       e?
+    sta l0033                                                         // a499: 85 33       .3
+    lda l0032                                                         // a49b: a5 32       .2
+    adc l003e                                                         // a49d: 65 3e       e>
+    sta l0032                                                         // a49f: 85 32       .2
+    lda l003d                                                         // a4a1: a5 3d       .=
+// $a4a3 referenced 1 time by $a469
+ca4a3
+    adc l0031                                                         // a4a3: 65 31       e1
+    sta l0031                                                         // a4a5: 85 31       .1
+    bcc ca4b9                                                         // a4a7: 90 10       ..
+// $a4a9 referenced 3 times by $a20d, $a4f2, $a511
+ca4a9
+    ror l0031                                                         // a4a9: 66 31       f1
+    ror l0032                                                         // a4ab: 66 32       f2
+    ror l0033                                                         // a4ad: 66 33       f3
+    ror l0034                                                         // a4af: 66 34       f4
+    ror l0035                                                         // a4b1: 66 35       f5
+    inc l0030                                                         // a4b3: e6 30       .0
+    bne ca4b9                                                         // a4b5: d0 02       ..
+    inc l002f                                                         // a4b7: e6 2f       ./
+// $a4b9 referenced 3 times by $a461, $a4a7, $a4b5
+ca4b9
+    rts                                                               // a4b9: 60          `
+
+// $a4ba referenced 2 times by $a1cd, $a3a1
+sub_ca4ba
+    clc                                                               // a4ba: 18          .
+    lda #$fc                                                          // a4bb: a9 fc       ..
+    tax                                                               // a4bd: aa          .
+    adc l0030                                                         // a4be: 65 30       e0
+    bcs ca4c4                                                         // a4c0: b0 02       ..
+    dec l002f                                                         // a4c2: c6 2f       ./
+// $a4c4 referenced 1 time by $a4c0
+ca4c4
+    sta l0030                                                         // a4c4: 85 30       .0
+    jsr ca426                                                         // a4c6: 20 26 a4     &.
+    dex                                                               // a4c9: ca          .
+    jsr ca426                                                         // a4ca: 20 26 a4     &.
+    inx                                                               // a4cd: e8          .
+// $a4ce referenced 1 time by $a4f6
+ca4ce
+    lda l0034,x                                                       // a4ce: b5 34       .4
+    rol                                                               // a4d0: 2a          *
+    lda l0033,x                                                       // a4d1: b5 33       .3
+    adc l0035                                                         // a4d3: 65 35       e5
+    sta l0035                                                         // a4d5: 85 35       .5
+    lda l0032,x                                                       // a4d7: b5 32       .2
+    adc l0034                                                         // a4d9: 65 34       e4
+    sta l0034                                                         // a4db: 85 34       .4
+    lda l0031,x                                                       // a4dd: b5 31       .1
+    adc l0033                                                         // a4df: 65 33       e3
+    sta l0033                                                         // a4e1: 85 33       .3
+    txa                                                               // a4e3: 8a          .
+    beq ca4e8                                                         // a4e4: f0 02       ..
+    lda l0031                                                         // a4e6: a5 31       .1
+// $a4e8 referenced 1 time by $a4e4
+ca4e8
+    adc l0032                                                         // a4e8: 65 32       e2
+    sta l0032                                                         // a4ea: 85 32       .2
+    bcc ca4f5                                                         // a4ec: 90 07       ..
+    inc l0031                                                         // a4ee: e6 31       .1
+    bne ca4f5                                                         // a4f0: d0 03       ..
+    jsr ca4a9                                                         // a4f2: 20 a9 a4     ..
+// $a4f5 referenced 2 times by $a4ec, $a4f0
+ca4f5
+    dex                                                               // a4f5: ca          .
+    bpl ca4ce                                                         // a4f6: 10 d6       ..
+    lda l0032                                                         // a4f8: a5 32       .2
+    rol                                                               // a4fa: 2a          *
+    lda l0031                                                         // a4fb: a5 31       .1
+    adc l0035                                                         // a4fd: 65 35       e5
+    sta l0035                                                         // a4ff: 85 35       .5
+    bcc ca513                                                         // a501: 90 10       ..
+// $a503 referenced 1 time by $a339
+sub_ca503
+    inc l0034                                                         // a503: e6 34       .4
+    bne ca513                                                         // a505: d0 0c       ..
+// $a507 referenced 1 time by $a722
+sub_ca507
+    inc l0033                                                         // a507: e6 33       .3
+    bne ca513                                                         // a509: d0 08       ..
+// $a50b referenced 1 time by $a6df
+sub_ca50b
+    inc l0032                                                         // a50b: e6 32       .2
+    bne ca513                                                         // a50d: d0 04       ..
+    inc l0031                                                         // a50f: e6 31       .1
+    beq ca4a9                                                         // a511: f0 96       ..
+// $a513 referenced 4 times by $a501, $a505, $a509, $a50d
+ca513
+    rts                                                               // a513: 60          `
+
+// $a514 referenced 5 times by $9d36, $a638, $a6e8, $a70a, $a9a3
+sub_ca514
+    stz l0041                                                         // a514: 64 41       dA
+    ldy #4                                                            // a516: a0 04       ..
+    lda (l004a),y                                                     // a518: b1 4a       .J
+    sta l0040                                                         // a51a: 85 40       .@
+    dey                                                               // a51c: 88          .
+    lda (l004a),y                                                     // a51d: b1 4a       .J
+    sta l003f                                                         // a51f: 85 3f       .?
+    dey                                                               // a521: 88          .
+    lda (l004a),y                                                     // a522: b1 4a       .J
+    sta l003e                                                         // a524: 85 3e       .>
+    dey                                                               // a526: 88          .
+    lda (l004a),y                                                     // a527: b1 4a       .J
+    sta l003b                                                         // a529: 85 3b       .;
+    tay                                                               // a52b: a8          .
+    lda (l004a)                                                       // a52c: b2 4a       .J
+    sta l003c                                                         // a52e: 85 3c       .<
+    bne ca53b                                                         // a530: d0 09       ..
+    tya                                                               // a532: 98          .
+    ora l003e                                                         // a533: 05 3e       .>
+    ora l003f                                                         // a535: 05 3f       .?
+    ora l0040                                                         // a537: 05 40       .@
+    beq ca53e                                                         // a539: f0 03       ..
+// $a53b referenced 1 time by $a530
+ca53b
+    tya                                                               // a53b: 98          .
+    ora #$80                                                          // a53c: 09 80       ..
+// $a53e referenced 1 time by $a539
+ca53e
+    sta l003d                                                         // a53e: 85 3d       .=
+    rts                                                               // a540: 60          `
+
+// $a541 referenced 1 time by $a8db
+sub_ca541
+    lda #$76 // 'v'                                                   // a541: a9 76       .v
+    bra ca547                                                         // a543: 80 02       ..
+// $a545 referenced 8 times by $9210, $a5c4, $a5ec, $a6cb, $a7ef, $a97b, $a9e9, $a9f2
+sub_ca545
+    lda #$6c // 'l'                                                   // a545: a9 6c       .l
+// $a547 referenced 2 times by $a0d3, $a543
+ca547
+    sta l004a                                                         // a547: 85 4a       .J
+    lda #4                                                            // a549: a9 04       ..
+    sta l004b                                                         // a54b: 85 4b       .K
+// $a54d referenced 2 times by $b6e2, $b704
+sub_ca54d
+    lda l0030                                                         // a54d: a5 30       .0
+    sta (l004a)                                                       // a54f: 92 4a       .J
+    ldy #1                                                            // a551: a0 01       ..
+    lda l002e                                                         // a553: a5 2e       ..
+    eor l0031                                                         // a555: 45 31       E1
+    and #$80                                                          // a557: 29 80       ).
+    eor l0031                                                         // a559: 45 31       E1
+    sta (l004a),y                                                     // a55b: 91 4a       .J
+    lda l0032                                                         // a55d: a5 32       .2
+    iny                                                               // a55f: c8          .
+    sta (l004a),y                                                     // a560: 91 4a       .J
+    lda l0033                                                         // a562: a5 33       .3
+    iny                                                               // a564: c8          .
+    sta (l004a),y                                                     // a565: 91 4a       .J
+    lda l0034                                                         // a567: a5 34       .4
+    iny                                                               // a569: c8          .
+    sta (l004a),y                                                     // a56a: 91 4a       .J
+    rts                                                               // a56c: 60          `
+
+// $a56d referenced 2 times by $a0c7, $a0d6
+sub_ca56d
+    jsr sub_cbc24                                                     // a56d: 20 24 bc     $.
+    bra ca57e                                                         // a570: 80 0c       ..
+// $a572 referenced 1 time by $a1f9
+sub_ca572
+    ldy #$bf                                                          // a572: a0 bf       ..
+    bra ca57a                                                         // a574: 80 04       ..
+// $a576 referenced 1 time by $b8d7
+sub_ca576
+    lda #$6c // 'l'                                                   // a576: a9 6c       .l
+    ldy #4                                                            // a578: a0 04       ..
+// $a57a referenced 1 time by $a574
+ca57a
+    sta l004a                                                         // a57a: 85 4a       .J
+    sty l004b                                                         // a57c: 84 4b       .K
+// $a57e referenced 2 times by $a570, $b19e
+ca57e
+    stz l0035                                                         // a57e: 64 35       d5
+    stz l002f                                                         // a580: 64 2f       d/
+    ldy #4                                                            // a582: a0 04       ..
+    lda (l004a),y                                                     // a584: b1 4a       .J
+    sta l0034                                                         // a586: 85 34       .4
+    dey                                                               // a588: 88          .
+    lda (l004a),y                                                     // a589: b1 4a       .J
+    sta l0033                                                         // a58b: 85 33       .3
+    dey                                                               // a58d: 88          .
+    lda (l004a),y                                                     // a58e: b1 4a       .J
+    sta l0032                                                         // a590: 85 32       .2
+    dey                                                               // a592: 88          .
+    lda (l004a),y                                                     // a593: b1 4a       .J
+    sta l002e                                                         // a595: 85 2e       ..
+    tay                                                               // a597: a8          .
+    lda (l004a)                                                       // a598: b2 4a       .J
+    sta l0030                                                         // a59a: 85 30       .0
+    bne ca5a7                                                         // a59c: d0 09       ..
+    tya                                                               // a59e: 98          .
+    ora l0032                                                         // a59f: 05 32       .2
+    ora l0033                                                         // a5a1: 05 33       .3
+    ora l0034                                                         // a5a3: 05 34       .4
+    beq ca5aa                                                         // a5a5: f0 03       ..
+// $a5a7 referenced 1 time by $a59c
+ca5a7
+    tya                                                               // a5a7: 98          .
+    ora #$80                                                          // a5a8: 09 80       ..
+// $a5aa referenced 1 time by $a5a5
+ca5aa
+    sta l0031                                                         // a5aa: 85 31       .1
+    rts                                                               // a5ac: 60          `
+
+// $a5ad referenced 3 times by $a8e0, $a8ee, $a9a0
+sub_ca5ad
+    clc                                                               // a5ad: 18          .
+    lda l004c                                                         // a5ae: a5 4c       .L
+    adc #5                                                            // a5b0: 69 05       i.
+// $a5b2 referenced 1 time by $aa50
+sub_ca5b2
+    sta l004c                                                         // a5b2: 85 4c       .L
+// $a5b4 referenced 3 times by $a631, $a701, $a7fc
+sub_ca5b4
+    ldy #$bf                                                          // a5b4: a0 bf       ..
+// $a5b6 referenced 1 time by $a5bf
+loop_ca5b6
+    sta l004a                                                         // a5b6: 85 4a       .J
+    sty l004b                                                         // a5b8: 84 4b       .K
+// $a5ba referenced 1 time by $a5e8
+ca5ba
+    rts                                                               // a5ba: 60          `
+
+// $a5bb referenced 2 times by $a8f8, $a9af
+sub_ca5bb
+    lda #$6c // 'l'                                                   // a5bb: a9 6c       .l
+// $a5bd referenced 1 time by $a8e8
+sub_ca5bd
+    ldy #4                                                            // a5bd: a0 04       ..
+    bra loop_ca5b6                                                    // a5bf: 80 f5       ..
+// $a5c1 referenced 1 time by $aa41
+sub_ca5c1
+    jsr cad10                                                         // a5c1: 20 10 ad     ..
+// $a5c4 referenced 1 time by $a95d
+sub_ca5c4
+    jsr sub_ca545                                                     // a5c4: 20 45 a5     E.
+    jsr sub_ca5f4                                                     // a5c7: 20 f4 a5     ..
+    inc l0030                                                         // a5ca: e6 30       .0
+// $a5cc referenced 2 times by $a5e3, $a90a
+sub_ca5cc
+    jsr cad10                                                         // a5cc: 20 10 ad     ..
+// $a5cf referenced 2 times by $a5f4, $aa39
+sub_ca5cf
+    stz l003b                                                         // a5cf: 64 3b       d;
+// $a5d1 referenced 1 time by $a993
+sub_ca5d1
+    ldy #$80                                                          // a5d1: a0 80       ..
+    sty l003d                                                         // a5d3: 84 3d       .=
+    iny                                                               // a5d5: c8          .
+    sty l003c                                                         // a5d6: 84 3c       .<
+    stz l003e                                                         // a5d8: 64 3e       d>
+    stz l003f                                                         // a5da: 64 3f       d?
+    stz l0040                                                         // a5dc: 64 40       d@
+    stz l0041                                                         // a5de: 64 41       dA
+    jmp ca70f                                                         // a5e0: 4c 0f a7    L..
+
+// $a5e3 referenced 2 times by $a7de, $a929
+sub_ca5e3
+    jsr sub_ca5cc                                                     // a5e3: 20 cc a5     ..
+    ldx l0031                                                         // a5e6: a6 31       .1
+    beq ca5ba                                                         // a5e8: f0 d0       ..
+    dec l0030                                                         // a5ea: c6 30       .0
+    jsr sub_ca545                                                     // a5ec: 20 45 a5     E.
+    txa                                                               // a5ef: 8a          .
+    eor l002e                                                         // a5f0: 45 2e       E.
+// $a5f2 referenced 1 time by $a96e
+sub_ca5f2
+    sta l002e                                                         // a5f2: 85 2e       ..
+// $a5f4 referenced 2 times by $a5c7, $a962
+sub_ca5f4
+    jsr sub_ca5cf                                                     // a5f4: 20 cf a5     ..
+    bra ca634                                                         // a5f7: 80 3b       .;
+// $a5f9 referenced 1 time by $a0cc
+sub_ca5f9
+    ldx #0                                                            // a5f9: a2 00       ..
+    tay                                                               // a5fb: a8          .
+    beq ca622                                                         // a5fc: f0 24       .$
+    bpl ca608                                                         // a5fe: 10 08       ..
+    dec                                                               // a600: 3a          :
+    eor #$ff                                                          // a601: 49 ff       I.
+    pha                                                               // a603: 48          H
+    jsr sub_ca62f                                                     // a604: 20 2f a6     /.
+// $a607 referenced 1 time by $a615
+loop_ca607
+    pla                                                               // a607: 68          h
+// $a608 referenced 1 time by $a5fe
+ca608
+    lsr                                                               // a608: 4a          J
+    beq ca61d                                                         // a609: f0 12       ..
+    pha                                                               // a60b: 48          H
+    bcc ca612                                                         // a60c: 90 04       ..
+    inx                                                               // a60e: e8          .
+    jsr cbc3a                                                         // a60f: 20 3a bc     :.
+// $a612 referenced 1 time by $a60c
+ca612
+    jsr ca6ce                                                         // a612: 20 ce a6     ..
+    bra loop_ca607                                                    // a615: 80 f0       ..
+// $a617 referenced 1 time by $a61e
+loop_ca617
+    jsr sub_cbc24                                                     // a617: 20 24 bc     $.
+    jsr ca6e4                                                         // a61a: 20 e4 a6     ..
+// $a61d referenced 1 time by $a609
+ca61d
+    dex                                                               // a61d: ca          .
+    bpl loop_ca617                                                    // a61e: 10 f7       ..
+    txa                                                               // a620: 8a          .
+    rts                                                               // a621: 60          `
+
+// $a622 referenced 3 times by $a1bc, $a5fc, $b6e5
+ca622
+    lda #$80                                                          // a622: a9 80       ..
+    sta l0031                                                         // a624: 85 31       .1
+    inc                                                               // a626: 1a          .
+    sta l0030                                                         // a627: 85 30       .0
+    jmp ca72f                                                         // a629: 4c 2f a7    L/.
+
+// $a62c referenced 1 time by $a636
+loop_ca62c
+    jmp c81ea                                                         // a62c: 4c ea 81    L..
+
+// $a62f referenced 3 times by $a604, $a92f, $a975
+sub_ca62f
+    lda #$b9                                                          // a62f: a9 b9       ..
+// $a631 referenced 1 time by $a8d8
+sub_ca631
+    jsr sub_ca5b4                                                     // a631: 20 b4 a5     ..
+// $a634 referenced 5 times by $a045, $a5f7, $a8e3, $a8fb, $a914
+ca634
+    lda l0031                                                         // a634: a5 31       .1
+    beq loop_ca62c                                                    // a636: f0 f4       ..
+    jsr sub_ca514                                                     // a638: 20 14 a5     ..
+    bne ca640                                                         // a63b: d0 03       ..
+    jmp ca72b                                                         // a63d: 4c 2b a7    L+.
+
+// $a640 referenced 1 time by $a63b
+ca640
+    lda l003b                                                         // a640: a5 3b       .;
+    eor l002e                                                         // a642: 45 2e       E.
+    sta l002e                                                         // a644: 85 2e       ..
+    sec                                                               // a646: 38          8
+    lda l003c                                                         // a647: a5 3c       .<
+    adc #$81                                                          // a649: 69 81       i.
+    rol l002f                                                         // a64b: 26 2f       &/
+    sbc l0030                                                         // a64d: e5 30       .0
+    bcs ca653                                                         // a64f: b0 02       ..
+    dec l002f                                                         // a651: c6 2f       ./
+// $a653 referenced 1 time by $a64f
+ca653
+    sta l0030                                                         // a653: 85 30       .0
+    lda l003d                                                         // a655: a5 3d       .=
+    clc                                                               // a657: 18          .
+    ldy #4                                                            // a658: a0 04       ..
+    sty l003c                                                         // a65a: 84 3c       .<
+// $a65c referenced 1 time by $a69e
+ca65c
+    ldx #8                                                            // a65c: a2 08       ..
+// $a65e referenced 1 time by $a697
+ca65e
+    bcs ca676                                                         // a65e: b0 16       ..
+    cmp l0031                                                         // a660: c5 31       .1
+    bne ca674                                                         // a662: d0 10       ..
+    ldy l003e                                                         // a664: a4 3e       .>
+    cpy l0032                                                         // a666: c4 32       .2
+    bne ca674                                                         // a668: d0 0a       ..
+    ldy l003f                                                         // a66a: a4 3f       .?
+    cpy l0033                                                         // a66c: c4 33       .3
+    bne ca674                                                         // a66e: d0 04       ..
+    ldy l0040                                                         // a670: a4 40       .@
+    cpy l0034                                                         // a672: c4 34       .4
+// $a674 referenced 3 times by $a662, $a668, $a66e
+ca674
+    bcc ca68d                                                         // a674: 90 17       ..
+// $a676 referenced 1 time by $a65e
+ca676
+    tay                                                               // a676: a8          .
+    lda l0040                                                         // a677: a5 40       .@
+    sbc l0034                                                         // a679: e5 34       .4
+    sta l0040                                                         // a67b: 85 40       .@
+    lda l003f                                                         // a67d: a5 3f       .?
+    sbc l0033                                                         // a67f: e5 33       .3
+    sta l003f                                                         // a681: 85 3f       .?
+    lda l003e                                                         // a683: a5 3e       .>
+    sbc l0032                                                         // a685: e5 32       .2
+    sta l003e                                                         // a687: 85 3e       .>
+    tya                                                               // a689: 98          .
+    sbc l0031                                                         // a68a: e5 31       .1
+    sec                                                               // a68c: 38          8
+// $a68d referenced 1 time by $a674
+ca68d
+    rol l003b                                                         // a68d: 26 3b       &;
+    asl l0040                                                         // a68f: 06 40       .@
+    rol l003f                                                         // a691: 26 3f       &?
+    rol l003e                                                         // a693: 26 3e       &>
+    rol                                                               // a695: 2a          *
+    dex                                                               // a696: ca          .
+    bne ca65e                                                         // a697: d0 c5       ..
+    ldx l003b                                                         // a699: a6 3b       .;
+    phx                                                               // a69b: da          .
+    dec l003c                                                         // a69c: c6 3c       .<
+    bne ca65c                                                         // a69e: d0 bc       ..
+    plx                                                               // a6a0: fa          .
+    ror                                                               // a6a1: 6a          j
+// $a6a2 referenced 1 time by $a8b0
+ca6a2
+    lsr l0031                                                         // a6a2: 46 31       F1
+    stx l0034                                                         // a6a4: 86 34       .4
+    ldx #3                                                            // a6a6: a2 03       ..
+// $a6a8 referenced 1 time by $a6b1
+loop_ca6a8
+    cmp l0031                                                         // a6a8: c5 31       .1
+    bcc ca6ae                                                         // a6aa: 90 02       ..
+    sbc l0031                                                         // a6ac: e5 31       .1
+// $a6ae referenced 1 time by $a6aa
+ca6ae
+    php                                                               // a6ae: 08          .
+    asl                                                               // a6af: 0a          .
+    dex                                                               // a6b0: ca          .
+    bne loop_ca6a8                                                    // a6b1: d0 f5       ..
+    plp                                                               // a6b3: 28          (
+    ror                                                               // a6b4: 6a          j
+    plp                                                               // a6b5: 28          (
+    ror                                                               // a6b6: 6a          j
+    plp                                                               // a6b7: 28          (
+    ror                                                               // a6b8: 6a          j
+    sta l0035                                                         // a6b9: 85 35       .5
+    pla                                                               // a6bb: 68          h
+    sta l0033                                                         // a6bc: 85 33       .3
+    pla                                                               // a6be: 68          h
+    sta l0032                                                         // a6bf: 85 32       .2
+    pla                                                               // a6c1: 68          h
+    sta l0031                                                         // a6c2: 85 31       .1
+// $a6c4 referenced 1 time by $aa97
+ca6c4
+    bmi ca712                                                         // a6c4: 30 4c       0L
+    jsr c8306                                                         // a6c6: 20 06 83     ..
+    bra ca712                                                         // a6c9: 80 47       .G
+// $a6cb referenced 2 times by $a8bc, $a907
+sub_ca6cb
+    jsr sub_ca545                                                     // a6cb: 20 45 a5     E.
+// $a6ce referenced 2 times by $a612, $a9ef
+ca6ce
+    jsr sub_ca3ed                                                     // a6ce: 20 ed a3     ..
+    lda l0030                                                         // a6d1: a5 30       .0
+    beq ca72b                                                         // a6d3: f0 56       .V
+    stz l0034                                                         // a6d5: 64 34       d4
+    asl l0040                                                         // a6d7: 06 40       .@
+    bcc ca6ed                                                         // a6d9: 90 12       ..
+    inc l0033                                                         // a6db: e6 33       .3
+    bne ca6ed                                                         // a6dd: d0 0e       ..
+    jsr sub_ca50b                                                     // a6df: 20 0b a5     ..
+    bra ca6ed                                                         // a6e2: 80 09       ..
+// $a6e4 referenced 3 times by $9fb3, $a61a, $a9c7
+ca6e4
+    lda l0031                                                         // a6e4: a5 31       .1
+    beq ca73b                                                         // a6e6: f0 53       .S
+    jsr sub_ca514                                                     // a6e8: 20 14 a5     ..
+// $a6eb referenced 1 time by $9fa2
+sub_ca6eb
+    beq ca72b                                                         // a6eb: f0 3e       .>
+// $a6ed referenced 3 times by $a6d9, $a6dd, $a6e2
+ca6ed
+    jsr sub_ca73e                                                     // a6ed: 20 3e a7     >.
+    bra ca712                                                         // a6f0: 80 20       .
+// $a6f2 referenced 2 times by $8362, $a729
+ca6f2
+    brk                                                               // a6f2: 00          .
+
+    .byt $14                                                          // a6f3: 14          .
+    .asc "Too big"                                                    // a6f4: 54 6f 6f... Too
+    .byt 0                                                            // a6fb: 00          .
+
+sub_ca6fc
+    jsr sub_ca901                                                     // a6fc: 20 01 a9     ..
+// $a6ff referenced 3 times by $a940, $a948, $ab56
+sub_ca6ff
+    lda #$90                                                          // a6ff: a9 90       ..
+    jsr sub_ca5b4                                                     // a701: 20 b4 a5     ..
+// $a704 referenced 2 times by $9f5c, $a9b2
+ca704
+    lda l0031                                                         // a704: a5 31       .1
+    eor l002e                                                         // a706: 45 2e       E.
+    sta l002e                                                         // a708: 85 2e       ..
+// $a70a referenced 5 times by $9f52, $a8eb, $a8f1, $a8fe, $b5fe
+ca70a
+    jsr sub_ca514                                                     // a70a: 20 14 a5     ..
+// $a70d referenced 1 time by $9f6b
+sub_ca70d
+    beq ca73b                                                         // a70d: f0 2c       .,
+// $a70f referenced 1 time by $a5e0
+ca70f
+    jsr sub_c8429                                                     // a70f: 20 29 84     ).
+// $a712 referenced 5 times by $a3a7, $a6c4, $a6c9, $a6f0, $a802
+ca712
+    lda l0035                                                         // a712: a5 35       .5
+    bpl ca725                                                         // a714: 10 0f       ..
+    asl                                                               // a716: 0a          .
+    bne ca71e                                                         // a717: d0 05       ..
+    rol                                                               // a719: 2a          *
+    and l0034                                                         // a71a: 25 34       %4
+    bne ca725                                                         // a71c: d0 07       ..
+// $a71e referenced 1 time by $a717
+ca71e
+    inc l0034                                                         // a71e: e6 34       .4
+    bne ca725                                                         // a720: d0 03       ..
+    jsr sub_ca507                                                     // a722: 20 07 a5     ..
+// $a725 referenced 3 times by $a714, $a71c, $a720
+ca725
+    lda l002f                                                         // a725: a5 2f       ./
+    beq ca739                                                         // a727: f0 10       ..
+    bpl ca6f2                                                         // a729: 10 c7       ..
+// $a72b referenced 7 times by $835b, $84cb, $a220, $a63d, $a6d3, $a6eb, $a9f5
+ca72b
+    stz l0030                                                         // a72b: 64 30       d0
+    stz l0031                                                         // a72d: 64 31       d1
+// $a72f referenced 1 time by $a629
+ca72f
+    stz l002e                                                         // a72f: 64 2e       d.
+// $a731 referenced 1 time by $82e8
+sub_ca731
+    stz l002f                                                         // a731: 64 2f       d/
+    stz l0032                                                         // a733: 64 32       d2
+    stz l0033                                                         // a735: 64 33       d3
+    stz l0034                                                         // a737: 64 34       d4
+// $a739 referenced 1 time by $a727
+ca739
+    stz l0035                                                         // a739: 64 35       d5
+// $a73b referenced 2 times by $a6e6, $a70d
+ca73b
+    lda #$ff                                                          // a73b: a9 ff       ..
+// $a73d referenced 1 time by $a7a7
+ca73d
+    rts                                                               // a73d: 60          `
+
+// $a73e referenced 3 times by $a6ed, $a9ac, $aab6
+sub_ca73e
+    clc                                                               // a73e: 18          .
+    lda l0030                                                         // a73f: a5 30       .0
+    adc l003c                                                         // a741: 65 3c       e<
+    rol l002f                                                         // a743: 26 2f       &/
+    sbc #$7f                                                          // a745: e9 7f       ..
+    sta l0030                                                         // a747: 85 30       .0
+    bcs ca74d                                                         // a749: b0 02       ..
+    dec l002f                                                         // a74b: c6 2f       ./
+// $a74d referenced 1 time by $a749
+ca74d
+    lda l002e                                                         // a74d: a5 2e       ..
+    eor l003b                                                         // a74f: 45 3b       E;
+    sta l002e                                                         // a751: 85 2e       ..
+    phx                                                               // a753: da          .
+    ldx #$f8                                                          // a754: a2 f8       ..
+    ldy #4                                                            // a756: a0 04       ..
+// $a758 referenced 1 time by $a761
+loop_ca758
+    lda l0039,x                                                       // a758: b5 39       .9
+    stz l0039,x                                                       // a75a: 74 39       t9
+    sta l0041,y                                                       // a75c: 99 41 00    .A.
+    inx                                                               // a75f: e8          .
+    dey                                                               // a760: 88          .
+    bne loop_ca758                                                    // a761: d0 f5       ..
+    stz l003c                                                         // a763: 64 3c       d<
+    stz l003b                                                         // a765: 64 3b       d;
+    stz l003a                                                         // a767: 64 3a       d:
+    bra ca79b                                                         // a769: 80 30       .0
+// $a76b referenced 1 time by $a79d
+ca76b
+    phx                                                               // a76b: da          .
+    lsr l003d                                                         // a76c: 46 3d       F=
+    ror l003e                                                         // a76e: 66 3e       f>
+    ror l003f                                                         // a770: 66 3f       f?
+    ror l0040                                                         // a772: 66 40       f@
+    ror l0041                                                         // a774: 66 41       fA
+// $a776 referenced 1 time by $a798
+ca776
+    asl l0046,x                                                       // a776: 16 46       .F
+    bcc ca797                                                         // a778: 90 1d       ..
+    clc                                                               // a77a: 18          .
+    tya                                                               // a77b: 98          .
+    adc l0042,x                                                       // a77c: 75 42       uB
+    tay                                                               // a77e: a8          .
+    lda l0034                                                         // a77f: a5 34       .4
+    adc l0041,x                                                       // a781: 75 41       uA
+    sta l0034                                                         // a783: 85 34       .4
+    lda l0033                                                         // a785: a5 33       .3
+    adc l0040,x                                                       // a787: 75 40       u@
+    sta l0033                                                         // a789: 85 33       .3
+    lda l0032                                                         // a78b: a5 32       .2
+    adc l003f,x                                                       // a78d: 75 3f       u?
+    sta l0032                                                         // a78f: 85 32       .2
+    lda l0031                                                         // a791: a5 31       .1
+    adc l003e,x                                                       // a793: 75 3e       u>
+    sta l0031                                                         // a795: 85 31       .1
+// $a797 referenced 1 time by $a778
+ca797
+    inx                                                               // a797: e8          .
+    bmi ca776                                                         // a798: 30 dc       0.
+    plx                                                               // a79a: fa          .
+// $a79b referenced 2 times by $a769, $a7a0
+ca79b
+    lda l0046,x                                                       // a79b: b5 46       .F
+    bne ca76b                                                         // a79d: d0 cc       ..
+    inx                                                               // a79f: e8          .
+    bmi ca79b                                                         // a7a0: 30 f9       0.
+    plx                                                               // a7a2: fa          .
+    sty l0035                                                         // a7a3: 84 35       .5
+    lda l0031                                                         // a7a5: a5 31       .1
+    bmi ca73d                                                         // a7a7: 30 94       0.
+    jmp c8306                                                         // a7a9: 4c 06 83    L..
+
+// $a7ac referenced 1 time by $a9bc
+sub_ca7ac
+    jsr sub_c979f                                                     // a7ac: 20 9f 97     ..
+// $a7af referenced 1 time by $a0d9
+sub_ca7af
+    lda l0031                                                         // a7af: a5 31       .1
+    eor l002e                                                         // a7b1: 45 2e       E.
+    bmi ca7cd                                                         // a7b3: 30 18       0.
+    brk                                                               // a7b5: 00          .
+
+    .byt $16                                                          // a7b6: 16          .
+    .asc "Log range"                                                  // a7b7: 4c 6f 67... Log
+
+// $a7c0 referenced 1 time by $a811
+ca7c0
+    brk                                                               // a7c0: 00          .
+
+    .byt $15                                                          // a7c1: 15          .
+    .asc "-ve roo"                                                    // a7c2: 2d 76 65... -ve
+// $a7c9 referenced 1 time by $a985
+la7c9
+    .byt $74,   0, $86, $8e                                           // a7c9: 74 00 86... t..
+
+// $a7cd referenced 1 time by $a7b3
+ca7cd
+    ldy #$80                                                          // a7cd: a0 80       ..
+    ldx l0030                                                         // a7cf: a6 30       .0
+    beq ca7db                                                         // a7d1: f0 08       ..
+    lda l0031                                                         // a7d3: a5 31       .1
+    cmp #$b5                                                          // a7d5: c9 b5       ..
+    bcs ca7db                                                         // a7d7: b0 02       ..
+    dex                                                               // a7d9: ca          .
+    iny                                                               // a7da: c8          .
+// $a7db referenced 2 times by $a7d1, $a7d7
+ca7db
+    phx                                                               // a7db: da          .
+    sty l0030                                                         // a7dc: 84 30       .0
+    jsr sub_ca5e3                                                     // a7de: 20 e3 a5     ..
+    lda l0030                                                         // a7e1: a5 30       .0
+    beq ca7ef                                                         // a7e3: f0 0a       ..
+    cmp #$6e // 'n'                                                   // a7e5: c9 6e       .n
+    bcc ca7ed                                                         // a7e7: 90 04       ..
+    clc                                                               // a7e9: 18          .
+    jsr sub_ca8b9                                                     // a7ea: 20 b9 a8     ..
+// $a7ed referenced 1 time by $a7e7
+ca7ed
+    inc l0030                                                         // a7ed: e6 30       .0
+// $a7ef referenced 1 time by $a7e3
+ca7ef
+    jsr sub_ca545                                                     // a7ef: 20 45 a5     E.
+    pla                                                               // a7f2: 68          h
+    eor #$80                                                          // a7f3: 49 80       I.
+    beq ca805                                                         // a7f5: f0 0e       ..
+    jsr sub_c82e6                                                     // a7f7: 20 e6 82     ..
+    lda #$9f                                                          // a7fa: a9 9f       ..
+    jsr sub_ca5b4                                                     // a7fc: 20 b4 a5     ..
+    jsr sub_ca9a3                                                     // a7ff: 20 a3 a9     ..
+    jsr ca712                                                         // a802: 20 12 a7     ..
+// $a805 referenced 2 times by $a7f5, $a80d
+ca805
+    jmp cad10                                                         // a805: 4c 10 ad    L..
+
+sub_ca808
+    jsr sub_c979f                                                     // a808: 20 9f 97     ..
+// $a80b referenced 1 time by $a911
+sub_ca80b
+    lda l0031                                                         // a80b: a5 31       .1
+    beq ca805                                                         // a80d: f0 f6       ..
+    lda l002e                                                         // a80f: a5 2e       ..
+    bmi ca7c0                                                         // a811: 30 ad       0.
+    lda l0030                                                         // a813: a5 30       .0
+    lsr                                                               // a815: 4a          J
+    php                                                               // a816: 08          .
+    adc #$41 // 'A'                                                   // a817: 69 41       iA
+    sta l0030                                                         // a819: 85 30       .0
+    lda l0031                                                         // a81b: a5 31       .1
+    plp                                                               // a81d: 28          (
+    bcc ca829                                                         // a81e: 90 09       ..
+    lsr                                                               // a820: 4a          J
+    ror l0032                                                         // a821: 66 32       f2
+    ror l0033                                                         // a823: 66 33       f3
+    ror l0034                                                         // a825: 66 34       f4
+    ror l0035                                                         // a827: 66 35       f5
+// $a829 referenced 1 time by $a81e
+ca829
+    stz l003e                                                         // a829: 64 3e       d>
+    stz l003f                                                         // a82b: 64 3f       d?
+    ldx #$68 // 'h'                                                   // a82d: a2 68       .h
+    sec                                                               // a82f: 38          8
+    sbc #$90                                                          // a830: e9 90       ..
+    bcs ca838                                                         // a832: b0 04       ..
+    adc #$50 // 'P'                                                   // a834: 69 50       iP
+    ldx #$48 // 'H'                                                   // a836: a2 48       .H
+// $a838 referenced 1 time by $a832
+ca838
+    sta l0031                                                         // a838: 85 31       .1
+    txa                                                               // a83a: 8a          .
+    ldx #$fc                                                          // a83b: a2 fc       ..
+    ldy #$0c                                                          // a83d: a0 0c       ..
+// $a83f referenced 1 time by $a89e
+ca83f
+    sta l0041,x                                                       // a83f: 95 41       .A
+// $a841 referenced 1 time by $a87d
+ca841
+    asl l0033                                                         // a841: 06 33       .3
+    rol l0032                                                         // a843: 26 32       &2
+    rol l0031                                                         // a845: 26 31       &1
+    lda l0031                                                         // a847: a5 31       .1
+    cmp l003d                                                         // a849: c5 3d       .=
+    bne ca857                                                         // a84b: d0 0a       ..
+    lda l0032                                                         // a84d: a5 32       .2
+    cmp l003e                                                         // a84f: c5 3e       .>
+    bne ca857                                                         // a851: d0 04       ..
+    lda l0033                                                         // a853: a5 33       .3
+    cmp l003f                                                         // a855: c5 3f       .?
+// $a857 referenced 2 times by $a84b, $a851
+ca857
+    bcc ca875                                                         // a857: 90 1c       ..
+    lda l0033                                                         // a859: a5 33       .3
+    sbc l003f                                                         // a85b: e5 3f       .?
+    sta l0033                                                         // a85d: 85 33       .3
+    lda l0032                                                         // a85f: a5 32       .2
+    sbc l003e                                                         // a861: e5 3e       .>
+    sta l0032                                                         // a863: 85 32       .2
+    lda l0031                                                         // a865: a5 31       .1
+    sbc l003d                                                         // a867: e5 3d       .=
+    sta l0031                                                         // a869: 85 31       .1
+    tya                                                               // a86b: 98          .
+    clc                                                               // a86c: 18          .
+    adc l0041,x                                                       // a86d: 75 41       uA
+    bcc ca878                                                         // a86f: 90 07       ..
+    inc l0040,x                                                       // a871: f6 40       .@
+    bra ca878                                                         // a873: 80 03       ..
+// $a875 referenced 1 time by $a857
+ca875
+    tya                                                               // a875: 98          .
+    eor l0041,x                                                       // a876: 55 41       UA
+// $a878 referenced 2 times by $a86f, $a873
+ca878
+    sta l0041,x                                                       // a878: 95 41       .A
+    tya                                                               // a87a: 98          .
+    lsr                                                               // a87b: 4a          J
+    tay                                                               // a87c: a8          .
+    bne ca841                                                         // a87d: d0 c2       ..
+    ldy l0040,x                                                       // a87f: b4 40       .@
+    phy                                                               // a881: 5a          Z
+    cpx #$fd                                                          // a882: e0 fd       ..
+    bne ca88a                                                         // a884: d0 04       ..
+    lda l0034                                                         // a886: a5 34       .4
+    sta l0033                                                         // a888: 85 33       .3
+// $a88a referenced 1 time by $a884
+ca88a
+    bcs ca899                                                         // a88a: b0 0d       ..
+    ply                                                               // a88c: 7a          z
+    ldy #4                                                            // a88d: a0 04       ..
+// $a88f referenced 1 time by $a895
+loop_ca88f
+    asl l0035                                                         // a88f: 06 35       .5
+    rol l0034                                                         // a891: 26 34       &4
+    rol                                                               // a893: 2a          *
+    dey                                                               // a894: 88          .
+    bne loop_ca88f                                                    // a895: d0 f8       ..
+    tsb l0033                                                         // a897: 04 33       .3
+// $a899 referenced 1 time by $a88a
+ca899
+    lda #$80                                                          // a899: a9 80       ..
+    ldy #$c0                                                          // a89b: a0 c0       ..
+    inx                                                               // a89d: e8          .
+    bne ca83f                                                         // a89e: d0 9f       ..
+    ldx l003d                                                         // a8a0: a6 3d       .=
+    lda l0031                                                         // a8a2: a5 31       .1
+    stx l0031                                                         // a8a4: 86 31       .1
+    ldx l0040                                                         // a8a6: a6 40       .@
+    asl                                                               // a8a8: 0a          .
+    cmp l0031                                                         // a8a9: c5 31       .1
+    bcc ca8b0                                                         // a8ab: 90 03       ..
+    sbc l0031                                                         // a8ad: e5 31       .1
+    inx                                                               // a8af: e8          .
+// $a8b0 referenced 1 time by $a8ab
+ca8b0
+    jmp ca6a2                                                         // a8b0: 4c a2 a6    L..
+
+// $a8b3 referenced 2 times by $a9e6, $aa3e
+sub_ca8b3
+    ldx #$ca                                                          // a8b3: a2 ca       ..
+    dec l0030                                                         // a8b5: c6 30       .0
+    bra ca8bb                                                         // a8b7: 80 02       ..
+// $a8b9 referenced 2 times by $a7ea, $a938
+sub_ca8b9
+    ldx #$e7                                                          // a8b9: a2 e7       ..
+// $a8bb referenced 1 time by $a8b7
+ca8bb
+    php                                                               // a8bb: 08          .
+    jsr sub_ca6cb                                                     // a8bc: 20 cb a6     ..
+    plp                                                               // a8bf: 28          (
+    ror l002e                                                         // a8c0: 66 2e       f.
+    txa                                                               // a8c2: 8a          .
+    jsr sub_caa55                                                     // a8c3: 20 55 aa     U.
+    dec                                                               // a8c6: 3a          :
+    dec                                                               // a8c7: 3a          :
+    sta l0047                                                         // a8c8: 85 47       .G
+    txa                                                               // a8ca: 8a          .
+    iny                                                               // a8cb: c8          .
+    clc                                                               // a8cc: 18          .
+// $a8cd referenced 1 time by $a8d0
+loop_ca8cd
+    adc #$0a                                                          // a8cd: 69 0a       i.
+    dey                                                               // a8cf: 88          .
+    bpl loop_ca8cd                                                    // a8d0: 10 fb       ..
+    adc #$f1                                                          // a8d2: 69 f1       i.
+    sta l004c                                                         // a8d4: 85 4c       .L
+    lda #$be                                                          // a8d6: a9 be       ..
+    jsr sub_ca631                                                     // a8d8: 20 31 a6     1.
+    jsr sub_ca541                                                     // a8db: 20 41 a5     A.
+    bra ca8ee                                                         // a8de: 80 0e       ..
+// $a8e0 referenced 1 time by $a8f6
+loop_ca8e0
+    jsr sub_ca5ad                                                     // a8e0: 20 ad a5     ..
+    jsr ca634                                                         // a8e3: 20 34 a6     4.
+    lda #$76 // 'v'                                                   // a8e6: a9 76       .v
+    jsr sub_ca5bd                                                     // a8e8: 20 bd a5     ..
+    jsr ca70a                                                         // a8eb: 20 0a a7     ..
+// $a8ee referenced 1 time by $a8de
+ca8ee
+    jsr sub_ca5ad                                                     // a8ee: 20 ad a5     ..
+    jsr ca70a                                                         // a8f1: 20 0a a7     ..
+    inc l0047                                                         // a8f4: e6 47       .G
+    bmi loop_ca8e0                                                    // a8f6: 30 e8       0.
+    jsr sub_ca5bb                                                     // a8f8: 20 bb a5     ..
+    jsr ca634                                                         // a8fb: 20 34 a6     4.
+    jmp ca70a                                                         // a8fe: 4c 0a a7    L..
+
+// $a901 referenced 1 time by $a6fc
+sub_ca901
+    jsr sub_c979f                                                     // a901: 20 9f 97     ..
+    lda l002e                                                         // a904: a5 2e       ..
+    pha                                                               // a906: 48          H
+    jsr sub_ca6cb                                                     // a907: 20 cb a6     ..
+    jsr sub_ca5cc                                                     // a90a: 20 cc a5     ..
+    lda l0031                                                         // a90d: a5 31       .1
+    beq ca948                                                         // a90f: f0 37       .7
+    jsr sub_ca80b                                                     // a911: 20 0b a8     ..
+    jsr ca634                                                         // a914: 20 34 a6     4.
+    bra ca91f                                                         // a917: 80 06       ..
+sub_ca919
+    jsr sub_c979f                                                     // a919: 20 9f 97     ..
+    lda l002e                                                         // a91c: a5 2e       ..
+    pha                                                               // a91e: 48          H
+// $a91f referenced 1 time by $a917
+ca91f
+    stz l002e                                                         // a91f: 64 2e       d.
+    lda #$c7                                                          // a921: a9 c7       ..
+    jsr sub_caa55                                                     // a923: 20 55 aa     U.
+    php                                                               // a926: 08          .
+    bne ca92d                                                         // a927: d0 04       ..
+    jsr sub_ca5e3                                                     // a929: 20 e3 a5     ..
+    sec                                                               // a92c: 38          8
+// $a92d referenced 1 time by $a927
+ca92d
+    bcs ca932                                                         // a92d: b0 03       ..
+    jsr sub_ca62f                                                     // a92f: 20 2f a6     /.
+// $a932 referenced 1 time by $a92d
+ca932
+    lda l0030                                                         // a932: a5 30       .0
+    cmp #$6d // 'm'                                                   // a934: c9 6d       .m
+    bcc ca93b                                                         // a936: 90 03       ..
+    jsr sub_ca8b9                                                     // a938: 20 b9 a8     ..
+// $a93b referenced 1 time by $a936
+ca93b
+    plp                                                               // a93b: 28          (
+    bne ca946                                                         // a93c: d0 08       ..
+    inc l0030                                                         // a93e: e6 30       .0
+    jsr sub_ca6ff                                                     // a940: 20 ff a6     ..
+    dec l0030                                                         // a943: c6 30       .0
+    sec                                                               // a945: 38          8
+// $a946 referenced 1 time by $a93c
+ca946
+    bcs ca94b                                                         // a946: b0 03       ..
+// $a948 referenced 1 time by $a90f
+ca948
+    jsr sub_ca6ff                                                     // a948: 20 ff a6     ..
+// $a94b referenced 1 time by $a946
+ca94b
+    pla                                                               // a94b: 68          h
+    jmp cad14                                                         // a94c: 4c 14 ad    L..
+
+sub_ca94f
+    jsr sub_ca9d1                                                     // a94f: 20 d1 a9     ..
+    bra ca959                                                         // a952: 80 05       ..
+sub_ca954
+    jsr sub_ca9d1                                                     // a954: 20 d1 a9     ..
+    inc l0049                                                         // a957: e6 49       .I
+// $a959 referenced 1 time by $a952
+ca959
+    lsr l0049                                                         // a959: 46 49       FI
+    bcc ca962                                                         // a95b: 90 05       ..
+    jsr sub_ca5c4                                                     // a95d: 20 c4 a5     ..
+    bra ca965                                                         // a960: 80 03       ..
+// $a962 referenced 1 time by $a95b
+ca962
+    jsr sub_ca5f4                                                     // a962: 20 f4 a5     ..
+// $a965 referenced 1 time by $a960
+ca965
+    lsr l0049                                                         // a965: 46 49       FI
+    bcs ca978                                                         // a967: b0 0f       ..
+// $a969 referenced 1 time by $a973
+loop_ca969
+    tay                                                               // a969: a8          .
+    rts                                                               // a96a: 60          `
+
+sub_ca96b
+    jsr sub_ca9d1                                                     // a96b: 20 d1 a9     ..
+    jsr sub_ca5f2                                                     // a96e: 20 f2 a5     ..
+    lsr l0049                                                         // a971: 46 49       FI
+    bcc loop_ca969                                                    // a973: 90 f4       ..
+    jsr sub_ca62f                                                     // a975: 20 2f a6     /.
+// $a978 referenced 1 time by $a967
+ca978
+    jmp cad10                                                         // a978: 4c 10 ad    L..
+
+// $a97b referenced 2 times by $a9dd, $aa30
+sub_ca97b
+    jsr sub_ca545                                                     // a97b: 20 45 a5     E.
+    lda l0030                                                         // a97e: a5 30       .0
+    ldx #0                                                            // a980: a2 00       ..
+// $a982 referenced 1 time by $a988
+loop_ca982
+    dey                                                               // a982: 88          .
+    stx l0031,y                                                       // a983: 96 31       .1
+    cmp la7c9,y                                                       // a985: d9 c9 a7    ...
+    bcc loop_ca982                                                    // a988: 90 f8       ..
+    lda l004c                                                         // a98a: a5 4c       .L
+    jsr ca9c1                                                         // a98c: 20 c1 a9     ..
+    lda l002e                                                         // a98f: a5 2e       ..
+    sta l003b                                                         // a991: 85 3b       .;
+    jsr sub_ca5d1                                                     // a993: 20 d1 a5     ..
+    dec l0030                                                         // a996: c6 30       .0
+    jsr sub_c9788                                                     // a998: 20 88 97     ..
+    sta l0049                                                         // a99b: 85 49       .I
+    jsr c828d                                                         // a99d: 20 8d 82     ..
+    jsr sub_ca5ad                                                     // a9a0: 20 ad a5     ..
+// $a9a3 referenced 1 time by $a7ff
+sub_ca9a3
+    jsr sub_ca514                                                     // a9a3: 20 14 a5     ..
+    ldy #5                                                            // a9a6: a0 05       ..
+    lda (l004a),y                                                     // a9a8: b1 4a       .J
+    sta l0041                                                         // a9aa: 85 41       .A
+    jsr sub_ca73e                                                     // a9ac: 20 3e a7     >.
+    jsr sub_ca5bb                                                     // a9af: 20 bb a5     ..
+    jmp ca704                                                         // a9b2: 4c 04 a7    L..
+
+sub_ca9b5
+    jsr sub_c979f                                                     // a9b5: 20 9f 97     ..
+    lda #$ca                                                          // a9b8: a9 ca       ..
+    bra ca9c1                                                         // a9ba: 80 05       ..
+sub_ca9bc
+    jsr sub_ca7ac                                                     // a9bc: 20 ac a7     ..
+    lda #$82                                                          // a9bf: a9 82       ..
+// $a9c1 referenced 3 times by $a98c, $a9ba, $a9cf
+ca9c1
+    ldy #$bf                                                          // a9c1: a0 bf       ..
+// $a9c3 referenced 1 time by $a0e0
+sub_ca9c3
+    sty l004b                                                         // a9c3: 84 4b       .K
+    sta l004a                                                         // a9c5: 85 4a       .J
+    jmp ca6e4                                                         // a9c7: 4c e4 a6    L..
+
+sub_ca9ca
+    jsr sub_c979f                                                     // a9ca: 20 9f 97     ..
+    lda #$cf                                                          // a9cd: a9 cf       ..
+    bra ca9c1                                                         // a9cf: 80 f0       ..
+// $a9d1 referenced 3 times by $a94f, $a954, $a96b
+sub_ca9d1
+    jsr sub_c979f                                                     // a9d1: 20 9f 97     ..
+    lda #$8b                                                          // a9d4: a9 8b       ..
+    jsr sub_caa50                                                     // a9d6: 20 50 aa     P.
+    bcc caa07                                                         // a9d9: 90 2c       .,
+    bne ca9e0                                                         // a9db: d0 03       ..
+    jsr sub_ca97b                                                     // a9dd: 20 7b a9     {.
+// $a9e0 referenced 1 time by $a9db
+ca9e0
+    lda #$6e // 'n'                                                   // a9e0: a9 6e       .n
+    cmp l0030                                                         // a9e2: c5 30       .0
+    bcs ca9f2                                                         // a9e4: b0 0c       ..
+    jsr sub_ca8b3                                                     // a9e6: 20 b3 a8     ..
+    jsr sub_ca545                                                     // a9e9: 20 45 a5     E.
+    inc l046c                                                         // a9ec: ee 6c 04    .l.
+// $a9ef referenced 1 time by $aa4d
+ca9ef
+    jmp ca6ce                                                         // a9ef: 4c ce a6    L..
+
+// $a9f2 referenced 1 time by $a9e4
+ca9f2
+    jsr sub_ca545                                                     // a9f2: 20 45 a5     E.
+// $a9f5 referenced 1 time by $a9fa
+loop_ca9f5
+    jmp ca72b                                                         // a9f5: 4c 2b a7    L+.
+
+// $a9f8 referenced 1 time by $aa1f
+ca9f8
+    lda l002e                                                         // a9f8: a5 2e       ..
+    bmi loop_ca9f5                                                    // a9fa: 30 f9       0.
+    brk                                                               // a9fc: 00          .
+
+    .byt $18                                                          // a9fd: 18          .
+    .asc "Exp range"                                                  // a9fe: 45 78 70... Exp
+
+// $aa07 referenced 1 time by $a9d9
+caa07
+    brk                                                               // aa07: 00          .
+
+    .byt $17                                                          // aa08: 17          .
+    .asc "Accuracy lost"                                              // aa09: 41 63 63... Acc
+    .byt 0                                                            // aa16: 00          .
+
+sub_caa17
+    jsr sub_c979f                                                     // aa17: 20 9f 97     ..
+// $aa1a referenced 1 time by $a0e3
+sub_caa1a
+    lda #$9a                                                          // aa1a: a9 9a       ..
+    jsr sub_caa50                                                     // aa1c: 20 50 aa     P.
+    bcc ca9f8                                                         // aa1f: 90 d7       ..
+    bne caa2c                                                         // aa21: d0 09       ..
+    lda l0030                                                         // aa23: a5 30       .0
+    inc                                                               // aa25: 1a          .
+    and #8                                                            // aa26: 29 08       ).
+    beq caa2c                                                         // aa28: f0 02       ..
+    dec l0030                                                         // aa2a: c6 30       .0
+// $aa2c referenced 2 times by $aa21, $aa28
+caa2c
+    dec                                                               // aa2c: 3a          :
+    pha                                                               // aa2d: 48          H
+    beq caa33                                                         // aa2e: f0 03       ..
+    jsr sub_ca97b                                                     // aa30: 20 7b a9     {.
+// $aa33 referenced 1 time by $aa2e
+caa33
+    lda l0030                                                         // aa33: a5 30       .0
+    cmp #$6a // 'j'                                                   // aa35: c9 6a       .j
+    bcs caa3e                                                         // aa37: b0 05       ..
+    jsr sub_ca5cf                                                     // aa39: 20 cf a5     ..
+    bra caa44                                                         // aa3c: 80 06       ..
+// $aa3e referenced 1 time by $aa37
+caa3e
+    jsr sub_ca8b3                                                     // aa3e: 20 b3 a8     ..
+    jsr sub_ca5c1                                                     // aa41: 20 c1 a5     ..
+// $aa44 referenced 1 time by $aa3c
+caa44
+    clc                                                               // aa44: 18          .
+    lda l0030                                                         // aa45: a5 30       .0
+    adc l0049                                                         // aa47: 65 49       eI
+    sta l0030                                                         // aa49: 85 30       .0
+    pla                                                               // aa4b: 68          h
+    dec                                                               // aa4c: 3a          :
+    bpl ca9ef                                                         // aa4d: 10 a0       ..
+    rts                                                               // aa4f: 60          `
+
+// $aa50 referenced 2 times by $a9d6, $aa1c
+sub_caa50
+    jsr sub_ca5b2                                                     // aa50: 20 b2 a5     ..
+    stz l0049                                                         // aa53: 64 49       dI
+// $aa55 referenced 2 times by $a8c3, $a923
+sub_caa55
+    phx                                                               // aa55: da          .
+    tax                                                               // aa56: aa          .
+    ldy #1                                                            // aa57: a0 01       ..
+// $aa59 referenced 1 time by $aa69
+loop_caa59
+    dex                                                               // aa59: ca          .
+    lda cbf00,x                                                       // aa5a: bd 00 bf    ...
+    cmp l0030                                                         // aa5d: c5 30       .0
+    bne caa66                                                         // aa5f: d0 05       ..
+    lda lbefe,x                                                       // aa61: bd fe be    ...
+    cmp l0031                                                         // aa64: c5 31       .1
+// $aa66 referenced 1 time by $aa5f
+caa66
+    bcs caa6b                                                         // aa66: b0 03       ..
+    dey                                                               // aa68: 88          .
+    bpl loop_caa59                                                    // aa69: 10 ee       ..
+// $aa6b referenced 1 time by $aa66
+caa6b
+    plx                                                               // aa6b: fa          .
+    tya                                                               // aa6c: 98          .
+    rts                                                               // aa6d: 60          `
+
+// $aa6e referenced 2 times by $ac12, $aefb
+sub_caa6e
+    jsr sub_c9779                                                     // aa6e: 20 79 97     y.
+    lda #osbyte_inkey                                                 // aa71: a9 81       ..
+    ldx l002a                                                         // aa73: a6 2a       .*
+    ldy l002b                                                         // aa75: a4 2b       .+
+    jmp osbyte                                                        // aa77: 4c f4 ff    L..
+
+// $aa7a referenced 2 times by $aaae, $aab0
+caa7a
+    jsr sub_c83d3                                                     // aa7a: 20 d3 83     ..
+// $aa7d referenced 1 time by $aaab
+caa7d
+    stz l002e                                                         // aa7d: 64 2e       d.
+    stz l002f                                                         // aa7f: 64 2f       d/
+    stz l0035                                                         // aa81: 64 35       d5
+    lda #$80                                                          // aa83: a9 80       ..
+    sta l0030                                                         // aa85: 85 30       .0
+    eor l000d                                                         // aa87: 45 0d       E.
+    sta l0034                                                         // aa89: 85 34       .4
+    eor l000e                                                         // aa8b: 45 0e       E.
+    sta l0033                                                         // aa8d: 85 33       .3
+    eor l000f                                                         // aa8f: 45 0f       E.
+    sta l0032                                                         // aa91: 85 32       .2
+    eor l0010                                                         // aa93: 45 10       E.
+    sta l0031                                                         // aa95: 85 31       .1
+    jmp ca6c4                                                         // aa97: 4c c4 a6    L..
+
+// $aa9a referenced 1 time by $aad1
+caa9a
+    inc l001b                                                         // aa9a: e6 1b       ..
+    jsr sub_c976c                                                     // aa9c: 20 6c 97     l.
+    lda l002d                                                         // aa9f: a5 2d       .-
+    bmi caac1                                                         // aaa1: 30 1e       0.
+    ora l002c                                                         // aaa3: 05 2c       .,
+    ora l002b                                                         // aaa5: 05 2b       .+
+    bne caab0                                                         // aaa7: d0 07       ..
+    lda l002a                                                         // aaa9: a5 2a       .*
+    beq caa7d                                                         // aaab: f0 d0       ..
+    dec                                                               // aaad: 3a          :
+    beq caa7a                                                         // aaae: f0 ca       ..
+// $aab0 referenced 1 time by $aaa7
+caab0
+    jsr caa7a                                                         // aab0: 20 7a aa     z.
+    jsr sub_c828a                                                     // aab3: 20 8a 82     ..
+    jsr sub_ca73e                                                     // aab6: 20 3e a7     >.
+    jsr sub_c9788                                                     // aab9: 20 88 97     ..
+    jsr sub_cbf2f                                                     // aabc: 20 2f bf     /.
+    bra caae8                                                         // aabf: 80 27       .'
+// $aac1 referenced 1 time by $aaa1
+caac1
+    ldx #$0d                                                          // aac1: a2 0d       ..
+    jsr sub_cbe06                                                     // aac3: 20 06 be     ..
+    lda #$40 // '@'                                                   // aac6: a9 40       .@
+    sta l0011                                                         // aac8: 85 11       ..
+    rts                                                               // aaca: 60          `
+
+sub_caacb
+    ldy l001b                                                         // aacb: a4 1b       ..
+    lda (l0019),y                                                     // aacd: b1 19       ..
+    cmp #$28 // '('                                                   // aacf: c9 28       .(
+    beq caa9a                                                         // aad1: f0 c7       ..
+    jsr sub_c83d3                                                     // aad3: 20 d3 83     ..
+    ldx #$0d                                                          // aad6: a2 0d       ..
+// $aad8 referenced 2 times by $a052, $b1d8
+sub_caad8
+    lda l0000,x                                                       // aad8: b5 00       ..
+    sta l002a                                                         // aada: 85 2a       .*
+    lda l0001,x                                                       // aadc: b5 01       ..
+    sta l002b                                                         // aade: 85 2b       .+
+    lda l0002,x                                                       // aae0: b5 02       ..
+    sta l002c                                                         // aae2: 85 2c       .,
+    lda l0003,x                                                       // aae4: b5 03       ..
+    sta l002d                                                         // aae6: 85 2d       .-
+// $aae8 referenced 4 times by $aabf, $aaf9, $ab12, $ab2d
+caae8
+    lda #$40 // '@'                                                   // aae8: a9 40       .@
+    rts                                                               // aaea: 60          `
+
+sub_caaeb
+    jsr sub_c9779                                                     // aaeb: 20 79 97     y.
+    ldx #3                                                            // aaee: a2 03       ..
+// $aaf0 referenced 1 time by $aaf7
+loop_caaf0
+    lda l002a,x                                                       // aaf0: b5 2a       .*
+    eor #$ff                                                          // aaf2: 49 ff       I.
+    sta l002a,x                                                       // aaf4: 95 2a       .*
+    dex                                                               // aaf6: ca          .
+    bpl loop_caaf0                                                    // aaf7: 10 f7       ..
+    bra caae8                                                         // aaf9: 80 ed       ..
+sub_caafb
+    jsr sub_cab14                                                     // aafb: 20 14 ab     ..
+    stx l002a                                                         // aafe: 86 2a       .*
+    rts                                                               // ab00: 60          `
+
+sub_cab01
+    jsr sub_c9779                                                     // ab01: 20 79 97     y.
+    jsr sub_c93c7                                                     // ab04: 20 c7 93     ..
+    sta l002a                                                         // ab07: 85 2a       .*
+    stx l002b                                                         // ab09: 86 2b       .+
+    sty l002c                                                         // ab0b: 84 2c       .,
+    php                                                               // ab0d: 08          .
+    pla                                                               // ab0e: 68          h
+    sta l002d                                                         // ab0f: 85 2d       .-
+    cld                                                               // ab11: d8          .
+    bra caae8                                                         // ab12: 80 d4       ..
+// $ab14 referenced 1 time by $aafb
+sub_cab14
+    lda #osbyte_read_text_cursor_pos                                  // ab14: a9 86       ..
+    jsr osbyte                                                        // ab16: 20 f4 ff     ..
+    tya                                                               // ab19: 98          .
+// $ab1a referenced 2 times by $ab35, $ab52
+cab1a
+    jmp cae60                                                         // ab1a: 4c 60 ae    L`.
+
+sub_cab1d
+    lda #2                                                            // ab1d: a9 02       ..
+    bra cab23                                                         // ab1f: 80 02       ..
+sub_cab21
+    lda #0                                                            // ab21: a9 00       ..
+// $ab23 referenced 1 time by $ab1f
+cab23
+    pha                                                               // ab23: 48          H
+    jsr sub_cba7a                                                     // ab24: 20 7a ba     z.
+    ldx #$2a // '*'                                                   // ab27: a2 2a       .*
+    pla                                                               // ab29: 68          h
+    jsr osargs                                                        // ab2a: 20 da ff     ..
+    bra caae8                                                         // ab2d: 80 b9       ..
+sub_cab2f
+    jsr sub_cba7a                                                     // ab2f: 20 7a ba     z.
+    jsr osbget                                                        // ab32: 20 d7 ff     ..
+    bra cab1a                                                         // ab35: 80 e3       ..
+sub_cab37
+    lda #$40 // '@'                                                   // ab37: a9 40       .@
+    bra cab41                                                         // ab39: 80 06       ..
+sub_cab3b
+    lda #$80                                                          // ab3b: a9 80       ..
+    bra cab41                                                         // ab3d: 80 02       ..
+sub_cab3f
+    lda #$c0                                                          // ab3f: a9 c0       ..
+// $ab41 referenced 2 times by $ab39, $ab3d
+cab41
+    pha                                                               // ab41: 48          H
+    jsr cad78                                                         // ab42: 20 78 ad     x.
+    bne cab9d                                                         // ab45: d0 56       .V
+    jsr sub_cbe6b                                                     // ab47: 20 6b be     k.
+    ldx #0                                                            // ab4a: a2 00       ..
+    ldy #6                                                            // ab4c: a0 06       ..
+    pla                                                               // ab4e: 68          h
+    jsr osfind                                                        // ab4f: 20 ce ff     ..
+    bra cab1a                                                         // ab52: 80 c6       ..
+sub_cab54
+    stz l0031                                                         // ab54: 64 31       d1
+    jsr sub_ca6ff                                                     // ab56: 20 ff a6     ..
+    inc l0030                                                         // ab59: e6 30       .0
+    rts                                                               // ab5b: 60          `
+
+sub_cab5c
+    jsr cad78                                                         // ab5c: 20 78 ad     x.
+    bne cab9d                                                         // ab5f: d0 3c       .<
+    inc l0036                                                         // ab61: e6 36       .6
+    ldy l0036                                                         // ab63: a4 36       .6
+    lda #$0d                                                          // ab65: a9 0d       ..
+    sta l05ff,y                                                       // ab67: 99 ff 05    ...
+    jsr cbc91                                                         // ab6a: 20 91 bc     ..
+    lda l0019                                                         // ab6d: a5 19       ..
+    pha                                                               // ab6f: 48          H
+    lda l001a                                                         // ab70: a5 1a       ..
+    pha                                                               // ab72: 48          H
+    lda l001b                                                         // ab73: a5 1b       ..
+    pha                                                               // ab75: 48          H
+    ldy l0004                                                         // ab76: a4 04       ..
+    ldx l0005                                                         // ab78: a6 05       ..
+    iny                                                               // ab7a: c8          .
+    sty l0019                                                         // ab7b: 84 19       ..
+    sty l0037                                                         // ab7d: 84 37       .7
+    bne cab82                                                         // ab7f: d0 01       ..
+    inx                                                               // ab81: e8          .
+// $ab82 referenced 1 time by $ab7f
+cab82
+    stx l001a                                                         // ab82: 86 1a       ..
+    stx l0038                                                         // ab84: 86 38       .8
+    jsr c8edc                                                         // ab86: 20 dc 8e     ..
+    stz l001b                                                         // ab89: 64 1b       d.
+    jsr sub_c9dff                                                     // ab8b: 20 ff 9d     ..
+    jsr cbd21                                                         // ab8e: 20 21 bd     !.
+// $ab91 referenced 1 time by $abdf
+cab91
+    pla                                                               // ab91: 68          h
+    sta l001b                                                         // ab92: 85 1b       ..
+    pla                                                               // ab94: 68          h
+    sta l001a                                                         // ab95: 85 1a       ..
+    pla                                                               // ab97: 68          h
+    sta l0019                                                         // ab98: 85 19       ..
+    lda l0027                                                         // ab9a: a5 27       .'
+    rts                                                               // ab9c: 60          `
+
+// $ab9d referenced 3 times by $ab45, $ab5f, $aba3
+cab9d
+    jmp c9155                                                         // ab9d: 4c 55 91    LU.
+
+sub_caba0
+    jsr cad78                                                         // aba0: 20 78 ad     x.
+    bne cab9d                                                         // aba3: d0 f8       ..
+// $aba5 referenced 1 time by $b96e
+sub_caba5
+    ldx l0036                                                         // aba5: a6 36       .6
+    stz l0600,x                                                       // aba7: 9e 00 06    ...
+    lda l0019                                                         // abaa: a5 19       ..
+    pha                                                               // abac: 48          H
+    lda l001a                                                         // abad: a5 1a       ..
+    pha                                                               // abaf: 48          H
+    lda l001b                                                         // abb0: a5 1b       ..
+    pha                                                               // abb2: 48          H
+    stz l001b                                                         // abb3: 64 1b       d.
+    stz l0019                                                         // abb5: 64 19       d.
+    lda #6                                                            // abb7: a9 06       ..
+    sta l001a                                                         // abb9: 85 1a       ..
+    jsr c8f92                                                         // abbb: 20 92 8f     ..
+    cmp #$2d // '-'                                                   // abbe: c9 2d       .-
+    beq cabd0                                                         // abc0: f0 0e       ..
+    cmp #$2b // '+'                                                   // abc2: c9 2b       .+
+    bne cabc9                                                         // abc4: d0 03       ..
+    jsr c8f92                                                         // abc6: 20 92 8f     ..
+// $abc9 referenced 1 time by $abc4
+cabc9
+    dec l001b                                                         // abc9: c6 1b       ..
+    jsr sub_ca2dd                                                     // abcb: 20 dd a2     ..
+    bra cabdd                                                         // abce: 80 0d       ..
+// $abd0 referenced 1 time by $abc0
+cabd0
+    jsr c8f92                                                         // abd0: 20 92 8f     ..
+    dec l001b                                                         // abd3: c6 1b       ..
+    jsr sub_ca2dd                                                     // abd5: 20 dd a2     ..
+    bcc cabdd                                                         // abd8: 90 03       ..
+    jsr sub_cad1c                                                     // abda: 20 1c ad     ..
+// $abdd referenced 2 times by $abce, $abd8
+cabdd
+    sta l0027                                                         // abdd: 85 27       .'
+    bra cab91                                                         // abdf: 80 b0       ..
+sub_cabe1
+    jsr cad78                                                         // abe1: 20 78 ad     x.
+    beq cac1c                                                         // abe4: f0 36       .6
+    bpl cac02                                                         // abe6: 10 1a       ..
+    lda l002e                                                         // abe8: a5 2e       ..
+    php                                                               // abea: 08          .
+    stz l002e                                                         // abeb: 64 2e       d.
+    jsr sub_c8349                                                     // abed: 20 49 83     I.
+    plp                                                               // abf0: 28          (
+    bpl cabfd                                                         // abf1: 10 0a       ..
+    lda l003d                                                         // abf3: a5 3d       .=
+    beq cabfa                                                         // abf5: f0 03       ..
+    jsr sub_c83c2                                                     // abf7: 20 c2 83     ..
+// $abfa referenced 1 time by $abf5
+cabfa
+    jsr sub_c83aa                                                     // abfa: 20 aa 83     ..
+// $abfd referenced 1 time by $abf1
+cabfd
+    jsr sub_c978b                                                     // abfd: 20 8b 97     ..
+    lda #$40 // '@'                                                   // ac00: a9 40       .@
+// $ac02 referenced 1 time by $abe6
+cac02
+    rts                                                               // ac02: 60          `
+
+sub_cac03
+    jsr cad78                                                         // ac03: 20 78 ad     x.
+    bne cac1c                                                         // ac06: d0 14       ..
+    lda l0036                                                         // ac08: a5 36       .6
+    beq cac2b                                                         // ac0a: f0 1f       ..
+    lda l0600                                                         // ac0c: ad 00 06    ...
+// $ac0f referenced 1 time by $ac5b
+cac0f
+    jmp cae60                                                         // ac0f: 4c 60 ae    L`.
+
+sub_cac12
+    jsr sub_caa6e                                                     // ac12: 20 6e aa     n.
+    tya                                                               // ac15: 98          .
+    bne cac2b                                                         // ac16: d0 13       ..
+    txa                                                               // ac18: 8a          .
+    jmp cae62                                                         // ac19: 4c 62 ae    Lb.
+
+// $ac1c referenced 5 times by $abe4, $ac06, $ac4b, $ac82, $ac90
+cac1c
+    jmp c9155                                                         // ac1c: 4c 55 91    LU.
+
+sub_cac1f
+    jsr sub_cba7a                                                     // ac1f: 20 7a ba     z.
+    tax                                                               // ac22: aa          .
+    lda #osbyte_check_eof                                             // ac23: a9 7f       ..
+    jsr osbyte                                                        // ac25: 20 f4 ff     ..
+    txa                                                               // ac28: 8a          .
+    beq cac2d                                                         // ac29: f0 02       ..
+// $ac2b referenced 6 times by $ac0a, $ac16, $ac44, $ac4f, $ac7b, $b3dd
+cac2b
+    ldx #$ff                                                          // ac2b: a2 ff       ..
+// $ac2d referenced 2 times by $ac29, $ac3a
+cac2d
+    stx l002a                                                         // ac2d: 86 2a       .*
+    stx l002b                                                         // ac2f: 86 2b       .+
+    stx l002c                                                         // ac31: 86 2c       .,
+    stx l002d                                                         // ac33: 86 2d       .-
+// $ac35 referenced 1 time by $ac57
+cac35
+    lda #$40 // '@'                                                   // ac35: a9 40       .@
+    rts                                                               // ac37: 60          `
+
+// $ac38 referenced 5 times by $97e6, $9ae1, $ac3e, $adf9, $b3d3
+cac38
+    ldx #0                                                            // ac38: a2 00       ..
+    bra cac2d                                                         // ac3a: 80 f1       ..
+// $ac3c referenced 1 time by $ac49
+loop_cac3c
+    lda l0031                                                         // ac3c: a5 31       .1
+    beq cac38                                                         // ac3e: f0 f8       ..
+    lda l002e                                                         // ac40: a5 2e       ..
+    bpl cac59                                                         // ac42: 10 15       ..
+    bra cac2b                                                         // ac44: 80 e5       ..
+sub_cac46
+    jsr cad78                                                         // ac46: 20 78 ad     x.
+    bmi loop_cac3c                                                    // ac49: 30 f1       0.
+    beq cac1c                                                         // ac4b: f0 cf       ..
+    lda l002d                                                         // ac4d: a5 2d       .-
+    bmi cac2b                                                         // ac4f: 30 da       0.
+    ora l002c                                                         // ac51: 05 2c       .,
+    ora l002b                                                         // ac53: 05 2b       .+
+    ora l002a                                                         // ac55: 05 2a       .*
+    beq cac35                                                         // ac57: f0 dc       ..
+// $ac59 referenced 1 time by $ac42
+cac59
+    lda #1                                                            // ac59: a9 01       ..
+// $ac5b referenced 1 time by $ac7d
+cac5b
+    bra cac0f                                                         // ac5b: 80 b2       ..
+sub_cac5d
+    jsr sub_c8fae                                                     // ac5d: 20 ae 8f     ..
+    jsr sub_c976c                                                     // ac60: 20 6c 97     l.
+    lda l002a                                                         // ac63: a5 2a       .*
+    pha                                                               // ac65: 48          H
+    ldx l002b                                                         // ac66: a6 2b       .+
+    jsr sub_cbd26                                                     // ac68: 20 26 bd     &.
+    stx l002d                                                         // ac6b: 86 2d       .-
+    pla                                                               // ac6d: 68          h
+    sta l002c                                                         // ac6e: 85 2c       .,
+    ldy #>(l002a)                                                     // ac70: a0 00       ..
+    ldx #<(l002a)                                                     // ac72: a2 2a       .*
+    lda #osword_read_pixel                                            // ac74: a9 09       ..
+    jsr osword                                                        // ac76: 20 f1 ff     ..
+    lda l002e                                                         // ac79: a5 2e       ..
+    bmi cac2b                                                         // ac7b: 30 ae       0.
+    bra cac5b                                                         // ac7d: 80 dc       ..
+sub_cac7f
+    jsr sub_c9dff                                                     // ac7f: 20 ff 9d     ..
+    bne cac1c                                                         // ac82: d0 98       ..
+    cpx #$2c // ','                                                   // ac84: e0 2c       .,
+    bne caca0                                                         // ac86: d0 18       ..
+    inc l001b                                                         // ac88: e6 1b       ..
+    jsr cbc91                                                         // ac8a: 20 91 bc     ..
+    jsr sub_c9dff                                                     // ac8d: 20 ff 9d     ..
+    bne cac1c                                                         // ac90: d0 8a       ..
+    lda #1                                                            // ac92: a9 01       ..
+    sta l002a                                                         // ac94: 85 2a       .*
+    inc l001b                                                         // ac96: e6 1b       ..
+    cpx #$29 // ')'                                                   // ac98: e0 29       .)
+    beq caca9                                                         // ac9a: f0 0d       ..
+    cpx #$2c // ','                                                   // ac9c: e0 2c       .,
+    beq caca3                                                         // ac9e: f0 03       ..
+// $aca0 referenced 1 time by $ac86
+caca0
+    jmp c8fbb                                                         // aca0: 4c bb 8f    L..
+
+// $aca3 referenced 1 time by $ac9e
+caca3
+    jsr sub_c9769                                                     // aca3: 20 69 97     i.
+    jsr sub_cbd12                                                     // aca6: 20 12 bd     ..
+// $aca9 referenced 1 time by $ac9a
+caca9
+    ldx l002a                                                         // aca9: a6 2a       .*
+    bne cacaf                                                         // acab: d0 02       ..
+    ldx #1                                                            // acad: a2 01       ..
+// $acaf referenced 1 time by $acab
+cacaf
+    stx l002a                                                         // acaf: 86 2a       .*
+    txa                                                               // acb1: 8a          .
+    dex                                                               // acb2: ca          .
+    stx l002d                                                         // acb3: 86 2d       .-
+    clc                                                               // acb5: 18          .
+    adc l0004                                                         // acb6: 65 04       e.
+    sta l0037                                                         // acb8: 85 37       .7
+    lda #0                                                            // acba: a9 00       ..
+    adc l0005                                                         // acbc: 65 05       e.
+    sta l0038                                                         // acbe: 85 38       .8
+    lda (l0004)                                                       // acc0: b2 04       ..
+    sec                                                               // acc2: 38          8
+    sbc l002d                                                         // acc3: e5 2d       .-
+    bcc cace8                                                         // acc5: 90 21       .!
+    sbc l0036                                                         // acc7: e5 36       .6
+    bcc cace8                                                         // acc9: 90 1d       ..
+    adc #0                                                            // accb: 69 00       i.
+    sta l002b                                                         // accd: 85 2b       .+
+    jsr cbd21                                                         // accf: 20 21 bd     !.
+// $acd2 referenced 2 times by $acf7, $acfb
+cacd2
+    ldy #0                                                            // acd2: a0 00       ..
+    ldx l0036                                                         // acd4: a6 36       .6
+    beq cace3                                                         // acd6: f0 0b       ..
+// $acd8 referenced 1 time by $ace1
+loop_cacd8
+    lda (l0037),y                                                     // acd8: b1 37       .7
+    cmp l0600,y                                                       // acda: d9 00 06    ...
+    bne cacef                                                         // acdd: d0 10       ..
+    iny                                                               // acdf: c8          .
+    dex                                                               // ace0: ca          .
+    bne loop_cacd8                                                    // ace1: d0 f5       ..
+// $ace3 referenced 1 time by $acd6
+cace3
+    lda l002a                                                         // ace3: a5 2a       .*
+// $ace5 referenced 1 time by $aced
+loop_cace5
+    jmp cae60                                                         // ace5: 4c 60 ae    L`.
+
+// $ace8 referenced 2 times by $acc5, $acc9
+cace8
+    jsr cbd21                                                         // ace8: 20 21 bd     !.
+// $aceb referenced 1 time by $acf3
+loop_caceb
+    lda #0                                                            // aceb: a9 00       ..
+    bra loop_cace5                                                    // aced: 80 f6       ..
+// $acef referenced 1 time by $acdd
+cacef
+    inc l002a                                                         // acef: e6 2a       .*
+    dec l002b                                                         // acf1: c6 2b       .+
+    beq loop_caceb                                                    // acf3: f0 f6       ..
+    inc l0037                                                         // acf5: e6 37       .7
+    bne cacd2                                                         // acf7: d0 d9       ..
+    inc l0038                                                         // acf9: e6 38       .8
+    bra cacd2                                                         // acfb: 80 d5       ..
+// $acfd referenced 2 times by $ad05, $ad1c
+cacfd
+    jmp c9155                                                         // acfd: 4c 55 91    LU.
+
+sub_cad00
+    jsr cad78                                                         // ad00: 20 78 ad     x.
+    bmi cad0d                                                         // ad03: 30 08       0.
+    beq cacfd                                                         // ad05: f0 f6       ..
+// $ad07 referenced 1 time by $81d7
+sub_cad07
+    bit l002d                                                         // ad07: 24 2d       $-
+    bmi cad20                                                         // ad09: 30 15       0.
+    bra cad37                                                         // ad0b: 80 2a       .*
+// $ad0d referenced 1 time by $ad03
+cad0d
+    stz l002e                                                         // ad0d: 64 2e       d.
+    rts                                                               // ad0f: 60          `
+
+// $ad10 referenced 6 times by $9f61, $a5c1, $a5cc, $a805, $a978, $ad1e
+cad10
+    lda l0031                                                         // ad10: a5 31       .1
+    eor l002e                                                         // ad12: 45 2e       E.
+// $ad14 referenced 1 time by $a94c
+cad14
+    sta l002e                                                         // ad14: 85 2e       ..
+    lda #$ff                                                          // ad16: a9 ff       ..
+    rts                                                               // ad18: 60          `
+
+// $ad19 referenced 1 time by $ad84
+cad19
+    jsr sub_cad8e                                                     // ad19: 20 8e ad     ..
+// $ad1c referenced 1 time by $abda
+sub_cad1c
+    beq cacfd                                                         // ad1c: f0 df       ..
+    bmi cad10                                                         // ad1e: 30 f0       0.
+// $ad20 referenced 5 times by $81c5, $8295, $9fe3, $a058, $ad09
+cad20
+    sec                                                               // ad20: 38          8
+    lda #0                                                            // ad21: a9 00       ..
+    tay                                                               // ad23: a8          .
+    sbc l002a                                                         // ad24: e5 2a       .*
+    sta l002a                                                         // ad26: 85 2a       .*
+    tya                                                               // ad28: 98          .
+    sbc l002b                                                         // ad29: e5 2b       .+
+    sta l002b                                                         // ad2b: 85 2b       .+
+    tya                                                               // ad2d: 98          .
+    sbc l002c                                                         // ad2e: e5 2c       .,
+    sta l002c                                                         // ad30: 85 2c       .,
+    tya                                                               // ad32: 98          .
+    sbc l002d                                                         // ad33: e5 2d       .-
+    sta l002d                                                         // ad35: 85 2d       .-
+// $ad37 referenced 1 time by $ad0b
+cad37
+    lda #$40 // '@'                                                   // ad37: a9 40       .@
+    rts                                                               // ad39: 60          `
+
+// $ad3a referenced 2 times by $b957, $b9c5
+sub_cad3a
+    jsr c8f92                                                         // ad3a: 20 92 8f     ..
+    cmp #$22 // '"'                                                   // ad3d: c9 22       ."
+    beq cad5b                                                         // ad3f: f0 1a       ..
+    ldx #0                                                            // ad41: a2 00       ..
+// $ad43 referenced 1 time by $ad50
+loop_cad43
+    lda (l0019),y                                                     // ad43: b1 19       ..
+    sta l0600,x                                                       // ad45: 9d 00 06    ...
+    iny                                                               // ad48: c8          .
+    inx                                                               // ad49: e8          .
+    cmp #$0d                                                          // ad4a: c9 0d       ..
+    beq cad52                                                         // ad4c: f0 04       ..
+    cmp #$2c // ','                                                   // ad4e: c9 2c       .,
+    bne loop_cad43                                                    // ad50: d0 f1       ..
+// $ad52 referenced 1 time by $ad4c
+cad52
+    dey                                                               // ad52: 88          .
+// $ad53 referenced 1 time by $ad73
+cad53
+    dex                                                               // ad53: ca          .
+    stx l0036                                                         // ad54: 86 36       .6
+    sty l001b                                                         // ad56: 84 1b       ..
+    lda #0                                                            // ad58: a9 00       ..
+    rts                                                               // ad5a: 60          `
+
+// $ad5b referenced 2 times by $ad3f, $ad88
+cad5b
+    ldx #0                                                            // ad5b: a2 00       ..
+// $ad5d referenced 1 time by $ad71
+loop_cad5d
+    iny                                                               // ad5d: c8          .
+// $ad5e referenced 1 time by $ad6b
+loop_cad5e
+    lda (l0019),y                                                     // ad5e: b1 19       ..
+    cmp #$0d                                                          // ad60: c9 0d       ..
+    beq cad75                                                         // ad62: f0 11       ..
+    sta l0600,x                                                       // ad64: 9d 00 06    ...
+    iny                                                               // ad67: c8          .
+    inx                                                               // ad68: e8          .
+    cmp #$22 // '"'                                                   // ad69: c9 22       ."
+    bne loop_cad5e                                                    // ad6b: d0 f1       ..
+    lda (l0019),y                                                     // ad6d: b1 19       ..
+    cmp #$22 // '"'                                                   // ad6f: c9 22       ."
+    beq loop_cad5d                                                    // ad71: f0 ea       ..
+    bne cad53                                                         // ad73: d0 de       ..
+// $ad75 referenced 1 time by $ad62
+cad75
+    jmp c9357                                                         // ad75: 4c 57 93    LW.
+
+// $ad78 referenced 14 times by $9779, $979f, $a06c, $a084, $ab42, $ab5c, $aba0, $abe1, $ac03, $ac46, $ad00, $ad80, $ae59, $af6e
+cad78
+    ldy l001b                                                         // ad78: a4 1b       ..
+    inc l001b                                                         // ad7a: e6 1b       ..
+    lda (l0019),y                                                     // ad7c: b1 19       ..
+    cmp #$20 // ' '                                                   // ad7e: c9 20       .
+    beq cad78                                                         // ad80: f0 f6       ..
+    cmp #$2d // '-'                                                   // ad82: c9 2d       .-
+    beq cad19                                                         // ad84: f0 93       ..
+    cmp #$22 // '"'                                                   // ad86: c9 22       ."
+    beq cad5b                                                         // ad88: f0 d1       ..
+    cmp #$2b // '+'                                                   // ad8a: c9 2b       .+
+    bne cad91                                                         // ad8c: d0 03       ..
+// $ad8e referenced 1 time by $ad19
+sub_cad8e
+    jsr c8f92                                                         // ad8e: 20 92 8f     ..
+// $ad91 referenced 1 time by $ad8c
+cad91
+    cmp #$8e                                                          // ad91: c9 8e       ..
+    bcc cad9c                                                         // ad93: 90 07       ..
+    cmp #$c6                                                          // ad95: c9 c6       ..
+    bcs cadce                                                         // ad97: b0 35       .5
+    jmp c90de                                                         // ad99: 4c de 90    L..
+
+// $ad9c referenced 1 time by $ad93
+cad9c
+    cmp #$3f // '?'                                                   // ad9c: c9 3f       .?
+    bcs cadac                                                         // ad9e: b0 0c       ..
+    cmp #$2e // '.'                                                   // ada0: c9 2e       ..
+    bcs cadb6                                                         // ada2: b0 12       ..
+    cmp #$26 // '&'                                                   // ada4: c9 26       .&
+    beq cadf9                                                         // ada6: f0 51       .Q
+    cmp #$28 // '('                                                   // ada8: c9 28       .(
+    beq cadee                                                         // adaa: f0 42       .B
+// $adac referenced 1 time by $ad9e
+cadac
+    dec l001b                                                         // adac: c6 1b       ..
+    jsr sub_c99d8                                                     // adae: 20 d8 99     ..
+    beq cadbc                                                         // adb1: f0 09       ..
+    jmp cb1de                                                         // adb3: 4c de b1    L..
+
+// $adb6 referenced 1 time by $ada2
+cadb6
+    jsr sub_ca2dd                                                     // adb6: 20 dd a2     ..
+    bcc cadce                                                         // adb9: 90 13       ..
+    rts                                                               // adbb: 60          `
+
+// $adbc referenced 1 time by $adb1
+cadbc
+    lda l0028                                                         // adbc: a5 28       .(
+    and #2                                                            // adbe: 29 02       ).
+    bne cadce                                                         // adc0: d0 0c       ..
+    bcs cadce                                                         // adc2: b0 0a       ..
+    stx l001b                                                         // adc4: 86 1b       ..
+// $adc6 referenced 1 time by $8a9b
+sub_cadc6
+    lda l0440                                                         // adc6: ad 40 04    .@.
+    ldy l0441                                                         // adc9: ac 41 04    .A.
+    bra cae3f                                                         // adcc: 80 71       .q
+// $adce referenced 6 times by $93c4, $ad97, $adb9, $adc0, $adc2, $ae46
+cadce
+    brk                                                               // adce: 00          .
+
+    .byt $1a                                                          // adcf: 1a          .
+    .asc "No such variable"                                           // add0: 4e 6f 20... No
+
+// $ade0 referenced 1 time by $adf5
+loop_cade0
+    brk                                                               // ade0: 00          .
+
+    .byt $1b, $8d, $29                                                // ade1: 1b 8d 29    ..)
+
+// $ade4 referenced 1 time by $ae18
+cade4
+    brk                                                               // ade4: 00          .
+
+    .byt $1c                                                          // ade5: 1c          .
+    .asc "Bad Hex"                                                    // ade6: 42 61 64... Bad
+    .byt 0                                                            // aded: 00          .
+
+// $adee referenced 3 times by $976c, $adaa, $af8e
+cadee
+    jsr sub_c9dff                                                     // adee: 20 ff 9d     ..
+    inc l001b                                                         // adf1: e6 1b       ..
+    cpx #$29 // ')'                                                   // adf3: e0 29       .)
+    bne loop_cade0                                                    // adf5: d0 e9       ..
+    tay                                                               // adf7: a8          .
+    rts                                                               // adf8: 60          `
+
+// $adf9 referenced 1 time by $ada6
+cadf9
+    jsr cac38                                                         // adf9: 20 38 ac     8.
+    bra cae00                                                         // adfc: 80 02       ..
+// $adfe referenced 1 time by $ae11
+loop_cadfe
+    inx                                                               // adfe: e8          .
+    pha                                                               // adff: 48          H
+// $ae00 referenced 1 time by $adfc
+cae00
+    iny                                                               // ae00: c8          .
+    lda (l0019),y                                                     // ae01: b1 19       ..
+    cmp #$41 // 'A'                                                   // ae03: c9 41       .A
+    bcc cae0d                                                         // ae05: 90 06       ..
+    sbc #$37 // '7'                                                   // ae07: e9 37       .7
+    cmp #$10                                                          // ae09: c9 10       ..
+    bra cae11                                                         // ae0b: 80 04       ..
+// $ae0d referenced 1 time by $ae05
+cae0d
+    sbc #$2f // '/'                                                   // ae0d: e9 2f       ./
+    cmp #$0a                                                          // ae0f: c9 0a       ..
+// $ae11 referenced 1 time by $ae0b
+cae11
+    bcc loop_cadfe                                                    // ae11: 90 eb       ..
+    sty l001b                                                         // ae13: 84 1b       ..
+    dex                                                               // ae15: ca          .
+    cpx #8                                                            // ae16: e0 08       ..
+    bcs cade4                                                         // ae18: b0 ca       ..
+    txa                                                               // ae1a: 8a          .
+    tay                                                               // ae1b: a8          .
+    ldx #0                                                            // ae1c: a2 00       ..
+// $ae1e referenced 1 time by $ae2f
+loop_cae1e
+    pla                                                               // ae1e: 68          h
+    sta l002a,x                                                       // ae1f: 95 2a       .*
+    dey                                                               // ae21: 88          .
+    bmi cae31                                                         // ae22: 30 0d       0.
+    inx                                                               // ae24: e8          .
+    pla                                                               // ae25: 68          h
+    asl                                                               // ae26: 0a          .
+    asl                                                               // ae27: 0a          .
+    asl                                                               // ae28: 0a          .
+    asl                                                               // ae29: 0a          .
+    ora l0029,x                                                       // ae2a: 15 29       .)
+    sta l0029,x                                                       // ae2c: 95 29       .)
+    dey                                                               // ae2e: 88          .
+    bpl loop_cae1e                                                    // ae2f: 10 ed       ..
+// $ae31 referenced 1 time by $ae22
+cae31
+    lda #$40 // '@'                                                   // ae31: a9 40       .@
+    rts                                                               // ae33: 60          `
+
+sub_cae34
+    jsr sub_c9779                                                     // ae34: 20 79 97     y.
+    ldx l002a                                                         // ae37: a6 2a       .*
+    lda #osbyte_read_adc_or_get_buffer_status                         // ae39: a9 80       ..
+    jsr osbyte                                                        // ae3b: 20 f4 ff     ..
+    txa                                                               // ae3e: 8a          .
+// $ae3f referenced 1 time by $adcc
+cae3f
+    bra cae62                                                         // ae3f: 80 21       .!
+sub_cae41
+    iny                                                               // ae41: c8          .
+    lda (l0019),y                                                     // ae42: b1 19       ..
+    cmp #$50 // 'P'                                                   // ae44: c9 50       .P
+    bne cadce                                                         // ae46: d0 86       ..
+    inc l001b                                                         // ae48: e6 1b       ..
+    lda l0012                                                         // ae4a: a5 12       ..
+    ldy l0013                                                         // ae4c: a4 13       ..
+    bra cae62                                                         // ae4e: 80 12       ..
+sub_cae50
+    ldy l0018                                                         // ae50: a4 18       ..
+    lda #0                                                            // ae52: a9 00       ..
+    bra cae62                                                         // ae54: 80 0c       ..
+// $ae56 referenced 2 times by $ae5c, $aec0
+cae56
+    jmp c9155                                                         // ae56: 4c 55 91    LU.
+
+sub_cae59
+    jsr cad78                                                         // ae59: 20 78 ad     x.
+    bne cae56                                                         // ae5c: d0 f8       ..
+    lda l0036                                                         // ae5e: a5 36       .6
+// $ae60 referenced 11 times by $8ff4, $9412, $941d, $964b, $ab1a, $ac0f, $ace5, $ae6f, $ae85, $ae8a, $b698
+cae60
+    ldy #0                                                            // ae60: a0 00       ..
+// $ae62 referenced 8 times by $ac19, $ae3f, $ae4e, $ae54, $ae75, $ae7b, $ae81, $b202
+cae62
+    sta l002a                                                         // ae62: 85 2a       .*
+    sty l002b                                                         // ae64: 84 2b       .+
+    stz l002c                                                         // ae66: 64 2c       d,
+    stz l002d                                                         // ae68: 64 2d       d-
+    lda #$40 // '@'                                                   // ae6a: a9 40       .@
+    rts                                                               // ae6c: 60          `
+
+sub_cae6d
+    lda l001e                                                         // ae6d: a5 1e       ..
+    bra cae60                                                         // ae6f: 80 ef       ..
+sub_cae71
+    lda l0000                                                         // ae71: a5 00       ..
+    ldy l0001                                                         // ae73: a4 01       ..
+    bra cae62                                                         // ae75: 80 eb       ..
+sub_cae77
+    lda l0006                                                         // ae77: a5 06       ..
+    ldy l0007                                                         // ae79: a4 07       ..
+    bra cae62                                                         // ae7b: 80 e5       ..
+sub_cae7d
+    ldy l0009                                                         // ae7d: a4 09       ..
+    lda l0008                                                         // ae7f: a5 08       ..
+    bra cae62                                                         // ae81: 80 df       ..
+sub_cae83
+    lda (l00fd)                                                       // ae83: b2 fd       ..
+    bra cae60                                                         // ae85: 80 d9       ..
+sub_cae87
+    jsr osrdch                                                        // ae87: 20 e0 ff     ..
+    bra cae60                                                         // ae8a: 80 d4       ..
+sub_cae8c
+    iny                                                               // ae8c: c8          .
+    lda (l0019),y                                                     // ae8d: b1 19       ..
+    cmp #$24 // '$'                                                   // ae8f: c9 24       .$
+    beq cae9f                                                         // ae91: f0 0c       ..
+    ldx #<(l002a)                                                     // ae93: a2 2a       .*
+    ldy #>(l002a)                                                     // ae95: a0 00       ..
+    lda #osword_read_clock                                            // ae97: a9 01       ..
+    jsr osword                                                        // ae99: 20 f1 ff     ..
+    lda #$40 // '@'                                                   // ae9c: a9 40       .@
+    rts                                                               // ae9e: 60          `
+
+// $ae9f referenced 1 time by $ae91
+cae9f
+    inc l001b                                                         // ae9f: e6 1b       ..
+    lda #osword_read_cmos_clock                                       // aea1: a9 0e       ..
+    ldx #<(l0600)                                                     // aea3: a2 00       ..
+    ldy #>(l0600)                                                     // aea5: a0 06       ..
+    stz l0600                                                         // aea7: 9c 00 06    ...
+    jsr osword                                                        // aeaa: 20 f1 ff     ..
+    lda #$18                                                          // aead: a9 18       ..
+    bra caed7                                                         // aeaf: 80 26       .&
+sub_caeb1
+    jsr osrdch                                                        // aeb1: 20 e0 ff     ..
+// $aeb4 referenced 2 times by $af01, $b26e
+caeb4
+    sta l0600                                                         // aeb4: 8d 00 06    ...
+    lda #1                                                            // aeb7: a9 01       ..
+    bra caed7                                                         // aeb9: 80 1c       ..
+sub_caebb
+    clc                                                               // aebb: 18          .
+sub_caebc
+    php                                                               // aebc: 08          .
+    jsr sub_c9dff                                                     // aebd: 20 ff 9d     ..
+    bne cae56                                                         // aec0: d0 94       ..
+    cpx #$2c // ','                                                   // aec2: e0 2c       .,
+    bne caf07                                                         // aec4: d0 41       .A
+    inc l001b                                                         // aec6: e6 1b       ..
+    jsr sub_c9769                                                     // aec8: 20 69 97     i.
+    jsr sub_cbd12                                                     // aecb: 20 12 bd     ..
+    plp                                                               // aece: 28          (
+    bcs caedc                                                         // aecf: b0 0b       ..
+    lda l002a                                                         // aed1: a5 2a       .*
+    cmp l0036                                                         // aed3: c5 36       .6
+    bcs caed9                                                         // aed5: b0 02       ..
+// $aed7 referenced 3 times by $aeaf, $aeb9, $af05
+caed7
+    sta l0036                                                         // aed7: 85 36       .6
+// $aed9 referenced 3 times by $aed5, $aee0, $aef9
+caed9
+    lda #0                                                            // aed9: a9 00       ..
+// $aedb referenced 2 times by $aee2, $aee9
+caedb
+    rts                                                               // aedb: 60          `
+
+// $aedc referenced 1 time by $aecf
+caedc
+    lda l0036                                                         // aedc: a5 36       .6
+    sbc l002a                                                         // aede: e5 2a       .*
+    bcc caed9                                                         // aee0: 90 f7       ..
+    beq caedb                                                         // aee2: f0 f7       ..
+    tax                                                               // aee4: aa          .
+    lda l002a                                                         // aee5: a5 2a       .*
+    sta l0036                                                         // aee7: 85 36       .6
+    beq caedb                                                         // aee9: f0 f0       ..
+    ldy #0                                                            // aeeb: a0 00       ..
+// $aeed referenced 1 time by $aef7
+loop_caeed
+    lda l0600,x                                                       // aeed: bd 00 06    ...
+    sta l0600,y                                                       // aef0: 99 00 06    ...
+    inx                                                               // aef3: e8          .
+    iny                                                               // aef4: c8          .
+    dec l002a                                                         // aef5: c6 2a       .*
+    bne loop_caeed                                                    // aef7: d0 f4       ..
+    bra caed9                                                         // aef9: 80 de       ..
+sub_caefb
+    jsr sub_caa6e                                                     // aefb: 20 6e aa     n.
+    txa                                                               // aefe: 8a          .
+    cpy #0                                                            // aeff: c0 00       ..
+    beq caeb4                                                         // af01: f0 b1       ..
+// $af03 referenced 2 times by $af39, $af4f
+caf03
+    lda #0                                                            // af03: a9 00       ..
+    bra caed7                                                         // af05: 80 d0       ..
+// $af07 referenced 3 times by $aec4, $af11, $af2a
+caf07
+    jmp c8fbb                                                         // af07: 4c bb 8f    L..
+
+sub_caf0a
+    jsr sub_c9dff                                                     // af0a: 20 ff 9d     ..
+    bne caf88                                                         // af0d: d0 79       .y
+    cpx #$2c // ','                                                   // af0f: e0 2c       .,
+    bne caf07                                                         // af11: d0 f4       ..
+    jsr cbc91                                                         // af13: 20 91 bc     ..
+    inc l001b                                                         // af16: e6 1b       ..
+    jsr sub_c9774                                                     // af18: 20 74 97     t.
+    lda l002a                                                         // af1b: a5 2a       .*
+    pha                                                               // af1d: 48          H
+    lda #$ff                                                          // af1e: a9 ff       ..
+    sta l002a                                                         // af20: 85 2a       .*
+    inc l001b                                                         // af22: e6 1b       ..
+    cpx #$29 // ')'                                                   // af24: e0 29       .)
+    beq caf2f                                                         // af26: f0 07       ..
+    cpx #$2c // ','                                                   // af28: e0 2c       .,
+    bne caf07                                                         // af2a: d0 db       ..
+    jsr sub_c976c                                                     // af2c: 20 6c 97     l.
+// $af2f referenced 1 time by $af26
+caf2f
+    jsr sub_cbd12                                                     // af2f: 20 12 bd     ..
+    pla                                                               // af32: 68          h
+    tay                                                               // af33: a8          .
+    clc                                                               // af34: 18          .
+    beq caf3d                                                         // af35: f0 06       ..
+    sbc l0036                                                         // af37: e5 36       .6
+    bcs caf03                                                         // af39: b0 c8       ..
+    dey                                                               // af3b: 88          .
+    tya                                                               // af3c: 98          .
+// $af3d referenced 1 time by $af35
+caf3d
+    sta l002c                                                         // af3d: 85 2c       .,
+    tax                                                               // af3f: aa          .
+    ldy #0                                                            // af40: a0 00       ..
+    lda l0036                                                         // af42: a5 36       .6
+    sec                                                               // af44: 38          8
+    sbc l002c                                                         // af45: e5 2c       .,
+    cmp l002a                                                         // af47: c5 2a       .*
+    bcs caf4d                                                         // af49: b0 02       ..
+    sta l002a                                                         // af4b: 85 2a       .*
+// $af4d referenced 1 time by $af49
+caf4d
+    lda l002a                                                         // af4d: a5 2a       .*
+    beq caf03                                                         // af4f: f0 b2       ..
+// $af51 referenced 1 time by $af5b
+loop_caf51
+    lda l0600,x                                                       // af51: bd 00 06    ...
+    sta l0600,y                                                       // af54: 99 00 06    ...
+    iny                                                               // af57: c8          .
+    inx                                                               // af58: e8          .
+    cpy l002a                                                         // af59: c4 2a       .*
+    bne loop_caf51                                                    // af5b: d0 f4       ..
+    sty l0036                                                         // af5d: 84 36       .6
+    bra cafb8                                                         // af5f: 80 57       .W
+sub_caf61
+    jsr c8f92                                                         // af61: 20 92 8f     ..
+    ldy #$ff                                                          // af64: a0 ff       ..
+    cmp #$7e // '~'                                                   // af66: c9 7e       .~
+    beq caf6d                                                         // af68: f0 03       ..
+    iny                                                               // af6a: c8          .
+    dec l001b                                                         // af6b: c6 1b       ..
+// $af6d referenced 1 time by $af68
+caf6d
+    phy                                                               // af6d: 5a          Z
+    jsr cad78                                                         // af6e: 20 78 ad     x.
+    beq caf88                                                         // af71: f0 15       ..
+    tay                                                               // af73: a8          .
+    pla                                                               // af74: 68          h
+    sta l0015                                                         // af75: 85 15       ..
+    lda l0403                                                         // af77: ad 03 04    ...
+    bne caf83                                                         // af7a: d0 07       ..
+    sta l0037                                                         // af7c: 85 37       .7
+    jsr ca19b                                                         // af7e: 20 9b a1     ..
+    bra cafb8                                                         // af81: 80 35       .5
+// $af83 referenced 1 time by $af7a
+caf83
+    jsr sub_ca181                                                     // af83: 20 81 a1     ..
+    bra cafb8                                                         // af86: 80 30       .0
+// $af88 referenced 3 times by $af0d, $af71, $af91
+caf88
+    jmp c9155                                                         // af88: 4c 55 91    LU.
+
+sub_caf8b
+    jsr sub_c8fae                                                     // af8b: 20 ae 8f     ..
+    jsr cadee                                                         // af8e: 20 ee ad     ..
+    bne caf88                                                         // af91: d0 f5       ..
+    jsr sub_cbd26                                                     // af93: 20 26 bd     &.
+    ldy l0036                                                         // af96: a4 36       .6
+    beq cafb8                                                         // af98: f0 1e       ..
+    lda l002a                                                         // af9a: a5 2a       .*
+    beq cafbb                                                         // af9c: f0 1d       ..
+    dec l002a                                                         // af9e: c6 2a       .*
+    beq cafb8                                                         // afa0: f0 16       ..
+// $afa2 referenced 1 time by $afb4
+loop_cafa2
+    ldx #0                                                            // afa2: a2 00       ..
+// $afa4 referenced 1 time by $afb0
+loop_cafa4
+    lda l0600,x                                                       // afa4: bd 00 06    ...
+    sta l0600,y                                                       // afa7: 99 00 06    ...
+    inx                                                               // afaa: e8          .
+    iny                                                               // afab: c8          .
+    beq cafbe                                                         // afac: f0 10       ..
+    cpx l0036                                                         // afae: e4 36       .6
+    bcc loop_cafa4                                                    // afb0: 90 f2       ..
+    dec l002a                                                         // afb2: c6 2a       .*
+    bne loop_cafa2                                                    // afb4: d0 ec       ..
+    sty l0036                                                         // afb6: 84 36       .6
+// $afb8 referenced 5 times by $af5f, $af81, $af86, $af98, $afa0
+cafb8
+    lda #0                                                            // afb8: a9 00       ..
+    rts                                                               // afba: 60          `
+
+// $afbb referenced 1 time by $af9c
+cafbb
+    sta l0036                                                         // afbb: 85 36       .6
+    rts                                                               // afbd: 60          `
+
+// $afbe referenced 1 time by $afac
+cafbe
+    jmp c9ecb                                                         // afbe: 4c cb 9e    L..
+
+// $afc1 referenced 1 time by $afdf
+loop_cafc1
+    pla                                                               // afc1: 68          h
+    sta l000c                                                         // afc2: 85 0c       ..
+    pla                                                               // afc4: 68          h
+    sta l000b                                                         // afc5: 85 0b       ..
+    brk                                                               // afc7: 00          .
+
+    .byt $1d                                                          // afc8: 1d          .
+    .asc "No such "                                                   // afc9: 4e 6f 20... No
+    .byt $a4, $2f, $f2,   0                                           // afd1: a4 2f f2... ./.
+
+// $afd5 referenced 1 time by $b0a3
+cafd5
+    lda l0018                                                         // afd5: a5 18       ..
+    sta l000c                                                         // afd7: 85 0c       ..
+    stz l000b                                                         // afd9: 64 0b       d.
+// $afdb referenced 2 times by $aff7, $affb
+cafdb
+    ldy #1                                                            // afdb: a0 01       ..
+    lda (l000b),y                                                     // afdd: b1 0b       ..
+    bmi loop_cafc1                                                    // afdf: 30 e0       0.
+    ldy #3                                                            // afe1: a0 03       ..
+// $afe3 referenced 1 time by $afe8
+loop_cafe3
+    iny                                                               // afe3: c8          .
+    lda (l000b),y                                                     // afe4: b1 0b       ..
+    cmp #$20 // ' '                                                   // afe6: c9 20       .
+    beq loop_cafe3                                                    // afe8: f0 f9       ..
+    cmp #$dd                                                          // afea: c9 dd       ..
+    beq caffd                                                         // afec: f0 0f       ..
+// $afee referenced 2 times by $b01e, $b02a
+cafee
+    ldy #3                                                            // afee: a0 03       ..
+    lda (l000b),y                                                     // aff0: b1 0b       ..
+    clc                                                               // aff2: 18          .
+    adc l000b                                                         // aff3: 65 0b       e.
+    sta l000b                                                         // aff5: 85 0b       ..
+    bcc cafdb                                                         // aff7: 90 e2       ..
+    inc l000c                                                         // aff9: e6 0c       ..
+    bra cafdb                                                         // affb: 80 de       ..
+// $affd referenced 1 time by $afec
+caffd
+    iny                                                               // affd: c8          .
+    sty l000a                                                         // affe: 84 0a       ..
+    jsr c8f9d                                                         // b000: 20 9d 8f     ..
+    tya                                                               // b003: 98          .
+    tax                                                               // b004: aa          .
+    clc                                                               // b005: 18          .
+    adc l000b                                                         // b006: 65 0b       e.
+    ldy l000c                                                         // b008: a4 0c       ..
+    bcc cb00e                                                         // b00a: 90 02       ..
+    iny                                                               // b00c: c8          .
+    clc                                                               // b00d: 18          .
+// $b00e referenced 1 time by $b00a
+cb00e
+    sbc #0                                                            // b00e: e9 00       ..
+    sta l003c                                                         // b010: 85 3c       .<
+    tya                                                               // b012: 98          .
+    sbc #0                                                            // b013: e9 00       ..
+    sta l003d                                                         // b015: 85 3d       .=
+    ldy #1                                                            // b017: a0 01       ..
+// $b019 referenced 1 time by $b023
+loop_cb019
+    inx                                                               // b019: e8          .
+    lda (l003c),y                                                     // b01a: b1 3c       .<
+    cmp (l0037),y                                                     // b01c: d1 37       .7
+    bne cafee                                                         // b01e: d0 ce       ..
+    iny                                                               // b020: c8          .
+    cpy l0039                                                         // b021: c4 39       .9
+    bne loop_cb019                                                    // b023: d0 f4       ..
+    lda (l003c),y                                                     // b025: b1 3c       .<
+    jsr sub_c8e41                                                     // b027: 20 41 8e     A.
+    bcs cafee                                                         // b02a: b0 c2       ..
+    txa                                                               // b02c: 8a          .
+    tay                                                               // b02d: a8          .
+    jsr c9c80                                                         // b02e: 20 80 9c     ..
+    jsr sub_c9914                                                     // b031: 20 14 99     ..
+    ldx #1                                                            // b034: a2 01       ..
+    jsr sub_c9952                                                     // b036: 20 52 99     R.
+    lda l000b                                                         // b039: a5 0b       ..
+    sta (l0002)                                                       // b03b: 92 02       ..
+    ldy #1                                                            // b03d: a0 01       ..
+    lda l000c                                                         // b03f: a5 0c       ..
+    sta (l0002),y                                                     // b041: 91 02       ..
+    iny                                                               // b043: c8          .
+    jsr sub_c995a                                                     // b044: 20 5a 99     Z.
+    jmp cb0b0                                                         // b047: 4c b0 b0    L..
+
+// $b04a referenced 1 time by $b09a
+cb04a
+    brk                                                               // b04a: 00          .
+
+    .byt $1e                                                          // b04b: 1e          .
+    .asc "Bad call"                                                   // b04c: 42 61 64... Bad
+    .byt 0                                                            // b054: 00          .
+
+sub_cb055
+    lda #$a4                                                          // b055: a9 a4       ..
+// $b057 referenced 2 times by $97b7, $b83c
+sub_cb057
+    sta l0027                                                         // b057: 85 27       .'
+    tsx                                                               // b059: ba          .
+    txa                                                               // b05a: 8a          .
+    clc                                                               // b05b: 18          .
+    adc l0004                                                         // b05c: 65 04       e.
+    jsr sub_cbd5e                                                     // b05e: 20 5e bd     ^.
+    txa                                                               // b061: 8a          .
+    sta (l0004)                                                       // b062: 92 04       ..
+    ldy #0                                                            // b064: a0 00       ..
+// $b066 referenced 1 time by $b06f
+loop_cb066
+    inx                                                               // b066: e8          .
+    iny                                                               // b067: c8          .
+    lda l0100,x                                                       // b068: bd 00 01    ...
+    sta (l0004),y                                                     // b06b: 91 04       ..
+    cpx #$ff                                                          // b06d: e0 ff       ..
+    bne loop_cb066                                                    // b06f: d0 f5       ..
+    txs                                                               // b071: 9a          .
+    lda l0027                                                         // b072: a5 27       .'
+    pha                                                               // b074: 48          H
+    lda l000a                                                         // b075: a5 0a       ..
+    pha                                                               // b077: 48          H
+    lda l000b                                                         // b078: a5 0b       ..
+    pha                                                               // b07a: 48          H
+    lda l000c                                                         // b07b: a5 0c       ..
+    pha                                                               // b07d: 48          H
+    lda l001b                                                         // b07e: a5 1b       ..
+    tax                                                               // b080: aa          .
+    clc                                                               // b081: 18          .
+    adc l0019                                                         // b082: 65 19       e.
+    ldy l001a                                                         // b084: a4 1a       ..
+    bcc cb08a                                                         // b086: 90 02       ..
+    iny                                                               // b088: c8          .
+    clc                                                               // b089: 18          .
+// $b08a referenced 1 time by $b086
+cb08a
+    sbc #1                                                            // b08a: e9 01       ..
+    sta l0037                                                         // b08c: 85 37       .7
+    tya                                                               // b08e: 98          .
+    sbc #0                                                            // b08f: e9 00       ..
+    sta l0038                                                         // b091: 85 38       .8
+    ldy #2                                                            // b093: a0 02       ..
+    jsr c9bbc                                                         // b095: 20 bc 9b     ..
+    cpy #2                                                            // b098: c0 02       ..
+    beq cb04a                                                         // b09a: f0 ae       ..
+    stx l001b                                                         // b09c: 86 1b       ..
+    jsr sub_c8139                                                     // b09e: 20 39 81     9.
+    bne cb0a6                                                         // b0a1: d0 03       ..
+    jmp cafd5                                                         // b0a3: 4c d5 af    L..
+
+// $b0a6 referenced 1 time by $b0a1
+cb0a6
+    lda (l002a)                                                       // b0a6: b2 2a       .*
+    sta l000b                                                         // b0a8: 85 0b       ..
+    ldy #1                                                            // b0aa: a0 01       ..
+    lda (l002a),y                                                     // b0ac: b1 2a       .*
+    sta l000c                                                         // b0ae: 85 0c       ..
+// $b0b0 referenced 1 time by $b047
+cb0b0
+    lda #0                                                            // b0b0: a9 00       ..
+    pha                                                               // b0b2: 48          H
+    stz l000a                                                         // b0b3: 64 0a       d.
+    jsr c8f9d                                                         // b0b5: 20 9d 8f     ..
+    cmp #$28 // '('                                                   // b0b8: c9 28       .(
+    beq cb109                                                         // b0ba: f0 4d       .M
+    dec l000a                                                         // b0bc: c6 0a       ..
+// $b0be referenced 1 time by $b1bc
+cb0be
+    lda l001b                                                         // b0be: a5 1b       ..
+    pha                                                               // b0c0: 48          H
+    lda l0019                                                         // b0c1: a5 19       ..
+    pha                                                               // b0c3: 48          H
+    lda l001a                                                         // b0c4: a5 1a       ..
+    pha                                                               // b0c6: 48          H
+    jsr c90d0                                                         // b0c7: 20 d0 90     ..
+    pla                                                               // b0ca: 68          h
+    sta l001a                                                         // b0cb: 85 1a       ..
+    pla                                                               // b0cd: 68          h
+    sta l0019                                                         // b0ce: 85 19       ..
+    pla                                                               // b0d0: 68          h
+    sta l001b                                                         // b0d1: 85 1b       ..
+    pla                                                               // b0d3: 68          h
+    beq cb0e2                                                         // b0d4: f0 0c       ..
+    sta l003f                                                         // b0d6: 85 3f       .?
+// $b0d8 referenced 1 time by $b0e0
+loop_cb0d8
+    jsr sub_cbd46                                                     // b0d8: 20 46 bd     F.
+    jsr sub_cbcaa                                                     // b0db: 20 aa bc     ..
+    dec l003f                                                         // b0de: c6 3f       .?
+    bne loop_cb0d8                                                    // b0e0: d0 f6       ..
+// $b0e2 referenced 1 time by $b0d4
+cb0e2
+    pla                                                               // b0e2: 68          h
+    sta l000c                                                         // b0e3: 85 0c       ..
+    pla                                                               // b0e5: 68          h
+    sta l000b                                                         // b0e6: 85 0b       ..
+    pla                                                               // b0e8: 68          h
+    sta l000a                                                         // b0e9: 85 0a       ..
+    pla                                                               // b0eb: 68          h
+    lda (l0004)                                                       // b0ec: b2 04       ..
+    tax                                                               // b0ee: aa          .
+    txs                                                               // b0ef: 9a          .
+    ldy #0                                                            // b0f0: a0 00       ..
+// $b0f2 referenced 1 time by $b0fb
+loop_cb0f2
+    iny                                                               // b0f2: c8          .
+    inx                                                               // b0f3: e8          .
+    lda (l0004),y                                                     // b0f4: b1 04       ..
+    sta l0100,x                                                       // b0f6: 9d 00 01    ...
+    cpx #$ff                                                          // b0f9: e0 ff       ..
+    bne loop_cb0f2                                                    // b0fb: d0 f5       ..
+    tya                                                               // b0fd: 98          .
+    adc l0004                                                         // b0fe: 65 04       e.
+    sta l0004                                                         // b100: 85 04       ..
+    bcc cb106                                                         // b102: 90 02       ..
+    inc l0005                                                         // b104: e6 05       ..
+// $b106 referenced 1 time by $b102
+cb106
+    lda l0027                                                         // b106: a5 27       .'
+    rts                                                               // b108: 60          `
+
+// $b109 referenced 2 times by $b0ba, $b136
+cb109
+    lda l001b                                                         // b109: a5 1b       ..
+    pha                                                               // b10b: 48          H
+    lda l0019                                                         // b10c: a5 19       ..
+    pha                                                               // b10e: 48          H
+    lda l001a                                                         // b10f: a5 1a       ..
+    pha                                                               // b111: 48          H
+    jsr sub_c997d                                                     // b112: 20 7d 99     }.
+    beq cb169                                                         // b115: f0 52       .R
+    lda l001b                                                         // b117: a5 1b       ..
+    sta l000a                                                         // b119: 85 0a       ..
+    pla                                                               // b11b: 68          h
+    sta l001a                                                         // b11c: 85 1a       ..
+    pla                                                               // b11e: 68          h
+    sta l0019                                                         // b11f: 85 19       ..
+    pla                                                               // b121: 68          h
+    sta l001b                                                         // b122: 85 1b       ..
+    plx                                                               // b124: fa          .
+    lda l002c                                                         // b125: a5 2c       .,
+    pha                                                               // b127: 48          H
+    lda l002b                                                         // b128: a5 2b       .+
+    pha                                                               // b12a: 48          H
+    lda l002a                                                         // b12b: a5 2a       .*
+    pha                                                               // b12d: 48          H
+    inx                                                               // b12e: e8          .
+    phx                                                               // b12f: da          .
+    jsr sub_cb1bf                                                     // b130: 20 bf b1     ..
+    jsr sub_c8da2                                                     // b133: 20 a2 8d     ..
+    beq cb109                                                         // b136: f0 d1       ..
+    cmp #$29 // ')'                                                   // b138: c9 29       .)
+    bne cb169                                                         // b13a: d0 2d       .-
+    lda #0                                                            // b13c: a9 00       ..
+    pha                                                               // b13e: 48          H
+    jsr c8f92                                                         // b13f: 20 92 8f     ..
+    cmp #$28 // '('                                                   // b142: c9 28       .(
+    bne cb169                                                         // b144: d0 23       .#
+// $b146 referenced 1 time by $b159
+loop_cb146
+    jsr sub_c9dff                                                     // b146: 20 ff 9d     ..
+    jsr sub_cbc62                                                     // b149: 20 62 bc     b.
+    lda l0027                                                         // b14c: a5 27       .'
+    sta l002d                                                         // b14e: 85 2d       .-
+    jsr cbc66                                                         // b150: 20 66 bc     f.
+    plx                                                               // b153: fa          .
+    inx                                                               // b154: e8          .
+    phx                                                               // b155: da          .
+    jsr sub_c8fa8                                                     // b156: 20 a8 8f     ..
+    beq loop_cb146                                                    // b159: f0 eb       ..
+    cmp #$29 // ')'                                                   // b15b: c9 29       .)
+    bne cb169                                                         // b15d: d0 0a       ..
+    pla                                                               // b15f: 68          h
+    pla                                                               // b160: 68          h
+    sta l004c                                                         // b161: 85 4c       .L
+    sta l004d                                                         // b163: 85 4d       .M
+    cpx l004c                                                         // b165: e4 4c       .L
+    beq cb17e                                                         // b167: f0 15       ..
+// $b169 referenced 6 times by $b115, $b13a, $b144, $b15d, $b18e, $b1ad
+cb169
+    ldx #$fb                                                          // b169: a2 fb       ..
+    txs                                                               // b16b: 9a          .
+    pla                                                               // b16c: 68          h
+    sta l000c                                                         // b16d: 85 0c       ..
+    pla                                                               // b16f: 68          h
+    sta l000b                                                         // b170: 85 0b       ..
+    brk                                                               // b172: 00          .
+
+    .byt $1f                                                          // b173: 1f          .
+    .asc "Arguments"                                                  // b174: 41 72 67... Arg
+    .byt 0                                                            // b17d: 00          .
+
+// $b17e referenced 2 times by $b167, $b1b7
+cb17e
+    jsr sub_cbd26                                                     // b17e: 20 26 bd     &.
+    pla                                                               // b181: 68          h
+    sta l002a                                                         // b182: 85 2a       .*
+    pla                                                               // b184: 68          h
+    sta l002b                                                         // b185: 85 2b       .+
+    pla                                                               // b187: 68          h
+    sta l002c                                                         // b188: 85 2c       .,
+    bmi cb1ab                                                         // b18a: 30 1f       0.
+    lda l002d                                                         // b18c: a5 2d       .-
+    beq cb169                                                         // b18e: f0 d9       ..
+    sta l0027                                                         // b190: 85 27       .'
+    ldx #$37 // '7'                                                   // b192: a2 37       .7
+    jsr sub_cbe06                                                     // b194: 20 06 be     ..
+    lda l0027                                                         // b197: a5 27       .'
+    bpl cb1a3                                                         // b199: 10 08       ..
+    jsr sub_cbc24                                                     // b19b: 20 24 bc     $.
+    jsr ca57e                                                         // b19e: 20 7e a5     ~.
+    bra cb1a6                                                         // b1a1: 80 03       ..
+// $b1a3 referenced 1 time by $b199
+cb1a3
+    jsr sub_cbd26                                                     // b1a3: 20 26 bd     &.
+// $b1a6 referenced 1 time by $b1a1
+cb1a6
+    jsr sub_cb372                                                     // b1a6: 20 72 b3     r.
+    bra cb1b5                                                         // b1a9: 80 0a       ..
+// $b1ab referenced 1 time by $b18a
+cb1ab
+    lda l002d                                                         // b1ab: a5 2d       .-
+    bne cb169                                                         // b1ad: d0 ba       ..
+    jsr sub_cbd12                                                     // b1af: 20 12 bd     ..
+    jsr sub_c9171                                                     // b1b2: 20 71 91     q.
+// $b1b5 referenced 1 time by $b1a9
+cb1b5
+    dec l004c                                                         // b1b5: c6 4c       .L
+    bne cb17e                                                         // b1b7: d0 c5       ..
+    lda l004d                                                         // b1b9: a5 4d       .M
+    pha                                                               // b1bb: 48          H
+    jmp cb0be                                                         // b1bc: 4c be b0    L..
+
+// $b1bf referenced 2 times by $97dc, $b130
+sub_cb1bf
+    ldy l002c                                                         // b1bf: a4 2c       .,
+    cpy #5                                                            // b1c1: c0 05       ..
+    bcs cb1ca                                                         // b1c3: b0 05       ..
+    ldx #$37 // '7'                                                   // b1c5: a2 37       .7
+    jsr sub_cbe06                                                     // b1c7: 20 06 be     ..
+// $b1ca referenced 1 time by $b1c3
+cb1ca
+    jsr cb1de                                                         // b1ca: 20 de b1     ..
+    php                                                               // b1cd: 08          .
+    jsr sub_cbc62                                                     // b1ce: 20 62 bc     b.
+    plp                                                               // b1d1: 28          (
+    beq cb1db                                                         // b1d2: f0 07       ..
+    bmi cb1db                                                         // b1d4: 30 05       0.
+    ldx #$37 // '7'                                                   // b1d6: a2 37       .7
+    jsr sub_caad8                                                     // b1d8: 20 d8 aa     ..
+// $b1db referenced 2 times by $b1d2, $b1d4
+cb1db
+    jmp cbc66                                                         // b1db: 4c 66 bc    Lf.
+
+// $b1de referenced 3 times by $9a7f, $adb3, $b1ca
+cb1de
+    ldy l002c                                                         // b1de: a4 2c       .,
+    bmi cb235                                                         // b1e0: 30 53       0S
+    beq cb200                                                         // b1e2: f0 1c       ..
+    cpy #5                                                            // b1e4: c0 05       ..
+    beq cb205                                                         // b1e6: f0 1d       ..
+    ldy #3                                                            // b1e8: a0 03       ..
+    lda (l002a),y                                                     // b1ea: b1 2a       .*
+    sta l002d                                                         // b1ec: 85 2d       .-
+    dey                                                               // b1ee: 88          .
+    lda (l002a),y                                                     // b1ef: b1 2a       .*
+    sta l002c                                                         // b1f1: 85 2c       .,
+    dey                                                               // b1f3: 88          .
+    lda (l002a),y                                                     // b1f4: b1 2a       .*
+    tax                                                               // b1f6: aa          .
+    lda (l002a)                                                       // b1f7: b2 2a       .*
+    sta l002a                                                         // b1f9: 85 2a       .*
+    stx l002b                                                         // b1fb: 86 2b       .+
+    lda #$40 // '@'                                                   // b1fd: a9 40       .@
+    rts                                                               // b1ff: 60          `
+
+// $b200 referenced 1 time by $b1e2
+cb200
+    lda (l002a),y                                                     // b200: b1 2a       .*
+    jmp cae62                                                         // b202: 4c 62 ae    Lb.
+
+// $b205 referenced 2 times by $b1e6, $b5f1
+cb205
+    stz l0035                                                         // b205: 64 35       d5
+    stz l002f                                                         // b207: 64 2f       d/
+    dey                                                               // b209: 88          .
+    lda (l002a),y                                                     // b20a: b1 2a       .*
+    sta l0034                                                         // b20c: 85 34       .4
+    dey                                                               // b20e: 88          .
+    lda (l002a),y                                                     // b20f: b1 2a       .*
+    sta l0033                                                         // b211: 85 33       .3
+    dey                                                               // b213: 88          .
+    lda (l002a),y                                                     // b214: b1 2a       .*
+    sta l0032                                                         // b216: 85 32       .2
+    dey                                                               // b218: 88          .
+    lda (l002a),y                                                     // b219: b1 2a       .*
+    sta l002e                                                         // b21b: 85 2e       ..
+    tay                                                               // b21d: a8          .
+    lda (l002a)                                                       // b21e: b2 2a       .*
+    sta l0030                                                         // b220: 85 30       .0
+    bne cb22d                                                         // b222: d0 09       ..
+    tya                                                               // b224: 98          .
+    ora l0032                                                         // b225: 05 32       .2
+    ora l0033                                                         // b227: 05 33       .3
+    ora l0034                                                         // b229: 05 34       .4
+    beq cb230                                                         // b22b: f0 03       ..
+// $b22d referenced 1 time by $b222
+cb22d
+    tya                                                               // b22d: 98          .
+    ora #$80                                                          // b22e: 09 80       ..
+// $b230 referenced 1 time by $b22b
+cb230
+    sta l0031                                                         // b230: 85 31       .1
+    lda #$ff                                                          // b232: a9 ff       ..
+    rts                                                               // b234: 60          `
+
+// $b235 referenced 1 time by $b1e0
+cb235
+    cpy #$80                                                          // b235: c0 80       ..
+    beq cb257                                                         // b237: f0 1e       ..
+    ldy #3                                                            // b239: a0 03       ..
+    lda (l002a),y                                                     // b23b: b1 2a       .*
+    sta l0036                                                         // b23d: 85 36       .6
+    beq cb256                                                         // b23f: f0 15       ..
+    ldy #1                                                            // b241: a0 01       ..
+    lda (l002a),y                                                     // b243: b1 2a       .*
+    sta l0038                                                         // b245: 85 38       .8
+    lda (l002a)                                                       // b247: b2 2a       .*
+    sta l0037                                                         // b249: 85 37       .7
+    ldy l0036                                                         // b24b: a4 36       .6
+// $b24d referenced 1 time by $b254
+loop_cb24d
+    dey                                                               // b24d: 88          .
+    lda (l0037),y                                                     // b24e: b1 37       .7
+    sta l0600,y                                                       // b250: 99 00 06    ...
+    tya                                                               // b253: 98          .
+    bne loop_cb24d                                                    // b254: d0 f7       ..
+// $b256 referenced 1 time by $b23f
+cb256
+    rts                                                               // b256: 60          `
+
+// $b257 referenced 1 time by $b237
+cb257
+    ldy #0                                                            // b257: a0 00       ..
+// $b259 referenced 1 time by $b263
+loop_cb259
+    lda (l002a),y                                                     // b259: b1 2a       .*
+    sta l0600,y                                                       // b25b: 99 00 06    ...
+    eor #$0d                                                          // b25e: 49 0d       I.
+    beq cb266                                                         // b260: f0 04       ..
+    iny                                                               // b262: c8          .
+    bne loop_cb259                                                    // b263: d0 f4       ..
+    tya                                                               // b265: 98          .
+// $b266 referenced 1 time by $b260
+cb266
+    sty l0036                                                         // b266: 84 36       .6
+    rts                                                               // b268: 60          `
+
+sub_cb269
+    jsr sub_c9779                                                     // b269: 20 79 97     y.
+    lda l002a                                                         // b26c: a5 2a       .*
+    jmp caeb4                                                         // b26e: 4c b4 ae    L..
+
+    .byt $a4, $0a, $f0,   1, $88, $20, $80, $9c, $64,   8, $64,   9   // b271: a4 0a f0... ...
+    .byt $a6, $18, $86                                                // b27d: a6 18 86    ...
+    .asc "8d7"                                                        // b280: 38 64 37    8d7
+    .byt $a4, $0c, $c0,   7, $f0, $28, $a6, $0b, $20, $5d, $8e, $c9   // b283: a4 0c c0... ...
+    .byt $0d, $d0, $18, $e4, $37, $98, $e5, $38, $90, $18, $20, $5d   // b28f: 0d d0 18... ...
+    .byt $8e,   9,   0, $30, $11, $85,   9, $20, $5d, $8e, $85,   8   // b29b: 8e 09 00... ...
+    .byt $20, $5d, $8e, $e4, $37, $98, $e5, $38, $b0, $da, $60, $a2   // b2a7: 20 5d 8e...  ].
+    .byt $ff, $86, $28, $9a, $e8, $a0,   0, $a9, $da, $20, $f4, $ff   // b2b3: ff 86 28... ..(
+    .byt $a9, $7e, $20, $f4, $ff, $20, $71, $b2, $64, $20, $b2, $fd   // b2bf: a9 7e 20... .~
+    .byt $d0,   3, $20, $e0, $b2, $a5, $16, $85, $0b, $a5, $17, $85   // b2cb: d0 03 20... ..
+    .byt $0c, $64, $0a, $20, $ff, $bb, $4c, $d0, $90                  // b2d7: 0c 64 0a... .d.
+
+// $b2e0 referenced 3 times by $9051, $905f, $b76c
+sub_cb2e0
+    lda #$e9                                                          // b2e0: a9 e9       ..
+    sta l0016                                                         // b2e2: 85 16       ..
+    lda #$b2                                                          // b2e4: a9 b2       ..
+    sta l0017                                                         // b2e6: 85 17       ..
+    rts                                                               // b2e8: 60          `
+
+    .byt $f6, $3a, $e7, $9e, $f1                                      // b2e9: f6 3a e7... .:.
+    .asc "", 34, " at line ", 34, ";"                                 // b2ee: 22 20 61... " a
+    .byt $9e, $3a, $e0, $8b, $f1, $3a, $e0, $0d                       // b2fa: 9e 3a e0... .:.
+
+sub_cb302
+    jsr sub_c9332                                                     // b302: 20 32 93     2.
+    ldx #3                                                            // b305: a2 03       ..
+// $b307 referenced 1 time by $b313
+loop_cb307
+    lda l002a                                                         // b307: a5 2a       .*
+    pha                                                               // b309: 48          H
+    lda l002b                                                         // b30a: a5 2b       .+
+    pha                                                               // b30c: 48          H
+    phx                                                               // b30d: da          .
+    jsr sub_c9771                                                     // b30e: 20 71 97     q.
+    plx                                                               // b311: fa          .
+    dex                                                               // b312: ca          .
+    bne loop_cb307                                                    // b313: d0 f2       ..
+    jsr sub_c9c5a                                                     // b315: 20 5a 9c     Z.
+    lda l002a                                                         // b318: a5 2a       .*
+    sta l003d                                                         // b31a: 85 3d       .=
+    lda l002b                                                         // b31c: a5 2b       .+
+    sta l003e                                                         // b31e: 85 3e       .>
+    ldy #7                                                            // b320: a0 07       ..
+    ldx #5                                                            // b322: a2 05       ..
+    bra cb341                                                         // b324: 80 1b       ..
+sub_cb326
+    jsr sub_c9332                                                     // b326: 20 32 93     2.
+    ldx #$0d                                                          // b329: a2 0d       ..
+// $b32b referenced 1 time by $b334
+loop_cb32b
+    lda l002a                                                         // b32b: a5 2a       .*
+    pha                                                               // b32d: 48          H
+    phx                                                               // b32e: da          .
+    jsr sub_c9771                                                     // b32f: 20 71 97     q.
+    plx                                                               // b332: fa          .
+    dex                                                               // b333: ca          .
+    bne loop_cb32b                                                    // b334: d0 f5       ..
+    jsr sub_c9c5a                                                     // b336: 20 5a 9c     Z.
+    lda l002a                                                         // b339: a5 2a       .*
+    sta l0044                                                         // b33b: 85 44       .D
+    ldx #$0c                                                          // b33d: a2 0c       ..
+    ldy #8                                                            // b33f: a0 08       ..
+// $b341 referenced 2 times by $b324, $b345
+cb341
+    pla                                                               // b341: 68          h
+    sta l0037,x                                                       // b342: 95 37       .7
+    dex                                                               // b344: ca          .
+    bpl cb341                                                         // b345: 10 fa       ..
+    tya                                                               // b347: 98          .
+    ldx #<(l0037)                                                     // b348: a2 37       .7
+    ldy #>(l0037)                                                     // b34a: a0 00       ..
+// $b34c referenced 1 time by $9750
+cb34c
+    jsr osword                                                        // b34c: 20 f1 ff     ..
+    bra cb35c                                                         // b34f: 80 0b       ..
+sub_cb351
+    jsr sub_c9332                                                     // b351: 20 32 93     2.
+    jsr sub_c9c5a                                                     // b354: 20 5a 9c     Z.
+    ldy l002a                                                         // b357: a4 2a       .*
+    dey                                                               // b359: 88          .
+    sty l0023                                                         // b35a: 84 23       .#
+// $b35c referenced 1 time by $b34f
+cb35c
+    jmp c90ca                                                         // b35c: 4c ca 90    L..
+
+// $b35f referenced 1 time by $b377
+loop_cb35f
+    jmp c9155                                                         // b35f: 4c 55 91    LU.
+
+// $b362 referenced 2 times by $b656, $b9ba
+sub_cb362
+    jsr sub_c9dff                                                     // b362: 20 ff 9d     ..
+// $b365 referenced 5 times by $8aa0, $9141, $95b8, $97eb, $b971
+sub_cb365
+    ply                                                               // b365: 7a          z
+    plx                                                               // b366: fa          .
+    pla                                                               // b367: 68          h
+    sta l0039                                                         // b368: 85 39       .9
+    pla                                                               // b36a: 68          h
+    sta l0038                                                         // b36b: 85 38       .8
+    pla                                                               // b36d: 68          h
+    sta l0037                                                         // b36e: 85 37       .7
+    phx                                                               // b370: da          .
+    phy                                                               // b371: 5a          Z
+// $b372 referenced 2 times by $b1a6, $b8dd
+sub_cb372
+    lda l0039                                                         // b372: a5 39       .9
+    lsr                                                               // b374: 4a          J
+    lda l0027                                                         // b375: a5 27       .'
+    beq loop_cb35f                                                    // b377: f0 e6       ..
+    bcs cb399                                                         // b379: b0 1e       ..
+    bpl cb380                                                         // b37b: 10 03       ..
+    jsr sub_c9788                                                     // b37d: 20 88 97     ..
+// $b380 referenced 1 time by $b37b
+cb380
+    lda l002a                                                         // b380: a5 2a       .*
+    sta (l0037)                                                       // b382: 92 37       .7
+    lda l0039                                                         // b384: a5 39       .9
+    beq cb398                                                         // b386: f0 10       ..
+    lda l002b                                                         // b388: a5 2b       .+
+    ldy #1                                                            // b38a: a0 01       ..
+    sta (l0037),y                                                     // b38c: 91 37       .7
+    lda l002c                                                         // b38e: a5 2c       .,
+    iny                                                               // b390: c8          .
+    sta (l0037),y                                                     // b391: 91 37       .7
+    lda l002d                                                         // b393: a5 2d       .-
+    iny                                                               // b395: c8          .
+    sta (l0037),y                                                     // b396: 91 37       .7
+// $b398 referenced 1 time by $b386
+cb398
+    rts                                                               // b398: 60          `
+
+// $b399 referenced 1 time by $b379
+cb399
+    bmi cb39e                                                         // b399: 30 03       0.
+    jsr c828d                                                         // b39b: 20 8d 82     ..
+// $b39e referenced 2 times by $b399, $b609
+cb39e
+    lda l0030                                                         // b39e: a5 30       .0
+    sta (l0037)                                                       // b3a0: 92 37       .7
+    ldy #1                                                            // b3a2: a0 01       ..
+    lda l002e                                                         // b3a4: a5 2e       ..
+    eor l0031                                                         // b3a6: 45 31       E1
+    and #$80                                                          // b3a8: 29 80       ).
+    eor l0031                                                         // b3aa: 45 31       E1
+    sta (l0037),y                                                     // b3ac: 91 37       .7
+    iny                                                               // b3ae: c8          .
+    lda l0032                                                         // b3af: a5 32       .2
+    sta (l0037),y                                                     // b3b1: 91 37       .7
+    iny                                                               // b3b3: c8          .
+    lda l0033                                                         // b3b4: a5 33       .3
+    sta (l0037),y                                                     // b3b6: 91 37       .7
+    iny                                                               // b3b8: c8          .
+    lda l0034                                                         // b3b9: a5 34       .4
+    sta (l0037),y                                                     // b3bb: 91 37       .7
+    rts                                                               // b3bd: 60          `
+
+// $b3be referenced 1 time by $bf56
+lb3be
+    .asc "EDIT 12,2"                                                  // b3be: 45 44 49... EDI
+    .byt $0d                                                          // b3c7: 0d          .
+
+sub_cb3c8
+    jsr sub_cbbdc                                                     // b3c8: 20 dc bb     ..
+    lda #$80                                                          // b3cb: a9 80       ..
+    sta l001f                                                         // b3cd: 85 1f       ..
+// $b3cf referenced 1 time by $b417
+cb3cf
+    stz l003b                                                         // b3cf: 64 3b       d;
+    stz l003c                                                         // b3d1: 64 3c       d<
+    jsr cac38                                                         // b3d3: 20 38 ac     8.
+    jsr sub_c9be2                                                     // b3d6: 20 e2 9b     ..
+    php                                                               // b3d9: 08          .
+    jsr cbc66                                                         // b3da: 20 66 bc     f.
+    jsr cac2b                                                         // b3dd: 20 2b ac     +.
+    lsr l002b                                                         // b3e0: 46 2b       F+
+    plp                                                               // b3e2: 28          (
+    bcc cb3f4                                                         // b3e3: 90 0f       ..
+    jsr sub_c8da2                                                     // b3e5: 20 a2 8d     ..
+    beq cb3fb                                                         // b3e8: f0 11       ..
+    jsr sub_cbd26                                                     // b3ea: 20 26 bd     &.
+    jsr cbc66                                                         // b3ed: 20 66 bc     f.
+    dec l000a                                                         // b3f0: c6 0a       ..
+    bra cb3fe                                                         // b3f2: 80 0a       ..
+// $b3f4 referenced 1 time by $b3e3
+cb3f4
+    jsr sub_c8da2                                                     // b3f4: 20 a2 8d     ..
+    beq cb3fb                                                         // b3f7: f0 02       ..
+    dec l000a                                                         // b3f9: c6 0a       ..
+// $b3fb referenced 2 times by $b3e8, $b3f7
+cb3fb
+    jsr sub_c9be2                                                     // b3fb: 20 e2 9b     ..
+// $b3fe referenced 1 time by $b3f2
+cb3fe
+    ldx #$31 // '1'                                                   // b3fe: a2 31       .1
+    jsr sub_cbe06                                                     // b400: 20 06 be     ..
+    jsr c8f9d                                                         // b403: 20 9d 8f     ..
+    cmp #$e7                                                          // b406: c9 e7       ..
+    bne cb428                                                         // b408: d0 1e       ..
+    jsr c8f9d                                                         // b40a: 20 9d 8f     ..
+    jsr c9c80                                                         // b40d: 20 80 9c     ..
+    bra cb42b                                                         // b410: 80 19       ..
+sub_cb412
+    iny                                                               // b412: c8          .
+    lda (l000b),y                                                     // b413: b1 0b       ..
+    cmp #$4f // 'O'                                                   // b415: c9 4f       .O
+    bne cb3cf                                                         // b417: d0 b6       ..
+    inc l000a                                                         // b419: e6 0a       ..
+    jsr sub_c9332                                                     // b41b: 20 32 93     2.
+    jsr c9c6a                                                         // b41e: 20 6a 9c     j.
+    lda l002a                                                         // b421: a5 2a       .*
+    sta l001f                                                         // b423: 85 1f       ..
+// $b425 referenced 1 time by $b46a
+cb425
+    jmp c904b                                                         // b425: 4c 4b 90    LK.
+
+// $b428 referenced 1 time by $b408
+cb428
+    jsr c9c74                                                         // b428: 20 74 9c     t.
+// $b42b referenced 1 time by $b410
+cb42b
+    lda l000b                                                         // b42b: a5 0b       ..
+    sta l0019                                                         // b42d: 85 19       ..
+    jsr sub_cbe25                                                     // b42f: 20 25 be     %.
+    jsr sub_cbd26                                                     // b432: 20 26 bd     &.
+    jsr sub_c8191                                                     // b435: 20 91 81     ..
+    lda l003d                                                         // b438: a5 3d       .=
+    sta l000b                                                         // b43a: 85 0b       ..
+    lda l003e                                                         // b43c: a5 3e       .>
+    sta l000c                                                         // b43e: 85 0c       ..
+    bcs cb45d                                                         // b440: b0 1b       ..
+    dey                                                               // b442: 88          .
+    bra cb454                                                         // b443: 80 0f       ..
+// $b445 referenced 1 time by $b4b8
+cb445
+    jsr cbdd4                                                         // b445: 20 d4 bd     ..
+    bit l001f                                                         // b448: 24 1f       $.
+    bmi cb451                                                         // b44a: 30 05       0.
+    lda #$0a                                                          // b44c: a9 0a       ..
+    jsr oswrch                                                        // b44e: 20 ee ff     ..
+// $b451 referenced 2 times by $b44a, $b4c4
+cb451
+    jsr c9c80                                                         // b451: 20 80 9c     ..
+// $b454 referenced 1 time by $b443
+cb454
+    lda (l000b),y                                                     // b454: b1 0b       ..
+    sta l002b                                                         // b456: 85 2b       .+
+    iny                                                               // b458: c8          .
+    lda (l000b),y                                                     // b459: b1 0b       ..
+    sta l002a                                                         // b45b: 85 2a       .*
+// $b45d referenced 1 time by $b440
+cb45d
+    lda l002a                                                         // b45d: a5 2a       .*
+    clc                                                               // b45f: 18          .
+    sbc l0031                                                         // b460: e5 31       .1
+    lda l002b                                                         // b462: a5 2b       .+
+    sbc l0032                                                         // b464: e5 32       .2
+    bcc cb46f                                                         // b466: 90 07       ..
+    bit l001f                                                         // b468: 24 1f       $.
+    bpl cb425                                                         // b46a: 10 b9       ..
+    jmp cbf54                                                         // b46c: 4c 54 bf    LT.
+
+// $b46f referenced 1 time by $b466
+cb46f
+    stz l004c                                                         // b46f: 64 4c       dL
+    stz l004d                                                         // b471: 64 4d       dM
+    ldy #4                                                            // b473: a0 04       ..
+    sty l000a                                                         // b475: 84 0a       ..
+    sty l001b                                                         // b477: 84 1b       ..
+    bit l003b                                                         // b479: 24 3b       $;
+    bpl cb47f                                                         // b47b: 10 02       ..
+    stz l003b                                                         // b47d: 64 3b       d;
+// $b47f referenced 1 time by $b47b
+cb47f
+    bit l003c                                                         // b47f: 24 3c       $<
+    bpl cb485                                                         // b481: 10 02       ..
+    stz l003c                                                         // b483: 64 3c       d<
+// $b485 referenced 2 times by $b481, $b4c0
+cb485
+    lda (l000b),y                                                     // b485: b1 0b       ..
+    cmp #$0d                                                          // b487: c9 0d       ..
+    beq cb4c2                                                         // b489: f0 37       .7
+    cmp #$f4                                                          // b48b: c9 f4       ..
+    beq cb495                                                         // b48d: f0 06       ..
+    cmp #$22 // '"'                                                   // b48f: c9 22       ."
+    bne cb497                                                         // b491: d0 04       ..
+    eor l004c                                                         // b493: 45 4c       EL
+// $b495 referenced 1 time by $b48d
+cb495
+    sta l004c                                                         // b495: 85 4c       .L
+// $b497 referenced 1 time by $b491
+cb497
+    ldx l004c                                                         // b497: a6 4c       .L
+    bne cb4a7                                                         // b499: d0 0c       ..
+    cmp #$ed                                                          // b49b: c9 ed       ..
+    bne cb4a1                                                         // b49d: d0 02       ..
+    dec l003b                                                         // b49f: c6 3b       .;
+// $b4a1 referenced 1 time by $b49d
+cb4a1
+    cmp #$fd                                                          // b4a1: c9 fd       ..
+    bne cb4a7                                                         // b4a3: d0 02       ..
+    dec l003c                                                         // b4a5: c6 3c       .<
+// $b4a7 referenced 2 times by $b499, $b4a3
+cb4a7
+    ldx l0019                                                         // b4a7: a6 19       ..
+// $b4a9 referenced 1 time by $b4b6
+loop_cb4a9
+    lda l0700,x                                                       // b4a9: bd 00 07    ...
+    cmp #$0d                                                          // b4ac: c9 0d       ..
+    beq cb4ba                                                         // b4ae: f0 0a       ..
+    cmp (l000b),y                                                     // b4b0: d1 0b       ..
+    bne cb4bc                                                         // b4b2: d0 08       ..
+    iny                                                               // b4b4: c8          .
+    inx                                                               // b4b5: e8          .
+    bra loop_cb4a9                                                    // b4b6: 80 f1       ..
+// $b4b8 referenced 1 time by $b4e6
+cb4b8
+    bra cb445                                                         // b4b8: 80 8b       ..
+// $b4ba referenced 1 time by $b4ae
+cb4ba
+    sta l004d                                                         // b4ba: 85 4d       .M
+// $b4bc referenced 1 time by $b4b2
+cb4bc
+    inc l001b                                                         // b4bc: e6 1b       ..
+    ldy l001b                                                         // b4be: a4 1b       ..
+    bra cb485                                                         // b4c0: 80 c3       ..
+// $b4c2 referenced 1 time by $b489
+cb4c2
+    lda l004d                                                         // b4c2: a5 4d       .M
+    beq cb451                                                         // b4c4: f0 8b       ..
+    jsr sub_ca0ec                                                     // b4c6: 20 ec a0     ..
+    lda #1                                                            // b4c9: a9 01       ..
+    inx                                                               // b4cb: e8          .
+    sec                                                               // b4cc: 38          8
+    jsr sub_cbdf4                                                     // b4cd: 20 f4 bd     ..
+    ldx l003b                                                         // b4d0: a6 3b       .;
+    lda #2                                                            // b4d2: a9 02       ..
+    jsr sub_cbdf3                                                     // b4d4: 20 f3 bd     ..
+    ldx l003c                                                         // b4d7: a6 3c       .<
+    lda #4                                                            // b4d9: a9 04       ..
+    jsr sub_cbdf3                                                     // b4db: 20 f3 bd     ..
+    stz l004c                                                         // b4de: 64 4c       dL
+// $b4e0 referenced 1 time by $b508
+cb4e0
+    ldy l000a                                                         // b4e0: a4 0a       ..
+// $b4e2 referenced 2 times by $b4f6, $b520
+cb4e2
+    lda (l000b),y                                                     // b4e2: b1 0b       ..
+    cmp #$0d                                                          // b4e4: c9 0d       ..
+    beq cb4b8                                                         // b4e6: f0 d0       ..
+    cmp #$22 // '"'                                                   // b4e8: c9 22       ."
+    bne cb4f8                                                         // b4ea: d0 0c       ..
+    eor l004c                                                         // b4ec: 45 4c       EL
+    sta l004c                                                         // b4ee: 85 4c       .L
+    lda #$22 // '"'                                                   // b4f0: a9 22       ."
+// $b4f2 referenced 1 time by $b4fa
+loop_cb4f2
+    jsr cbdd4                                                         // b4f2: 20 d4 bd     ..
+    iny                                                               // b4f5: c8          .
+    bra cb4e2                                                         // b4f6: 80 ea       ..
+// $b4f8 referenced 1 time by $b4ea
+cb4f8
+    ldx l004c                                                         // b4f8: a6 4c       .L
+    bne loop_cb4f2                                                    // b4fa: d0 f6       ..
+    cmp #$8d                                                          // b4fc: c9 8d       ..
+    bne cb50a                                                         // b4fe: d0 0a       ..
+    jsr sub_c9bee                                                     // b500: 20 ee 9b     ..
+    sty l000a                                                         // b503: 84 0a       ..
+    jsr sub_ca0e8                                                     // b505: 20 e8 a0     ..
+    bra cb4e0                                                         // b508: 80 d6       ..
+// $b50a referenced 1 time by $b4fe
+cb50a
+    cmp #$e3                                                          // b50a: c9 e3       ..
+    bne cb510                                                         // b50c: d0 02       ..
+    inc l003b                                                         // b50e: e6 3b       .;
+// $b510 referenced 1 time by $b50c
+cb510
+    cmp #$f5                                                          // b510: c9 f5       ..
+    bne cb516                                                         // b512: d0 02       ..
+    inc l003c                                                         // b514: e6 3c       .<
+// $b516 referenced 1 time by $b512
+cb516
+    cmp #$f4                                                          // b516: c9 f4       ..
+    bne cb51c                                                         // b518: d0 02       ..
+    sta l004c                                                         // b51a: 85 4c       .L
+// $b51c referenced 1 time by $b518
+cb51c
+    jsr sub_cbd77                                                     // b51c: 20 77 bd     w.
+    iny                                                               // b51f: c8          .
+    bra cb4e2                                                         // b520: 80 c0       ..
+// $b522 referenced 1 time by $b5ee
+cb522
+    jsr sub_c99c4                                                     // b522: 20 c4 99     ..
+    bne cb530                                                         // b525: d0 09       ..
+    ldx l0026                                                         // b527: a6 26       .&
+    beq cb563                                                         // b529: f0 38       .8
+    bcs cb56a                                                         // b52b: b0 3d       .=
+// $b52d referenced 1 time by $b530
+loop_cb52d
+    jmp c9c2d                                                         // b52d: 4c 2d 9c    L-.
+
+// $b530 referenced 1 time by $b525
+cb530
+    bcs loop_cb52d                                                    // b530: b0 fb       ..
+    ldx l0026                                                         // b532: a6 26       .&
+    beq cb563                                                         // b534: f0 2d       .-
+// $b536 referenced 1 time by $b552
+loop_cb536
+    lda l002a                                                         // b536: a5 2a       .*
+    cmp l0519,x                                                       // b538: dd 19 05    ...
+    bne cb54b                                                         // b53b: d0 0e       ..
+    lda l002b                                                         // b53d: a5 2b       .+
+    cmp l051a,x                                                       // b53f: dd 1a 05    ...
+    bne cb54b                                                         // b542: d0 07       ..
+    lda l002c                                                         // b544: a5 2c       .,
+    cmp l051b,x                                                       // b546: dd 1b 05    ...
+    beq cb56a                                                         // b549: f0 1f       ..
+// $b54b referenced 2 times by $b53b, $b542
+cb54b
+    txa                                                               // b54b: 8a          .
+    sec                                                               // b54c: 38          8
+    sbc #$0f                                                          // b54d: e9 0f       ..
+    tax                                                               // b54f: aa          .
+    stx l0026                                                         // b550: 86 26       .&
+    bne loop_cb536                                                    // b552: d0 e2       ..
+    brk                                                               // b554: 00          .
+
+    .asc "!Can't match "                                              // b555: 21 43 61... !Ca
+    .byt $e3                                                          // b562: e3          .
+
+// $b563 referenced 2 times by $b529, $b534
+cb563
+    brk                                                               // b563: 00          .
+
+    .asc " No "                                                       // b564: 20 4e 6f...  No
+    .byt $e3,   0                                                     // b568: e3 00       ..
+
+// $b56a referenced 2 times by $b52b, $b549
+cb56a
+    lda l0519,x                                                       // b56a: bd 19 05    ...
+    sta l002a                                                         // b56d: 85 2a       .*
+    lda l051a,x                                                       // b56f: bd 1a 05    ...
+    sta l002b                                                         // b572: 85 2b       .+
+    ldy l051b,x                                                       // b574: bc 1b 05    ...
+    cpy #5                                                            // b577: c0 05       ..
+    beq cb5f1                                                         // b579: f0 76       .v
+    lda (l002a)                                                       // b57b: b2 2a       .*
+    adc l051c,x                                                       // b57d: 7d 1c 05    }..
+    sta (l002a)                                                       // b580: 92 2a       .*
+    sta l0037                                                         // b582: 85 37       .7
+    ldy #1                                                            // b584: a0 01       ..
+    lda (l002a),y                                                     // b586: b1 2a       .*
+    adc l051d,x                                                       // b588: 7d 1d 05    }..
+    sta (l002a),y                                                     // b58b: 91 2a       .*
+    sta l0038                                                         // b58d: 85 38       .8
+    iny                                                               // b58f: c8          .
+    lda (l002a),y                                                     // b590: b1 2a       .*
+    adc l051e,x                                                       // b592: 7d 1e 05    }..
+    sta (l002a),y                                                     // b595: 91 2a       .*
+    sta l0039                                                         // b597: 85 39       .9
+    iny                                                               // b599: c8          .
+    lda (l002a),y                                                     // b59a: b1 2a       .*
+    adc l051f,x                                                       // b59c: 7d 1f 05    }..
+    sta (l002a),y                                                     // b59f: 91 2a       .*
+    tay                                                               // b5a1: a8          .
+    lda l0037                                                         // b5a2: a5 37       .7
+    sec                                                               // b5a4: 38          8
+    sbc l0521,x                                                       // b5a5: fd 21 05    .!.
+    sta l0037                                                         // b5a8: 85 37       .7
+    lda l0038                                                         // b5aa: a5 38       .8
+    sbc l0522,x                                                       // b5ac: fd 22 05    .".
+    tsb l0037                                                         // b5af: 04 37       .7
+    lda l0039                                                         // b5b1: a5 39       .9
+    sbc l0523,x                                                       // b5b3: fd 23 05    .#.
+    tsb l0037                                                         // b5b6: 04 37       .7
+    tya                                                               // b5b8: 98          .
+    sbc l0524,x                                                       // b5b9: fd 24 05    .$.
+    ora l0037                                                         // b5bc: 05 37       .7
+    beq cb5cf                                                         // b5be: f0 0f       ..
+    tya                                                               // b5c0: 98          .
+    eor l051f,x                                                       // b5c1: 5d 1f 05    ]..
+    eor l0524,x                                                       // b5c4: 5d 24 05    ]$.
+    bpl cb5cd                                                         // b5c7: 10 04       ..
+    bcs cb5cf                                                         // b5c9: b0 04       ..
+    bra cb5df                                                         // b5cb: 80 12       ..
+// $b5cd referenced 1 time by $b5c7
+cb5cd
+    bcs cb5df                                                         // b5cd: b0 10       ..
+// $b5cf referenced 5 times by $b5be, $b5c9, $b617, $b61e, $b622
+cb5cf
+    ldy l0526,x                                                       // b5cf: bc 26 05    .&.
+    lda l0527,x                                                       // b5d2: bd 27 05    .'.
+    sty l000b                                                         // b5d5: 84 0b       ..
+    sta l000c                                                         // b5d7: 85 0c       ..
+    jsr c9c8a                                                         // b5d9: 20 8a 9c     ..
+    jmp c90d0                                                         // b5dc: 4c d0 90    L..
+
+// $b5df referenced 4 times by $b5cb, $b5cd, $b620, $b624
+cb5df
+    txa                                                               // b5df: 8a          .
+    sec                                                               // b5e0: 38          8
+    sbc #$0f                                                          // b5e1: e9 0f       ..
+    sta l0026                                                         // b5e3: 85 26       .&
+    ldy l001b                                                         // b5e5: a4 1b       ..
+    sty l000a                                                         // b5e7: 84 0a       ..
+    jsr sub_c8da2                                                     // b5e9: 20 a2 8d     ..
+    bne cb626                                                         // b5ec: d0 38       .8
+    jmp cb522                                                         // b5ee: 4c 22 b5    L".
+
+// $b5f1 referenced 1 time by $b579
+cb5f1
+    jsr cb205                                                         // b5f1: 20 05 b2     ..
+    txa                                                               // b5f4: 8a          .
+    clc                                                               // b5f5: 18          .
+    adc #$1c                                                          // b5f6: 69 1c       i.
+    sta l004a                                                         // b5f8: 85 4a       .J
+    lda #5                                                            // b5fa: a9 05       ..
+    sta l004b                                                         // b5fc: 85 4b       .K
+    jsr ca70a                                                         // b5fe: 20 0a a7     ..
+    lda l002a                                                         // b601: a5 2a       .*
+    sta l0037                                                         // b603: 85 37       .7
+    lda l002b                                                         // b605: a5 2b       .+
+    sta l0038                                                         // b607: 85 38       .8
+    jsr cb39e                                                         // b609: 20 9e b3     ..
+    ldx l0026                                                         // b60c: a6 26       .&
+    txa                                                               // b60e: 8a          .
+    clc                                                               // b60f: 18          .
+    adc #$21 // '!'                                                   // b610: 69 21       i!
+    sta l004a                                                         // b612: 85 4a       .J
+    jsr sub_c9d36                                                     // b614: 20 36 9d     6.
+    beq cb5cf                                                         // b617: f0 b6       ..
+    lda l051d,x                                                       // b619: bd 1d 05    ...
+    bmi cb622                                                         // b61c: 30 04       0.
+    bcs cb5cf                                                         // b61e: b0 af       ..
+    bra cb5df                                                         // b620: 80 bd       ..
+// $b622 referenced 1 time by $b61c
+cb622
+    bcc cb5cf                                                         // b622: 90 ab       ..
+    bra cb5df                                                         // b624: 80 b9       ..
+// $b626 referenced 1 time by $b5ec
+cb626
+    jmp c90c5                                                         // b626: 4c c5 90    L..
+
+// $b629 referenced 2 times by $b64c, $b64e
+cb629
+    brk                                                               // b629: 00          .
+
+    .byt $22, $e3                                                     // b62a: 22 e3       ".
+    .asc " variable"                                                  // b62c: 20 76 61...  va
+
+// $b635 referenced 1 time by $b664
+cb635
+    brk                                                               // b635: 00          .
+
+    .asc "#Too many "                                                 // b636: 23 54 6f... #To
+    .byt $e3, $73                                                     // b640: e3 73       .s
+
+// $b642 referenced 1 time by $b65e
+loop_cb642
+    brk                                                               // b642: 00          .
+
+    .asc "$No "                                                       // b643: 24 4e 6f... $No
+    .byt $b8,   0                                                     // b647: b8 00       ..
+
+sub_cb649
+    jsr sub_c997d                                                     // b649: 20 7d 99     }.
+    beq cb629                                                         // b64c: f0 db       ..
+    bcs cb629                                                         // b64e: b0 d9       ..
+    jsr sub_cbc83                                                     // b650: 20 83 bc     ..
+    jsr sub_c9c4a                                                     // b653: 20 4a 9c     J.
+    jsr sub_cb362                                                     // b656: 20 62 b3     b.
+    jsr c8f92                                                         // b659: 20 92 8f     ..
+    cmp #$b8                                                          // b65c: c9 b8       ..
+    bne loop_cb642                                                    // b65e: d0 e2       ..
+    ldy l0026                                                         // b660: a4 26       .&
+    cpy #$96                                                          // b662: c0 96       ..
+    bcs cb635                                                         // b664: b0 cf       ..
+    tya                                                               // b666: 98          .
+    adc #$0f                                                          // b667: 69 0f       i.
+    sta l0026                                                         // b669: 85 26       .&
+    lda l0037                                                         // b66b: a5 37       .7
+    sta l0528,y                                                       // b66d: 99 28 05    .(.
+    lda l0038                                                         // b670: a5 38       .8
+    sta l0529,y                                                       // b672: 99 29 05    .).
+    lda l0039                                                         // b675: a5 39       .9
+    sta l052a,y                                                       // b677: 99 2a 05    .*.
+    lsr                                                               // b67a: 4a          J
+    bcs cb6d1                                                         // b67b: b0 54       .T
+    jsr sub_c9774                                                     // b67d: 20 74 97     t.
+    ldy l0026                                                         // b680: a4 26       .&
+    lda l002a                                                         // b682: a5 2a       .*
+    sta l0521,y                                                       // b684: 99 21 05    .!.
+    lda l002b                                                         // b687: a5 2b       .+
+    sta l0522,y                                                       // b689: 99 22 05    .".
+    lda l002c                                                         // b68c: a5 2c       .,
+    sta l0523,y                                                       // b68e: 99 23 05    .#.
+    lda l002d                                                         // b691: a5 2d       .-
+    sta l0524,y                                                       // b693: 99 24 05    .$.
+    lda #1                                                            // b696: a9 01       ..
+    jsr cae60                                                         // b698: 20 60 ae     `.
+    jsr c8f92                                                         // b69b: 20 92 8f     ..
+    cmp #$88                                                          // b69e: c9 88       ..
+    bne cb6a7                                                         // b6a0: d0 05       ..
+    jsr sub_c9774                                                     // b6a2: 20 74 97     t.
+    ldy l001b                                                         // b6a5: a4 1b       ..
+// $b6a7 referenced 1 time by $b6a0
+cb6a7
+    sty l000a                                                         // b6a7: 84 0a       ..
+    ldy l0026                                                         // b6a9: a4 26       .&
+    lda l002a                                                         // b6ab: a5 2a       .*
+    sta l051c,y                                                       // b6ad: 99 1c 05    ...
+    lda l002b                                                         // b6b0: a5 2b       .+
+    sta l051d,y                                                       // b6b2: 99 1d 05    ...
+    lda l002c                                                         // b6b5: a5 2c       .,
+    sta l051e,y                                                       // b6b7: 99 1e 05    ...
+    lda l002d                                                         // b6ba: a5 2d       .-
+    sta l051f,y                                                       // b6bc: 99 1f 05    ...
+// $b6bf referenced 1 time by $b707
+cb6bf
+    jsr sub_c9c93                                                     // b6bf: 20 93 9c     ..
+    ldy l0026                                                         // b6c2: a4 26       .&
+    lda l000b                                                         // b6c4: a5 0b       ..
+    sta l0526,y                                                       // b6c6: 99 26 05    .&.
+    lda l000c                                                         // b6c9: a5 0c       ..
+    sta l0527,y                                                       // b6cb: 99 27 05    .'.
+    jmp c90d0                                                         // b6ce: 4c d0 90    L..
+
+// $b6d1 referenced 1 time by $b67b
+cb6d1
+    jsr sub_c9dff                                                     // b6d1: 20 ff 9d     ..
+    jsr sub_c97a2                                                     // b6d4: 20 a2 97     ..
+    lda l0026                                                         // b6d7: a5 26       .&
+    clc                                                               // b6d9: 18          .
+    adc #$21 // '!'                                                   // b6da: 69 21       i!
+    sta l004a                                                         // b6dc: 85 4a       .J
+    lda #5                                                            // b6de: a9 05       ..
+    sta l004b                                                         // b6e0: 85 4b       .K
+    jsr sub_ca54d                                                     // b6e2: 20 4d a5     M.
+    jsr ca622                                                         // b6e5: 20 22 a6     ".
+    jsr c8f92                                                         // b6e8: 20 92 8f     ..
+    cmp #$88                                                          // b6eb: c9 88       ..
+    bne cb6f7                                                         // b6ed: d0 08       ..
+    jsr sub_c9dff                                                     // b6ef: 20 ff 9d     ..
+    jsr sub_c97a2                                                     // b6f2: 20 a2 97     ..
+    ldy l001b                                                         // b6f5: a4 1b       ..
+// $b6f7 referenced 1 time by $b6ed
+cb6f7
+    sty l000a                                                         // b6f7: 84 0a       ..
+    lda l0026                                                         // b6f9: a5 26       .&
+    clc                                                               // b6fb: 18          .
+    adc #$1c                                                          // b6fc: 69 1c       i.
+    sta l004a                                                         // b6fe: 85 4a       .J
+    lda #5                                                            // b700: a9 05       ..
+    sta l004b                                                         // b702: 85 4b       .K
+    jsr sub_ca54d                                                     // b704: 20 4d a5     M.
+    bra cb6bf                                                         // b707: 80 b6       ..
+sub_cb709
+    jsr sub_cb85a                                                     // b709: 20 5a b8     Z.
+// $b70c referenced 1 time by $b802
+cb70c
+    jsr c9c6a                                                         // b70c: 20 6a 9c     j.
+    ldy l0025                                                         // b70f: a4 25       .%
+    cpy #$1a                                                          // b711: c0 1a       ..
+    bcs cb723                                                         // b713: b0 0e       ..
+    lda l000b                                                         // b715: a5 0b       ..
+    sta l05cc,y                                                       // b717: 99 cc 05    ...
+    lda l000c                                                         // b71a: a5 0c       ..
+    sta l05e6,y                                                       // b71c: 99 e6 05    ...
+    inc l0025                                                         // b71f: e6 25       .%
+    bra cb753                                                         // b721: 80 30       .0
+// $b723 referenced 1 time by $b713
+cb723
+    brk                                                               // b723: 00          .
+
+    .asc "%Too many "                                                 // b724: 25 54 6f... %To
+    .byt $e4, $73                                                     // b72e: e4 73       .s
+
+// $b730 referenced 1 time by $b73c
+loop_cb730
+    brk                                                               // b730: 00          .
+
+    .asc "&No "                                                       // b731: 26 4e 6f... &No
+    .byt $e4,   0                                                     // b735: e4 00       ..
+
+sub_cb737
+    jsr c9c6a                                                         // b737: 20 6a 9c     j.
+    ldx l0025                                                         // b73a: a6 25       .%
+    beq loop_cb730                                                    // b73c: f0 f2       ..
+    dec l0025                                                         // b73e: c6 25       .%
+    ldy l05cb,x                                                       // b740: bc cb 05    ...
+    lda l05e5,x                                                       // b743: bd e5 05    ...
+    sty l000b                                                         // b746: 84 0b       ..
+    sta l000c                                                         // b748: 85 0c       ..
+// $b74a referenced 1 time by $b76f
+cb74a
+    jmp c90ca                                                         // b74a: 4c ca 90    L..
+
+sub_cb74d
+    jsr sub_cb85a                                                     // b74d: 20 5a b8     Z.
+    jsr c9c6a                                                         // b750: 20 6a 9c     j.
+// $b753 referenced 3 times by $9cf8, $b721, $b7f7
+cb753
+    lda l0020                                                         // b753: a5 20       .
+    beq cb75a                                                         // b755: f0 03       ..
+    jsr sub_c9d0f                                                     // b757: 20 0f 9d     ..
+// $b75a referenced 1 time by $b755
+cb75a
+    ldy #4                                                            // b75a: a0 04       ..
+    sty l000a                                                         // b75c: 84 0a       ..
+    ldy l003d                                                         // b75e: a4 3d       .=
+    lda l003e                                                         // b760: a5 3e       .>
+// $b762 referenced 1 time by $ba69
+cb762
+    sty l000b                                                         // b762: 84 0b       ..
+    sta l000c                                                         // b764: 85 0c       ..
+    jmp c90d0                                                         // b766: 4c d0 90    L..
+
+// $b769 referenced 1 time by $b776
+loop_cb769
+    jsr c9c6a                                                         // b769: 20 6a 9c     j.
+    jsr sub_cb2e0                                                     // b76c: 20 e0 b2     ..
+    bra cb74a                                                         // b76f: 80 d9       ..
+// $b771 referenced 1 time by $b790
+loop_cb771
+    jsr c8f9d                                                         // b771: 20 9d 8f     ..
+    cmp #$87                                                          // b774: c9 87       ..
+    beq loop_cb769                                                    // b776: f0 f1       ..
+    ldy l000a                                                         // b778: a4 0a       ..
+    dey                                                               // b77a: 88          .
+    jsr c9c80                                                         // b77b: 20 80 9c     ..
+    stz l000a                                                         // b77e: 64 0a       d.
+    lda l000b                                                         // b780: a5 0b       ..
+    sta l0016                                                         // b782: 85 16       ..
+    lda l000c                                                         // b784: a5 0c       ..
+    sta l0017                                                         // b786: 85 17       ..
+    jmp c9073                                                         // b788: 4c 73 90    Ls.
+
+sub_cb78b
+    jsr c8f9d                                                         // b78b: 20 9d 8f     ..
+    cmp #$85                                                          // b78e: c9 85       ..
+    beq loop_cb771                                                    // b790: f0 df       ..
+    dec l000a                                                         // b792: c6 0a       ..
+    jsr sub_c9332                                                     // b794: 20 32 93     2.
+    cpx #$f2                                                          // b797: e0 f2       ..
+    beq cb7a4                                                         // b799: f0 09       ..
+    iny                                                               // b79b: c8          .
+    cpx #$e5                                                          // b79c: e0 e5       ..
+    beq cb7a4                                                         // b79e: f0 04       ..
+    cpx #$e4                                                          // b7a0: e0 e4       ..
+    bne cb81a                                                         // b7a2: d0 76       .v
+// $b7a4 referenced 2 times by $b799, $b79e
+cb7a4
+    phx                                                               // b7a4: da          .
+    lda l002b                                                         // b7a5: a5 2b       .+
+    ora l002c                                                         // b7a7: 05 2c       .,
+    ora l002d                                                         // b7a9: 05 2d       .-
+    bne cb805                                                         // b7ab: d0 58       .X
+    dec l002a                                                         // b7ad: c6 2a       .*
+    beq cb7e6                                                         // b7af: f0 35       .5
+    bmi cb805                                                         // b7b1: 30 52       0R
+// $b7b3 referenced 4 times by $b7cc, $b7dc, $b7e0, $b7e4
+cb7b3
+    lda (l000b),y                                                     // b7b3: b1 0b       ..
+    cmp #$0d                                                          // b7b5: c9 0d       ..
+    beq cb805                                                         // b7b7: f0 4c       .L
+    cmp #$3a // ':'                                                   // b7b9: c9 3a       .:
+    beq cb805                                                         // b7bb: f0 48       .H
+    cmp #$8b                                                          // b7bd: c9 8b       ..
+    beq cb805                                                         // b7bf: f0 44       .D
+    iny                                                               // b7c1: c8          .
+    cmp #$22 // '"'                                                   // b7c2: c9 22       ."
+    bne cb7ca                                                         // b7c4: d0 04       ..
+    eor l002b                                                         // b7c6: 45 2b       E+
+    sta l002b                                                         // b7c8: 85 2b       .+
+// $b7ca referenced 1 time by $b7c4
+cb7ca
+    ldx l002b                                                         // b7ca: a6 2b       .+
+    bne cb7b3                                                         // b7cc: d0 e5       ..
+    cmp #$29 // ')'                                                   // b7ce: c9 29       .)
+    bne cb7d4                                                         // b7d0: d0 02       ..
+    dec l002c                                                         // b7d2: c6 2c       .,
+// $b7d4 referenced 1 time by $b7d0
+cb7d4
+    cmp #$28 // '('                                                   // b7d4: c9 28       .(
+    bne cb7da                                                         // b7d6: d0 02       ..
+    inc l002c                                                         // b7d8: e6 2c       .,
+// $b7da referenced 1 time by $b7d6
+cb7da
+    cmp #$2c // ','                                                   // b7da: c9 2c       .,
+    bne cb7b3                                                         // b7dc: d0 d5       ..
+    ldx l002c                                                         // b7de: a6 2c       .,
+    bne cb7b3                                                         // b7e0: d0 d1       ..
+    dec l002a                                                         // b7e2: c6 2a       .*
+    bne cb7b3                                                         // b7e4: d0 cd       ..
+// $b7e6 referenced 1 time by $b7af
+cb7e6
+    pla                                                               // b7e6: 68          h
+    cmp #$f2                                                          // b7e7: c9 f2       ..
+    beq cb833                                                         // b7e9: f0 48       .H
+    sty l000a                                                         // b7eb: 84 0a       ..
+    cmp #$e4                                                          // b7ed: c9 e4       ..
+    beq cb7fa                                                         // b7ef: f0 09       ..
+    jsr sub_cb85a                                                     // b7f1: 20 5a b8     Z.
+    jsr c9c8a                                                         // b7f4: 20 8a 9c     ..
+    jmp cb753                                                         // b7f7: 4c 53 b7    LS.
+
+// $b7fa referenced 1 time by $b7ef
+cb7fa
+    jsr sub_cb85a                                                     // b7fa: 20 5a b8     Z.
+    ldy l000a                                                         // b7fd: a4 0a       ..
+    jsr sub_cb84d                                                     // b7ff: 20 4d b8     M.
+    jmp cb70c                                                         // b802: 4c 0c b7    L..
+
+// $b805 referenced 5 times by $b7ab, $b7b1, $b7b7, $b7bb, $b7bf
+cb805
+    pla                                                               // b805: 68          h
+// $b806 referenced 1 time by $b80f
+loop_cb806
+    lda (l000b),y                                                     // b806: b1 0b       ..
+    iny                                                               // b808: c8          .
+    cmp #$8b                                                          // b809: c9 8b       ..
+    beq cb847                                                         // b80b: f0 3a       .:
+    cmp #$0d                                                          // b80d: c9 0d       ..
+    bne loop_cb806                                                    // b80f: d0 f5       ..
+    brk                                                               // b811: 00          .
+
+    .byt $28, $ee                                                     // b812: 28 ee       (.
+    .asc " range"                                                     // b814: 20 72 61...  ra
+
+// $b81a referenced 2 times by $b7a2, $b83a
+cb81a
+    brk                                                               // b81a: 00          .
+
+    .byt $27, $ee                                                     // b81b: 27 ee       '.
+    .asc " syntax"                                                    // b81d: 20 73 79...  sy
+
+// $b824 referenced 1 time by $b869
+cb824
+    brk                                                               // b824: 00          .
+
+    .asc ")No such line"                                              // b825: 29 4e 6f... )No
+    .byt 0                                                            // b832: 00          .
+
+// $b833 referenced 1 time by $b7e9
+cb833
+    sty l001b                                                         // b833: 84 1b       ..
+    jsr c8f92                                                         // b835: 20 92 8f     ..
+    cmp #$f2                                                          // b838: c9 f2       ..
+    bne cb81a                                                         // b83a: d0 de       ..
+    jsr sub_cb057                                                     // b83c: 20 57 b0     W.
+    ldy l001b                                                         // b83f: a4 1b       ..
+    jsr sub_cb84d                                                     // b841: 20 4d b8     M.
+    jmp c90c7                                                         // b844: 4c c7 90    L..
+
+// $b847 referenced 1 time by $b80b
+cb847
+    sty l000a                                                         // b847: 84 0a       ..
+    jmp c9ced                                                         // b849: 4c ed 9c    L..
+
+// $b84c referenced 1 time by $b855
+loop_cb84c
+    iny                                                               // b84c: c8          .
+// $b84d referenced 2 times by $b7ff, $b841
+sub_cb84d
+    lda (l000b),y                                                     // b84d: b1 0b       ..
+    cmp #$0d                                                          // b84f: c9 0d       ..
+    beq cb857                                                         // b851: f0 04       ..
+    cmp #$3a // ':'                                                   // b853: c9 3a       .:
+    bne loop_cb84c                                                    // b855: d0 f5       ..
+// $b857 referenced 1 time by $b851
+cb857
+    sty l000a                                                         // b857: 84 0a       ..
+    rts                                                               // b859: 60          `
+
+// $b85a referenced 5 times by $b709, $b74d, $b7f1, $b7fa, $b994
+sub_cb85a
+    jsr sub_c9be2                                                     // b85a: 20 e2 9b     ..
+    bcs cb866                                                         // b85d: b0 07       ..
+    jsr sub_c9332                                                     // b85f: 20 32 93     2.
+    lda #$80                                                          // b862: a9 80       ..
+    trb l002b                                                         // b864: 14 2b       .+
+// $b866 referenced 2 times by $9cf2, $b85d
+cb866
+    jsr sub_c8191                                                     // b866: 20 91 81     ..
+    bcc cb824                                                         // b869: 90 b9       ..
+    rts                                                               // b86b: 60          `
+
+// $b86c referenced 2 times by $b8a2, $b8bc
+cb86c
+    jmp c9155                                                         // b86c: 4c 55 91    LU.
+
+// $b86f referenced 1 time by $b88a
+loop_cb86f
+    jmp c9c2d                                                         // b86f: 4c 2d 9c    L-.
+
+// $b872 referenced 1 time by $b882
+loop_cb872
+    sty l000a                                                         // b872: 84 0a       ..
+// $b874 referenced 1 time by $b8e4
+cb874
+    jmp c90c7                                                         // b874: 4c c7 90    L..
+
+// $b877 referenced 1 time by $b8e9
+cb877
+    jsr sub_cba6c                                                     // b877: 20 6c ba     l.
+    sty l004c                                                         // b87a: 84 4c       .L
+    jsr c9338                                                         // b87c: 20 38 93     8.
+// $b87f referenced 2 times by $b8b8, $b8e0
+cb87f
+    jsr sub_c8da2                                                     // b87f: 20 a2 8d     ..
+    bne loop_cb872                                                    // b882: d0 ee       ..
+    lda l004c                                                         // b884: a5 4c       .L
+    pha                                                               // b886: 48          H
+    jsr sub_c997d                                                     // b887: 20 7d 99     }.
+    beq loop_cb86f                                                    // b88a: f0 e3       ..
+    jsr c9338                                                         // b88c: 20 38 93     8.
+    pla                                                               // b88f: 68          h
+    sta l004c                                                         // b890: 85 4c       .L
+    php                                                               // b892: 08          .
+    jsr cbc66                                                         // b893: 20 66 bc     f.
+sub_cb896
+    ldy l004c                                                         // b896: a4 4c       .L
+    jsr osbget                                                        // b898: 20 d7 ff     ..
+    sta l0027                                                         // b89b: 85 27       .'
+    plp                                                               // b89d: 28          (
+    bcc cb8ba                                                         // b89e: 90 1a       ..
+    lda l0027                                                         // b8a0: a5 27       .'
+    bne cb86c                                                         // b8a2: d0 c8       ..
+    jsr osbget                                                        // b8a4: 20 d7 ff     ..
+    sta l0036                                                         // b8a7: 85 36       .6
+    tax                                                               // b8a9: aa          .
+    beq cb8b5                                                         // b8aa: f0 09       ..
+// $b8ac referenced 1 time by $b8b3
+loop_cb8ac
+    jsr osbget                                                        // b8ac: 20 d7 ff     ..
+    sta l05ff,x                                                       // b8af: 9d ff 05    ...
+    dex                                                               // b8b2: ca          .
+    bne loop_cb8ac                                                    // b8b3: d0 f7       ..
+// $b8b5 referenced 1 time by $b8aa
+cb8b5
+    jsr sub_c916e                                                     // b8b5: 20 6e 91     n.
+    bra cb87f                                                         // b8b8: 80 c5       ..
+// $b8ba referenced 1 time by $b89e
+cb8ba
+    lda l0027                                                         // b8ba: a5 27       .'
+    beq cb86c                                                         // b8bc: f0 ae       ..
+    bmi cb8cc                                                         // b8be: 30 0c       0.
+    ldx #3                                                            // b8c0: a2 03       ..
+// $b8c2 referenced 1 time by $b8c8
+loop_cb8c2
+    jsr osbget                                                        // b8c2: 20 d7 ff     ..
+    sta l002a,x                                                       // b8c5: 95 2a       .*
+    dex                                                               // b8c7: ca          .
+    bpl loop_cb8c2                                                    // b8c8: 10 f8       ..
+    bra cb8da                                                         // b8ca: 80 0e       ..
+// $b8cc referenced 1 time by $b8be
+cb8cc
+    ldx #4                                                            // b8cc: a2 04       ..
+// $b8ce referenced 1 time by $b8d5
+loop_cb8ce
+    jsr osbget                                                        // b8ce: 20 d7 ff     ..
+    sta l046c,x                                                       // b8d1: 9d 6c 04    .l.
+    dex                                                               // b8d4: ca          .
+    bpl loop_cb8ce                                                    // b8d5: 10 f7       ..
+    jsr sub_ca576                                                     // b8d7: 20 76 a5     v.
+// $b8da referenced 1 time by $b8ca
+cb8da
+    jsr sub_cbd46                                                     // b8da: 20 46 bd     F.
+    jsr sub_cb372                                                     // b8dd: 20 72 b3     r.
+    bra cb87f                                                         // b8e0: 80 9d       ..
+// $b8e2 referenced 1 time by $b922
+cb8e2
+    pla                                                               // b8e2: 68          h
+    pla                                                               // b8e3: 68          h
+    bra cb874                                                         // b8e4: 80 8e       ..
+sub_cb8e6
+    jsr sub_c8d9c                                                     // b8e6: 20 9c 8d     ..
+    beq cb877                                                         // b8e9: f0 8c       ..
+    cmp #$86                                                          // b8eb: c9 86       ..
+    beq cb8f2                                                         // b8ed: f0 03       ..
+    dec l000a                                                         // b8ef: c6 0a       ..
+    clc                                                               // b8f1: 18          .
+// $b8f2 referenced 1 time by $b8ed
+cb8f2
+    ror l004c                                                         // b8f2: 66 4c       fL
+    lsr l004c                                                         // b8f4: 46 4c       FL
+    lda #$ff                                                          // b8f6: a9 ff       ..
+    sta l004d                                                         // b8f8: 85 4d       .M
+// $b8fa referenced 3 times by $b911, $b915, $b974
+cb8fa
+    jsr sub_c935c                                                     // b8fa: 20 5c 93     \.
+    bcs cb909                                                         // b8fd: b0 0a       ..
+// $b8ff referenced 1 time by $b902
+loop_cb8ff
+    jsr sub_c935c                                                     // b8ff: 20 5c 93     \.
+    bcc loop_cb8ff                                                    // b902: 90 fb       ..
+    ldx #$ff                                                          // b904: a2 ff       ..
+    stx l004d                                                         // b906: 86 4d       .M
+    clc                                                               // b908: 18          .
+// $b909 referenced 1 time by $b8fd
+cb909
+    php                                                               // b909: 08          .
+    asl l004c                                                         // b90a: 06 4c       .L
+    plp                                                               // b90c: 28          (
+    ror l004c                                                         // b90d: 66 4c       fL
+    cmp #$2c // ','                                                   // b90f: c9 2c       .,
+    beq cb8fa                                                         // b911: f0 e7       ..
+    cmp #$3b // ';'                                                   // b913: c9 3b       .;
+    beq cb8fa                                                         // b915: f0 e3       ..
+    dec l000a                                                         // b917: c6 0a       ..
+    lda l004c                                                         // b919: a5 4c       .L
+    pha                                                               // b91b: 48          H
+    lda l004d                                                         // b91c: a5 4d       .M
+    pha                                                               // b91e: 48          H
+    jsr sub_c997d                                                     // b91f: 20 7d 99     }.
+    beq cb8e2                                                         // b922: f0 be       ..
+    pla                                                               // b924: 68          h
+    sta l004d                                                         // b925: 85 4d       .M
+    pla                                                               // b927: 68          h
+    sta l004c                                                         // b928: 85 4c       .L
+    jsr c9338                                                         // b92a: 20 38 93     8.
+    php                                                               // b92d: 08          .
+    bit l004c                                                         // b92e: 24 4c       $L
+    bvs cb938                                                         // b930: 70 06       p.
+    lda l004d                                                         // b932: a5 4d       .M
+    cmp #$ff                                                          // b934: c9 ff       ..
+    bne cb94f                                                         // b936: d0 17       ..
+// $b938 referenced 1 time by $b930
+cb938
+    bit l004c                                                         // b938: 24 4c       $L
+    bpl cb941                                                         // b93a: 10 05       ..
+    lda #$3f // '?'                                                   // b93c: a9 3f       .?
+    jsr oswrch                                                        // b93e: 20 ee ff     ..
+// $b941 referenced 1 time by $b93a
+cb941
+    jsr sub_cbaa0                                                     // b941: 20 a0 ba     ..
+    sty l0036                                                         // b944: 84 36       .6
+    asl l004c                                                         // b946: 06 4c       .L
+    clc                                                               // b948: 18          .
+    ror l004c                                                         // b949: 66 4c       fL
+    bit l004c                                                         // b94b: 24 4c       $L
+    bvs cb968                                                         // b94d: 70 19       p.
+// $b94f referenced 1 time by $b936
+cb94f
+    sta l001b                                                         // b94f: 85 1b       ..
+    stz l0019                                                         // b951: 64 19       d.
+    lda #6                                                            // b953: a9 06       ..
+    sta l001a                                                         // b955: 85 1a       ..
+    jsr sub_cad3a                                                     // b957: 20 3a ad     :.
+// $b95a referenced 1 time by $b961
+loop_cb95a
+    jsr sub_c8fa8                                                     // b95a: 20 a8 8f     ..
+    beq cb965                                                         // b95d: f0 06       ..
+    cmp #$0d                                                          // b95f: c9 0d       ..
+    bne loop_cb95a                                                    // b961: d0 f7       ..
+    ldy #$fe                                                          // b963: a0 fe       ..
+// $b965 referenced 1 time by $b95d
+cb965
+    iny                                                               // b965: c8          .
+    sty l004d                                                         // b966: 84 4d       .M
+// $b968 referenced 1 time by $b94d
+cb968
+    plp                                                               // b968: 28          (
+    bcs cb976                                                         // b969: b0 0b       ..
+    jsr sub_cbc83                                                     // b96b: 20 83 bc     ..
+    jsr sub_caba5                                                     // b96e: 20 a5 ab     ..
+    jsr sub_cb365                                                     // b971: 20 65 b3     e.
+// $b974 referenced 1 time by $b97b
+loop_cb974
+    bra cb8fa                                                         // b974: 80 84       ..
+// $b976 referenced 1 time by $b969
+cb976
+    stz l0027                                                         // b976: 64 27       d'
+    jsr sub_c9171                                                     // b978: 20 71 91     q.
+    bra loop_cb974                                                    // b97b: 80 f7       ..
+sub_cb97d
+    stz l003d                                                         // b97d: 64 3d       d=
+    ldy l0018                                                         // b97f: a4 18       ..
+    sty l003e                                                         // b981: 84 3e       .>
+    jsr c8f9d                                                         // b983: 20 9d 8f     ..
+    dec l000a                                                         // b986: c6 0a       ..
+    cmp #$3a // ':'                                                   // b988: c9 3a       .:
+    beq cb997                                                         // b98a: f0 0b       ..
+    cmp #$0d                                                          // b98c: c9 0d       ..
+    beq cb997                                                         // b98e: f0 07       ..
+    cmp #$8b                                                          // b990: c9 8b       ..
+    beq cb997                                                         // b992: f0 03       ..
+    jsr sub_cb85a                                                     // b994: 20 5a b8     Z.
+// $b997 referenced 3 times by $b98a, $b98e, $b992
+cb997
+    jsr c9c6a                                                         // b997: 20 6a 9c     j.
+    lda l003d                                                         // b99a: a5 3d       .=
+    sta l001c                                                         // b99c: 85 1c       ..
+    lda l003e                                                         // b99e: a5 3e       .>
+    sta l001d                                                         // b9a0: 85 1d       ..
+    jmp c90ca                                                         // b9a2: 4c ca 90    L..
+
+// $b9a5 referenced 2 times by $b9b0, $b9da
+cb9a5
+    jsr sub_c8da2                                                     // b9a5: 20 a2 8d     ..
+    beq cb9ad                                                         // b9a8: f0 03       ..
+    jmp c90c5                                                         // b9aa: 4c c5 90    L..
+
+// $b9ad referenced 1 time by $b9a8
+cb9ad
+    jsr sub_c997d                                                     // b9ad: 20 7d 99     }.
+    beq cb9a5                                                         // b9b0: f0 f3       ..
+    bcs cb9bf                                                         // b9b2: b0 0b       ..
+    jsr sub_cb9dc                                                     // b9b4: 20 dc b9     ..
+    jsr sub_cbc83                                                     // b9b7: 20 83 bc     ..
+    jsr sub_cb362                                                     // b9ba: 20 62 b3     b.
+    bra cb9cd                                                         // b9bd: 80 0e       ..
+// $b9bf referenced 1 time by $b9b2
+cb9bf
+    jsr sub_cb9dc                                                     // b9bf: 20 dc b9     ..
+    jsr cbc66                                                         // b9c2: 20 66 bc     f.
+    jsr sub_cad3a                                                     // b9c5: 20 3a ad     :.
+    sta l0027                                                         // b9c8: 85 27       .'
+    jsr sub_c916e                                                     // b9ca: 20 6e 91     n.
+// $b9cd referenced 1 time by $b9bd
+cb9cd
+    clc                                                               // b9cd: 18          .
+    lda l001b                                                         // b9ce: a5 1b       ..
+    adc l0019                                                         // b9d0: 65 19       e.
+    sta l001c                                                         // b9d2: 85 1c       ..
+    lda l001a                                                         // b9d4: a5 1a       ..
+    adc #0                                                            // b9d6: 69 00       i.
+    sta l001d                                                         // b9d8: 85 1d       ..
+    bra cb9a5                                                         // b9da: 80 c9       ..
+// $b9dc referenced 2 times by $b9b4, $b9bf
+sub_cb9dc
+    jsr c9338                                                         // b9dc: 20 38 93     8.
+    lda l001c                                                         // b9df: a5 1c       ..
+    sta l0019                                                         // b9e1: 85 19       ..
+    lda l001d                                                         // b9e3: a5 1d       ..
+    sta l001a                                                         // b9e5: 85 1a       ..
+    stz l001b                                                         // b9e7: 64 1b       d.
+    jsr sub_c8fa8                                                     // b9e9: 20 a8 8f     ..
+    beq cba46                                                         // b9ec: f0 58       .X
+    cmp #$dc                                                          // b9ee: c9 dc       ..
+    beq cba46                                                         // b9f0: f0 54       .T
+    cmp #$0d                                                          // b9f2: c9 0d       ..
+    beq cb9ff                                                         // b9f4: f0 09       ..
+// $b9f6 referenced 1 time by $b9fd
+loop_cb9f6
+    jsr sub_c8fa8                                                     // b9f6: 20 a8 8f     ..
+    beq cba46                                                         // b9f9: f0 4b       .K
+    cmp #$0d                                                          // b9fb: c9 0d       ..
+    bne loop_cb9f6                                                    // b9fd: d0 f7       ..
+// $b9ff referenced 3 times by $b9f4, $ba1b, $ba1f
+cb9ff
+    ldy l001b                                                         // b9ff: a4 1b       ..
+    lda (l0019),y                                                     // ba01: b1 19       ..
+    bmi cba21                                                         // ba03: 30 1c       0.
+    iny                                                               // ba05: c8          .
+    iny                                                               // ba06: c8          .
+    lda (l0019),y                                                     // ba07: b1 19       ..
+    tax                                                               // ba09: aa          .
+// $ba0a referenced 1 time by $ba0f
+loop_cba0a
+    iny                                                               // ba0a: c8          .
+    lda (l0019),y                                                     // ba0b: b1 19       ..
+    cmp #$20 // ' '                                                   // ba0d: c9 20       .
+    beq loop_cba0a                                                    // ba0f: f0 f9       ..
+    cmp #$dc                                                          // ba11: c9 dc       ..
+    beq cba43                                                         // ba13: f0 2e       ..
+    txa                                                               // ba15: 8a          .
+    clc                                                               // ba16: 18          .
+    adc l0019                                                         // ba17: 65 19       e.
+    sta l0019                                                         // ba19: 85 19       ..
+    bcc cb9ff                                                         // ba1b: 90 e2       ..
+    inc l001a                                                         // ba1d: e6 1a       ..
+    bra cb9ff                                                         // ba1f: 80 de       ..
+// $ba21 referenced 1 time by $ba03
+cba21
+    brk                                                               // ba21: 00          .
+
+    .asc "*Out of "                                                   // ba22: 2a 4f 75... *Ou
+    .byt $dc                                                          // ba2a: dc          .
+
+// $ba2b referenced 1 time by $ba52
+cba2b
+    brk                                                               // ba2b: 00          .
+
+    .asc "+No "                                                       // ba2c: 2b 4e 6f... +No
+    .byt $f5                                                          // ba30: f5          .
+
+// $ba31 referenced 1 time by $ba7f
+cba31
+    brk                                                               // ba31: 00          .
+
+    .byt $2d, $8d, $23                                                // ba32: 2d 8d 23    -.#
+
+// $ba35 referenced 1 time by $ba8c
+cba35
+    brk                                                               // ba35: 00          .
+
+    .asc ",Too many "                                                 // ba36: 2c 54 6f... ,To
+    .byt $f5, $73,   0                                                // ba40: f5 73 00    .s.
+
+// $ba43 referenced 1 time by $ba13
+cba43
+    iny                                                               // ba43: c8          .
+    sty l001b                                                         // ba44: 84 1b       ..
+// $ba46 referenced 3 times by $b9ec, $b9f0, $b9f9
+cba46
+    rts                                                               // ba46: 60          `
+
+sub_cba47
+    jsr sub_c9df3                                                     // ba47: 20 f3 9d     ..
+    jsr c9c55                                                         // ba4a: 20 55 9c     U.
+    jsr sub_c9781                                                     // ba4d: 20 81 97     ..
+    ldx l0024                                                         // ba50: a6 24       .$
+    beq cba2b                                                         // ba52: f0 d7       ..
+    lda l002a                                                         // ba54: a5 2a       .*
+    ora l002b                                                         // ba56: 05 2b       .+
+    ora l002c                                                         // ba58: 05 2c       .,
+    ora l002d                                                         // ba5a: 05 2d       .-
+    beq cba63                                                         // ba5c: f0 05       ..
+    dec l0024                                                         // ba5e: c6 24       .$
+    jmp c90ca                                                         // ba60: 4c ca 90    L..
+
+// $ba63 referenced 1 time by $ba5c
+cba63
+    ldy l04ff,x                                                       // ba63: bc ff 04    ...
+    lda l0513,x                                                       // ba66: bd 13 05    ...
+    jmp cb762                                                         // ba69: 4c 62 b7    Lb.
+
+// $ba6c referenced 2 times by $9204, $b877
+sub_cba6c
+    dec l000a                                                         // ba6c: c6 0a       ..
+// $ba6e referenced 3 times by $beda, $beee, $befd
+sub_cba6e
+    lda l000a                                                         // ba6e: a5 0a       ..
+    sta l001b                                                         // ba70: 85 1b       ..
+    lda l000b                                                         // ba72: a5 0b       ..
+    sta l0019                                                         // ba74: 85 19       ..
+    lda l000c                                                         // ba76: a5 0c       ..
+    sta l001a                                                         // ba78: 85 1a       ..
+// $ba7a referenced 3 times by $ab24, $ab2f, $ac1f
+sub_cba7a
+    jsr c8f92                                                         // ba7a: 20 92 8f     ..
+    cmp #$23 // '#'                                                   // ba7d: c9 23       .#
+    bne cba31                                                         // ba7f: d0 b0       ..
+    jsr sub_c9779                                                     // ba81: 20 79 97     y.
+    ldy l002a                                                         // ba84: a4 2a       .*
+    tya                                                               // ba86: 98          .
+    rts                                                               // ba87: 60          `
+
+sub_cba88
+    ldx l0024                                                         // ba88: a6 24       .$
+    cpx #$14                                                          // ba8a: e0 14       ..
+    bcs cba35                                                         // ba8c: b0 a7       ..
+    jsr c9c80                                                         // ba8e: 20 80 9c     ..
+    lda l000b                                                         // ba91: a5 0b       ..
+    sta l0500,x                                                       // ba93: 9d 00 05    ...
+    lda l000c                                                         // ba96: a5 0c       ..
+    sta l0514,x                                                       // ba98: 9d 14 05    ...
+    inc l0024                                                         // ba9b: e6 24       .$
+    jmp c90d0                                                         // ba9d: 4c d0 90    L..
+
+// $baa0 referenced 1 time by $b941
+sub_cbaa0
+    lda #6                                                            // baa0: a9 06       ..
+    bra cbaa6                                                         // baa2: 80 02       ..
+// $baa4 referenced 2 times by $9059, $955b
+sub_cbaa4
+    lda #7                                                            // baa4: a9 07       ..
+// $baa6 referenced 1 time by $baa2
+cbaa6
+    stz l0037                                                         // baa6: 64 37       d7
+    sta l0038                                                         // baa8: 85 38       .8
+    lda #$ee                                                          // baaa: a9 ee       ..
+    sta l0039                                                         // baac: 85 39       .9
+    lda #$20 // ' '                                                   // baae: a9 20       .
+    sta l003a                                                         // bab0: 85 3a       .:
+    ldy #$ff                                                          // bab2: a0 ff       ..
+    sty l003b                                                         // bab4: 84 3b       .;
+    iny                                                               // bab6: c8          .
+    ldx #$37 // '7'                                                   // bab7: a2 37       .7
+    tya                                                               // bab9: 98          .
+    jsr osword                                                        // baba: 20 f1 ff     ..
+    bcc cbac5                                                         // babd: 90 06       ..
+    jmp c9c41                                                         // babf: 4c 41 9c    LA.
+
+// $bac2 referenced 8 times by $8a14, $8a68, $9285, $9319, $932a, $9538, $98c6, $bdc6
+sub_cbac2
+    jsr osnewl                                                        // bac2: 20 e7 ff     ..
+// $bac5 referenced 2 times by $babd, $bddf
+cbac5
+    stz l001e                                                         // bac5: 64 1e       d.
+    rts                                                               // bac7: 60          `
+
+// $bac8 referenced 2 times by $93fa, $bb47
+sub_cbac8
+    jsr sub_c8191                                                     // bac8: 20 91 81     ..
+    bcc cbb1a                                                         // bacb: 90 4d       .M
+    lda l003d                                                         // bacd: a5 3d       .=
+    sta l0037                                                         // bacf: 85 37       .7
+    sta l0012                                                         // bad1: 85 12       ..
+    lda l003e                                                         // bad3: a5 3e       .>
+    sta l0038                                                         // bad5: 85 38       .8
+    sta l0013                                                         // bad7: 85 13       ..
+    ldy #3                                                            // bad9: a0 03       ..
+    lda (l0037),y                                                     // badb: b1 37       .7
+    clc                                                               // badd: 18          .
+    adc l0037                                                         // bade: 65 37       e7
+    sta l0037                                                         // bae0: 85 37       .7
+    bcc cbae6                                                         // bae2: 90 02       ..
+    inc l0038                                                         // bae4: e6 38       .8
+// $bae6 referenced 1 time by $bae2
+cbae6
+    ldy #0                                                            // bae6: a0 00       ..
+// $bae8 referenced 2 times by $bb04, $bb0a
+cbae8
+    lda (l0037),y                                                     // bae8: b1 37       .7
+    sta (l0012),y                                                     // baea: 91 12       ..
+    cmp #$0d                                                          // baec: c9 0d       ..
+    bne cbb03                                                         // baee: d0 13       ..
+    iny                                                               // baf0: c8          .
+    bne cbaf7                                                         // baf1: d0 04       ..
+    inc l0038                                                         // baf3: e6 38       .8
+    inc l0013                                                         // baf5: e6 13       ..
+// $baf7 referenced 1 time by $baf1
+cbaf7
+    lda (l0037),y                                                     // baf7: b1 37       .7
+    sta (l0012),y                                                     // baf9: 91 12       ..
+    bmi cbb0c                                                         // bafb: 30 0f       0.
+    jsr sub_cbb0f                                                     // bafd: 20 0f bb     ..
+    jsr sub_cbb0f                                                     // bb00: 20 0f bb     ..
+// $bb03 referenced 1 time by $baee
+cbb03
+    iny                                                               // bb03: c8          .
+    bne cbae8                                                         // bb04: d0 e2       ..
+    inc l0038                                                         // bb06: e6 38       .8
+    inc l0013                                                         // bb08: e6 13       ..
+    bra cbae8                                                         // bb0a: 80 dc       ..
+// $bb0c referenced 1 time by $bafb
+cbb0c
+    jmp cbe45                                                         // bb0c: 4c 45 be    LE.
+
+// $bb0f referenced 2 times by $bafd, $bb00
+sub_cbb0f
+    iny                                                               // bb0f: c8          .
+    bne cbb16                                                         // bb10: d0 04       ..
+    inc l0013                                                         // bb12: e6 13       ..
+    inc l0038                                                         // bb14: e6 38       .8
+// $bb16 referenced 1 time by $bb10
+cbb16
+    lda (l0037),y                                                     // bb16: b1 37       .7
+    sta (l0012),y                                                     // bb18: 91 12       ..
+// $bb1a referenced 3 times by $bacb, $bb36, $bb54
+cbb1a
+    rts                                                               // bb1a: 60          `
+
+// $bb1b referenced 2 times by $903d, $9062
+sub_cbb1b
+    ldx #$ff                                                          // bb1b: a2 ff       ..
+    stx l0028                                                         // bb1d: 86 28       .(
+    stx l003c                                                         // bb1f: 86 3c       .<
+    jsr sub_cbbff                                                     // bb21: 20 ff bb     ..
+    lda l000b                                                         // bb24: a5 0b       ..
+    sta l0037                                                         // bb26: 85 37       .7
+    lda l000c                                                         // bb28: a5 0c       ..
+    sta l0038                                                         // bb2a: 85 38       .8
+    stz l003b                                                         // bb2c: 64 3b       d;
+    stz l000a                                                         // bb2e: 64 0a       d.
+    jsr c8e6f                                                         // bb30: 20 6f 8e     o.
+    jsr sub_c9be2                                                     // bb33: 20 e2 9b     ..
+    bcc cbb1a                                                         // bb36: 90 e2       ..
+// $bb38 referenced 1 time by $9566
+sub_cbb38
+    lda l001f                                                         // bb38: a5 1f       ..
+    beq cbb45                                                         // bb3a: f0 09       ..
+// $bb3c referenced 1 time by $bb42
+loop_cbb3c
+    lda l0700,y                                                       // bb3c: b9 00 07    ...
+    iny                                                               // bb3f: c8          .
+    cmp #$20 // ' '                                                   // bb40: c9 20       .
+    beq loop_cbb3c                                                    // bb42: f0 f8       ..
+    dey                                                               // bb44: 88          .
+// $bb45 referenced 1 time by $bb3a
+cbb45
+    sty l003b                                                         // bb45: 84 3b       .;
+    jsr sub_cbac8                                                     // bb47: 20 c8 ba     ..
+    ldy #7                                                            // bb4a: a0 07       ..
+    sty l003c                                                         // bb4c: 84 3c       .<
+    ldy #0                                                            // bb4e: a0 00       ..
+    lda #$0d                                                          // bb50: a9 0d       ..
+    cmp (l003b)                                                       // bb52: d2 3b       .;
+    beq cbb1a                                                         // bb54: f0 c4       ..
+// $bb56 referenced 1 time by $bb59
+loop_cbb56
+    iny                                                               // bb56: c8          .
+    cmp (l003b),y                                                     // bb57: d1 3b       .;
+    bne loop_cbb56                                                    // bb59: d0 fb       ..
+    lda #$20 // ' '                                                   // bb5b: a9 20       .
+// $bb5d referenced 1 time by $bb62
+loop_cbb5d
+    dey                                                               // bb5d: 88          .
+    beq cbb64                                                         // bb5e: f0 04       ..
+    cmp (l003b),y                                                     // bb60: d1 3b       .;
+    beq loop_cbb5d                                                    // bb62: f0 f9       ..
+// $bb64 referenced 1 time by $bb5e
+cbb64
+    iny                                                               // bb64: c8          .
+    lda #$0d                                                          // bb65: a9 0d       ..
+    sta (l003b),y                                                     // bb67: 91 3b       .;
+    iny                                                               // bb69: c8          .
+    iny                                                               // bb6a: c8          .
+    iny                                                               // bb6b: c8          .
+    iny                                                               // bb6c: c8          .
+    sty l003f                                                         // bb6d: 84 3f       .?
+    lda l0012                                                         // bb6f: a5 12       ..
+    sta l0039                                                         // bb71: 85 39       .9
+    lda l0013                                                         // bb73: a5 13       ..
+    sta l003a                                                         // bb75: 85 3a       .:
+    jsr sub_cbe44                                                     // bb77: 20 44 be     D.
+    sta l0037                                                         // bb7a: 85 37       .7
+    lda l0013                                                         // bb7c: a5 13       ..
+    sta l0038                                                         // bb7e: 85 38       .8
+    dey                                                               // bb80: 88          .
+    lda l0006                                                         // bb81: a5 06       ..
+    cmp l0012                                                         // bb83: c5 12       ..
+    lda l0007                                                         // bb85: a5 07       ..
+    sbc l0013                                                         // bb87: e5 13       ..
+    bcs cbb9b                                                         // bb89: b0 10       ..
+    jsr sub_cbe25                                                     // bb8b: 20 25 be     %.
+    jsr sub_cbbdc                                                     // bb8e: 20 dc bb     ..
+    brk                                                               // bb91: 00          .
+
+    .byt   0, $86                                                     // bb92: 00 86       ..
+    .asc " space"                                                     // bb94: 20 73 70...  sp
+    .byt 0                                                            // bb9a: 00          .
+
+// $bb9b referenced 2 times by $bb89, $bbb4
+cbb9b
+    lda (l0039),y                                                     // bb9b: b1 39       .9
+    sta (l0037),y                                                     // bb9d: 91 37       .7
+    tya                                                               // bb9f: 98          .
+    bne cbba6                                                         // bba0: d0 04       ..
+    dec l003a                                                         // bba2: c6 3a       .:
+    dec l0038                                                         // bba4: c6 38       .8
+// $bba6 referenced 1 time by $bba0
+cbba6
+    dey                                                               // bba6: 88          .
+    tya                                                               // bba7: 98          .
+    adc l0039                                                         // bba8: 65 39       e9
+    ldx l003a                                                         // bbaa: a6 3a       .:
+    bcc cbbaf                                                         // bbac: 90 01       ..
+    inx                                                               // bbae: e8          .
+// $bbaf referenced 1 time by $bbac
+cbbaf
+    cmp l003d                                                         // bbaf: c5 3d       .=
+    txa                                                               // bbb1: 8a          .
+    sbc l003e                                                         // bbb2: e5 3e       .>
+    bcs cbb9b                                                         // bbb4: b0 e5       ..
+    ldy #1                                                            // bbb6: a0 01       ..
+    lda l002b                                                         // bbb8: a5 2b       .+
+    sta (l003d),y                                                     // bbba: 91 3d       .=
+    iny                                                               // bbbc: c8          .
+    lda l002a                                                         // bbbd: a5 2a       .*
+    sta (l003d),y                                                     // bbbf: 91 3d       .=
+    iny                                                               // bbc1: c8          .
+    lda l003f                                                         // bbc2: a5 3f       .?
+    sta (l003d),y                                                     // bbc4: 91 3d       .=
+    sec                                                               // bbc6: 38          8
+    tya                                                               // bbc7: 98          .
+    adc l003d                                                         // bbc8: 65 3d       e=
+    sta l003d                                                         // bbca: 85 3d       .=
+    bcc cbbd0                                                         // bbcc: 90 02       ..
+    inc l003e                                                         // bbce: e6 3e       .>
+// $bbd0 referenced 1 time by $bbcc
+cbbd0
+    ldy #$ff                                                          // bbd0: a0 ff       ..
+// $bbd2 referenced 1 time by $bbd9
+loop_cbbd2
+    iny                                                               // bbd2: c8          .
+    lda (l003b),y                                                     // bbd3: b1 3b       .;
+    sta (l003d),y                                                     // bbd5: 91 3d       .=
+    cmp #$0d                                                          // bbd7: c9 0d       ..
+    bne loop_cbbd2                                                    // bbd9: d0 f7       ..
+    rts                                                               // bbdb: 60          `
+
+// $bbdc referenced 7 times by $8fda, $9048, $9569, $9706, $b3c8, $bb8e, $bd71
+sub_cbbdc
+    lda l0012                                                         // bbdc: a5 12       ..
+    sta l0000                                                         // bbde: 85 00       ..
+    sta l0002                                                         // bbe0: 85 02       ..
+    lda l0013                                                         // bbe2: a5 13       ..
+    sta l0001                                                         // bbe4: 85 01       ..
+    sta l0003                                                         // bbe6: 85 03       ..
+    jsr sub_cbbff                                                     // bbe8: 20 ff bb     ..
+// $bbeb referenced 1 time by $96f4
+sub_cbbeb
+    ldx #$10                                                          // bbeb: a2 10       ..
+// $bbed referenced 1 time by $bbf4
+loop_cbbed
+    lda lbf71,x                                                       // bbed: bd 71 bf    .q.
+    sta l07ef,x                                                       // bbf0: 9d ef 07    ...
+    dex                                                               // bbf3: ca          .
+    bne loop_cbbed                                                    // bbf4: d0 f7       ..
+    ldx #$80                                                          // bbf6: a2 80       ..
+// $bbf8 referenced 1 time by $bbfc
+loop_cbbf8
+    stz l047f,x                                                       // bbf8: 9e 7f 04    ...
+    dex                                                               // bbfb: ca          .
+    bne loop_cbbf8                                                    // bbfc: d0 fa       ..
+    rts                                                               // bbfe: 60          `
+
+// $bbff referenced 2 times by $bb21, $bbe8
+sub_cbbff
+    lda l0018                                                         // bbff: a5 18       ..
+    sta l001d                                                         // bc01: 85 1d       ..
+    lda l0006                                                         // bc03: a5 06       ..
+    sta l0004                                                         // bc05: 85 04       ..
+    lda l0007                                                         // bc07: a5 07       ..
+    sta l0005                                                         // bc09: 85 05       ..
+    lda #$80                                                          // bc0b: a9 80       ..
+    trb l001f                                                         // bc0d: 14 1f       ..
+    stz l0024                                                         // bc0f: 64 24       d$
+    stz l0026                                                         // bc11: 64 26       d&
+    stz l0025                                                         // bc13: 64 25       d%
+    stz l001c                                                         // bc15: 64 1c       d.
+    rts                                                               // bc17: 60          `
+
+// $bc18 referenced 2 times by $9f4f, $9f59
+sub_cbc18
+    jsr cbc3a                                                         // bc18: 20 3a bc     :.
+    jsr sub_ca026                                                     // bc1b: 20 26 a0     &.
+// $bc1e referenced 1 time by $a042
+sub_cbc1e
+    stx l0027                                                         // bc1e: 86 27       .'
+// $bc20 referenced 1 time by $9fb0
+sub_cbc20
+    tay                                                               // bc20: a8          .
+    jsr sub_c97a2                                                     // bc21: 20 a2 97     ..
+// $bc24 referenced 4 times by $9d33, $a56d, $a617, $b19b
+sub_cbc24
+    lda l0004                                                         // bc24: a5 04       ..
+    clc                                                               // bc26: 18          .
+    sta l004a                                                         // bc27: 85 4a       .J
+    adc #5                                                            // bc29: 69 05       i.
+    sta l0004                                                         // bc2b: 85 04       ..
+    lda l0005                                                         // bc2d: a5 05       ..
+    sta l004b                                                         // bc2f: 85 4b       .K
+    adc #0                                                            // bc31: 69 00       i.
+    sta l0005                                                         // bc33: 85 05       ..
+    rts                                                               // bc35: 60          `
+
+// $bc36 referenced 2 times by $a03c, $a081
+sub_cbc36
+    tay                                                               // bc36: a8          .
+    jsr sub_c97a2                                                     // bc37: 20 a2 97     ..
+// $bc3a referenced 5 times by $9d29, $9faa, $a60f, $bc18, $bc64
+cbc3a
+    lda l0004                                                         // bc3a: a5 04       ..
+    sec                                                               // bc3c: 38          8
+    sbc #5                                                            // bc3d: e9 05       ..
+    jsr sub_cbd5e                                                     // bc3f: 20 5e bd     ^.
+    lda l0030                                                         // bc42: a5 30       .0
+    sta (l0004)                                                       // bc44: 92 04       ..
+    ldy #1                                                            // bc46: a0 01       ..
+    lda l002e                                                         // bc48: a5 2e       ..
+    eor l0031                                                         // bc4a: 45 31       E1
+    and #$80                                                          // bc4c: 29 80       ).
+    eor l0031                                                         // bc4e: 45 31       E1
+    sta (l0004),y                                                     // bc50: 91 04       ..
+    iny                                                               // bc52: c8          .
+    lda l0032                                                         // bc53: a5 32       .2
+    sta (l0004),y                                                     // bc55: 91 04       ..
+    iny                                                               // bc57: c8          .
+    lda l0033                                                         // bc58: a5 33       .3
+    sta (l0004),y                                                     // bc5a: 91 04       ..
+    iny                                                               // bc5c: c8          .
+    lda l0034                                                         // bc5d: a5 34       .4
+    sta (l0004),y                                                     // bc5f: 91 04       ..
+    rts                                                               // bc61: 60          `
+
+// $bc62 referenced 2 times by $b149, $b1ce
+sub_cbc62
+    beq cbc91                                                         // bc62: f0 2d       .-
+    bmi cbc3a                                                         // bc64: 30 d4       0.
+// $bc66 referenced 20 times by $8fb1, $9114, $9387, $93df, $9418, $9555, $964e, $9889, $9ae6, $9b27, $9e42, $9e50, $a023, $a069, $b150, $b1db, $b3da, $b3ed, $b893, $b9c2
+cbc66
+    lda l0004                                                         // bc66: a5 04       ..
+    sec                                                               // bc68: 38          8
+    sbc #4                                                            // bc69: e9 04       ..
+    jsr sub_cbd5e                                                     // bc6b: 20 5e bd     ^.
+    ldy #3                                                            // bc6e: a0 03       ..
+    lda l002d                                                         // bc70: a5 2d       .-
+    sta (l0004),y                                                     // bc72: 91 04       ..
+    dey                                                               // bc74: 88          .
+    lda l002c                                                         // bc75: a5 2c       .,
+    sta (l0004),y                                                     // bc77: 91 04       ..
+    dey                                                               // bc79: 88          .
+    lda l002b                                                         // bc7a: a5 2b       .+
+    sta (l0004),y                                                     // bc7c: 91 04       ..
+    lda l002a                                                         // bc7e: a5 2a       .*
+    sta (l0004)                                                       // bc80: 92 04       ..
+    rts                                                               // bc82: 60          `
+
+// $bc83 referenced 6 times by $8a98, $9588, $97e3, $b650, $b96b, $b9b7
+sub_cbc83
+    ply                                                               // bc83: 7a          z
+    plx                                                               // bc84: fa          .
+    lda l002a                                                         // bc85: a5 2a       .*
+    pha                                                               // bc87: 48          H
+    lda l002b                                                         // bc88: a5 2b       .+
+    pha                                                               // bc8a: 48          H
+    lda l002c                                                         // bc8b: a5 2c       .,
+    pha                                                               // bc8d: 48          H
+    phx                                                               // bc8e: da          .
+    phy                                                               // bc8f: 5a          Z
+    rts                                                               // bc90: 60          `
+
+// $bc91 referenced 7 times by $9769, $9dc4, $9edd, $ab6a, $ac8a, $af13, $bc62
+cbc91
+    clc                                                               // bc91: 18          .
+    lda l0004                                                         // bc92: a5 04       ..
+    sbc l0036                                                         // bc94: e5 36       .6
+    jsr sub_cbd5e                                                     // bc96: 20 5e bd     ^.
+    ldy l0036                                                         // bc99: a4 36       .6
+    beq cbca5                                                         // bc9b: f0 08       ..
+// $bc9d referenced 1 time by $bca3
+loop_cbc9d
+    lda l05ff,y                                                       // bc9d: b9 ff 05    ...
+    sta (l0004),y                                                     // bca0: 91 04       ..
+    dey                                                               // bca2: 88          .
+    bne loop_cbc9d                                                    // bca3: d0 f8       ..
+// $bca5 referenced 1 time by $bc9b
+cbca5
+    lda l0036                                                         // bca5: a5 36       .6
+    sta (l0004)                                                       // bca7: 92 04       ..
+    rts                                                               // bca9: 60          `
+
+// $bcaa referenced 1 time by $b0db
+sub_cbcaa
+    lda l0039                                                         // bcaa: a5 39       .9
+    cmp #$80                                                          // bcac: c9 80       ..
+    beq cbcd5                                                         // bcae: f0 25       .%
+    bcc cbcea                                                         // bcb0: 90 38       .8
+    lda (l0004)                                                       // bcb2: b2 04       ..
+    tax                                                               // bcb4: aa          .
+    beq cbccd                                                         // bcb5: f0 16       ..
+    lda (l0037)                                                       // bcb7: b2 37       .7
+    sbc #1                                                            // bcb9: e9 01       ..
+    sta l0039                                                         // bcbb: 85 39       .9
+    ldy #1                                                            // bcbd: a0 01       ..
+    lda (l0037),y                                                     // bcbf: b1 37       .7
+    sbc #0                                                            // bcc1: e9 00       ..
+    sta l003a                                                         // bcc3: 85 3a       .:
+// $bcc5 referenced 1 time by $bccb
+loop_cbcc5
+    lda (l0004),y                                                     // bcc5: b1 04       ..
+    sta (l0039),y                                                     // bcc7: 91 39       .9
+    iny                                                               // bcc9: c8          .
+    dex                                                               // bcca: ca          .
+    bne loop_cbcc5                                                    // bccb: d0 f8       ..
+// $bccd referenced 1 time by $bcb5
+cbccd
+    lda (l0004)                                                       // bccd: b2 04       ..
+    ldy #3                                                            // bccf: a0 03       ..
+// $bcd1 referenced 1 time by $bce8
+loop_cbcd1
+    sta (l0037),y                                                     // bcd1: 91 37       .7
+    bra cbd21                                                         // bcd3: 80 4c       .L
+// $bcd5 referenced 1 time by $bcae
+cbcd5
+    lda (l0004)                                                       // bcd5: b2 04       ..
+    ldy #0                                                            // bcd7: a0 00       ..
+    tax                                                               // bcd9: aa          .
+    beq cbce6                                                         // bcda: f0 0a       ..
+// $bcdc referenced 1 time by $bce4
+loop_cbcdc
+    iny                                                               // bcdc: c8          .
+    lda (l0004),y                                                     // bcdd: b1 04       ..
+    dey                                                               // bcdf: 88          .
+    sta (l0037),y                                                     // bce0: 91 37       .7
+    iny                                                               // bce2: c8          .
+    dex                                                               // bce3: ca          .
+    bne loop_cbcdc                                                    // bce4: d0 f6       ..
+// $bce6 referenced 1 time by $bcda
+cbce6
+    lda #$0d                                                          // bce6: a9 0d       ..
+    bne loop_cbcd1                                                    // bce8: d0 e7       ..
+// $bcea referenced 1 time by $bcb0
+cbcea
+    lda (l0004)                                                       // bcea: b2 04       ..
+    sta (l0037)                                                       // bcec: 92 37       .7
+    ldy #4                                                            // bcee: a0 04       ..
+    lda l0039                                                         // bcf0: a5 39       .9
+    beq cbd0e                                                         // bcf2: f0 1a       ..
+    ldy #1                                                            // bcf4: a0 01       ..
+    lda (l0004),y                                                     // bcf6: b1 04       ..
+    sta (l0037),y                                                     // bcf8: 91 37       .7
+    iny                                                               // bcfa: c8          .
+    lda (l0004),y                                                     // bcfb: b1 04       ..
+    sta (l0037),y                                                     // bcfd: 91 37       .7
+    iny                                                               // bcff: c8          .
+    lda (l0004),y                                                     // bd00: b1 04       ..
+    sta (l0037),y                                                     // bd02: 91 37       .7
+    iny                                                               // bd04: c8          .
+    cpy l0039                                                         // bd05: c4 39       .9
+    bcs cbd0e                                                         // bd07: b0 05       ..
+    lda (l0004),y                                                     // bd09: b1 04       ..
+    sta (l0037),y                                                     // bd0b: 91 37       .7
+    iny                                                               // bd0d: c8          .
+// $bd0e referenced 2 times by $bcf2, $bd07
+cbd0e
+    tya                                                               // bd0e: 98          .
+    clc                                                               // bd0f: 18          .
+    bra cbd3d                                                         // bd10: 80 2b       .+
+// $bd12 referenced 5 times by $9efc, $aca6, $aecb, $af2f, $b1af
+sub_cbd12
+    lda (l0004)                                                       // bd12: b2 04       ..
+    sta l0036                                                         // bd14: 85 36       .6
+    beq cbd23                                                         // bd16: f0 0b       ..
+    tay                                                               // bd18: a8          .
+// $bd19 referenced 1 time by $bd1f
+loop_cbd19
+    lda (l0004),y                                                     // bd19: b1 04       ..
+    sta l05ff,y                                                       // bd1b: 99 ff 05    ...
+    dey                                                               // bd1e: 88          .
+    bne loop_cbd19                                                    // bd1f: d0 f8       ..
+// $bd21 referenced 5 times by $9dea, $ab8e, $accf, $ace8, $bcd3
+cbd21
+    lda (l0004)                                                       // bd21: b2 04       ..
+// $bd23 referenced 1 time by $bd16
+cbd23
+    sec                                                               // bd23: 38          8
+    bra cbd3d                                                         // bd24: 80 17       ..
+// $bd26 referenced 13 times by $8287, $916e, $93ba, $93f7, $9552, $955e, $9fed, $ac68, $af93, $b17e, $b1a3, $b3ea, $b432
+sub_cbd26
+    ldy #3                                                            // bd26: a0 03       ..
+    lda (l0004),y                                                     // bd28: b1 04       ..
+    sta l002d                                                         // bd2a: 85 2d       .-
+    dey                                                               // bd2c: 88          .
+    lda (l0004),y                                                     // bd2d: b1 04       ..
+    sta l002c                                                         // bd2f: 85 2c       .,
+    dey                                                               // bd31: 88          .
+    lda (l0004),y                                                     // bd32: b1 04       ..
+    sta l002b                                                         // bd34: 85 2b       .+
+    lda (l0004)                                                       // bd36: b2 04       ..
+    sta l002a                                                         // bd38: 85 2a       .*
+// $bd3a referenced 3 times by $9e23, $9e66, $bd5c
+cbd3a
+    clc                                                               // bd3a: 18          .
+    lda #4                                                            // bd3b: a9 04       ..
+// $bd3d referenced 2 times by $bd10, $bd24
+cbd3d
+    adc l0004                                                         // bd3d: 65 04       e.
+    sta l0004                                                         // bd3f: 85 04       ..
+    bcc cbd45                                                         // bd41: 90 02       ..
+    inc l0005                                                         // bd43: e6 05       ..
+// $bd45 referenced 1 time by $bd41
+cbd45
+    rts                                                               // bd45: 60          `
+
+// $bd46 referenced 3 times by $989b, $b0d8, $b8da
+sub_cbd46
+    ldx #$37 // '7'                                                   // bd46: a2 37       .7
+// $bd48 referenced 5 times by $81dc, $944c, $95c8, $9af4, $9b35
+sub_cbd48
+    ldy #3                                                            // bd48: a0 03       ..
+    lda (l0004),y                                                     // bd4a: b1 04       ..
+    sta l0003,x                                                       // bd4c: 95 03       ..
+    dey                                                               // bd4e: 88          .
+    lda (l0004),y                                                     // bd4f: b1 04       ..
+    sta l0002,x                                                       // bd51: 95 02       ..
+    dey                                                               // bd53: 88          .
+    lda (l0004),y                                                     // bd54: b1 04       ..
+    sta l0001,x                                                       // bd56: 95 01       ..
+    lda (l0004)                                                       // bd58: b2 04       ..
+    sta l0000,x                                                       // bd5a: 95 00       ..
+    bra cbd3a                                                         // bd5c: 80 dc       ..
+// $bd5e referenced 4 times by $b05e, $bc3f, $bc6b, $bc96
+sub_cbd5e
+    sta l0004                                                         // bd5e: 85 04       ..
+    bcs cbd64                                                         // bd60: b0 02       ..
+    dec l0005                                                         // bd62: c6 05       ..
+// $bd64 referenced 1 time by $bd60
+cbd64
+    ldy l0005                                                         // bd64: a4 05       ..
+    cpy l0003                                                         // bd66: c4 03       ..
+    bcc cbd74                                                         // bd68: 90 0a       ..
+    bne cbd70                                                         // bd6a: d0 04       ..
+    cmp l0002                                                         // bd6c: c5 02       ..
+    bcc cbd74                                                         // bd6e: 90 04       ..
+// $bd70 referenced 1 time by $bd6a
+cbd70
+    rts                                                               // bd70: 60          `
+
+// $bd71 referenced 1 time by $bdef
+cbd71
+    jsr sub_cbbdc                                                     // bd71: 20 dc bb     ..
+// $bd74 referenced 2 times by $bd68, $bd6e
+cbd74
+    jmp c9164                                                         // bd74: 4c 64 91    Ld.
+
+// $bd77 referenced 4 times by $8a3c, $8a5e, $98cf, $b51c
+sub_cbd77
+    sta l0037                                                         // bd77: 85 37       .7
+    cmp #$80                                                          // bd79: c9 80       ..
+    bcc cbdd4                                                         // bd7b: 90 57       .W
+    lda #$13                                                          // bd7d: a9 13       ..
+    sta l0038                                                         // bd7f: 85 38       .8
+    lda #$85                                                          // bd81: a9 85       ..
+    sta l0039                                                         // bd83: 85 39       .9
+    phy                                                               // bd85: 5a          Z
+// $bd86 referenced 2 times by $bd98, $bd9c
+cbd86
+    ldy #0                                                            // bd86: a0 00       ..
+// $bd88 referenced 1 time by $bd8b
+loop_cbd88
+    iny                                                               // bd88: c8          .
+    lda (l0038),y                                                     // bd89: b1 38       .8
+    bpl loop_cbd88                                                    // bd8b: 10 fb       ..
+    cmp l0037                                                         // bd8d: c5 37       .7
+    beq cbd9e                                                         // bd8f: f0 0d       ..
+    iny                                                               // bd91: c8          .
+    tya                                                               // bd92: 98          .
+    sec                                                               // bd93: 38          8
+    adc l0038                                                         // bd94: 65 38       e8
+    sta l0038                                                         // bd96: 85 38       .8
+    bcc cbd86                                                         // bd98: 90 ec       ..
+    inc l0039                                                         // bd9a: e6 39       .9
+    bra cbd86                                                         // bd9c: 80 e8       ..
+// $bd9e referenced 1 time by $bd8f
+cbd9e
+    ldy #0                                                            // bd9e: a0 00       ..
+// $bda0 referenced 1 time by $bda8
+loop_cbda0
+    lda (l0038),y                                                     // bda0: b1 38       .8
+    bmi cbdaa                                                         // bda2: 30 06       0.
+    jsr cbdd4                                                         // bda4: 20 d4 bd     ..
+    iny                                                               // bda7: c8          .
+    bne loop_cbda0                                                    // bda8: d0 f6       ..
+// $bdaa referenced 1 time by $bda2
+cbdaa
+    ply                                                               // bdaa: 7a          z
+    rts                                                               // bdab: 60          `
+
+// $bdac referenced 2 times by $89fb, $bdcf
+sub_cbdac
+    pha                                                               // bdac: 48          H
+    lsr                                                               // bdad: 4a          J
+    lsr                                                               // bdae: 4a          J
+    lsr                                                               // bdaf: 4a          J
+    lsr                                                               // bdb0: 4a          J
+    jsr sub_cbdb7                                                     // bdb1: 20 b7 bd     ..
+    pla                                                               // bdb4: 68          h
+    and #$0f                                                          // bdb5: 29 0f       ).
+// $bdb7 referenced 1 time by $bdb1
+sub_cbdb7
+    cmp #$0a                                                          // bdb7: c9 0a       ..
+    bcc cbdbd                                                         // bdb9: 90 02       ..
+    adc #6                                                            // bdbb: 69 06       i.
+// $bdbd referenced 1 time by $bdb9
+cbdbd
+    adc #$30 // '0'                                                   // bdbd: 69 30       i0
+// $bdbf referenced 1 time by $bdda
+loop_cbdbf
+    pha                                                               // bdbf: 48          H
+    lda l0023                                                         // bdc0: a5 23       .#
+    cmp l001e                                                         // bdc2: c5 1e       ..
+    bcs cbdc9                                                         // bdc4: b0 03       ..
+    jsr sub_cbac2                                                     // bdc6: 20 c2 ba     ..
+// $bdc9 referenced 1 time by $bdc4
+cbdc9
+    pla                                                               // bdc9: 68          h
+    inc l001e                                                         // bdca: e6 1e       ..
+    jmp (wrchv)                                                       // bdcc: 6c 0e 02    l..
+
+// $bdcf referenced 2 times by $8a00, $8a20
+sub_cbdcf
+    jsr sub_cbdac                                                     // bdcf: 20 ac bd     ..
+// $bdd2 referenced 4 times by $9268, $92d4, $9d26, $bdff
+cbdd2
+    lda #$20 // ' '                                                   // bdd2: a9 20       .
+// $bdd4 referenced 5 times by $a12a, $b445, $b4f2, $bd7b, $bda4
+cbdd4
+    bit l001f                                                         // bdd4: 24 1f       $.
+    bmi cbde2                                                         // bdd6: 30 0a       0.
+// $bdd8 referenced 4 times by $92e3, $937c, $9d1b, $9d23
+sub_cbdd8
+    cmp #$0d                                                          // bdd8: c9 0d       ..
+    bne loop_cbdbf                                                    // bdda: d0 e3       ..
+    jsr oswrch                                                        // bddc: 20 ee ff     ..
+    jmp cbac5                                                         // bddf: 4c c5 ba    L..
+
+// $bde2 referenced 1 time by $bdd6
+cbde2
+    sta (l0002)                                                       // bde2: 92 02       ..
+    inc l0002                                                         // bde4: e6 02       ..
+    bne cbe05                                                         // bde6: d0 1d       ..
+    inc l0003                                                         // bde8: e6 03       ..
+    pha                                                               // bdea: 48          H
+    lda l0003                                                         // bdeb: a5 03       ..
+    eor l0007                                                         // bded: 45 07       E.
+    beq cbd71                                                         // bdef: f0 80       ..
+    pla                                                               // bdf1: 68          h
+    rts                                                               // bdf2: 60          `
+
+// $bdf3 referenced 2 times by $b4d4, $b4db
+sub_cbdf3
+    clc                                                               // bdf3: 18          .
+// $bdf4 referenced 1 time by $b4cd
+sub_cbdf4
+    and l001f                                                         // bdf4: 25 1f       %.
+    beq cbe05                                                         // bdf6: f0 0d       ..
+    txa                                                               // bdf8: 8a          .
+    bmi cbe05                                                         // bdf9: 30 0a       0.
+    rol                                                               // bdfb: 2a          *
+    tax                                                               // bdfc: aa          .
+    beq cbe05                                                         // bdfd: f0 06       ..
+// $bdff referenced 6 times by $8a19, $8a2f, $8a4b, $9325, $a121, $be03
+cbdff
+    jsr cbdd2                                                         // bdff: 20 d2 bd     ..
+    dex                                                               // be02: ca          .
+    bne cbdff                                                         // be03: d0 fa       ..
+// $be05 referenced 4 times by $bde6, $bdf6, $bdf9, $bdfd
+cbe05
+    rts                                                               // be05: 60          `
+
+// $be06 referenced 6 times by $8d6a, $9fea, $aac3, $b194, $b1c7, $b400
+sub_cbe06
+    lda l002a                                                         // be06: a5 2a       .*
+    sta l0000,x                                                       // be08: 95 00       ..
+    lda l002b                                                         // be0a: a5 2b       .+
+    sta l0001,x                                                       // be0c: 95 01       ..
+    lda l002c                                                         // be0e: a5 2c       .,
+    sta l0002,x                                                       // be10: 95 02       ..
+    lda l002d                                                         // be12: a5 2d       .-
+    sta l0003,x                                                       // be14: 95 03       ..
+    rts                                                               // be16: 60          `
+
+// $be17 referenced 2 times by $8fc0, $8fe5
+sub_cbe17
+    jsr sub_cbe81                                                     // be17: 20 81 be     ..
+    stz l003d                                                         // be1a: 64 3d       d=
+    ldy #>(l0037)                                                     // be1c: a0 00       ..
+    lda #osfile_load                                                  // be1e: a9 ff       ..
+    ldx #<(l0037)                                                     // be20: a2 37       .7
+    jsr osfile                                                        // be22: 20 dd ff     ..
+// $be25 referenced 6 times by $8fd2, $8fed, $944f, $b42f, $bb8b, $be95
+sub_cbe25
+    lda l0018                                                         // be25: a5 18       ..
+    sta l0013                                                         // be27: 85 13       ..
+    stz l0012                                                         // be29: 64 12       d.
+    ldy #1                                                            // be2b: a0 01       ..
+// $be2d referenced 1 time by $be41
+loop_cbe2d
+    lda (l0012)                                                       // be2d: b2 12       ..
+    cmp #$0d                                                          // be2f: c9 0d       ..
+    bne cbe51                                                         // be31: d0 1e       ..
+    lda (l0012),y                                                     // be33: b1 12       ..
+    bmi cbe43                                                         // be35: 30 0c       0.
+    ldy #3                                                            // be37: a0 03       ..
+    lda (l0012),y                                                     // be39: b1 12       ..
+    beq cbe51                                                         // be3b: f0 14       ..
+    clc                                                               // be3d: 18          .
+    jsr sub_cbe46                                                     // be3e: 20 46 be     F.
+    bra loop_cbe2d                                                    // be41: 80 ea       ..
+// $be43 referenced 1 time by $be35
+cbe43
+    iny                                                               // be43: c8          .
+// $be44 referenced 1 time by $bb77
+sub_cbe44
+    clc                                                               // be44: 18          .
+// $be45 referenced 1 time by $bb0c
+cbe45
+    tya                                                               // be45: 98          .
+// $be46 referenced 1 time by $be3e
+sub_cbe46
+    adc l0012                                                         // be46: 65 12       e.
+    sta l0012                                                         // be48: 85 12       ..
+    bcc cbe4e                                                         // be4a: 90 02       ..
+    inc l0013                                                         // be4c: e6 13       ..
+// $be4e referenced 1 time by $be4a
+cbe4e
+    ldy #1                                                            // be4e: a0 01       ..
+    rts                                                               // be50: 60          `
+
+// $be51 referenced 2 times by $be31, $be3b
+cbe51
+    jsr sub_cbf0f                                                     // be51: 20 0f bf     ..
+    ora l6142                                                         // be54: 0d 42 61    .Ba
+    stz l0020                                                         // be57: 64 20       d
+    bvs lbecd                                                         // be59: 70 72       pr
+    .asc "ogram"                                                      // be5b: 6f 67 72... ogr
+    .byt $0d, $ea, $4c, $4b, $90                                      // be60: 0d ea 4c... ..L
+
+// $be65 referenced 1 time by $be7b
+sub_cbe65
+    stz l0037                                                         // be65: 64 37       d7
+    lda #6                                                            // be67: a9 06       ..
+    sta l0038                                                         // be69: 85 38       .8
+// $be6b referenced 2 times by $91ef, $ab47
+sub_cbe6b
+    ldy l0036                                                         // be6b: a4 36       .6
+    lda #$0d                                                          // be6d: a9 0d       ..
+    sta l0600,y                                                       // be6f: 99 00 06    ...
+    rts                                                               // be72: 60          `
+
+// $be73 referenced 1 time by $be79
+loop_cbe73
+    jmp c9155                                                         // be73: 4c 55 91    LU.
+
+// $be76 referenced 2 times by $be81, $bec7
+sub_cbe76
+    jsr sub_c9df3                                                     // be76: 20 f3 9d     ..
+    bne loop_cbe73                                                    // be79: d0 f8       ..
+    jsr sub_cbe65                                                     // be7b: 20 65 be     e.
+    jmp c9c55                                                         // be7e: 4c 55 9c    LU.
+
+// $be81 referenced 2 times by $be17, $be98
+sub_cbe81
+    jsr sub_cbe76                                                     // be81: 20 76 be     v.
+    dey                                                               // be84: 88          .
+    sty l0039                                                         // be85: 84 39       .9
+    lda l0018                                                         // be87: a5 18       ..
+    sta l003a                                                         // be89: 85 3a       .:
+// $be8b referenced 1 time by $9834
+sub_cbe8b
+    lda #osbyte_read_high_order_address                               // be8b: a9 82       ..
+    jsr osbyte                                                        // be8d: 20 f4 ff     ..
+    stx l003b                                                         // be90: 86 3b       .;
+    sty l003c                                                         // be92: 84 3c       .<
+    rts                                                               // be94: 60          `
+
+sub_cbe95
+    jsr sub_cbe25                                                     // be95: 20 25 be     %.
+    jsr sub_cbe81                                                     // be98: 20 81 be     ..
+    stx l003f                                                         // be9b: 86 3f       .?
+    sty l0040                                                         // be9d: 84 40       .@
+    stx l0043                                                         // be9f: 86 43       .C
+    sty l0044                                                         // bea1: 84 44       .D
+    stx l0047                                                         // bea3: 86 47       .G
+    sty l0048                                                         // bea5: 84 48       .H
+    stz l0041                                                         // bea7: 64 41       dA
+    ldx l0012                                                         // bea9: a6 12       ..
+    stx l0045                                                         // beab: 86 45       .E
+    ldx l0013                                                         // bead: a6 13       ..
+    stx l0046                                                         // beaf: 86 46       .F
+    ldx #$e7                                                          // beb1: a2 e7       ..
+    stx l003d                                                         // beb3: 86 3d       .=
+    ldx #$80                                                          // beb5: a2 80       ..
+    stx l003e                                                         // beb7: 86 3e       .>
+    ldx l0018                                                         // beb9: a6 18       ..
+    stx l0042                                                         // bebb: 86 42       .B
+    lda #osfile_save                                                  // bebd: a9 00       ..
+    tay                                                               // bebf: a8          .
+    ldx #<(l0037)                                                     // bec0: a2 37       .7
+    jsr osfile                                                        // bec2: 20 dd ff     ..
+    bra cbeeb                                                         // bec5: 80 24       .$
+sub_cbec7
+    jsr sub_cbe76                                                     // bec7: 20 76 be     v.
+    ldx #<(l0600)                                                     // beca: a2 00       ..
+sub_cbecc
+lbecd = sub_cbecc+1
+    ldy #>(l0600)                                                     // becc: a0 06       ..
+// overlapping: asl l0020                                             // becd: 06 20       .
+// $becd referenced 1 time by $be59
+    jsr oscli                                                         // bece: 20 f7 ff     ..
+    bra cbeeb                                                         // bed1: 80 18       ..
+// $bed3 referenced 1 time by $90ad
+cbed3
+    lda #3                                                            // bed3: a9 03       ..
+    bra cbed9                                                         // bed5: 80 02       ..
+sub_cbed7
+    lda #1                                                            // bed7: a9 01       ..
+// $bed9 referenced 1 time by $bed5
+cbed9
+    pha                                                               // bed9: 48          H
+    jsr sub_cba6e                                                     // beda: 20 6e ba     n.
+    phy                                                               // bedd: 5a          Z
+    jsr c9c16                                                         // bede: 20 16 9c     ..
+    jsr sub_c9781                                                     // bee1: 20 81 97     ..
+    ply                                                               // bee4: 7a          z
+    ldx #$2a // '*'                                                   // bee5: a2 2a       .*
+    pla                                                               // bee7: 68          h
+    jsr osargs                                                        // bee8: 20 da ff     ..
+// $beeb referenced 4 times by $bec5, $bed1, $befb, $bf0d
+cbeeb
+    jmp c90ca                                                         // beeb: 4c ca 90    L..
+
+sub_cbeee
+    jsr sub_cba6e                                                     // beee: 20 6e ba     n.
+    jsr sub_c9c5a                                                     // bef1: 20 5a 9c     Z.
+    ldy l002a                                                         // bef4: a4 2a       .*
+    lda #0                                                            // bef6: a9 00       ..
+    jsr osfind                                                        // bef8: 20 ce ff     ..
+    bra cbeeb                                                         // befb: 80 ee       ..
+sub_cbefd
+lbefe = sub_cbefd+1
+    jsr sub_cba6e                                                     // befd: 20 6e ba     n.
+// $befe referenced 1 time by $aa61
+// $bf00 referenced 1 time by $aa5a
+cbf00
+    pha                                                               // bf00: 48          H
+    jsr sub_c9771                                                     // bf01: 20 71 97     q.
+    jsr sub_c9c5a                                                     // bf04: 20 5a 9c     Z.
+    ply                                                               // bf07: 7a          z
+    lda l002a                                                         // bf08: a5 2a       .*
+    jsr osbput                                                        // bf0a: 20 d4 ff     ..
+    bra cbeeb                                                         // bf0d: 80 dc       ..
+// $bf0f referenced 2 times by $951f, $be51
+sub_cbf0f
+    pla                                                               // bf0f: 68          h
+    sta l0037                                                         // bf10: 85 37       .7
+    pla                                                               // bf12: 68          h
+    sta l0038                                                         // bf13: 85 38       .8
+    bra cbf1a                                                         // bf15: 80 03       ..
+// $bf17 referenced 1 time by $bf1d
+loop_cbf17
+    jsr osasci                                                        // bf17: 20 e3 ff     ..
+// $bf1a referenced 1 time by $bf15
+cbf1a
+    jsr sub_c8e66                                                     // bf1a: 20 66 8e     f.
+    bpl loop_cbf17                                                    // bf1d: 10 f8       ..
+    jmp (l0037)                                                       // bf1f: 6c 37 00    l7.
+
+// $bf22 referenced 4 times by $8ff7, $8ffb, $9007, $9012
+sub_cbf22
+    lda #osword_read_io_memory                                        // bf22: a9 05       ..
+    phx                                                               // bf24: da          .
+    ldx #<(l002a)                                                     // bf25: a2 2a       .*
+    ldy #>(l002a)                                                     // bf27: a0 00       ..
+    jsr osword                                                        // bf29: 20 f1 ff     ..
+    plx                                                               // bf2c: fa          .
+    lda l002e                                                         // bf2d: a5 2e       ..
+// $bf2f referenced 4 times by $9400, $958e, $965e, $aabc
+sub_cbf2f
+    inc l002a                                                         // bf2f: e6 2a       .*
+    bne cbf3d                                                         // bf31: d0 0a       ..
+    inc l002b                                                         // bf33: e6 2b       .+
+    bne cbf3d                                                         // bf35: d0 06       ..
+    inc l002c                                                         // bf37: e6 2c       .,
+    bne cbf3d                                                         // bf39: d0 02       ..
+    inc l002d                                                         // bf3b: e6 2d       .-
+// $bf3d referenced 3 times by $bf31, $bf35, $bf39
+cbf3d
+    rts                                                               // bf3d: 60          `
+
+// $bf3e referenced 2 times by $9019, $9045
+sub_cbf3e
+    lda #$0d                                                          // bf3e: a9 0d       ..
+    ldy l0018                                                         // bf40: a4 18       ..
+    sty l0013                                                         // bf42: 84 13       ..
+    stz l0012                                                         // bf44: 64 12       d.
+    stz l0020                                                         // bf46: 64 20       d
+    sta (l0012)                                                       // bf48: 92 12       ..
+    lda #$ff                                                          // bf4a: a9 ff       ..
+    ldy #1                                                            // bf4c: a0 01       ..
+    sta (l0012),y                                                     // bf4e: 91 12       ..
+    iny                                                               // bf50: c8          .
+    sty l0012                                                         // bf51: 84 12       ..
+    rts                                                               // bf53: 60          `
+
+// $bf54 referenced 1 time by $b46c
+cbf54
+    ldy #9                                                            // bf54: a0 09       ..
+// $bf56 referenced 1 time by $bf5d
+loop_cbf56
+    lda lb3be,y                                                       // bf56: b9 be b3    ...
+    sta l0600,y                                                       // bf59: 99 00 06    ...
+    dey                                                               // bf5c: 88          .
+    bpl loop_cbf56                                                    // bf5d: 10 f7       ..
+    ldx #<(l0600)                                                     // bf5f: a2 00       ..
+    ldy #>(l0600)                                                     // bf61: a0 06       ..
+    jmp oscli                                                         // bf63: 4c f7 ff    L..
+
+// $bf66 referenced 1 time by $80ac
+sub_cbf66
+    lda #osbyte_read_tube_presence                                    // bf66: a9 ea       ..
+    ldx #0                                                            // bf68: a2 00       ..
+    ldy #$ff                                                          // bf6a: a0 ff       ..
+    jsr osbyte                                                        // bf6c: 20 f4 ff     ..
+    txa                                                               // bf6f: 8a          .
+    rts                                                               // bf70: 60          `
+
+// $bf71 referenced 1 time by $bbed
+lbf71
+    .byt $52, $0b, $a8, $34, $a6, $e4, $a6, $0a, $a7, $10, $ad, $7e   // bf71: 52 0b a8... R..
+    .byt $a5, $4d, $a5, $4a, $2e, $7f, $5e, $5b, $d8, $aa,   0, $ca   // bf7d: a5 4d a5... .M.
+    .byt $98, $80, $81, $22, $f9, $83, $6e, $81, $49, $0f, $da, $a2   // bf89: 98 80 81... ...
+    .byt $21, $b3, $b2, $87, $80, $82, $38, $aa, $3b, $29, $80, $31   // bf95: 21 b3 b2... !..
+    .byt $72, $17, $f7, $d1, $5f, $5b, $e6, $ff, $66, $2b, $cc, $77   // bfa1: 72 17 f7... r..
+    .byt $6d,   6, $37, $bd, $73, $51, $b7, $17, $7a, $23, $d7, $0a   // bfad: 6d 06 37... m.7
+    .byt $81,   0,   0,   0,   0, $82, $40,   0,   0,   0, $9a, $d4   // bfb9: 81 00 00... ...
+    .byt $82, $7f, $b9, $ff, $78, $7b, $0e, $fa, $35, $12, $86, $65   // bfc5: 82 7f b9... ...
+    .byt $2e, $e0, $d3, $7e, $88, $88, $88, $89, $7b, $8c             // bfd1: 2e e0 d3... ...
+    .asc "o-Y"                                                        // bfdb: 6f 2d 59    o-Y
+    .byt $81, $99, $99, $99, $9a, $f3, $9e, $7b, $77, $81, $c0,   0   // bfde: 81 99 99... ...
+    .byt   0,   0, $80, $93, $e6, $90,   0, $81, $c4                  // bfea: 00 00 80... ...
+    .asc "DDD"                                                        // bff3: 44 44 44    DDD
+    .byt $80, $9d, $fd, $13,   4, $81, $e6                            // bff6: 80 9d fd... ...
+    .asc "fff"                                                        // bffd: 66 66 66    fff
+pydis_end
+
+// Label references by decreasing frequency:
+//     l002a:              206
+//     l0037:              133
+//     l002b:              119
+//     l0031:               88
+//     l000b:               82
+//     l001b:               82
+//     l000a:               81
+//     l003d:               78
+//     l0004:               75
+//     l002c:               75
+//     l0033:               66
+//     l0032:               65
+//     l0034:               63
+//     l0039:               59
+//     l0038:               58
+//     l0030:               57
+//     l002d:               56
+//     l0019:               52
+//     l003f:               52
+//     l0036:               51
+//     l003b:               49
+//     l002e:               48
+//     l003e:               48
+//     l0035:               42
+//     l000c:               37
+//     l003c:               36
+//     l0040:               34
+//     l004c:               31
+//     l0002:               29
+//     l003a:               29
+//     l0600:               29
+//     c8f9d:               29
+//     l0027:               28
+//     l004a:               25
+//     c9c6a:               24
+//     sub_c9332:           23
+//     l0003:               22
+//     l001a:               22
+//     l0012:               21
+//     l0041:               21
+//     l0048:               21
+//     cbc66:               20
+//     sub_c8da2:           18
+//     l0005:               17
+//     l002f:               17
+//     l004d:               16
+//     c8f92:               16
+//     l0013:               15
+//     l0018:               15
+//     l0049:               15
+//     oswrch:              15
+//     c9155:               14
+//     sub_c9dff:           14
+//     cad78:               14
+//     l0026:               13
+//     sub_cbd26:           13
+//     l0029:               12
+//     c90ca:               11
+//     ca2cc:               11
+//     cae60:               11
+//     osbyte:              11
+//     l0007:               10
+//     l000d:               10
+//     l0028:               10
+//     l0042:               10
+//     sub_c9779:           10
+//     sub_c9be2:           10
+//     c9c80:               10
+//     l000f:                9
+//     l001f:                9
+//     l05ff:                9
+//     sub_c8e5f:            9
+//     sub_c997d:            9
+//     sub_c9c5a:            9
+//     l0000:                8
+//     l0001:                8
+//     l0006:                8
+//     l001e:                8
+//     l0047:                8
+//     l004b:                8
+//     c828d:                8
+//     sub_c8d86:            8
+//     c90d0:                8
+//     c9338:                8
+//     c95f1:                8
+//     sub_c979f:            8
+//     sub_c9df3:            8
+//     sub_ca545:            8
+//     cae62:                8
+//     sub_cbac2:            8
+//     l0014:                7
+//     sub_c8fa8:            7
+//     c9048:                7
+//     sub_c9774:            7
+//     sub_c9783:            7
+//     c9c2d:                7
+//     ca72b:                7
+//     sub_cbbdc:            7
+//     cbc91:                7
+//     l000e:                6
+//     l0015:                6
+//     l0020:                6
+//     romsel_copy:          6
+//     c8b1b:                6
+//     c8bf9:                6
+//     sub_c8d9c:            6
+//     sub_c8e41:            6
+//     c8e6c:                6
+//     c904b:                6
+//     c90c5:                6
+//     sub_c976c:            6
+//     sub_c9771:            6
+//     c9e85:                6
+//     cac2b:                6
+//     cad10:                6
+//     cadce:                6
+//     cb169:                6
+//     sub_cbc83:            6
+//     cbdff:                6
+//     sub_cbe06:            6
+//     sub_cbe25:            6
+//     osbput:               6
+//     osbget:               6
+//     osword:               6
+//     l0010:                5
+//     l0024:                5
+//     l0025:                5
+//     os_text_ptr:          5
+//     l0400:                5
+//     c84ce:                5
+//     sub_c8d94:            5
+//     c932d:                5
+//     c9784:                5
+//     sub_c9788:            5
+//     sub_c97a2:            5
+//     c9a46:                5
+//     c9e83:                5
+//     c9f4c:                5
+//     ca261:                5
+//     sub_ca514:            5
+//     ca634:                5
+//     ca70a:                5
+//     ca712:                5
+//     cac1c:                5
+//     cac38:                5
+//     cad20:                5
+//     cafb8:                5
+//     sub_cb365:            5
+//     cb5cf:                5
+//     cb805:                5
+//     sub_cb85a:            5
+//     cbc3a:                5
+//     sub_cbd12:            5
+//     cbd21:                5
+//     sub_cbd48:            5
+//     cbdd4:                5
+//     l0011:                4
+//     l001c:                4
+//     l001d:                4
+//     l0046:                4
+//     l0100:                4
+//     l0440:                4
+//     l0441:                4
+//     sub_c8149:            4
+//     c815d:                4
+//     c820f:                4
+//     c84a3:                4
+//     c8af2:                4
+//     c8ce3:                4
+//     c8dfc:                4
+//     c8e51:                4
+//     c8ee7:                4
+//     c9045:                4
+//     c90c7:                4
+//     c9207:                4
+//     c9700:                4
+//     sub_c977e:            4
+//     sub_c9781:            4
+//     c9808:                4
+//     sub_c9952:            4
+//     c9c16:                4
+//     c9c8a:                4
+//     c9d75:                4
+//     sub_c9f07:            4
+//     c9f0a:                4
+//     sub_ca06c:            4
+//     ca0d1:                4
+//     ca2fb:                4
+//     ca426:                4
+//     ca513:                4
+//     caae8:                4
+//     cb5df:                4
+//     cb7b3:                4
+//     sub_cbc24:            4
+//     sub_cbd5e:            4
+//     sub_cbd77:            4
+//     cbdd2:                4
+//     sub_cbdd8:            4
+//     cbe05:                4
+//     cbeeb:                4
+//     sub_cbf22:            4
+//     sub_cbf2f:            4
+//     l0016:                3
+//     l0023:                3
+//     l00fd:                3
+//     l0401:                3
+//     l046c:                3
+//     l051d:                3
+//     l051f:                3
+//     l0524:                3
+//     c806a:                3
+//     sub_c80d8:            3
+//     c8190:                3
+//     sub_c8191:            3
+//     c827c:                3
+//     c82dd:                3
+//     c8304:                3
+//     c83d2:                3
+//     c8b10:                3
+//     c8bb2:                3
+//     c8c1b:                3
+//     c8c1e:                3
+//     c8cbb:                3
+//     c8d64:                3
+//     sub_c8d89:            3
+//     sub_c8d8c:            3
+//     c8e3f:                3
+//     sub_c8e66:            3
+//     c8e6f:                3
+//     c8e9c:                3
+//     c8ed0:                3
+//     c8edc:                3
+//     c8fbb:                3
+//     c9164:                3
+//     sub_c916e:            3
+//     c926e:                3
+//     c9276:                3
+//     c9288:                3
+//     c92da:                3
+//     sub_c9330:            3
+//     c93d7:                3
+//     sub_c953d:            3
+//     c96b8:                3
+//     c96ca:                3
+//     c979c:                3
+//     c98bd:                3
+//     c990c:                3
+//     sub_c990f:            3
+//     sub_c9923:            3
+//     c9a14:                3
+//     c9a28:                3
+//     sub_c9b97:            3
+//     c9bda:                3
+//     c9c55:                3
+//     c9c74:                3
+//     sub_c9d0f:            3
+//     sub_c9d7f:            3
+//     sub_ca0e8:            3
+//     ca126:                3
+//     ca174:                3
+//     sub_ca2dd:            3
+//     ca385:                3
+//     sub_ca3ed:            3
+//     sub_ca46b:            3
+//     ca4a9:                3
+//     ca4b9:                3
+//     sub_ca5ad:            3
+//     sub_ca5b4:            3
+//     ca622:                3
+//     sub_ca62f:            3
+//     ca674:                3
+//     ca6e4:                3
+//     ca6ed:                3
+//     sub_ca6ff:            3
+//     ca725:                3
+//     sub_ca73e:            3
+//     ca9c1:                3
+//     sub_ca9d1:            3
+//     cab9d:                3
+//     cadee:                3
+//     caed7:                3
+//     caed9:                3
+//     caf07:                3
+//     caf88:                3
+//     cb1de:                3
+//     sub_cb2e0:            3
+//     cb753:                3
+//     cb8fa:                3
+//     cb997:                3
+//     cb9ff:                3
+//     cba46:                3
+//     sub_cba6e:            3
+//     sub_cba7a:            3
+//     cbb1a:                3
+//     cbd3a:                3
+//     sub_cbd46:            3
+//     cbf3d:                3
+//     osnewl:               3
+//     oscli:                3
+//     l0017:                2
+//     l0021:                2
+//     l0022:                2
+//     l0044:                2
+//     l004e:                2
+//     l01ff:                2
+//     wrchv:                2
+//     l0402:                2
+//     l0403:                2
+//     l043c:                2
+//     l043d:                2
+//     l0519:                2
+//     l051a:                2
+//     l051b:                2
+//     l051c:                2
+//     l051e:                2
+//     l0521:                2
+//     l0522:                2
+//     l0523:                2
+//     l0526:                2
+//     l0527:                2
+//     l0700:                2
+//     c8067:                2
+//     c808f:                2
+//     c80a8:                2
+//     c80cc:                2
+//     c8151:                2
+//     c8197:                2
+//     c81b9:                2
+//     sub_c81bd:            2
+//     sub_c8287:            2
+//     sub_c828a:            2
+//     c82ae:                2
+//     c82f4:                2
+//     c82fb:                2
+//     c8306:                2
+//     sub_c83d3:            2
+//     c840a:                2
+//     sub_c8429:            2
+//     c89dd:                2
+//     c8b40:                2
+//     c8b5f:                2
+//     c8b62:                2
+//     c8b83:                2
+//     c8c31:                2
+//     c8c99:                2
+//     c8ca4:                2
+//     c8cbd:                2
+//     c8d34:                2
+//     c8d6e:                2
+//     sub_c8da8:            2
+//     c8dc9:                2
+//     c8e57:                2
+//     c8e7d:                2
+//     c8eb6:                2
+//     c8f1a:                2
+//     c8f26:                2
+//     c8f41:                2
+//     c8f5d:                2
+//     sub_c8fae:            2
+//     c9073:                2
+//     c90de:                2
+//     c914f:                2
+//     sub_c9171:            2
+//     c9193:                2
+//     c91ad:                2
+//     c91d1:                2
+//     c9285:                2
+//     sub_c933d:            2
+//     c9357:                2
+//     sub_c935c:            2
+//     sub_c93c7:            2
+//     sub_c9410:            2
+//     sub_c9436:            2
+//     c947f:                2
+//     c94ba:                2
+//     c94e4:                2
+//     c950d:                2
+//     c9555:                2
+//     sub_c95cb:            2
+//     c9635:                2
+//     sub_c9769:            2
+//     c979b:                2
+//     c97ee:                2
+//     c9866:                2
+//     c986a:                2
+//     c98c0:                2
+//     c98dc:                2
+//     c9928:                2
+//     c9977:                2
+//     c997a:                2
+//     c999f:                2
+//     sub_c99c4:            2
+//     c99fa:                2
+//     c9a3a:                2
+//     c9a75:                2
+//     c9ac1:                2
+//     sub_c9ac9:            2
+//     c9bae:                2
+//     c9bbc:                2
+//     c9bce:                2
+//     sub_c9bee:            2
+//     sub_c9c0a:            2
+//     c9c3b:                2
+//     c9c41:                2
+//     sub_c9c4a:            2
+//     c9c6c:                2
+//     c9cc6:                2
+//     c9ced:                2
+//     c9d7c:                2
+//     sub_c9d81:            2
+//     c9dc1:                2
+//     sub_c9e3f:            2
+//     sub_c9e6d:            2
+//     c9ecb:                2
+//     c9f55:                2
+//     c9f9a:                2
+//     c9fa7:                2
+//     sub_ca023:            2
+//     sub_ca026:            2
+//     ca029:                2
+//     ca05b:                2
+//     sub_ca069:            2
+//     ca06f:                2
+//     ca081:                2
+//     ca09c:                2
+//     ca0c5:                2
+//     sub_ca0ec:            2
+//     ca158:                2
+//     sub_ca181:            2
+//     ca19b:                2
+//     ca19d:                2
+//     ca1d4:                2
+//     ca220:                2
+//     ca2b7:                2
+//     sub_ca2ca:            2
+//     ca2d6:                2
+//     ca303:                2
+//     ca357:                2
+//     ca3a1:                2
+//     ca3a7:                2
+//     ca3e5:                2
+//     ca3e9:                2
+//     ca446:                2
+//     ca452:                2
+//     ca47a:                2
+//     sub_ca4ba:            2
+//     ca4f5:                2
+//     ca547:                2
+//     sub_ca54d:            2
+//     sub_ca56d:            2
+//     ca57e:                2
+//     sub_ca5bb:            2
+//     sub_ca5cc:            2
+//     sub_ca5cf:            2
+//     sub_ca5e3:            2
+//     sub_ca5f4:            2
+//     sub_ca6cb:            2
+//     ca6ce:                2
+//     ca6f2:                2
+//     ca704:                2
+//     ca73b:                2
+//     ca79b:                2
+//     ca7db:                2
+//     ca805:                2
+//     ca857:                2
+//     ca878:                2
+//     sub_ca8b3:            2
+//     sub_ca8b9:            2
+//     sub_ca97b:            2
+//     caa2c:                2
+//     sub_caa50:            2
+//     sub_caa55:            2
+//     sub_caa6e:            2
+//     caa7a:                2
+//     sub_caad8:            2
+//     cab1a:                2
+//     cab41:                2
+//     cabdd:                2
+//     cac2d:                2
+//     cacd2:                2
+//     cace8:                2
+//     cacfd:                2
+//     sub_cad3a:            2
+//     cad5b:                2
+//     cae56:                2
+//     caeb4:                2
+//     caedb:                2
+//     caf03:                2
+//     cafdb:                2
+//     cafee:                2
+//     sub_cb057:            2
+//     cb109:                2
+//     cb17e:                2
+//     sub_cb1bf:            2
+//     cb1db:                2
+//     cb205:                2
+//     cb341:                2
+//     sub_cb362:            2
+//     sub_cb372:            2
+//     cb39e:                2
+//     cb3fb:                2
+//     cb451:                2
+//     cb485:                2
+//     cb4a7:                2
+//     cb4e2:                2
+//     cb54b:                2
+//     cb563:                2
+//     cb56a:                2
+//     cb629:                2
+//     cb7a4:                2
+//     cb81a:                2
+//     sub_cb84d:            2
+//     cb866:                2
+//     cb86c:                2
+//     cb87f:                2
+//     cb9a5:                2
+//     sub_cb9dc:            2
+//     sub_cba6c:            2
+//     sub_cbaa4:            2
+//     cbac5:                2
+//     sub_cbac8:            2
+//     cbae8:                2
+//     sub_cbb0f:            2
+//     sub_cbb1b:            2
+//     cbb9b:                2
+//     sub_cbbff:            2
+//     sub_cbc18:            2
+//     sub_cbc36:            2
+//     sub_cbc62:            2
+//     cbd0e:                2
+//     cbd3d:                2
+//     cbd74:                2
+//     cbd86:                2
+//     sub_cbdac:            2
+//     sub_cbdcf:            2
+//     sub_cbdf3:            2
+//     sub_cbe17:            2
+//     cbe51:                2
+//     sub_cbe6b:            2
+//     sub_cbe76:            2
+//     sub_cbe81:            2
+//     sub_cbf0f:            2
+//     sub_cbf3e:            2
+//     osfind:               2
+//     osargs:               2
+//     osfile:               2
+//     osrdch:               2
+//     osasci:               2
+//     l0008:                1
+//     l0009:                1
+//     l0043:                1
+//     l0045:                1
+//     l0061:                1
+//     l0064:                1
+//     l0066:                1
+//     l00c1:                1
+//     l00e1:                1
+//     l00e6:                1
+//     l00fe:                1
+//     l00ff:                1
+//     l0106:                1
+//     brkv:                 1
+//     brkv+1:               1
+//     l0404:                1
+//     l040c:                1
+//     l0460:                1
+//     l0464:                1
+//     l0469:                1
+//     l047f:                1
+//     l04ff:                1
+//     l0500:                1
+//     l0513:                1
+//     l0514:                1
+//     l0528:                1
+//     l0529:                1
+//     l052a:                1
+//     l05cb:                1
+//     l05cc:                1
+//     l05e5:                1
+//     l05e6:                1
+//     l07ef:                1
+//     l0bb1:                1
+//     l0e4e:                1
+//     l4e4e:                1
+//     l5252:                1
+//     l6142:                1
+//     l7461:                1
+//     l7f0e:                1
+//     l7f13:                1
+//     service_handler:      1
+//     c8040:                1
+//     c804c:                1
+//     loop_c8057:           1
+//     c805e:                1
+//     c8070:                1
+//     loop_c8091:           1
+//     copy_to_stack_loop:   1
+//     l80c2:                1
+//     l80dd:                1
+//     l80e2:                1
+//     language_handler:     1
+//     c80ff:                1
+//     sub_c8139:            1
+//     c8168:                1
+//     loop_c8176:           1
+//     c817a:                1
+//     c8187:                1
+//     loop_c819f:           1
+//     c81ad:                1
+//     c81c8:                1
+//     loop_c81e1:           1
+//     c81ea:                1
+//     c81fd:                1
+//     loop_c8206:           1
+//     c8210:                1
+//     c8230:                1
+//     loop_c8235:           1
+//     c823f:                1
+//     c8242:                1
+//     c8246:                1
+//     loop_c8252:           1
+//     c825b:                1
+//     c829a:                1
+//     loop_c82b2:           1
+//     c82be:                1
+//     c82c8:                1
+//     c82d8:                1
+//     sub_c82e6:            1
+//     loop_c82f7:           1
+//     loop_c8314:           1
+//     c832f:                1
+//     loop_c8331:           1
+//     c833b:                1
+//     c8345:                1
+//     c8346:                1
+//     sub_c8349:            1
+//     sub_c834f:            1
+//     c8353:                1
+//     c835e:                1
+//     c8362:                1
+//     loop_c8365:           1
+//     c8371:                1
+//     c8372:                1
+//     c8392:                1
+//     loop_c839e:           1
+//     c83a6:                1
+//     sub_c83aa:            1
+//     c83c1:                1
+//     sub_c83c2:            1
+//     c83d5:                1
+//     loop_c8428:           1
+//     loop_c8440:           1
+//     c8456:                1
+//     loop_c845b:           1
+//     c846a:                1
+//     loop_c847b:           1
+//     c8491:                1
+//     loop_c8496:           1
+//     c84ad:                1
+//     c84f4:                1
+//     l880a:                1
+//     l8909:                1
+//     l894e:                1
+//     l8993:                1
+//     c89bf:                1
+//     loop_c89d7:           1
+//     c89f4:                1
+//     c8a0b:                1
+//     loop_c8a11:           1
+//     c8a1e:                1
+//     c8a28:                1
+//     loop_c8a2a:           1
+//     c8a34:                1
+//     loop_c8a3c:           1
+//     c8a44:                1
+//     c8a4b:                1
+//     loop_c8a4f:           1
+//     loop_c8a54:           1
+//     loop_c8a5e:           1
+//     c8a64:                1
+//     c8a68:                1
+//     c8a6b:                1
+//     loop_c8a6e:           1
+//     c8a79:                1
+//     c8a8b:                1
+//     c8a8e:                1
+//     c8a91:                1
+//     sub_c8aa8:            1
+//     loop_c8ac3:           1
+//     loop_c8ad4:           1
+//     c8adf:                1
+//     loop_c8ae3:           1
+//     c8aef:                1
+//     c8af5:                1
+//     c8b33:                1
+//     c8b4b:                1
+//     c8b55:                1
+//     c8b63:                1
+//     c8b98:                1
+//     c8b9b:                1
+//     c8b9c:                1
+//     loop_c8b9e:           1
+//     c8ba3:                1
+//     c8baf:                1
+//     c8bb4:                1
+//     c8bb6:                1
+//     c8bbd:                1
+//     c8bc4:                1
+//     c8bde:                1
+//     c8be9:                1
+//     c8c01:                1
+//     loop_c8c15:           1
+//     c8c24:                1
+//     c8c41:                1
+//     c8c43:                1
+//     c8c55:                1
+//     c8c57:                1
+//     c8c5e:                1
+//     c8c74:                1
+//     c8c84:                1
+//     c8c87:                1
+//     c8c96:                1
+//     loop_c8c9b:           1
+//     c8ca7:                1
+//     c8cb8:                1
+//     c8cc0:                1
+//     c8ce6:                1
+//     c8cfd:                1
+//     c8d16:                1
+//     c8d37:                1
+//     c8d44:                1
+//     loop_c8d71:           1
+//     c8d74:                1
+//     loop_c8db7:           1
+//     sub_c8dc1:            1
+//     c8dff:                1
+//     loop_c8e16:           1
+//     sub_c8e1f:            1
+//     sub_c8e58:            1
+//     c8e8d:                1
+//     loop_c8e91:           1
+//     c8e9d:                1
+//     sub_c8ea4:            1
+//     c8ea6:                1
+//     c8eaa:                1
+//     c8ebe:                1
+//     loop_c8ee2:           1
+//     c8ef3:                1
+//     c8f03:                1
+//     loop_c8f0b:           1
+//     c8f25:                1
+//     c8f32:                1
+//     c8f3d:                1
+//     c8f52:                1
+//     c8f6d:                1
+//     c8f74:                1
+//     loop_c8f7a:           1
+//     c8f86:                1
+//     c8f87:                1
+//     c8f8c:                1
+//     c8f9c:                1
+//     loop_c8fa7:           1
+//     sub_c8fb4:            1
+//     c8fda:                1
+//     c8ff2:                1
+//     loop_c9004:           1
+//     c901c:                1
+//     loop_c9024:           1
+//     c9033:                1
+//     c905c:                1
+//     c9069:                1
+//     loop_c9078:           1
+//     c907d:                1
+//     c9082:                1
+//     c9086:                1
+//     c90a0:                1
+//     loop_c90a6:           1
+//     loop_c90ad:           1
+//     c90b0:                1
+//     c90d2:                1
+//     c90e3:                1
+//     c90ea:                1
+//     c9108:                1
+//     c9112:                1
+//     c9123:                1
+//     c9135:                1
+//     c9146:                1
+//     loop_c91e4:           1
+//     c91ee:                1
+//     c91ef:                1
+//     loop_c91f6:           1
+//     c9201:                1
+//     c9204:                1
+//     loop_c9220:           1
+//     c922a:                1
+//     loop_c922c:           1
+//     c9237:                1
+//     loop_c923f:           1
+//     c924a:                1
+//     c9259:                1
+//     loop_c9260:           1
+//     loop_c9268:           1
+//     c9274:                1
+//     loop_c928b:           1
+//     c929e:                1
+//     loop_c92d4:           1
+//     loop_c92e0:           1
+//     c92ed:                1
+//     loop_c92f0:           1
+//     c9304:                1
+//     c931e:                1
+//     c9321:                1
+//     c9325:                1
+//     c932a:                1
+//     loop_c9355:           1
+//     loop_c9356:           1
+//     loop_c9368:           1
+//     c937c:                1
+//     c938f:                1
+//     c93b4:                1
+//     c93c4:                1
+//     loop_c93fa:           1
+//     c9433:                1
+//     sub_c943e:            1
+//     loop_c9455:           1
+//     c9469:                1
+//     c9476:                1
+//     c9487:                1
+//     loop_c948a:           1
+//     c94aa:                1
+//     c94b0:                1
+//     c94c8:                1
+//     c94d1:                1
+//     c94d5:                1
+//     c94de:                1
+//     c9509:                1
+//     c951d:                1
+//     c951f:                1
+//     c954b:                1
+//     c9579:                1
+//     c957c:                1
+//     c957f:                1
+//     c95be:                1
+//     sub_c95c6:            1
+//     loop_c95cf:           1
+//     c95e0:                1
+//     c95f9:                1
+//     c9606:                1
+//     c9628:                1
+//     c9632:                1
+//     c963b:                1
+//     c964e:                1
+//     c968d:                1
+//     c96bf:                1
+//     c971b:                1
+//     loop_c9724:           1
+//     loop_c9728:           1
+//     c972c:                1
+//     c9735:                1
+//     loop_c9750:           1
+//     c9753:                1
+//     sub_c978b:            1
+//     loop_c97c0:           1
+//     loop_c97c6:           1
+//     c97d2:                1
+//     c97fe:                1
+//     c9801:                1
+//     c9877:                1
+//     c9889:                1
+//     loop_c98cb:           1
+//     c98d7:                1
+//     loop_c98df:           1
+//     loop_c9904:           1
+//     sub_c9914:            1
+//     loop_c992a:           1
+//     c9937:                1
+//     loop_c9948:           1
+//     loop_c9954:           1
+//     sub_c995a:            1
+//     c9962:                1
+//     c996e:                1
+//     c9979:                1
+//     c9990:                1
+//     c99a0:                1
+//     c99a2:                1
+//     c99ab:                1
+//     c99ba:                1
+//     loop_c99cf:           1
+//     sub_c99d0:            1
+//     sub_c99d6:            1
+//     sub_c99d8:            1
+//     c9a0e:                1
+//     c9a58:                1
+//     c9a63:                1
+//     c9a67:                1
+//     c9a76:                1
+//     c9a79:                1
+//     c9a7b:                1
+//     c9a99:                1
+//     c9aa0:                1
+//     c9aa5:                1
+//     loop_c9ab6:           1
+//     c9abc:                1
+//     c9ae6:                1
+//     c9b4c:                1
+//     c9b5a:                1
+//     c9b78:                1
+//     c9b80:                1
+//     c9b8a:                1
+//     sub_c9bba:            1
+//     c9bd2:                1
+//     c9bdb:                1
+//     loop_c9be0:           1
+//     c9c08:                1
+//     c9c24:                1
+//     c9c52:                1
+//     loop_c9c6d:           1
+//     sub_c9c8e:            1
+//     loop_c9c92:           1
+//     sub_c9c93:            1
+//     sub_c9ca2:            1
+//     c9cb6:                1
+//     sub_c9cb8:            1
+//     c9cc1:                1
+//     c9cc5:                1
+//     loop_c9cc9:           1
+//     c9cd6:                1
+//     loop_c9ce8:           1
+//     c9ceb:                1
+//     c9cfb:                1
+//     loop_c9cfd:           1
+//     c9d0c:                1
+//     c9d29:                1
+//     sub_c9d36:            1
+//     c9d43:                1
+//     c9d57:                1
+//     c9d79:                1
+//     c9d7b:                1
+//     sub_c9d82:            1
+//     c9db4:                1
+//     c9dba:                1
+//     c9dbe:                1
+//     c9dbf:                1
+//     c9dc0:                1
+//     c9dc4:                1
+//     c9dd5:                1
+//     loop_c9dd7:           1
+//     c9de5:                1
+//     c9de9:                1
+//     c9e02:                1
+//     c9e10:                1
+//     loop_c9e18:           1
+//     loop_c9e23:           1
+//     c9e2a:                1
+//     loop_c9e32:           1
+//     sub_c9e45:            1
+//     c9e48:                1
+//     c9e4d:                1
+//     loop_c9e5b:           1
+//     c9e78:                1
+//     c9e79:                1
+//     c9e90:                1
+//     c9ea6:                1
+//     c9ead:                1
+//     c9eb2:                1
+//     c9ec2:                1
+//     c9edd:                1
+//     loop_c9ef2:           1
+//     c9f13:                1
+//     c9f3b:                1
+//     c9f4f:                1
+//     loop_c9f59:           1
+//     loop_c9f61:           1
+//     c9f64:                1
+//     c9f70:                1
+//     c9f9d:                1
+//     loop_c9faa:           1
+//     c9fb6:                1
+//     c9fb8:                1
+//     loop_c9fbb:           1
+//     c9fe6:                1
+//     c9ff4:                1
+//     ca00f:                1
+//     ca03b:                1
+//     ca03c:                1
+//     ca04a:                1
+//     ca04d:                1
+//     loop_ca052:           1
+//     ca05f:                1
+//     loop_ca070:           1
+//     ca09f:                1
+//     loop_ca0b8:           1
+//     ca0c7:                1
+//     ca0ee:                1
+//     loop_ca0f2:           1
+//     loop_ca0f5:           1
+//     ca10a:                1
+//     loop_ca10f:           1
+//     ca116:                1
+//     ca131:                1
+//     ca137:                1
+//     loop_ca13b:           1
+//     loop_ca151:           1
+//     ca160:                1
+//     ca169:                1
+//     ca18a:                1
+//     ca197:                1
+//     ca1af:                1
+//     ca1bc:                1
+//     ca1c1:                1
+//     ca1cd:                1
+//     ca1d0:                1
+//     ca1ed:                1
+//     ca1ef:                1
+//     ca204:                1
+//     loop_ca207:           1
+//     ca212:                1
+//     ca21c:                1
+//     ca22a:                1
+//     ca23e:                1
+//     ca24a:                1
+//     loop_ca256:           1
+//     ca25f:                1
+//     loop_ca263:           1
+//     ca26f:                1
+//     loop_ca27d:           1
+//     ca28a:                1
+//     ca28c:                1
+//     ca290:                1
+//     ca2a3:                1
+//     ca2b3:                1
+//     sub_ca2b8:            1
+//     loop_ca2bb:           1
+//     ca2c9:                1
+//     ca2fd:                1
+//     ca325:                1
+//     ca333:                1
+//     ca33e:                1
+//     ca342:                1
+//     ca348:                1
+//     ca34c:                1
+//     ca36b:                1
+//     ca37e:                1
+//     ca393:                1
+//     loop_ca399:           1
+//     ca3aa:                1
+//     loop_ca3ae:           1
+//     sub_ca3b5:            1
+//     sub_ca3c0:            1
+//     ca3c3:                1
+//     sub_ca40a:            1
+//     sub_ca419:            1
+//     ca42c:                1
+//     ca489:                1
+//     ca4a3:                1
+//     ca4c4:                1
+//     ca4ce:                1
+//     ca4e8:                1
+//     sub_ca503:            1
+//     sub_ca507:            1
+//     sub_ca50b:            1
+//     ca53b:                1
+//     ca53e:                1
+//     sub_ca541:            1
+//     sub_ca572:            1
+//     sub_ca576:            1
+//     ca57a:                1
+//     ca5a7:                1
+//     ca5aa:                1
+//     sub_ca5b2:            1
+//     loop_ca5b6:           1
+//     ca5ba:                1
+//     sub_ca5bd:            1
+//     sub_ca5c1:            1
+//     sub_ca5c4:            1
+//     sub_ca5d1:            1
+//     sub_ca5f2:            1
+//     sub_ca5f9:            1
+//     loop_ca607:           1
+//     ca608:                1
+//     ca612:                1
+//     loop_ca617:           1
+//     ca61d:                1
+//     loop_ca62c:           1
+//     sub_ca631:            1
+//     ca640:                1
+//     ca653:                1
+//     ca65c:                1
+//     ca65e:                1
+//     ca676:                1
+//     ca68d:                1
+//     ca6a2:                1
+//     loop_ca6a8:           1
+//     ca6ae:                1
+//     ca6c4:                1
+//     sub_ca6eb:            1
+//     sub_ca70d:            1
+//     ca70f:                1
+//     ca71e:                1
+//     ca72f:                1
+//     sub_ca731:            1
+//     ca739:                1
+//     ca73d:                1
+//     ca74d:                1
+//     loop_ca758:           1
+//     ca76b:                1
+//     ca776:                1
+//     ca797:                1
+//     sub_ca7ac:            1
+//     sub_ca7af:            1
+//     ca7c0:                1
+//     la7c9:                1
+//     ca7cd:                1
+//     ca7ed:                1
+//     ca7ef:                1
+//     sub_ca80b:            1
+//     ca829:                1
+//     ca838:                1
+//     ca83f:                1
+//     ca841:                1
+//     ca875:                1
+//     ca88a:                1
+//     loop_ca88f:           1
+//     ca899:                1
+//     ca8b0:                1
+//     ca8bb:                1
+//     loop_ca8cd:           1
+//     loop_ca8e0:           1
+//     ca8ee:                1
+//     sub_ca901:            1
+//     ca91f:                1
+//     ca92d:                1
+//     ca932:                1
+//     ca93b:                1
+//     ca946:                1
+//     ca948:                1
+//     ca94b:                1
+//     ca959:                1
+//     ca962:                1
+//     ca965:                1
+//     loop_ca969:           1
+//     ca978:                1
+//     loop_ca982:           1
+//     sub_ca9a3:            1
+//     sub_ca9c3:            1
+//     ca9e0:                1
+//     ca9ef:                1
+//     ca9f2:                1
+//     loop_ca9f5:           1
+//     ca9f8:                1
+//     caa07:                1
+//     sub_caa1a:            1
+//     caa33:                1
+//     caa3e:                1
+//     caa44:                1
+//     loop_caa59:           1
+//     caa66:                1
+//     caa6b:                1
+//     caa7d:                1
+//     caa9a:                1
+//     caab0:                1
+//     caac1:                1
+//     loop_caaf0:           1
+//     sub_cab14:            1
+//     cab23:                1
+//     cab82:                1
+//     cab91:                1
+//     sub_caba5:            1
+//     cabc9:                1
+//     cabd0:                1
+//     cabfa:                1
+//     cabfd:                1
+//     cac02:                1
+//     cac0f:                1
+//     cac35:                1
+//     loop_cac3c:           1
+//     cac59:                1
+//     cac5b:                1
+//     caca0:                1
+//     caca3:                1
+//     caca9:                1
+//     cacaf:                1
+//     loop_cacd8:           1
+//     cace3:                1
+//     loop_cace5:           1
+//     loop_caceb:           1
+//     cacef:                1
+//     sub_cad07:            1
+//     cad0d:                1
+//     cad14:                1
+//     cad19:                1
+//     sub_cad1c:            1
+//     cad37:                1
+//     loop_cad43:           1
+//     cad52:                1
+//     cad53:                1
+//     loop_cad5d:           1
+//     loop_cad5e:           1
+//     cad75:                1
+//     sub_cad8e:            1
+//     cad91:                1
+//     cad9c:                1
+//     cadac:                1
+//     cadb6:                1
+//     cadbc:                1
+//     sub_cadc6:            1
+//     loop_cade0:           1
+//     cade4:                1
+//     cadf9:                1
+//     loop_cadfe:           1
+//     cae00:                1
+//     cae0d:                1
+//     cae11:                1
+//     loop_cae1e:           1
+//     cae31:                1
+//     cae3f:                1
+//     cae9f:                1
+//     caedc:                1
+//     loop_caeed:           1
+//     caf2f:                1
+//     caf3d:                1
+//     caf4d:                1
+//     loop_caf51:           1
+//     caf6d:                1
+//     caf83:                1
+//     loop_cafa2:           1
+//     loop_cafa4:           1
+//     cafbb:                1
+//     cafbe:                1
+//     loop_cafc1:           1
+//     cafd5:                1
+//     loop_cafe3:           1
+//     caffd:                1
+//     cb00e:                1
+//     loop_cb019:           1
+//     cb04a:                1
+//     loop_cb066:           1
+//     cb08a:                1
+//     cb0a6:                1
+//     cb0b0:                1
+//     cb0be:                1
+//     loop_cb0d8:           1
+//     cb0e2:                1
+//     loop_cb0f2:           1
+//     cb106:                1
+//     loop_cb146:           1
+//     cb1a3:                1
+//     cb1a6:                1
+//     cb1ab:                1
+//     cb1b5:                1
+//     cb1ca:                1
+//     cb200:                1
+//     cb22d:                1
+//     cb230:                1
+//     cb235:                1
+//     loop_cb24d:           1
+//     cb256:                1
+//     cb257:                1
+//     loop_cb259:           1
+//     cb266:                1
+//     loop_cb307:           1
+//     loop_cb32b:           1
+//     cb34c:                1
+//     cb35c:                1
+//     loop_cb35f:           1
+//     cb380:                1
+//     cb398:                1
+//     cb399:                1
+//     lb3be:                1
+//     cb3cf:                1
+//     cb3f4:                1
+//     cb3fe:                1
+//     cb425:                1
+//     cb428:                1
+//     cb42b:                1
+//     cb445:                1
+//     cb454:                1
+//     cb45d:                1
+//     cb46f:                1
+//     cb47f:                1
+//     cb495:                1
+//     cb497:                1
+//     cb4a1:                1
+//     loop_cb4a9:           1
+//     cb4b8:                1
+//     cb4ba:                1
+//     cb4bc:                1
+//     cb4c2:                1
+//     cb4e0:                1
+//     loop_cb4f2:           1
+//     cb4f8:                1
+//     cb50a:                1
+//     cb510:                1
+//     cb516:                1
+//     cb51c:                1
+//     cb522:                1
+//     loop_cb52d:           1
+//     cb530:                1
+//     loop_cb536:           1
+//     cb5cd:                1
+//     cb5f1:                1
+//     cb622:                1
+//     cb626:                1
+//     cb635:                1
+//     loop_cb642:           1
+//     cb6a7:                1
+//     cb6bf:                1
+//     cb6d1:                1
+//     cb6f7:                1
+//     cb70c:                1
+//     cb723:                1
+//     loop_cb730:           1
+//     cb74a:                1
+//     cb75a:                1
+//     cb762:                1
+//     loop_cb769:           1
+//     loop_cb771:           1
+//     cb7ca:                1
+//     cb7d4:                1
+//     cb7da:                1
+//     cb7e6:                1
+//     cb7fa:                1
+//     loop_cb806:           1
+//     cb824:                1
+//     cb833:                1
+//     cb847:                1
+//     loop_cb84c:           1
+//     cb857:                1
+//     loop_cb86f:           1
+//     loop_cb872:           1
+//     cb874:                1
+//     cb877:                1
+//     loop_cb8ac:           1
+//     cb8b5:                1
+//     cb8ba:                1
+//     loop_cb8c2:           1
+//     cb8cc:                1
+//     loop_cb8ce:           1
+//     cb8da:                1
+//     cb8e2:                1
+//     cb8f2:                1
+//     loop_cb8ff:           1
+//     cb909:                1
+//     cb938:                1
+//     cb941:                1
+//     cb94f:                1
+//     loop_cb95a:           1
+//     cb965:                1
+//     cb968:                1
+//     loop_cb974:           1
+//     cb976:                1
+//     cb9ad:                1
+//     cb9bf:                1
+//     cb9cd:                1
+//     loop_cb9f6:           1
+//     loop_cba0a:           1
+//     cba21:                1
+//     cba2b:                1
+//     cba31:                1
+//     cba35:                1
+//     cba43:                1
+//     cba63:                1
+//     sub_cbaa0:            1
+//     cbaa6:                1
+//     cbae6:                1
+//     cbaf7:                1
+//     cbb03:                1
+//     cbb0c:                1
+//     cbb16:                1
+//     sub_cbb38:            1
+//     loop_cbb3c:           1
+//     cbb45:                1
+//     loop_cbb56:           1
+//     loop_cbb5d:           1
+//     cbb64:                1
+//     cbba6:                1
+//     cbbaf:                1
+//     cbbd0:                1
+//     loop_cbbd2:           1
+//     sub_cbbeb:            1
+//     loop_cbbed:           1
+//     loop_cbbf8:           1
+//     sub_cbc1e:            1
+//     sub_cbc20:            1
+//     loop_cbc9d:           1
+//     cbca5:                1
+//     sub_cbcaa:            1
+//     loop_cbcc5:           1
+//     cbccd:                1
+//     loop_cbcd1:           1
+//     cbcd5:                1
+//     loop_cbcdc:           1
+//     cbce6:                1
+//     cbcea:                1
+//     loop_cbd19:           1
+//     cbd23:                1
+//     cbd45:                1
+//     cbd64:                1
+//     cbd70:                1
+//     cbd71:                1
+//     loop_cbd88:           1
+//     cbd9e:                1
+//     loop_cbda0:           1
+//     cbdaa:                1
+//     sub_cbdb7:            1
+//     cbdbd:                1
+//     loop_cbdbf:           1
+//     cbdc9:                1
+//     cbde2:                1
+//     sub_cbdf4:            1
+//     loop_cbe2d:           1
+//     cbe43:                1
+//     sub_cbe44:            1
+//     cbe45:                1
+//     sub_cbe46:            1
+//     cbe4e:                1
+//     sub_cbe65:            1
+//     loop_cbe73:           1
+//     sub_cbe8b:            1
+//     lbecd:                1
+//     cbed3:                1
+//     cbed9:                1
+//     lbefe:                1
+//     cbf00:                1
+//     loop_cbf17:           1
+//     cbf1a:                1
+//     cbf54:                1
+//     loop_cbf56:           1
+//     sub_cbf66:            1
+//     lbf71:                1
+//     le09c:                1
+
+// Automatically generated labels:
+//     c8040
+//     c804c
+//     c805e
+//     c8067
+//     c806a
+//     c8070
+//     c808f
+//     c80a8
+//     c80cc
+//     c80ff
+//     c8151
+//     c815d
+//     c8168
+//     c817a
+//     c8187
+//     c8190
+//     c8197
+//     c81ad
+//     c81b9
+//     c81c8
+//     c81ea
+//     c81fd
+//     c820f
+//     c8210
+//     c8230
+//     c823f
+//     c8242
+//     c8246
+//     c825b
+//     c827c
+//     c828d
+//     c829a
+//     c82ae
+//     c82be
+//     c82c8
+//     c82d8
+//     c82dd
+//     c82f4
+//     c82fb
+//     c8304
+//     c8306
+//     c832f
+//     c833b
+//     c8345
+//     c8346
+//     c8353
+//     c835e
+//     c8362
+//     c8371
+//     c8372
+//     c8392
+//     c83a6
+//     c83c1
+//     c83d2
+//     c83d5
+//     c840a
+//     c8456
+//     c846a
+//     c8491
+//     c84a3
+//     c84ad
+//     c84ce
+//     c84f4
+//     c89bf
+//     c89dd
+//     c89f4
+//     c8a0b
+//     c8a1e
+//     c8a28
+//     c8a34
+//     c8a44
+//     c8a4b
+//     c8a64
+//     c8a68
+//     c8a6b
+//     c8a79
+//     c8a8b
+//     c8a8e
+//     c8a91
+//     c8adf
+//     c8aef
+//     c8af2
+//     c8af5
+//     c8b10
+//     c8b1b
+//     c8b33
+//     c8b40
+//     c8b4b
+//     c8b55
+//     c8b5f
+//     c8b62
+//     c8b63
+//     c8b83
+//     c8b98
+//     c8b9b
+//     c8b9c
+//     c8ba3
+//     c8baf
+//     c8bb2
+//     c8bb4
+//     c8bb6
+//     c8bbd
+//     c8bc4
+//     c8bde
+//     c8be9
+//     c8bf9
+//     c8c01
+//     c8c1b
+//     c8c1e
+//     c8c24
+//     c8c31
+//     c8c41
+//     c8c43
+//     c8c55
+//     c8c57
+//     c8c5e
+//     c8c74
+//     c8c84
+//     c8c87
+//     c8c96
+//     c8c99
+//     c8ca4
+//     c8ca7
+//     c8cb8
+//     c8cbb
+//     c8cbd
+//     c8cc0
+//     c8ce3
+//     c8ce6
+//     c8cfd
+//     c8d16
+//     c8d34
+//     c8d37
+//     c8d44
+//     c8d64
+//     c8d6e
+//     c8d74
+//     c8dc9
+//     c8dfc
+//     c8dff
+//     c8e3f
+//     c8e51
+//     c8e57
+//     c8e6c
+//     c8e6f
+//     c8e7d
+//     c8e8d
+//     c8e9c
+//     c8e9d
+//     c8ea6
+//     c8eaa
+//     c8eb6
+//     c8ebe
+//     c8ed0
+//     c8edc
+//     c8ee7
+//     c8ef3
+//     c8f03
+//     c8f1a
+//     c8f25
+//     c8f26
+//     c8f32
+//     c8f3d
+//     c8f41
+//     c8f52
+//     c8f5d
+//     c8f6d
+//     c8f74
+//     c8f86
+//     c8f87
+//     c8f8c
+//     c8f92
+//     c8f9c
+//     c8f9d
+//     c8fbb
+//     c8fda
+//     c8ff2
+//     c901c
+//     c9033
+//     c9045
+//     c9048
+//     c904b
+//     c905c
+//     c9069
+//     c9073
+//     c907d
+//     c9082
+//     c9086
+//     c90a0
+//     c90b0
+//     c90c5
+//     c90c7
+//     c90ca
+//     c90d0
+//     c90d2
+//     c90de
+//     c90e3
+//     c90ea
+//     c9108
+//     c9112
+//     c9123
+//     c9135
+//     c9146
+//     c914f
+//     c9155
+//     c9164
+//     c9193
+//     c91ad
+//     c91d1
+//     c91ee
+//     c91ef
+//     c9201
+//     c9204
+//     c9207
+//     c922a
+//     c9237
+//     c924a
+//     c9259
+//     c926e
+//     c9274
+//     c9276
+//     c9285
+//     c9288
+//     c929e
+//     c92da
+//     c92ed
+//     c9304
+//     c931e
+//     c9321
+//     c9325
+//     c932a
+//     c932d
+//     c9338
+//     c9357
+//     c937c
+//     c938f
+//     c93b4
+//     c93c4
+//     c93d7
+//     c9433
+//     c9469
+//     c9476
+//     c947f
+//     c9487
+//     c94aa
+//     c94b0
+//     c94ba
+//     c94c8
+//     c94d1
+//     c94d5
+//     c94de
+//     c94e4
+//     c9509
+//     c950d
+//     c951d
+//     c951f
+//     c954b
+//     c9555
+//     c9579
+//     c957c
+//     c957f
+//     c95be
+//     c95e0
+//     c95f1
+//     c95f9
+//     c9606
+//     c9628
+//     c9632
+//     c9635
+//     c963b
+//     c964e
+//     c968d
+//     c96b8
+//     c96bf
+//     c96ca
+//     c9700
+//     c971b
+//     c972c
+//     c9735
+//     c9753
+//     c9784
+//     c979b
+//     c979c
+//     c97d2
+//     c97ee
+//     c97fe
+//     c9801
+//     c9808
+//     c9866
+//     c986a
+//     c9877
+//     c9889
+//     c98bd
+//     c98c0
+//     c98d7
+//     c98dc
+//     c990c
+//     c9928
+//     c9937
+//     c9962
+//     c996e
+//     c9977
+//     c9979
+//     c997a
+//     c9990
+//     c999f
+//     c99a0
+//     c99a2
+//     c99ab
+//     c99ba
+//     c99fa
+//     c9a0e
+//     c9a14
+//     c9a28
+//     c9a3a
+//     c9a46
+//     c9a58
+//     c9a63
+//     c9a67
+//     c9a75
+//     c9a76
+//     c9a79
+//     c9a7b
+//     c9a99
+//     c9aa0
+//     c9aa5
+//     c9abc
+//     c9ac1
+//     c9ae6
+//     c9b4c
+//     c9b5a
+//     c9b78
+//     c9b80
+//     c9b8a
+//     c9bae
+//     c9bbc
+//     c9bce
+//     c9bd2
+//     c9bda
+//     c9bdb
+//     c9c08
+//     c9c16
+//     c9c24
+//     c9c2d
+//     c9c3b
+//     c9c41
+//     c9c52
+//     c9c55
+//     c9c6a
+//     c9c6c
+//     c9c74
+//     c9c80
+//     c9c8a
+//     c9cb6
+//     c9cc1
+//     c9cc5
+//     c9cc6
+//     c9cd6
+//     c9ceb
+//     c9ced
+//     c9cfb
+//     c9d0c
+//     c9d29
+//     c9d43
+//     c9d57
+//     c9d75
+//     c9d79
+//     c9d7b
+//     c9d7c
+//     c9db4
+//     c9dba
+//     c9dbe
+//     c9dbf
+//     c9dc0
+//     c9dc1
+//     c9dc4
+//     c9dd5
+//     c9de5
+//     c9de9
+//     c9e02
+//     c9e10
+//     c9e2a
+//     c9e48
+//     c9e4d
+//     c9e78
+//     c9e79
+//     c9e83
+//     c9e85
+//     c9e90
+//     c9ea6
+//     c9ead
+//     c9eb2
+//     c9ec2
+//     c9ecb
+//     c9edd
+//     c9f0a
+//     c9f13
+//     c9f3b
+//     c9f4c
+//     c9f4f
+//     c9f55
+//     c9f64
+//     c9f70
+//     c9f9a
+//     c9f9d
+//     c9fa7
+//     c9fb6
+//     c9fb8
+//     c9fe6
+//     c9ff4
+//     ca00f
+//     ca029
+//     ca03b
+//     ca03c
+//     ca04a
+//     ca04d
+//     ca05b
+//     ca05f
+//     ca06f
+//     ca081
+//     ca09c
+//     ca09f
+//     ca0c5
+//     ca0c7
+//     ca0d1
+//     ca0ee
+//     ca10a
+//     ca116
+//     ca126
+//     ca131
+//     ca137
+//     ca158
+//     ca160
+//     ca169
+//     ca174
+//     ca18a
+//     ca197
+//     ca19b
+//     ca19d
+//     ca1af
+//     ca1bc
+//     ca1c1
+//     ca1cd
+//     ca1d0
+//     ca1d4
+//     ca1ed
+//     ca1ef
+//     ca204
+//     ca212
+//     ca21c
+//     ca220
+//     ca22a
+//     ca23e
+//     ca24a
+//     ca25f
+//     ca261
+//     ca26f
+//     ca28a
+//     ca28c
+//     ca290
+//     ca2a3
+//     ca2b3
+//     ca2b7
+//     ca2c9
+//     ca2cc
+//     ca2d6
+//     ca2fb
+//     ca2fd
+//     ca303
+//     ca325
+//     ca333
+//     ca33e
+//     ca342
+//     ca348
+//     ca34c
+//     ca357
+//     ca36b
+//     ca37e
+//     ca385
+//     ca393
+//     ca3a1
+//     ca3a7
+//     ca3aa
+//     ca3c3
+//     ca3e5
+//     ca3e9
+//     ca426
+//     ca42c
+//     ca446
+//     ca452
+//     ca47a
+//     ca489
+//     ca4a3
+//     ca4a9
+//     ca4b9
+//     ca4c4
+//     ca4ce
+//     ca4e8
+//     ca4f5
+//     ca513
+//     ca53b
+//     ca53e
+//     ca547
+//     ca57a
+//     ca57e
+//     ca5a7
+//     ca5aa
+//     ca5ba
+//     ca608
+//     ca612
+//     ca61d
+//     ca622
+//     ca634
+//     ca640
+//     ca653
+//     ca65c
+//     ca65e
+//     ca674
+//     ca676
+//     ca68d
+//     ca6a2
+//     ca6ae
+//     ca6c4
+//     ca6ce
+//     ca6e4
+//     ca6ed
+//     ca6f2
+//     ca704
+//     ca70a
+//     ca70f
+//     ca712
+//     ca71e
+//     ca725
+//     ca72b
+//     ca72f
+//     ca739
+//     ca73b
+//     ca73d
+//     ca74d
+//     ca76b
+//     ca776
+//     ca797
+//     ca79b
+//     ca7c0
+//     ca7cd
+//     ca7db
+//     ca7ed
+//     ca7ef
+//     ca805
+//     ca829
+//     ca838
+//     ca83f
+//     ca841
+//     ca857
+//     ca875
+//     ca878
+//     ca88a
+//     ca899
+//     ca8b0
+//     ca8bb
+//     ca8ee
+//     ca91f
+//     ca92d
+//     ca932
+//     ca93b
+//     ca946
+//     ca948
+//     ca94b
+//     ca959
+//     ca962
+//     ca965
+//     ca978
+//     ca9c1
+//     ca9e0
+//     ca9ef
+//     ca9f2
+//     ca9f8
+//     caa07
+//     caa2c
+//     caa33
+//     caa3e
+//     caa44
+//     caa66
+//     caa6b
+//     caa7a
+//     caa7d
+//     caa9a
+//     caab0
+//     caac1
+//     caae8
+//     cab1a
+//     cab23
+//     cab41
+//     cab82
+//     cab91
+//     cab9d
+//     cabc9
+//     cabd0
+//     cabdd
+//     cabfa
+//     cabfd
+//     cac02
+//     cac0f
+//     cac1c
+//     cac2b
+//     cac2d
+//     cac35
+//     cac38
+//     cac59
+//     cac5b
+//     caca0
+//     caca3
+//     caca9
+//     cacaf
+//     cacd2
+//     cace3
+//     cace8
+//     cacef
+//     cacfd
+//     cad0d
+//     cad10
+//     cad14
+//     cad19
+//     cad20
+//     cad37
+//     cad52
+//     cad53
+//     cad5b
+//     cad75
+//     cad78
+//     cad91
+//     cad9c
+//     cadac
+//     cadb6
+//     cadbc
+//     cadce
+//     cade4
+//     cadee
+//     cadf9
+//     cae00
+//     cae0d
+//     cae11
+//     cae31
+//     cae3f
+//     cae56
+//     cae60
+//     cae62
+//     cae9f
+//     caeb4
+//     caed7
+//     caed9
+//     caedb
+//     caedc
+//     caf03
+//     caf07
+//     caf2f
+//     caf3d
+//     caf4d
+//     caf6d
+//     caf83
+//     caf88
+//     cafb8
+//     cafbb
+//     cafbe
+//     cafd5
+//     cafdb
+//     cafee
+//     caffd
+//     cb00e
+//     cb04a
+//     cb08a
+//     cb0a6
+//     cb0b0
+//     cb0be
+//     cb0e2
+//     cb106
+//     cb109
+//     cb169
+//     cb17e
+//     cb1a3
+//     cb1a6
+//     cb1ab
+//     cb1b5
+//     cb1ca
+//     cb1db
+//     cb1de
+//     cb200
+//     cb205
+//     cb22d
+//     cb230
+//     cb235
+//     cb256
+//     cb257
+//     cb266
+//     cb341
+//     cb34c
+//     cb35c
+//     cb380
+//     cb398
+//     cb399
+//     cb39e
+//     cb3cf
+//     cb3f4
+//     cb3fb
+//     cb3fe
+//     cb425
+//     cb428
+//     cb42b
+//     cb445
+//     cb451
+//     cb454
+//     cb45d
+//     cb46f
+//     cb47f
+//     cb485
+//     cb495
+//     cb497
+//     cb4a1
+//     cb4a7
+//     cb4b8
+//     cb4ba
+//     cb4bc
+//     cb4c2
+//     cb4e0
+//     cb4e2
+//     cb4f8
+//     cb50a
+//     cb510
+//     cb516
+//     cb51c
+//     cb522
+//     cb530
+//     cb54b
+//     cb563
+//     cb56a
+//     cb5cd
+//     cb5cf
+//     cb5df
+//     cb5f1
+//     cb622
+//     cb626
+//     cb629
+//     cb635
+//     cb6a7
+//     cb6bf
+//     cb6d1
+//     cb6f7
+//     cb70c
+//     cb723
+//     cb74a
+//     cb753
+//     cb75a
+//     cb762
+//     cb7a4
+//     cb7b3
+//     cb7ca
+//     cb7d4
+//     cb7da
+//     cb7e6
+//     cb7fa
+//     cb805
+//     cb81a
+//     cb824
+//     cb833
+//     cb847
+//     cb857
+//     cb866
+//     cb86c
+//     cb874
+//     cb877
+//     cb87f
+//     cb8b5
+//     cb8ba
+//     cb8cc
+//     cb8da
+//     cb8e2
+//     cb8f2
+//     cb8fa
+//     cb909
+//     cb938
+//     cb941
+//     cb94f
+//     cb965
+//     cb968
+//     cb976
+//     cb997
+//     cb9a5
+//     cb9ad
+//     cb9bf
+//     cb9cd
+//     cb9ff
+//     cba21
+//     cba2b
+//     cba31
+//     cba35
+//     cba43
+//     cba46
+//     cba63
+//     cbaa6
+//     cbac5
+//     cbae6
+//     cbae8
+//     cbaf7
+//     cbb03
+//     cbb0c
+//     cbb16
+//     cbb1a
+//     cbb45
+//     cbb64
+//     cbb9b
+//     cbba6
+//     cbbaf
+//     cbbd0
+//     cbc3a
+//     cbc66
+//     cbc91
+//     cbca5
+//     cbccd
+//     cbcd5
+//     cbce6
+//     cbcea
+//     cbd0e
+//     cbd21
+//     cbd23
+//     cbd3a
+//     cbd3d
+//     cbd45
+//     cbd64
+//     cbd70
+//     cbd71
+//     cbd74
+//     cbd86
+//     cbd9e
+//     cbdaa
+//     cbdbd
+//     cbdc9
+//     cbdd2
+//     cbdd4
+//     cbde2
+//     cbdff
+//     cbe05
+//     cbe43
+//     cbe45
+//     cbe4e
+//     cbe51
+//     cbed3
+//     cbed9
+//     cbeeb
+//     cbf00
+//     cbf1a
+//     cbf3d
+//     cbf54
+//     l0000
+//     l0001
+//     l0002
+//     l0003
+//     l0004
+//     l0005
+//     l0006
+//     l0007
+//     l0008
+//     l0009
+//     l000a
+//     l000b
+//     l000c
+//     l000d
+//     l000e
+//     l000f
+//     l0010
+//     l0011
+//     l0012
+//     l0013
+//     l0014
+//     l0015
+//     l0016
+//     l0017
+//     l0018
+//     l0019
+//     l001a
+//     l001b
+//     l001c
+//     l001d
+//     l001e
+//     l001f
+//     l0020
+//     l0021
+//     l0022
+//     l0023
+//     l0024
+//     l0025
+//     l0026
+//     l0027
+//     l0028
+//     l0029
+//     l002a
+//     l002b
+//     l002c
+//     l002d
+//     l002e
+//     l002f
+//     l0030
+//     l0031
+//     l0032
+//     l0033
+//     l0034
+//     l0035
+//     l0036
+//     l0037
+//     l0038
+//     l0039
+//     l003a
+//     l003b
+//     l003c
+//     l003d
+//     l003e
+//     l003f
+//     l0040
+//     l0041
+//     l0042
+//     l0043
+//     l0044
+//     l0045
+//     l0046
+//     l0047
+//     l0048
+//     l0049
+//     l004a
+//     l004b
+//     l004c
+//     l004d
+//     l004e
+//     l0061
+//     l0064
+//     l0066
+//     l00c1
+//     l00e1
+//     l00e6
+//     l00fd
+//     l00fe
+//     l00ff
+//     l0100
+//     l0106
+//     l01ff
+//     l0400
+//     l0401
+//     l0402
+//     l0403
+//     l0404
+//     l040c
+//     l043c
+//     l043d
+//     l0440
+//     l0441
+//     l0460
+//     l0464
+//     l0469
+//     l046c
+//     l047f
+//     l04ff
+//     l0500
+//     l0513
+//     l0514
+//     l0519
+//     l051a
+//     l051b
+//     l051c
+//     l051d
+//     l051e
+//     l051f
+//     l0521
+//     l0522
+//     l0523
+//     l0524
+//     l0526
+//     l0527
+//     l0528
+//     l0529
+//     l052a
+//     l05cb
+//     l05cc
+//     l05e5
+//     l05e6
+//     l05ff
+//     l0600
+//     l0700
+//     l07ef
+//     l0bb1
+//     l0e4e
+//     l4e4e
+//     l5252
+//     l6142
+//     l7461
+//     l7f0e
+//     l7f13
+//     l80c2
+//     l80dd
+//     l80e2
+//     l880a
+//     l8826
+//     l8909
+//     l894e
+//     l8993
+//     la7c9
+//     lb3be
+//     lbecd
+//     lbefe
+//     lbf71
+//     le09c
+//     loop_c8057
+//     loop_c8091
+//     loop_c8176
+//     loop_c819f
+//     loop_c81e1
+//     loop_c8206
+//     loop_c8235
+//     loop_c8252
+//     loop_c82b2
+//     loop_c82f7
+//     loop_c8314
+//     loop_c8331
+//     loop_c8365
+//     loop_c839e
+//     loop_c8428
+//     loop_c8440
+//     loop_c845b
+//     loop_c847b
+//     loop_c8496
+//     loop_c89d7
+//     loop_c8a11
+//     loop_c8a2a
+//     loop_c8a3c
+//     loop_c8a4f
+//     loop_c8a54
+//     loop_c8a5e
+//     loop_c8a6e
+//     loop_c8ac3
+//     loop_c8ad4
+//     loop_c8ae3
+//     loop_c8b9e
+//     loop_c8c15
+//     loop_c8c9b
+//     loop_c8d71
+//     loop_c8db7
+//     loop_c8e16
+//     loop_c8e91
+//     loop_c8ee2
+//     loop_c8f0b
+//     loop_c8f7a
+//     loop_c8fa7
+//     loop_c9004
+//     loop_c9024
+//     loop_c9078
+//     loop_c90a6
+//     loop_c90ad
+//     loop_c91e4
+//     loop_c91f6
+//     loop_c9220
+//     loop_c922c
+//     loop_c923f
+//     loop_c9260
+//     loop_c9268
+//     loop_c928b
+//     loop_c92d4
+//     loop_c92e0
+//     loop_c92f0
+//     loop_c9355
+//     loop_c9356
+//     loop_c9368
+//     loop_c93fa
+//     loop_c9455
+//     loop_c948a
+//     loop_c95cf
+//     loop_c9724
+//     loop_c9728
+//     loop_c9750
+//     loop_c97c0
+//     loop_c97c6
+//     loop_c98cb
+//     loop_c98df
+//     loop_c9904
+//     loop_c992a
+//     loop_c9948
+//     loop_c9954
+//     loop_c99cf
+//     loop_c9ab6
+//     loop_c9be0
+//     loop_c9c6d
+//     loop_c9c92
+//     loop_c9cc9
+//     loop_c9ce8
+//     loop_c9cfd
+//     loop_c9dd7
+//     loop_c9e18
+//     loop_c9e23
+//     loop_c9e32
+//     loop_c9e5b
+//     loop_c9ef2
+//     loop_c9f59
+//     loop_c9f61
+//     loop_c9faa
+//     loop_c9fbb
+//     loop_ca052
+//     loop_ca070
+//     loop_ca0b8
+//     loop_ca0f2
+//     loop_ca0f5
+//     loop_ca10f
+//     loop_ca13b
+//     loop_ca151
+//     loop_ca207
+//     loop_ca256
+//     loop_ca263
+//     loop_ca27d
+//     loop_ca2bb
+//     loop_ca399
+//     loop_ca3ae
+//     loop_ca5b6
+//     loop_ca607
+//     loop_ca617
+//     loop_ca62c
+//     loop_ca6a8
+//     loop_ca758
+//     loop_ca88f
+//     loop_ca8cd
+//     loop_ca8e0
+//     loop_ca969
+//     loop_ca982
+//     loop_ca9f5
+//     loop_caa59
+//     loop_caaf0
+//     loop_cac3c
+//     loop_cacd8
+//     loop_cace5
+//     loop_caceb
+//     loop_cad43
+//     loop_cad5d
+//     loop_cad5e
+//     loop_cade0
+//     loop_cadfe
+//     loop_cae1e
+//     loop_caeed
+//     loop_caf51
+//     loop_cafa2
+//     loop_cafa4
+//     loop_cafc1
+//     loop_cafe3
+//     loop_cb019
+//     loop_cb066
+//     loop_cb0d8
+//     loop_cb0f2
+//     loop_cb146
+//     loop_cb24d
+//     loop_cb259
+//     loop_cb307
+//     loop_cb32b
+//     loop_cb35f
+//     loop_cb4a9
+//     loop_cb4f2
+//     loop_cb52d
+//     loop_cb536
+//     loop_cb642
+//     loop_cb730
+//     loop_cb769
+//     loop_cb771
+//     loop_cb806
+//     loop_cb84c
+//     loop_cb86f
+//     loop_cb872
+//     loop_cb8ac
+//     loop_cb8c2
+//     loop_cb8ce
+//     loop_cb8ff
+//     loop_cb95a
+//     loop_cb974
+//     loop_cb9f6
+//     loop_cba0a
+//     loop_cbb3c
+//     loop_cbb56
+//     loop_cbb5d
+//     loop_cbbd2
+//     loop_cbbed
+//     loop_cbbf8
+//     loop_cbc9d
+//     loop_cbcc5
+//     loop_cbcd1
+//     loop_cbcdc
+//     loop_cbd19
+//     loop_cbd88
+//     loop_cbda0
+//     loop_cbdbf
+//     loop_cbe2d
+//     loop_cbe73
+//     loop_cbf17
+//     loop_cbf56
+//     sub_c80d8
+//     sub_c8139
+//     sub_c8149
+//     sub_c8191
+//     sub_c81bd
+//     sub_c8287
+//     sub_c828a
+//     sub_c82e6
+//     sub_c8349
+//     sub_c834b
+//     sub_c834f
+//     sub_c83aa
+//     sub_c83c2
+//     sub_c83d3
+//     sub_c8429
+//     sub_c8984
+//     sub_c8992
+//     sub_c8aa8
+//     sub_c8d86
+//     sub_c8d89
+//     sub_c8d8c
+//     sub_c8d94
+//     sub_c8d9c
+//     sub_c8da2
+//     sub_c8da8
+//     sub_c8dc1
+//     sub_c8e1f
+//     sub_c8e41
+//     sub_c8e58
+//     sub_c8e5f
+//     sub_c8e66
+//     sub_c8ea4
+//     sub_c8fa8
+//     sub_c8fae
+//     sub_c8fb4
+//     sub_c8fc0
+//     sub_c8fc5
+//     sub_c8fd7
+//     sub_c8fe5
+//     sub_c8fea
+//     sub_c9042
+//     sub_c910d
+//     sub_c9149
+//     sub_c916e
+//     sub_c9171
+//     sub_c9250
+//     sub_c9330
+//     sub_c9332
+//     sub_c933d
+//     sub_c935c
+//     sub_c9381
+//     sub_c93c7
+//     sub_c93da
+//     sub_c9410
+//     sub_c9436
+//     sub_c943e
+//     sub_c9447
+//     sub_c953d
+//     sub_c954c
+//     sub_c95c6
+//     sub_c95cb
+//     sub_c96d4
+//     sub_c96e5
+//     sub_c96f9
+//     sub_c9703
+//     sub_c970b
+//     sub_c973e
+//     sub_c9769
+//     sub_c976c
+//     sub_c9771
+//     sub_c9774
+//     sub_c9779
+//     sub_c977e
+//     sub_c9781
+//     sub_c9783
+//     sub_c9788
+//     sub_c978b
+//     sub_c979f
+//     sub_c97a2
+//     sub_c97a9
+//     sub_c9810
+//     sub_c9824
+//     sub_c982e
+//     sub_c9871
+//     sub_c9875
+//     sub_c9880
+//     sub_c98af
+//     sub_c98b6
+//     sub_c98c3
+//     sub_c990f
+//     sub_c9914
+//     sub_c9923
+//     sub_c9952
+//     sub_c995a
+//     sub_c997d
+//     sub_c99c4
+//     sub_c99d0
+//     sub_c99d6
+//     sub_c99d8
+//     sub_c9ac9
+//     sub_c9b97
+//     sub_c9bba
+//     sub_c9be2
+//     sub_c9bee
+//     sub_c9c0a
+//     sub_c9c4a
+//     sub_c9c5a
+//     sub_c9c5e
+//     sub_c9c8e
+//     sub_c9c93
+//     sub_c9ca2
+//     sub_c9cb8
+//     sub_c9ccc
+//     sub_c9d0f
+//     sub_c9d36
+//     sub_c9d7f
+//     sub_c9d81
+//     sub_c9d82
+//     sub_c9df3
+//     sub_c9dff
+//     sub_c9e3f
+//     sub_c9e45
+//     sub_c9e6d
+//     sub_c9f07
+//     sub_ca023
+//     sub_ca026
+//     sub_ca069
+//     sub_ca06c
+//     sub_ca0e8
+//     sub_ca0ec
+//     sub_ca181
+//     sub_ca2b8
+//     sub_ca2ca
+//     sub_ca2dd
+//     sub_ca3b5
+//     sub_ca3c0
+//     sub_ca3ed
+//     sub_ca40a
+//     sub_ca419
+//     sub_ca46b
+//     sub_ca4ba
+//     sub_ca503
+//     sub_ca507
+//     sub_ca50b
+//     sub_ca514
+//     sub_ca541
+//     sub_ca545
+//     sub_ca54d
+//     sub_ca56d
+//     sub_ca572
+//     sub_ca576
+//     sub_ca5ad
+//     sub_ca5b2
+//     sub_ca5b4
+//     sub_ca5bb
+//     sub_ca5bd
+//     sub_ca5c1
+//     sub_ca5c4
+//     sub_ca5cc
+//     sub_ca5cf
+//     sub_ca5d1
+//     sub_ca5e3
+//     sub_ca5f2
+//     sub_ca5f4
+//     sub_ca5f9
+//     sub_ca62f
+//     sub_ca631
+//     sub_ca6cb
+//     sub_ca6eb
+//     sub_ca6fc
+//     sub_ca6ff
+//     sub_ca70d
+//     sub_ca731
+//     sub_ca73e
+//     sub_ca7ac
+//     sub_ca7af
+//     sub_ca808
+//     sub_ca80b
+//     sub_ca8b3
+//     sub_ca8b9
+//     sub_ca901
+//     sub_ca919
+//     sub_ca94f
+//     sub_ca954
+//     sub_ca96b
+//     sub_ca97b
+//     sub_ca9a3
+//     sub_ca9b5
+//     sub_ca9bc
+//     sub_ca9c3
+//     sub_ca9ca
+//     sub_ca9d1
+//     sub_caa17
+//     sub_caa1a
+//     sub_caa50
+//     sub_caa55
+//     sub_caa6e
+//     sub_caacb
+//     sub_caad8
+//     sub_caaeb
+//     sub_caafb
+//     sub_cab01
+//     sub_cab14
+//     sub_cab1d
+//     sub_cab21
+//     sub_cab2f
+//     sub_cab37
+//     sub_cab3b
+//     sub_cab3f
+//     sub_cab54
+//     sub_cab5c
+//     sub_caba0
+//     sub_caba5
+//     sub_cabe1
+//     sub_cac03
+//     sub_cac12
+//     sub_cac1f
+//     sub_cac46
+//     sub_cac5d
+//     sub_cac7f
+//     sub_cad00
+//     sub_cad07
+//     sub_cad1c
+//     sub_cad3a
+//     sub_cad8e
+//     sub_cadc6
+//     sub_cae34
+//     sub_cae41
+//     sub_cae50
+//     sub_cae59
+//     sub_cae6d
+//     sub_cae71
+//     sub_cae77
+//     sub_cae7d
+//     sub_cae83
+//     sub_cae87
+//     sub_cae8c
+//     sub_caeb1
+//     sub_caebb
+//     sub_caebc
+//     sub_caefb
+//     sub_caf0a
+//     sub_caf61
+//     sub_caf8b
+//     sub_cb055
+//     sub_cb057
+//     sub_cb1bf
+//     sub_cb269
+//     sub_cb2e0
+//     sub_cb302
+//     sub_cb326
+//     sub_cb351
+//     sub_cb362
+//     sub_cb365
+//     sub_cb372
+//     sub_cb3c8
+//     sub_cb412
+//     sub_cb649
+//     sub_cb709
+//     sub_cb737
+//     sub_cb74d
+//     sub_cb78b
+//     sub_cb84d
+//     sub_cb85a
+//     sub_cb896
+//     sub_cb8e6
+//     sub_cb97d
+//     sub_cb9dc
+//     sub_cba47
+//     sub_cba6c
+//     sub_cba6e
+//     sub_cba7a
+//     sub_cba88
+//     sub_cbaa0
+//     sub_cbaa4
+//     sub_cbac2
+//     sub_cbac8
+//     sub_cbb0f
+//     sub_cbb1b
+//     sub_cbb38
+//     sub_cbbdc
+//     sub_cbbeb
+//     sub_cbbff
+//     sub_cbc18
+//     sub_cbc1e
+//     sub_cbc20
+//     sub_cbc24
+//     sub_cbc36
+//     sub_cbc62
+//     sub_cbc83
+//     sub_cbcaa
+//     sub_cbd12
+//     sub_cbd26
+//     sub_cbd46
+//     sub_cbd48
+//     sub_cbd5e
+//     sub_cbd77
+//     sub_cbdac
+//     sub_cbdb7
+//     sub_cbdcf
+//     sub_cbdd8
+//     sub_cbdf3
+//     sub_cbdf4
+//     sub_cbe06
+//     sub_cbe17
+//     sub_cbe25
+//     sub_cbe44
+//     sub_cbe46
+//     sub_cbe65
+//     sub_cbe6b
+//     sub_cbe76
+//     sub_cbe81
+//     sub_cbe8b
+//     sub_cbe95
+//     sub_cbec7
+//     sub_cbecc
+//     sub_cbed7
+//     sub_cbeee
+//     sub_cbefd
+//     sub_cbf0f
+//     sub_cbf22
+//     sub_cbf2f
+//     sub_cbf3e
+//     sub_cbf66

--- a/examples/known_good/dfs226_acme.asm
+++ b/examples/known_good/dfs226_acme.asm
@@ -1,0 +1,13996 @@
+; Constants
+opcode_bcs                            = 176
+opcode_rti                            = 64
+osbyte_close_spool_exec               = 119
+osbyte_explode_chars                  = 20
+osbyte_issue_service_request          = 143
+osbyte_read_himem                     = 132
+osbyte_read_oshwm                     = 131
+osbyte_read_rom_info_table_low        = 170
+osbyte_read_tube_presence             = 234
+osbyte_read_write_spool_file_handle   = 199
+osbyte_read_write_startup_options     = 255
+osbyte_rw_exec_handle                 = 198
+osbyte_scan_keyboard_from_16          = 122
+osbyte_write_keys_pressed             = 120
+osfile_load                           = 255
+osfile_read_catalogue_info            = 5
+osfile_save                           = 0
+service_absolute_workspace_claimed    = 10
+service_boot                          = 3
+service_check_swr_presence            = 43
+service_claim_absolute_workspace      = 1
+service_claim_private_workspace       = 2
+service_help                          = 9
+service_select_filing_system          = 18
+service_tube_post_init                = 254
+service_unrecognised_command          = 4
+service_unrecognised_osword           = 8
+tube_brkv_handler_fwd                 = 22
+
+; Memory locations
+l0000               = $00
+l0001               = $01
+l0002               = $02
+l0003               = $03
+l0012               = $12
+l0013               = $13
+l0014               = $14
+l0015               = $15
+l00a0               = $a0
+l00a1               = $a1
+l00a2               = $a2
+l00a3               = $a3
+l00a4               = $a4
+l00a5               = $a5
+l00a6               = $a6
+l00a7               = $a7
+l00a8               = $a8
+l00a9               = $a9
+l00aa               = $aa
+l00ab               = $ab
+l00ac               = $ac
+l00ad               = $ad
+l00ae               = $ae
+l00af               = $af
+l00b0               = $b0
+l00b1               = $b1
+l00b2               = $b2
+l00b3               = $b3
+l00b4               = $b4
+l00b5               = $b5
+l00b6               = $b6
+l00b7               = $b7
+l00b8               = $b8
+l00b9               = $b9
+l00ba               = $ba
+l00bb               = $bb
+l00bc               = $bc
+l00bd               = $bd
+l00be               = $be
+l00bf               = $bf
+l00c0               = $c0
+l00c1               = $c1
+l00c2               = $c2
+l00c3               = $c3
+l00c4               = $c4
+l00c5               = $c5
+l00c6               = $c6
+l00c7               = $c7
+l00c8               = $c8
+l00c9               = $c9
+l00ca               = $ca
+l00cc               = $cc
+l00cd               = $cd
+l00ce               = $ce
+l00cf               = $cf
+l00ef               = $ef
+l00f0               = $f0
+l00f1               = $f1
+os_text_ptr         = $f2
+l00f3               = $f3
+romsel_copy         = $f4
+osrdsc_ptr          = $f6
+l00f7               = $f7
+l00fd               = $fd
+l00ff               = $ff
+l0100               = $0100
+l0101               = $0101
+l0102               = $0102
+l0103               = $0103
+l0104               = $0104
+l0105               = $0105
+l0107               = $0107
+l0109               = $0109
+l010b               = $010b
+l010c               = $010c
+l010d               = $010d
+l010e               = $010e
+l0128               = $0128
+brkv                = $0202
+bytev               = $020a
+filev               = $0212
+fscv                = $021e
+evntv               = $0220
+l028d               = $028d
+l0700               = $0700
+l0cff               = $0cff
+l0df0               = $0df0
+l0e00               = $0e00
+l0e07               = $0e07
+l0e08               = $0e08
+l0e0e               = $0e0e
+l0e0f               = $0e0f
+l0e10               = $0e10
+l0ef8               = $0ef8
+l0f00               = $0f00
+l0f04               = $0f04
+l0f05               = $0f05
+l0f06               = $0f06
+l0f07               = $0f07
+l0f08               = $0f08
+l0f09               = $0f09
+l0f0a               = $0f0a
+l0f0b               = $0f0b
+l0f0c               = $0f0c
+l0f0d               = $0f0d
+l0f0e               = $0f0e
+l0f0f               = $0f0f
+l0f10               = $0f10
+l1000               = $1000
+l1001               = $1001
+l1002               = $1002
+l1003               = $1003
+l1004               = $1004
+l1005               = $1005
+l1006               = $1006
+l1007               = $1007
+l100e               = $100e
+l1045               = $1045
+l1047               = $1047
+l104d               = $104d
+l104e               = $104e
+l1050               = $1050
+l1058               = $1058
+l105f               = $105f
+l1060               = $1060
+l1061               = $1061
+l1062               = $1062
+l1063               = $1063
+l1064               = $1064
+l1065               = $1065
+l1067               = $1067
+l1069               = $1069
+l1072               = $1072
+l1074               = $1074
+l1075               = $1075
+l1076               = $1076
+l1077               = $1077
+l1078               = $1078
+l1079               = $1079
+l107a               = $107a
+l107d               = $107d
+l107e               = $107e
+l107f               = $107f
+l1081               = $1081
+l1082               = $1082
+l1083               = $1083
+l1086               = $1086
+l1087               = $1087
+l1088               = $1088
+l1089               = $1089
+l108a               = $108a
+l108b               = $108b
+l108c               = $108c
+l108f               = $108f
+l1090               = $1090
+l1091               = $1091
+l1092               = $1092
+l1093               = $1093
+l1094               = $1094
+l1095               = $1095
+l1096               = $1096
+l1097               = $1097
+l1098               = $1098
+l1099               = $1099
+l109a               = $109a
+l109b               = $109b
+l109d               = $109d
+l109e               = $109e
+l109f               = $109f
+l10c0               = $10c0
+l10c1               = $10c1
+l10c2               = $10c2
+l10c3               = $10c3
+l10c4               = $10c4
+l10c5               = $10c5
+l10c6               = $10c6
+l10c7               = $10c7
+l10c9               = $10c9
+l10ca               = $10ca
+l10cb               = $10cb
+l10cc               = $10cc
+l10cd               = $10cd
+l10ce               = $10ce
+l10cf               = $10cf
+l10d0               = $10d0
+l10d1               = $10d1
+l10d2               = $10d2
+l10d3               = $10d3
+l10d6               = $10d6
+l10d7               = $10d7
+l10d8               = $10d8
+l10d9               = $10d9
+l10da               = $10da
+l10db               = $10db
+l10dc               = $10dc
+l10dd               = $10dd
+l10de               = $10de
+l10e2               = $10e2
+l10e3               = $10e3
+l10e4               = $10e4
+l1100               = $1100
+l1109               = $1109
+l110b               = $110b
+l110c               = $110c
+l110d               = $110d
+l110e               = $110e
+l110f               = $110f
+l1110               = $1110
+l1111               = $1111
+l1112               = $1112
+l1113               = $1113
+l1114               = $1114
+l1115               = $1115
+l1116               = $1116
+l1117               = $1117
+l1119               = $1119
+l111a               = $111a
+l111b               = $111b
+l111c               = $111c
+l111d               = $111d
+romsel              = $fe30
+lfe80               = $fe80
+lfe84               = $fe84
+lfe85               = $fe85
+lfe86               = $fe86
+lfe87               = $fe87
+tube_host_r1_status = $fee0
+tube_host_r1_data   = $fee1
+tube_host_r2_status = $fee2
+tube_host_r2_data   = $fee3
+tube_host_r3_data   = $fee5
+tube_host_r4_status = $fee6
+tube_host_r4_data   = $fee7
+osrdsc              = $ffb9
+gsinit              = $ffc2
+gsread              = $ffc5
+osfind              = $ffce
+osgbpb              = $ffd1
+osbput              = $ffd4
+osbget              = $ffd7
+osargs              = $ffda
+osfile              = $ffdd
+osrdch              = $ffe0
+osasci              = $ffe3
+osnewl              = $ffe7
+oswrch              = $ffee
+osword              = $fff1
+osbyte              = $fff4
+oscli               = $fff7
+
+    * = $8000
+
+; Sideways ROM header
+; $8000 referenced 1 time by $04e2
+rom_header
+language_entry
+pydis_start
+l8001 = rom_header+1
+l8002 = rom_header+2
+    !byte 0, 0, 0                                                     ; 8000: 00 00 00    ...
+; $8001 referenced 1 time by $04e7
+; $8002 referenced 1 time by $04ec
+
+; $8003 referenced 1 time by $04f1
+service_entry
+l8004 = service_entry+1
+    jmp service_handler                                               ; 8003: 4c c8 be    L..
+
+; $8004 referenced 1 time by $04f4
+; $8006 referenced 1 time by $04d6
+rom_type
+    !byte $82                                                         ; 8006: 82          .
+; $8007 referenced 1 time by $04de
+copyright_offset
+    !byte copyright - rom_header                                      ; 8007: 11          .
+binary_version
+    !byte $7b                                                         ; 8008: 7b          {
+title
+    !text "DFS"                                                       ; 8009: 44 46 53    DFS
+version
+    !byte 0                                                           ; 800c: 00          .
+    !text "2.26"                                                      ; 800d: 32 2e 32... 2.2
+copyright
+    !byte 0                                                           ; 8011: 00          .
+    !text "(C)1985 Acorn", 0                                          ; 8012: 28 43 29... (C)
+
+; $8020 referenced 1 time by $9575
+sub_c8020
+    jmp (fscv)                                                        ; 8020: 6c 1e 02    l..
+
+; $8023 referenced 4 times by $8a6e, $94c6, $94d5, $9c00
+generate_error_precheck_disc
+    jsr generate_error_precheck                                       ; 8023: 20 38 80     8.
+    !byte 0                                                           ; 8026: 00          .
+    !text "Disc "                                                     ; 8027: 44 69 73... Dis
+
+    bcc generate_error2                                               ; 802c: 90 21       .!
+; $802e referenced 6 times by $8125, $889a, $89a5, $8a24, $8a3e, $8ba2
+generate_error_precheck_bad
+    jsr generate_error_precheck                                       ; 802e: 20 38 80     8.
+    !byte 0                                                           ; 8031: 00          .
+    !text "Bad "                                                      ; 8032: 42 61 64... Bad
+
+    bcc generate_error2                                               ; 8036: 90 17       ..
+; $8038 referenced 11 times by $8023, $802e, $8b18, $8bd8, $9a55, $9c70, $9c82, $9e80, $9e8c, $9f6e, $9fc8
+generate_error_precheck
+    lda l10dd                                                         ; 8038: ad dd 10    ...
+    bne c8040                                                         ; 803b: d0 03       ..
+    jsr sub_c9e30                                                     ; 803d: 20 30 9e     0.
+; $8040 referenced 1 time by $803b
+c8040
+    lda #%########                                                    ; 8040: a9 ff       ..
+    sta l1082                                                         ; 8042: 8d 82 10    ...
+    sta l10dd                                                         ; 8045: 8d dd 10    ...
+; Generate an OS error using inline data. Called as either:
+;     jsr XXX:equb errnum, "error message", 0
+; to actually generate an error now, or as:
+;     jsr XXX:equb errnum, "partial error message", instruction...
+; to partially construct an error (on the stack) and continue executing
+; 'instruction' afterwards; its opcode must have its top bit set. Carry is
+; always clear on exit.
+; $8048 referenced 4 times by $822a, $9439, $947c, $a14f
+generate_error
+    ldx #2                                                            ; 8048: a2 02       ..
+    lda #0                                                            ; 804a: a9 00       ..
+    sta l0100                                                         ; 804c: 8d 00 01    ...
+; $804f referenced 7 times by $802c, $8036, $94da, $94e9, $94f7, $9507, $9511
+generate_error2
+    sta l00b3                                                         ; 804f: 85 b3       ..
+    pla                                                               ; 8051: 68          h
+    sta l00ae                                                         ; 8052: 85 ae       ..
+    pla                                                               ; 8054: 68          h
+    sta l00af                                                         ; 8055: 85 af       ..
+; XXX: Redundant lda l00b3? Is sta l00b3 above redundant too?
+    lda l00b3                                                         ; 8057: a5 b3       ..
+    ldy #0                                                            ; 8059: a0 00       ..
+    jsr inc16_ae                                                      ; 805b: 20 dc 83     ..
+    lda (l00ae),y                                                     ; 805e: b1 ae       ..
+    sta l0101                                                         ; 8060: 8d 01 01    ...
+    dex                                                               ; 8063: ca          .
+; $8064 referenced 1 time by $806f
+loop_c8064
+    jsr inc16_ae                                                      ; 8064: 20 dc 83     ..
+    inx                                                               ; 8067: e8          .
+    lda (l00ae),y                                                     ; 8068: b1 ae       ..
+    sta l0100,x                                                       ; 806a: 9d 00 01    ...
+    bmi c8096                                                         ; 806d: 30 27       0'
+    bne loop_c8064                                                    ; 806f: d0 f3       ..
+    jsr sub_c8f75                                                     ; 8071: 20 75 8f     u.
+    jmp l0100                                                         ; 8074: 4c 00 01    L..
+
+; Print (XXX: using l809f, which seems to be quite fancy) an inline
+; string terminated by a top-bit set instruction to execute after
+; printing the string. Carry is always clear on exit.
+; $8077 referenced 31 times by $84a5, $84b0, $84c8, $84dc, $84f1, $850d, $87ce, $9558, $a10c, $a247, $a298, $a34d, $a364, $a394, $a3a3, $a3ae, $a3bd, $a3e4, $a3ec, $a5f0, $a5fb, $a605, $a667, $a678, $a68a, $a699, $a70a, $a719, $aa5a, $aa65, $aebf
+print_inline_l809f_top_bit_clear
+    sta l00b3                                                         ; 8077: 85 b3       ..
+    pla                                                               ; 8079: 68          h
+    sta l00ae                                                         ; 807a: 85 ae       ..
+    pla                                                               ; 807c: 68          h
+    sta l00af                                                         ; 807d: 85 af       ..
+    lda l00b3                                                         ; 807f: a5 b3       ..
+    pha                                                               ; 8081: 48          H
+    tya                                                               ; 8082: 98          .
+    pha                                                               ; 8083: 48          H
+    ldy #0                                                            ; 8084: a0 00       ..
+; $8086 referenced 1 time by $8090
+loop_c8086
+    jsr inc16_ae                                                      ; 8086: 20 dc 83     ..
+    lda (l00ae),y                                                     ; 8089: b1 ae       ..
+    bmi c8093                                                         ; 808b: 30 06       0.
+    jsr c809f                                                         ; 808d: 20 9f 80     ..
+    jmp loop_c8086                                                    ; 8090: 4c 86 80    L..
+
+; $8093 referenced 1 time by $808b
+c8093
+    pla                                                               ; 8093: 68          h
+    tay                                                               ; 8094: a8          .
+    pla                                                               ; 8095: 68          h
+; $8096 referenced 1 time by $806d
+c8096
+    clc                                                               ; 8096: 18          .
+    jmp (l00ae)                                                       ; 8097: 6c ae 00    l..
+
+; $809a referenced 2 times by $84ff, $8519
+sub_c809a
+    jsr sub_c80c3                                                     ; 809a: 20 c3 80     ..
+; $809d referenced 1 time by $8187
+sub_c809d
+    lda #$2e ; '.'                                                    ; 809d: a9 2e       ..
+; $809f referenced 20 times by $808d, $80c6, $8184, $8191, $81a2, $849d, $84ea, $8505, $851f, $a1c3, $a3df, $a40c, $a621, $a6bd, $a6c0, $aa6d, $aa7b, $aa87, $aa8c, $aabe
+c809f
+    jsr sub_c83e3                                                     ; 809f: 20 e3 83     ..
+    pha                                                               ; 80a2: 48          H
+    lda #$ec                                                          ; 80a3: a9 ec       ..
+    jsr osbyte_read                                                   ; 80a5: 20 e5 9a     ..
+    txa                                                               ; 80a8: 8a          .
+    pha                                                               ; 80a9: 48          H
+    ora #$10                                                          ; 80aa: 09 10       ..
+    jsr sub_c9ad3                                                     ; 80ac: 20 d3 9a     ..
+    pla                                                               ; 80af: 68          h
+    tax                                                               ; 80b0: aa          .
+    pla                                                               ; 80b1: 68          h
+    jsr osasci                                                        ; 80b2: 20 e3 ff     ..
+    jmp c9ad4                                                         ; 80b5: 4c d4 9a    L..
+
+; $80b8 referenced 1 time by $aa62
+sub_c80b8
+    jsr sub_c841b                                                     ; 80b8: 20 1b 84     ..
+; $80bb referenced 5 times by $8368, $8373, $84ad, $a295, $a6c6
+sub_c80bb
+    pha                                                               ; 80bb: 48          H
+    jsr sub_c81bf                                                     ; 80bc: 20 bf 81     ..
+    jsr sub_c80c3                                                     ; 80bf: 20 c3 80     ..
+    pla                                                               ; 80c2: 68          h
+; $80c3 referenced 10 times by $809a, $80bf, $8362, $84c0, $84d9, $a25c, $a291, $a361, $a36f, $a696
+sub_c80c3
+    jsr sub_c80c8                                                     ; 80c3: 20 c8 80     ..
+    bne c809f                                                         ; 80c6: d0 d7       ..
+; $80c8 referenced 4 times by $80c3, $952e, $a9ca, $ac6a
+sub_c80c8
+    and #$0f                                                          ; 80c8: 29 0f       ).
+    cmp #$0a                                                          ; 80ca: c9 0a       ..
+    bcc c80d0                                                         ; 80cc: 90 02       ..
+    adc #6                                                            ; 80ce: 69 06       i.
+; $80d0 referenced 1 time by $80cc
+c80d0
+    adc #'0'                                                          ; 80d0: 69 30       i0
+    rts                                                               ; 80d2: 60          `
+
+; $80d3 referenced 1 time by $979d
+sub_c80d3
+    jsr sub_c80e3                                                     ; 80d3: 20 e3 80     ..
+    dex                                                               ; 80d6: ca          .
+    dex                                                               ; 80d7: ca          .
+    jsr sub_c80db                                                     ; 80d8: 20 db 80     ..
+; $80db referenced 1 time by $80d8
+sub_c80db
+    lda (l00b0),y                                                     ; 80db: b1 b0       ..
+    sta l1072,x                                                       ; 80dd: 9d 72 10    .r.
+    inx                                                               ; 80e0: e8          .
+    iny                                                               ; 80e1: c8          .
+    rts                                                               ; 80e2: 60          `
+
+; $80e3 referenced 2 times by $80d3, $979a
+sub_c80e3
+    jsr sub_c80e6                                                     ; 80e3: 20 e6 80     ..
+; $80e6 referenced 1 time by $80e3
+sub_c80e6
+    lda (l00b0),y                                                     ; 80e6: b1 b0       ..
+    sta l00ba,x                                                       ; 80e8: 95 ba       ..
+    inx                                                               ; 80ea: e8          .
+    iny                                                               ; 80eb: c8          .
+    rts                                                               ; 80ec: 60          `
+
+; $80ed referenced 5 times by $821d, $89ec, $8bb2, $8bc7, $a46c
+sub_c80ed
+    jsr sub_c8b7b                                                     ; 80ed: 20 7b 8b     {.
+    jmp c8103                                                         ; 80f0: 4c 03 81    L..
+
+; $80f3 referenced 5 times by $8222, $8879, $8a77, $9a78, $9c22
+sub_c80f3
+    jsr sub_c8b7b                                                     ; 80f3: 20 7b 8b     {.
+; $80f6 referenced 1 time by $8892
+sub_c80f6
+    lda l00ba                                                         ; 80f6: a5 ba       ..
+    sta os_text_ptr                                                   ; 80f8: 85 f2       ..
+    lda l00bb                                                         ; 80fa: a5 bb       ..
+    sta l00f3                                                         ; 80fc: 85 f3       ..
+    ldy #0                                                            ; 80fe: a0 00       ..
+    jsr clc_jmp_gsinit                                                ; 8100: 20 4c 87     L.
+; $8103 referenced 3 times by $80f0, $8113, $8123
+c8103
+    ldx #$20                                                          ; 8103: a2 20       .
+    jsr sub_c8149                                                     ; 8105: 20 49 81     I.
+    bcs c8125                                                         ; 8108: b0 1b       ..
+    sta l1000                                                         ; 810a: 8d 00 10    ...
+    cmp #'.'                                                          ; 810d: c9 2e       ..
+    bne c8115                                                         ; 810f: d0 04       ..
+; $8111 referenced 1 time by $8136
+c8111
+    stx l00cc                                                         ; 8111: 86 cc       ..
+    beq c8103                                                         ; 8113: f0 ee       ..
+; $8115 referenced 1 time by $810f
+c8115
+    cmp #$3a ; ':'                                                    ; 8115: c9 3a       .:
+    bne c812e                                                         ; 8117: d0 15       ..
+    jsr c8b8b                                                         ; 8119: 20 8b 8b     ..
+    jsr sub_c8149                                                     ; 811c: 20 49 81     I.
+    bcs c8125                                                         ; 811f: b0 04       ..
+    cmp #$2e ; '.'                                                    ; 8121: c9 2e       ..
+    beq c8103                                                         ; 8123: f0 de       ..
+; $8125 referenced 5 times by $8108, $811f, $8147, $8155, $8159
+c8125
+    jsr generate_error_precheck_bad                                   ; 8125: 20 2e 80     ..
+    !byte $cc                                                         ; 8128: cc          .
+    !text "name"                                                      ; 8129: 6e 61 6d... nam
+    !byte 0                                                           ; 812d: 00          .
+
+; $812e referenced 1 time by $8117
+c812e
+    tax                                                               ; 812e: aa          .
+    jsr sub_c8149                                                     ; 812f: 20 49 81     I.
+    bcs c815d                                                         ; 8132: b0 29       .)
+    cmp #$2e ; '.'                                                    ; 8134: c9 2e       ..
+    beq c8111                                                         ; 8136: f0 d9       ..
+    ldx #1                                                            ; 8138: a2 01       ..
+; $813a referenced 1 time by $8145
+loop_c813a
+    sta l1000,x                                                       ; 813a: 9d 00 10    ...
+    inx                                                               ; 813d: e8          .
+    jsr sub_c8149                                                     ; 813e: 20 49 81     I.
+    bcs c815f                                                         ; 8141: b0 1c       ..
+    cpx #7                                                            ; 8143: e0 07       ..
+    bne loop_c813a                                                    ; 8145: d0 f3       ..
+    beq c8125                                                         ; 8147: f0 dc       ..
+; $8149 referenced 11 times by $8105, $811c, $812f, $813e, $8990, $899c, $89af, $89cb, $8a19, $8b8b, $a143
+sub_c8149
+    jsr gsread                                                        ; 8149: 20 c5 ff     ..
+    php                                                               ; 814c: 08          .
+    and #$7f                                                          ; 814d: 29 7f       ).
+    cmp #13                                                           ; 814f: c9 0d       ..
+    beq c815b                                                         ; 8151: f0 08       ..
+    cmp #$20 ; ' '                                                    ; 8153: c9 20       .
+    bcc c8125                                                         ; 8155: 90 ce       ..
+    cmp #$7f                                                          ; 8157: c9 7f       ..
+    beq c8125                                                         ; 8159: f0 ca       ..
+; $815b referenced 1 time by $8151
+c815b
+    plp                                                               ; 815b: 28          (
+    rts                                                               ; 815c: 60          `
+
+; $815d referenced 2 times by $8132, $8248
+c815d
+    ldx #1                                                            ; 815d: a2 01       ..
+; $815f referenced 1 time by $8141
+c815f
+    lda #$20 ; ' '                                                    ; 815f: a9 20       .
+; $8161 referenced 1 time by $8167
+loop_c8161
+    sta l1000,x                                                       ; 8161: 9d 00 10    ...
+    inx                                                               ; 8164: e8          .
+    cpx #$40 ; '@'                                                    ; 8165: e0 40       .@
+    bne loop_c8161                                                    ; 8167: d0 f8       ..
+    ldx #6                                                            ; 8169: a2 06       ..
+; $816b referenced 1 time by $8171
+loop_c816b
+    lda l1000,x                                                       ; 816b: bd 00 10    ...
+    sta l00c5,x                                                       ; 816e: 95 c5       ..
+    dex                                                               ; 8170: ca          .
+    bpl loop_c816b                                                    ; 8171: 10 f8       ..
+    rts                                                               ; 8173: 60          `
+
+; $8174 referenced 4 times by $833d, $85cd, $875e, $87a5
+sub_c8174
+    jsr sub_c83e3                                                     ; 8174: 20 e3 83     ..
+    lda l0e0f,y                                                       ; 8177: b9 0f 0e    ...
+    php                                                               ; 817a: 08          .
+    and #$7f                                                          ; 817b: 29 7f       ).
+    bne c8184                                                         ; 817d: d0 05       ..
+    jsr sub_cac0c                                                     ; 817f: 20 0c ac     ..
+    beq c818a                                                         ; 8182: f0 06       ..
+; $8184 referenced 1 time by $817d
+c8184
+    jsr c809f                                                         ; 8184: 20 9f 80     ..
+    jsr sub_c809d                                                     ; 8187: 20 9d 80     ..
+; $818a referenced 1 time by $8182
+c818a
+    ldx #6                                                            ; 818a: a2 06       ..
+; $818c referenced 1 time by $8196
+loop_c818c
+    lda l0e08,y                                                       ; 818c: b9 08 0e    ...
+    and #$7f                                                          ; 818f: 29 7f       ).
+    jsr c809f                                                         ; 8191: 20 9f 80     ..
+    iny                                                               ; 8194: c8          .
+    dex                                                               ; 8195: ca          .
+    bpl loop_c818c                                                    ; 8196: 10 f4       ..
+    jsr sub_cac0c                                                     ; 8198: 20 0c ac     ..
+    lda #$20 ; ' '                                                    ; 819b: a9 20       .
+    plp                                                               ; 819d: 28          (
+    bpl c81a2                                                         ; 819e: 10 02       ..
+    lda #$4c ; 'L'                                                    ; 81a0: a9 4c       .L
+; $81a2 referenced 1 time by $819e
+c81a2
+    jsr c809f                                                         ; 81a2: 20 9f 80     ..
+    ldy #1                                                            ; 81a5: a0 01       ..
+; $81a7 referenced 4 times by $81ab, $84c5, $850a, $85c2
+c81a7
+    jsr cac0f                                                         ; 81a7: 20 0f ac     ..
+    dey                                                               ; 81aa: 88          .
+    bne c81a7                                                         ; 81ab: d0 fa       ..
+    rts                                                               ; 81ad: 60          `
+
+; $81ae referenced 2 times by $88a9, $8b6b
+sub_c81ae
+    lsr                                                               ; 81ae: 4a          J
+    lsr                                                               ; 81af: 4a          J
+; $81b0 referenced 8 times by $81f5, $85e6, $9cdb, $9cfd, $a2c6, $a49f, $a505, $a8e6
+sub_c81b0
+    lsr                                                               ; 81b0: 4a          J
+    lsr                                                               ; 81b1: 4a          J
+    lsr                                                               ; 81b2: 4a          J
+    lsr                                                               ; 81b3: 4a          J
+    and #3                                                            ; 81b4: 29 03       ).
+    rts                                                               ; 81b6: 60          `
+
+; $81b7 referenced 1 time by $8b54
+sub_c81b7
+    and #8                                                            ; 81b7: 29 08       ).
+    beq c81bd                                                         ; 81b9: f0 02       ..
+    lda #3                                                            ; 81bb: a9 03       ..
+; $81bd referenced 1 time by $81b9
+c81bd
+    rts                                                               ; 81bd: 60          `
+
+; $81be referenced 3 times by $9cb3, $9d0c, $9e00
+sub_c81be
+    lsr                                                               ; 81be: 4a          J
+; $81bf referenced 8 times by $80bc, $84d5, $9527, $9644, $98fb, $a18d, $a9c3, $ac63
+sub_c81bf
+    lsr                                                               ; 81bf: 4a          J
+; $81c0 referenced 1 time by $a90d
+sub_c81c0
+    lsr                                                               ; 81c0: 4a          J
+    lsr                                                               ; 81c1: 4a          J
+    lsr                                                               ; 81c2: 4a          J
+    rts                                                               ; 81c3: 60          `
+
+; $81c4 referenced 1 time by $9e2a
+sub_c81c4
+    asl                                                               ; 81c4: 0a          .
+; $81c5 referenced 2 times by $8a5d, $9bae
+sub_c81c5
+    asl                                                               ; 81c5: 0a          .
+    asl                                                               ; 81c6: 0a          .
+    asl                                                               ; 81c7: 0a          .
+    asl                                                               ; 81c8: 0a          .
+    rts                                                               ; 81c9: 60          `
+
+; $81ca referenced 1 time by $8867
+sub_c81ca
+    lda #5                                                            ; 81ca: a9 05       ..
+    sta l1095                                                         ; 81cc: 8d 95 10    ...
+    lda l00cd                                                         ; 81cf: a5 cd       ..
+    sta l1090                                                         ; 81d1: 8d 90 10    ...
+    lda #$0a                                                          ; 81d4: a9 0a       ..
+    sta l00b0                                                         ; 81d6: 85 b0       ..
+    lda l00bc                                                         ; 81d8: a5 bc       ..
+    sta l1091                                                         ; 81da: 8d 91 10    ...
+    lda l00bd                                                         ; 81dd: a5 bd       ..
+    sta l1092                                                         ; 81df: 8d 92 10    ...
+    lda l1074                                                         ; 81e2: ad 74 10    .t.
+    sta l1093                                                         ; 81e5: 8d 93 10    ...
+    lda l1075                                                         ; 81e8: ad 75 10    .u.
+    sta l1094                                                         ; 81eb: 8d 94 10    ...
+    lda #$ff                                                          ; 81ee: a9 ff       ..
+    sta l1097                                                         ; 81f0: 8d 97 10    ...
+    lda l00c2                                                         ; 81f3: a5 c2       ..
+    jsr sub_c81b0                                                     ; 81f5: 20 b0 81     ..
+    sta l109a                                                         ; 81f8: 8d 9a 10    ...
+    lda l00c0                                                         ; 81fb: a5 c0       ..
+    sta l109b                                                         ; 81fd: 8d 9b 10    ...
+    lda l00c1                                                         ; 8200: a5 c1       ..
+    sta l1099                                                         ; 8202: 8d 99 10    ...
+    lda l00c2                                                         ; 8205: a5 c2       ..
+    and #$03                                                          ; 8207: 29 03       ).
+    tax                                                               ; 8209: aa          .
+    lda l00c3                                                         ; 820a: a5 c3       ..
+; $820c referenced 1 time by $8215
+loop_c820c
+    sec                                                               ; 820c: 38          8
+; $820d referenced 1 time by $8212
+loop_c820d
+    inc l1097                                                         ; 820d: ee 97 10    ...
+    sbc l00b0                                                         ; 8210: e5 b0       ..
+    bcs loop_c820d                                                    ; 8212: b0 f9       ..
+    dex                                                               ; 8214: ca          .
+    bpl loop_c820c                                                    ; 8215: 10 f5       ..
+    adc l00b0                                                         ; 8217: 65 b0       e.
+    sta l1098                                                         ; 8219: 8d 98 10    ...
+; $821c referenced 1 time by $8228
+loop_c821c
+    rts                                                               ; 821c: 60          `
+
+; $821d referenced 4 times by $825a, $8756, $8788, $879d
+sub_c821d
+    jsr sub_c80ed                                                     ; 821d: 20 ed 80     ..
+    bmi c8225                                                         ; 8220: 30 03       0.
+; $8222 referenced 1 time by $881b
+sub_c8222
+    jsr sub_c80f3                                                     ; 8222: 20 f3 80     ..
+; $8225 referenced 4 times by $8220, $824e, $8bb7, $a478
+c8225
+    jsr sub_c8284                                                     ; 8225: 20 84 82     ..
+    bcs loop_c821c                                                    ; 8228: b0 f2       ..
+; $822a referenced 2 times by $89fd, $ab17
+c822a
+    jsr generate_error                                                ; 822a: 20 48 80     H.
+    !byte $d6                                                         ; 822d: d6          .
+    !text "Not found"                                                 ; 822e: 4e 6f 74... Not
+    !byte 0                                                           ; 8237: 00          .
+
+sub_c8238
+    jsr sub_c8b7b                                                     ; 8238: 20 7b 8b     {.
+    jsr clc_jmp_gsinit                                                ; 823b: 20 4c 87     L.
+    beq c8243                                                         ; 823e: f0 03       ..
+    jsr c898a                                                         ; 8240: 20 8a 89     ..
+; $8243 referenced 1 time by $823e
+c8243
+    lda #$2a ; '*'                                                    ; 8243: a9 2a       .*
+    sta l1000                                                         ; 8245: 8d 00 10    ...
+    jsr c815d                                                         ; 8248: 20 5d 81     ].
+    jsr sub_c99ac                                                     ; 824b: 20 ac 99     ..
+    jsr c8225                                                         ; 824e: 20 25 82     %.
+    jmp c825d                                                         ; 8251: 4c 5d 82    L].
+
+sub_c8254
+    jsr sub_c99ac                                                     ; 8254: 20 ac 99     ..
+    jsr sub_ca14a                                                     ; 8257: 20 4a a1     J.
+    jsr sub_c821d                                                     ; 825a: 20 1d 82     ..
+; $825d referenced 2 times by $8251, $8263
+c825d
+    jsr sub_c833a                                                     ; 825d: 20 3a 83     :.
+    jsr sub_c8280                                                     ; 8260: 20 80 82     ..
+    bcs c825d                                                         ; 8263: b0 f8       ..
+    rts                                                               ; 8265: 60          `
+
+; $8266 referenced 2 times by $887f, $8895
+sub_c8266
+    jsr sub_c93f9                                                     ; 8266: 20 f9 93     ..
+    lda #0                                                            ; 8269: a9 00       ..
+    beq c828b                                                         ; 826b: f0 1e       ..
+; $826d referenced 2 times by $9bd9, $a4f2
+sub_c826d
+    ldx #6                                                            ; 826d: a2 06       ..
+; $826f referenced 1 time by $8275
+loop_c826f
+    lda l00c5,x                                                       ; 826f: b5 c5       ..
+    sta l1058,x                                                       ; 8271: 9d 58 10    .X.
+    dex                                                               ; 8274: ca          .
+    bpl loop_c826f                                                    ; 8275: 10 f8       ..
+    lda #$20 ; ' '                                                    ; 8277: a9 20       .
+    sta l105f                                                         ; 8279: 8d 5f 10    ._.
+    lda #$58 ; 'X'                                                    ; 827c: a9 58       .X
+    bne c8286                                                         ; 827e: d0 06       ..
+; $8280 referenced 6 times by $8260, $877c, $87ab, $87c6, $8a10, $a4db
+sub_c8280
+    ldx #0                                                            ; 8280: a2 00       ..
+    beq c8290                                                         ; 8282: f0 0c       ..
+; $8284 referenced 7 times by $8225, $87bb, $89f8, $8a7a, $8bcf, $9a7b, $9c28
+sub_c8284
+    lda #0                                                            ; 8284: a9 00       ..
+; $8286 referenced 1 time by $827e
+c8286
+    pha                                                               ; 8286: 48          H
+    jsr sub_c93fd                                                     ; 8287: 20 fd 93     ..
+    pla                                                               ; 828a: 68          h
+; $828b referenced 1 time by $826b
+c828b
+    tax                                                               ; 828b: aa          .
+    lda #0                                                            ; 828c: a9 00       ..
+    sta l00b6                                                         ; 828e: 85 b6       ..
+; $8290 referenced 3 times by $8282, $82a4, $82ad
+c8290
+    ldy #0                                                            ; 8290: a0 00       ..
+    lda #$0e                                                          ; 8292: a9 0e       ..
+    sta l00b7                                                         ; 8294: 85 b7       ..
+    lda l00b6                                                         ; 8296: a5 b6       ..
+    cmp l0f05                                                         ; 8298: cd 05 0f    ...
+    bcs c82e6                                                         ; 829b: b0 49       .I
+    adc #8                                                            ; 829d: 69 08       i.
+    sta l00b6                                                         ; 829f: 85 b6       ..
+    jsr sub_c82bb                                                     ; 82a1: 20 bb 82     ..
+    bcc c8290                                                         ; 82a4: 90 ea       ..
+    lda l00cc                                                         ; 82a6: a5 cc       ..
+    ldy #7                                                            ; 82a8: a0 07       ..
+    jsr sub_c82e8                                                     ; 82aa: 20 e8 82     ..
+    bne c8290                                                         ; 82ad: d0 e1       ..
+    ldy l00b6                                                         ; 82af: a4 b6       ..
+    sec                                                               ; 82b1: 38          8
+; $82b2 referenced 4 times by $87e8, $8aca, $a27c, $a848
+sub_c82b2
+    dey                                                               ; 82b2: 88          .
+    dey                                                               ; 82b3: 88          .
+    dey                                                               ; 82b4: 88          .
+    dey                                                               ; 82b5: 88          .
+    dey                                                               ; 82b6: 88          .
+    dey                                                               ; 82b7: 88          .
+    dey                                                               ; 82b8: 88          .
+    dey                                                               ; 82b9: 88          .
+    rts                                                               ; 82ba: 60          `
+
+; $82bb referenced 2 times by $82a1, $82c7
+sub_c82bb
+    jsr sub_c83e3                                                     ; 82bb: 20 e3 83     ..
+; $82be referenced 1 time by $82e4
+c82be
+    lda l1000,x                                                       ; 82be: bd 00 10    ...
+    cmp l10ce                                                         ; 82c1: cd ce 10    ...
+    bne c82d9                                                         ; 82c4: d0 13       ..
+    inx                                                               ; 82c6: e8          .
+; $82c7 referenced 1 time by $82cf
+loop_c82c7
+    jsr sub_c82bb                                                     ; 82c7: 20 bb 82     ..
+    bcs c82e7                                                         ; 82ca: b0 1b       ..
+    iny                                                               ; 82cc: c8          .
+    cpy #7                                                            ; 82cd: c0 07       ..
+    bcc loop_c82c7                                                    ; 82cf: 90 f6       ..
+; $82d1 referenced 1 time by $82db
+loop_c82d1
+    lda l1000,x                                                       ; 82d1: bd 00 10    ...
+    cmp #$20 ; ' '                                                    ; 82d4: c9 20       .
+    bne c82e6                                                         ; 82d6: d0 0e       ..
+    rts                                                               ; 82d8: 60          `
+
+; $82d9 referenced 1 time by $82c4
+c82d9
+    cpy #7                                                            ; 82d9: c0 07       ..
+    bcs loop_c82d1                                                    ; 82db: b0 f4       ..
+    jsr sub_c82e8                                                     ; 82dd: 20 e8 82     ..
+    bne c82e6                                                         ; 82e0: d0 04       ..
+    inx                                                               ; 82e2: e8          .
+    iny                                                               ; 82e3: c8          .
+    bne c82be                                                         ; 82e4: d0 d8       ..
+; $82e6 referenced 3 times by $829b, $82d6, $82e0
+c82e6
+    clc                                                               ; 82e6: 18          .
+; $82e7 referenced 1 time by $82ca
+c82e7
+    rts                                                               ; 82e7: 60          `
+
+; $82e8 referenced 2 times by $82aa, $82dd
+sub_c82e8
+    cmp l10ce                                                         ; 82e8: cd ce 10    ...
+    beq c82fd                                                         ; 82eb: f0 10       ..
+    cmp l10cd                                                         ; 82ed: cd cd 10    ...
+    beq c82fd                                                         ; 82f0: f0 0b       ..
+    jsr sub_c8327                                                     ; 82f2: 20 27 83     '.
+    eor (l00b6),y                                                     ; 82f5: 51 b6       Q.
+    bcs c82fb                                                         ; 82f7: b0 02       ..
+    and #%01011111                                                    ; 82f9: 29 5f       )_
+; $82fb referenced 1 time by $82f7
+c82fb
+    and #$7f                                                          ; 82fb: 29 7f       ).
+; $82fd referenced 2 times by $82eb, $82f0
+c82fd
+    rts                                                               ; 82fd: 60          `
+
+; $82fe referenced 6 times by $8441, $8567, $857e, $858e, $aa2b, $aa3b
+sub_c82fe
+    php                                                               ; 82fe: 08          .
+    jsr sub_c8327                                                     ; 82ff: 20 27 83     '.
+    bcs c8306                                                         ; 8302: b0 02       ..
+    and #$5f ; '_'                                                    ; 8304: 29 5f       )_
+; $8306 referenced 1 time by $8302
+c8306
+    and #$7f                                                          ; 8306: 29 7f       ).
+    plp                                                               ; 8308: 28          (
+    rts                                                               ; 8309: 60          `
+
+; $830a referenced 5 times by $878e, $87e3, $8a7f, $99c4, $a4f7
+sub_c830a
+    jsr sub_c9a60                                                     ; 830a: 20 60 9a     `.
+; $830d referenced 1 time by $831d
+loop_c830d
+    lda l0e10,y                                                       ; 830d: b9 10 0e    ...
+    sta l0e08,y                                                       ; 8310: 99 08 0e    ...
+    lda l0f10,y                                                       ; 8313: b9 10 0f    ...
+    sta l0f08,y                                                       ; 8316: 99 08 0f    ...
+    iny                                                               ; 8319: c8          .
+    cpy l0f05                                                         ; 831a: cc 05 0f    ...
+    bcc loop_c830d                                                    ; 831d: 90 ee       ..
+    tya                                                               ; 831f: 98          .
+    sbc #8                                                            ; 8320: e9 08       ..
+    sta l0f05                                                         ; 8322: 8d 05 0f    ...
+    clc                                                               ; 8325: 18          .
+; $8326 referenced 1 time by $8338
+loop_c8326
+    rts                                                               ; 8326: 60          `
+
+; $8327 referenced 4 times by $82f2, $82ff, $8736, $98a8
+sub_c8327
+    pha                                                               ; 8327: 48          H
+    and #$5f ; '_'                                                    ; 8328: 29 5f       )_
+    cmp #$41 ; 'A'                                                    ; 832a: c9 41       .A
+    bcc c8332                                                         ; 832c: 90 04       ..
+    cmp #$5b ; '['                                                    ; 832e: c9 5b       .[
+    bcc c8333                                                         ; 8330: 90 01       ..
+; $8332 referenced 1 time by $832c
+c8332
+    sec                                                               ; 8332: 38          8
+; $8333 referenced 1 time by $8330
+c8333
+    pla                                                               ; 8333: 68          h
+    rts                                                               ; 8334: 60          `
+
+; $8335 referenced 5 times by $878b, $884f, $8a0d, $8b04, $a2ad
+sub_c8335
+    bit l10c6                                                         ; 8335: 2c c6 10    ,..
+    bmi loop_c8326                                                    ; 8338: 30 ec       0.
+; $833a referenced 3 times by $825d, $a30f, $a482
+sub_c833a
+    jsr sub_c83e3                                                     ; 833a: 20 e3 83     ..
+    jsr sub_c8174                                                     ; 833d: 20 74 81     t.
+    tya                                                               ; 8340: 98          .
+    pha                                                               ; 8341: 48          H
+    lda #$60 ; '`'                                                    ; 8342: a9 60       .`
+    sta l00b0                                                         ; 8344: 85 b0       ..
+    lda #$10                                                          ; 8346: a9 10       ..
+    sta l00b1                                                         ; 8348: 85 b1       ..
+    jsr sub_c8386                                                     ; 834a: 20 86 83     ..
+    ldy #2                                                            ; 834d: a0 02       ..
+    jsr cac0f                                                         ; 834f: 20 0f ac     ..
+    jsr sub_c836e                                                     ; 8352: 20 6e 83     n.
+    jsr sub_c836e                                                     ; 8355: 20 6e 83     n.
+    jsr sub_c836e                                                     ; 8358: 20 6e 83     n.
+    pla                                                               ; 835b: 68          h
+    tay                                                               ; 835c: a8          .
+    lda l0f0e,y                                                       ; 835d: b9 0e 0f    ...
+    and #3                                                            ; 8360: 29 03       ).
+    jsr sub_c80c3                                                     ; 8362: 20 c3 80     ..
+    lda l0f0f,y                                                       ; 8365: b9 0f 0f    ...
+    jsr sub_c80bb                                                     ; 8368: 20 bb 80     ..
+    jmp ca3dc                                                         ; 836b: 4c dc a3    L..
+
+; $836e referenced 3 times by $8352, $8355, $8358
+sub_c836e
+    ldx #3                                                            ; 836e: a2 03       ..
+; $8370 referenced 1 time by $8378
+loop_c8370
+    lda l1062,y                                                       ; 8370: b9 62 10    .b.
+    jsr sub_c80bb                                                     ; 8373: 20 bb 80     ..
+    dey                                                               ; 8376: 88          .
+    dex                                                               ; 8377: ca          .
+    bne loop_c8370                                                    ; 8378: d0 f6       ..
+    jsr sub_c87db                                                     ; 837a: 20 db 87     ..
+    jmp cac0f                                                         ; 837d: 4c 0f ac    L..
+
+; $8380 referenced 7 times by $89bd, $975e, $9bf8, $a26a, $a4d1, $a4ef, $a7fc
+sub_c8380
+    jsr sub_c83e3                                                     ; 8380: 20 e3 83     ..
+    jmp c940c                                                         ; 8383: 4c 0c 94    L..
+
+; $8386 referenced 5 times by $834a, $8821, $885f, $99b8, $99c1
+sub_c8386
+    jsr sub_c83e3                                                     ; 8386: 20 e3 83     ..
+    tya                                                               ; 8389: 98          .
+    pha                                                               ; 838a: 48          H
+    tax                                                               ; 838b: aa          .
+    ldy #$12                                                          ; 838c: a0 12       ..
+    lda #0                                                            ; 838e: a9 00       ..
+; $8390 referenced 1 time by $8395
+loop_c8390
+    dey                                                               ; 8390: 88          .
+    sta (l00b0),y                                                     ; 8391: 91 b0       ..
+    cpy #2                                                            ; 8393: c0 02       ..
+    bne loop_c8390                                                    ; 8395: d0 f9       ..
+; $8397 referenced 1 time by $839e
+loop_c8397
+    jsr sub_c83d1                                                     ; 8397: 20 d1 83     ..
+    iny                                                               ; 839a: c8          .
+    iny                                                               ; 839b: c8          .
+    cpy #$0e                                                          ; 839c: c0 0e       ..
+    bne loop_c8397                                                    ; 839e: d0 f7       ..
+    pla                                                               ; 83a0: 68          h
+    tax                                                               ; 83a1: aa          .
+    lda l0e0f,x                                                       ; 83a2: bd 0f 0e    ...
+    bpl c83ab                                                         ; 83a5: 10 04       ..
+    lda #8                                                            ; 83a7: a9 08       ..
+    sta (l00b0),y                                                     ; 83a9: 91 b0       ..
+; $83ab referenced 1 time by $83a5
+c83ab
+    lda l0f0e,x                                                       ; 83ab: bd 0e 0f    ...
+    ldy #4                                                            ; 83ae: a0 04       ..
+    jsr sub_c83bf                                                     ; 83b0: 20 bf 83     ..
+    ldy #$0c                                                          ; 83b3: a0 0c       ..
+    lsr                                                               ; 83b5: 4a          J
+    lsr                                                               ; 83b6: 4a          J
+    pha                                                               ; 83b7: 48          H
+    and #3                                                            ; 83b8: 29 03       ).
+    sta (l00b0),y                                                     ; 83ba: 91 b0       ..
+    pla                                                               ; 83bc: 68          h
+    ldy #8                                                            ; 83bd: a0 08       ..
+; $83bf referenced 1 time by $83b0
+sub_c83bf
+    lsr                                                               ; 83bf: 4a          J
+    lsr                                                               ; 83c0: 4a          J
+    pha                                                               ; 83c1: 48          H
+    and #3                                                            ; 83c2: 29 03       ).
+    cmp #3                                                            ; 83c4: c9 03       ..
+    bne c83cd                                                         ; 83c6: d0 05       ..
+    lda #$ff                                                          ; 83c8: a9 ff       ..
+    sta (l00b0),y                                                     ; 83ca: 91 b0       ..
+    iny                                                               ; 83cc: c8          .
+; $83cd referenced 1 time by $83c6
+c83cd
+    sta (l00b0),y                                                     ; 83cd: 91 b0       ..
+    pla                                                               ; 83cf: 68          h
+    rts                                                               ; 83d0: 60          `
+
+; $83d1 referenced 1 time by $8397
+sub_c83d1
+    jsr sub_c83d4                                                     ; 83d1: 20 d4 83     ..
+; $83d4 referenced 1 time by $83d1
+sub_c83d4
+    lda l0f08,x                                                       ; 83d4: bd 08 0f    ...
+    sta (l00b0),y                                                     ; 83d7: 91 b0       ..
+    inx                                                               ; 83d9: e8          .
+    iny                                                               ; 83da: c8          .
+    rts                                                               ; 83db: 60          `
+
+; $83dc referenced 4 times by $805b, $8064, $8086, $a9ab
+inc16_ae
+    inc l00ae                                                         ; 83dc: e6 ae       ..
+    bne c83e2                                                         ; 83de: d0 02       ..
+    inc l00af                                                         ; 83e0: e6 af       ..
+; $83e2 referenced 1 time by $83de
+c83e2
+    rts                                                               ; 83e2: 60          `
+
+; $83e3 referenced 29 times by $809f, $8174, $82bb, $833a, $8380, $8386, $8951, $8a32, $96c3, $97cd, $993b, $99f3, $9a0f, $9a32, $9a63, $9ac8, $9ad8, $9b51, $9bf2, $9c10, $9d9b, $9f7c, $9f82, $a06c, $a190, $a1b4, $a379, $a384, $ac72
+sub_c83e3
+    pha                                                               ; 83e3: 48          H
+    txa                                                               ; 83e4: 8a          .
+    pha                                                               ; 83e5: 48          H
+    tya                                                               ; 83e6: 98          .
+    pha                                                               ; 83e7: 48          H
+    lda #$84                                                          ; 83e8: a9 84       ..
+    pha                                                               ; 83ea: 48          H
+    lda #5                                                            ; 83eb: a9 05       ..
+    pha                                                               ; 83ed: 48          H
+; $83ee referenced 1 time by $8411
+sub_c83ee
+    ldy #5                                                            ; 83ee: a0 05       ..
+; $83f0 referenced 1 time by $83f6
+loop_c83f0
+    tsx                                                               ; 83f0: ba          .
+    lda l0107,x                                                       ; 83f1: bd 07 01    ...
+    pha                                                               ; 83f4: 48          H
+    dey                                                               ; 83f5: 88          .
+    bne loop_c83f0                                                    ; 83f6: d0 f8       ..
+    ldy #$0a                                                          ; 83f8: a0 0a       ..
+; $83fa referenced 1 time by $8402
+loop_c83fa
+    lda l0109,x                                                       ; 83fa: bd 09 01    ...
+    sta l010b,x                                                       ; 83fd: 9d 0b 01    ...
+    dex                                                               ; 8400: ca          .
+    dey                                                               ; 8401: 88          .
+    bne loop_c83fa                                                    ; 8402: d0 f6       ..
+    pla                                                               ; 8404: 68          h
+    pla                                                               ; 8405: 68          h
+; $8406 referenced 1 time by $8418
+loop_c8406
+    pla                                                               ; 8406: 68          h
+    tay                                                               ; 8407: a8          .
+    pla                                                               ; 8408: 68          h
+    tax                                                               ; 8409: aa          .
+    pla                                                               ; 840a: 68          h
+    rts                                                               ; 840b: 60          `
+
+; $840c referenced 5 times by $841b, $9785, $9c16, $9e94, $aadd
+sub_c840c
+    pha                                                               ; 840c: 48          H
+    txa                                                               ; 840d: 8a          .
+    pha                                                               ; 840e: 48          H
+    tya                                                               ; 840f: 98          .
+    pha                                                               ; 8410: 48          H
+    jsr sub_c83ee                                                     ; 8411: 20 ee 83     ..
+    tsx                                                               ; 8414: ba          .
+    sta l0103,x                                                       ; 8415: 9d 03 01    ...
+    jmp loop_c8406                                                    ; 8418: 4c 06 84    L..
+
+; $841b referenced 2 times by $80b8, $a9bf
+sub_c841b
+    jsr sub_c840c                                                     ; 841b: 20 0c 84     ..
+    tay                                                               ; 841e: a8          .
+    beq c842b                                                         ; 841f: f0 0a       ..
+    clc                                                               ; 8421: 18          .
+    sed                                                               ; 8422: f8          .
+    lda #0                                                            ; 8423: a9 00       ..
+; $8425 referenced 1 time by $8428
+loop_c8425
+    adc #1                                                            ; 8425: 69 01       i.
+    dey                                                               ; 8427: 88          .
+    bne loop_c8425                                                    ; 8428: d0 fb       ..
+    cld                                                               ; 842a: d8          .
+; $842b referenced 1 time by $841f
+c842b
+    rts                                                               ; 842b: 60          `
+
+; $842c referenced 1 time by $abb1
+sub_c842c
+    and #$7f                                                          ; 842c: 29 7f       ).
+    cmp #$7f                                                          ; 842e: c9 7f       ..
+    beq c8436                                                         ; 8430: f0 04       ..
+    cmp #$20 ; ' '                                                    ; 8432: c9 20       .
+    bcs c8438                                                         ; 8434: b0 02       ..
+; $8436 referenced 1 time by $8430
+c8436
+    lda #$2e ; '.'                                                    ; 8436: a9 2e       ..
+; $8438 referenced 1 time by $8434
+c8438
+    rts                                                               ; 8438: 60          `
+
+; $8439 referenced 2 times by $8444, $8463
+sub_c8439
+    sec                                                               ; 8439: 38          8
+    sbc #$30 ; '0'                                                    ; 843a: e9 30       .0
+    bcc c8454                                                         ; 843c: 90 16       ..
+    cmp #$0a                                                          ; 843e: c9 0a       ..
+    rts                                                               ; 8440: 60          `
+
+    jsr sub_c82fe                                                     ; 8441: 20 fe 82     ..
+    jsr sub_c8439                                                     ; 8444: 20 39 84     9.
+    bcc c8453                                                         ; 8447: 90 0a       ..
+    sbc #7                                                            ; 8449: e9 07       ..
+    bcc c8454                                                         ; 844b: 90 07       ..
+    cmp #$0a                                                          ; 844d: c9 0a       ..
+    bcc c8454                                                         ; 844f: 90 03       ..
+    cmp #$10                                                          ; 8451: c9 10       ..
+; $8453 referenced 1 time by $8447
+c8453
+    rts                                                               ; 8453: 60          `
+
+; $8454 referenced 3 times by $843c, $844b, $844f
+c8454
+    sec                                                               ; 8454: 38          8
+    rts                                                               ; 8455: 60          `
+
+; $8456 referenced 3 times by $87f7, $a5ce, $a9e7
+sub_c8456
+    jsr clc_jmp_gsinit                                                ; 8456: 20 4c 87     L.
+    sec                                                               ; 8459: 38          8
+    beq c8482                                                         ; 845a: f0 26       .&
+    php                                                               ; 845c: 08          .
+    lda #0                                                            ; 845d: a9 00       ..
+    sta l00b9                                                         ; 845f: 85 b9       ..
+    beq c8477                                                         ; 8461: f0 14       ..
+; $8463 referenced 1 time by $847a
+loop_c8463
+    jsr sub_c8439                                                     ; 8463: 20 39 84     9.
+    bcs c8481                                                         ; 8466: b0 19       ..
+    sta l00b8                                                         ; 8468: 85 b8       ..
+    lda l00b9                                                         ; 846a: a5 b9       ..
+    asl                                                               ; 846c: 0a          .
+    sta l00b9                                                         ; 846d: 85 b9       ..
+    asl                                                               ; 846f: 0a          .
+    asl                                                               ; 8470: 0a          .
+    adc l00b9                                                         ; 8471: 65 b9       e.
+    adc l00b8                                                         ; 8473: 65 b8       e.
+    sta l00b9                                                         ; 8475: 85 b9       ..
+; $8477 referenced 1 time by $8461
+c8477
+    jsr gsread                                                        ; 8477: 20 c5 ff     ..
+    bcc loop_c8463                                                    ; 847a: 90 e7       ..
+    lda l00b9                                                         ; 847c: a5 b9       ..
+    plp                                                               ; 847e: 28          (
+    clc                                                               ; 847f: 18          .
+    rts                                                               ; 8480: 60          `
+
+; $8481 referenced 1 time by $8466
+c8481
+    plp                                                               ; 8481: 28          (
+; $8482 referenced 1 time by $845a
+c8482
+    rts                                                               ; 8482: 60          `
+
+    jsr sub_c8745                                                     ; 8483: 20 45 87     E.
+    jsr sub_c8b86                                                     ; 8486: 20 86 8b     ..
+    jsr c940c                                                         ; 8489: 20 0c 94     ..
+    ldy #$ff                                                          ; 848c: a0 ff       ..
+    sty l00a8                                                         ; 848e: 84 a8       ..
+    iny                                                               ; 8490: c8          .
+    sty l00aa                                                         ; 8491: 84 aa       ..
+; $8493 referenced 1 time by $84a3
+loop_c8493
+    lda l0e00,y                                                       ; 8493: b9 00 0e    ...
+    cpy #8                                                            ; 8496: c0 08       ..
+    bcc c849d                                                         ; 8498: 90 03       ..
+    lda l0ef8,y                                                       ; 849a: b9 f8 0e    ...
+; $849d referenced 1 time by $8498
+c849d
+    jsr c809f                                                         ; 849d: 20 9f 80     ..
+    iny                                                               ; 84a0: c8          .
+    cpy #$0c                                                          ; 84a1: c0 0c       ..
+    bne loop_c8493                                                    ; 84a3: d0 ee       ..
+    jsr print_inline_l809f_top_bit_clear                              ; 84a5: 20 77 80     w.
+    !text " ("                                                        ; 84a8: 20 28        (
+
+    lda l0f04                                                         ; 84aa: ad 04 0f    ...
+    jsr sub_c80bb                                                     ; 84ad: 20 bb 80     ..
+    jsr print_inline_l809f_top_bit_clear                              ; 84b0: 20 77 80     w.
+    !text ") FM", $0d, "Drive "                                       ; 84b3: 29 20 46... ) F
+
+    lda l00cd                                                         ; 84be: a5 cd       ..
+    jsr sub_c80c3                                                     ; 84c0: 20 c3 80     ..
+    ldy #$0d                                                          ; 84c3: a0 0d       ..
+    jsr c81a7                                                         ; 84c5: 20 a7 81     ..
+    jsr print_inline_l809f_top_bit_clear                              ; 84c8: 20 77 80     w.
+    !text "Option "                                                   ; 84cb: 4f 70 74... Opt
+
+    lda l0f06                                                         ; 84d2: ad 06 0f    ...
+    jsr sub_c81bf                                                     ; 84d5: 20 bf 81     ..
+    pha                                                               ; 84d8: 48          H
+    jsr sub_c80c3                                                     ; 84d9: 20 c3 80     ..
+    jsr print_inline_l809f_top_bit_clear                              ; 84dc: 20 77 80     w.
+    !text " ("                                                        ; 84df: 20 28        (
+
+    ldy #3                                                            ; 84e1: a0 03       ..
+    pla                                                               ; 84e3: 68          h
+    asl                                                               ; 84e4: 0a          .
+    asl                                                               ; 84e5: 0a          .
+    tax                                                               ; 84e6: aa          .
+; $84e7 referenced 1 time by $84ef
+loop_c84e7
+    lda opt4_table,x                                                  ; 84e7: bd d3 85    ...
+    jsr c809f                                                         ; 84ea: 20 9f 80     ..
+    inx                                                               ; 84ed: e8          .
+    dey                                                               ; 84ee: 88          .
+    bpl loop_c84e7                                                    ; 84ef: 10 f6       ..
+    jsr print_inline_l809f_top_bit_clear                              ; 84f1: 20 77 80     w.
+    !text ")", $0d, "Dir. :"                                          ; 84f4: 29 0d 44... ).D
+
+    lda l10ca                                                         ; 84fc: ad ca 10    ...
+    jsr sub_c809a                                                     ; 84ff: 20 9a 80     ..
+    lda l10c9                                                         ; 8502: ad c9 10    ...
+    jsr c809f                                                         ; 8505: 20 9f 80     ..
+    ldy #$0b                                                          ; 8508: a0 0b       ..
+    jsr c81a7                                                         ; 850a: 20 a7 81     ..
+    jsr print_inline_l809f_top_bit_clear                              ; 850d: 20 77 80     w.
+    !text "Lib. :"                                                    ; 8510: 4c 69 62... Lib
+
+    lda l10cc                                                         ; 8516: ad cc 10    ...
+    jsr sub_c809a                                                     ; 8519: 20 9a 80     ..
+    lda l10cb                                                         ; 851c: ad cb 10    ...
+    jsr c809f                                                         ; 851f: 20 9f 80     ..
+    jsr ca3dc                                                         ; 8522: 20 dc a3     ..
+    ldy #0                                                            ; 8525: a0 00       ..
+; $8527 referenced 1 time by $8541
+loop_c8527
+    cpy l0f05                                                         ; 8527: cc 05 0f    ...
+    bcs c8543                                                         ; 852a: b0 17       ..
+    lda l0e0f,y                                                       ; 852c: b9 0f 0e    ...
+    eor l10c9                                                         ; 852f: 4d c9 10    M..
+    and #$5f ; '_'                                                    ; 8532: 29 5f       )_
+    bne c853e                                                         ; 8534: d0 08       ..
+    lda l0e0f,y                                                       ; 8536: b9 0f 0e    ...
+    and #$80                                                          ; 8539: 29 80       ).
+    sta l0e0f,y                                                       ; 853b: 99 0f 0e    ...
+; $853e referenced 1 time by $8534
+c853e
+    jsr sub_c87da                                                     ; 853e: 20 da 87     ..
+    bcc loop_c8527                                                    ; 8541: 90 e4       ..
+; $8543 referenced 2 times by $852a, $85d0
+c8543
+    ldy #0                                                            ; 8543: a0 00       ..
+    jsr sub_c8555                                                     ; 8545: 20 55 85     U.
+    bcc c8560                                                         ; 8548: 90 16       ..
+    lda #$ff                                                          ; 854a: a9 ff       ..
+    sta l1082                                                         ; 854c: 8d 82 10    ...
+    jmp ca3dc                                                         ; 854f: 4c dc a3    L..
+
+; $8552 referenced 1 time by $855d
+loop_c8552
+    jsr sub_c87da                                                     ; 8552: 20 da 87     ..
+; $8555 referenced 2 times by $8545, $8573
+sub_c8555
+    cpy l0f05                                                         ; 8555: cc 05 0f    ...
+    bcs c855f                                                         ; 8558: b0 05       ..
+    lda l0e08,y                                                       ; 855a: b9 08 0e    ...
+    bmi loop_c8552                                                    ; 855d: 30 f3       0.
+; $855f referenced 1 time by $8558
+c855f
+    rts                                                               ; 855f: 60          `
+
+; $8560 referenced 2 times by $8548, $8594
+c8560
+    sty l00ab                                                         ; 8560: 84 ab       ..
+    ldx #0                                                            ; 8562: a2 00       ..
+; $8564 referenced 1 time by $8571
+loop_c8564
+    lda l0e08,y                                                       ; 8564: b9 08 0e    ...
+    jsr sub_c82fe                                                     ; 8567: 20 fe 82     ..
+    sta l1060,x                                                       ; 856a: 9d 60 10    .`.
+    iny                                                               ; 856d: c8          .
+    inx                                                               ; 856e: e8          .
+    cpx #8                                                            ; 856f: e0 08       ..
+    bne loop_c8564                                                    ; 8571: d0 f1       ..
+; $8573 referenced 1 time by $8599
+c8573
+    jsr sub_c8555                                                     ; 8573: 20 55 85     U.
+    bcs c859b                                                         ; 8576: b0 23       .#
+    sec                                                               ; 8578: 38          8
+    ldx #6                                                            ; 8579: a2 06       ..
+; $857b referenced 1 time by $8586
+loop_c857b
+    lda l0e0e,y                                                       ; 857b: b9 0e 0e    ...
+    jsr sub_c82fe                                                     ; 857e: 20 fe 82     ..
+    sbc l1060,x                                                       ; 8581: fd 60 10    .`.
+    dey                                                               ; 8584: 88          .
+    dex                                                               ; 8585: ca          .
+    bpl loop_c857b                                                    ; 8586: 10 f3       ..
+    jsr sub_c87db                                                     ; 8588: 20 db 87     ..
+    lda l0e0f,y                                                       ; 858b: b9 0f 0e    ...
+    jsr sub_c82fe                                                     ; 858e: 20 fe 82     ..
+    sbc l1067                                                         ; 8591: ed 67 10    .g.
+    bcc c8560                                                         ; 8594: 90 ca       ..
+    jsr sub_c87da                                                     ; 8596: 20 da 87     ..
+    bcs c8573                                                         ; 8599: b0 d8       ..
+; $859b referenced 1 time by $8576
+c859b
+    ldy l00ab                                                         ; 859b: a4 ab       ..
+    lda l0e08,y                                                       ; 859d: b9 08 0e    ...
+    ora #$80                                                          ; 85a0: 09 80       ..
+    sta l0e08,y                                                       ; 85a2: 99 08 0e    ...
+    lda l1067                                                         ; 85a5: ad 67 10    .g.
+    cmp l00aa                                                         ; 85a8: c5 aa       ..
+    beq c85bc                                                         ; 85aa: f0 10       ..
+    ldx l00aa                                                         ; 85ac: a6 aa       ..
+    sta l00aa                                                         ; 85ae: 85 aa       ..
+    bne c85bc                                                         ; 85b0: d0 0a       ..
+    jsr ca3dc                                                         ; 85b2: 20 dc a3     ..
+; $85b5 referenced 1 time by $85be
+loop_c85b5
+    jsr ca3dc                                                         ; 85b5: 20 dc a3     ..
+    ldy #$ff                                                          ; 85b8: a0 ff       ..
+    bne c85c5                                                         ; 85ba: d0 09       ..
+; $85bc referenced 2 times by $85aa, $85b0
+c85bc
+    ldy l00a8                                                         ; 85bc: a4 a8       ..
+    bne loop_c85b5                                                    ; 85be: d0 f5       ..
+    ldy #5                                                            ; 85c0: a0 05       ..
+    jsr c81a7                                                         ; 85c2: 20 a7 81     ..
+; $85c5 referenced 1 time by $85ba
+c85c5
+    iny                                                               ; 85c5: c8          .
+    sty l00a8                                                         ; 85c6: 84 a8       ..
+    ldy l00ab                                                         ; 85c8: a4 ab       ..
+    jsr sub_cac0c                                                     ; 85ca: 20 0c ac     ..
+    jsr sub_c8174                                                     ; 85cd: 20 74 81     t.
+    jmp c8543                                                         ; 85d0: 4c 43 85    LC.
+
+; $85d3 referenced 1 time by $84e7
+opt4_table
+    !text "off", 0                                                    ; 85d3: 6f 66 66... off
+    !text "LOAD"                                                      ; 85d7: 4c 4f 41... LOA
+    !text "RUN", 0                                                    ; 85db: 52 55 4e... RUN
+    !text "EXEC"                                                      ; 85df: 45 58 45... EXE
+
+; $85e3 referenced 1 time by $8acd
+sub_c85e3
+    lda l0f0e,y                                                       ; 85e3: b9 0e 0f    ...
+    jsr sub_c81b0                                                     ; 85e6: 20 b0 81     ..
+    sta l00c2                                                         ; 85e9: 85 c2       ..
+    clc                                                               ; 85eb: 18          .
+    lda #$ff                                                          ; 85ec: a9 ff       ..
+    adc l0f0c,y                                                       ; 85ee: 79 0c 0f    y..
+    lda l0f0f,y                                                       ; 85f1: b9 0f 0f    ...
+    adc l0f0d,y                                                       ; 85f4: 79 0d 0f    y..
+    sta l00c3                                                         ; 85f7: 85 c3       ..
+    lda l0f0e,y                                                       ; 85f9: b9 0e 0f    ...
+    and #3                                                            ; 85fc: 29 03       ).
+    adc l00c2                                                         ; 85fe: 65 c2       e.
+    sta l00c2                                                         ; 8600: 85 c2       ..
+; $8602 referenced 1 time by $8ac2
+sub_c8602
+    sec                                                               ; 8602: 38          8
+    lda l0f07,y                                                       ; 8603: b9 07 0f    ...
+    sbc l00c3                                                         ; 8606: e5 c3       ..
+    pha                                                               ; 8608: 48          H
+    lda l0f06,y                                                       ; 8609: b9 06 0f    ...
+    and #3                                                            ; 860c: 29 03       ).
+    sbc l00c2                                                         ; 860e: e5 c2       ..
+    tax                                                               ; 8610: aa          .
+    lda #0                                                            ; 8611: a9 00       ..
+    cmp l00c0                                                         ; 8613: c5 c0       ..
+    pla                                                               ; 8615: 68          h
+    sbc l00c1                                                         ; 8616: e5 c1       ..
+    txa                                                               ; 8618: 8a          .
+    sbc l00c4                                                         ; 8619: e5 c4       ..
+    rts                                                               ; 861b: 60          `
+
+; $861c referenced 6 times by $870e, $8719, $8726, $873c, $a16f, $a187
+command_table
+    !text "ACCESS"                                                    ; 861c: 41 43 43... ACC
+; $861d referenced 1 time by $8740
+    !byte >(sub_c89e6-1)                                              ; 8622: 89          .
+    !byte <(sub_c89e6-1)                                              ; 8623: e5          .
+    !byte $32                                                         ; 8624: 32          2
+    !text "BACKUP"                                                    ; 8625: 42 41 43... BAC
+    !byte >(sub_ca417-1)                                              ; 862b: a4          .
+    !byte <(sub_ca417-1)                                              ; 862c: 16          .
+    !byte 4                                                           ; 862d: 04          .
+    !text "CLOSE"                                                     ; 862e: 43 4c 4f... CLO
+    !byte >(sub_c9b59-1)                                              ; 8633: 9b          .
+    !byte <(sub_c9b59-1)                                              ; 8634: 58          X
+    !byte 0                                                           ; 8635: 00          .
+    !text "COMPACT"                                                   ; 8636: 43 4f 4d... COM
+    !byte >(sub_ca244-1)                                              ; 863d: a2          .
+    !byte <(sub_ca244-1)                                              ; 863e: 43          C
+    !byte 7                                                           ; 863f: 07          .
+    !text "COPY"                                                      ; 8640: 43 4f 50... COP
+    !byte >(sub_ca463-1)                                              ; 8644: a4          .
+    !byte <(sub_ca463-1)                                              ; 8645: 62          b
+    !byte $24                                                         ; 8646: 24          $
+    !text "DELETE"                                                    ; 8647: 44 45 4c... DEL
+    !byte >(sub_c8782-1)                                              ; 864d: 87          .
+    !byte <(sub_c8782-1)                                              ; 864e: 81          .
+    !byte 1                                                           ; 864f: 01          .
+    !text "DESTROY"                                                   ; 8650: 44 45 53... DES
+    !byte >(sub_c8794-1)                                              ; 8657: 87          .
+    !byte <(sub_c8794-1)                                              ; 8658: 93          .
+    !byte 2                                                           ; 8659: 02          .
+    !text "DIR"                                                       ; 865a: 44 49 52    DIR
+    !byte >(sub_c893f-1)                                              ; 865d: 89          .
+    !byte <(sub_c893f-1)                                              ; 865e: 3e          >
+    !byte 6                                                           ; 865f: 06          .
+    !text "DRIVE"                                                     ; 8660: 44 52 49... DRI
+    !byte >(sub_c87ee-1)                                              ; 8665: 87          .
+    !byte <(sub_c87ee-1)                                              ; 8666: ed          .
+    !byte 9                                                           ; 8667: 09          .
+    !text "ENABLE"                                                    ; 8668: 45 4e 41... ENA
+    !byte >(sub_c8b47-1)                                              ; 866e: 8b          .
+    !byte <(sub_c8b47-1)                                              ; 866f: 46          F
+    !byte 0                                                           ; 8670: 00          .
+    !text "EX"                                                        ; 8671: 45 58       EX
+    !byte >(sub_c8238-1)                                              ; 8673: 82          .
+    !byte <(sub_c8238-1)                                              ; 8674: 37          7
+    !byte 6                                                           ; 8675: 06          .
+    !text "FORM"                                                      ; 8676: 46 4f 52... FOR
+    !byte >(sub_ca5bf-1)                                              ; 867a: a5          .
+    !byte <(sub_ca5bf-1)                                              ; 867b: be          .
+    !byte $ba                                                         ; 867c: ba          .
+    !text "FREE"                                                      ; 867d: 46 52 45... FRE
+    !byte >(sub_ca7f3-1)                                              ; 8681: a7          .
+    !byte <(sub_ca7f3-1)                                              ; 8682: f2          .
+    !byte 7                                                           ; 8683: 07          .
+    !text "INFO"                                                      ; 8684: 49 4e 46... INF
+    !byte >(sub_c8254-1)                                              ; 8688: 82          .
+    !byte <(sub_c8254-1)                                              ; 8689: 53          S
+    !byte 2                                                           ; 868a: 02          .
+    !text "LIB"                                                       ; 868b: 4c 49 42    LIB
+    !byte >(sub_c8943-1)                                              ; 868e: 89          .
+    !byte <(sub_c8943-1)                                              ; 868f: 42          B
+    !byte 6                                                           ; 8690: 06          .
+    !text "MAP"                                                       ; 8691: 4d 41 50    MAP
+    !byte >(sub_ca7f6-1)                                              ; 8694: a7          .
+    !byte <(sub_ca7f6-1)                                              ; 8695: f5          .
+    !byte 7                                                           ; 8696: 07          .
+    !text "RENAME"                                                    ; 8697: 52 45 4e... REN
+    !byte >(sub_c8bac-1)                                              ; 869d: 8b          .
+    !byte <(sub_c8bac-1)                                              ; 869e: ab          .
+    !byte 5                                                           ; 869f: 05          .
+    !text "TITLE"                                                     ; 86a0: 54 49 54... TIT
+    !byte >(sub_c89b7-1)                                              ; 86a5: 89          .
+    !byte <(sub_c89b7-1)                                              ; 86a6: b6          .
+    !byte 8                                                           ; 86a7: 08          .
+    !text "VERIFY"                                                    ; 86a8: 56 45 52... VER
+    !byte >(sub_ca5bb-1)                                              ; 86ae: a5          .
+    !byte <(sub_ca5bb-1)                                              ; 86af: ba          .
+    !byte $0b                                                         ; 86b0: 0b          .
+    !text "WIPE"                                                      ; 86b1: 57 49 50... WIP
+    !byte >(sub_c8750-1)                                              ; 86b5: 87          .
+    !byte <(sub_c8750-1)                                              ; 86b6: 4f          O
+    !byte   2, $88, $72                                               ; 86b7: 02 88 72    ..r
+    !text "BUILD"                                                     ; 86ba: 42 55 49... BUI
+    !byte >(sub_cabc5-1)                                              ; 86bf: ab          .
+    !byte <(sub_cabc5-1)                                              ; 86c0: c4          .
+    !byte 1                                                           ; 86c1: 01          .
+    !text "DISC"                                                      ; 86c2: 44 49 53... DIS
+    !byte >(c956d-1)                                                  ; 86c6: 95          .
+    !byte <(c956d-1)                                                  ; 86c7: 6c          l
+    !byte 0                                                           ; 86c8: 00          .
+    !text "DUMP"                                                      ; 86c9: 44 55 4d... DUM
+    !byte >(sub_cab46-1)                                              ; 86cd: ab          .
+    !byte <(sub_cab46-1)                                              ; 86ce: 45          E
+    !byte 1                                                           ; 86cf: 01          .
+    !text "LIST"                                                      ; 86d0: 4c 49 53... LIS
+    !byte >(sub_cab04-1)                                              ; 86d4: ab          .
+    !byte <(sub_cab04-1)                                              ; 86d5: 03          .
+    !byte 1                                                           ; 86d6: 01          .
+    !text "ROMS"                                                      ; 86d7: 52 4f 4d... ROM
+    !byte >(sub_ca9d0-1)                                              ; 86db: a9          .
+    !byte <(sub_ca9d0-1)                                              ; 86dc: cf          .
+    !byte $0c                                                         ; 86dd: 0c          .
+    !text "TYPE"                                                      ; 86de: 54 59 50... TYP
+    !byte >(sub_caafd-1)                                              ; 86e2: aa          .
+    !byte <(sub_caafd-1)                                              ; 86e3: fc          .
+    !byte 1                                                           ; 86e4: 01          .
+    !text "DISK"                                                      ; 86e5: 44 49 53... DIS
+    !byte >(c956d-1)                                                  ; 86e9: 95          .
+    !byte <(c956d-1)                                                  ; 86ea: 6c          l
+    !byte   0, $86, $1a                                               ; 86eb: 00 86 1a    ...
+    !text "DFS"                                                       ; 86ee: 44 46 53    DFS
+    !byte >(sub_ca106-1)                                              ; 86f1: a1          .
+    !byte <(sub_ca106-1)                                              ; 86f2: 05          .
+    !byte 0                                                           ; 86f3: 00          .
+    !text "UTILS"                                                     ; 86f4: 55 54 49... UTI
+    !byte >(sub_ca137-1)                                              ; 86f9: a1          .
+    !byte <(sub_ca137-1)                                              ; 86fa: 36          6
+    !byte   0, $a1                                                    ; 86fb: 00 a1       ..
+    !text "= E"                                                       ; 86fd: 3d 20 45    = E
+    !byte $87, $a2, $fd                                               ; 8700: 87 a2 fd    ...
+
+; $8703 referenced 2 times by $96f2, $a134
+c8703
+    tya                                                               ; 8703: 98          .
+    pha                                                               ; 8704: 48          H
+; $8705 referenced 2 times by $872f, $8739
+c8705
+    inx                                                               ; 8705: e8          .
+    inx                                                               ; 8706: e8          .
+    pla                                                               ; 8707: 68          h
+    pha                                                               ; 8708: 48          H
+    tay                                                               ; 8709: a8          .
+    jsr clc_jmp_gsinit                                                ; 870a: 20 4c 87     L.
+    inx                                                               ; 870d: e8          .
+    lda command_table,x                                               ; 870e: bd 1c 86    ...
+    bmi c873b                                                         ; 8711: 30 28       0(
+    dex                                                               ; 8713: ca          .
+    dey                                                               ; 8714: 88          .
+    stx l00bf                                                         ; 8715: 86 bf       ..
+; $8717 referenced 1 time by $8722
+loop_c8717
+    inx                                                               ; 8717: e8          .
+    iny                                                               ; 8718: c8          .
+    lda command_table,x                                               ; 8719: bd 1c 86    ...
+    bmi c8734                                                         ; 871c: 30 16       0.
+    eor (os_text_ptr),y                                               ; 871e: 51 f2       Q.
+    and #$5f ; '_'                                                    ; 8720: 29 5f       )_
+    beq loop_c8717                                                    ; 8722: f0 f3       ..
+    dex                                                               ; 8724: ca          .
+; $8725 referenced 1 time by $8729
+loop_c8725
+    inx                                                               ; 8725: e8          .
+    lda command_table,x                                               ; 8726: bd 1c 86    ...
+    bpl loop_c8725                                                    ; 8729: 10 fa       ..
+    lda (os_text_ptr),y                                               ; 872b: b1 f2       ..
+    cmp #$2e ; '.'                                                    ; 872d: c9 2e       ..
+    bne c8705                                                         ; 872f: d0 d4       ..
+    iny                                                               ; 8731: c8          .
+    bcs c873b                                                         ; 8732: b0 07       ..
+; $8734 referenced 1 time by $871c
+c8734
+    lda (os_text_ptr),y                                               ; 8734: b1 f2       ..
+    jsr sub_c8327                                                     ; 8736: 20 27 83     '.
+    bcc c8705                                                         ; 8739: 90 ca       ..
+; $873b referenced 2 times by $8711, $8732
+c873b
+    pla                                                               ; 873b: 68          h
+    lda command_table,x                                               ; 873c: bd 1c 86    ...
+    pha                                                               ; 873f: 48          H
+    lda command_table+1,x                                             ; 8740: bd 1d 86    ...
+    pha                                                               ; 8743: 48          H
+    rts                                                               ; 8744: 60          `
+
+; $8745 referenced 2 times by $8483, $8870
+sub_c8745
+    stx os_text_ptr                                                   ; 8745: 86 f2       ..
+    sty l00f3                                                         ; 8747: 84 f3       ..
+    ldy #0                                                            ; 8749: a0 00       ..
+    rts                                                               ; 874b: 60          `
+
+; $874c referenced 12 times by $8100, $823b, $8456, $870a, $897e, $89f1, $8b86, $a13e, $a14a, $a5e5, $a657, $a9f7
+clc_jmp_gsinit
+    clc                                                               ; 874c: 18          .
+    jmp gsinit                                                        ; 874d: 4c c2 ff    L..
+
+sub_c8750
+    jsr sub_c99ac                                                     ; 8750: 20 ac 99     ..
+    jsr sub_ca14a                                                     ; 8753: 20 4a a1     J.
+    jsr sub_c821d                                                     ; 8756: 20 1d 82     ..
+; $8759 referenced 1 time by $877f
+c8759
+    lda l0e0f,y                                                       ; 8759: b9 0f 0e    ...
+    bmi c877c                                                         ; 875c: 30 1e       0.
+    jsr sub_c8174                                                     ; 875e: 20 74 81     t.
+    jsr sub_ca3e4                                                     ; 8761: 20 e4 a3     ..
+    bne c8779                                                         ; 8764: d0 13       ..
+    ldx l00b6                                                         ; 8766: a6 b6       ..
+    jsr sub_c9bf2                                                     ; 8768: 20 f2 9b     ..
+    stx l00b6                                                         ; 876b: 86 b6       ..
+    jsr sub_c87e3                                                     ; 876d: 20 e3 87     ..
+    sty l00ab                                                         ; 8770: 84 ab       ..
+    jsr c93e6                                                         ; 8772: 20 e6 93     ..
+    lda l00ab                                                         ; 8775: a5 ab       ..
+    sta l00b6                                                         ; 8777: 85 b6       ..
+; $8779 referenced 1 time by $8764
+c8779
+    jsr ca3dc                                                         ; 8779: 20 dc a3     ..
+; $877c referenced 1 time by $875c
+c877c
+    jsr sub_c8280                                                     ; 877c: 20 80 82     ..
+    bcs c8759                                                         ; 877f: b0 d8       ..
+    rts                                                               ; 8781: 60          `
+
+sub_c8782
+    jsr c99a3                                                         ; 8782: 20 a3 99     ..
+    jsr sub_ca14a                                                     ; 8785: 20 4a a1     J.
+    jsr sub_c821d                                                     ; 8788: 20 1d 82     ..
+    jsr sub_c8335                                                     ; 878b: 20 35 83     5.
+    jsr sub_c830a                                                     ; 878e: 20 0a 83     ..
+    jmp c93e6                                                         ; 8791: 4c e6 93    L..
+
+sub_c8794
+    jsr sub_ca315                                                     ; 8794: 20 15 a3     ..
+    jsr sub_c99ac                                                     ; 8797: 20 ac 99     ..
+    jsr sub_ca14a                                                     ; 879a: 20 4a a1     J.
+    jsr sub_c821d                                                     ; 879d: 20 1d 82     ..
+; $87a0 referenced 1 time by $87ae
+loop_c87a0
+    lda l0e0f,y                                                       ; 87a0: b9 0f 0e    ...
+    bmi c87ab                                                         ; 87a3: 30 06       0.
+    jsr sub_c8174                                                     ; 87a5: 20 74 81     t.
+    jsr ca3dc                                                         ; 87a8: 20 dc a3     ..
+; $87ab referenced 1 time by $87a3
+c87ab
+    jsr sub_c8280                                                     ; 87ab: 20 80 82     ..
+    bcs loop_c87a0                                                    ; 87ae: b0 f0       ..
+    jsr sub_ca3ec                                                     ; 87b0: 20 ec a3     ..
+    beq c87b8                                                         ; 87b3: f0 03       ..
+    jmp ca3dc                                                         ; 87b5: 4c dc a3    L..
+
+; $87b8 referenced 1 time by $87b3
+c87b8
+    jsr sub_c9bf2                                                     ; 87b8: 20 f2 9b     ..
+    jsr sub_c8284                                                     ; 87bb: 20 84 82     ..
+; $87be referenced 1 time by $87c9
+loop_c87be
+    lda l0e0f,y                                                       ; 87be: b9 0f 0e    ...
+    bmi c87c6                                                         ; 87c1: 30 03       0.
+    jsr sub_c87e3                                                     ; 87c3: 20 e3 87     ..
+; $87c6 referenced 1 time by $87c1
+c87c6
+    jsr sub_c8280                                                     ; 87c6: 20 80 82     ..
+    bcs loop_c87be                                                    ; 87c9: b0 f3       ..
+    jsr c93e6                                                         ; 87cb: 20 e6 93     ..
+    jsr print_inline_l809f_top_bit_clear                              ; 87ce: 20 77 80     w.
+    !text $0d, "Deleted", $0d                                         ; 87d1: 0d 44 65... .De
+
+; $87da referenced 6 times by $853e, $8552, $8596, $8b0c, $8be5, $98b5
+sub_c87da
+    iny                                                               ; 87da: c8          .
+; $87db referenced 2 times by $837a, $8588
+sub_c87db
+    iny                                                               ; 87db: c8          .
+    iny                                                               ; 87dc: c8          .
+    iny                                                               ; 87dd: c8          .
+    iny                                                               ; 87de: c8          .
+    iny                                                               ; 87df: c8          .
+    iny                                                               ; 87e0: c8          .
+    iny                                                               ; 87e1: c8          .
+    rts                                                               ; 87e2: 60          `
+
+; $87e3 referenced 2 times by $876d, $87c3
+sub_c87e3
+    jsr sub_c830a                                                     ; 87e3: 20 0a 83     ..
+    ldy l00b6                                                         ; 87e6: a4 b6       ..
+    jsr sub_c82b2                                                     ; 87e8: 20 b2 82     ..
+    sty l00b6                                                         ; 87eb: 84 b6       ..
+    rts                                                               ; 87ed: 60          `
+
+sub_c87ee
+    jsr sub_ca14a                                                     ; 87ee: 20 4a a1     J.
+    jsr c8b8b                                                         ; 87f1: 20 8b 8b     ..
+    sta l10ca                                                         ; 87f4: 8d ca 10    ...
+    jsr sub_c8456                                                     ; 87f7: 20 56 84     V.
+    beq c8815                                                         ; 87fa: f0 19       ..
+    cmp #$28 ; '('                                                    ; 87fc: c9 28       .(
+    beq c8808                                                         ; 87fe: f0 08       ..
+    cmp #$50 ; 'P'                                                    ; 8800: c9 50       .P
+    clc                                                               ; 8802: 18          .
+    beq c8808                                                         ; 8803: f0 03       ..
+    jmp ca14f                                                         ; 8805: 4c 4f a1    LO.
+
+; $8808 referenced 2 times by $87fe, $8803
+c8808
+    php                                                               ; 8808: 08          .
+    ldx l10ca                                                         ; 8809: ae ca 10    ...
+    lda l10de,x                                                       ; 880c: bd de 10    ...
+    rol                                                               ; 880f: 2a          *
+    plp                                                               ; 8810: 28          (
+    ror                                                               ; 8811: 6a          j
+    sta l10de,x                                                       ; 8812: 9d de 10    ...
+; $8815 referenced 1 time by $87fa
+c8815
+    rts                                                               ; 8815: 60          `
+
+; $8816 referenced 8 times by $888f, $8985, $898d, $8b83, $8b9d, $9bef, $a475, $a4ce
+c8816
+    and #3                                                            ; 8816: 29 03       ).
+    sta l00cd                                                         ; 8818: 85 cd       ..
+    rts                                                               ; 881a: 60          `
+
+    jsr sub_c8222                                                     ; 881b: 20 22 82     ".
+    jsr sub_c9a82                                                     ; 881e: 20 82 9a     ..
+    jsr sub_c8386                                                     ; 8821: 20 86 83     ..
+    lda #$80                                                          ; 8824: a9 80       ..
+; $8826 referenced 1 time by $88f6
+sub_c8826
+    sta l1096                                                         ; 8826: 8d 96 10    ...
+    sty l00ba                                                         ; 8829: 84 ba       ..
+    ldx #0                                                            ; 882b: a2 00       ..
+    lda l00be                                                         ; 882d: a5 be       ..
+    bne c8837                                                         ; 882f: d0 06       ..
+    iny                                                               ; 8831: c8          .
+    iny                                                               ; 8832: c8          .
+    ldx #2                                                            ; 8833: a2 02       ..
+    bne c883f                                                         ; 8835: d0 08       ..
+; $8837 referenced 1 time by $882f
+c8837
+    lda l0f0e,y                                                       ; 8837: b9 0e 0f    ...
+    sta l00c2                                                         ; 883a: 85 c2       ..
+    jsr sub_c8b4d                                                     ; 883c: 20 4d 8b     M.
+; $883f referenced 2 times by $8835, $8848
+c883f
+    lda l0f08,y                                                       ; 883f: b9 08 0f    ...
+    sta l00bc,x                                                       ; 8842: 95 bc       ..
+    iny                                                               ; 8844: c8          .
+    inx                                                               ; 8845: e8          .
+    cpx #8                                                            ; 8846: e0 08       ..
+    bne c883f                                                         ; 8848: d0 f5       ..
+    jsr sub_c8b64                                                     ; 884a: 20 64 8b     d.
+    ldy l00ba                                                         ; 884d: a4 ba       ..
+    jsr sub_c8335                                                     ; 884f: 20 35 83     5.
+    jmp c8867                                                         ; 8852: 4c 67 88    Lg.
+
+; $8855 referenced 2 times by $9f61, $a561
+sub_c8855
+    lda #$80                                                          ; 8855: a9 80       ..
+    bne c8864                                                         ; 8857: d0 0b       ..
+    jsr sub_c8a77                                                     ; 8859: 20 77 8a     w.
+    jsr sub_c9a82                                                     ; 885c: 20 82 9a     ..
+    jsr sub_c8386                                                     ; 885f: 20 86 83     ..
+; $8862 referenced 2 times by $9f51, $a587
+sub_c8862
+    lda #$a0                                                          ; 8862: a9 a0       ..
+; $8864 referenced 1 time by $8857
+c8864
+    sta l1096                                                         ; 8864: 8d 96 10    ...
+; $8867 referenced 1 time by $8852
+c8867
+    jsr sub_c81ca                                                     ; 8867: 20 ca 81     ..
+    jsr sub_c9445                                                     ; 886a: 20 45 94     E.
+    lda #1                                                            ; 886d: a9 01       ..
+    rts                                                               ; 886f: 60          `
+
+    jsr sub_c8745                                                     ; 8870: 20 45 87     E.
+    jsr sub_c8932                                                     ; 8873: 20 32 89     2.
+    sty l10da                                                         ; 8876: 8c da 10    ...
+    jsr sub_c80f3                                                     ; 8879: 20 f3 80     ..
+    sty l10d9                                                         ; 887c: 8c d9 10    ...
+    jsr sub_c8266                                                     ; 887f: 20 66 82     f.
+    bcs c88a6                                                         ; 8882: b0 22       ."
+    ldy l10da                                                         ; 8884: ac da 10    ...
+    lda l10cb                                                         ; 8887: ad cb 10    ...
+    sta l00cc                                                         ; 888a: 85 cc       ..
+    lda l10cc                                                         ; 888c: ad cc 10    ...
+    jsr c8816                                                         ; 888f: 20 16 88     ..
+    jsr sub_c80f6                                                     ; 8892: 20 f6 80     ..
+    jsr sub_c8266                                                     ; 8895: 20 66 82     f.
+    bcs c88a6                                                         ; 8898: b0 0c       ..
+    jsr generate_error_precheck_bad                                   ; 889a: 20 2e 80     ..
+    !byte $fe                                                         ; 889d: fe          .
+    !text "command"                                                   ; 889e: 63 6f 6d... com
+    !byte 0                                                           ; 88a5: 00          .
+
+; $88a6 referenced 2 times by $8882, $8898
+c88a6
+    lda l0f0e,y                                                       ; 88a6: b9 0e 0f    ...
+    jsr sub_c81ae                                                     ; 88a9: 20 ae 81     ..
+    cmp #3                                                            ; 88ac: c9 03       ..
+    bne c88f4                                                         ; 88ae: d0 44       .D
+    lda l0f0a,y                                                       ; 88b0: b9 0a 0f    ...
+    and l0f0b,y                                                       ; 88b3: 39 0b 0f    9..
+    cmp #$ff                                                          ; 88b6: c9 ff       ..
+    bne c88f4                                                         ; 88b8: d0 3a       .:
+    ldx #6                                                            ; 88ba: a2 06       ..
+; $88bc referenced 1 time by $88c3
+loop_c88bc
+    lda l1000,x                                                       ; 88bc: bd 00 10    ...
+    sta l1007,x                                                       ; 88bf: 9d 07 10    ...
+    dex                                                               ; 88c2: ca          .
+    bpl loop_c88bc                                                    ; 88c3: 10 f7       ..
+    lda #$0d                                                          ; 88c5: a9 0d       ..
+    sta l100e                                                         ; 88c7: 8d 0e 10    ...
+    lda #$45 ; 'E'                                                    ; 88ca: a9 45       .E
+    sta l1000                                                         ; 88cc: 8d 00 10    ...
+    lda #$2e ; '.'                                                    ; 88cf: a9 2e       ..
+    sta l1001                                                         ; 88d1: 8d 01 10    ...
+    lda #$3a ; ':'                                                    ; 88d4: a9 3a       .:
+    sta l1002                                                         ; 88d6: 8d 02 10    ...
+    lda l00cd                                                         ; 88d9: a5 cd       ..
+    ora #$30 ; '0'                                                    ; 88db: 09 30       .0
+    sta l1003                                                         ; 88dd: 8d 03 10    ...
+    lda #$2e ; '.'                                                    ; 88e0: a9 2e       ..
+    sta l1004                                                         ; 88e2: 8d 04 10    ...
+    sta l1006                                                         ; 88e5: 8d 06 10    ...
+    lda l00cc                                                         ; 88e8: a5 cc       ..
+    sta l1005                                                         ; 88ea: 8d 05 10    ...
+    ldx #<(l1000)                                                     ; 88ed: a2 00       ..
+    ldy #>(l1000)                                                     ; 88ef: a0 10       ..
+    jmp oscli                                                         ; 88f1: 4c f7 ff    L..
+
+; $88f4 referenced 2 times by $88ae, $88b8
+c88f4
+    lda #$81                                                          ; 88f4: a9 81       ..
+    jsr sub_c8826                                                     ; 88f6: 20 26 88     &.
+    clc                                                               ; 88f9: 18          .
+    lda l10d9                                                         ; 88fa: ad d9 10    ...
+    tay                                                               ; 88fd: a8          .
+    adc os_text_ptr                                                   ; 88fe: 65 f2       e.
+    sta l10d9                                                         ; 8900: 8d d9 10    ...
+    lda l00f3                                                         ; 8903: a5 f3       ..
+    adc #0                                                            ; 8905: 69 00       i.
+    sta l10da                                                         ; 8907: 8d da 10    ...
+    lda l1076                                                         ; 890a: ad 76 10    .v.
+    and l1077                                                         ; 890d: 2d 77 10    -w.
+    ora l10d6                                                         ; 8910: 0d d6 10    ...
+    cmp #$ff                                                          ; 8913: c9 ff       ..
+    beq c892d                                                         ; 8915: f0 16       ..
+    lda l00be                                                         ; 8917: a5 be       ..
+    sta l1074                                                         ; 8919: 8d 74 10    .t.
+    lda l00bf                                                         ; 891c: a5 bf       ..
+    sta l1075                                                         ; 891e: 8d 75 10    .u.
+    jsr sub_c8f6b                                                     ; 8921: 20 6b 8f     k.
+    ldx #$74 ; 't'                                                    ; 8924: a2 74       .t
+    ldy #$10                                                          ; 8926: a0 10       ..
+    lda #4                                                            ; 8928: a9 04       ..
+    jmp tube_entry                                                    ; 892a: 4c 06 04    L..
+
+; $892d referenced 1 time by $8915
+c892d
+    lda #1                                                            ; 892d: a9 01       ..
+    jmp (l00be)                                                       ; 892f: 6c be 00    l..
+
+; $8932 referenced 1 time by $8873
+sub_c8932
+    lda #$ff                                                          ; 8932: a9 ff       ..
+    sta l00be                                                         ; 8934: 85 be       ..
+    lda os_text_ptr                                                   ; 8936: a5 f2       ..
+    sta l00ba                                                         ; 8938: 85 ba       ..
+    lda l00f3                                                         ; 893a: a5 f3       ..
+    sta l00bb                                                         ; 893c: 85 bb       ..
+    rts                                                               ; 893e: 60          `
+
+sub_c893f
+    ldx #0                                                            ; 893f: a2 00       ..
+    beq c8945                                                         ; 8941: f0 02       ..
+sub_c8943
+    ldx #2                                                            ; 8943: a2 02       ..
+; $8945 referenced 1 time by $8941
+c8945
+    jsr sub_c8979                                                     ; 8945: 20 79 89     y.
+    sta l10ca,x                                                       ; 8948: 9d ca 10    ...
+    lda l00cc                                                         ; 894b: a5 cc       ..
+    sta l10c9,x                                                       ; 894d: 9d c9 10    ...
+    rts                                                               ; 8950: 60          `
+
+; $8951 referenced 2 times by $96b4, $9729
+sub_c8951
+    jsr sub_c83e3                                                     ; 8951: 20 e3 83     ..
+    lda l00b0                                                         ; 8954: a5 b0       ..
+    pha                                                               ; 8956: 48          H
+    lda l00b1                                                         ; 8957: a5 b1       ..
+    pha                                                               ; 8959: 48          H
+    jsr sub_c9ab8                                                     ; 895a: 20 b8 9a     ..
+    ldy #0                                                            ; 895d: a0 00       ..
+; $895f referenced 1 time by $8970
+loop_c895f
+    cpy #$c0                                                          ; 895f: c0 c0       ..
+    bcc c8968                                                         ; 8961: 90 05       ..
+    lda l1000,y                                                       ; 8963: b9 00 10    ...
+    bcs c896b                                                         ; 8966: b0 03       ..
+; $8968 referenced 1 time by $8961
+c8968
+    lda l1100,y                                                       ; 8968: b9 00 11    ...
+; $896b referenced 1 time by $8966
+c896b
+    sta (l00b0),y                                                     ; 896b: 91 b0       ..
+    iny                                                               ; 896d: c8          .
+    cpy #$ee                                                          ; 896e: c0 ee       ..
+    bne loop_c895f                                                    ; 8970: d0 ed       ..
+    pla                                                               ; 8972: 68          h
+    sta l00b1                                                         ; 8973: 85 b1       ..
+    pla                                                               ; 8975: 68          h
+    sta l00b0                                                         ; 8976: 85 b0       ..
+    rts                                                               ; 8978: 60          `
+
+; $8979 referenced 1 time by $8945
+sub_c8979
+    lda l10c9                                                         ; 8979: ad c9 10    ...
+    sta l00cc                                                         ; 897c: 85 cc       ..
+    jsr clc_jmp_gsinit                                                ; 897e: 20 4c 87     L.
+    bne c898a                                                         ; 8981: d0 07       ..
+    lda #0                                                            ; 8983: a9 00       ..
+    jsr c8816                                                         ; 8985: 20 16 88     ..
+    beq c89b4                                                         ; 8988: f0 2a       .*
+; $898a referenced 2 times by $8240, $8981
+c898a
+    lda l10ca                                                         ; 898a: ad ca 10    ...
+    jsr c8816                                                         ; 898d: 20 16 88     ..
+; $8990 referenced 1 time by $89a3
+loop_c8990
+    jsr sub_c8149                                                     ; 8990: 20 49 81     I.
+    bcs c89a5                                                         ; 8993: b0 10       ..
+    cmp #$3a ; ':'                                                    ; 8995: c9 3a       .:
+    bne c89ad                                                         ; 8997: d0 14       ..
+    jsr c8b8b                                                         ; 8999: 20 8b 8b     ..
+    jsr sub_c8149                                                     ; 899c: 20 49 81     I.
+    bcs c89b4                                                         ; 899f: b0 13       ..
+    cmp #$2e ; '.'                                                    ; 89a1: c9 2e       ..
+    beq loop_c8990                                                    ; 89a3: f0 eb       ..
+; $89a5 referenced 2 times by $8993, $89b2
+c89a5
+    jsr generate_error_precheck_bad                                   ; 89a5: 20 2e 80     ..
+    !byte $ce                                                         ; 89a8: ce          .
+    !text "dir"                                                       ; 89a9: 64 69 72    dir
+    !byte 0                                                           ; 89ac: 00          .
+
+; $89ad referenced 1 time by $8997
+c89ad
+    sta l00cc                                                         ; 89ad: 85 cc       ..
+    jsr sub_c8149                                                     ; 89af: 20 49 81     I.
+    bcc c89a5                                                         ; 89b2: 90 f1       ..
+; $89b4 referenced 2 times by $8988, $899f
+c89b4
+    lda l00cd                                                         ; 89b4: a5 cd       ..
+    rts                                                               ; 89b6: 60          `
+
+sub_c89b7
+    jsr sub_ca14a                                                     ; 89b7: 20 4a a1     J.
+    jsr sub_c8b7b                                                     ; 89ba: 20 7b 8b     {.
+    jsr sub_c8380                                                     ; 89bd: 20 80 83     ..
+    ldx #$0b                                                          ; 89c0: a2 0b       ..
+    lda #0                                                            ; 89c2: a9 00       ..
+; $89c4 referenced 1 time by $89c8
+loop_c89c4
+    jsr sub_c89da                                                     ; 89c4: 20 da 89     ..
+    dex                                                               ; 89c7: ca          .
+    bpl loop_c89c4                                                    ; 89c8: 10 fa       ..
+; $89ca referenced 1 time by $89d5
+loop_c89ca
+    inx                                                               ; 89ca: e8          .
+    jsr sub_c8149                                                     ; 89cb: 20 49 81     I.
+    bcs c89d7                                                         ; 89ce: b0 07       ..
+    jsr sub_c89da                                                     ; 89d0: 20 da 89     ..
+    cpx #$0b                                                          ; 89d3: e0 0b       ..
+    bcc loop_c89ca                                                    ; 89d5: 90 f3       ..
+; $89d7 referenced 3 times by $89ce, $8a15, $99ed
+c89d7
+    jmp c93e6                                                         ; 89d7: 4c e6 93    L..
+
+; $89da referenced 2 times by $89c4, $89d0
+sub_c89da
+    cpx #8                                                            ; 89da: e0 08       ..
+    bcc c89e2                                                         ; 89dc: 90 04       ..
+    sta l0ef8,x                                                       ; 89de: 9d f8 0e    ...
+    rts                                                               ; 89e1: 60          `
+
+; $89e2 referenced 1 time by $89dc
+c89e2
+    sta l0e00,x                                                       ; 89e2: 9d 00 0e    ...
+    rts                                                               ; 89e5: 60          `
+
+sub_c89e6
+    jsr sub_c99ac                                                     ; 89e6: 20 ac 99     ..
+    jsr sub_ca14a                                                     ; 89e9: 20 4a a1     J.
+    jsr sub_c80ed                                                     ; 89ec: 20 ed 80     ..
+    ldx #0                                                            ; 89ef: a2 00       ..
+    jsr clc_jmp_gsinit                                                ; 89f1: 20 4c 87     L.
+    bne c8a19                                                         ; 89f4: d0 23       .#
+; $89f6 referenced 1 time by $8a1c
+c89f6
+    stx l00aa                                                         ; 89f6: 86 aa       ..
+    jsr sub_c8284                                                     ; 89f8: 20 84 82     ..
+    bcs c8a00                                                         ; 89fb: b0 03       ..
+    jmp c822a                                                         ; 89fd: 4c 2a 82    L*.
+
+; $8a00 referenced 2 times by $89fb, $8a13
+c8a00
+    jsr sub_c9a63                                                     ; 8a00: 20 63 9a     c.
+    lda l0e0f,y                                                       ; 8a03: b9 0f 0e    ...
+    and #$7f                                                          ; 8a06: 29 7f       ).
+    ora l00aa                                                         ; 8a08: 05 aa       ..
+    sta l0e0f,y                                                       ; 8a0a: 99 0f 0e    ...
+    jsr sub_c8335                                                     ; 8a0d: 20 35 83     5.
+    jsr sub_c8280                                                     ; 8a10: 20 80 82     ..
+    bcs c8a00                                                         ; 8a13: b0 eb       ..
+    bcc c89d7                                                         ; 8a15: 90 c0       ..
+; $8a17 referenced 1 time by $8a22
+loop_c8a17
+    ldx #$80                                                          ; 8a17: a2 80       ..
+; $8a19 referenced 1 time by $89f4
+c8a19
+    jsr sub_c8149                                                     ; 8a19: 20 49 81     I.
+    bcs c89f6                                                         ; 8a1c: b0 d8       ..
+    and #$5f ; '_'                                                    ; 8a1e: 29 5f       )_
+    cmp #$4c ; 'L'                                                    ; 8a20: c9 4c       .L
+    beq loop_c8a17                                                    ; 8a22: f0 f3       ..
+    jsr generate_error_precheck_bad                                   ; 8a24: 20 2e 80     ..
+    !byte $cf                                                         ; 8a27: cf          .
+    !text "attribute"                                                 ; 8a28: 61 74 74... att
+    !byte 0                                                           ; 8a31: 00          .
+
+    jsr sub_c83e3                                                     ; 8a32: 20 e3 83     ..
+    txa                                                               ; 8a35: 8a          .
+    cmp #4                                                            ; 8a36: c9 04       ..
+    beq c8a54                                                         ; 8a38: f0 1a       ..
+    cmp #2                                                            ; 8a3a: c9 02       ..
+    bcc c8a49                                                         ; 8a3c: 90 0b       ..
+    jsr generate_error_precheck_bad                                   ; 8a3e: 20 2e 80     ..
+    !byte $cb                                                         ; 8a41: cb          .
+    !text "option"                                                    ; 8a42: 6f 70 74... opt
+    !byte 0                                                           ; 8a48: 00          .
+
+; $8a49 referenced 1 time by $8a3c
+c8a49
+    ldx #$ff                                                          ; 8a49: a2 ff       ..
+    tya                                                               ; 8a4b: 98          .
+    beq c8a50                                                         ; 8a4c: f0 02       ..
+    ldx #0                                                            ; 8a4e: a2 00       ..
+; $8a50 referenced 1 time by $8a4c
+c8a50
+    stx l10c6                                                         ; 8a50: 8e c6 10    ...
+    rts                                                               ; 8a53: 60          `
+
+; $8a54 referenced 1 time by $8a38
+c8a54
+    tya                                                               ; 8a54: 98          .
+    pha                                                               ; 8a55: 48          H
+    jsr sub_c8b7b                                                     ; 8a56: 20 7b 8b     {.
+    jsr c940c                                                         ; 8a59: 20 0c 94     ..
+    pla                                                               ; 8a5c: 68          h
+    jsr sub_c81c5                                                     ; 8a5d: 20 c5 81     ..
+    eor l0f06                                                         ; 8a60: 4d 06 0f    M..
+    and #$30 ; '0'                                                    ; 8a63: 29 30       )0
+    eor l0f06                                                         ; 8a65: 4d 06 0f    M..
+    sta l0f06                                                         ; 8a68: 8d 06 0f    ...
+    jmp c93e6                                                         ; 8a6b: 4c e6 93    L..
+
+; $8a6e referenced 2 times by $8ac8, $a414
+c8a6e
+    jsr generate_error_precheck_disc                                  ; 8a6e: 20 23 80     #.
+    !byte $c6                                                         ; 8a71: c6          .
+    !text "full"                                                      ; 8a72: 66 75 6c... ful
+    !byte 0                                                           ; 8a76: 00          .
+
+; $8a77 referenced 2 times by $8859, $9c4e
+sub_c8a77
+    jsr sub_c80f3                                                     ; 8a77: 20 f3 80     ..
+    jsr sub_c8284                                                     ; 8a7a: 20 84 82     ..
+    bcc c8a82                                                         ; 8a7d: 90 03       ..
+    jsr sub_c830a                                                     ; 8a7f: 20 0a 83     ..
+; $8a82 referenced 1 time by $8a7d
+c8a82
+    lda l00c0                                                         ; 8a82: a5 c0       ..
+    pha                                                               ; 8a84: 48          H
+    lda l00c1                                                         ; 8a85: a5 c1       ..
+    pha                                                               ; 8a87: 48          H
+    sec                                                               ; 8a88: 38          8
+    lda l00c2                                                         ; 8a89: a5 c2       ..
+    sbc l00c0                                                         ; 8a8b: e5 c0       ..
+    sta l00c0                                                         ; 8a8d: 85 c0       ..
+    lda l00c3                                                         ; 8a8f: a5 c3       ..
+    sbc l00c1                                                         ; 8a91: e5 c1       ..
+    sta l00c1                                                         ; 8a93: 85 c1       ..
+    lda l107a                                                         ; 8a95: ad 7a 10    .z.
+    sbc l1078                                                         ; 8a98: ed 78 10    .x.
+    sta l00c4                                                         ; 8a9b: 85 c4       ..
+    jsr sub_c8ab3                                                     ; 8a9d: 20 b3 8a     ..
+    lda l1079                                                         ; 8aa0: ad 79 10    .y.
+    sta l1075                                                         ; 8aa3: 8d 75 10    .u.
+    lda l1078                                                         ; 8aa6: ad 78 10    .x.
+    sta l1074                                                         ; 8aa9: 8d 74 10    .t.
+    pla                                                               ; 8aac: 68          h
+    sta l00bd                                                         ; 8aad: 85 bd       ..
+    pla                                                               ; 8aaf: 68          h
+    sta l00bc                                                         ; 8ab0: 85 bc       ..
+    rts                                                               ; 8ab2: 60          `
+
+; $8ab3 referenced 2 times by $8a9d, $a50a
+sub_c8ab3
+    lda #0                                                            ; 8ab3: a9 00       ..
+    sta l00c2                                                         ; 8ab5: 85 c2       ..
+    lda #2                                                            ; 8ab7: a9 02       ..
+    sta l00c3                                                         ; 8ab9: 85 c3       ..
+    ldy l0f05                                                         ; 8abb: ac 05 0f    ...
+    cpy #$f8                                                          ; 8abe: c0 f8       ..
+    bcs c8b18                                                         ; 8ac0: b0 56       .V
+    jsr sub_c8602                                                     ; 8ac2: 20 02 86     ..
+    jmp c8ad0                                                         ; 8ac5: 4c d0 8a    L..
+
+; $8ac8 referenced 1 time by $8ad1
+loop_c8ac8
+    beq c8a6e                                                         ; 8ac8: f0 a4       ..
+    jsr sub_c82b2                                                     ; 8aca: 20 b2 82     ..
+    jsr sub_c85e3                                                     ; 8acd: 20 e3 85     ..
+; $8ad0 referenced 1 time by $8ac5
+c8ad0
+    tya                                                               ; 8ad0: 98          .
+    bcc loop_c8ac8                                                    ; 8ad1: 90 f5       ..
+    sty l00b0                                                         ; 8ad3: 84 b0       ..
+    ldy l0f05                                                         ; 8ad5: ac 05 0f    ...
+; $8ad8 referenced 1 time by $8ae9
+loop_c8ad8
+    cpy l00b0                                                         ; 8ad8: c4 b0       ..
+    beq c8aeb                                                         ; 8ada: f0 0f       ..
+    lda l0e07,y                                                       ; 8adc: b9 07 0e    ...
+    sta l0e0f,y                                                       ; 8adf: 99 0f 0e    ...
+    lda l0f07,y                                                       ; 8ae2: b9 07 0f    ...
+    sta l0f0f,y                                                       ; 8ae5: 99 0f 0f    ...
+    dey                                                               ; 8ae8: 88          .
+    bcs loop_c8ad8                                                    ; 8ae9: b0 ed       ..
+; $8aeb referenced 1 time by $8ada
+c8aeb
+    ldx #0                                                            ; 8aeb: a2 00       ..
+    jsr sub_c8b25                                                     ; 8aed: 20 25 8b     %.
+; $8af0 referenced 1 time by $8af9
+loop_c8af0
+    lda l00c5,x                                                       ; 8af0: b5 c5       ..
+    sta l0e08,y                                                       ; 8af2: 99 08 0e    ...
+    iny                                                               ; 8af5: c8          .
+    inx                                                               ; 8af6: e8          .
+    cpx #8                                                            ; 8af7: e0 08       ..
+    bne loop_c8af0                                                    ; 8af9: d0 f5       ..
+; $8afb referenced 1 time by $8b02
+loop_c8afb
+    lda l00bb,x                                                       ; 8afb: b5 bb       ..
+    dey                                                               ; 8afd: 88          .
+    sta l0f08,y                                                       ; 8afe: 99 08 0f    ...
+    dex                                                               ; 8b01: ca          .
+    bne loop_c8afb                                                    ; 8b02: d0 f7       ..
+    jsr sub_c8335                                                     ; 8b04: 20 35 83     5.
+    tya                                                               ; 8b07: 98          .
+    pha                                                               ; 8b08: 48          H
+    ldy l0f05                                                         ; 8b09: ac 05 0f    ...
+    jsr sub_c87da                                                     ; 8b0c: 20 da 87     ..
+    sty l0f05                                                         ; 8b0f: 8c 05 0f    ...
+    jsr c93e6                                                         ; 8b12: 20 e6 93     ..
+    pla                                                               ; 8b15: 68          h
+    tay                                                               ; 8b16: a8          .
+    rts                                                               ; 8b17: 60          `
+
+; $8b18 referenced 1 time by $8ac0
+c8b18
+    jsr generate_error_precheck                                       ; 8b18: 20 38 80     8.
+    !byte $be                                                         ; 8b1b: be          .
+    !text "Cat full"                                                  ; 8b1c: 43 61 74... Cat
+    !byte 0                                                           ; 8b24: 00          .
+
+; $8b25 referenced 1 time by $8aed
+sub_c8b25
+    lda l1076                                                         ; 8b25: ad 76 10    .v.
+    and #3                                                            ; 8b28: 29 03       ).
+    asl                                                               ; 8b2a: 0a          .
+    asl                                                               ; 8b2b: 0a          .
+    eor l00c4                                                         ; 8b2c: 45 c4       E.
+    and #$fc                                                          ; 8b2e: 29 fc       ).
+    eor l00c4                                                         ; 8b30: 45 c4       E.
+    asl                                                               ; 8b32: 0a          .
+    asl                                                               ; 8b33: 0a          .
+    eor l1074                                                         ; 8b34: 4d 74 10    Mt.
+    and #$fc                                                          ; 8b37: 29 fc       ).
+    eor l1074                                                         ; 8b39: 4d 74 10    Mt.
+    asl                                                               ; 8b3c: 0a          .
+    asl                                                               ; 8b3d: 0a          .
+    eor l00c2                                                         ; 8b3e: 45 c2       E.
+    and #$fc                                                          ; 8b40: 29 fc       ).
+    eor l00c2                                                         ; 8b42: 45 c2       E.
+    sta l00c2                                                         ; 8b44: 85 c2       ..
+    rts                                                               ; 8b46: 60          `
+
+sub_c8b47
+    lda #1                                                            ; 8b47: a9 01       ..
+    sta l10c7                                                         ; 8b49: 8d c7 10    ...
+    rts                                                               ; 8b4c: 60          `
+
+; $8b4d referenced 2 times by $883c, $a4fd
+sub_c8b4d
+    lda #0                                                            ; 8b4d: a9 00       ..
+    sta l1075                                                         ; 8b4f: 8d 75 10    .u.
+    lda l00c2                                                         ; 8b52: a5 c2       ..
+    jsr sub_c81b7                                                     ; 8b54: 20 b7 81     ..
+    cmp #3                                                            ; 8b57: c9 03       ..
+    bne c8b60                                                         ; 8b59: d0 05       ..
+    lda #$ff                                                          ; 8b5b: a9 ff       ..
+    sta l1075                                                         ; 8b5d: 8d 75 10    .u.
+; $8b60 referenced 1 time by $8b59
+c8b60
+    sta l1074                                                         ; 8b60: 8d 74 10    .t.
+    rts                                                               ; 8b63: 60          `
+
+; $8b64 referenced 2 times by $884a, $a500
+sub_c8b64
+    lda #0                                                            ; 8b64: a9 00       ..
+    sta l1077                                                         ; 8b66: 8d 77 10    .w.
+    lda l00c2                                                         ; 8b69: a5 c2       ..
+    jsr sub_c81ae                                                     ; 8b6b: 20 ae 81     ..
+    cmp #3                                                            ; 8b6e: c9 03       ..
+    bne c8b77                                                         ; 8b70: d0 05       ..
+    lda #$ff                                                          ; 8b72: a9 ff       ..
+    sta l1077                                                         ; 8b74: 8d 77 10    .w.
+; $8b77 referenced 1 time by $8b70
+c8b77
+    sta l1076                                                         ; 8b77: 8d 76 10    .v.
+    rts                                                               ; 8b7a: 60          `
+
+; $8b7b referenced 8 times by $80ed, $80f3, $8238, $89ba, $8a56, $975b, $988b, $98d7
+sub_c8b7b
+    lda l10c9                                                         ; 8b7b: ad c9 10    ...
+    sta l00cc                                                         ; 8b7e: 85 cc       ..
+; $8b80 referenced 1 time by $8b89
+loop_c8b80
+    lda l10ca                                                         ; 8b80: ad ca 10    ...
+    jmp c8816                                                         ; 8b83: 4c 16 88    L..
+
+; $8b86 referenced 3 times by $8486, $a244, $a7f9
+sub_c8b86
+    jsr clc_jmp_gsinit                                                ; 8b86: 20 4c 87     L.
+    beq loop_c8b80                                                    ; 8b89: f0 f5       ..
+; $8b8b referenced 7 times by $8119, $87f1, $8999, $8b92, $a327, $a330, $a637
+c8b8b
+    jsr sub_c8149                                                     ; 8b8b: 20 49 81     I.
+    bcs c8ba2                                                         ; 8b8e: b0 12       ..
+    cmp #$3a ; ':'                                                    ; 8b90: c9 3a       .:
+    beq c8b8b                                                         ; 8b92: f0 f7       ..
+    sec                                                               ; 8b94: 38          8
+    sbc #$30 ; '0'                                                    ; 8b95: e9 30       .0
+    bcc c8ba2                                                         ; 8b97: 90 09       ..
+    cmp #4                                                            ; 8b99: c9 04       ..
+    bcs c8ba2                                                         ; 8b9b: b0 05       ..
+    jsr c8816                                                         ; 8b9d: 20 16 88     ..
+    clc                                                               ; 8ba0: 18          .
+    rts                                                               ; 8ba1: 60          `
+
+; $8ba2 referenced 5 times by $8b8e, $8b97, $8b9b, $8bcd, $a660
+c8ba2
+    jsr generate_error_precheck_bad                                   ; 8ba2: 20 2e 80     ..
+    !byte $cd                                                         ; 8ba5: cd          .
+    !text "drive"                                                     ; 8ba6: 64 72 69... dri
+    !byte 0                                                           ; 8bab: 00          .
+
+sub_c8bac
+    jsr c99a3                                                         ; 8bac: 20 a3 99     ..
+    jsr sub_ca14a                                                     ; 8baf: 20 4a a1     J.
+    jsr sub_c80ed                                                     ; 8bb2: 20 ed 80     ..
+    tya                                                               ; 8bb5: 98          .
+    pha                                                               ; 8bb6: 48          H
+    jsr c8225                                                         ; 8bb7: 20 25 82     %.
+    jsr sub_c9a60                                                     ; 8bba: 20 60 9a     `.
+    sty l00c4                                                         ; 8bbd: 84 c4       ..
+    pla                                                               ; 8bbf: 68          h
+    tay                                                               ; 8bc0: a8          .
+    jsr sub_ca14a                                                     ; 8bc1: 20 4a a1     J.
+    lda l00cd                                                         ; 8bc4: a5 cd       ..
+    pha                                                               ; 8bc6: 48          H
+    jsr sub_c80ed                                                     ; 8bc7: 20 ed 80     ..
+    pla                                                               ; 8bca: 68          h
+    cmp l00cd                                                         ; 8bcb: c5 cd       ..
+    bne c8ba2                                                         ; 8bcd: d0 d3       ..
+    jsr sub_c8284                                                     ; 8bcf: 20 84 82     ..
+    bcc c8be3                                                         ; 8bd2: 90 0f       ..
+    cpy l00c4                                                         ; 8bd4: c4 c4       ..
+    beq c8be3                                                         ; 8bd6: f0 0b       ..
+    jsr generate_error_precheck                                       ; 8bd8: 20 38 80     8.
+    !byte $c4                                                         ; 8bdb: c4          .
+    !text "Exists"                                                    ; 8bdc: 45 78 69... Exi
+    !byte 0                                                           ; 8be2: 00          .
+
+; $8be3 referenced 2 times by $8bd2, $8bd6
+c8be3
+    ldy l00c4                                                         ; 8be3: a4 c4       ..
+    jsr sub_c87da                                                     ; 8be5: 20 da 87     ..
+    ldx #7                                                            ; 8be8: a2 07       ..
+; $8bea referenced 1 time by $8bf1
+loop_c8bea
+    lda l00c5,x                                                       ; 8bea: b5 c5       ..
+    sta l0e07,y                                                       ; 8bec: 99 07 0e    ...
+    dey                                                               ; 8bef: 88          .
+    dex                                                               ; 8bf0: ca          .
+    bpl loop_c8bea                                                    ; 8bf1: 10 f7       ..
+    jmp c93e6                                                         ; 8bf3: 4c e6 93    L..
+
+; $8bf6 referenced 1 time by $9466
+sub_c8bf6
+    clc                                                               ; 8bf6: 18          .
+    bcc c8bfb                                                         ; 8bf7: 90 02       ..
+; $8bf9 referenced 1 time by $9211
+sub_c8bf9
+    cli                                                               ; 8bf9: 58          X
+    sec                                                               ; 8bfa: 38          8
+; $8bfb referenced 1 time by $8bf7
+c8bfb
+    ror l00b2                                                         ; 8bfb: 66 b2       f.
+    stx l00b0                                                         ; 8bfd: 86 b0       ..
+    sty l00b1                                                         ; 8bff: 84 b1       ..
+    cld                                                               ; 8c01: d8          .
+    jsr sub_c8c65                                                     ; 8c02: 20 65 8c     e.
+    lda l00a2                                                         ; 8c05: a5 a2       ..
+    bne c8c12                                                         ; 8c07: d0 09       ..
+    ldy #5                                                            ; 8c09: a0 05       ..
+    lda (l00b0),y                                                     ; 8c0b: b1 b0       ..
+    beq c8c12                                                         ; 8c0d: f0 03       ..
+    jsr sub_c8d1a                                                     ; 8c0f: 20 1a 8d     ..
+; $8c12 referenced 2 times by $8c07, $8c0d
+c8c12
+    ldy #5                                                            ; 8c12: a0 05       ..
+    lda (l00b0),y                                                     ; 8c14: b1 b0       ..
+    clc                                                               ; 8c16: 18          .
+    adc #7                                                            ; 8c17: 69 07       i.
+    tay                                                               ; 8c19: a8          .
+    lda l00a2                                                         ; 8c1a: a5 a2       ..
+    jsr sub_c8c56                                                     ; 8c1c: 20 56 8c     V.
+    sta (l00b0),y                                                     ; 8c1f: 91 b0       ..
+    ldx l00a7                                                         ; 8c21: a6 a7       ..
+    cpx #$80                                                          ; 8c23: e0 80       ..
+    bne c8c2e                                                         ; 8c25: d0 07       ..
+    lda lfe84                                                         ; 8c27: ad 84 fe    ...
+    and #$20 ; ' '                                                    ; 8c2a: 29 20       )
+    ora (l00b0),y                                                     ; 8c2c: 11 b0       ..
+; $8c2e referenced 1 time by $8c25
+c8c2e
+    pha                                                               ; 8c2e: 48          H
+    and #$df                                                          ; 8c2f: 29 df       ).
+    cmp #$18                                                          ; 8c31: c9 18       ..
+    bne c8c3a                                                         ; 8c33: d0 05       ..
+    lda #$ff                                                          ; 8c35: a9 ff       ..
+    sta l1087                                                         ; 8c37: 8d 87 10    ...
+; $8c3a referenced 1 time by $8c33
+c8c3a
+    lda l00cd                                                         ; 8c3a: a5 cd       ..
+    and #1                                                            ; 8c3c: 29 01       ).
+    tay                                                               ; 8c3e: a8          .
+    lda l00ce                                                         ; 8c3f: a5 ce       ..
+    sta l1088,y                                                       ; 8c41: 99 88 10    ...
+    jsr c8f2a                                                         ; 8c44: 20 2a 8f     *.
+    bit l00a1                                                         ; 8c47: 24 a1       $.
+    bpl c8c4e                                                         ; 8c49: 10 03       ..
+    jsr sub_c8f7a                                                     ; 8c4b: 20 7a 8f     z.
+; $8c4e referenced 1 time by $8c49
+c8c4e
+    jsr sub_c8f5e                                                     ; 8c4e: 20 5e 8f     ^.
+    lda lfe87                                                         ; 8c51: ad 87 fe    ...
+    pla                                                               ; 8c54: 68          h
+    rts                                                               ; 8c55: 60          `
+
+; $8c56 referenced 1 time by $8c1c
+sub_c8c56
+    ldx #5                                                            ; 8c56: a2 05       ..
+; $8c58 referenced 1 time by $8c5e
+loop_c8c58
+    cmp l9139,x                                                       ; 8c58: dd 39 91    .9.
+    beq c8c61                                                         ; 8c5b: f0 04       ..
+    dex                                                               ; 8c5d: ca          .
+    bpl loop_c8c58                                                    ; 8c5e: 10 f8       ..
+    rts                                                               ; 8c60: 60          `
+
+; $8c61 referenced 1 time by $8c5b
+c8c61
+    lda l913f,x                                                       ; 8c61: bd 3f 91    .?.
+    rts                                                               ; 8c64: 60          `
+
+; $8c65 referenced 1 time by $8c02
+sub_c8c65
+    jsr sub_c8f4f                                                     ; 8c65: 20 4f 8f     O.
+    jsr sub_c8f82                                                     ; 8c68: 20 82 8f     ..
+    lda #0                                                            ; 8c6b: a9 00       ..
+    sta l00a1                                                         ; 8c6d: 85 a1       ..
+    ldy #9                                                            ; 8c6f: a0 09       ..
+; $8c71 referenced 1 time by $8c79
+loop_c8c71
+    lda (l00b0),y                                                     ; 8c71: b1 b0       ..
+    sta l00aa,y                                                       ; 8c73: 99 aa 00    ...
+    iny                                                               ; 8c76: c8          .
+    cpy #$0c                                                          ; 8c77: c0 0c       ..
+    bne loop_c8c71                                                    ; 8c79: d0 f6       ..
+    ldy #6                                                            ; 8c7b: a0 06       ..
+    lda (l00b0),y                                                     ; 8c7d: b1 b0       ..
+    and #$f0                                                          ; 8c7f: 29 f0       ).
+    cmp #$a0                                                          ; 8c81: c9 a0       ..
+    beq c8c87                                                         ; 8c83: f0 02       ..
+    cmp #$f0                                                          ; 8c85: c9 f0       ..
+; $8c87 referenced 1 time by $8c83
+c8c87
+    ror l00a1                                                         ; 8c87: 66 a1       f.
+    ldy #3                                                            ; 8c89: a0 03       ..
+    lda (l00b0),y                                                     ; 8c8b: b1 b0       ..
+    iny                                                               ; 8c8d: c8          .
+    and (l00b0),y                                                     ; 8c8e: 31 b0       1.
+    cmp #$ff                                                          ; 8c90: c9 ff       ..
+    clc                                                               ; 8c92: 18          .
+    beq c8cb2                                                         ; 8c93: f0 1d       ..
+    jsr sub_c8f3f                                                     ; 8c95: 20 3f 8f     ?.
+    clc                                                               ; 8c98: 18          .
+    bmi c8cb2                                                         ; 8c99: 30 17       0.
+    jsr sub_c8f6b                                                     ; 8c9b: 20 6b 8f     k.
+    lda l00a1                                                         ; 8c9e: a5 a1       ..
+    rol                                                               ; 8ca0: 2a          *
+    rol                                                               ; 8ca1: 2a          *
+    and #1                                                            ; 8ca2: 29 01       ).
+    eor #1                                                            ; 8ca4: 49 01       I.
+    ldx l00b0                                                         ; 8ca6: a6 b0       ..
+    ldy l00b1                                                         ; 8ca8: a4 b1       ..
+    inx                                                               ; 8caa: e8          .
+    bne c8cae                                                         ; 8cab: d0 01       ..
+    iny                                                               ; 8cad: c8          .
+; $8cae referenced 1 time by $8cab
+c8cae
+    jsr tube_entry                                                    ; 8cae: 20 06 04     ..
+    sec                                                               ; 8cb1: 38          8
+; $8cb2 referenced 2 times by $8c93, $8c99
+c8cb2
+    ror l00a1                                                         ; 8cb2: 66 a1       f.
+    jsr sub_c8f94                                                     ; 8cb4: 20 94 8f     ..
+    ldy #0                                                            ; 8cb7: a0 00       ..
+    lda (l00b0),y                                                     ; 8cb9: b1 b0       ..
+    bmi c8cc1                                                         ; 8cbb: 30 04       0.
+    and #$0f                                                          ; 8cbd: 29 0f       ).
+    sta l00cd                                                         ; 8cbf: 85 cd       ..
+; $8cc1 referenced 1 time by $8cbb
+c8cc1
+    lda l00cd                                                         ; 8cc1: a5 cd       ..
+    and #3                                                            ; 8cc3: 29 03       ).
+    tax                                                               ; 8cc5: aa          .
+    lda l10de,x                                                       ; 8cc6: bd de 10    ...
+    sta l108a                                                         ; 8cc9: 8d 8a 10    ...
+    lda l00cd                                                         ; 8ccc: a5 cd       ..
+    ldy #$0a                                                          ; 8cce: a0 0a       ..
+    and #8                                                            ; 8cd0: 29 08       ).
+    beq c8cd6                                                         ; 8cd2: f0 02       ..
+    ldy #$10                                                          ; 8cd4: a0 10       ..
+; $8cd6 referenced 1 time by $8cd2
+c8cd6
+    sty l00a3                                                         ; 8cd6: 84 a3       ..
+    eor l911d,x                                                       ; 8cd8: 5d 1d 91    ]..
+    sta lfe80                                                         ; 8cdb: 8d 80 fe    ...
+    lsr                                                               ; 8cde: 4a          J
+    ldx l1088                                                         ; 8cdf: ae 88 10    ...
+    bcs c8ce7                                                         ; 8ce2: b0 03       ..
+    ldx l1089                                                         ; 8ce4: ae 89 10    ...
+; $8ce7 referenced 1 time by $8ce2
+c8ce7
+    ldy #0                                                            ; 8ce7: a0 00       ..
+    sty l00a2                                                         ; 8ce9: 84 a2       ..
+    lda l1087                                                         ; 8ceb: ad 87 10    ...
+    bit l1087                                                         ; 8cee: 2c 87 10    ,..
+    bcc c8cfc                                                         ; 8cf1: 90 09       ..
+    bpl c8d0d                                                         ; 8cf3: 10 18       ..
+    sty l1088                                                         ; 8cf5: 8c 88 10    ...
+    and #$7f                                                          ; 8cf8: 29 7f       ).
+    bpl c8d03                                                         ; 8cfa: 10 07       ..
+; $8cfc referenced 1 time by $8cf1
+c8cfc
+    bvc c8d0d                                                         ; 8cfc: 50 0f       P.
+    sty l1089                                                         ; 8cfe: 8c 89 10    ...
+    and #$bf                                                          ; 8d01: 29 bf       ).
+; $8d03 referenced 1 time by $8cfa
+c8d03
+    sta l1087                                                         ; 8d03: 8d 87 10    ...
+    lda #0                                                            ; 8d06: a9 00       ..
+    jsr c8e12                                                         ; 8d08: 20 12 8e     ..
+    ldx #0                                                            ; 8d0b: a2 00       ..
+; $8d0d referenced 2 times by $8cf3, $8cfc
+c8d0d
+    txa                                                               ; 8d0d: 8a          .
+    sta l00ce                                                         ; 8d0e: 85 ce       ..
+    jsr c8f2a                                                         ; 8d10: 20 2a 8f     *.
+; $8d13 referenced 2 times by $8d1d, $8d25
+c8d13
+    rts                                                               ; 8d13: 60          `
+
+; $8d14 referenced 1 time by $8d29
+loop_c8d14
+    jmp c8eaf                                                         ; 8d14: 4c af 8e    L..
+
+; $8d17 referenced 1 time by $8d2d
+loop_c8d17
+    jmp c8e12                                                         ; 8d17: 4c 12 8e    L..
+
+; $8d1a referenced 1 time by $8c0f
+sub_c8d1a
+    jsr sub_c8eff                                                     ; 8d1a: 20 ff 8e     ..
+    bne c8d13                                                         ; 8d1d: d0 f4       ..
+    ldy #6                                                            ; 8d1f: a0 06       ..
+    lda (l00b0),y                                                     ; 8d21: b1 b0       ..
+    cmp #$10                                                          ; 8d23: c9 10       ..
+    beq c8d13                                                         ; 8d25: f0 ec       ..
+    cmp #$c0                                                          ; 8d27: c9 c0       ..
+    beq loop_c8d14                                                    ; 8d29: f0 e9       ..
+    cmp #$e0                                                          ; 8d2b: c9 e0       ..
+    bcs loop_c8d17                                                    ; 8d2d: b0 e8       ..
+    ldy #8                                                            ; 8d2f: a0 08       ..
+    lda (l00b0),y                                                     ; 8d31: b1 b0       ..
+    bit l00b2                                                         ; 8d33: 24 b2       $.
+    bmi c8d92                                                         ; 8d35: 30 5b       0[
+    ldx l00b5                                                         ; 8d37: a6 b5       ..
+    beq c8d41                                                         ; 8d39: f0 06       ..
+    inc l00b3                                                         ; 8d3b: e6 b3       ..
+    bne c8d41                                                         ; 8d3d: d0 02       ..
+    inc l00b4                                                         ; 8d3f: e6 b4       ..
+; $8d41 referenced 3 times by $8d39, $8d3d, $8d8f
+c8d41
+    jsr nmi_handler2_rom_end                                          ; 8d41: 20 fb 90     ..
+    sta l00cf                                                         ; 8d44: 85 cf       ..
+    sbc l00a3                                                         ; 8d46: e5 a3       ..
+    eor #$ff                                                          ; 8d48: 49 ff       I.
+    clc                                                               ; 8d4a: 18          .
+    adc #1                                                            ; 8d4b: 69 01       i.
+    sta l00a5                                                         ; 8d4d: 85 a5       ..
+    lda l00b4                                                         ; 8d4f: a5 b4       ..
+    bne c8d74                                                         ; 8d51: d0 21       .!
+    lda l00b3                                                         ; 8d53: a5 b3       ..
+    beq c8d91                                                         ; 8d55: f0 3a       .:
+    cmp l00a5                                                         ; 8d57: c5 a5       ..
+    beq c8d5d                                                         ; 8d59: f0 02       ..
+    bcs c8d74                                                         ; 8d5b: b0 17       ..
+; $8d5d referenced 1 time by $8d59
+c8d5d
+    sta l00a5                                                         ; 8d5d: 85 a5       ..
+    ldx l00b5                                                         ; 8d5f: a6 b5       ..
+    beq c8d74                                                         ; 8d61: f0 11       ..
+    stx l00a6                                                         ; 8d63: 86 a6       ..
+    ror l00a1                                                         ; 8d65: 66 a1       f.
+    sec                                                               ; 8d67: 38          8
+    rol l00a1                                                         ; 8d68: 26 a1       &.
+    cmp #1                                                            ; 8d6a: c9 01       ..
+    bne c8d74                                                         ; 8d6c: d0 06       ..
+    lda nmi_lda_immXXX4+1                                             ; 8d6e: ad 22 0d    .".
+    sta nmi_lda_immXXX3+1                                             ; 8d71: 8d 4c 0d    .L.
+; $8d74 referenced 4 times by $8d51, $8d5b, $8d61, $8d6c
+c8d74
+    lda l00b3                                                         ; 8d74: a5 b3       ..
+    sec                                                               ; 8d76: 38          8
+    sbc l00a5                                                         ; 8d77: e5 a5       ..
+    sta l00b3                                                         ; 8d79: 85 b3       ..
+    lda l00b4                                                         ; 8d7b: a5 b4       ..
+    sbc #0                                                            ; 8d7d: e9 00       ..
+    sta l00b4                                                         ; 8d7f: 85 b4       ..
+    jsr c8e0e                                                         ; 8d81: 20 0e 8e     ..
+    bne c8d91                                                         ; 8d84: d0 0b       ..
+    lda l00b3                                                         ; 8d86: a5 b3       ..
+    ora l00b4                                                         ; 8d88: 05 b4       ..
+    beq c8d91                                                         ; 8d8a: f0 05       ..
+    jsr c8ecc                                                         ; 8d8c: 20 cc 8e     ..
+    beq c8d41                                                         ; 8d8f: f0 b0       ..
+; $8d91 referenced 4 times by $8d55, $8d84, $8d8a, $8d9d
+c8d91
+    rts                                                               ; 8d91: 60          `
+
+; $8d92 referenced 1 time by $8d35
+c8d92
+    jsr nmi_handler2_rom_end                                          ; 8d92: 20 fb 90     ..
+    sta l00cf                                                         ; 8d95: 85 cf       ..
+    ldy #9                                                            ; 8d97: a0 09       ..
+    lda (l00b0),y                                                     ; 8d99: b1 b0       ..
+    and #$1f                                                          ; 8d9b: 29 1f       ).
+    beq c8d91                                                         ; 8d9d: f0 f2       ..
+    sta l00a5                                                         ; 8d9f: 85 a5       ..
+    bit l00a1                                                         ; 8da1: 24 a1       $.
+    bvs c8e0e                                                         ; 8da3: 70 69       pi
+    bit l108a                                                         ; 8da5: 2c 8a 10    ,..
+    bvc c8e0e                                                         ; 8da8: 50 64       Pd
+    ldx #$33 ; '3'                                                    ; 8daa: a2 33       .3
+; $8dac referenced 1 time by $8db3
+loop_c8dac
+    lda c0d60,x                                                       ; 8dac: bd 60 0d    .`.
+    sta l1000,x                                                       ; 8daf: 9d 00 10    ...
+    dex                                                               ; 8db2: ca          .
+    bpl loop_c8dac                                                    ; 8db3: 10 f7       ..
+    jsr sub_c8dc6                                                     ; 8db5: 20 c6 8d     ..
+    ldx #$33 ; '3'                                                    ; 8db8: a2 33       .3
+; $8dba referenced 1 time by $8dc1
+loop_c8dba
+    lda l1000,x                                                       ; 8dba: bd 00 10    ...
+    sta c0d60,x                                                       ; 8dbd: 9d 60 0d    .`.
+    dex                                                               ; 8dc0: ca          .
+    bpl loop_c8dba                                                    ; 8dc1: 10 f7       ..
+    lda l00a2                                                         ; 8dc3: a5 a2       ..
+    rts                                                               ; 8dc5: 60          `
+
+; $8dc6 referenced 1 time by $8db5
+sub_c8dc6
+    lda #0                                                            ; 8dc6: a9 00       ..
+    sta l00b4                                                         ; 8dc8: 85 b4       ..
+    lda (l00b0),y                                                     ; 8dca: b1 b0       ..
+    and #$e0                                                          ; 8dcc: 29 e0       ).
+    bne c8dd2                                                         ; 8dce: d0 02       ..
+    lda #$10                                                          ; 8dd0: a9 10       ..
+; $8dd2 referenced 1 time by $8dce
+c8dd2
+    asl                                                               ; 8dd2: 0a          .
+    rol l00b4                                                         ; 8dd3: 26 b4       &.
+    asl                                                               ; 8dd5: 0a          .
+    rol l00b4                                                         ; 8dd6: 26 b4       &.
+    asl                                                               ; 8dd8: 0a          .
+    rol l00b4                                                         ; 8dd9: 26 b4       &.
+    sta l00b3                                                         ; 8ddb: 85 b3       ..
+    tax                                                               ; 8ddd: aa          .
+    beq c8de2                                                         ; 8dde: f0 02       ..
+    inc l00b4                                                         ; 8de0: e6 b4       ..
+; $8de2 referenced 1 time by $8dde
+c8de2
+    jsr nmi3_handler_rom_end                                          ; 8de2: 20 3e 90     >.
+    lda #$14                                                          ; 8de5: a9 14       ..
+    sta l00b7                                                         ; 8de7: 85 b7       ..
+; $8de9 referenced 1 time by $8dfc
+loop_c8de9
+    lda #$e0                                                          ; 8de9: a9 e0       ..
+    sta l00a2                                                         ; 8deb: 85 a2       ..
+    sta lfe84                                                         ; 8ded: 8d 84 fe    ...
+; $8df0 referenced 1 time by $8df2
+loop_c8df0
+    lda l00a2                                                         ; 8df0: a5 a2       ..
+    bmi loop_c8df0                                                    ; 8df2: 30 fc       0.
+    bne c8e0d                                                         ; 8df4: d0 17       ..
+    lda l00a5                                                         ; 8df6: a5 a5       ..
+    beq c8e03                                                         ; 8df8: f0 09       ..
+    dec l00b7                                                         ; 8dfa: c6 b7       ..
+    bne loop_c8de9                                                    ; 8dfc: d0 eb       ..
+    lda #$10                                                          ; 8dfe: a9 10       ..
+    sta l00a2                                                         ; 8e00: 85 a2       ..
+    rts                                                               ; 8e02: 60          `
+
+; $8e03 referenced 1 time by $8df8
+c8e03
+    lda l00b6                                                         ; 8e03: a5 b6       ..
+    eor #$fb                                                          ; 8e05: 49 fb       I.
+    beq c8e0d                                                         ; 8e07: f0 04       ..
+    lda #$20 ; ' '                                                    ; 8e09: a9 20       .
+    sta l00a2                                                         ; 8e0b: 85 a2       ..
+; $8e0d referenced 2 times by $8df4, $8e07
+c8e0d
+    rts                                                               ; 8e0d: 60          `
+
+; $8e0e referenced 4 times by $8d81, $8da3, $8da8, $8ec2
+c8e0e
+    ldy #6                                                            ; 8e0e: a0 06       ..
+    lda (l00b0),y                                                     ; 8e10: b1 b0       ..
+; $8e12 referenced 4 times by $8d08, $8d17, $8efc, $8f21
+c8e12
+    ldy #$ff                                                          ; 8e12: a0 ff       ..
+; $8e14 referenced 1 time by $8e18
+loop_c8e14
+    iny                                                               ; 8e14: c8          .
+    cmp l9121,y                                                       ; 8e15: d9 21 91    .!.
+    bne loop_c8e14                                                    ; 8e18: d0 fa       ..
+    pha                                                               ; 8e1a: 48          H
+    lda nmi_and_table,y                                               ; 8e1b: b9 2d 91    .-.
+    sta nmi_and_imm+1                                                 ; 8e1e: 8d 05 0d    ...
+    ror l00a2                                                         ; 8e21: 66 a2       f.
+    pla                                                               ; 8e23: 68          h
+    bpl c8e72                                                         ; 8e24: 10 4c       .L
+    bit l00a1                                                         ; 8e26: 24 a1       $.
+    bvc c8e32                                                         ; 8e28: 50 08       P.
+    ldy l00ce                                                         ; 8e2a: a4 ce       ..
+    cpy #$14                                                          ; 8e2c: c0 14       ..
+    bcc c8e32                                                         ; 8e2e: 90 02       ..
+    ora #2                                                            ; 8e30: 09 02       ..
+; $8e32 referenced 2 times by $8e28, $8e2e
+c8e32
+    sta l00a7                                                         ; 8e32: 85 a7       ..
+    ldy #1                                                            ; 8e34: a0 01       ..
+    cmp #$c0                                                          ; 8e36: c9 c0       ..
+    beq c8e53                                                         ; 8e38: f0 19       ..
+    ora #4                                                            ; 8e3a: 09 04       ..
+    bcs c8e53                                                         ; 8e3c: b0 15       ..
+    ldy l00a5                                                         ; 8e3e: a4 a5       ..
+    cmp #$85                                                          ; 8e40: c9 85       ..
+    beq c8e4d                                                         ; 8e42: f0 09       ..
+    cmp #$87                                                          ; 8e44: c9 87       ..
+    bne c8e53                                                         ; 8e46: d0 0b       ..
+    lda #nmi_XXX1-(nmi_beq+2)                                         ; 8e48: a9 48       .H
+    sta nmi_beq+1                                                     ; 8e4a: 8d 09 0d    ...
+; $8e4d referenced 1 time by $8e42
+c8e4d
+    lda #$80                                                          ; 8e4d: a9 80       ..
+    sta l00a7                                                         ; 8e4f: 85 a7       ..
+    lda #$84                                                          ; 8e51: a9 84       ..
+; $8e53 referenced 3 times by $8e38, $8e3c, $8e46
+c8e53
+    sty l00a5                                                         ; 8e53: 84 a5       ..
+    sta lfe84                                                         ; 8e55: 8d 84 fe    ...
+    cmp #$f0                                                          ; 8e58: c9 f0       ..
+    bcc c8e64                                                         ; 8e5a: 90 08       ..
+    jsr c8e9f                                                         ; 8e5c: 20 9f 8e     ..
+    and #$5c ; '\'                                                    ; 8e5f: 29 5c       )\
+    sta l00a2                                                         ; 8e61: 85 a2       ..
+    rts                                                               ; 8e63: 60          `
+
+; $8e64 referenced 4 times by $8e5a, $8e66, $8e7f, $8e83
+c8e64
+    lda l00a2                                                         ; 8e64: a5 a2       ..
+    bmi c8e64                                                         ; 8e66: 30 fc       0.
+    cmp #$20 ; ' '                                                    ; 8e68: c9 20       .
+    bne c8e6f                                                         ; 8e6a: d0 03       ..
+    jsr c8ea5                                                         ; 8e6c: 20 a5 8e     ..
+; $8e6f referenced 1 time by $8e6a
+c8e6f
+    lda l00a2                                                         ; 8e6f: a5 a2       ..
+    rts                                                               ; 8e71: 60          `
+
+; $8e72 referenced 1 time by $8e24
+c8e72
+    ldy #1                                                            ; 8e72: a0 01       ..
+    sty l00a5                                                         ; 8e74: 84 a5       ..
+    ora l00a4                                                         ; 8e76: 05 a4       ..
+    sta l00a7                                                         ; 8e78: 85 a7       ..
+    sta lfe84                                                         ; 8e7a: 8d 84 fe    ...
+    bit l00b2                                                         ; 8e7d: 24 b2       $.
+    bmi c8e64                                                         ; 8e7f: 30 e3       0.
+    cmp #$20 ; ' '                                                    ; 8e81: c9 20       .
+    bcs c8e64                                                         ; 8e83: b0 df       ..
+; $8e85 referenced 1 time by $8e8b
+loop_c8e85
+    lda l00a2                                                         ; 8e85: a5 a2       ..
+    bpl c8e9e                                                         ; 8e87: 10 15       ..
+    lda l00ff                                                         ; 8e89: a5 ff       ..
+    bpl loop_c8e85                                                    ; 8e8b: 10 f8       ..
+    lda #opcode_rti                                                   ; 8e8d: a9 40       .@
+    sta nmi_handler_ram                                               ; 8e8f: 8d 00 0d    ...
+    lda #0                                                            ; 8e92: a9 00       ..
+    sta lfe80                                                         ; 8e94: 8d 80 fe    ...
+    lda l00ff                                                         ; 8e97: a5 ff       ..
+    sta l1082                                                         ; 8e99: 8d 82 10    ...
+    sta l00a2                                                         ; 8e9c: 85 a2       ..
+; $8e9e referenced 1 time by $8e87
+c8e9e
+    rts                                                               ; 8e9e: 60          `
+
+; $8e9f referenced 2 times by $8e5c, $8ea3
+c8e9f
+    lda lfe84                                                         ; 8e9f: ad 84 fe    ...
+    ror                                                               ; 8ea2: 6a          j
+    bcc c8e9f                                                         ; 8ea3: 90 fa       ..
+; $8ea5 referenced 2 times by $8e6c, $8ea9
+c8ea5
+    lda lfe84                                                         ; 8ea5: ad 84 fe    ...
+    ror                                                               ; 8ea8: 6a          j
+    bcs c8ea5                                                         ; 8ea9: b0 fa       ..
+    lda lfe84                                                         ; 8eab: ad 84 fe    ...
+    rts                                                               ; 8eae: 60          `
+
+; $8eaf referenced 1 time by $8d14
+c8eaf
+    lda #nmi_XXX1-(nmi_beq+2)                                         ; 8eaf: a9 48       .H
+    sta nmi_lda_immXXX3+1                                             ; 8eb1: 8d 4c 0d    .L.
+    ldx nmi_beq+1                                                     ; 8eb4: ae 09 0d    ...
+; $8eb7 referenced 2 times by $8eb9, $8ec9
+c8eb7
+    sbc #1                                                            ; 8eb7: e9 01       ..
+    bne c8eb7                                                         ; 8eb9: d0 fc       ..
+    stx nmi_beq+1                                                     ; 8ebb: 8e 09 0d    ...
+    lda #4                                                            ; 8ebe: a9 04       ..
+    sta l00a6                                                         ; 8ec0: 85 a6       ..
+    jsr c8e0e                                                         ; 8ec2: 20 0e 8e     ..
+    bne c8ecb                                                         ; 8ec5: d0 04       ..
+    dec l00b3                                                         ; 8ec7: c6 b3       ..
+    bne c8eb7                                                         ; 8ec9: d0 ec       ..
+; $8ecb referenced 1 time by $8ec5
+c8ecb
+    rts                                                               ; 8ecb: 60          `
+
+; $8ecc referenced 3 times by $8d8c, $8ee2, $8ee7
+c8ecc
+    jsr sub_c8eec                                                     ; 8ecc: 20 ec 8e     ..
+    bne c8eeb                                                         ; 8ecf: d0 1a       ..
+    lda l00cd                                                         ; 8ed1: a5 cd       ..
+    and #1                                                            ; 8ed3: 29 01       ).
+    asl                                                               ; 8ed5: 0a          .
+    tay                                                               ; 8ed6: a8          .
+    lda l00ce                                                         ; 8ed7: a5 ce       ..
+    bit l108a                                                         ; 8ed9: 2c 8a 10    ,..
+    bpl c8edf                                                         ; 8edc: 10 01       ..
+    lsr                                                               ; 8ede: 4a          J
+; $8edf referenced 1 time by $8edc
+c8edf
+    cmp l108b,y                                                       ; 8edf: d9 8b 10    ...
+    beq c8ecc                                                         ; 8ee2: f0 e8       ..
+    cmp l108c,y                                                       ; 8ee4: d9 8c 10    ...
+    beq c8ecc                                                         ; 8ee7: f0 e3       ..
+    lda #0                                                            ; 8ee9: a9 00       ..
+; $8eeb referenced 2 times by $8ecf, $8ef6
+c8eeb
+    rts                                                               ; 8eeb: 60          `
+
+; $8eec referenced 1 time by $8ecc
+sub_c8eec
+    bit l108a                                                         ; 8eec: 2c 8a 10    ,..
+    bpl c8ef8                                                         ; 8eef: 10 07       ..
+    lda #$40 ; '@'                                                    ; 8ef1: a9 40       .@
+    jsr sub_c8efa                                                     ; 8ef3: 20 fa 8e     ..
+    bne c8eeb                                                         ; 8ef6: d0 f3       ..
+; $8ef8 referenced 1 time by $8eef
+c8ef8
+    lda #$50 ; 'P'                                                    ; 8ef8: a9 50       .P
+; $8efa referenced 1 time by $8ef3
+sub_c8efa
+    inc l00ce                                                         ; 8efa: e6 ce       ..
+    jmp c8e12                                                         ; 8efc: 4c 12 8e    L..
+
+; $8eff referenced 1 time by $8d1a
+sub_c8eff
+    lda l00cd                                                         ; 8eff: a5 cd       ..
+    and #1                                                            ; 8f01: 29 01       ).
+    asl                                                               ; 8f03: 0a          .
+    tax                                                               ; 8f04: aa          .
+    ldy #7                                                            ; 8f05: a0 07       ..
+    lda (l00b0),y                                                     ; 8f07: b1 b0       ..
+    jsr sub_c8f33                                                     ; 8f09: 20 33 8f     3.
+    bit l108a                                                         ; 8f0c: 2c 8a 10    ,..
+    bpl c8f12                                                         ; 8f0f: 10 01       ..
+    asl                                                               ; 8f11: 0a          .
+; $8f12 referenced 1 time by $8f0f
+c8f12
+    sta l00ce                                                         ; 8f12: 85 ce       ..
+    tay                                                               ; 8f14: a8          .
+    beq c8f21                                                         ; 8f15: f0 0a       ..
+; $8f17 referenced 1 time by $8f1d
+loop_c8f17
+    sta lfe87                                                         ; 8f17: 8d 87 fe    ...
+    cmp lfe87                                                         ; 8f1a: cd 87 fe    ...
+    bne loop_c8f17                                                    ; 8f1d: d0 f8       ..
+    lda #$10                                                          ; 8f1f: a9 10       ..
+; $8f21 referenced 1 time by $8f15
+c8f21
+    jsr c8e12                                                         ; 8f21: 20 12 8e     ..
+    bne c8f3e                                                         ; 8f24: d0 18       ..
+    ldy #7                                                            ; 8f26: a0 07       ..
+    lda (l00b0),y                                                     ; 8f28: b1 b0       ..
+; $8f2a referenced 3 times by $8c44, $8d10, $8f30
+c8f2a
+    sta lfe85                                                         ; 8f2a: 8d 85 fe    ...
+    cmp lfe85                                                         ; 8f2d: cd 85 fe    ...
+    bne c8f2a                                                         ; 8f30: d0 f8       ..
+    rts                                                               ; 8f32: 60          `
+
+; $8f33 referenced 1 time by $8f09
+sub_c8f33
+    jsr sub_c8f37                                                     ; 8f33: 20 37 8f     7.
+    inx                                                               ; 8f36: e8          .
+; $8f37 referenced 1 time by $8f33
+sub_c8f37
+    cmp l108b,x                                                       ; 8f37: dd 8b 10    ...
+    bcc c8f3e                                                         ; 8f3a: 90 02       ..
+    adc #0                                                            ; 8f3c: 69 00       i.
+; $8f3e referenced 2 times by $8f24, $8f3a
+c8f3e
+    rts                                                               ; 8f3e: 60          `
+
+; $8f3f referenced 5 times by $8c95, $8f75, $92b0, $932b, $9628
+sub_c8f3f
+    lda #osbyte_read_tube_presence                                    ; 8f3f: a9 ea       ..
+    ldx #0                                                            ; 8f41: a2 00       ..
+    ldy #$ff                                                          ; 8f43: a0 ff       ..
+    jsr osbyte                                                        ; 8f45: 20 f4 ff     ..
+    txa                                                               ; 8f48: 8a          .
+    eor #$ff                                                          ; 8f49: 49 ff       I.
+    sta l10d6                                                         ; 8f4b: 8d d6 10    ...
+    rts                                                               ; 8f4e: 60          `
+
+; $8f4f referenced 1 time by $8c65
+sub_c8f4f
+    lda #osbyte_issue_service_request                                 ; 8f4f: a9 8f       ..
+    ldx #$0c                                                          ; 8f51: a2 0c       ..
+    ldy #$ff                                                          ; 8f53: a0 ff       ..
+    jsr osbyte                                                        ; 8f55: 20 f4 ff     ..
+    sty l00a0                                                         ; 8f58: 84 a0       ..
+    inc l10d3                                                         ; 8f5a: ee d3 10    ...
+    rts                                                               ; 8f5d: 60          `
+
+; $8f5e referenced 1 time by $8c4e
+sub_c8f5e
+    ldy l00a0                                                         ; 8f5e: a4 a0       ..
+    lda #osbyte_issue_service_request                                 ; 8f60: a9 8f       ..
+    ldx #$0b                                                          ; 8f62: a2 0b       ..
+    jsr osbyte                                                        ; 8f64: 20 f4 ff     ..
+    dec l10d3                                                         ; 8f67: ce d3 10    ...
+    rts                                                               ; 8f6a: 60          `
+
+; $8f6b referenced 4 times by $8921, $8c9b, $933e, $9819
+sub_c8f6b
+    pha                                                               ; 8f6b: 48          H
+; $8f6c referenced 1 time by $8f71
+loop_c8f6c
+    lda #$c1                                                          ; 8f6c: a9 c1       ..
+    jsr tube_entry                                                    ; 8f6e: 20 06 04     ..
+    bcc loop_c8f6c                                                    ; 8f71: 90 f9       ..
+    pla                                                               ; 8f73: 68          h
+    rts                                                               ; 8f74: 60          `
+
+; $8f75 referenced 1 time by $8071
+sub_c8f75
+    jsr sub_c8f3f                                                     ; 8f75: 20 3f 8f     ?.
+    bmi c8f81                                                         ; 8f78: 30 07       0.
+; $8f7a referenced 3 times by $8c4b, $9364, $97e3
+sub_c8f7a
+    pha                                                               ; 8f7a: 48          H
+    lda #$81                                                          ; 8f7b: a9 81       ..
+    jsr tube_entry                                                    ; 8f7d: 20 06 04     ..
+    pla                                                               ; 8f80: 68          h
+; $8f81 referenced 1 time by $8f78
+c8f81
+    rts                                                               ; 8f81: 60          `
+
+; $8f82 referenced 1 time by $8c68
+sub_c8f82
+    lda #osbyte_read_write_startup_options                            ; 8f82: a9 ff       ..
+    ldx #0                                                            ; 8f84: a2 00       ..
+    tay                                                               ; 8f86: a8          .
+    jsr osbyte                                                        ; 8f87: 20 f4 ff     ..
+    txa                                                               ; 8f8a: 8a          .
+    lsr                                                               ; 8f8b: 4a          J
+    lsr                                                               ; 8f8c: 4a          J
+    lsr                                                               ; 8f8d: 4a          J
+    lsr                                                               ; 8f8e: 4a          J
+    and #3                                                            ; 8f8f: 29 03       ).
+    sta l00a4                                                         ; 8f91: 85 a4       ..
+    rts                                                               ; 8f93: 60          `
+
+; $8f94 referenced 1 time by $8cb4
+sub_c8f94
+    ldx #nmi_handler_rom_end-nmi_handler_rom_start-1                  ; 8f94: a2 5d       .]
+; $8f96 referenced 1 time by $8f9d
+loop_c8f96
+    lda nmi_handler_rom_start,x                                       ; 8f96: bd d2 8f    ...
+    sta nmi_handler_ram,x                                             ; 8f99: 9d 00 0d    ...
+    dex                                                               ; 8f9c: ca          .
+    bpl loop_c8f96                                                    ; 8f9d: 10 f7       ..
+    ldx #3                                                            ; 8f9f: a2 03       ..
+    bit l00a1                                                         ; 8fa1: 24 a1       $.
+    bvc c8fb5                                                         ; 8fa3: 50 10       P.
+    lda #nmi_XXX8-(nmi_beq+2)                                         ; 8fa5: a9 4d       .M
+    sta nmi_lda_immXXX4+1                                             ; 8fa7: 8d 22 0d    .".
+    ldx #nmi3_handler_rom_end-nmi3_handler_rom_start                  ; 8faa: a2 0e       ..
+; $8fac referenced 1 time by $8fb3
+loop_c8fac
+    lda nmi3_handler_rom_start-1,x                                    ; 8fac: bd 2f 90    ./.
+    sta nmi_XXX2-1,x                                                  ; 8faf: 9d 38 0d    .8.
+    dex                                                               ; 8fb2: ca          .
+    bne loop_c8fac                                                    ; 8fb3: d0 f7       ..
+; $8fb5 referenced 1 time by $8fa3
+c8fb5
+    bit l00a1                                                         ; 8fb5: 24 a1       $.
+    bmi c8fc7                                                         ; 8fb7: 30 0e       0.
+    ldy #1                                                            ; 8fb9: a0 01       ..
+    lda (l00b0),y                                                     ; 8fbb: b1 b0       ..
+    sta nmi_lda_abs+1,x                                               ; 8fbd: 9d 3a 0d    .:.
+    iny                                                               ; 8fc0: c8          .
+    lda (l00b0),y                                                     ; 8fc1: b1 b0       ..
+    sta nmi_lda_abs+2,x                                               ; 8fc3: 9d 3b 0d    .;.
+    rts                                                               ; 8fc6: 60          `
+
+; $8fc7 referenced 1 time by $8fb7
+c8fc7
+    lda #opcode_bcs                                                   ; 8fc7: a9 b0       ..
+    sta nmi_XXX6                                                      ; 8fc9: 8d 3f 0d    .?.
+    lda #nmi_XXX7-(nmi_XXX6+2)                                        ; 8fcc: a9 06       ..
+    sta nmi_XXX6+1                                                    ; 8fce: 8d 40 0d    .@.
+    rts                                                               ; 8fd1: 60          `
+
+; $8fd2 referenced 1 time by $8f96
+nmi_handler_rom_start
+; $8fd2 referenced 1 time by $8f96
+
+!pseudopc $0d00 {
+; $8fd2 referenced 1 time by $8f96
+nmi_handler_ram
+    pha                                                               ; 8fd2: 48          H   :0d00[4]
+    lda lfe84                                                         ; 8fd3: ad 84 fe    ... :0d01[4]
+; The operand of this and is modified at runtime.
+nmi_and_imm
+    and #$18                                                          ; 8fd6: 29 18       ).  :0d04[4]
+    cmp #3                                                            ; 8fd8: c9 03       ..  :0d06[4]
+; The operand of this "beq" is modified at runtime.
+nmi_beq
+    beq nmi_XXX2                                                      ; 8fda: f0 2f       ./  :0d08[4]
+    and #$fc                                                          ; 8fdc: 29 fc       ).  :0d0a[4]
+    bne l0d12                                                         ; 8fde: d0 04       ..  :0d0c[4]
+    dec l00a5                                                         ; 8fe0: c6 a5       ..  :0d0e[4]
+    bne nmi_lda_zp                                                    ; 8fe2: d0 04       ..  :0d10[4]
+l0d12
+    sta l00a2                                                         ; 8fe4: 85 a2       ..  :0d12[4]
+    pla                                                               ; 8fe6: 68          h   :0d14[4]
+    rti                                                               ; 8fe7: 40          @   :0d15[4]
+
+; The operand of this lda is modified at runtime.
+nmi_lda_zp
+    lda l00a5                                                         ; 8fe8: a5 a5       ..  :0d16[4]
+; This instruction is patched at runtime to toggle between cmp #/bcs.
+nmi_cmp_imm_or_bcs
+    cmp #1                                                            ; 8fea: c9 01       ..  :0d18[4]
+    bne l0d26                                                         ; 8fec: d0 0a       ..  :0d1a[4]
+    lda l00a1                                                         ; 8fee: a5 a1       ..  :0d1c[4]
+    ror                                                               ; 8ff0: 6a          j   :0d1e[4]
+l0d1f
+nmi_XXX5 = l0d1f+1
+    bcc l0d26                                                         ; 8ff1: 90 05       ..  :0d1f[4]
+; One patched variant of the code transfers control to nmi_XXX5, which
+; is the
+; second byte of the following bcc instruction. That is always &05,
+; which is
+; ORA #. XXX: correct?
+; The operand of this lda is modified at runtime.
+nmi_lda_immXXX4
+    lda #nmi_XXX1-(nmi_beq+2)                                         ; 8ff3: a9 48       .H  :0d21[4]
+    sta nmi_lda_immXXX3+1                                             ; 8ff5: 8d 4c 0d    .L. :0d23[4]
+l0d26
+    inc l00cf                                                         ; 8ff8: e6 cf       ..  :0d26[4]
+    lda l00cf                                                         ; 8ffa: a5 cf       ..  :0d28[4]
+l0d2a
+    sta lfe86                                                         ; 8ffc: 8d 86 fe    ... :0d2a[4]
+    cmp lfe86                                                         ; 8fff: cd 86 fe    ... :0d2d[4]
+    bne l0d2a                                                         ; 9002: d0 f8       ..  :0d30[4]
+    lda l00a7                                                         ; 9004: a5 a7       ..  :0d32[4]
+    sta lfe84                                                         ; 9006: 8d 84 fe    ... :0d34[4]
+    pla                                                               ; 9009: 68          h   :0d37[4]
+    rti                                                               ; 900a: 40          @   :0d38[4]
+
+nmi_XXX2
+    lda lfe87                                                         ; 900b: ad 87 fe    ... :0d39[4]
+; The operand of this sta is modified at runtime.
+nmi_sta_abs
+    sta tube_host_r3_data                                             ; 900e: 8d e5 fe    ... :0d3c[4]
+; The first two bytes of the following instruction may be patched at
+; runtime.
+nmi_XXX6
+    inc nmi_sta_abs+1                                                 ; 9011: ee 3d 0d    .=. :0d3f[4]
+    bne nmi_XXX7                                                      ; 9014: d0 03       ..  :0d42[4]
+    inc nmi_sta_abs+2                                                 ; 9016: ee 3e 0d    .>. :0d44[4]
+nmi_XXX7
+    dec l00a6                                                         ; 9019: c6 a6       ..  :0d47[4]
+    bne l0d50                                                         ; 901b: d0 05       ..  :0d49[4]
+; The operand of this lda is modified at runtime.
+nmi_lda_immXXX3
+    lda #nmi_XXX2-(nmi_beq+2)                                         ; 901d: a9 2f       ./  :0d4b[4]
+    sta nmi_beq+1                                                     ; 901f: 8d 09 0d    ... :0d4d[4]
+l0d50
+    pla                                                               ; 9022: 68          h   :0d50[4]
+    rti                                                               ; 9023: 40          @   :0d51[4]
+
+nmi_XXX1
+    lda lfe87                                                         ; 9024: ad 87 fe    ... :0d52[4]
+    pla                                                               ; 9027: 68          h   :0d55[4]
+    rti                                                               ; 9028: 40          @   :0d56[4]
+
+nmi_XXX8
+    lda #0                                                            ; 9029: a9 00       ..  :0d57[4]
+    sta lfe87                                                         ; 902b: 8d 87 fe    ... :0d59[4]
+    pla                                                               ; 902e: 68          h   :0d5c[4]
+; $902f referenced 1 time by $8fac
+    rti                                                               ; 902f: 40          @   :0d5d[4]
+
+; The operand of this lda is modified at runtime.
+}
+
+; The operand of this lda is modified at runtime.
+nmi_handler_rom_end
+nmi3_handler_rom_start
+; The operand of this lda is modified at runtime.
+
+!pseudopc $0d39 {
+; The operand of this lda is modified at runtime.
+nmi_lda_abs
+    lda tube_host_r3_data                                             ; 9030: ad e5 fe    ... :0d39[5]
+    sta lfe87                                                         ; 9033: 8d 87 fe    ... :0d3c[5]
+    inc nmi_lda_abs+1                                                 ; 9036: ee 3a 0d    .:. :0d3f[5]
+    bne nmi_XXX7                                                      ; 9039: d0 03       ..  :0d42[5]
+    inc nmi_lda_abs+2                                                 ; 903b: ee 3b 0d    .;. :0d44[5]
+; $903e referenced 1 time by $8de2
+}
+
+; $903e referenced 1 time by $8de2
+nmi3_handler_rom_end
+; $903e referenced 1 time by $8de2
+    ldx nmi_sta_abs+1                                                 ; 903e: ae 3d 0d    .=.
+    lda nmi_sta_abs+2                                                 ; 9041: ad 3e 0d    .>.
+    pha                                                               ; 9044: 48          H
+    ldy #nmi_handler2_rom_end-nmi_handler2_rom_start                  ; 9045: a0 94       ..
+; $9047 referenced 1 time by $904e
+loop_c9047
+    lda nmi_handler2_rom_start-1,y                                    ; 9047: b9 66 90    .f.
+    sta l0cff,y                                                       ; 904a: 99 ff 0c    ...
+    dey                                                               ; 904d: 88          .
+    bne loop_c9047                                                    ; 904e: d0 f7       ..
+    pla                                                               ; 9050: 68          h
+    bit l00a1                                                         ; 9051: 24 a1       $.
+    bpl c9060                                                         ; 9053: 10 0b       ..
+    lda #opcode_bcs                                                   ; 9055: a9 b0       ..
+    sta nmi_cmp_imm_or_bcs                                            ; 9057: 8d 18 0d    ...
+    lda #nmi_XXX5-(nmi_cmp_imm_or_bcs+2)                              ; 905a: a9 06       ..
+    sta nmi_cmp_imm_or_bcs+1                                          ; 905c: 8d 19 0d    ...
+    rts                                                               ; 905f: 60          `
+
+; $9060 referenced 1 time by $9053
+c9060
+    stx nmi_lda_zp                                                    ; 9060: 8e 16 0d    ...
+    sta nmi_lda_zp+1                                                  ; 9063: 8d 17 0d    ...
+; $9066 referenced 1 time by $9047
+    rts                                                               ; 9066: 60          `
+
+nmi_handler2_rom_start
+
+!pseudopc $0d00 {
+    pha                                                               ; 9067: 48          H   :0d00[6]
+    lda lfe84                                                         ; 9068: ad 84 fe    ... :0d01[6]
+    and #$1b                                                          ; 906b: 29 1b       ).  :0d04[6]
+    cmp #3                                                            ; 906d: c9 03       ..  :0d06[6]
+    bne l0d0f                                                         ; 906f: d0 05       ..  :0d08[6]
+    lda lfe87                                                         ; 9071: ad 87 fe    ... :0d0a[6]
+; The operand of this bcs is modified at runtime
+nmi_bcs
+    bcs nmi_XXX21                                                     ; 9074: b0 26       .&  :0d0d[6]
+l0d0f
+    and #$fc                                                          ; 9076: 29 fc       ).  :0d0f[6]
+    sta l00a2                                                         ; 9078: 85 a2       ..  :0d11[6]
+    pla                                                               ; 907a: 68          h   :0d13[6]
+    rti                                                               ; 907b: 40          @   :0d14[6]
+
+; The operand of this sta is modified at runtime.
+nmi_XXX17
+nmi_sta_abs2
+    sta tube_host_r3_data                                             ; 907c: 8d e5 fe    ... :0d15[6]
+    inc nmi_sta_abs2+1                                                ; 907f: ee 16 0d    ... :0d18[6]
+    bne nmi_XXX18                                                     ; 9082: d0 03       ..  :0d1b[6]
+    inc nmi_sta_abs2+2                                                ; 9084: ee 17 0d    ... :0d1d[6]
+nmi_XXX18
+    dec l00a6                                                         ; 9087: c6 a6       ..  :0d20[6]
+    bne nmi_XXX23                                                     ; 9089: d0 0f       ..  :0d22[6]
+    dec l00a7                                                         ; 908b: c6 a7       ..  :0d24[6]
+    bne nmi_XXX23                                                     ; 908d: d0 0b       ..  :0d26[6]
+    lda #nmi_XXX22-(nmi_bcs+2)                                        ; 908f: a9 77       .w  :0d28[6]
+    dec l00a5                                                         ; 9091: c6 a5       ..  :0d2a[6]
+    bne l0d30                                                         ; 9093: d0 02       ..  :0d2c[6]
+    lda #nmi_XXX23-(nmi_bcs+2)                                        ; 9095: a9 24       .$  :0d2e[6]
+l0d30
+    sta nmi_bcs+1                                                     ; 9097: 8d 0e 0d    ... :0d30[6]
+nmi_XXX23
+    pla                                                               ; 909a: 68          h   :0d33[6]
+    rti                                                               ; 909b: 40          @   :0d34[6]
+
+nmi_XXX21
+    cmp #$fe                                                          ; 909c: c9 fe       ..  :0d35[6]
+    beq l0d3d                                                         ; 909e: f0 04       ..  :0d37[6]
+    cmp #$ce                                                          ; 90a0: c9 ce       ..  :0d39[6]
+    bne nmi_XXX23                                                     ; 90a2: d0 f6       ..  :0d3b[6]
+l0d3d
+    lda #nmi_XXX10-(nmi_bcs+2)                                        ; 90a4: a9 32       .2  :0d3d[6]
+    bne l0d30                                                         ; 90a6: d0 ef       ..  :0d3f[6]
+nmi_XXX10
+    sbc lfe87                                                         ; 90a8: ed 87 fe    ... :0d41[6]
+    sta l00b5                                                         ; 90ab: 85 b5       ..  :0d44[6]
+    lda #nmi_XXX11-(nmi_bcs+2)                                        ; 90ad: a9 3b       .;  :0d46[6]
+    bne l0d30                                                         ; 90af: d0 e6       ..  :0d48[6]
+nmi_XXX11
+    lda #nmi_XXX12-(nmi_bcs+2)                                        ; 90b1: a9 3f       .?  :0d4a[6]
+    bne l0d30                                                         ; 90b3: d0 e2       ..  :0d4c[6]
+nmi_XXX12
+    sbc l00cf                                                         ; 90b5: e5 cf       ..  :0d4e[6]
+    ora l00b5                                                         ; 90b7: 05 b5       ..  :0d50[6]
+    sta l00b5                                                         ; 90b9: 85 b5       ..  :0d52[6]
+    lda #nmi_XXX13-(nmi_bcs+2)                                        ; 90bb: a9 49       .I  :0d54[6]
+    bne l0d30                                                         ; 90bd: d0 d8       ..  :0d56[6]
+nmi_XXX13
+    lda #nmi_XXX14-(nmi_bcs+2)                                        ; 90bf: a9 4d       .M  :0d58[6]
+    bne l0d30                                                         ; 90c1: d0 d4       ..  :0d5a[6]
+nmi_XXX14
+    lda l00b3                                                         ; 90c3: a5 b3       ..  :0d5c[6]
+    sta l00a6                                                         ; 90c5: 85 a6       ..  :0d5e[6]
+; $90c7 referenced 2 times by $8dac, $8dbd
+c0d60
+    lda #nmi_XXX15-(nmi_bcs+2)                                        ; 90c7: a9 55       .U  :0d60[6]
+    bne l0d30                                                         ; 90c9: d0 cc       ..  :0d62[6]
+nmi_XXX15
+    lda l00b4                                                         ; 90cb: a5 b4       ..  :0d64[6]
+    sta l00a7                                                         ; 90cd: 85 a7       ..  :0d66[6]
+    lda #nmi_XXX16-(nmi_bcs+2)                                        ; 90cf: a9 5d       .]  :0d68[6]
+    bne l0d30                                                         ; 90d1: d0 c4       ..  :0d6a[6]
+nmi_XXX16
+    cmp #$fb                                                          ; 90d3: c9 fb       ..  :0d6c[6]
+    beq c0d74                                                         ; 90d5: f0 04       ..  :0d6e[6]
+    cmp #$f8                                                          ; 90d7: c9 f8       ..  :0d70[6]
+    bne nmi_XXX23                                                     ; 90d9: d0 bf       ..  :0d72[6]
+; $90db referenced 1 time by $0d6e
+c0d74
+    sta l00b6                                                         ; 90db: 85 b6       ..  :0d74[6]
+    lda l00b5                                                         ; 90dd: a5 b5       ..  :0d76[6]
+    bne c0d80                                                         ; 90df: d0 06       ..  :0d78[6]
+    inc l00cf                                                         ; 90e1: e6 cf       ..  :0d7a[6]
+    lda #nmi_XXX17-(nmi_bcs+2)                                        ; 90e3: a9 06       ..  :0d7c[6]
+    bne l0d30                                                         ; 90e5: d0 b0       ..  :0d7e[6]
+; $90e7 referenced 1 time by $0d78
+c0d80
+    inc l00a5                                                         ; 90e7: e6 a5       ..  :0d80[6]
+    lda #nmi_XXX18-(nmi_bcs+2)                                        ; 90e9: a9 11       ..  :0d82[6]
+    bne l0d30                                                         ; 90eb: d0 aa       ..  :0d84[6]
+nmi_XXX22
+    lda #nmi_XXX19-(nmi_bcs+2)                                        ; 90ed: a9 7b       .{  :0d86[6]
+    bne l0d30                                                         ; 90ef: d0 a6       ..  :0d88[6]
+nmi_XXX19
+    lda #nmi_XXX20-(nmi_bcs+2)                                        ; 90f1: a9 7f       ..  :0d8a[6]
+    bne l0d30                                                         ; 90f3: d0 a2       ..  :0d8c[6]
+nmi_XXX20
+    bne nmi_XXX23                                                     ; 90f5: d0 a3       ..  :0d8e[6]
+    lda #nmi_XXX21-(nmi_bcs+2)                                        ; 90f7: a9 26       .&  :0d90[6]
+    bne l0d30                                                         ; 90f9: d0 9c       ..  :0d92[6]
+; $90fb referenced 3 times by $8d41, $8d92, $9101
+}
+
+; $90fb referenced 3 times by $8d41, $8d92, $9101
+nmi_handler2_rom_end
+; $90fb referenced 3 times by $8d41, $8d92, $9101
+    sta lfe86                                                         ; 90fb: 8d 86 fe    ...
+    cmp lfe86                                                         ; 90fe: cd 86 fe    ...
+    bne nmi_handler2_rom_end                                          ; 9101: d0 f8       ..
+    rts                                                               ; 9103: 60          `
+
+; $9104 referenced 1 time by $966b
+set_c_iff_have_fdc
+    ldx #0                                                            ; 9104: a2 00       ..
+    lda #$5a ; 'Z'                                                    ; 9106: a9 5a       .Z
+; $9108 referenced 1 time by $9111
+loop_c9108
+    sta lfe85                                                         ; 9108: 8d 85 fe    ...
+    cmp lfe85                                                         ; 910b: cd 85 fe    ...
+    beq c9115                                                         ; 910e: f0 05       ..
+    dex                                                               ; 9110: ca          .
+    bne loop_c9108                                                    ; 9111: d0 f5       ..
+; $9113 referenced 1 time by $911a
+loop_c9113
+    clc                                                               ; 9113: 18          .
+    rts                                                               ; 9114: 60          `
+
+; $9115 referenced 1 time by $910e
+c9115
+    lda lfe80                                                         ; 9115: ad 80 fe    ...
+    and #3                                                            ; 9118: 29 03       ).
+    beq loop_c9113                                                    ; 911a: f0 f7       ..
+    rts                                                               ; 911c: 60          `
+
+; $911d referenced 1 time by $8cd8
+l911d
+    !text ")*-."                                                      ; 911d: 29 2a 2d... )*-
+; $9121 referenced 1 time by $8e15
+l9121
+    !byte   0, $10, $40, $50, $80, $81, $83, $a0, $a1, $c0, $e0, $f0  ; 9121: 00 10 40... ..@
+; $912d referenced 1 time by $8e1b
+nmi_and_table
+    !byte $18, $18, $18, $18, $3f, $1f, $1f, $5f, $5f, $17, $1b, $5f  ; 912d: 18 18 18... ...
+; $9139 referenced 1 time by $8c58
+l9139
+    !byte   8, $10, $18, $20, $40,   0                                ; 9139: 08 10 18... ...
+; $913f referenced 1 time by $8c61
+l913f
+    !byte $0e, $18, $0c, $20, $12,   0                                ; 913f: 0e 18 0c... ...
+; $9145 referenced 1 time by $92e3
+l9145
+    !byte $6d                                                         ; 9145: 6d          m
+; $9146 referenced 1 time by $92e8
+l9146
+    !byte $91, $49, $91                                               ; 9146: 91 49 91    .I.
+    !byte $3c, $0c,   3                                               ; 9149: 3c 0c 03    <..
+    !byte   1,   1,   1                                               ; 914c: 01 01 01    ...
+    !byte   1,   1,   1                                               ; 914f: 01 01 01    ...
+    !byte $16, $0c,   3                                               ; 9152: 16 0c 03    ...
+    !byte   1, $ff,   1                                               ; 9155: 01 ff 01    ...
+    !byte   1, $18,   4                                               ; 9158: 01 18 04    ...
+    !byte $4e,   0, $f5                                               ; 915b: 4e 00 f5    N..
+    !byte $fe,   0,   0                                               ; 915e: fe 00 00    ...
+    !byte   0,   0, $f7                                               ; 9161: 00 00 f7    ...
+    !byte $4e,   0                                                    ; 9164: 4e 00       N.
+    !byte $f5, $fb, $5a, $5a, $f7, $4e, $4e, $10,   6,   0,   1,   1  ; 9166: f5 fb 5a... ..Z
+    !byte   1,   1,   1,   1, $0b,   6,   0,   1, $ff,   1,   1, $13  ; 9172: 01 01 01... ...
+    !byte   3, $ff,   0,   0, $fe,   0,   0,   0,   0, $f7, $ff,   0  ; 917e: 03 ff 00... ...
+    !byte   0, $fb, $e5, $e5, $f7, $ff, $ff                           ; 918a: 00 fb e5... ...
+; $9191 referenced 1 time by $91df
+l9191
+    !byte $0a, $0b, $0e, $0f, $12, $13, $16, $17, $1b, $1e, $1f       ; 9191: 0a 0b 0e... ...
+    !text "#) 0"                                                      ; 919c: 23 29 20... #)
+; $91a0 referenced 1 time by $9201
+l91a0
+    !byte $a0, $a0, $a1, $a1, $80, $80, $81, $81, $c0, $83, $83, $f0  ; 91a0: a0 a0 a1... ...
+    !byte $10, $e0, $f0                                               ; 91ac: 10 e0 f0    ...
+
+; $91af referenced 3 times by $9758, $a6dc, $a700
+c91af
+    lda #$ff                                                          ; 91af: a9 ff       ..
+    sta l1082                                                         ; 91b1: 8d 82 10    ...
+    stx l00c7                                                         ; 91b4: 86 c7       ..
+    sty l00c8                                                         ; 91b6: 84 c8       ..
+    ldy #$0c                                                          ; 91b8: a0 0c       ..
+; $91ba referenced 1 time by $91c0
+loop_c91ba
+    lda (l00c7),y                                                     ; 91ba: b1 c7       ..
+    sta l00ba,y                                                       ; 91bc: 99 ba 00    ...
+    dey                                                               ; 91bf: 88          .
+    bpl loop_c91ba                                                    ; 91c0: 10 f8       ..
+    ldx #$0c                                                          ; 91c2: a2 0c       ..
+    lda l00bf                                                         ; 91c4: a5 bf       ..
+    cmp #$0a                                                          ; 91c6: c9 0a       ..
+    bne c91cc                                                         ; 91c8: d0 02       ..
+    ldx #$0e                                                          ; 91ca: a2 0e       ..
+; $91cc referenced 1 time by $91c8
+c91cc
+    lda l00c0                                                         ; 91cc: a5 c0       ..
+    and #$3f ; '?'                                                    ; 91ce: 29 3f       )?
+    cmp #$3a ; ':'                                                    ; 91d0: c9 3a       .:
+    beq c921f                                                         ; 91d2: f0 4b       .K
+    cmp #$3d ; '='                                                    ; 91d4: c9 3d       .=
+    beq c923f                                                         ; 91d6: f0 67       .g
+    cmp #$35 ; '5'                                                    ; 91d8: c9 35       .5
+    bne c91df                                                         ; 91da: d0 03       ..
+    jmp c925a                                                         ; 91dc: 4c 5a 92    LZ.
+
+; $91df referenced 2 times by $91da, $91e5
+c91df
+    cmp l9191,x                                                       ; 91df: dd 91 91    ...
+    beq c91eb                                                         ; 91e2: f0 07       ..
+    dex                                                               ; 91e4: ca          .
+    bpl c91df                                                         ; 91e5: 10 f8       ..
+; $91e7 referenced 1 time by $91ff
+loop_c91e7
+    lda #$fe                                                          ; 91e7: a9 fe       ..
+    bmi c9214                                                         ; 91e9: 30 29       0)
+; $91eb referenced 1 time by $91e2
+c91eb
+    cmp #$23 ; '#'                                                    ; 91eb: c9 23       .#
+    beq c91f3                                                         ; 91ed: f0 04       ..
+    cpx #4                                                            ; 91ef: e0 04       ..
+    bcs c9201                                                         ; 91f1: b0 0e       ..
+; $91f3 referenced 1 time by $91ed
+c91f3
+    lda l00ba                                                         ; 91f3: a5 ba       ..
+    bpl c91f9                                                         ; 91f5: 10 02       ..
+    lda l00cd                                                         ; 91f7: a5 cd       ..
+; $91f9 referenced 1 time by $91f5
+c91f9
+    and #3                                                            ; 91f9: 29 03       ).
+    tay                                                               ; 91fb: a8          .
+    lda l10de,y                                                       ; 91fc: b9 de 10    ...
+    bmi loop_c91e7                                                    ; 91ff: 30 e6       0.
+; $9201 referenced 1 time by $91f1
+c9201
+    ldy l91a0,x                                                       ; 9201: bc a0 91    ...
+    sty l00c0                                                         ; 9204: 84 c0       ..
+    cpy #$f0                                                          ; 9206: c0 f0       ..
+    bne c920d                                                         ; 9208: d0 03       ..
+    jsr sub_c929d                                                     ; 920a: 20 9d 92     ..
+; $920d referenced 1 time by $9208
+c920d
+    ldx #$ba                                                          ; 920d: a2 ba       ..
+    ldy #0                                                            ; 920f: a0 00       ..
+    jsr sub_c8bf9                                                     ; 9211: 20 f9 8b     ..
+; $9214 referenced 3 times by $91e9, $9257, $9276
+c9214
+    pha                                                               ; 9214: 48          H
+    lda l00bf                                                         ; 9215: a5 bf       ..
+    clc                                                               ; 9217: 18          .
+    adc #7                                                            ; 9218: 69 07       i.
+    tay                                                               ; 921a: a8          .
+    pla                                                               ; 921b: 68          h
+    sta (l00c7),y                                                     ; 921c: 91 c7       ..
+    rts                                                               ; 921e: 60          `
+
+; $921f referenced 1 time by $91d2
+c921f
+    jsr sub_c928a                                                     ; 921f: 20 8a 92     ..
+    bcs c922b                                                         ; 9222: b0 07       ..
+    lda l00c2                                                         ; 9224: a5 c2       ..
+    sta l108b,x                                                       ; 9226: 9d 8b 10    ...
+    bcc c923b                                                         ; 9229: 90 10       ..
+; $922b referenced 1 time by $9222
+c922b
+    jsr sub_c9279                                                     ; 922b: 20 79 92     y.
+    bcc c9257                                                         ; 922e: 90 27       .'
+    lda l00c2                                                         ; 9230: a5 c2       ..
+    ldy l10de,x                                                       ; 9232: bc de 10    ...
+    bpl c9238                                                         ; 9235: 10 01       ..
+    asl                                                               ; 9237: 0a          .
+; $9238 referenced 1 time by $9235
+c9238
+    sta l1088,x                                                       ; 9238: 9d 88 10    ...
+; $923b referenced 1 time by $9229
+c923b
+    lda #0                                                            ; 923b: a9 00       ..
+    beq c9257                                                         ; 923d: f0 18       ..
+; $923f referenced 1 time by $91d6
+c923f
+    jsr sub_c928a                                                     ; 923f: 20 8a 92     ..
+    bcs c9249                                                         ; 9242: b0 05       ..
+    lda l108b,x                                                       ; 9244: bd 8b 10    ...
+    bcc c9257                                                         ; 9247: 90 0e       ..
+; $9249 referenced 1 time by $9242
+c9249
+    jsr sub_c9279                                                     ; 9249: 20 79 92     y.
+    bcc c9257                                                         ; 924c: 90 09       ..
+    lda l1088,x                                                       ; 924e: bd 88 10    ...
+    ldy l10de,x                                                       ; 9251: bc de 10    ...
+    bpl c9257                                                         ; 9254: 10 01       ..
+    lsr                                                               ; 9256: 4a          J
+; $9257 referenced 5 times by $922e, $923d, $9247, $924c, $9254
+c9257
+    jmp c9214                                                         ; 9257: 4c 14 92    L..
+
+; $925a referenced 1 time by $91dc
+c925a
+    lda #$ff                                                          ; 925a: a9 ff       ..
+    ldx #0                                                            ; 925c: a2 00       ..
+    ldy l00c1                                                         ; 925e: a4 c1       ..
+    cpy #$10                                                          ; 9260: c0 10       ..
+    beq c926a                                                         ; 9262: f0 06       ..
+    cpy #$18                                                          ; 9264: c0 18       ..
+    bne c9276                                                         ; 9266: d0 0e       ..
+    inx                                                               ; 9268: e8          .
+    inx                                                               ; 9269: e8          .
+; $926a referenced 1 time by $9262
+c926a
+    lda l00c2                                                         ; 926a: a5 c2       ..
+    sta l108b,x                                                       ; 926c: 9d 8b 10    ...
+    lda l00c3                                                         ; 926f: a5 c3       ..
+    sta l108c,x                                                       ; 9271: 9d 8c 10    ...
+    lda #0                                                            ; 9274: a9 00       ..
+; $9276 referenced 1 time by $9266
+c9276
+    jmp c9214                                                         ; 9276: 4c 14 92    L..
+
+; $9279 referenced 2 times by $922b, $9249
+sub_c9279
+    ldx #0                                                            ; 9279: a2 00       ..
+    lda l00c1                                                         ; 927b: a5 c1       ..
+    cmp #$12                                                          ; 927d: c9 12       ..
+    beq c9289                                                         ; 927f: f0 08       ..
+    inx                                                               ; 9281: e8          .
+    cmp #$1a                                                          ; 9282: c9 1a       ..
+    beq c9289                                                         ; 9284: f0 03       ..
+    lda #$fe                                                          ; 9286: a9 fe       ..
+    clc                                                               ; 9288: 18          .
+; $9289 referenced 2 times by $927f, $9284
+c9289
+    rts                                                               ; 9289: 60          `
+
+; $928a referenced 2 times by $921f, $923f
+sub_c928a
+    lda l00c1                                                         ; 928a: a5 c1       ..
+    and #$f6                                                          ; 928c: 29 f6       ).
+    cmp #$10                                                          ; 928e: c9 10       ..
+    sec                                                               ; 9290: 38          8
+    bne c929c                                                         ; 9291: d0 09       ..
+    lda l00c1                                                         ; 9293: a5 c1       ..
+    lsr                                                               ; 9295: 4a          J
+    lsr                                                               ; 9296: 4a          J
+    ora l00c1                                                         ; 9297: 05 c1       ..
+    and #3                                                            ; 9299: 29 03       ).
+    tax                                                               ; 929b: aa          .
+; $929c referenced 1 time by $9291
+c929c
+    rts                                                               ; 929c: 60          `
+
+; $929d referenced 1 time by $920a
+sub_c929d
+    jsr sub_c9a8d                                                     ; 929d: 20 8d 9a     ..
+    lda l00bb                                                         ; 92a0: a5 bb       ..
+    sta l00b0                                                         ; 92a2: 85 b0       ..
+    sta l00b4                                                         ; 92a4: 85 b4       ..
+    clc                                                               ; 92a6: 18          .
+    adc #$80                                                          ; 92a7: 69 80       i.
+    sta l00b2                                                         ; 92a9: 85 b2       ..
+    lda l00bc                                                         ; 92ab: a5 bc       ..
+    sta l00b1                                                         ; 92ad: 85 b1       ..
+    php                                                               ; 92af: 08          .
+    jsr sub_c8f3f                                                     ; 92b0: 20 3f 8f     ?.
+    bmi c92bd                                                         ; 92b3: 30 08       0.
+    lda l00bd                                                         ; 92b5: a5 bd       ..
+    ora l00be                                                         ; 92b7: 05 be       ..
+    cmp #$ff                                                          ; 92b9: c9 ff       ..
+    bne c92c4                                                         ; 92bb: d0 07       ..
+; $92bd referenced 1 time by $92b3
+c92bd
+    lda l00b1                                                         ; 92bd: a5 b1       ..
+    cmp l10cf                                                         ; 92bf: cd cf 10    ...
+    bcs c92c7                                                         ; 92c2: b0 03       ..
+; $92c4 referenced 1 time by $92bb
+c92c4
+    lda l10cf                                                         ; 92c4: ad cf 10    ...
+; $92c7 referenced 1 time by $92c2
+c92c7
+    plp                                                               ; 92c7: 28          (
+    sta l00b5                                                         ; 92c8: 85 b5       ..
+    adc #0                                                            ; 92ca: 69 00       i.
+    sta l00b3                                                         ; 92cc: 85 b3       ..
+    inc l00b5                                                         ; 92ce: e6 b5       ..
+    lda l00ba                                                         ; 92d0: a5 ba       ..
+    bpl c92d6                                                         ; 92d2: 10 02       ..
+    lda #0                                                            ; 92d4: a9 00       ..
+; $92d6 referenced 1 time by $92d2
+c92d6
+    rol                                                               ; 92d6: 2a          *
+    rol                                                               ; 92d7: 2a          *
+    rol                                                               ; 92d8: 2a          *
+    sta l108a                                                         ; 92d9: 8d 8a 10    ...
+    ldx #2                                                            ; 92dc: a2 02       ..
+    rol                                                               ; 92de: 2a          *
+    bmi c92e3                                                         ; 92df: 30 02       0.
+    ldx #0                                                            ; 92e1: a2 00       ..
+; $92e3 referenced 1 time by $92df
+c92e3
+    lda l9145,x                                                       ; 92e3: bd 45 91    .E.
+    sta l00b6                                                         ; 92e6: 85 b6       ..
+    lda l9146,x                                                       ; 92e8: bd 46 91    .F.
+    sta l00b7                                                         ; 92eb: 85 b7       ..
+    ldy #$23 ; '#'                                                    ; 92ed: a0 23       .#
+; $92ef referenced 1 time by $92f4
+loop_c92ef
+    lda (l00b6),y                                                     ; 92ef: b1 b6       ..
+    sta (l00b2),y                                                     ; 92f1: 91 b2       ..
+    dey                                                               ; 92f3: 88          .
+    bpl loop_c92ef                                                    ; 92f4: 10 f9       ..
+    iny                                                               ; 92f6: c8          .
+    sty l00b6                                                         ; 92f7: 84 b6       ..
+    lda l00c3                                                         ; 92f9: a5 c3       ..
+    pha                                                               ; 92fb: 48          H
+    and #$e0                                                          ; 92fc: 29 e0       ).
+    bne c9302                                                         ; 92fe: d0 02       ..
+    lda #$10                                                          ; 9300: a9 10       ..
+; $9302 referenced 1 time by $92fe
+c9302
+    asl                                                               ; 9302: 0a          .
+    rol l00b6                                                         ; 9303: 26 b6       &.
+    asl                                                               ; 9305: 0a          .
+    rol l00b6                                                         ; 9306: 26 b6       &.
+    asl                                                               ; 9308: 0a          .
+    rol l00b6                                                         ; 9309: 26 b6       &.
+    ldy #$0d                                                          ; 930b: a0 0d       ..
+    sta (l00b2),y                                                     ; 930d: 91 b2       ..
+    lda l00b6                                                         ; 930f: a5 b6       ..
+    iny                                                               ; 9311: c8          .
+    sta (l00b2),y                                                     ; 9312: 91 b2       ..
+    pla                                                               ; 9314: 68          h
+    and #$1f                                                          ; 9315: 29 1f       ).
+    sta l00b9                                                         ; 9317: 85 b9       ..
+    lda l00c2                                                         ; 9319: a5 c2       ..
+    ldy #$10                                                          ; 931b: a0 10       ..
+    sta (l00b2),y                                                     ; 931d: 91 b2       ..
+    lda l00c5                                                         ; 931f: a5 c5       ..
+    ldy #0                                                            ; 9321: a0 00       ..
+    sta (l00b2),y                                                     ; 9323: 91 b2       ..
+    tya                                                               ; 9325: 98          .
+    sta l00b8                                                         ; 9326: 85 b8       ..
+    jsr sub_c93d3                                                     ; 9328: 20 d3 93     ..
+    jsr sub_c8f3f                                                     ; 932b: 20 3f 8f     ?.
+    bmi c9367                                                         ; 932e: 30 37       07
+    lda l00bd                                                         ; 9330: a5 bd       ..
+    and l00be                                                         ; 9332: 25 be       %.
+    cmp #$ff                                                          ; 9334: c9 ff       ..
+    beq c9367                                                         ; 9336: f0 2f       ./
+    lda #$ff                                                          ; 9338: a9 ff       ..
+    sta l00bd                                                         ; 933a: 85 bd       ..
+    sta l00be                                                         ; 933c: 85 be       ..
+    jsr sub_c8f6b                                                     ; 933e: 20 6b 8f     k.
+    ldx #$bb                                                          ; 9341: a2 bb       ..
+    ldy #0                                                            ; 9343: a0 00       ..
+    tya                                                               ; 9345: 98          .
+    jsr tube_entry                                                    ; 9346: 20 06 04     ..
+    ldx l00b5                                                         ; 9349: a6 b5       ..
+    dex                                                               ; 934b: ca          .
+    stx l00b1                                                         ; 934c: 86 b1       ..
+    lda l00b9                                                         ; 934e: a5 b9       ..
+    asl                                                               ; 9350: 0a          .
+    asl                                                               ; 9351: 0a          .
+    tax                                                               ; 9352: aa          .
+    ldy #0                                                            ; 9353: a0 00       ..
+; $9355 referenced 1 time by $9362
+loop_c9355
+    lda #7                                                            ; 9355: a9 07       ..
+; $9357 referenced 1 time by $9359
+loop_c9357
+    sbc #1                                                            ; 9357: e9 01       ..
+    bne loop_c9357                                                    ; 9359: d0 fc       ..
+    lda tube_host_r3_data                                             ; 935b: ad e5 fe    ...
+    sta (l00b0),y                                                     ; 935e: 91 b0       ..
+    iny                                                               ; 9360: c8          .
+    dex                                                               ; 9361: ca          .
+    bpl loop_c9355                                                    ; 9362: 10 f1       ..
+    jsr sub_c8f7a                                                     ; 9364: 20 7a 8f     z.
+; $9367 referenced 2 times by $932e, $9336
+c9367
+    lda l00b5                                                         ; 9367: a5 b5       ..
+    sta l00bc                                                         ; 9369: 85 bc       ..
+; $936b referenced 1 time by $939c
+c936b
+    ldy #$16                                                          ; 936b: a0 16       ..
+    ldx #0                                                            ; 936d: a2 00       ..
+; $936f referenced 1 time by $937c
+loop_c936f
+    lda (l00b0,x)                                                     ; 936f: a1 b0       ..
+    sta (l00b2),y                                                     ; 9371: 91 b2       ..
+    inc l00b0                                                         ; 9373: e6 b0       ..
+    bne c9379                                                         ; 9375: d0 02       ..
+    inc l00b1                                                         ; 9377: e6 b1       ..
+; $9379 referenced 1 time by $9375
+c9379
+    iny                                                               ; 9379: c8          .
+    cpy #$1a                                                          ; 937a: c0 1a       ..
+    bne loop_c936f                                                    ; 937c: d0 f1       ..
+    lda #1                                                            ; 937e: a9 01       ..
+    sta l00b6                                                         ; 9380: 85 b6       ..
+; $9382 referenced 1 time by $9396
+loop_c9382
+    lda l00b6                                                         ; 9382: a5 b6       ..
+    cmp #$0e                                                          ; 9384: c9 0e       ..
+    bne c938d                                                         ; 9386: d0 05       ..
+    jsr sub_c93b4                                                     ; 9388: 20 b4 93     ..
+    beq c9390                                                         ; 938b: f0 03       ..
+; $938d referenced 1 time by $9386
+c938d
+    jsr sub_c93d3                                                     ; 938d: 20 d3 93     ..
+; $9390 referenced 1 time by $938b
+c9390
+    inc l00b6                                                         ; 9390: e6 b6       ..
+    lda l00b6                                                         ; 9392: a5 b6       ..
+    cmp #$11                                                          ; 9394: c9 11       ..
+    bne loop_c9382                                                    ; 9396: d0 ea       ..
+    inc l00b8                                                         ; 9398: e6 b8       ..
+    dec l00b9                                                         ; 939a: c6 b9       ..
+    bne c936b                                                         ; 939c: d0 cd       ..
+    tay                                                               ; 939e: a8          .
+    lda #$0e                                                          ; 939f: a9 0e       ..
+    bit l108a                                                         ; 93a1: 2c 8a 10    ,..
+    bvc c93a8                                                         ; 93a4: 50 02       P.
+    lda #$1a                                                          ; 93a6: a9 1a       ..
+; $93a8 referenced 1 time by $93a4
+c93a8
+    clc                                                               ; 93a8: 18          .
+    adc l00bc                                                         ; 93a9: 65 bc       e.
+    sbc l00b5                                                         ; 93ab: e5 b5       ..
+    bcs c93b1                                                         ; 93ad: b0 02       ..
+    lda #1                                                            ; 93af: a9 01       ..
+; $93b1 referenced 1 time by $93ad
+c93b1
+    sta (l00b2),y                                                     ; 93b1: 91 b2       ..
+    tya                                                               ; 93b3: 98          .
+; $93b4 referenced 1 time by $9388
+sub_c93b4
+    jsr sub_c93c5                                                     ; 93b4: 20 c5 93     ..
+    beq c93c4                                                         ; 93b7: f0 0b       ..
+    stx l00b7                                                         ; 93b9: 86 b7       ..
+    ldx #0                                                            ; 93bb: a2 00       ..
+; $93bd referenced 1 time by $93c2
+loop_c93bd
+    jsr sub_c93d8                                                     ; 93bd: 20 d8 93     ..
+    dec l00b7                                                         ; 93c0: c6 b7       ..
+    bne loop_c93bd                                                    ; 93c2: d0 f9       ..
+; $93c4 referenced 1 time by $93b7
+c93c4
+    rts                                                               ; 93c4: 60          `
+
+; $93c5 referenced 2 times by $93b4, $93d3
+sub_c93c5
+    tay                                                               ; 93c5: a8          .
+    lda (l00b2),y                                                     ; 93c6: b1 b2       ..
+    tax                                                               ; 93c8: aa          .
+    tya                                                               ; 93c9: 98          .
+    clc                                                               ; 93ca: 18          .
+    adc #$12                                                          ; 93cb: 69 12       i.
+    tay                                                               ; 93cd: a8          .
+    lda (l00b2),y                                                     ; 93ce: b1 b2       ..
+    cpx #0                                                            ; 93d0: e0 00       ..
+    rts                                                               ; 93d2: 60          `
+
+; $93d3 referenced 2 times by $9328, $938d
+sub_c93d3
+    jsr sub_c93c5                                                     ; 93d3: 20 c5 93     ..
+    beq c93e5                                                         ; 93d6: f0 0d       ..
+; $93d8 referenced 1 time by $93bd
+sub_c93d8
+    ldy #0                                                            ; 93d8: a0 00       ..
+; $93da referenced 1 time by $93e3
+loop_c93da
+    sta (l00b4),y                                                     ; 93da: 91 b4       ..
+    inc l00b4                                                         ; 93dc: e6 b4       ..
+    bne c93e2                                                         ; 93de: d0 02       ..
+    inc l00b5                                                         ; 93e0: e6 b5       ..
+; $93e2 referenced 1 time by $93de
+c93e2
+    dex                                                               ; 93e2: ca          .
+    bne loop_c93da                                                    ; 93e3: d0 f5       ..
+; $93e5 referenced 1 time by $93d6
+c93e5
+    rts                                                               ; 93e5: 60          `
+
+; $93e6 referenced 10 times by $8772, $8791, $87cb, $89d7, $8a6b, $8b12, $8bf3, $9bbc, $9fff, $a30a
+c93e6
+    lda l0f04                                                         ; 93e6: ad 04 0f    ...
+    clc                                                               ; 93e9: 18          .
+    sed                                                               ; 93ea: f8          .
+    adc #1                                                            ; 93eb: 69 01       i.
+    sta l0f04                                                         ; 93ed: 8d 04 0f    ...
+    cld                                                               ; 93f0: d8          .
+; $93f1 referenced 1 time by $a737
+sub_c93f1
+    ldy #$a0                                                          ; 93f1: a0 a0       ..
+    bne c940e                                                         ; 93f3: d0 19       ..
+; $93f5 referenced 2 times by $9636, $a7ce
+sub_c93f5
+    ldy #$81                                                          ; 93f5: a0 81       ..
+    bne c940e                                                         ; 93f7: d0 15       ..
+; $93f9 referenced 1 time by $8266
+sub_c93f9
+    ldy #$81                                                          ; 93f9: a0 81       ..
+    bne c93ff                                                         ; 93fb: d0 02       ..
+; $93fd referenced 3 times by $8287, $988e, $98da
+sub_c93fd
+    ldy #$80                                                          ; 93fd: a0 80       ..
+; $93ff referenced 1 time by $93fb
+c93ff
+    bit lfe84                                                         ; 93ff: 2c 84 fe    ,..
+    bpl c940e                                                         ; 9402: 10 0a       ..
+    lda l1082                                                         ; 9404: ad 82 10    ...
+    cmp l00cd                                                         ; 9407: c5 cd       ..
+    bne c940e                                                         ; 9409: d0 03       ..
+    rts                                                               ; 940b: 60          `
+
+; $940c referenced 6 times by $8383, $8489, $8a59, $a431, $a448, $a460
+c940c
+    ldy #$80                                                          ; 940c: a0 80       ..
+; $940e referenced 4 times by $93f3, $93f7, $9402, $9409
+c940e
+    jsr sub_c9536                                                     ; 940e: 20 36 95     6.
+    sty l1096                                                         ; 9411: 8c 96 10    ...
+    lda l00cd                                                         ; 9414: a5 cd       ..
+    sta l1090                                                         ; 9416: 8d 90 10    ...
+    lda #2                                                            ; 9419: a9 02       ..
+    sta l1099                                                         ; 941b: 8d 99 10    ...
+    lda #$0e                                                          ; 941e: a9 0e       ..
+    sta l1092                                                         ; 9420: 8d 92 10    ...
+    dec l1093                                                         ; 9423: ce 93 10    ...
+    dec l1094                                                         ; 9426: ce 94 10    ...
+    jsr sub_c9445                                                     ; 9429: 20 45 94     E.
+    lda l00cd                                                         ; 942c: a5 cd       ..
+    sta l1082                                                         ; 942e: 8d 82 10    ...
+    rts                                                               ; 9431: 60          `
+
+; $9432 referenced 2 times by $944d, $a6f9
+sub_c9432
+    bit l00ff                                                         ; 9432: 24 ff       $.
+    bpl c9444                                                         ; 9434: 10 0e       ..
+; $9436 referenced 4 times by $946c, $a411, $a65d, $abc2
+c9436
+    jsr sub_c9ad8                                                     ; 9436: 20 d8 9a     ..
+    jsr generate_error                                                ; 9439: 20 48 80     H.
+    !byte $11                                                         ; 943c: 11          .
+    !text "Escape"                                                    ; 943d: 45 73 63... Esc
+    !byte 0                                                           ; 9443: 00          .
+
+; $9444 referenced 3 times by $9434, $946a, $947a
+c9444
+    rts                                                               ; 9444: 60          `
+
+; $9445 referenced 2 times by $886a, $9429
+sub_c9445
+    jsr sub_c9516                                                     ; 9445: 20 16 95     ..
+    lda #6                                                            ; 9448: a9 06       ..
+    sta l109e                                                         ; 944a: 8d 9e 10    ...
+    jsr sub_c9432                                                     ; 944d: 20 32 94     2.
+; $9450 referenced 1 time by $94bf
+c9450
+    lda l1097                                                         ; 9450: ad 97 10    ...
+    ldx l1090                                                         ; 9453: ae 90 10    ...
+    ldy l10de,x                                                       ; 9456: bc de 10    ...
+    bpl c945c                                                         ; 9459: 10 01       ..
+    asl                                                               ; 945b: 0a          .
+; $945c referenced 1 time by $9459
+c945c
+    ldy #$18                                                          ; 945c: a0 18       ..
+    cmp #$50 ; 'P'                                                    ; 945e: c9 50       .P
+    bcs c94c1                                                         ; 9460: b0 5f       ._
+    ldx #$90                                                          ; 9462: a2 90       ..
+    ldy #$10                                                          ; 9464: a0 10       ..
+    jsr sub_c8bf6                                                     ; 9466: 20 f6 8b     ..
+    tay                                                               ; 9469: a8          .
+    beq c9444                                                         ; 946a: f0 d8       ..
+    bmi c9436                                                         ; 946c: 30 c8       0.
+    cmp #$12                                                          ; 946e: c9 12       ..
+    beq c94c6                                                         ; 9470: f0 54       .T
+    cmp #$20 ; ' '                                                    ; 9472: c9 20       .
+    bne c948d                                                         ; 9474: d0 17       ..
+    lda l1096                                                         ; 9476: ad 96 10    ...
+    ror                                                               ; 9479: 6a          j
+    bcs c9444                                                         ; 947a: b0 c8       ..
+    jsr generate_error                                                ; 947c: 20 48 80     H.
+    !byte $bc                                                         ; 947f: bc          .
+    !text "Execute only"                                              ; 9480: 45 78 65... Exe
+    !byte 0                                                           ; 948c: 00          .
+
+; $948d referenced 1 time by $9474
+c948d
+    cmp #$18                                                          ; 948d: c9 18       ..
+    bne c94bc                                                         ; 948f: d0 2b       .+
+    lda l108a                                                         ; 9491: ad 8a 10    ...
+    cmp #4                                                            ; 9494: c9 04       ..
+    bne c94a9                                                         ; 9496: d0 11       ..
+    ldx l1096                                                         ; 9498: ae 96 10    ...
+    cpx #$81                                                          ; 949b: e0 81       ..
+    bne c94a9                                                         ; 949d: d0 0a       ..
+    lda #$ff                                                          ; 949f: a9 ff       ..
+    eor l108b                                                         ; 94a1: 4d 8b 10    M..
+    sta l108b                                                         ; 94a4: 8d 8b 10    ...
+    bcs c94bc                                                         ; 94a7: b0 13       ..
+; $94a9 referenced 2 times by $9496, $949d
+c94a9
+    ldx l00ce                                                         ; 94a9: a6 ce       ..
+    beq c94bc                                                         ; 94ab: f0 0f       ..
+    rol                                                               ; 94ad: 2a          *
+    and #$80                                                          ; 94ae: 29 80       ).
+    ldx l1090                                                         ; 94b0: ae 90 10    ...
+    eor l10de,x                                                       ; 94b3: 5d de 10    ]..
+    sta l10de,x                                                       ; 94b6: 9d de 10    ...
+    jsr sub_c9516                                                     ; 94b9: 20 16 95     ..
+; $94bc referenced 3 times by $948f, $94a7, $94ab
+c94bc
+    dec l109e                                                         ; 94bc: ce 9e 10    ...
+    bne c9450                                                         ; 94bf: d0 8f       ..
+; $94c1 referenced 1 time by $9460
+c94c1
+    tya                                                               ; 94c1: 98          .
+; $94c2 referenced 1 time by $a70f
+c94c2
+    cmp #$12                                                          ; 94c2: c9 12       ..
+    bne c94d4                                                         ; 94c4: d0 0e       ..
+; $94c6 referenced 2 times by $9470, $9523
+c94c6
+    jsr generate_error_precheck_disc                                  ; 94c6: 20 23 80     #.
+    !byte $c9                                                         ; 94c9: c9          .
+    !text "read only"                                                 ; 94ca: 72 65 61... rea
+    !byte 0                                                           ; 94d3: 00          .
+
+; $94d4 referenced 1 time by $94c4
+c94d4
+    pha                                                               ; 94d4: 48          H
+    jsr generate_error_precheck_disc                                  ; 94d5: 20 23 80     #.
+    !byte 0                                                           ; 94d8: 00          .
+
+    nop                                                               ; 94d9: ea          .
+    jsr generate_error2                                               ; 94da: 20 4f 80     O.
+    !byte $c7                                                         ; 94dd: c7          .
+    !text "fault "                                                    ; 94de: 66 61 75... fau
+
+    nop                                                               ; 94e4: ea          .
+    pla                                                               ; 94e5: 68          h
+    jsr sub_c9526                                                     ; 94e6: 20 26 95     &.
+    jsr generate_error2                                               ; 94e9: 20 4f 80     O.
+    !byte 0                                                           ; 94ec: 00          .
+    !text " at :"                                                     ; 94ed: 20 61 74...  at
+
+    lda l00cd                                                         ; 94f2: a5 cd       ..
+    jsr sub_c952e                                                     ; 94f4: 20 2e 95     ..
+    jsr generate_error2                                               ; 94f7: 20 4f 80     O.
+    !byte 0                                                           ; 94fa: 00          .
+    !text " "                                                         ; 94fb: 20
+
+    lda l00ce                                                         ; 94fc: a5 ce       ..
+    bit l108a                                                         ; 94fe: 2c 8a 10    ,..
+    bpl c9504                                                         ; 9501: 10 01       ..
+    lsr                                                               ; 9503: 4a          J
+; $9504 referenced 1 time by $9501
+c9504
+    jsr sub_c9526                                                     ; 9504: 20 26 95     &.
+    jsr generate_error2                                               ; 9507: 20 4f 80     O.
+    !byte 0                                                           ; 950a: 00          .
+    !text "/"                                                         ; 950b: 2f          /
+
+    lda l00cf                                                         ; 950c: a5 cf       ..
+    jsr sub_c9526                                                     ; 950e: 20 26 95     &.
+    jsr generate_error2                                               ; 9511: 20 4f 80     O.
+    !byte $c7,   0                                                    ; 9514: c7 00       ..
+
+; $9516 referenced 2 times by $9445, $94b9
+sub_c9516
+    lda l1096                                                         ; 9516: ad 96 10    ...
+    cmp #$a0                                                          ; 9519: c9 a0       ..
+    bcc c9535                                                         ; 951b: 90 18       ..
+    ldx l1090                                                         ; 951d: ae 90 10    ...
+    lda l10de,x                                                       ; 9520: bd de 10    ...
+    bmi c94c6                                                         ; 9523: 30 a1       0.
+    rts                                                               ; 9525: 60          `
+
+; $9526 referenced 3 times by $94e6, $9504, $950e
+sub_c9526
+    pha                                                               ; 9526: 48          H
+    jsr sub_c81bf                                                     ; 9527: 20 bf 81     ..
+    jsr sub_c952e                                                     ; 952a: 20 2e 95     ..
+    pla                                                               ; 952d: 68          h
+; $952e referenced 2 times by $94f4, $952a
+sub_c952e
+    jsr sub_c80c8                                                     ; 952e: 20 c8 80     ..
+    sta l0100,x                                                       ; 9531: 9d 00 01    ...
+    inx                                                               ; 9534: e8          .
+; $9535 referenced 1 time by $951b
+c9535
+    rts                                                               ; 9535: 60          `
+
+; $9536 referenced 1 time by $940e
+sub_c9536
+    ldx #$0d                                                          ; 9536: a2 0d       ..
+    lda #0                                                            ; 9538: a9 00       ..
+; $953a referenced 1 time by $953e
+loop_c953a
+    sta l108f,x                                                       ; 953a: 9d 8f 10    ...
+    dex                                                               ; 953d: ca          .
+    bne loop_c953a                                                    ; 953e: d0 fa       ..
+    lda #5                                                            ; 9540: a9 05       ..
+    sta l1095                                                         ; 9542: 8d 95 10    ...
+    rts                                                               ; 9545: 60          `
+
+    !text "L.!BOOT", $0d                                              ; 9546: 4c 2e 21... L.!
+    !text "E.!BOOT", $0d                                              ; 954e: 45 2e 21... E.!
+
+; $9556 referenced 1 time by $96e9
+c9556
+    lda l00b3                                                         ; 9556: a5 b3       ..
+    jsr print_inline_l809f_top_bit_clear                              ; 9558: 20 77 80     w.
+    !text "Acorn 1770 DFS", $0d, $0d                                  ; 955b: 41 63 6f... Aco
+
+    bcc c956f                                                         ; 956b: 90 02       ..
+; $956d referenced 1 time by $96fd
+c956d
+    lda #$ff                                                          ; 956d: a9 ff       ..
+; $956f referenced 1 time by $956b
+c956f
+    jsr zero_stacked_XXX                                              ; 956f: 20 8e 9d     ..
+    pha                                                               ; 9572: 48          H
+    lda #6                                                            ; 9573: a9 06       ..
+    jsr sub_c8020                                                     ; 9575: 20 20 80      .
+    lda lfe87                                                         ; 9578: ad 87 fe    ...
+    ldx #$0d                                                          ; 957b: a2 0d       ..
+; $957d referenced 1 time by $9584
+loop_c957d
+    lda l9aec,x                                                       ; 957d: bd ec 9a    ...
+    sta filev,x                                                       ; 9580: 9d 12 02    ...
+    dex                                                               ; 9583: ca          .
+    bpl loop_c957d                                                    ; 9584: 10 f7       ..
+    lda #$a8                                                          ; 9586: a9 a8       ..
+    jsr osbyte_read                                                   ; 9588: 20 e5 9a     ..
+    sty l00b1                                                         ; 958b: 84 b1       ..
+    stx l00b0                                                         ; 958d: 86 b0       ..
+    ldx #7                                                            ; 958f: a2 07       ..
+    ldy #$1b                                                          ; 9591: a0 1b       ..
+; $9593 referenced 1 time by $95a5
+loop_c9593
+    lda c9adf,y                                                       ; 9593: b9 df 9a    ...
+    sta (l00b0),y                                                     ; 9596: 91 b0       ..
+    iny                                                               ; 9598: c8          .
+    lda c9adf,y                                                       ; 9599: b9 df 9a    ...
+    sta (l00b0),y                                                     ; 959c: 91 b0       ..
+    iny                                                               ; 959e: c8          .
+    lda romsel_copy                                                   ; 959f: a5 f4       ..
+    sta (l00b0),y                                                     ; 95a1: 91 b0       ..
+    iny                                                               ; 95a3: c8          .
+    dex                                                               ; 95a4: ca          .
+    bne loop_c9593                                                    ; 95a5: d0 ec       ..
+    sty l1082                                                         ; 95a7: 8c 82 10    ...
+    sty l1083                                                         ; 95aa: 8c 83 10    ...
+    stx l00cd                                                         ; 95ad: 86 cd       ..
+    lda #$ff                                                          ; 95af: a9 ff       ..
+    sta l1087                                                         ; 95b1: 8d 87 10    ...
+    ldy #3                                                            ; 95b4: a0 03       ..
+; $95b6 referenced 1 time by $95ba
+loop_c95b6
+    sta l108b,y                                                       ; 95b6: 99 8b 10    ...
+    dey                                                               ; 95b9: 88          .
+    bpl loop_c95b6                                                    ; 95ba: 10 fa       ..
+    ldx #$0f                                                          ; 95bc: a2 0f       ..
+    jsr c9adf                                                         ; 95be: 20 df 9a     ..
+    jsr sub_c9ab8                                                     ; 95c1: 20 b8 9a     ..
+    ldy #$d3                                                          ; 95c4: a0 d3       ..
+    lda (l00b0),y                                                     ; 95c6: b1 b0       ..
+    bpl c95fd                                                         ; 95c8: 10 33       .3
+    pla                                                               ; 95ca: 68          h
+    pha                                                               ; 95cb: 48          H
+    beq c95fd                                                         ; 95cc: f0 2f       ./
+    ldy #$d4                                                          ; 95ce: a0 d4       ..
+    lda (l00b0),y                                                     ; 95d0: b1 b0       ..
+    bmi c9628                                                         ; 95d2: 30 54       0T
+    jsr sub_c9aa3                                                     ; 95d4: 20 a3 9a     ..
+    ldy #0                                                            ; 95d7: a0 00       ..
+; $95d9 referenced 1 time by $95e8
+loop_c95d9
+    lda (l00b0),y                                                     ; 95d9: b1 b0       ..
+    cpy #$c0                                                          ; 95db: c0 c0       ..
+    bcc c95e4                                                         ; 95dd: 90 05       ..
+    sta l1000,y                                                       ; 95df: 99 00 10    ...
+    bcs c95e7                                                         ; 95e2: b0 03       ..
+; $95e4 referenced 1 time by $95dd
+c95e4
+    sta l1100,y                                                       ; 95e4: 99 00 11    ...
+; $95e7 referenced 1 time by $95e2
+c95e7
+    dey                                                               ; 95e7: 88          .
+    bne loop_c95d9                                                    ; 95e8: d0 ef       ..
+    lda #$a0                                                          ; 95ea: a9 a0       ..
+; $95ec referenced 1 time by $95f9
+loop_c95ec
+    tay                                                               ; 95ec: a8          .
+    pha                                                               ; 95ed: 48          H
+    lda #$3f ; '?'                                                    ; 95ee: a9 3f       .?
+    jsr sub_c9f16                                                     ; 95f0: 20 16 9f     ..
+    pla                                                               ; 95f3: 68          h
+    sta l111d,y                                                       ; 95f4: 99 1d 11    ...
+    sbc #$1f                                                          ; 95f7: e9 1f       ..
+    bne loop_c95ec                                                    ; 95f9: d0 f1       ..
+    beq c9628                                                         ; 95fb: f0 2b       .+
+; $95fd referenced 2 times by $95c8, $95cc
+c95fd
+    jsr sub_c9aa3                                                     ; 95fd: 20 a3 9a     ..
+    lda #$24 ; '$'                                                    ; 9600: a9 24       .$
+    sta l10c9                                                         ; 9602: 8d c9 10    ...
+    sta l10cb                                                         ; 9605: 8d cb 10    ...
+    ldy #0                                                            ; 9608: a0 00       ..
+    sty l10ca                                                         ; 960a: 8c ca 10    ...
+    sty l10cc                                                         ; 960d: 8c cc 10    ...
+    ldy #0                                                            ; 9610: a0 00       ..
+    sty l10c0                                                         ; 9612: 8c c0 10    ...
+    ldx #3                                                            ; 9615: a2 03       ..
+    tya                                                               ; 9617: 98          .
+; $9618 referenced 1 time by $961c
+loop_c9618
+    sta l10de,x                                                       ; 9618: 9d de 10    ...
+    dex                                                               ; 961b: ca          .
+    bne loop_c9618                                                    ; 961c: d0 fa       ..
+    dey                                                               ; 961e: 88          .
+    sty l10c7                                                         ; 961f: 8c c7 10    ...
+    sty l10c6                                                         ; 9622: 8c c6 10    ...
+    sty l10dd                                                         ; 9625: 8c dd 10    ...
+; $9628 referenced 2 times by $95d2, $95fb
+c9628
+    jsr sub_c8f3f                                                     ; 9628: 20 3f 8f     ?.
+    pla                                                               ; 962b: 68          h
+    bne c9649                                                         ; 962c: d0 1b       ..
+    lda #4                                                            ; 962e: a9 04       ..
+    ora l10de                                                         ; 9630: 0d de 10    ...
+    sta l10de                                                         ; 9633: 8d de 10    ...
+    jsr sub_c93f5                                                     ; 9636: 20 f5 93     ..
+    lda #$fb                                                          ; 9639: a9 fb       ..
+    and l10de                                                         ; 963b: 2d de 10    -..
+    sta l10de                                                         ; 963e: 8d de 10    ...
+    lda l0f06                                                         ; 9641: ad 06 0f    ...
+    jsr sub_c81bf                                                     ; 9644: 20 bf 81     ..
+    bne c964a                                                         ; 9647: d0 01       ..
+; $9649 referenced 1 time by $962c
+c9649
+    rts                                                               ; 9649: 60          `
+
+; $964a referenced 1 time by $9647
+c964a
+    ldy #$95                                                          ; 964a: a0 95       ..
+    ldx #$46 ; 'F'                                                    ; 964c: a2 46       .F
+    cmp #2                                                            ; 964e: c9 02       ..
+    bcc c965a                                                         ; 9650: 90 08       ..
+    beq c9658                                                         ; 9652: f0 04       ..
+    ldx #$4e ; 'N'                                                    ; 9654: a2 4e       .N
+    bne c965a                                                         ; 9656: d0 02       ..
+; $9658 referenced 1 time by $9652
+c9658
+    ldx #$50 ; 'P'                                                    ; 9658: a2 50       .P
+; $965a referenced 2 times by $9650, $9656
+c965a
+    jmp oscli                                                         ; 965a: 4c f7 ff    L..
+
+; $965d referenced 1 time by $b1b1
+sub_c965d
+    jsr service_handler_help_and_tube                                 ; 965d: 20 a9 ae     ..
+    pha                                                               ; 9660: 48          H
+    lda l0df0,x                                                       ; 9661: bd f0 0d    ...
+    bmi pla_rts                                                       ; 9664: 30 5b       0[
+    pla                                                               ; 9666: 68          h
+    cmp #service_claim_absolute_workspace                             ; 9667: c9 01       ..
+    bne c9683                                                         ; 9669: d0 18       ..
+    jsr set_c_iff_have_fdc                                            ; 966b: 20 04 91     ..
+    ldx romsel_copy                                                   ; 966e: a6 f4       ..
+    bcs c967a                                                         ; 9670: b0 08       ..
+    lda #$80                                                          ; 9672: a9 80       ..
+    sta l0df0,x                                                       ; 9674: 9d f0 0d    ...
+    lda #1                                                            ; 9677: a9 01       ..
+    rts                                                               ; 9679: 60          `
+
+; $967a referenced 1 time by $9670
+c967a
+    lda #service_claim_absolute_workspace                             ; 967a: a9 01       ..
+    cpy #$17                                                          ; 967c: c0 17       ..
+    bcs c9682                                                         ; 967e: b0 02       ..
+    ldy #$17                                                          ; 9680: a0 17       ..
+; $9682 referenced 1 time by $967e
+c9682
+    rts                                                               ; 9682: 60          `
+
+; $9683 referenced 1 time by $9669
+c9683
+    cmp #service_claim_private_workspace                              ; 9683: c9 02       ..
+    bne c96c3                                                         ; 9685: d0 3c       .<
+    pha                                                               ; 9687: 48          H
+    tya                                                               ; 9688: 98          .
+    pha                                                               ; 9689: 48          H
+    sta l00b1                                                         ; 968a: 85 b1       ..
+    ldy l0df0,x                                                       ; 968c: bc f0 0d    ...
+    sta l0df0,x                                                       ; 968f: 9d f0 0d    ...
+    lda #0                                                            ; 9692: a9 00       ..
+    sta l00b0                                                         ; 9694: 85 b0       ..
+    cpy l00b1                                                         ; 9696: c4 b1       ..
+    beq c969e                                                         ; 9698: f0 04       ..
+    ldy #$d3                                                          ; 969a: a0 d3       ..
+    sta (l00b0),y                                                     ; 969c: 91 b0       ..
+; $969e referenced 1 time by $9698
+c969e
+    lda #$fd                                                          ; 969e: a9 fd       ..
+    jsr osbyte_read                                                   ; 96a0: 20 e5 9a     ..
+    dex                                                               ; 96a3: ca          .
+    txa                                                               ; 96a4: 8a          .
+    ldy #$d3                                                          ; 96a5: a0 d3       ..
+    and (l00b0),y                                                     ; 96a7: 31 b0       1.
+    sta (l00b0),y                                                     ; 96a9: 91 b0       ..
+    php                                                               ; 96ab: 08          .
+    iny                                                               ; 96ac: c8          .
+    plp                                                               ; 96ad: 28          (
+    bpl c96b7                                                         ; 96ae: 10 07       ..
+    lda (l00b0),y                                                     ; 96b0: b1 b0       ..
+    bpl c96b7                                                         ; 96b2: 10 03       ..
+    jsr sub_c8951                                                     ; 96b4: 20 51 89     Q.
+; $96b7 referenced 2 times by $96ae, $96b2
+c96b7
+    lda #0                                                            ; 96b7: a9 00       ..
+    sta (l00b0),y                                                     ; 96b9: 91 b0       ..
+    ldx romsel_copy                                                   ; 96bb: a6 f4       ..
+    pla                                                               ; 96bd: 68          h
+    tay                                                               ; 96be: a8          .
+    iny                                                               ; 96bf: c8          .
+    iny                                                               ; 96c0: c8          .
+; $96c1 referenced 1 time by $9664
+pla_rts
+    pla                                                               ; 96c1: 68          h
+; $96c2 referenced 1 time by $96df
+loop_c96c2
+    rts                                                               ; 96c2: 60          `
+
+; $96c3 referenced 1 time by $9685
+c96c3
+    jsr sub_c83e3                                                     ; 96c3: 20 e3 83     ..
+    cmp #service_boot                                                 ; 96c6: c9 03       ..
+    bne c96ec                                                         ; 96c8: d0 22       ."
+    sty l00b3                                                         ; 96ca: 84 b3       ..
+    lda #0                                                            ; 96cc: a9 00       ..
+    sta l10de                                                         ; 96ce: 8d de 10    ...
+    lda #osbyte_scan_keyboard_from_16                                 ; 96d1: a9 7a       .z
+    jsr osbyte                                                        ; 96d3: 20 f4 ff     ..
+    txa                                                               ; 96d6: 8a          .
+    bmi c96e9                                                         ; 96d7: 30 10       0.
+    cmp #$32 ; '2'                                                    ; 96d9: c9 32       .2
+    beq c96e4                                                         ; 96db: f0 07       ..
+    cmp #$61 ; 'a'                                                    ; 96dd: c9 61       .a
+    bne loop_c96c2                                                    ; 96df: d0 e1       ..
+    jsr sub_cac72                                                     ; 96e1: 20 72 ac     r.
+; $96e4 referenced 1 time by $96db
+c96e4
+    lda #osbyte_write_keys_pressed                                    ; 96e4: a9 78       .x
+    jsr osbyte                                                        ; 96e6: 20 f4 ff     ..
+; $96e9 referenced 1 time by $96d7
+c96e9
+    jmp c9556                                                         ; 96e9: 4c 56 95    LV.
+
+; $96ec referenced 1 time by $96c8
+c96ec
+    cmp #service_unrecognised_command                                 ; 96ec: c9 04       ..
+    bne c96f5                                                         ; 96ee: d0 05       ..
+    ldx #$9b                                                          ; 96f0: a2 9b       ..
+; $96f2 referenced 1 time by $970a
+loop_c96f2
+    jmp c8703                                                         ; 96f2: 4c 03 87    L..
+
+; $96f5 referenced 1 time by $96ee
+c96f5
+    cmp #service_select_filing_system                                 ; 96f5: c9 12       ..
+    bne c9700                                                         ; 96f7: d0 07       ..
+    cpy #4                                                            ; 96f9: c0 04       ..
+    bne c973c                                                         ; 96fb: d0 3f       .?
+    jmp c956d                                                         ; 96fd: 4c 6d 95    Lm.
+
+; $9700 referenced 1 time by $96f7
+c9700
+    cmp #service_help                                                 ; 9700: c9 09       ..
+    bne c9714                                                         ; 9702: d0 10       ..
+    lda (os_text_ptr),y                                               ; 9704: b1 f2       ..
+    ldx #$cf                                                          ; 9706: a2 cf       ..
+    cmp #$0d                                                          ; 9708: c9 0d       ..
+    bne loop_c96f2                                                    ; 970a: d0 e6       ..
+    tya                                                               ; 970c: 98          .
+    inx                                                               ; 970d: e8          .
+    inx                                                               ; 970e: e8          .
+    ldy #2                                                            ; 970f: a0 02       ..
+    jmp ca10b                                                         ; 9711: 4c 0b a1    L..
+
+; $9714 referenced 1 time by $9702
+c9714
+    jsr zero_stacked_XXX                                              ; 9714: 20 8e 9d     ..
+    cmp #service_absolute_workspace_claimed                           ; 9717: c9 0a       ..
+    bne c973d                                                         ; 9719: d0 22       ."
+    jsr sub_c9ab8                                                     ; 971b: 20 b8 9a     ..
+    ldy #$d4                                                          ; 971e: a0 d4       ..
+    lda (l00b0),y                                                     ; 9720: b1 b0       ..
+    bpl c9736                                                         ; 9722: 10 12       ..
+    ldy #0                                                            ; 9724: a0 00       ..
+    jsr sub_c9d75                                                     ; 9726: 20 75 9d     u.
+    jsr sub_c8951                                                     ; 9729: 20 51 89     Q.
+    jsr sub_c9ab8                                                     ; 972c: 20 b8 9a     ..
+    ldy #$d4                                                          ; 972f: a0 d4       ..
+    lda #0                                                            ; 9731: a9 00       ..
+    sta (l00b0),y                                                     ; 9733: 91 b0       ..
+    rts                                                               ; 9735: 60          `
+
+; $9736 referenced 1 time by $9722
+c9736
+    lda #$0a                                                          ; 9736: a9 0a       ..
+; $9738 referenced 3 times by $973f, $9743, $9747
+c9738
+    tsx                                                               ; 9738: ba          .
+    sta l0105,x                                                       ; 9739: 9d 05 01    ...
+; $973c referenced 1 time by $96fb
+c973c
+    rts                                                               ; 973c: 60          `
+
+; $973d referenced 1 time by $9719
+c973d
+    cmp #service_unrecognised_osword                                  ; 973d: c9 08       ..
+    bne c9738                                                         ; 973f: d0 f7       ..
+    ldy l00ef                                                         ; 9741: a4 ef       ..
+    bmi c9738                                                         ; 9743: 30 f3       0.
+    cpy #$7d ; '}'                                                    ; 9745: c0 7d       .}
+    bcc c9738                                                         ; 9747: 90 ef       ..
+    ldx l00f0                                                         ; 9749: a6 f0       ..
+    stx l00c7                                                         ; 974b: 86 c7       ..
+    ldx l00f1                                                         ; 974d: a6 f1       ..
+    stx l00c8                                                         ; 974f: 86 c8       ..
+    iny                                                               ; 9751: c8          .
+    bpl c975b                                                         ; 9752: 10 07       ..
+    ldx l00c7                                                         ; 9754: a6 c7       ..
+    ldy l00c8                                                         ; 9756: a4 c8       ..
+    jmp c91af                                                         ; 9758: 4c af 91    L..
+
+; $975b referenced 1 time by $9752
+c975b
+    jsr sub_c8b7b                                                     ; 975b: 20 7b 8b     {.
+    jsr sub_c8380                                                     ; 975e: 20 80 83     ..
+    iny                                                               ; 9761: c8          .
+    bmi c976c                                                         ; 9762: 30 08       0.
+    ldy #0                                                            ; 9764: a0 00       ..
+    lda l0f04                                                         ; 9766: ad 04 0f    ...
+    sta (l00c7),y                                                     ; 9769: 91 c7       ..
+    rts                                                               ; 976b: 60          `
+
+; $976c referenced 1 time by $9762
+c976c
+    lda #0                                                            ; 976c: a9 00       ..
+    tay                                                               ; 976e: a8          .
+    sta (l00c7),y                                                     ; 976f: 91 c7       ..
+    iny                                                               ; 9771: c8          .
+    lda l0f07                                                         ; 9772: ad 07 0f    ...
+    sta (l00c7),y                                                     ; 9775: 91 c7       ..
+    iny                                                               ; 9777: c8          .
+    lda l0f06                                                         ; 9778: ad 06 0f    ...
+    and #3                                                            ; 977b: 29 03       ).
+    sta (l00c7),y                                                     ; 977d: 91 c7       ..
+    iny                                                               ; 977f: c8          .
+    lda #0                                                            ; 9780: a9 00       ..
+    sta (l00c7),y                                                     ; 9782: 91 c7       ..
+    rts                                                               ; 9784: 60          `
+
+sub_c9785
+    jsr sub_c840c                                                     ; 9785: 20 0c 84     ..
+    pha                                                               ; 9788: 48          H
+    jsr c99a3                                                         ; 9789: 20 a3 99     ..
+    stx l00b0                                                         ; 978c: 86 b0       ..
+    stx l10db                                                         ; 978e: 8e db 10    ...
+    sty l00b1                                                         ; 9791: 84 b1       ..
+    sty l10dc                                                         ; 9793: 8c dc 10    ...
+    ldx #0                                                            ; 9796: a2 00       ..
+    ldy #0                                                            ; 9798: a0 00       ..
+    jsr sub_c80e3                                                     ; 979a: 20 e3 80     ..
+; $979d referenced 1 time by $97a2
+loop_c979d
+    jsr sub_c80d3                                                     ; 979d: 20 d3 80     ..
+    cpy #$12                                                          ; 97a0: c0 12       ..
+    bne loop_c979d                                                    ; 97a2: d0 f9       ..
+    pla                                                               ; 97a4: 68          h
+    tax                                                               ; 97a5: aa          .
+    inx                                                               ; 97a6: e8          .
+    cpx #8                                                            ; 97a7: e0 08       ..
+    bcs c97b3                                                         ; 97a9: b0 08       ..
+    lda l9b29,x                                                       ; 97ab: bd 29 9b    .).
+    pha                                                               ; 97ae: 48          H
+    lda l9b21,x                                                       ; 97af: bd 21 9b    .!.
+    pha                                                               ; 97b2: 48          H
+; $97b3 referenced 2 times by $97a9, $97b8
+c97b3
+    lda #0                                                            ; 97b3: a9 00       ..
+    rts                                                               ; 97b5: 60          `
+
+sub_c97b6
+    cmp #9                                                            ; 97b6: c9 09       ..
+    bcs c97b3                                                         ; 97b8: b0 f9       ..
+    stx l00b5                                                         ; 97ba: 86 b5       ..
+    tax                                                               ; 97bc: aa          .
+    lda l9b18,x                                                       ; 97bd: bd 18 9b    ...
+    pha                                                               ; 97c0: 48          H
+    lda l9b0f,x                                                       ; 97c1: bd 0f 9b    ...
+    pha                                                               ; 97c4: 48          H
+    txa                                                               ; 97c5: 8a          .
+    ldx l00b5                                                         ; 97c6: a6 b5       ..
+; $97c8 referenced 1 time by $97cb
+loop_c97c8
+    rts                                                               ; 97c8: 60          `
+
+sub_c97c9
+    cmp #9                                                            ; 97c9: c9 09       ..
+    bcs loop_c97c8                                                    ; 97cb: b0 fb       ..
+    jsr sub_c83e3                                                     ; 97cd: 20 e3 83     ..
+    jsr zero_stacked_XXX                                              ; 97d0: 20 8e 9d     ..
+    stx l107d                                                         ; 97d3: 8e 7d 10    .}.
+    sty l107e                                                         ; 97d6: 8c 7e 10    .~.
+    tay                                                               ; 97d9: a8          .
+    jsr sub_c97e8                                                     ; 97da: 20 e8 97     ..
+    php                                                               ; 97dd: 08          .
+    bit l1081                                                         ; 97de: 2c 81 10    ,..
+    bpl c97e6                                                         ; 97e1: 10 03       ..
+    jsr sub_c8f7a                                                     ; 97e3: 20 7a 8f     z.
+; $97e6 referenced 1 time by $97e1
+c97e6
+    plp                                                               ; 97e6: 28          (
+    rts                                                               ; 97e7: 60          `
+
+; $97e8 referenced 1 time by $97da
+sub_c97e8
+    lda l9b31,y                                                       ; 97e8: b9 31 9b    .1.
+    sta l10d7                                                         ; 97eb: 8d d7 10    ...
+    lda l9b3a,y                                                       ; 97ee: b9 3a 9b    .:.
+    sta l10d8                                                         ; 97f1: 8d d8 10    ...
+    lda l9b43,y                                                       ; 97f4: b9 43 9b    .C.
+    lsr                                                               ; 97f7: 4a          J
+    php                                                               ; 97f8: 08          .
+    lsr                                                               ; 97f9: 4a          J
+    php                                                               ; 97fa: 08          .
+    sta l107f                                                         ; 97fb: 8d 7f 10    ...
+    jsr sub_c995a                                                     ; 97fe: 20 5a 99     Z.
+    ldy #$0c                                                          ; 9801: a0 0c       ..
+; $9803 referenced 1 time by $9809
+loop_c9803
+    lda (l00b4),y                                                     ; 9803: b1 b4       ..
+    sta l1060,y                                                       ; 9805: 99 60 10    .`.
+    dey                                                               ; 9808: 88          .
+    bpl loop_c9803                                                    ; 9809: 10 f8       ..
+    lda l1063                                                         ; 980b: ad 63 10    .c.
+    and l1064                                                         ; 980e: 2d 64 10    -d.
+    ora l10d6                                                         ; 9811: 0d d6 10    ...
+    clc                                                               ; 9814: 18          .
+    adc #1                                                            ; 9815: 69 01       i.
+    beq c981f                                                         ; 9817: f0 06       ..
+    jsr sub_c8f6b                                                     ; 9819: 20 6b 8f     k.
+    clc                                                               ; 981c: 18          .
+    lda #$ff                                                          ; 981d: a9 ff       ..
+; $981f referenced 1 time by $9817
+c981f
+    sta l1081                                                         ; 981f: 8d 81 10    ...
+    lda l107f                                                         ; 9822: ad 7f 10    ...
+    bcs c982e                                                         ; 9825: b0 07       ..
+    ldx #$61 ; 'a'                                                    ; 9827: a2 61       .a
+    ldy #$10                                                          ; 9829: a0 10       ..
+    jsr tube_entry                                                    ; 982b: 20 06 04     ..
+; $982e referenced 1 time by $9825
+c982e
+    plp                                                               ; 982e: 28          (
+    bcs c9835                                                         ; 982f: b0 04       ..
+    plp                                                               ; 9831: 28          (
+; $9832 referenced 1 time by $9861
+sub_c9832
+    jmp (l10d7)                                                       ; 9832: 6c d7 10    l..
+
+; $9835 referenced 1 time by $982f
+c9835
+    ldx #3                                                            ; 9835: a2 03       ..
+; $9837 referenced 1 time by $983d
+loop_c9837
+    lda l1069,x                                                       ; 9837: bd 69 10    .i.
+    sta l00b6,x                                                       ; 983a: 95 b6       ..
+    dex                                                               ; 983c: ca          .
+    bpl loop_c9837                                                    ; 983d: 10 f8       ..
+    ldx #$b6                                                          ; 983f: a2 b6       ..
+    ldy l1060                                                         ; 9841: ac 60 10    .`.
+    lda #0                                                            ; 9844: a9 00       ..
+    plp                                                               ; 9846: 28          (
+    bcs c984c                                                         ; 9847: b0 03       ..
+    jsr ca06c                                                         ; 9849: 20 6c a0     l.
+; $984c referenced 1 time by $9847
+c984c
+    jsr c9dd5                                                         ; 984c: 20 d5 9d     ..
+    ldx #3                                                            ; 984f: a2 03       ..
+; $9851 referenced 1 time by $9857
+loop_c9851
+    lda l00b6,x                                                       ; 9851: b5 b6       ..
+    sta l1069,x                                                       ; 9853: 9d 69 10    .i.
+    dex                                                               ; 9856: ca          .
+    bpl loop_c9851                                                    ; 9857: 10 f8       ..
+; $9859 referenced 1 time by $989b
+c9859
+    jsr invert_l1065                                                  ; 9859: 20 4c 99     L.
+    bmi c986b                                                         ; 985c: 30 0d       0.
+; $985e referenced 1 time by $9870
+loop_c985e
+    ldy l1060                                                         ; 985e: ac 60 10    .`.
+    jsr sub_c9832                                                     ; 9861: 20 32 98     2.
+    bcs c9873                                                         ; 9864: b0 0d       ..
+    ldx #9                                                            ; 9866: a2 09       ..
+    jsr sub_c9940                                                     ; 9868: 20 40 99     @.
+; $986b referenced 1 time by $985c
+c986b
+    ldx #5                                                            ; 986b: a2 05       ..
+    jsr sub_c9940                                                     ; 986d: 20 40 99     @.
+    bne loop_c985e                                                    ; 9870: d0 ec       ..
+    clc                                                               ; 9872: 18          .
+; $9873 referenced 1 time by $9864
+c9873
+    php                                                               ; 9873: 08          .
+    jsr invert_l1065                                                  ; 9874: 20 4c 99     L.
+    ldx #5                                                            ; 9877: a2 05       ..
+    jsr sub_c9940                                                     ; 9879: 20 40 99     @.
+    ldy #$0c                                                          ; 987c: a0 0c       ..
+    jsr sub_c995a                                                     ; 987e: 20 5a 99     Z.
+; $9881 referenced 1 time by $9887
+loop_c9881
+    lda l1060,y                                                       ; 9881: b9 60 10    .`.
+    sta (l00b4),y                                                     ; 9884: 91 b4       ..
+    dey                                                               ; 9886: 88          .
+    bpl loop_c9881                                                    ; 9887: 10 f8       ..
+    plp                                                               ; 9889: 28          (
+    rts                                                               ; 988a: 60          `
+
+    jsr sub_c8b7b                                                     ; 988b: 20 7b 8b     {.
+    jsr sub_c93fd                                                     ; 988e: 20 fd 93     ..
+    lda #$9d                                                          ; 9891: a9 9d       ..
+    sta l10d7                                                         ; 9893: 8d d7 10    ...
+    lda #$98                                                          ; 9896: a9 98       ..
+    sta l10d8                                                         ; 9898: 8d d8 10    ...
+    bne c9859                                                         ; 989b: d0 bc       ..
+    ldy l1069                                                         ; 989d: ac 69 10    .i.
+; $98a0 referenced 1 time by $98b8
+loop_c98a0
+    cpy l0f05                                                         ; 98a0: cc 05 0f    ...
+    bcs c98cd                                                         ; 98a3: b0 28       .(
+    lda l0e0f,y                                                       ; 98a5: b9 0f 0e    ...
+    jsr sub_c8327                                                     ; 98a8: 20 27 83     '.
+    eor l00cc                                                         ; 98ab: 45 cc       E.
+    bcs c98b1                                                         ; 98ad: b0 02       ..
+    and #$df                                                          ; 98af: 29 df       ).
+; $98b1 referenced 1 time by $98ad
+c98b1
+    and #$7f                                                          ; 98b1: 29 7f       ).
+    beq c98ba                                                         ; 98b3: f0 05       ..
+    jsr sub_c87da                                                     ; 98b5: 20 da 87     ..
+    bne loop_c98a0                                                    ; 98b8: d0 e6       ..
+; $98ba referenced 1 time by $98b3
+c98ba
+    lda #7                                                            ; 98ba: a9 07       ..
+    jsr c996e                                                         ; 98bc: 20 6e 99     n.
+    sta l00b0                                                         ; 98bf: 85 b0       ..
+; $98c1 referenced 1 time by $98ca
+loop_c98c1
+    lda l0e08,y                                                       ; 98c1: b9 08 0e    ...
+    jsr c996e                                                         ; 98c4: 20 6e 99     n.
+    iny                                                               ; 98c7: c8          .
+    dec l00b0                                                         ; 98c8: c6 b0       ..
+    bne loop_c98c1                                                    ; 98ca: d0 f5       ..
+    clc                                                               ; 98cc: 18          .
+; $98cd referenced 1 time by $98a3
+c98cd
+    sty l1069                                                         ; 98cd: 8c 69 10    .i.
+    lda l0f04                                                         ; 98d0: ad 04 0f    ...
+    sta l1060                                                         ; 98d3: 8d 60 10    .`.
+    rts                                                               ; 98d6: 60          `
+
+    jsr sub_c8b7b                                                     ; 98d7: 20 7b 8b     {.
+    jsr sub_c93fd                                                     ; 98da: 20 fd 93     ..
+    lda #$0c                                                          ; 98dd: a9 0c       ..
+    jsr c996e                                                         ; 98df: 20 6e 99     n.
+    ldy #0                                                            ; 98e2: a0 00       ..
+; $98e4 referenced 1 time by $98f6
+loop_c98e4
+    cpy #8                                                            ; 98e4: c0 08       ..
+    bcs c98ed                                                         ; 98e6: b0 05       ..
+    lda l0e00,y                                                       ; 98e8: b9 00 0e    ...
+    bcc c98f0                                                         ; 98eb: 90 03       ..
+; $98ed referenced 1 time by $98e6
+c98ed
+    lda l0ef8,y                                                       ; 98ed: b9 f8 0e    ...
+; $98f0 referenced 1 time by $98eb
+c98f0
+    jsr c996e                                                         ; 98f0: 20 6e 99     n.
+    iny                                                               ; 98f3: c8          .
+    cpy #$0c                                                          ; 98f4: c0 0c       ..
+    bne loop_c98e4                                                    ; 98f6: d0 ec       ..
+    lda l0f06                                                         ; 98f8: ad 06 0f    ...
+    jsr sub_c81bf                                                     ; 98fb: 20 bf 81     ..
+    jsr c996e                                                         ; 98fe: 20 6e 99     n.
+    lda l00cd                                                         ; 9901: a5 cd       ..
+    jmp c996e                                                         ; 9903: 4c 6e 99    Ln.
+
+    jsr sub_c9965                                                     ; 9906: 20 65 99     e.
+    lda l10ca                                                         ; 9909: ad ca 10    ...
+    ora #$30 ; '0'                                                    ; 990c: 09 30       .0
+    jsr c996e                                                         ; 990e: 20 6e 99     n.
+    jsr sub_c9965                                                     ; 9911: 20 65 99     e.
+    lda l10c9                                                         ; 9914: ad c9 10    ...
+    bne c996e                                                         ; 9917: d0 55       .U
+    jsr sub_c9965                                                     ; 9919: 20 65 99     e.
+    lda l10cc                                                         ; 991c: ad cc 10    ...
+    ora #$30 ; '0'                                                    ; 991f: 09 30       .0
+    jsr c996e                                                         ; 9921: 20 6e 99     n.
+    jsr sub_c9965                                                     ; 9924: 20 65 99     e.
+    lda l10cb                                                         ; 9927: ad cb 10    ...
+    bne c996e                                                         ; 992a: d0 42       .B
+; $992c referenced 2 times by $9978, $9993
+sub_c992c
+    pha                                                               ; 992c: 48          H
+    lda l1061                                                         ; 992d: ad 61 10    .a.
+    sta l00b8                                                         ; 9930: 85 b8       ..
+    lda l1062                                                         ; 9932: ad 62 10    .b.
+    sta l00b9                                                         ; 9935: 85 b9       ..
+    ldx #0                                                            ; 9937: a2 00       ..
+    pla                                                               ; 9939: 68          h
+    rts                                                               ; 993a: 60          `
+
+; $993b referenced 4 times by $9976, $997d, $9990, $9998
+c993b
+    jsr sub_c83e3                                                     ; 993b: 20 e3 83     ..
+    ldx #1                                                            ; 993e: a2 01       ..
+; $9940 referenced 3 times by $9868, $986d, $9879
+sub_c9940
+    ldy #4                                                            ; 9940: a0 04       ..
+; $9942 referenced 1 time by $9949
+loop_c9942
+    inc l1060,x                                                       ; 9942: fe 60 10    .`.
+    bne c994b                                                         ; 9945: d0 04       ..
+    inx                                                               ; 9947: e8          .
+    dey                                                               ; 9948: 88          .
+    bne loop_c9942                                                    ; 9949: d0 f7       ..
+; $994b referenced 1 time by $9945
+c994b
+    rts                                                               ; 994b: 60          `
+
+; Invert the 32-bit value at l1065
+; $994c referenced 2 times by $9859, $9874
+invert_l1065
+    ldx #3                                                            ; 994c: a2 03       ..
+; $994e referenced 1 time by $9957
+loop_c994e
+    lda #$ff                                                          ; 994e: a9 ff       ..
+    eor l1065,x                                                       ; 9950: 5d 65 10    ]e.
+    sta l1065,x                                                       ; 9953: 9d 65 10    .e.
+    dex                                                               ; 9956: ca          .
+    bpl loop_c994e                                                    ; 9957: 10 f5       ..
+    rts                                                               ; 9959: 60          `
+
+; $995a referenced 2 times by $97fe, $987e
+sub_c995a
+    lda l107d                                                         ; 995a: ad 7d 10    .}.
+    sta l00b4                                                         ; 995d: 85 b4       ..
+    lda l107e                                                         ; 995f: ad 7e 10    .~.
+    sta l00b5                                                         ; 9962: 85 b5       ..
+; $9964 referenced 1 time by $996c
+loop_c9964
+    rts                                                               ; 9964: 60          `
+
+; $9965 referenced 4 times by $9906, $9911, $9919, $9924
+sub_c9965
+    lda #1                                                            ; 9965: a9 01       ..
+    bne c996e                                                         ; 9967: d0 05       ..
+    jsr sub_c9e94                                                     ; 9969: 20 94 9e     ..
+    bcs loop_c9964                                                    ; 996c: b0 f6       ..
+; $996e referenced 11 times by $98bc, $98c4, $98df, $98f0, $98fe, $9903, $990e, $9917, $9921, $992a, $9967
+c996e
+    bit l1081                                                         ; 996e: 2c 81 10    ,..
+    bpl c9978                                                         ; 9971: 10 05       ..
+    sta tube_host_r3_data                                             ; 9973: 8d e5 fe    ...
+    bmi c993b                                                         ; 9976: 30 c3       0.
+; $9978 referenced 1 time by $9971
+c9978
+    jsr sub_c992c                                                     ; 9978: 20 2c 99     ,.
+    sta (l00b8,x)                                                     ; 997b: 81 b8       ..
+    jmp c993b                                                         ; 997d: 4c 3b 99    L;.
+
+    jsr sub_c9988                                                     ; 9980: 20 88 99     ..
+    jsr sub_c9f82                                                     ; 9983: 20 82 9f     ..
+    clc                                                               ; 9986: 18          .
+    rts                                                               ; 9987: 60          `
+
+; $9988 referenced 1 time by $9980
+sub_c9988
+    bit l1081                                                         ; 9988: 2c 81 10    ,..
+    bpl c9993                                                         ; 998b: 10 06       ..
+    lda tube_host_r3_data                                             ; 998d: ad e5 fe    ...
+    jmp c993b                                                         ; 9990: 4c 3b 99    L;.
+
+; $9993 referenced 1 time by $998b
+c9993
+    jsr sub_c992c                                                     ; 9993: 20 2c 99     ,.
+    lda (l00b8,x)                                                     ; 9996: a1 b8       ..
+    jmp c993b                                                         ; 9998: 4c 3b 99    L;.
+
+    bit l10c7                                                         ; 999b: 2c c7 10    ,..
+    bmi c99a3                                                         ; 999e: 30 03       0.
+    dec l10c7                                                         ; 99a0: ce c7 10    ...
+; $99a3 referenced 5 times by $8782, $8bac, $9789, $999e, $9c25
+c99a3
+    lda #$ff                                                          ; 99a3: a9 ff       ..
+    sta l10ce                                                         ; 99a5: 8d ce 10    ...
+; $99a8 referenced 1 time by $99b3
+loop_c99a8
+    sta l10cd                                                         ; 99a8: 8d cd 10    ...
+    rts                                                               ; 99ab: 60          `
+
+; $99ac referenced 6 times by $824b, $8254, $8750, $8797, $89e6, $a463
+sub_c99ac
+    lda #$2a ; '*'                                                    ; 99ac: a9 2a       .*
+    sta l10ce                                                         ; 99ae: 8d ce 10    ...
+    lda #$23 ; '#'                                                    ; 99b1: a9 23       .#
+    bne loop_c99a8                                                    ; 99b3: d0 f3       ..
+    jsr sub_c9a6e                                                     ; 99b5: 20 6e 9a     n.
+    jsr sub_c8386                                                     ; 99b8: 20 86 83     ..
+    lda #1                                                            ; 99bb: a9 01       ..
+    rts                                                               ; 99bd: 60          `
+
+    jsr sub_c9a4b                                                     ; 99be: 20 4b 9a     K.
+    jsr sub_c8386                                                     ; 99c1: 20 86 83     ..
+    jsr sub_c830a                                                     ; 99c4: 20 0a 83     ..
+    bcc c99ed                                                         ; 99c7: 90 24       .$
+    jsr sub_c9a6e                                                     ; 99c9: 20 6e 9a     n.
+    jsr sub_c99f3                                                     ; 99cc: 20 f3 99     ..
+    jsr sub_c9a0f                                                     ; 99cf: 20 0f 9a     ..
+    bvc c99ea                                                         ; 99d2: 50 16       P.
+    jsr sub_c9a6e                                                     ; 99d4: 20 6e 9a     n.
+    jsr sub_c9a0f                                                     ; 99d7: 20 0f 9a     ..
+    bvc c99ed                                                         ; 99da: 50 11       P.
+    jsr sub_c9a6e                                                     ; 99dc: 20 6e 9a     n.
+    jsr sub_c99f3                                                     ; 99df: 20 f3 99     ..
+    bvc c99ed                                                         ; 99e2: 50 09       P.
+    jsr sub_c9a6e                                                     ; 99e4: 20 6e 9a     n.
+    jsr sub_c9a63                                                     ; 99e7: 20 63 9a     c.
+; $99ea referenced 1 time by $99d2
+c99ea
+    jsr sub_c9a32                                                     ; 99ea: 20 32 9a     2.
+; $99ed referenced 3 times by $99c7, $99da, $99e2
+c99ed
+    jsr c89d7                                                         ; 99ed: 20 d7 89     ..
+    lda #1                                                            ; 99f0: a9 01       ..
+    rts                                                               ; 99f2: 60          `
+
+; $99f3 referenced 2 times by $99cc, $99df
+sub_c99f3
+    jsr sub_c83e3                                                     ; 99f3: 20 e3 83     ..
+    ldy #2                                                            ; 99f6: a0 02       ..
+    lda (l00b0),y                                                     ; 99f8: b1 b0       ..
+    sta l0f08,x                                                       ; 99fa: 9d 08 0f    ...
+    iny                                                               ; 99fd: c8          .
+    lda (l00b0),y                                                     ; 99fe: b1 b0       ..
+    sta l0f09,x                                                       ; 9a00: 9d 09 0f    ...
+    iny                                                               ; 9a03: c8          .
+    lda (l00b0),y                                                     ; 9a04: b1 b0       ..
+    asl                                                               ; 9a06: 0a          .
+    asl                                                               ; 9a07: 0a          .
+    eor l0f0e,x                                                       ; 9a08: 5d 0e 0f    ]..
+    and #$0c                                                          ; 9a0b: 29 0c       ).
+    bpl c9a2a                                                         ; 9a0d: 10 1b       ..
+; $9a0f referenced 2 times by $99cf, $99d7
+sub_c9a0f
+    jsr sub_c83e3                                                     ; 9a0f: 20 e3 83     ..
+    ldy #6                                                            ; 9a12: a0 06       ..
+    lda (l00b0),y                                                     ; 9a14: b1 b0       ..
+    sta l0f0a,x                                                       ; 9a16: 9d 0a 0f    ...
+    iny                                                               ; 9a19: c8          .
+    lda (l00b0),y                                                     ; 9a1a: b1 b0       ..
+    sta l0f0b,x                                                       ; 9a1c: 9d 0b 0f    ...
+    iny                                                               ; 9a1f: c8          .
+    lda (l00b0),y                                                     ; 9a20: b1 b0       ..
+    ror                                                               ; 9a22: 6a          j
+    ror                                                               ; 9a23: 6a          j
+    ror                                                               ; 9a24: 6a          j
+    eor l0f0e,x                                                       ; 9a25: 5d 0e 0f    ]..
+    and #$c0                                                          ; 9a28: 29 c0       ).
+; $9a2a referenced 1 time by $9a0d
+c9a2a
+    eor l0f0e,x                                                       ; 9a2a: 5d 0e 0f    ]..
+    sta l0f0e,x                                                       ; 9a2d: 9d 0e 0f    ...
+    clv                                                               ; 9a30: b8          .
+    rts                                                               ; 9a31: 60          `
+
+; $9a32 referenced 1 time by $99ea
+sub_c9a32
+    jsr sub_c83e3                                                     ; 9a32: 20 e3 83     ..
+    ldy #$0e                                                          ; 9a35: a0 0e       ..
+    lda (l00b0),y                                                     ; 9a37: b1 b0       ..
+    and #$0a                                                          ; 9a39: 29 0a       ).
+    beq c9a3f                                                         ; 9a3b: f0 02       ..
+    lda #$80                                                          ; 9a3d: a9 80       ..
+; $9a3f referenced 1 time by $9a3b
+c9a3f
+    eor l0e0f,x                                                       ; 9a3f: 5d 0f 0e    ]..
+    and #$80                                                          ; 9a42: 29 80       ).
+    eor l0e0f,x                                                       ; 9a44: 5d 0f 0e    ]..
+    sta l0e0f,x                                                       ; 9a47: 9d 0f 0e    ...
+    rts                                                               ; 9a4a: 60          `
+
+; $9a4b referenced 1 time by $99be
+sub_c9a4b
+    jsr sub_c9a78                                                     ; 9a4b: 20 78 9a     x.
+    bcc c9a73                                                         ; 9a4e: 90 23       .#
+; $9a50 referenced 2 times by $9a60, $9c55
+sub_c9a50
+    lda l0e0f,y                                                       ; 9a50: b9 0f 0e    ...
+    bpl c9a77                                                         ; 9a53: 10 22       ."
+; $9a55 referenced 1 time by $9f6b
+generate_error_precheck_locked
+    jsr generate_error_precheck                                       ; 9a55: 20 38 80     8.
+    !byte $c3                                                         ; 9a58: c3          .
+    !text "Locked"                                                    ; 9a59: 4c 6f 63... Loc
+    !byte 0                                                           ; 9a5f: 00          .
+
+; $9a60 referenced 2 times by $830a, $8bba
+sub_c9a60
+    jsr sub_c9a50                                                     ; 9a60: 20 50 9a     P.
+; $9a63 referenced 2 times by $8a00, $99e7
+sub_c9a63
+    jsr sub_c83e3                                                     ; 9a63: 20 e3 83     ..
+    jsr sub_c9d1e                                                     ; 9a66: 20 1e 9d     ..
+    bcc c9a8c                                                         ; 9a69: 90 21       .!
+    jmp generate_error_precheck_open                                  ; 9a6b: 4c 82 9c    L..
+
+; $9a6e referenced 5 times by $99b5, $99c9, $99d4, $99dc, $99e4
+sub_c9a6e
+    jsr sub_c9a78                                                     ; 9a6e: 20 78 9a     x.
+    bcs c9a8c                                                         ; 9a71: b0 19       ..
+; $9a73 referenced 1 time by $9a4e
+c9a73
+    pla                                                               ; 9a73: 68          h
+    pla                                                               ; 9a74: 68          h
+    lda #0                                                            ; 9a75: a9 00       ..
+; $9a77 referenced 1 time by $9a53
+c9a77
+    rts                                                               ; 9a77: 60          `
+
+; $9a78 referenced 2 times by $9a4b, $9a6e
+sub_c9a78
+    jsr sub_c80f3                                                     ; 9a78: 20 f3 80     ..
+    jsr sub_c8284                                                     ; 9a7b: 20 84 82     ..
+    bcc c9a8c                                                         ; 9a7e: 90 0c       ..
+    tya                                                               ; 9a80: 98          .
+    tax                                                               ; 9a81: aa          .
+; $9a82 referenced 2 times by $881e, $885c
+sub_c9a82
+    lda l10db                                                         ; 9a82: ad db 10    ...
+    sta l00b0                                                         ; 9a85: 85 b0       ..
+    lda l10dc                                                         ; 9a87: ad dc 10    ...
+    sta l00b1                                                         ; 9a8a: 85 b1       ..
+; $9a8c referenced 3 times by $9a69, $9a71, $9a7e
+c9a8c
+    rts                                                               ; 9a8c: 60          `
+
+; $9a8d referenced 4 times by $929d, $a267, $a34a, $a64f
+sub_c9a8d
+    lda #osbyte_read_oshwm                                            ; 9a8d: a9 83       ..
+    jsr osbyte                                                        ; 9a8f: 20 f4 ff     ..
+    sty l10cf                                                         ; 9a92: 8c cf 10    ...
+    lda #osbyte_read_himem                                            ; 9a95: a9 84       ..
+    jsr osbyte                                                        ; 9a97: 20 f4 ff     ..
+    tya                                                               ; 9a9a: 98          .
+    sec                                                               ; 9a9b: 38          8
+    sbc l10cf                                                         ; 9a9c: ed cf 10    ...
+    sta l10d0                                                         ; 9a9f: 8d d0 10    ...
+    rts                                                               ; 9aa2: 60          `
+
+; $9aa3 referenced 2 times by $95d4, $95fd
+sub_c9aa3
+    ldx #$0a                                                          ; 9aa3: a2 0a       ..
+    jsr c9adf                                                         ; 9aa5: 20 df 9a     ..
+    jsr sub_c9ab8                                                     ; 9aa8: 20 b8 9a     ..
+    ldy #$d3                                                          ; 9aab: a0 d3       ..
+    lda #$ff                                                          ; 9aad: a9 ff       ..
+    sta (l00b0),y                                                     ; 9aaf: 91 b0       ..
+    sta l10d3                                                         ; 9ab1: 8d d3 10    ...
+    iny                                                               ; 9ab4: c8          .
+    sta (l00b0),y                                                     ; 9ab5: 91 b0       ..
+    rts                                                               ; 9ab7: 60          `
+
+; $9ab8 referenced 5 times by $895a, $95c1, $971b, $972c, $9aa8
+sub_c9ab8
+    pha                                                               ; 9ab8: 48          H
+    ldx romsel_copy                                                   ; 9ab9: a6 f4       ..
+    lda #0                                                            ; 9abb: a9 00       ..
+    sta l00b0                                                         ; 9abd: 85 b0       ..
+    lda l0df0,x                                                       ; 9abf: bd f0 0d    ...
+    and #$3f ; '?'                                                    ; 9ac2: 29 3f       )?
+    sta l00b1                                                         ; 9ac4: 85 b1       ..
+    pla                                                               ; 9ac6: 68          h
+    rts                                                               ; 9ac7: 60          `
+
+; $9ac8 referenced 2 times by $a3d4, $a3fb
+sub_c9ac8
+    jsr sub_c83e3                                                     ; 9ac8: 20 e3 83     ..
+    lda #$0f                                                          ; 9acb: a9 0f       ..
+    ldx #1                                                            ; 9acd: a2 01       ..
+    ldy #0                                                            ; 9acf: a0 00       ..
+    beq c9ae9                                                         ; 9ad1: f0 16       ..
+; $9ad3 referenced 1 time by $80ac
+sub_c9ad3
+    tax                                                               ; 9ad3: aa          .
+; $9ad4 referenced 1 time by $80b5
+c9ad4
+    lda #3                                                            ; 9ad4: a9 03       ..
+    bne c9ae9                                                         ; 9ad6: d0 11       ..
+; $9ad8 referenced 2 times by $9436, $abbc
+sub_c9ad8
+    jsr sub_c83e3                                                     ; 9ad8: 20 e3 83     ..
+    lda #$7e ; '~'                                                    ; 9adb: a9 7e       .~
+    bne c9ae9                                                         ; 9add: d0 0a       ..
+; $9adf referenced 4 times by $9593, $9599, $95be, $9aa5
+c9adf
+    lda #$8f                                                          ; 9adf: a9 8f       ..
+    bne c9ae9                                                         ; 9ae1: d0 06       ..
+    lda #osbyte_read_write_startup_options                            ; 9ae3: a9 ff       ..
+; $9ae5 referenced 8 times by $80a5, $9588, $96a0, $9e32, $9e43, $aae2, $ac7c, $aeb7
+osbyte_read
+    ldx #0                                                            ; 9ae5: a2 00       ..
+    ldy #$ff                                                          ; 9ae7: a0 ff       ..
+; $9ae9 referenced 4 times by $9ad1, $9ad6, $9add, $9ae1
+c9ae9
+    jmp osbyte                                                        ; 9ae9: 4c f4 ff    L..
+
+; $9aec referenced 1 time by $957d
+l9aec
+    !byte $1b, $ff, $1e, $ff, $21, $ff, $24, $ff, $27, $ff, $2a, $ff  ; 9aec: 1b ff 1e... ...
+    !byte $2d, $ff                                                    ; 9af8: 2d ff       -.
+    !word sub_c9785                                                   ; 9afa: 85 97       ..
+    !byte 0                                                           ; 9afc: 00          .
+    !word sub_c9d9b                                                   ; 9afd: 9b 9d       ..
+    !byte 0                                                           ; 9aff: 00          .
+    !word sub_c9e94                                                   ; 9b00: 94 9e       ..
+    !byte 0                                                           ; 9b02: 00          .
+    !word sub_c9f82                                                   ; 9b03: 82 9f       ..
+    !byte 0                                                           ; 9b05: 00          .
+    !word sub_c97c9                                                   ; 9b06: c9 97       ..
+    !byte 0                                                           ; 9b08: 00          .
+    !word sub_c9c0c                                                   ; 9b09: 0c 9c       ..
+    !byte 0                                                           ; 9b0b: 00          .
+    !word sub_c97b6                                                   ; 9b0c: b6 97       ..
+    !byte 0                                                           ; 9b0e: 00          .
+; $9b0f referenced 1 time by $97c1
+l9b0f
+    !text "1", $5c, "o"                                               ; 9b0f: 31 5c 6f    1\o
+    !byte $fd, $6f, $82, $50, $4b, $9a                                ; 9b12: fd 6f 82... .o.
+; $9b18 referenced 1 time by $97bd
+l9b18
+    !byte $8a, $9e, $88, $86, $88, $84, $9b, $9b, $99                 ; 9b18: 8a 9e 88... ...
+; $9b21 referenced 1 time by $97af
+l9b21
+    !byte $1a, $58, $c8, $db, $d3, $e3, $b4, $bd                      ; 9b21: 1a 58 c8... .X.
+; $9b29 referenced 1 time by $97ab
+l9b29
+    !byte $88, $88, $99, $99, $99, $99, $99, $99                      ; 9b29: 88 88 99... ...
+; $9b31 referenced 1 time by $97e8
+l9b31
+    !byte $1b, $80, $80, $69, $69, $d7,   6, $19, $8b                 ; 9b31: 1b 80 80... ...
+; $9b3a referenced 1 time by $97ee
+l9b3a
+    !byte $86, $99, $99, $99, $99, $98, $99, $99, $98                 ; 9b3a: 86 99 99... ...
+; $9b43 referenced 1 time by $97f4
+l9b43
+    !byte   4,   2,   3,   6,   7,   4,   4,   4,   4, $a2, $11, $a0  ; 9b43: 04 02 03... ...
+    !byte $15                                                         ; 9b4f: 15          .
+
+; $9b50 referenced 1 time by $9b66
+loop_c9b50
+    rts                                                               ; 9b50: 60          `
+
+; $9b51 referenced 1 time by $9b5e
+sub_c9b51
+    jsr sub_c83e3                                                     ; 9b51: 20 e3 83     ..
+    lda #osbyte_close_spool_exec                                      ; 9b54: a9 77       .w
+    jmp osbyte                                                        ; 9b56: 4c f4 ff    L..
+
+sub_c9b59
+    lda #$20 ; ' '                                                    ; 9b59: a9 20       .
+    sta l1086                                                         ; 9b5b: 8d 86 10    ...
+; $9b5e referenced 1 time by $9b74
+loop_c9b5e
+    jsr sub_c9b51                                                     ; 9b5e: 20 51 9b     Q.
+; $9b61 referenced 1 time by $9d81
+sub_c9b61
+    lda #0                                                            ; 9b61: a9 00       ..
+; $9b63 referenced 1 time by $9b6c
+loop_c9b63
+    clc                                                               ; 9b63: 18          .
+    adc #$20 ; ' '                                                    ; 9b64: 69 20       i
+    beq loop_c9b50                                                    ; 9b66: f0 e8       ..
+    tay                                                               ; 9b68: a8          .
+    jsr sub_c9b79                                                     ; 9b69: 20 79 9b     y.
+    bne loop_c9b63                                                    ; 9b6c: d0 f5       ..
+; $9b6e referenced 2 times by $9c13, $9d86
+c9b6e
+    lda #$20 ; ' '                                                    ; 9b6e: a9 20       .
+    sta l1086                                                         ; 9b70: 8d 86 10    ...
+    tya                                                               ; 9b73: 98          .
+    beq loop_c9b5e                                                    ; 9b74: f0 e8       ..
+    jsr sub_c9e75                                                     ; 9b76: 20 75 9e     u.
+; $9b79 referenced 2 times by $9b69, $a264
+sub_c9b79
+    pha                                                               ; 9b79: 48          H
+    jsr sub_c9df4                                                     ; 9b7a: 20 f4 9d     ..
+    bcs c9bc5                                                         ; 9b7d: b0 46       .F
+    lda l111b,y                                                       ; 9b7f: b9 1b 11    ...
+    eor #$ff                                                          ; 9b82: 49 ff       I.
+    and l10c0                                                         ; 9b84: 2d c0 10    -..
+    sta l10c0                                                         ; 9b87: 8d c0 10    ...
+    lda l1117,y                                                       ; 9b8a: b9 17 11    ...
+    and #$60 ; '`'                                                    ; 9b8d: 29 60       )`
+    beq c9bc5                                                         ; 9b8f: f0 34       .4
+    jsr sub_c9bca                                                     ; 9b91: 20 ca 9b     ..
+    lda l1117,y                                                       ; 9b94: b9 17 11    ...
+    and l1086                                                         ; 9b97: 2d 86 10    -..
+    beq c9bc2                                                         ; 9b9a: f0 26       .&
+    ldx l10c3                                                         ; 9b9c: ae c3 10    ...
+    lda l1114,y                                                       ; 9b9f: b9 14 11    ...
+    sta l0f0c,x                                                       ; 9ba2: 9d 0c 0f    ...
+    lda l1115,y                                                       ; 9ba5: b9 15 11    ...
+    sta l0f0d,x                                                       ; 9ba8: 9d 0d 0f    ...
+    lda l1116,y                                                       ; 9bab: b9 16 11    ...
+    jsr sub_c81c5                                                     ; 9bae: 20 c5 81     ..
+    eor l0f0e,x                                                       ; 9bb1: 5d 0e 0f    ]..
+    and #$30 ; '0'                                                    ; 9bb4: 29 30       )0
+    eor l0f0e,x                                                       ; 9bb6: 5d 0e 0f    ]..
+    sta l0f0e,x                                                       ; 9bb9: 9d 0e 0f    ...
+    jsr c93e6                                                         ; 9bbc: 20 e6 93     ..
+    ldy l10c2                                                         ; 9bbf: ac c2 10    ...
+; $9bc2 referenced 1 time by $9b9a
+c9bc2
+    jsr sub_c9f1e                                                     ; 9bc2: 20 1e 9f     ..
+; $9bc5 referenced 2 times by $9b7d, $9b8f
+c9bc5
+    ldx l10c5                                                         ; 9bc5: ae c5 10    ...
+    pla                                                               ; 9bc8: 68          h
+    rts                                                               ; 9bc9: 60          `
+
+; $9bca referenced 1 time by $9b91
+sub_c9bca
+    jsr sub_c9be5                                                     ; 9bca: 20 e5 9b     ..
+; $9bcd referenced 1 time by $9f9f
+sub_c9bcd
+    ldx #6                                                            ; 9bcd: a2 06       ..
+; $9bcf referenced 1 time by $9bd7
+loop_c9bcf
+    lda l110c,y                                                       ; 9bcf: b9 0c 11    ...
+    sta l00c5,x                                                       ; 9bd2: 95 c5       ..
+    dey                                                               ; 9bd4: 88          .
+    dey                                                               ; 9bd5: 88          .
+    dex                                                               ; 9bd6: ca          .
+    bpl loop_c9bcf                                                    ; 9bd7: 10 f6       ..
+    jsr sub_c826d                                                     ; 9bd9: 20 6d 82     m.
+    bcc generate_error_precheck_disc_changed                          ; 9bdc: 90 22       ."
+    sty l10c3                                                         ; 9bde: 8c c3 10    ...
+    ldy l10c2                                                         ; 9be1: ac c2 10    ...
+; $9be4 referenced 1 time by $9bfe
+loop_c9be4
+    rts                                                               ; 9be4: 60          `
+
+; $9be5 referenced 3 times by $9bca, $9eb8, $9f93
+sub_c9be5
+    lda l110e,y                                                       ; 9be5: b9 0e 11    ...
+    and #$7f                                                          ; 9be8: 29 7f       ).
+    sta l00cc                                                         ; 9bea: 85 cc       ..
+    lda l1117,y                                                       ; 9bec: b9 17 11    ...
+    jmp c8816                                                         ; 9bef: 4c 16 88    L..
+
+; $9bf2 referenced 2 times by $8768, $87b8
+sub_c9bf2
+    jsr sub_c83e3                                                     ; 9bf2: 20 e3 83     ..
+    lda l0f04                                                         ; 9bf5: ad 04 0f    ...
+    jsr sub_c8380                                                     ; 9bf8: 20 80 83     ..
+    cmp l0f04                                                         ; 9bfb: cd 04 0f    ...
+    beq loop_c9be4                                                    ; 9bfe: f0 e4       ..
+; $9c00 referenced 1 time by $9bdc
+generate_error_precheck_disc_changed
+    jsr generate_error_precheck_disc                                  ; 9c00: 20 23 80     #.
+    !byte $c8                                                         ; 9c03: c8          .
+    !text "changed"                                                   ; 9c04: 63 68 61... cha
+    !byte 0                                                           ; 9c0b: 00          .
+
+sub_c9c0c
+    and #$c0                                                          ; 9c0c: 29 c0       ).
+    bne c9c16                                                         ; 9c0e: d0 06       ..
+    jsr sub_c83e3                                                     ; 9c10: 20 e3 83     ..
+    jmp c9b6e                                                         ; 9c13: 4c 6e 9b    Ln.
+
+; $9c16 referenced 1 time by $9c0e
+c9c16
+    jsr sub_c840c                                                     ; 9c16: 20 0c 84     ..
+    stx l00ba                                                         ; 9c19: 86 ba       ..
+    sty l00bb                                                         ; 9c1b: 84 bb       ..
+    sta l00b4                                                         ; 9c1d: 85 b4       ..
+    bit l00b4                                                         ; 9c1f: 24 b4       $.
+    php                                                               ; 9c21: 08          .
+    jsr sub_c80f3                                                     ; 9c22: 20 f3 80     ..
+    jsr c99a3                                                         ; 9c25: 20 a3 99     ..
+    jsr sub_c8284                                                     ; 9c28: 20 84 82     ..
+    bcs c9c51                                                         ; 9c2b: b0 24       .$
+    plp                                                               ; 9c2d: 28          (
+    bvc c9c33                                                         ; 9c2e: 50 03       P.
+    lda #0                                                            ; 9c30: a9 00       ..
+    rts                                                               ; 9c32: 60          `
+
+; $9c33 referenced 1 time by $9c2e
+c9c33
+    php                                                               ; 9c33: 08          .
+    lda #0                                                            ; 9c34: a9 00       ..
+    ldx #7                                                            ; 9c36: a2 07       ..
+; $9c38 referenced 1 time by $9c3e
+loop_c9c38
+    sta l00bc,x                                                       ; 9c38: 95 bc       ..
+    sta l1074,x                                                       ; 9c3a: 9d 74 10    .t.
+    dex                                                               ; 9c3d: ca          .
+    bpl loop_c9c38                                                    ; 9c3e: 10 f8       ..
+    dec l00be                                                         ; 9c40: c6 be       ..
+    dec l00bf                                                         ; 9c42: c6 bf       ..
+    dec l1076                                                         ; 9c44: ce 76 10    .v.
+    dec l1077                                                         ; 9c47: ce 77 10    .w.
+    lda #$40 ; '@'                                                    ; 9c4a: a9 40       .@
+    sta l00c3                                                         ; 9c4c: 85 c3       ..
+    jsr sub_c8a77                                                     ; 9c4e: 20 77 8a     w.
+; $9c51 referenced 1 time by $9c2b
+c9c51
+    plp                                                               ; 9c51: 28          (
+    php                                                               ; 9c52: 08          .
+    bvs c9c58                                                         ; 9c53: 70 03       p.
+    jsr sub_c9a50                                                     ; 9c55: 20 50 9a     P.
+; $9c58 referenced 1 time by $9c53
+c9c58
+    jsr sub_c9d1e                                                     ; 9c58: 20 1e 9d     ..
+    bcc c9c6b                                                         ; 9c5b: 90 0e       ..
+; $9c5d referenced 1 time by $9c69
+loop_c9c5d
+    lda l110c,y                                                       ; 9c5d: b9 0c 11    ...
+    bpl generate_error_precheck_open                                  ; 9c60: 10 20       .
+    plp                                                               ; 9c62: 28          (
+    php                                                               ; 9c63: 08          .
+    bmi generate_error_precheck_open                                  ; 9c64: 30 1c       0.
+    jsr sub_c9d19                                                     ; 9c66: 20 19 9d     ..
+    bcs loop_c9c5d                                                    ; 9c69: b0 f2       ..
+; $9c6b referenced 1 time by $9c5b
+c9c6b
+    ldy l10c2                                                         ; 9c6b: ac c2 10    ...
+    bne c9c8b                                                         ; 9c6e: d0 1b       ..
+    jsr generate_error_precheck                                       ; 9c70: 20 38 80     8.
+    !byte $c0                                                         ; 9c73: c0          .
+    !text "Too many open"                                             ; 9c74: 54 6f 6f... Too
+    !byte 0                                                           ; 9c81: 00          .
+
+; $9c82 referenced 3 times by $9a6b, $9c60, $9c64
+generate_error_precheck_open
+    jsr generate_error_precheck                                       ; 9c82: 20 38 80     8.
+    !byte $c2                                                         ; 9c85: c2          .
+    !text "Open"                                                      ; 9c86: 4f 70 65... Ope
+    !byte 0                                                           ; 9c8a: 00          .
+
+; $9c8b referenced 1 time by $9c6e
+c9c8b
+    lda #8                                                            ; 9c8b: a9 08       ..
+    sta l10c4                                                         ; 9c8d: 8d c4 10    ...
+; $9c90 referenced 1 time by $9ca2
+loop_c9c90
+    lda l0e08,x                                                       ; 9c90: bd 08 0e    ...
+    sta l1100,y                                                       ; 9c93: 99 00 11    ...
+    iny                                                               ; 9c96: c8          .
+    lda l0f08,x                                                       ; 9c97: bd 08 0f    ...
+    sta l1100,y                                                       ; 9c9a: 99 00 11    ...
+    iny                                                               ; 9c9d: c8          .
+    inx                                                               ; 9c9e: e8          .
+    dec l10c4                                                         ; 9c9f: ce c4 10    ...
+    bne loop_c9c90                                                    ; 9ca2: d0 ec       ..
+    ldx #$10                                                          ; 9ca4: a2 10       ..
+    lda #0                                                            ; 9ca6: a9 00       ..
+; $9ca8 referenced 1 time by $9cad
+loop_c9ca8
+    sta l1100,y                                                       ; 9ca8: 99 00 11    ...
+    iny                                                               ; 9cab: c8          .
+    dex                                                               ; 9cac: ca          .
+    bne loop_c9ca8                                                    ; 9cad: d0 f9       ..
+    lda l10c2                                                         ; 9caf: ad c2 10    ...
+    tay                                                               ; 9cb2: a8          .
+    jsr sub_c81be                                                     ; 9cb3: 20 be 81     ..
+    adc #$11                                                          ; 9cb6: 69 11       i.
+    sta l1113,y                                                       ; 9cb8: 99 13 11    ...
+    lda l10c1                                                         ; 9cbb: ad c1 10    ...
+    sta l111b,y                                                       ; 9cbe: 99 1b 11    ...
+    ora l10c0                                                         ; 9cc1: 0d c0 10    ...
+    sta l10c0                                                         ; 9cc4: 8d c0 10    ...
+    lda l1109,y                                                       ; 9cc7: b9 09 11    ...
+    adc #$ff                                                          ; 9cca: 69 ff       i.
+    lda l110b,y                                                       ; 9ccc: b9 0b 11    ...
+    adc #0                                                            ; 9ccf: 69 00       i.
+    sta l1119,y                                                       ; 9cd1: 99 19 11    ...
+    lda l110d,y                                                       ; 9cd4: b9 0d 11    ...
+    ora #$0f                                                          ; 9cd7: 09 0f       ..
+    adc #0                                                            ; 9cd9: 69 00       i.
+    jsr sub_c81b0                                                     ; 9cdb: 20 b0 81     ..
+    sta l111a,y                                                       ; 9cde: 99 1a 11    ...
+    plp                                                               ; 9ce1: 28          (
+    bvc c9d12                                                         ; 9ce2: 50 2e       P.
+    bmi c9cee                                                         ; 9ce4: 30 08       0.
+    lda #$80                                                          ; 9ce6: a9 80       ..
+    ora l110c,y                                                       ; 9ce8: 19 0c 11    ...
+    sta l110c,y                                                       ; 9ceb: 99 0c 11    ...
+; $9cee referenced 1 time by $9ce4
+c9cee
+    lda l1109,y                                                       ; 9cee: b9 09 11    ...
+    sta l1114,y                                                       ; 9cf1: 99 14 11    ...
+    lda l110b,y                                                       ; 9cf4: b9 0b 11    ...
+    sta l1115,y                                                       ; 9cf7: 99 15 11    ...
+    lda l110d,y                                                       ; 9cfa: b9 0d 11    ...
+    jsr sub_c81b0                                                     ; 9cfd: 20 b0 81     ..
+    sta l1116,y                                                       ; 9d00: 99 16 11    ...
+; $9d03 referenced 1 time by $9d17
+loop_c9d03
+    lda l00cd                                                         ; 9d03: a5 cd       ..
+    ora l1117,y                                                       ; 9d05: 19 17 11    ...
+    sta l1117,y                                                       ; 9d08: 99 17 11    ...
+    tya                                                               ; 9d0b: 98          .
+    jsr sub_c81be                                                     ; 9d0c: 20 be 81     ..
+    ora #$10                                                          ; 9d0f: 09 10       ..
+    rts                                                               ; 9d11: 60          `
+
+; $9d12 referenced 1 time by $9ce2
+c9d12
+    lda #$20 ; ' '                                                    ; 9d12: a9 20       .
+    sta l1117,y                                                       ; 9d14: 99 17 11    ...
+    bne loop_c9d03                                                    ; 9d17: d0 ea       ..
+; $9d19 referenced 1 time by $9c66
+sub_c9d19
+    txa                                                               ; 9d19: 8a          .
+    pha                                                               ; 9d1a: 48          H
+    jmp c9d5d                                                         ; 9d1b: 4c 5d 9d    L].
+
+; $9d1e referenced 2 times by $9a66, $9c58
+sub_c9d1e
+    lda #0                                                            ; 9d1e: a9 00       ..
+    sta l10c2                                                         ; 9d20: 8d c2 10    ...
+    lda #8                                                            ; 9d23: a9 08       ..
+    sta l00b5                                                         ; 9d25: 85 b5       ..
+    tya                                                               ; 9d27: 98          .
+    tax                                                               ; 9d28: aa          .
+    ldy #$a0                                                          ; 9d29: a0 a0       ..
+; $9d2b referenced 1 time by $9d6f
+c9d2b
+    sty l00b3                                                         ; 9d2b: 84 b3       ..
+    txa                                                               ; 9d2d: 8a          .
+    pha                                                               ; 9d2e: 48          H
+    lda #8                                                            ; 9d2f: a9 08       ..
+    sta l00b2                                                         ; 9d31: 85 b2       ..
+    lda l00b5                                                         ; 9d33: a5 b5       ..
+    bit l10c0                                                         ; 9d35: 2c c0 10    ,..
+    beq c9d57                                                         ; 9d38: f0 1d       ..
+    lda l1117,y                                                       ; 9d3a: b9 17 11    ...
+    eor l00cd                                                         ; 9d3d: 45 cd       E.
+    and #3                                                            ; 9d3f: 29 03       ).
+    bne c9d5d                                                         ; 9d41: d0 1a       ..
+; $9d43 referenced 1 time by $9d52
+loop_c9d43
+    lda l0e08,x                                                       ; 9d43: bd 08 0e    ...
+    eor l1100,y                                                       ; 9d46: 59 00 11    Y..
+    and #$7f                                                          ; 9d49: 29 7f       ).
+    bne c9d5d                                                         ; 9d4b: d0 10       ..
+    inx                                                               ; 9d4d: e8          .
+    iny                                                               ; 9d4e: c8          .
+    iny                                                               ; 9d4f: c8          .
+    dec l00b2                                                         ; 9d50: c6 b2       ..
+    bne loop_c9d43                                                    ; 9d52: d0 ef       ..
+    sec                                                               ; 9d54: 38          8
+    bcs c9d67                                                         ; 9d55: b0 10       ..
+; $9d57 referenced 1 time by $9d38
+c9d57
+    sty l10c2                                                         ; 9d57: 8c c2 10    ...
+    sta l10c1                                                         ; 9d5a: 8d c1 10    ...
+; $9d5d referenced 3 times by $9d1b, $9d41, $9d4b
+c9d5d
+    sec                                                               ; 9d5d: 38          8
+    lda l00b3                                                         ; 9d5e: a5 b3       ..
+    sbc #$20 ; ' '                                                    ; 9d60: e9 20       .
+    sta l00b3                                                         ; 9d62: 85 b3       ..
+    asl l00b5                                                         ; 9d64: 06 b5       ..
+    clc                                                               ; 9d66: 18          .
+; $9d67 referenced 1 time by $9d55
+c9d67
+    pla                                                               ; 9d67: 68          h
+    tax                                                               ; 9d68: aa          .
+    ldy l00b3                                                         ; 9d69: a4 b3       ..
+    lda l00b5                                                         ; 9d6b: a5 b5       ..
+    bcs c9d71                                                         ; 9d6d: b0 02       ..
+    bne c9d2b                                                         ; 9d6f: d0 ba       ..
+; $9d71 referenced 1 time by $9d6d
+c9d71
+    rts                                                               ; 9d71: 60          `
+
+; $9d72 referenced 1 time by $9da0
+c9d72
+    jsr zero_stacked_XXX                                              ; 9d72: 20 8e 9d     ..
+; $9d75 referenced 1 time by $9726
+sub_c9d75
+    lda l10c0                                                         ; 9d75: ad c0 10    ...
+    pha                                                               ; 9d78: 48          H
+    lda #0                                                            ; 9d79: a9 00       ..
+    sta l1086                                                         ; 9d7b: 8d 86 10    ...
+    tya                                                               ; 9d7e: 98          .
+    bne c9d86                                                         ; 9d7f: d0 05       ..
+    jsr sub_c9b61                                                     ; 9d81: 20 61 9b     a.
+    beq c9d89                                                         ; 9d84: f0 03       ..
+; $9d86 referenced 1 time by $9d7f
+c9d86
+    jsr c9b6e                                                         ; 9d86: 20 6e 9b     n.
+; $9d89 referenced 1 time by $9d84
+c9d89
+    pla                                                               ; 9d89: 68          h
+    sta l10c0                                                         ; 9d8a: 8d c0 10    ...
+    rts                                                               ; 9d8d: 60          `
+
+; $9d8e referenced 6 times by $956f, $9714, $97d0, $9d72, $9daa, $9db8
+zero_stacked_XXX
+    pha                                                               ; 9d8e: 48          H
+    txa                                                               ; 9d8f: 8a          .
+    pha                                                               ; 9d90: 48          H
+    lda #0                                                            ; 9d91: a9 00       ..
+    tsx                                                               ; 9d93: ba          .
+    sta l0109,x                                                       ; 9d94: 9d 09 01    ...
+    pla                                                               ; 9d97: 68          h
+    tax                                                               ; 9d98: aa          .
+    pla                                                               ; 9d99: 68          h
+    rts                                                               ; 9d9a: 60          `
+
+sub_c9d9b
+    jsr sub_c83e3                                                     ; 9d9b: 20 e3 83     ..
+    cmp #$ff                                                          ; 9d9e: c9 ff       ..
+    beq c9d72                                                         ; 9da0: f0 d0       ..
+    cpy #0                                                            ; 9da2: c0 00       ..
+    beq c9db4                                                         ; 9da4: f0 0e       ..
+    cmp #3                                                            ; 9da6: c9 03       ..
+    bcs c9dcd                                                         ; 9da8: b0 23       .#
+    jsr zero_stacked_XXX                                              ; 9daa: 20 8e 9d     ..
+    cmp #1                                                            ; 9dad: c9 01       ..
+    bne c9dd5                                                         ; 9daf: d0 24       .$
+    jmp ca06c                                                         ; 9db1: 4c 6c a0    Ll.
+
+; $9db4 referenced 1 time by $9da4
+c9db4
+    cmp #2                                                            ; 9db4: c9 02       ..
+    bcs c9dcd                                                         ; 9db6: b0 15       ..
+    jsr zero_stacked_XXX                                              ; 9db8: 20 8e 9d     ..
+    beq c9dce                                                         ; 9dbb: f0 11       ..
+    lda #$ff                                                          ; 9dbd: a9 ff       ..
+    sta l0002,x                                                       ; 9dbf: 95 02       ..
+    sta l0003,x                                                       ; 9dc1: 95 03       ..
+    lda l10d9                                                         ; 9dc3: ad d9 10    ...
+    sta l0000,x                                                       ; 9dc6: 95 00       ..
+    lda l10da                                                         ; 9dc8: ad da 10    ...
+    sta l0001,x                                                       ; 9dcb: 95 01       ..
+; $9dcd referenced 2 times by $9da8, $9db6
+c9dcd
+    rts                                                               ; 9dcd: 60          `
+
+; $9dce referenced 1 time by $9dbb
+c9dce
+    lda #4                                                            ; 9dce: a9 04       ..
+    tsx                                                               ; 9dd0: ba          .
+    sta l0105,x                                                       ; 9dd1: 9d 05 01    ...
+    rts                                                               ; 9dd4: 60          `
+
+; $9dd5 referenced 2 times by $984c, $9daf
+c9dd5
+    jsr sub_c9e75                                                     ; 9dd5: 20 75 9e     u.
+    sty l10c2                                                         ; 9dd8: 8c c2 10    ...
+    asl                                                               ; 9ddb: 0a          .
+    adc l10c2                                                         ; 9ddc: 6d c2 10    m..
+    tay                                                               ; 9ddf: a8          .
+    lda l1110,y                                                       ; 9de0: b9 10 11    ...
+    sta l0000,x                                                       ; 9de3: 95 00       ..
+    lda l1111,y                                                       ; 9de5: b9 11 11    ...
+    sta l0001,x                                                       ; 9de8: 95 01       ..
+    lda l1112,y                                                       ; 9dea: b9 12 11    ...
+    sta l0002,x                                                       ; 9ded: 95 02       ..
+    lda #0                                                            ; 9def: a9 00       ..
+    sta l0003,x                                                       ; 9df1: 95 03       ..
+    rts                                                               ; 9df3: 60          `
+
+; $9df4 referenced 2 times by $9b7a, $9e78
+sub_c9df4
+    pha                                                               ; 9df4: 48          H
+    stx l10c5                                                         ; 9df5: 8e c5 10    ...
+    tya                                                               ; 9df8: 98          .
+    and #$e0                                                          ; 9df9: 29 e0       ).
+    sta l10c2                                                         ; 9dfb: 8d c2 10    ...
+    beq c9e13                                                         ; 9dfe: f0 13       ..
+    jsr sub_c81be                                                     ; 9e00: 20 be 81     ..
+    tay                                                               ; 9e03: a8          .
+    lda #0                                                            ; 9e04: a9 00       ..
+    sec                                                               ; 9e06: 38          8
+; $9e07 referenced 1 time by $9e09
+loop_c9e07
+    ror                                                               ; 9e07: 6a          j
+    dey                                                               ; 9e08: 88          .
+    bne loop_c9e07                                                    ; 9e09: d0 fc       ..
+    ldy l10c2                                                         ; 9e0b: ac c2 10    ...
+    bit l10c0                                                         ; 9e0e: 2c c0 10    ,..
+    bne c9e16                                                         ; 9e11: d0 03       ..
+; $9e13 referenced 1 time by $9dfe
+c9e13
+    pla                                                               ; 9e13: 68          h
+    sec                                                               ; 9e14: 38          8
+    rts                                                               ; 9e15: 60          `
+
+; $9e16 referenced 1 time by $9e11
+c9e16
+    pla                                                               ; 9e16: 68          h
+    clc                                                               ; 9e17: 18          .
+    rts                                                               ; 9e18: 60          `
+
+    !byte $48, $8a, $4c, $20, $9e                                     ; 9e19: 48 8a 4c... H.L
+
+; $9e1e referenced 2 times by $9e56, $9e75
+sub_c9e1e
+    pha                                                               ; 9e1e: 48          H
+    tya                                                               ; 9e1f: 98          .
+    cmp #$10                                                          ; 9e20: c9 10       ..
+    bcc c9e28                                                         ; 9e22: 90 04       ..
+    cmp #$18                                                          ; 9e24: c9 18       ..
+    bcc c9e2a                                                         ; 9e26: 90 02       ..
+; $9e28 referenced 1 time by $9e22
+c9e28
+    lda #8                                                            ; 9e28: a9 08       ..
+; $9e2a referenced 1 time by $9e26
+c9e2a
+    jsr sub_c81c4                                                     ; 9e2a: 20 c4 81     ..
+    tay                                                               ; 9e2d: a8          .
+    pla                                                               ; 9e2e: 68          h
+    rts                                                               ; 9e2f: 60          `
+
+; $9e30 referenced 3 times by $803d, $9e7d, $9fc5
+sub_c9e30
+    lda #osbyte_rw_exec_handle                                        ; 9e30: a9 c6       ..
+    jsr osbyte_read                                                   ; 9e32: 20 e5 9a     ..
+    txa                                                               ; 9e35: 8a          .
+    beq c9e41                                                         ; 9e36: f0 09       ..
+    jsr sub_c9e54                                                     ; 9e38: 20 54 9e     T.
+    bne c9e41                                                         ; 9e3b: d0 04       ..
+    lda #osbyte_rw_exec_handle                                        ; 9e3d: a9 c6       ..
+    bne osbyte_write_0                                                ; 9e3f: d0 0c       ..
+; $9e41 referenced 2 times by $9e36, $9e3b
+c9e41
+    lda #osbyte_read_write_spool_file_handle                          ; 9e41: a9 c7       ..
+    jsr osbyte_read                                                   ; 9e43: 20 e5 9a     ..
+    jsr sub_c9e54                                                     ; 9e46: 20 54 9e     T.
+    bne c9e5c                                                         ; 9e49: d0 11       ..
+    lda #osbyte_read_write_spool_file_handle                          ; 9e4b: a9 c7       ..
+; $9e4d referenced 1 time by $9e3f
+osbyte_write_0
+    ldx #0                                                            ; 9e4d: a2 00       ..
+    ldy #0                                                            ; 9e4f: a0 00       ..
+    jmp osbyte                                                        ; 9e51: 4c f4 ff    L..
+
+; $9e54 referenced 2 times by $9e38, $9e46
+sub_c9e54
+    txa                                                               ; 9e54: 8a          .
+    tay                                                               ; 9e55: a8          .
+    jsr sub_c9e1e                                                     ; 9e56: 20 1e 9e     ..
+    cpy l10c2                                                         ; 9e59: cc c2 10    ...
+; $9e5c referenced 1 time by $9e49
+c9e5c
+    rts                                                               ; 9e5c: 60          `
+
+    pha                                                               ; 9e5d: 48          H
+    tya                                                               ; 9e5e: 98          .
+    pha                                                               ; 9e5f: 48          H
+    txa                                                               ; 9e60: 8a          .
+    tay                                                               ; 9e61: a8          .
+    jsr sub_c9e75                                                     ; 9e62: 20 75 9e     u.
+    tya                                                               ; 9e65: 98          .
+    jsr sub_ca0de                                                     ; 9e66: 20 de a0     ..
+    bne c9e6f                                                         ; 9e69: d0 04       ..
+    ldx #$ff                                                          ; 9e6b: a2 ff       ..
+    bne c9e71                                                         ; 9e6d: d0 02       ..
+; $9e6f referenced 1 time by $9e69
+c9e6f
+    ldx #0                                                            ; 9e6f: a2 00       ..
+; $9e71 referenced 1 time by $9e6d
+c9e71
+    pla                                                               ; 9e71: 68          h
+    tay                                                               ; 9e72: a8          .
+    pla                                                               ; 9e73: 68          h
+; $9e74 referenced 1 time by $9e7b
+loop_c9e74
+    rts                                                               ; 9e74: 60          `
+
+; $9e75 referenced 6 times by $9b76, $9dd5, $9e62, $9e97, $9f85, $a06f
+sub_c9e75
+    jsr sub_c9e1e                                                     ; 9e75: 20 1e 9e     ..
+    jsr sub_c9df4                                                     ; 9e78: 20 f4 9d     ..
+    bcc loop_c9e74                                                    ; 9e7b: 90 f7       ..
+    jsr sub_c9e30                                                     ; 9e7d: 20 30 9e     0.
+    jsr generate_error_precheck                                       ; 9e80: 20 38 80     8.
+    !byte $de                                                         ; 9e83: de          .
+    !text "Channel"                                                   ; 9e84: 43 68 61... Cha
+    !byte 0                                                           ; 9e8b: 00          .
+
+; $9e8c referenced 1 time by $9ea5
+loop_c9e8c
+    jsr generate_error_precheck                                       ; 9e8c: 20 38 80     8.
+    !byte $df                                                         ; 9e8f: df          .
+    !text "EOF"                                                       ; 9e90: 45 4f 46    EOF
+    !byte 0                                                           ; 9e93: 00          .
+
+; $9e94 referenced 1 time by $9969
+sub_c9e94
+    jsr sub_c840c                                                     ; 9e94: 20 0c 84     ..
+    jsr sub_c9e75                                                     ; 9e97: 20 75 9e     u.
+    tya                                                               ; 9e9a: 98          .
+    jsr sub_ca0de                                                     ; 9e9b: 20 de a0     ..
+    bne c9eb3                                                         ; 9e9e: d0 13       ..
+    lda l1117,y                                                       ; 9ea0: b9 17 11    ...
+    and #$10                                                          ; 9ea3: 29 10       ).
+    bne loop_c9e8c                                                    ; 9ea5: d0 e5       ..
+    lda #$10                                                          ; 9ea7: a9 10       ..
+    jsr sub_c9f0f                                                     ; 9ea9: 20 0f 9f     ..
+    ldx l10c5                                                         ; 9eac: ae c5 10    ...
+    lda #$fe                                                          ; 9eaf: a9 fe       ..
+    sec                                                               ; 9eb1: 38          8
+    rts                                                               ; 9eb2: 60          `
+
+; $9eb3 referenced 1 time by $9e9e
+c9eb3
+    lda l1117,y                                                       ; 9eb3: b9 17 11    ...
+    bmi c9ec2                                                         ; 9eb6: 30 0a       0.
+    jsr sub_c9be5                                                     ; 9eb8: 20 e5 9b     ..
+    jsr sub_c9f1e                                                     ; 9ebb: 20 1e 9f     ..
+    sec                                                               ; 9ebe: 38          8
+    jsr sub_c9f26                                                     ; 9ebf: 20 26 9f     &.
+; $9ec2 referenced 1 time by $9eb6
+c9ec2
+    lda l1110,y                                                       ; 9ec2: b9 10 11    ...
+    sta l00ba                                                         ; 9ec5: 85 ba       ..
+    lda l1113,y                                                       ; 9ec7: b9 13 11    ...
+    sta l00bb                                                         ; 9eca: 85 bb       ..
+    ldy #0                                                            ; 9ecc: a0 00       ..
+    lda (l00ba),y                                                     ; 9ece: b1 ba       ..
+    pha                                                               ; 9ed0: 48          H
+    ldy l10c2                                                         ; 9ed1: ac c2 10    ...
+    ldx l00ba                                                         ; 9ed4: a6 ba       ..
+    inx                                                               ; 9ed6: e8          .
+    txa                                                               ; 9ed7: 8a          .
+    sta l1110,y                                                       ; 9ed8: 99 10 11    ...
+    bne c9ef1                                                         ; 9edb: d0 14       ..
+    clc                                                               ; 9edd: 18          .
+    lda l1111,y                                                       ; 9ede: b9 11 11    ...
+    adc #1                                                            ; 9ee1: 69 01       i.
+    sta l1111,y                                                       ; 9ee3: 99 11 11    ...
+    lda l1112,y                                                       ; 9ee6: b9 12 11    ...
+    adc #0                                                            ; 9ee9: 69 00       i.
+    sta l1112,y                                                       ; 9eeb: 99 12 11    ...
+    jsr sub_c9f14                                                     ; 9eee: 20 14 9f     ..
+; $9ef1 referenced 1 time by $9edb
+c9ef1
+    clc                                                               ; 9ef1: 18          .
+    pla                                                               ; 9ef2: 68          h
+    rts                                                               ; 9ef3: 60          `
+
+; $9ef4 referenced 2 times by $9f5e, $a018
+sub_c9ef4
+    clc                                                               ; 9ef4: 18          .
+    lda l110f,y                                                       ; 9ef5: b9 0f 11    ...
+    adc l1111,y                                                       ; 9ef8: 79 11 11    y..
+    sta l00c3                                                         ; 9efb: 85 c3       ..
+    sta l111c,y                                                       ; 9efd: 99 1c 11    ...
+    lda l110d,y                                                       ; 9f00: b9 0d 11    ...
+    and #3                                                            ; 9f03: 29 03       ).
+    adc l1112,y                                                       ; 9f05: 79 12 11    y..
+    sta l00c2                                                         ; 9f08: 85 c2       ..
+    sta l111d,y                                                       ; 9f0a: 99 1d 11    ...
+; $9f0d referenced 1 time by $a0db
+c9f0d
+    lda #$80                                                          ; 9f0d: a9 80       ..
+; $9f0f referenced 3 times by $9ea9, $a035, $a05c
+sub_c9f0f
+    ora l1117,y                                                       ; 9f0f: 19 17 11    ...
+    bne c9f19                                                         ; 9f12: d0 05       ..
+; $9f14 referenced 2 times by $9eee, $a041
+sub_c9f14
+    lda #$7f                                                          ; 9f14: a9 7f       ..
+; $9f16 referenced 3 times by $95f0, $9f59, $a0ba
+sub_c9f16
+    and l1117,y                                                       ; 9f16: 39 17 11    9..
+; $9f19 referenced 1 time by $9f12
+c9f19
+    sta l1117,y                                                       ; 9f19: 99 17 11    ...
+    clc                                                               ; 9f1c: 18          .
+    rts                                                               ; 9f1d: 60          `
+
+; $9f1e referenced 3 times by $9bc2, $9ebb, $a00a
+sub_c9f1e
+    lda l1117,y                                                       ; 9f1e: b9 17 11    ...
+    and #$40 ; '@'                                                    ; 9f21: 29 40       )@
+    beq c9f6a                                                         ; 9f23: f0 45       .E
+    clc                                                               ; 9f25: 18          .
+; $9f26 referenced 2 times by $9ebf, $a01e
+sub_c9f26
+    php                                                               ; 9f26: 08          .
+    inc l10dd                                                         ; 9f27: ee dd 10    ...
+    ldy l10c2                                                         ; 9f2a: ac c2 10    ...
+    lda l1113,y                                                       ; 9f2d: b9 13 11    ...
+    sta l00bd                                                         ; 9f30: 85 bd       ..
+    lda #$ff                                                          ; 9f32: a9 ff       ..
+    sta l1074                                                         ; 9f34: 8d 74 10    .t.
+    sta l1075                                                         ; 9f37: 8d 75 10    .u.
+    lda #0                                                            ; 9f3a: a9 00       ..
+    sta l00bc                                                         ; 9f3c: 85 bc       ..
+    sta l00c0                                                         ; 9f3e: 85 c0       ..
+    lda #1                                                            ; 9f40: a9 01       ..
+    sta l00c1                                                         ; 9f42: 85 c1       ..
+    plp                                                               ; 9f44: 28          (
+    bcs c9f5e                                                         ; 9f45: b0 17       ..
+    lda l111c,y                                                       ; 9f47: b9 1c 11    ...
+    sta l00c3                                                         ; 9f4a: 85 c3       ..
+    lda l111d,y                                                       ; 9f4c: b9 1d 11    ...
+    sta l00c2                                                         ; 9f4f: 85 c2       ..
+    jsr sub_c8862                                                     ; 9f51: 20 62 88     b.
+    ldy l10c2                                                         ; 9f54: ac c2 10    ...
+    lda #$bf                                                          ; 9f57: a9 bf       ..
+    jsr sub_c9f16                                                     ; 9f59: 20 16 9f     ..
+    bcc c9f64                                                         ; 9f5c: 90 06       ..
+; $9f5e referenced 1 time by $9f45
+c9f5e
+    jsr sub_c9ef4                                                     ; 9f5e: 20 f4 9e     ..
+    jsr sub_c8855                                                     ; 9f61: 20 55 88     U.
+; $9f64 referenced 1 time by $9f5c
+c9f64
+    dec l10dd                                                         ; 9f64: ce dd 10    ...
+    ldy l10c2                                                         ; 9f67: ac c2 10    ...
+; $9f6a referenced 1 time by $9f23
+c9f6a
+    rts                                                               ; 9f6a: 60          `
+
+; $9f6b referenced 1 time by $9f91
+c9f6b
+    jmp generate_error_precheck_locked                                ; 9f6b: 4c 55 9a    LU.
+
+; $9f6e referenced 1 time by $9f8c
+loop_c9f6e
+    jsr generate_error_precheck                                       ; 9f6e: 20 38 80     8.
+    !byte $c1                                                         ; 9f71: c1          .
+    !text "Read only"                                                 ; 9f72: 52 65 61... Rea
+    !byte 0                                                           ; 9f7b: 00          .
+
+; $9f7c referenced 1 time by $a09a
+sub_c9f7c
+    jsr sub_c83e3                                                     ; 9f7c: 20 e3 83     ..
+    jmp c9f88                                                         ; 9f7f: 4c 88 9f    L..
+
+; $9f82 referenced 1 time by $9983
+sub_c9f82
+    jsr sub_c83e3                                                     ; 9f82: 20 e3 83     ..
+    jsr sub_c9e75                                                     ; 9f85: 20 75 9e     u.
+; $9f88 referenced 1 time by $9f7f
+c9f88
+    pha                                                               ; 9f88: 48          H
+    lda l110c,y                                                       ; 9f89: b9 0c 11    ...
+    bmi loop_c9f6e                                                    ; 9f8c: 30 e0       0.
+    lda l110e,y                                                       ; 9f8e: b9 0e 11    ...
+    bmi c9f6b                                                         ; 9f91: 30 d8       0.
+    jsr sub_c9be5                                                     ; 9f93: 20 e5 9b     ..
+    tya                                                               ; 9f96: 98          .
+    clc                                                               ; 9f97: 18          .
+    adc #4                                                            ; 9f98: 69 04       i.
+    jsr sub_ca0de                                                     ; 9f9a: 20 de a0     ..
+    bne ca005                                                         ; 9f9d: d0 66       .f
+    jsr sub_c9bcd                                                     ; 9f9f: 20 cd 9b     ..
+    ldx l10c3                                                         ; 9fa2: ae c3 10    ...
+    sec                                                               ; 9fa5: 38          8
+    lda l0f07,x                                                       ; 9fa6: bd 07 0f    ...
+    sbc l0f0f,x                                                       ; 9fa9: fd 0f 0f    ...
+    pha                                                               ; 9fac: 48          H
+    lda l0f06,x                                                       ; 9fad: bd 06 0f    ...
+    sbc l0f0e,x                                                       ; 9fb0: fd 0e 0f    ...
+    and #3                                                            ; 9fb3: 29 03       ).
+    cmp l111a,y                                                       ; 9fb5: d9 1a 11    ...
+    bne c9fd9                                                         ; 9fb8: d0 1f       ..
+    pla                                                               ; 9fba: 68          h
+    cmp l1119,y                                                       ; 9fbb: d9 19 11    ...
+    bne c9ff4                                                         ; 9fbe: d0 34       .4
+    sty l00b4                                                         ; 9fc0: 84 b4       ..
+    sty l10c2                                                         ; 9fc2: 8c c2 10    ...
+    jsr sub_c9e30                                                     ; 9fc5: 20 30 9e     0.
+    jsr generate_error_precheck                                       ; 9fc8: 20 38 80     8.
+    !byte $bf                                                         ; 9fcb: bf          .
+    !text "Can't extend"                                              ; 9fcc: 43 61 6e... Can
+    !byte 0                                                           ; 9fd8: 00          .
+
+; $9fd9 referenced 1 time by $9fb8
+c9fd9
+    lda l111a,y                                                       ; 9fd9: b9 1a 11    ...
+    clc                                                               ; 9fdc: 18          .
+    adc #1                                                            ; 9fdd: 69 01       i.
+    sta l111a,y                                                       ; 9fdf: 99 1a 11    ...
+    asl                                                               ; 9fe2: 0a          .
+    asl                                                               ; 9fe3: 0a          .
+    asl                                                               ; 9fe4: 0a          .
+    asl                                                               ; 9fe5: 0a          .
+    eor l0f0e,x                                                       ; 9fe6: 5d 0e 0f    ]..
+    and #$30 ; '0'                                                    ; 9fe9: 29 30       )0
+    eor l0f0e,x                                                       ; 9feb: 5d 0e 0f    ]..
+    sta l0f0e,x                                                       ; 9fee: 9d 0e 0f    ...
+    pla                                                               ; 9ff1: 68          h
+    lda #0                                                            ; 9ff2: a9 00       ..
+; $9ff4 referenced 1 time by $9fbe
+c9ff4
+    sta l0f0d,x                                                       ; 9ff4: 9d 0d 0f    ...
+    sta l1119,y                                                       ; 9ff7: 99 19 11    ...
+    lda #0                                                            ; 9ffa: a9 00       ..
+    sta l0f0c,x                                                       ; 9ffc: 9d 0c 0f    ...
+    jsr c93e6                                                         ; 9fff: 20 e6 93     ..
+    ldy l10c2                                                         ; a002: ac c2 10    ...
+; $a005 referenced 1 time by $9f9d
+ca005
+    lda l1117,y                                                       ; a005: b9 17 11    ...
+    bmi ca021                                                         ; a008: 30 17       0.
+    jsr sub_c9f1e                                                     ; a00a: 20 1e 9f     ..
+    lda l1114,y                                                       ; a00d: b9 14 11    ...
+    bne ca01d                                                         ; a010: d0 0b       ..
+    tya                                                               ; a012: 98          .
+    jsr sub_ca0de                                                     ; a013: 20 de a0     ..
+    bne ca01d                                                         ; a016: d0 05       ..
+    jsr sub_c9ef4                                                     ; a018: 20 f4 9e     ..
+    bne ca021                                                         ; a01b: d0 04       ..
+; $a01d referenced 2 times by $a010, $a016
+ca01d
+    sec                                                               ; a01d: 38          8
+    jsr sub_c9f26                                                     ; a01e: 20 26 9f     &.
+; $a021 referenced 2 times by $a008, $a01b
+ca021
+    lda l1110,y                                                       ; a021: b9 10 11    ...
+    sta l00ba                                                         ; a024: 85 ba       ..
+    lda l1113,y                                                       ; a026: b9 13 11    ...
+    sta l00bb                                                         ; a029: 85 bb       ..
+    pla                                                               ; a02b: 68          h
+    ldy #0                                                            ; a02c: a0 00       ..
+    sta (l00ba),y                                                     ; a02e: 91 ba       ..
+    ldy l10c2                                                         ; a030: ac c2 10    ...
+    lda #$40 ; '@'                                                    ; a033: a9 40       .@
+    jsr sub_c9f0f                                                     ; a035: 20 0f 9f     ..
+    inc l00ba                                                         ; a038: e6 ba       ..
+    lda l00ba                                                         ; a03a: a5 ba       ..
+    sta l1110,y                                                       ; a03c: 99 10 11    ...
+    bne ca054                                                         ; a03f: d0 13       ..
+    jsr sub_c9f14                                                     ; a041: 20 14 9f     ..
+    lda l1111,y                                                       ; a044: b9 11 11    ...
+    adc #1                                                            ; a047: 69 01       i.
+    sta l1111,y                                                       ; a049: 99 11 11    ...
+    lda l1112,y                                                       ; a04c: b9 12 11    ...
+    adc #0                                                            ; a04f: 69 00       i.
+    sta l1112,y                                                       ; a051: 99 12 11    ...
+; $a054 referenced 1 time by $a03f
+ca054
+    tya                                                               ; a054: 98          .
+    jsr sub_ca0de                                                     ; a055: 20 de a0     ..
+    bcc ca06b                                                         ; a058: 90 11       ..
+    lda #$20 ; ' '                                                    ; a05a: a9 20       .
+    jsr sub_c9f0f                                                     ; a05c: 20 0f 9f     ..
+    ldx #2                                                            ; a05f: a2 02       ..
+; $a061 referenced 1 time by $a069
+loop_ca061
+    lda l1110,y                                                       ; a061: b9 10 11    ...
+    sta l1114,y                                                       ; a064: 99 14 11    ...
+    iny                                                               ; a067: c8          .
+    dex                                                               ; a068: ca          .
+    bpl loop_ca061                                                    ; a069: 10 f6       ..
+; $a06b referenced 3 times by $a058, $a0d1, $a0d9
+ca06b
+    rts                                                               ; a06b: 60          `
+
+; $a06c referenced 2 times by $9849, $9db1
+ca06c
+    jsr sub_c83e3                                                     ; a06c: 20 e3 83     ..
+    jsr sub_c9e75                                                     ; a06f: 20 75 9e     u.
+    ldy l10c2                                                         ; a072: ac c2 10    ...
+; $a075 referenced 1 time by $a0a6
+ca075
+    jsr sub_ca0f6                                                     ; a075: 20 f6 a0     ..
+    bcs ca0a9                                                         ; a078: b0 2f       ./
+    lda l1114,y                                                       ; a07a: b9 14 11    ...
+    sta l1110,y                                                       ; a07d: 99 10 11    ...
+    lda l1115,y                                                       ; a080: b9 15 11    ...
+    sta l1111,y                                                       ; a083: 99 11 11    ...
+    lda l1116,y                                                       ; a086: b9 16 11    ...
+    sta l1112,y                                                       ; a089: 99 12 11    ...
+    jsr sub_ca0b8                                                     ; a08c: 20 b8 a0     ..
+    lda l00b6                                                         ; a08f: a5 b6       ..
+    pha                                                               ; a091: 48          H
+    lda l00b7                                                         ; a092: a5 b7       ..
+    pha                                                               ; a094: 48          H
+    lda l00b8                                                         ; a095: a5 b8       ..
+    pha                                                               ; a097: 48          H
+    lda #0                                                            ; a098: a9 00       ..
+    jsr sub_c9f7c                                                     ; a09a: 20 7c 9f     |.
+    pla                                                               ; a09d: 68          h
+    sta l00b8                                                         ; a09e: 85 b8       ..
+    pla                                                               ; a0a0: 68          h
+    sta l00b7                                                         ; a0a1: 85 b7       ..
+    pla                                                               ; a0a3: 68          h
+    sta l00b6                                                         ; a0a4: 85 b6       ..
+    jmp ca075                                                         ; a0a6: 4c 75 a0    Lu.
+
+; $a0a9 referenced 1 time by $a078
+ca0a9
+    lda l0000,x                                                       ; a0a9: b5 00       ..
+    sta l1110,y                                                       ; a0ab: 99 10 11    ...
+    lda l0001,x                                                       ; a0ae: b5 01       ..
+    sta l1111,y                                                       ; a0b0: 99 11 11    ...
+    lda l0002,x                                                       ; a0b3: b5 02       ..
+    sta l1112,y                                                       ; a0b5: 99 12 11    ...
+; $a0b8 referenced 1 time by $a08c
+sub_ca0b8
+    lda #$6f ; 'o'                                                    ; a0b8: a9 6f       .o
+    jsr sub_c9f16                                                     ; a0ba: 20 16 9f     ..
+    lda l110f,y                                                       ; a0bd: b9 0f 11    ...
+    adc l1111,y                                                       ; a0c0: 79 11 11    y..
+    sta l10c4                                                         ; a0c3: 8d c4 10    ...
+    lda l110d,y                                                       ; a0c6: b9 0d 11    ...
+    and #3                                                            ; a0c9: 29 03       ).
+    adc l1112,y                                                       ; a0cb: 79 12 11    y..
+    cmp l111d,y                                                       ; a0ce: d9 1d 11    ...
+    bne ca06b                                                         ; a0d1: d0 98       ..
+    lda l10c4                                                         ; a0d3: ad c4 10    ...
+    cmp l111c,y                                                       ; a0d6: d9 1c 11    ...
+    bne ca06b                                                         ; a0d9: d0 90       ..
+    jmp c9f0d                                                         ; a0db: 4c 0d 9f    L..
+
+; $a0de referenced 5 times by $9e66, $9e9b, $9f9a, $a013, $a055
+sub_ca0de
+    tax                                                               ; a0de: aa          .
+    lda l1112,y                                                       ; a0df: b9 12 11    ...
+    cmp l1116,x                                                       ; a0e2: dd 16 11    ...
+    bne ca0f5                                                         ; a0e5: d0 0e       ..
+    lda l1111,y                                                       ; a0e7: b9 11 11    ...
+    cmp l1115,x                                                       ; a0ea: dd 15 11    ...
+    bne ca0f5                                                         ; a0ed: d0 06       ..
+    lda l1110,y                                                       ; a0ef: b9 10 11    ...
+    cmp l1114,x                                                       ; a0f2: dd 14 11    ...
+; $a0f5 referenced 2 times by $a0e5, $a0ed
+ca0f5
+    rts                                                               ; a0f5: 60          `
+
+; $a0f6 referenced 1 time by $a075
+sub_ca0f6
+    lda l1114,y                                                       ; a0f6: b9 14 11    ...
+    cmp l0000,x                                                       ; a0f9: d5 00       ..
+    lda l1115,y                                                       ; a0fb: b9 15 11    ...
+    sbc l0001,x                                                       ; a0fe: f5 01       ..
+    lda l1116,y                                                       ; a100: b9 16 11    ...
+    sbc l0002,x                                                       ; a103: f5 02       ..
+    rts                                                               ; a105: 60          `
+
+sub_ca106
+    tya                                                               ; a106: 98          .
+    ldx #$ff                                                          ; a107: a2 ff       ..
+    ldy #$14                                                          ; a109: a0 14       ..
+; $a10b referenced 2 times by $9711, $a13c
+ca10b
+    pha                                                               ; a10b: 48          H
+    jsr print_inline_l809f_top_bit_clear                              ; a10c: 20 77 80     w.
+    !text $0d, "DFS 2.26", $0d                                        ; a10f: 0d 44 46... .DF
+
+    stx l00bf                                                         ; a119: 86 bf       ..
+    sty l00b7                                                         ; a11b: 84 b7       ..
+; $a11d referenced 1 time by $a12e
+loop_ca11d
+    lda #0                                                            ; a11d: a9 00       ..
+    sta l00b9                                                         ; a11f: 85 b9       ..
+    ldy #2                                                            ; a121: a0 02       ..
+    jsr sub_ca1c6                                                     ; a123: 20 c6 a1     ..
+    jsr sub_ca168                                                     ; a126: 20 68 a1     h.
+    jsr ca3dc                                                         ; a129: 20 dc a3     ..
+    dec l00b7                                                         ; a12c: c6 b7       ..
+    bne loop_ca11d                                                    ; a12e: d0 ed       ..
+    pla                                                               ; a130: 68          h
+    tay                                                               ; a131: a8          .
+; $a132 referenced 1 time by $a148
+loop_ca132
+    ldx #$cf                                                          ; a132: a2 cf       ..
+    jmp c8703                                                         ; a134: 4c 03 87    L..
+
+sub_ca137
+    tya                                                               ; a137: 98          .
+    ldx #$9d                                                          ; a138: a2 9d       ..
+    ldy #6                                                            ; a13a: a0 06       ..
+    bne ca10b                                                         ; a13c: d0 cd       ..
+    jsr clc_jmp_gsinit                                                ; a13e: 20 4c 87     L.
+    beq ca1c0                                                         ; a141: f0 7d       .}
+; $a143 referenced 1 time by $a146
+loop_ca143
+    jsr sub_c8149                                                     ; a143: 20 49 81     I.
+    bcc loop_ca143                                                    ; a146: 90 fb       ..
+    bcs loop_ca132                                                    ; a148: b0 e8       ..
+; $a14a referenced 13 times by $8257, $8753, $8785, $879a, $87ee, $89b7, $89e9, $8baf, $8bc1, $a324, $a32d, $a469, $a5cb
+sub_ca14a
+    jsr clc_jmp_gsinit                                                ; a14a: 20 4c 87     L.
+    bne ca1c0                                                         ; a14d: d0 71       .q
+; $a14f referenced 3 times by $8805, $a5e2, $ac25
+ca14f
+    jsr generate_error                                                ; a14f: 20 48 80     H.
+    !byte $dc                                                         ; a152: dc          .
+    !text "Syntax: "                                                  ; a153: 53 79 6e... Syn
+
+    stx l00b9                                                         ; a15b: 86 b9       ..
+    jsr sub_ca168                                                     ; a15d: 20 68 a1     h.
+    lda #0                                                            ; a160: a9 00       ..
+    jsr sub_ca1b4                                                     ; a162: 20 b4 a1     ..
+    jmp l0100                                                         ; a165: 4c 00 01    L..
+
+; $a168 referenced 2 times by $a126, $a15d
+sub_ca168
+    ldx l00bf                                                         ; a168: a6 bf       ..
+    lda #9                                                            ; a16a: a9 09       ..
+    sta l00b8                                                         ; a16c: 85 b8       ..
+; $a16e referenced 1 time by $a177
+loop_ca16e
+    inx                                                               ; a16e: e8          .
+    lda command_table,x                                               ; a16f: bd 1c 86    ...
+    bmi ca17a                                                         ; a172: 30 06       0.
+    jsr sub_ca1b4                                                     ; a174: 20 b4 a1     ..
+    jmp loop_ca16e                                                    ; a177: 4c 6e a1    Ln.
+
+; $a17a referenced 1 time by $a172
+ca17a
+    ldy l00b8                                                         ; a17a: a4 b8       ..
+    cpy #$0c                                                          ; a17c: c0 0c       ..
+    beq ca183                                                         ; a17e: f0 03       ..
+    jsr sub_ca1c6                                                     ; a180: 20 c6 a1     ..
+; $a183 referenced 1 time by $a17e
+ca183
+    inx                                                               ; a183: e8          .
+    inx                                                               ; a184: e8          .
+    stx l00bf                                                         ; a185: 86 bf       ..
+    lda command_table,x                                               ; a187: bd 1c 86    ...
+    jsr sub_ca190                                                     ; a18a: 20 90 a1     ..
+    jsr sub_c81bf                                                     ; a18d: 20 bf 81     ..
+; $a190 referenced 1 time by $a18a
+sub_ca190
+    jsr sub_c83e3                                                     ; a190: 20 e3 83     ..
+    and #$0f                                                          ; a193: 29 0f       ).
+    beq ca1c0                                                         ; a195: f0 29       .)
+    tay                                                               ; a197: a8          .
+    lda #$20 ; ' '                                                    ; a198: a9 20       .
+    jsr sub_ca1b4                                                     ; a19a: 20 b4 a1     ..
+    ldx #$ff                                                          ; a19d: a2 ff       ..
+; $a19f referenced 2 times by $a1a3, $a1a6
+ca19f
+    inx                                                               ; a19f: e8          .
+    lda la1d3,x                                                       ; a1a0: bd d3 a1    ...
+    bpl ca19f                                                         ; a1a3: 10 fa       ..
+    dey                                                               ; a1a5: 88          .
+    bne ca19f                                                         ; a1a6: d0 f7       ..
+    and #$7f                                                          ; a1a8: 29 7f       ).
+; $a1aa referenced 1 time by $a1b1
+loop_ca1aa
+    jsr sub_ca1b4                                                     ; a1aa: 20 b4 a1     ..
+    inx                                                               ; a1ad: e8          .
+    lda la1d3,x                                                       ; a1ae: bd d3 a1    ...
+    bpl loop_ca1aa                                                    ; a1b1: 10 f7       ..
+    rts                                                               ; a1b3: 60          `
+
+; $a1b4 referenced 5 times by $a162, $a174, $a19a, $a1aa, $a1cc
+sub_ca1b4
+    jsr sub_c83e3                                                     ; a1b4: 20 e3 83     ..
+    ldx l00b9                                                         ; a1b7: a6 b9       ..
+    beq ca1c1                                                         ; a1b9: f0 06       ..
+    inc l00b9                                                         ; a1bb: e6 b9       ..
+    sta l0100,x                                                       ; a1bd: 9d 00 01    ...
+; $a1c0 referenced 3 times by $a141, $a14d, $a195
+ca1c0
+    rts                                                               ; a1c0: 60          `
+
+; $a1c1 referenced 1 time by $a1b9
+ca1c1
+    dec l00b8                                                         ; a1c1: c6 b8       ..
+    jmp c809f                                                         ; a1c3: 4c 9f 80    L..
+
+; $a1c6 referenced 2 times by $a123, $a180
+sub_ca1c6
+    lda l00b9                                                         ; a1c6: a5 b9       ..
+    bne ca1d2                                                         ; a1c8: d0 08       ..
+    lda #$20 ; ' '                                                    ; a1ca: a9 20       .
+; $a1cc referenced 1 time by $a1d0
+loop_ca1cc
+    jsr sub_ca1b4                                                     ; a1cc: 20 b4 a1     ..
+    dey                                                               ; a1cf: 88          .
+    bne loop_ca1cc                                                    ; a1d0: d0 fa       ..
+; $a1d2 referenced 1 time by $a1c8
+ca1d2
+    rts                                                               ; a1d2: 60          `
+
+; $a1d3 referenced 2 times by $a1a0, $a1ae
+la1d3
+    !byte $bc                                                         ; a1d3: bc          .
+    !text "fsp>"                                                      ; a1d4: 66 73 70... fsp
+    !byte $bc                                                         ; a1d8: bc          .
+    !text "afsp>"                                                     ; a1d9: 61 66 73... afs
+    !byte $a8, $4c, $29, $bc                                          ; a1de: a8 4c 29... .L)
+    !text "source> <dest.>"                                           ; a1e2: 73 6f 75... sou
+    !byte $bc                                                         ; a1f1: bc          .
+    !text "old fsp> <new fsp>"                                        ; a1f2: 6f 6c 64... old
+    !byte $a8                                                         ; a204: a8          .
+    !text "<dir>)"                                                    ; a205: 3c 64 69... <di
+    !byte $a8                                                         ; a20b: a8          .
+    !text "<drive>)"                                                  ; a20c: 3c 64 72... <dr
+    !byte $bc                                                         ; a214: bc          .
+    !text "title>"                                                    ; a215: 74 69 74... tit
+    !byte $bc                                                         ; a21b: bc          .
+    !text "drive> (40)(80)"                                           ; a21c: 64 72 69... dri
+    !byte $b4                                                         ; a22b: b4          .
+    !text "0/80"                                                      ; a22c: 30 2f 38... 0/8
+    !byte $a8                                                         ; a230: a8          .
+    !text "<drive>)..."                                               ; a231: 3c 64 72... <dr
+    !byte $a8                                                         ; a23c: a8          .
+    !text "<rom>)"                                                    ; a23d: 3c 72 6f... <ro
+    !byte $ff                                                         ; a243: ff          .
+
+sub_ca244
+    jsr sub_c8b86                                                     ; a244: 20 86 8b     ..
+    jsr print_inline_l809f_top_bit_clear                              ; a247: 20 77 80     w.
+    !text "Compacting :"                                              ; a24a: 43 6f 6d... Com
+
+    sta l10d1                                                         ; a256: 8d d1 10    ...
+    sta l10d2                                                         ; a259: 8d d2 10    ...
+    jsr sub_c80c3                                                     ; a25c: 20 c3 80     ..
+    jsr ca3dc                                                         ; a25f: 20 dc a3     ..
+    ldy #0                                                            ; a262: a0 00       ..
+    jsr sub_c9b79                                                     ; a264: 20 79 9b     y.
+    jsr sub_c9a8d                                                     ; a267: 20 8d 9a     ..
+    jsr sub_c8380                                                     ; a26a: 20 80 83     ..
+    ldy l0f05                                                         ; a26d: ac 05 0f    ...
+    sty l00ca                                                         ; a270: 84 ca       ..
+    lda #2                                                            ; a272: a9 02       ..
+    sta l00c8                                                         ; a274: 85 c8       ..
+    lda #0                                                            ; a276: a9 00       ..
+    sta l00c9                                                         ; a278: 85 c9       ..
+; $a27a referenced 1 time by $a312
+ca27a
+    ldy l00ca                                                         ; a27a: a4 ca       ..
+    jsr sub_c82b2                                                     ; a27c: 20 b2 82     ..
+    cpy #$f8                                                          ; a27f: c0 f8       ..
+    bne ca2ab                                                         ; a281: d0 28       .(
+    lda l0f07                                                         ; a283: ad 07 0f    ...
+    sec                                                               ; a286: 38          8
+    sbc l00c8                                                         ; a287: e5 c8       ..
+    pha                                                               ; a289: 48          H
+    lda l0f06                                                         ; a28a: ad 06 0f    ...
+    and #3                                                            ; a28d: 29 03       ).
+    sbc l00c9                                                         ; a28f: e5 c9       ..
+    jsr sub_c80c3                                                     ; a291: 20 c3 80     ..
+    pla                                                               ; a294: 68          h
+    jsr sub_c80bb                                                     ; a295: 20 bb 80     ..
+    jsr print_inline_l809f_top_bit_clear                              ; a298: 20 77 80     w.
+    !text " free sectors", $0d                                        ; a29b: 20 66 72...  fr
+
+    nop                                                               ; a2a9: ea          .
+    rts                                                               ; a2aa: 60          `
+
+; $a2ab referenced 1 time by $a281
+ca2ab
+    sty l00ca                                                         ; a2ab: 84 ca       ..
+    jsr sub_c8335                                                     ; a2ad: 20 35 83     5.
+    ldy l00ca                                                         ; a2b0: a4 ca       ..
+    lda l0f0c,y                                                       ; a2b2: b9 0c 0f    ...
+    cmp #1                                                            ; a2b5: c9 01       ..
+    lda #0                                                            ; a2b7: a9 00       ..
+    sta l00bc                                                         ; a2b9: 85 bc       ..
+    sta l00c0                                                         ; a2bb: 85 c0       ..
+    adc l0f0d,y                                                       ; a2bd: 79 0d 0f    y..
+    sta l00c4                                                         ; a2c0: 85 c4       ..
+    lda l0f0e,y                                                       ; a2c2: b9 0e 0f    ...
+    php                                                               ; a2c5: 08          .
+    jsr sub_c81b0                                                     ; a2c6: 20 b0 81     ..
+    plp                                                               ; a2c9: 28          (
+    adc #0                                                            ; a2ca: 69 00       i.
+    sta l00c5                                                         ; a2cc: 85 c5       ..
+    lda l0f0f,y                                                       ; a2ce: b9 0f 0f    ...
+    sta l00c6                                                         ; a2d1: 85 c6       ..
+    lda l0f0e,y                                                       ; a2d3: b9 0e 0f    ...
+    and #3                                                            ; a2d6: 29 03       ).
+    sta l00c7                                                         ; a2d8: 85 c7       ..
+    cmp l00c9                                                         ; a2da: c5 c9       ..
+    bne ca2f2                                                         ; a2dc: d0 14       ..
+    lda l00c6                                                         ; a2de: a5 c6       ..
+    cmp l00c8                                                         ; a2e0: c5 c8       ..
+    bne ca2f2                                                         ; a2e2: d0 0e       ..
+    clc                                                               ; a2e4: 18          .
+    adc l00c4                                                         ; a2e5: 65 c4       e.
+    sta l00c8                                                         ; a2e7: 85 c8       ..
+    lda l00c9                                                         ; a2e9: a5 c9       ..
+    adc l00c5                                                         ; a2eb: 65 c5       e.
+    sta l00c9                                                         ; a2ed: 85 c9       ..
+    jmp ca30d                                                         ; a2ef: 4c 0d a3    L..
+
+; $a2f2 referenced 2 times by $a2dc, $a2e2
+ca2f2
+    lda l00c8                                                         ; a2f2: a5 c8       ..
+    sta l0f0f,y                                                       ; a2f4: 99 0f 0f    ...
+    lda l0f0e,y                                                       ; a2f7: b9 0e 0f    ...
+    and #$fc                                                          ; a2fa: 29 fc       ).
+    ora l00c9                                                         ; a2fc: 05 c9       ..
+    sta l0f0e,y                                                       ; a2fe: 99 0e 0f    ...
+    lda #0                                                            ; a301: a9 00       ..
+    sta l00a8                                                         ; a303: 85 a8       ..
+    sta l00a9                                                         ; a305: 85 a9       ..
+    jsr sub_ca530                                                     ; a307: 20 30 a5     0.
+    jsr c93e6                                                         ; a30a: 20 e6 93     ..
+; $a30d referenced 1 time by $a2ef
+ca30d
+    ldy l00ca                                                         ; a30d: a4 ca       ..
+    jsr sub_c833a                                                     ; a30f: 20 3a 83     :.
+    jmp ca27a                                                         ; a312: 4c 7a a2    Lz.
+
+; $a315 referenced 3 times by $8794, $a41a, $a64c
+sub_ca315
+    bit l10c7                                                         ; a315: 2c c7 10    ,..
+    bpl ca378                                                         ; a318: 10 5e       .^
+    jsr sub_ca3ec                                                     ; a31a: 20 ec a3     ..
+    beq ca321                                                         ; a31d: f0 02       ..
+    pla                                                               ; a31f: 68          h
+    pla                                                               ; a320: 68          h
+; $a321 referenced 1 time by $a31d
+ca321
+    jmp ca3dc                                                         ; a321: 4c dc a3    L..
+
+; $a324 referenced 2 times by $a417, $a466
+sub_ca324
+    jsr sub_ca14a                                                     ; a324: 20 4a a1     J.
+    jsr c8b8b                                                         ; a327: 20 8b 8b     ..
+    sta l10d1                                                         ; a32a: 8d d1 10    ...
+    jsr sub_ca14a                                                     ; a32d: 20 4a a1     J.
+    jsr c8b8b                                                         ; a330: 20 8b 8b     ..
+    sta l10d2                                                         ; a333: 8d d2 10    ...
+    tya                                                               ; a336: 98          .
+    pha                                                               ; a337: 48          H
+    lda #0                                                            ; a338: a9 00       ..
+    sta l00a9                                                         ; a33a: 85 a9       ..
+    lda l10d2                                                         ; a33c: ad d2 10    ...
+    cmp l10d1                                                         ; a33f: cd d1 10    ...
+    bne ca34a                                                         ; a342: d0 06       ..
+    lda #$ff                                                          ; a344: a9 ff       ..
+    sta l00a9                                                         ; a346: 85 a9       ..
+    sta l00aa                                                         ; a348: 85 aa       ..
+; $a34a referenced 1 time by $a342
+ca34a
+    jsr sub_c9a8d                                                     ; a34a: 20 8d 9a     ..
+    jsr print_inline_l809f_top_bit_clear                              ; a34d: 20 77 80     w.
+    !text "Copying from :"                                            ; a350: 43 6f 70... Cop
+
+    lda l10d1                                                         ; a35e: ad d1 10    ...
+    jsr sub_c80c3                                                     ; a361: 20 c3 80     ..
+    jsr print_inline_l809f_top_bit_clear                              ; a364: 20 77 80     w.
+    !text " to :"                                                     ; a367: 20 74 6f...  to
+
+    lda l10d2                                                         ; a36c: ad d2 10    ...
+    jsr sub_c80c3                                                     ; a36f: 20 c3 80     ..
+    jsr ca3dc                                                         ; a372: 20 dc a3     ..
+    pla                                                               ; a375: 68          h
+    tay                                                               ; a376: a8          .
+    clc                                                               ; a377: 18          .
+; $a378 referenced 1 time by $a318
+ca378
+    rts                                                               ; a378: 60          `
+
+; $a379 referenced 4 times by $a429, $a46f, $a4c8, $a55b
+sub_ca379
+    jsr sub_c83e3                                                     ; a379: 20 e3 83     ..
+    bit l00a9                                                         ; a37c: 24 a9       $.
+    bpl ca38b                                                         ; a37e: 10 0b       ..
+    lda #0                                                            ; a380: a9 00       ..
+    beq ca38e                                                         ; a382: f0 0a       ..
+; $a384 referenced 3 times by $a440, $a4e4, $a581
+sub_ca384
+    jsr sub_c83e3                                                     ; a384: 20 e3 83     ..
+    bit l00a9                                                         ; a387: 24 a9       $.
+    bmi ca38c                                                         ; a389: 30 01       0.
+; $a38b referenced 2 times by $a37e, $a390
+ca38b
+    rts                                                               ; a38b: 60          `
+
+; $a38c referenced 1 time by $a389
+ca38c
+    lda #$80                                                          ; a38c: a9 80       ..
+; $a38e referenced 1 time by $a382
+ca38e
+    cmp l00aa                                                         ; a38e: c5 aa       ..
+    beq ca38b                                                         ; a390: f0 f9       ..
+    sta l00aa                                                         ; a392: 85 aa       ..
+    jsr print_inline_l809f_top_bit_clear                              ; a394: 20 77 80     w.
+    !text "Insert "                                                   ; a397: 49 6e 73... Ins
+
+    nop                                                               ; a39e: ea          .
+    bit l00aa                                                         ; a39f: 24 aa       $.
+    bmi ca3ae                                                         ; a3a1: 30 0b       0.
+    jsr print_inline_l809f_top_bit_clear                              ; a3a3: 20 77 80     w.
+    !text "source"                                                    ; a3a6: 73 6f 75... sou
+
+    bcc ca3bd                                                         ; a3ac: 90 0f       ..
+; $a3ae referenced 1 time by $a3a1
+ca3ae
+    jsr print_inline_l809f_top_bit_clear                              ; a3ae: 20 77 80     w.
+    !text "destination"                                               ; a3b1: 64 65 73... des
+
+    nop                                                               ; a3bc: ea          .
+; $a3bd referenced 1 time by $a3ac
+ca3bd
+    jsr print_inline_l809f_top_bit_clear                              ; a3bd: 20 77 80     w.
+    !text " disc and hit a key"                                       ; a3c0: 20 64 69...  di
+
+    nop                                                               ; a3d3: ea          .
+    jsr sub_c9ac8                                                     ; a3d4: 20 c8 9a     ..
+    jsr osrdch                                                        ; a3d7: 20 e0 ff     ..
+    bcs ca411                                                         ; a3da: b0 35       .5
+; $a3dc referenced 16 times by $836b, $8522, $854f, $85b2, $85b5, $8779, $87a8, $87b5, $a129, $a25f, $a321, $a372, $a62f, $a6b0, $a73a, $aa95
+ca3dc
+    pha                                                               ; a3dc: 48          H
+    lda #$0d                                                          ; a3dd: a9 0d       ..
+    jsr c809f                                                         ; a3df: 20 9f 80     ..
+    pla                                                               ; a3e2: 68          h
+    rts                                                               ; a3e3: 60          `
+
+; $a3e4 referenced 1 time by $8761
+sub_ca3e4
+    jsr print_inline_l809f_top_bit_clear                              ; a3e4: 20 77 80     w.
+    !text " : "                                                       ; a3e7: 20 3a 20     :
+
+    bcc ca3fb                                                         ; a3ea: 90 0f       ..
+; $a3ec referenced 2 times by $87b0, $a31a
+sub_ca3ec
+    jsr print_inline_l809f_top_bit_clear                              ; a3ec: 20 77 80     w.
+    !text "Go (Y/N) ? "                                               ; a3ef: 47 6f 20... Go
+
+    nop                                                               ; a3fa: ea          .
+; $a3fb referenced 1 time by $a3ea
+ca3fb
+    jsr sub_c9ac8                                                     ; a3fb: 20 c8 9a     ..
+    jsr osrdch                                                        ; a3fe: 20 e0 ff     ..
+    bcs ca411                                                         ; a401: b0 0e       ..
+    and #$5f ; '_'                                                    ; a403: 29 5f       )_
+    cmp #$59 ; 'Y'                                                    ; a405: c9 59       .Y
+    php                                                               ; a407: 08          .
+    beq ca40c                                                         ; a408: f0 02       ..
+    lda #$4e ; 'N'                                                    ; a40a: a9 4e       .N
+; $a40c referenced 1 time by $a408
+ca40c
+    jsr c809f                                                         ; a40c: 20 9f 80     ..
+    plp                                                               ; a40f: 28          (
+    rts                                                               ; a410: 60          `
+
+; $a411 referenced 2 times by $a3da, $a401
+ca411
+    jmp c9436                                                         ; a411: 4c 36 94    L6.
+
+; $a414 referenced 2 times by $a452, $a45b
+ca414
+    jmp c8a6e                                                         ; a414: 4c 6e 8a    Ln.
+
+sub_ca417
+    jsr sub_ca324                                                     ; a417: 20 24 a3     $.
+    jsr sub_ca315                                                     ; a41a: 20 15 a3     ..
+    lda #0                                                            ; a41d: a9 00       ..
+    sta l00c7                                                         ; a41f: 85 c7       ..
+    sta l00c9                                                         ; a421: 85 c9       ..
+    sta l00c8                                                         ; a423: 85 c8       ..
+    sta l00c6                                                         ; a425: 85 c6       ..
+    sta l00a8                                                         ; a427: 85 a8       ..
+    jsr sub_ca379                                                     ; a429: 20 79 a3     y.
+    lda l10d1                                                         ; a42c: ad d1 10    ...
+    sta l00cd                                                         ; a42f: 85 cd       ..
+    jsr c940c                                                         ; a431: 20 0c 94     ..
+    lda l0f07                                                         ; a434: ad 07 0f    ...
+    sta l00c4                                                         ; a437: 85 c4       ..
+    lda l0f06                                                         ; a439: ad 06 0f    ...
+    and #3                                                            ; a43c: 29 03       ).
+    sta l00c5                                                         ; a43e: 85 c5       ..
+    jsr sub_ca384                                                     ; a440: 20 84 a3     ..
+    lda l10d2                                                         ; a443: ad d2 10    ...
+    sta l00cd                                                         ; a446: 85 cd       ..
+    jsr c940c                                                         ; a448: 20 0c 94     ..
+    lda l0f06                                                         ; a44b: ad 06 0f    ...
+    and #3                                                            ; a44e: 29 03       ).
+    cmp l00c5                                                         ; a450: c5 c5       ..
+    bcc ca414                                                         ; a452: 90 c0       ..
+    bne ca45d                                                         ; a454: d0 07       ..
+    lda l0f07                                                         ; a456: ad 07 0f    ...
+    cmp l00c4                                                         ; a459: c5 c4       ..
+    bcc ca414                                                         ; a45b: 90 b7       ..
+; $a45d referenced 1 time by $a454
+ca45d
+    jsr sub_ca530                                                     ; a45d: 20 30 a5     0.
+    jmp c940c                                                         ; a460: 4c 0c 94    L..
+
+sub_ca463
+    jsr sub_c99ac                                                     ; a463: 20 ac 99     ..
+    jsr sub_ca324                                                     ; a466: 20 24 a3     $.
+    jsr sub_ca14a                                                     ; a469: 20 4a a1     J.
+    jsr sub_c80ed                                                     ; a46c: 20 ed 80     ..
+    jsr sub_ca379                                                     ; a46f: 20 79 a3     y.
+    lda l10d1                                                         ; a472: ad d1 10    ...
+    jsr c8816                                                         ; a475: 20 16 88     ..
+    jsr c8225                                                         ; a478: 20 25 82     %.
+; $a47b referenced 1 time by $a4de
+ca47b
+    lda l00cc                                                         ; a47b: a5 cc       ..
+    pha                                                               ; a47d: 48          H
+    lda l00b6                                                         ; a47e: a5 b6       ..
+    sta l00ab                                                         ; a480: 85 ab       ..
+    jsr sub_c833a                                                     ; a482: 20 3a 83     :.
+    ldx #0                                                            ; a485: a2 00       ..
+; $a487 referenced 1 time by $a49b
+loop_ca487
+    lda l0e08,y                                                       ; a487: b9 08 0e    ...
+    sta l00c5,x                                                       ; a48a: 95 c5       ..
+    sta l1050,x                                                       ; a48c: 9d 50 10    .P.
+    lda l0f08,y                                                       ; a48f: b9 08 0f    ...
+    sta l00bb,x                                                       ; a492: 95 bb       ..
+    sta l1047,x                                                       ; a494: 9d 47 10    .G.
+    inx                                                               ; a497: e8          .
+    iny                                                               ; a498: c8          .
+    cpx #8                                                            ; a499: e0 08       ..
+    bne loop_ca487                                                    ; a49b: d0 ea       ..
+    lda l00c1                                                         ; a49d: a5 c1       ..
+    jsr sub_c81b0                                                     ; a49f: 20 b0 81     ..
+    sta l00c3                                                         ; a4a2: 85 c3       ..
+    lda l00bf                                                         ; a4a4: a5 bf       ..
+    clc                                                               ; a4a6: 18          .
+    adc #$ff                                                          ; a4a7: 69 ff       i.
+    lda l00c0                                                         ; a4a9: a5 c0       ..
+    adc #0                                                            ; a4ab: 69 00       i.
+    sta l00c4                                                         ; a4ad: 85 c4       ..
+    lda l00c3                                                         ; a4af: a5 c3       ..
+    adc #0                                                            ; a4b1: 69 00       i.
+    sta l00c5                                                         ; a4b3: 85 c5       ..
+    lda l104e                                                         ; a4b5: ad 4e 10    .N.
+    sta l00c6                                                         ; a4b8: 85 c6       ..
+    lda l104d                                                         ; a4ba: ad 4d 10    .M.
+    and #3                                                            ; a4bd: 29 03       ).
+    sta l00c7                                                         ; a4bf: 85 c7       ..
+    lda #$ff                                                          ; a4c1: a9 ff       ..
+    sta l00a8                                                         ; a4c3: 85 a8       ..
+    jsr sub_ca530                                                     ; a4c5: 20 30 a5     0.
+    jsr sub_ca379                                                     ; a4c8: 20 79 a3     y.
+    lda l10d1                                                         ; a4cb: ad d1 10    ...
+    jsr c8816                                                         ; a4ce: 20 16 88     ..
+    jsr sub_c8380                                                     ; a4d1: 20 80 83     ..
+    lda l00ab                                                         ; a4d4: a5 ab       ..
+    sta l00b6                                                         ; a4d6: 85 b6       ..
+    pla                                                               ; a4d8: 68          h
+    sta l00cc                                                         ; a4d9: 85 cc       ..
+    jsr sub_c8280                                                     ; a4db: 20 80 82     ..
+    bcs ca47b                                                         ; a4de: b0 9b       ..
+    rts                                                               ; a4e0: 60          `
+
+; $a4e1 referenced 1 time by $a56d
+sub_ca4e1
+    jsr sub_ca51f                                                     ; a4e1: 20 1f a5     ..
+    jsr sub_ca384                                                     ; a4e4: 20 84 a3     ..
+    lda l10d2                                                         ; a4e7: ad d2 10    ...
+    sta l00cd                                                         ; a4ea: 85 cd       ..
+    lda l00cc                                                         ; a4ec: a5 cc       ..
+    pha                                                               ; a4ee: 48          H
+    jsr sub_c8380                                                     ; a4ef: 20 80 83     ..
+    jsr sub_c826d                                                     ; a4f2: 20 6d 82     m.
+    bcc ca4fa                                                         ; a4f5: 90 03       ..
+    jsr sub_c830a                                                     ; a4f7: 20 0a 83     ..
+; $a4fa referenced 1 time by $a4f5
+ca4fa
+    pla                                                               ; a4fa: 68          h
+    sta l00cc                                                         ; a4fb: 85 cc       ..
+    jsr sub_c8b4d                                                     ; a4fd: 20 4d 8b     M.
+    jsr sub_c8b64                                                     ; a500: 20 64 8b     d.
+    lda l00c2                                                         ; a503: a5 c2       ..
+    jsr sub_c81b0                                                     ; a505: 20 b0 81     ..
+    sta l00c4                                                         ; a508: 85 c4       ..
+    jsr sub_c8ab3                                                     ; a50a: 20 b3 8a     ..
+    lda l00c2                                                         ; a50d: a5 c2       ..
+    and #3                                                            ; a50f: 29 03       ).
+    pha                                                               ; a511: 48          H
+    lda l00c3                                                         ; a512: a5 c3       ..
+    pha                                                               ; a514: 48          H
+    jsr sub_ca51f                                                     ; a515: 20 1f a5     ..
+    pla                                                               ; a518: 68          h
+    sta l00c8                                                         ; a519: 85 c8       ..
+    pla                                                               ; a51b: 68          h
+    sta l00c9                                                         ; a51c: 85 c9       ..
+    rts                                                               ; a51e: 60          `
+
+; $a51f referenced 2 times by $a4e1, $a515
+sub_ca51f
+    ldx #$11                                                          ; a51f: a2 11       ..
+; $a521 referenced 1 time by $a52d
+loop_ca521
+    lda l1045,x                                                       ; a521: bd 45 10    .E.
+    ldy l00ba,x                                                       ; a524: b4 ba       ..
+    sta l00ba,x                                                       ; a526: 95 ba       ..
+    tya                                                               ; a528: 98          .
+    sta l1045,x                                                       ; a529: 9d 45 10    .E.
+    dex                                                               ; a52c: ca          .
+    bpl loop_ca521                                                    ; a52d: 10 f2       ..
+    rts                                                               ; a52f: 60          `
+
+; $a530 referenced 3 times by $a307, $a45d, $a4c5
+sub_ca530
+    lda #0                                                            ; a530: a9 00       ..
+    sta l00bc                                                         ; a532: 85 bc       ..
+    sta l00c0                                                         ; a534: 85 c0       ..
+    beq ca5ab                                                         ; a536: f0 73       .s
+; $a538 referenced 1 time by $a5af
+ca538
+    lda l00c4                                                         ; a538: a5 c4       ..
+    tay                                                               ; a53a: a8          .
+    cmp l10d0                                                         ; a53b: cd d0 10    ...
+    lda l00c5                                                         ; a53e: a5 c5       ..
+    sbc #0                                                            ; a540: e9 00       ..
+    bcc ca547                                                         ; a542: 90 03       ..
+    ldy l10d0                                                         ; a544: ac d0 10    ...
+; $a547 referenced 1 time by $a542
+ca547
+    sty l00c1                                                         ; a547: 84 c1       ..
+    lda l00c6                                                         ; a549: a5 c6       ..
+    sta l00c3                                                         ; a54b: 85 c3       ..
+    lda l00c7                                                         ; a54d: a5 c7       ..
+    sta l00c2                                                         ; a54f: 85 c2       ..
+    lda l10cf                                                         ; a551: ad cf 10    ...
+    sta l00bd                                                         ; a554: 85 bd       ..
+    lda l10d1                                                         ; a556: ad d1 10    ...
+    sta l00cd                                                         ; a559: 85 cd       ..
+    jsr sub_ca379                                                     ; a55b: 20 79 a3     y.
+    jsr sub_ca5b2                                                     ; a55e: 20 b2 a5     ..
+    jsr sub_c8855                                                     ; a561: 20 55 88     U.
+    lda l10d2                                                         ; a564: ad d2 10    ...
+    sta l00cd                                                         ; a567: 85 cd       ..
+    bit l00a8                                                         ; a569: 24 a8       $.
+    bpl ca574                                                         ; a56b: 10 07       ..
+    jsr sub_ca4e1                                                     ; a56d: 20 e1 a4     ..
+    lda #0                                                            ; a570: a9 00       ..
+    sta l00a8                                                         ; a572: 85 a8       ..
+; $a574 referenced 1 time by $a56b
+ca574
+    lda l00c8                                                         ; a574: a5 c8       ..
+    sta l00c3                                                         ; a576: 85 c3       ..
+    lda l00c9                                                         ; a578: a5 c9       ..
+    sta l00c2                                                         ; a57a: 85 c2       ..
+    lda l10cf                                                         ; a57c: ad cf 10    ...
+    sta l00bd                                                         ; a57f: 85 bd       ..
+    jsr sub_ca384                                                     ; a581: 20 84 a3     ..
+    jsr sub_ca5b2                                                     ; a584: 20 b2 a5     ..
+    jsr sub_c8862                                                     ; a587: 20 62 88     b.
+    lda l00c1                                                         ; a58a: a5 c1       ..
+    clc                                                               ; a58c: 18          .
+    adc l00c8                                                         ; a58d: 65 c8       e.
+    sta l00c8                                                         ; a58f: 85 c8       ..
+    bcc ca595                                                         ; a591: 90 02       ..
+    inc l00c9                                                         ; a593: e6 c9       ..
+; $a595 referenced 1 time by $a591
+ca595
+    lda l00c1                                                         ; a595: a5 c1       ..
+    clc                                                               ; a597: 18          .
+    adc l00c6                                                         ; a598: 65 c6       e.
+    sta l00c6                                                         ; a59a: 85 c6       ..
+    bcc ca5a0                                                         ; a59c: 90 02       ..
+    inc l00c7                                                         ; a59e: e6 c7       ..
+; $a5a0 referenced 1 time by $a59c
+ca5a0
+    sec                                                               ; a5a0: 38          8
+    lda l00c4                                                         ; a5a1: a5 c4       ..
+    sbc l00c1                                                         ; a5a3: e5 c1       ..
+    sta l00c4                                                         ; a5a5: 85 c4       ..
+    bcs ca5ab                                                         ; a5a7: b0 02       ..
+    dec l00c5                                                         ; a5a9: c6 c5       ..
+; $a5ab referenced 2 times by $a536, $a5a7
+ca5ab
+    lda l00c4                                                         ; a5ab: a5 c4       ..
+    ora l00c5                                                         ; a5ad: 05 c5       ..
+    bne ca538                                                         ; a5af: d0 87       ..
+    rts                                                               ; a5b1: 60          `
+
+; $a5b2 referenced 2 times by $a55e, $a584
+sub_ca5b2
+    lda #$ff                                                          ; a5b2: a9 ff       ..
+    sta l1074                                                         ; a5b4: 8d 74 10    .t.
+    sta l1075                                                         ; a5b7: 8d 75 10    .u.
+    rts                                                               ; a5ba: 60          `
+
+sub_ca5bb
+    lda #0                                                            ; a5bb: a9 00       ..
+    beq ca5c4                                                         ; a5bd: f0 05       ..
+sub_ca5bf
+    lda #$ff                                                          ; a5bf: a9 ff       ..
+    sta l1082                                                         ; a5c1: 8d 82 10    ...
+; $a5c4 referenced 1 time by $a5bd
+ca5c4
+    sta l00c9                                                         ; a5c4: 85 c9       ..
+    sta l1090                                                         ; a5c6: 8d 90 10    ...
+    bpl ca5e5                                                         ; a5c9: 10 1a       ..
+    jsr sub_ca14a                                                     ; a5cb: 20 4a a1     J.
+    jsr sub_c8456                                                     ; a5ce: 20 56 84     V.
+    sta l109f                                                         ; a5d1: 8d 9f 10    ...
+    bcs ca5e2                                                         ; a5d4: b0 0c       ..
+    cmp #$23 ; '#'                                                    ; a5d6: c9 23       .#
+    beq ca5e5                                                         ; a5d8: f0 0b       ..
+    cmp #$28 ; '('                                                    ; a5da: c9 28       .(
+    beq ca5e5                                                         ; a5dc: f0 07       ..
+    cmp #$50 ; 'P'                                                    ; a5de: c9 50       .P
+    beq ca5e5                                                         ; a5e0: f0 03       ..
+; $a5e2 referenced 1 time by $a5d4
+ca5e2
+    jmp ca14f                                                         ; a5e2: 4c 4f a1    LO.
+
+; $a5e5 referenced 4 times by $a5c9, $a5d8, $a5dc, $a5e0
+ca5e5
+    jsr clc_jmp_gsinit                                                ; a5e5: 20 4c 87     L.
+    sty l00ca                                                         ; a5e8: 84 ca       ..
+    bne ca637                                                         ; a5ea: d0 4b       .K
+    bit l00c9                                                         ; a5ec: 24 c9       $.
+    bmi ca5fb                                                         ; a5ee: 30 0b       0.
+    jsr print_inline_l809f_top_bit_clear                              ; a5f0: 20 77 80     w.
+    !text "Verify"                                                    ; a5f3: 56 65 72... Ver
+
+    bcc ca605                                                         ; a5f9: 90 0a       ..
+; $a5fb referenced 1 time by $a5ee
+ca5fb
+    jsr print_inline_l809f_top_bit_clear                              ; a5fb: 20 77 80     w.
+    !text "Format"                                                    ; a5fe: 46 6f 72... For
+
+    nop                                                               ; a604: ea          .
+; $a605 referenced 1 time by $a5f9
+ca605
+    jsr print_inline_l809f_top_bit_clear                              ; a605: 20 77 80     w.
+    !text " which drive ? "                                           ; a608: 20 77 68...  wh
+
+    nop                                                               ; a617: ea          .
+    jsr osrdch                                                        ; a618: 20 e0 ff     ..
+    bcs ca65d                                                         ; a61b: b0 40       .@
+    cmp #$20 ; ' '                                                    ; a61d: c9 20       .
+    bcc ca660                                                         ; a61f: 90 3f       .?
+    jsr c809f                                                         ; a621: 20 9f 80     ..
+    sec                                                               ; a624: 38          8
+    sbc #$30 ; '0'                                                    ; a625: e9 30       .0
+    bcc ca660                                                         ; a627: 90 37       .7
+    cmp #4                                                            ; a629: c9 04       ..
+    bcs ca660                                                         ; a62b: b0 33       .3
+    sta l00cd                                                         ; a62d: 85 cd       ..
+    jsr ca3dc                                                         ; a62f: 20 dc a3     ..
+    ldy l00ca                                                         ; a632: a4 ca       ..
+    jmp ca63a                                                         ; a634: 4c 3a a6    L:.
+
+; $a637 referenced 2 times by $a5ea, $a65a
+ca637
+    jsr c8b8b                                                         ; a637: 20 8b 8b     ..
+; $a63a referenced 1 time by $a634
+ca63a
+    sty l00ca                                                         ; a63a: 84 ca       ..
+    bit l00c9                                                         ; a63c: 24 c9       $.
+    bpl ca647                                                         ; a63e: 10 07       ..
+    ldx l00cd                                                         ; a640: a6 cd       ..
+    lda #0                                                            ; a642: a9 00       ..
+    sta l10de,x                                                       ; a644: 9d de 10    ...
+; $a647 referenced 1 time by $a63e
+ca647
+    bit l1090                                                         ; a647: 2c 90 10    ,..
+    bpl ca652                                                         ; a64a: 10 06       ..
+    jsr sub_ca315                                                     ; a64c: 20 15 a3     ..
+    jsr sub_c9a8d                                                     ; a64f: 20 8d 9a     ..
+; $a652 referenced 1 time by $a64a
+ca652
+    jsr sub_ca663                                                     ; a652: 20 63 a6     c.
+    ldy l00ca                                                         ; a655: a4 ca       ..
+    jsr clc_jmp_gsinit                                                ; a657: 20 4c 87     L.
+    bne ca637                                                         ; a65a: d0 db       ..
+    rts                                                               ; a65c: 60          `
+
+; $a65d referenced 1 time by $a61b
+ca65d
+    jmp c9436                                                         ; a65d: 4c 36 94    L6.
+
+; $a660 referenced 3 times by $a61f, $a627, $a62b
+ca660
+    jmp c8ba2                                                         ; a660: 4c a2 8b    L..
+
+; $a663 referenced 1 time by $a652
+sub_ca663
+    bit l00c9                                                         ; a663: 24 c9       $.
+    bmi ca675                                                         ; a665: 30 0e       0.
+    jsr print_inline_l809f_top_bit_clear                              ; a667: 20 77 80     w.
+    !text "Verifying"                                                 ; a66a: 56 65 72... Ver
+
+    bcc ca68a                                                         ; a673: 90 15       ..
+; $a675 referenced 1 time by $a665
+ca675
+    jsr sub_ca76c                                                     ; a675: 20 6c a7     l.
+    jsr print_inline_l809f_top_bit_clear                              ; a678: 20 77 80     w.
+    !text "Formatting"                                                ; a67b: 46 6f 72... For
+
+    ldx l00cd                                                         ; a685: a6 cd       ..
+    stx l1090                                                         ; a687: 8e 90 10    ...
+; $a68a referenced 1 time by $a673
+ca68a
+    jsr print_inline_l809f_top_bit_clear                              ; a68a: 20 77 80     w.
+    !text " drive "                                                   ; a68d: 20 64 72...  dr
+
+    lda l00cd                                                         ; a694: a5 cd       ..
+    jsr sub_c80c3                                                     ; a696: 20 c3 80     ..
+    jsr print_inline_l809f_top_bit_clear                              ; a699: 20 77 80     w.
+    !text " track   "                                                 ; a69c: 20 74 72...  tr
+
+    nop                                                               ; a6a5: ea          .
+    bit l00c9                                                         ; a6a6: 24 c9       $.
+    bmi ca6b6                                                         ; a6a8: 30 0c       0.
+    jsr sub_ca7ce                                                     ; a6aa: 20 ce a7     ..
+    txa                                                               ; a6ad: 8a          .
+    bne ca6b3                                                         ; a6ae: d0 03       ..
+    jmp ca3dc                                                         ; a6b0: 4c dc a3    L..
+
+; $a6b3 referenced 1 time by $a6ae
+ca6b3
+    sta l109f                                                         ; a6b3: 8d 9f 10    ...
+; $a6b6 referenced 1 time by $a6a8
+ca6b6
+    lda #0                                                            ; a6b6: a9 00       ..
+    sta l1097                                                         ; a6b8: 8d 97 10    ...
+; $a6bb referenced 1 time by $a731
+ca6bb
+    lda #8                                                            ; a6bb: a9 08       ..
+    jsr c809f                                                         ; a6bd: 20 9f 80     ..
+    jsr c809f                                                         ; a6c0: 20 9f 80     ..
+    lda l1097                                                         ; a6c3: ad 97 10    ...
+    jsr sub_c80bb                                                     ; a6c6: 20 bb 80     ..
+    lda #6                                                            ; a6c9: a9 06       ..
+    sta l109d                                                         ; a6cb: 8d 9d 10    ...
+; $a6ce referenced 1 time by $a708
+ca6ce
+    jsr sub_ca73d                                                     ; a6ce: 20 3d a7     =.
+    bit l00c9                                                         ; a6d1: 24 c9       $.
+    bpl ca6e2                                                         ; a6d3: 10 0d       ..
+    jsr sub_ca788                                                     ; a6d5: 20 88 a7     ..
+    ldx #$90                                                          ; a6d8: a2 90       ..
+    ldy #$10                                                          ; a6da: a0 10       ..
+    jsr c91af                                                         ; a6dc: 20 af 91     ..
+    tax                                                               ; a6df: aa          .
+    bne ca70a                                                         ; a6e0: d0 28       .(
+; $a6e2 referenced 1 time by $a6d3
+ca6e2
+    lda #0                                                            ; a6e2: a9 00       ..
+    sta l1098                                                         ; a6e4: 8d 98 10    ...
+    lda l1099                                                         ; a6e7: ad 99 10    ...
+    and #$1f                                                          ; a6ea: 29 1f       ).
+    sta l1099                                                         ; a6ec: 8d 99 10    ...
+    lda #3                                                            ; a6ef: a9 03       ..
+    sta l1095                                                         ; a6f1: 8d 95 10    ...
+    lda #$5f ; '_'                                                    ; a6f4: a9 5f       ._
+    sta l1096                                                         ; a6f6: 8d 96 10    ...
+    jsr sub_c9432                                                     ; a6f9: 20 32 94     2.
+    ldx #$90                                                          ; a6fc: a2 90       ..
+    ldy #$10                                                          ; a6fe: a0 10       ..
+    jsr c91af                                                         ; a700: 20 af 91     ..
+    beq ca712                                                         ; a703: f0 0d       ..
+    dec l109d                                                         ; a705: ce 9d 10    ...
+    bne ca6ce                                                         ; a708: d0 c4       ..
+; $a70a referenced 1 time by $a6e0
+ca70a
+    jsr print_inline_l809f_top_bit_clear                              ; a70a: 20 77 80     w.
+    !text "?"                                                         ; a70d: 3f          ?
+
+    nop                                                               ; a70e: ea          .
+    jmp c94c2                                                         ; a70f: 4c c2 94    L..
+
+; $a712 referenced 1 time by $a703
+ca712
+    lda l109d                                                         ; a712: ad 9d 10    ...
+    cmp #6                                                            ; a715: c9 06       ..
+    beq ca721                                                         ; a717: f0 08       ..
+    jsr print_inline_l809f_top_bit_clear                              ; a719: 20 77 80     w.
+    !text "?   "                                                      ; a71c: 3f 20 20... ?
+
+    nop                                                               ; a720: ea          .
+; $a721 referenced 1 time by $a717
+ca721
+    bit l00c9                                                         ; a721: 24 c9       $.
+    bpl ca728                                                         ; a723: 10 03       ..
+    jsr sub_ca779                                                     ; a725: 20 79 a7     y.
+; $a728 referenced 1 time by $a723
+ca728
+    inc l1097                                                         ; a728: ee 97 10    ...
+    lda l1097                                                         ; a72b: ad 97 10    ...
+    cmp l109f                                                         ; a72e: cd 9f 10    ...
+    bne ca6bb                                                         ; a731: d0 88       ..
+    bit l00c9                                                         ; a733: 24 c9       $.
+    bpl ca73a                                                         ; a735: 10 03       ..
+    jsr sub_c93f1                                                     ; a737: 20 f1 93     ..
+; $a73a referenced 1 time by $a735
+ca73a
+    jmp ca3dc                                                         ; a73a: 4c dc a3    L..
+
+; $a73d referenced 1 time by $a6ce
+sub_ca73d
+    ldx #0                                                            ; a73d: a2 00       ..
+    stx l1091                                                         ; a73f: 8e 91 10    ...
+    stx l109a                                                         ; a742: 8e 9a 10    ...
+    dex                                                               ; a745: ca          .
+    stx l1093                                                         ; a746: 8e 93 10    ...
+    stx l1094                                                         ; a749: 8e 94 10    ...
+    lda l10cf                                                         ; a74c: ad cf 10    ...
+    sta l1092                                                         ; a74f: 8d 92 10    ...
+    lda #5                                                            ; a752: a9 05       ..
+    sta l1095                                                         ; a754: 8d 95 10    ...
+    lda #$63 ; 'c'                                                    ; a757: a9 63       .c
+    sta l1096                                                         ; a759: 8d 96 10    ...
+    lda #$2a ; '*'                                                    ; a75c: a9 2a       .*
+    sta l1099                                                         ; a75e: 8d 99 10    ...
+    ldx #$10                                                          ; a761: a2 10       ..
+    ldy #$13                                                          ; a763: a0 13       ..
+    stx l109b                                                         ; a765: 8e 9b 10    ...
+    sty l1098                                                         ; a768: 8c 98 10    ...
+    rts                                                               ; a76b: 60          `
+
+; $a76c referenced 1 time by $a675
+sub_ca76c
+    lda #0                                                            ; a76c: a9 00       ..
+    tay                                                               ; a76e: a8          .
+; $a76f referenced 1 time by $a776
+loop_ca76f
+    sta l0e00,y                                                       ; a76f: 99 00 0e    ...
+    sta l0f00,y                                                       ; a772: 99 00 0f    ...
+    iny                                                               ; a775: c8          .
+    bne loop_ca76f                                                    ; a776: d0 f7       ..
+    rts                                                               ; a778: 60          `
+
+; $a779 referenced 1 time by $a725
+sub_ca779
+    lda #$0a                                                          ; a779: a9 0a       ..
+    clc                                                               ; a77b: 18          .
+    adc l0f07                                                         ; a77c: 6d 07 0f    m..
+    sta l0f07                                                         ; a77f: 8d 07 0f    ...
+    bcc ca787                                                         ; a782: 90 03       ..
+    inc l0f06                                                         ; a784: ee 06 0f    ...
+; $a787 referenced 1 time by $a782
+ca787
+    rts                                                               ; a787: 60          `
+
+; $a788 referenced 1 time by $a6d5
+sub_ca788
+    lda #0                                                            ; a788: a9 00       ..
+    sta l00b0                                                         ; a78a: 85 b0       ..
+    lda l10cf                                                         ; a78c: ad cf 10    ...
+    sta l00b1                                                         ; a78f: 85 b1       ..
+    lda #$0a                                                          ; a791: a9 0a       ..
+    sta l00b2                                                         ; a793: 85 b2       ..
+    lda l1097                                                         ; a795: ad 97 10    ...
+    beq ca7a4                                                         ; a798: f0 0a       ..
+    ldy #2                                                            ; a79a: a0 02       ..
+    lda (l00b0),y                                                     ; a79c: b1 b0       ..
+    clc                                                               ; a79e: 18          .
+    adc #7                                                            ; a79f: 69 07       i.
+    jsr sub_ca7c5                                                     ; a7a1: 20 c5 a7     ..
+; $a7a4 referenced 1 time by $a798
+ca7a4
+    tax                                                               ; a7a4: aa          .
+    ldy #0                                                            ; a7a5: a0 00       ..
+; $a7a7 referenced 1 time by $a7c1
+loop_ca7a7
+    lda l1097                                                         ; a7a7: ad 97 10    ...
+    sta (l00b0),y                                                     ; a7aa: 91 b0       ..
+    iny                                                               ; a7ac: c8          .
+    lda #0                                                            ; a7ad: a9 00       ..
+    sta (l00b0),y                                                     ; a7af: 91 b0       ..
+    iny                                                               ; a7b1: c8          .
+    txa                                                               ; a7b2: 8a          .
+    sta (l00b0),y                                                     ; a7b3: 91 b0       ..
+    iny                                                               ; a7b5: c8          .
+    lda #1                                                            ; a7b6: a9 01       ..
+    sta (l00b0),y                                                     ; a7b8: 91 b0       ..
+    iny                                                               ; a7ba: c8          .
+    inx                                                               ; a7bb: e8          .
+    jsr sub_ca7c4                                                     ; a7bc: 20 c4 a7     ..
+    dec l00b2                                                         ; a7bf: c6 b2       ..
+    bne loop_ca7a7                                                    ; a7c1: d0 e4       ..
+    rts                                                               ; a7c3: 60          `
+
+; $a7c4 referenced 1 time by $a7bc
+sub_ca7c4
+    txa                                                               ; a7c4: 8a          .
+; $a7c5 referenced 1 time by $a7a1
+sub_ca7c5
+    sec                                                               ; a7c5: 38          8
+; $a7c6 referenced 1 time by $a7c8
+loop_ca7c6
+    sbc #$0a                                                          ; a7c6: e9 0a       ..
+    bcs loop_ca7c6                                                    ; a7c8: b0 fc       ..
+    adc #$0a                                                          ; a7ca: 69 0a       i.
+    tax                                                               ; a7cc: aa          .
+    rts                                                               ; a7cd: 60          `
+
+; $a7ce referenced 1 time by $a6aa
+sub_ca7ce
+    jsr sub_c93f5                                                     ; a7ce: 20 f5 93     ..
+    lda l0f06                                                         ; a7d1: ad 06 0f    ...
+    and #3                                                            ; a7d4: 29 03       ).
+    tax                                                               ; a7d6: aa          .
+    lda l0f07                                                         ; a7d7: ad 07 0f    ...
+    ldy #$0a                                                          ; a7da: a0 0a       ..
+    sty l00b0                                                         ; a7dc: 84 b0       ..
+    ldy #$ff                                                          ; a7de: a0 ff       ..
+; $a7e0 referenced 1 time by $a7e7
+loop_ca7e0
+    sec                                                               ; a7e0: 38          8
+; $a7e1 referenced 1 time by $a7e4
+loop_ca7e1
+    iny                                                               ; a7e1: c8          .
+    sbc l00b0                                                         ; a7e2: e5 b0       ..
+    bcs loop_ca7e1                                                    ; a7e4: b0 fb       ..
+    dex                                                               ; a7e6: ca          .
+    bpl loop_ca7e0                                                    ; a7e7: 10 f7       ..
+    adc l00b0                                                         ; a7e9: 65 b0       e.
+    pha                                                               ; a7eb: 48          H
+    tya                                                               ; a7ec: 98          .
+    tax                                                               ; a7ed: aa          .
+    pla                                                               ; a7ee: 68          h
+    beq ca7f2                                                         ; a7ef: f0 01       ..
+    inx                                                               ; a7f1: e8          .
+; $a7f2 referenced 1 time by $a7ef
+ca7f2
+    rts                                                               ; a7f2: 60          `
+
+sub_ca7f3
+    sec                                                               ; a7f3: 38          8
+    bcs ca7f7                                                         ; a7f4: b0 01       ..
+sub_ca7f6
+    clc                                                               ; a7f6: 18          .
+; $a7f7 referenced 1 time by $a7f4
+ca7f7
+    ror l00c6                                                         ; a7f7: 66 c6       f.
+    jsr sub_c8b86                                                     ; a7f9: 20 86 8b     ..
+    jsr sub_c8380                                                     ; a7fc: 20 80 83     ..
+    bit l00c6                                                         ; a7ff: 24 c6       $.
+    bmi ca818                                                         ; a801: 30 15       0.
+    jsr print_inline_osasci_top_bit_clear                             ; a803: 20 9c a9     ..
+    !text "Address :  Length", $0d                                    ; a806: 41 64 64... Add
+
+; $a818 referenced 1 time by $a801
+ca818
+    lda l0f06                                                         ; a818: ad 06 0f    ...
+    and #3                                                            ; a81b: 29 03       ).
+    sta l00c5                                                         ; a81d: 85 c5       ..
+    sta l00c2                                                         ; a81f: 85 c2       ..
+    lda l0f07                                                         ; a821: ad 07 0f    ...
+    sta l00c4                                                         ; a824: 85 c4       ..
+    sec                                                               ; a826: 38          8
+    sbc #2                                                            ; a827: e9 02       ..
+    sta l00c1                                                         ; a829: 85 c1       ..
+    bcs ca82f                                                         ; a82b: b0 02       ..
+    dec l00c2                                                         ; a82d: c6 c2       ..
+; $a82f referenced 1 time by $a82b
+ca82f
+    lda #2                                                            ; a82f: a9 02       ..
+    sta l00bb                                                         ; a831: 85 bb       ..
+    lda #0                                                            ; a833: a9 00       ..
+    sta l00bc                                                         ; a835: 85 bc       ..
+    sta l00bf                                                         ; a837: 85 bf       ..
+    sta l00c0                                                         ; a839: 85 c0       ..
+    lda l0f05                                                         ; a83b: ad 05 0f    ...
+    and #$f8                                                          ; a83e: 29 f8       ).
+    tay                                                               ; a840: a8          .
+    beq ca86b                                                         ; a841: f0 28       .(
+    bne ca856                                                         ; a843: d0 11       ..
+; $a845 referenced 2 times by $a869, $a889
+ca845
+    jsr sub_ca8e2                                                     ; a845: 20 e2 a8     ..
+    jsr sub_c82b2                                                     ; a848: 20 b2 82     ..
+    lda l00c4                                                         ; a84b: a5 c4       ..
+    sec                                                               ; a84d: 38          8
+    sbc l00bb                                                         ; a84e: e5 bb       ..
+    lda l00c5                                                         ; a850: a5 c5       ..
+    sbc l00bc                                                         ; a852: e5 bc       ..
+    bcc ca86b                                                         ; a854: 90 15       ..
+; $a856 referenced 1 time by $a843
+ca856
+    lda l0f07,y                                                       ; a856: b9 07 0f    ...
+    sec                                                               ; a859: 38          8
+    sbc l00bb                                                         ; a85a: e5 bb       ..
+    sta l00c1                                                         ; a85c: 85 c1       ..
+    php                                                               ; a85e: 08          .
+    lda l0f06,y                                                       ; a85f: b9 06 0f    ...
+    and #3                                                            ; a862: 29 03       ).
+    plp                                                               ; a864: 28          (
+    sbc l00bc                                                         ; a865: e5 bc       ..
+    sta l00c2                                                         ; a867: 85 c2       ..
+    bcc ca845                                                         ; a869: 90 da       ..
+; $a86b referenced 2 times by $a841, $a854
+ca86b
+    sty l00bd                                                         ; a86b: 84 bd       ..
+    bit l00c6                                                         ; a86d: 24 c6       $.
+    bmi ca87a                                                         ; a86f: 30 09       0.
+    lda l00c1                                                         ; a871: a5 c1       ..
+    ora l00c2                                                         ; a873: 05 c2       ..
+    beq ca87a                                                         ; a875: f0 03       ..
+    jsr sub_ca8be                                                     ; a877: 20 be a8     ..
+; $a87a referenced 2 times by $a86f, $a875
+ca87a
+    lda l00c1                                                         ; a87a: a5 c1       ..
+    clc                                                               ; a87c: 18          .
+    adc l00bf                                                         ; a87d: 65 bf       e.
+    sta l00bf                                                         ; a87f: 85 bf       ..
+    lda l00c2                                                         ; a881: a5 c2       ..
+    adc l00c0                                                         ; a883: 65 c0       e.
+    sta l00c0                                                         ; a885: 85 c0       ..
+    ldy l00bd                                                         ; a887: a4 bd       ..
+    bne ca845                                                         ; a889: d0 ba       ..
+    bit l00c6                                                         ; a88b: 24 c6       $.
+    bpl ca8bd                                                         ; a88d: 10 2e       ..
+    tay                                                               ; a88f: a8          .
+    ldx l00bf                                                         ; a890: a6 bf       ..
+    lda #$f8                                                          ; a892: a9 f8       ..
+    sec                                                               ; a894: 38          8
+    sbc l0f05                                                         ; a895: ed 05 0f    ...
+    jsr sub_ca90d                                                     ; a898: 20 0d a9     ..
+    jsr print_inline_osasci_top_bit_clear                             ; a89b: 20 9c a9     ..
+    !text "Free", $0d                                                 ; a89e: 46 72 65... Fre
+
+    lda l00c4                                                         ; a8a3: a5 c4       ..
+    sec                                                               ; a8a5: 38          8
+    sbc l00bf                                                         ; a8a6: e5 bf       ..
+    tax                                                               ; a8a8: aa          .
+    lda l00c5                                                         ; a8a9: a5 c5       ..
+    sbc l00c0                                                         ; a8ab: e5 c0       ..
+    tay                                                               ; a8ad: a8          .
+    lda l0f05                                                         ; a8ae: ad 05 0f    ...
+    jsr sub_ca90d                                                     ; a8b1: 20 0d a9     ..
+    jsr print_inline_osasci_top_bit_clear                             ; a8b4: 20 9c a9     ..
+    !text "Used", $0d                                                 ; a8b7: 55 73 65... Use
+
+    nop                                                               ; a8bc: ea          .
+; $a8bd referenced 1 time by $a88d
+ca8bd
+    rts                                                               ; a8bd: 60          `
+
+; $a8be referenced 1 time by $a877
+sub_ca8be
+    lda l00bc                                                         ; a8be: a5 bc       ..
+    jsr sub_ca9ca                                                     ; a8c0: 20 ca a9     ..
+    lda l00bb                                                         ; a8c3: a5 bb       ..
+    jsr sub_ca9c2                                                     ; a8c5: 20 c2 a9     ..
+    jsr print_inline_osasci_top_bit_clear                             ; a8c8: 20 9c a9     ..
+    !text "     :  "                                                  ; a8cb: 20 20 20...
+
+    lda l00c2                                                         ; a8d3: a5 c2       ..
+    jsr sub_ca9ca                                                     ; a8d5: 20 ca a9     ..
+    lda l00c1                                                         ; a8d8: a5 c1       ..
+    jsr sub_ca9c2                                                     ; a8da: 20 c2 a9     ..
+    lda #$0d                                                          ; a8dd: a9 0d       ..
+    jsr osasci                                                        ; a8df: 20 e3 ff     ..
+; $a8e2 referenced 1 time by $a845
+sub_ca8e2
+    lda l0f06,y                                                       ; a8e2: b9 06 0f    ...
+    pha                                                               ; a8e5: 48          H
+    jsr sub_c81b0                                                     ; a8e6: 20 b0 81     ..
+    sta l00bc                                                         ; a8e9: 85 bc       ..
+    pla                                                               ; a8eb: 68          h
+    and #3                                                            ; a8ec: 29 03       ).
+    clc                                                               ; a8ee: 18          .
+    adc l00bc                                                         ; a8ef: 65 bc       e.
+    sta l00bc                                                         ; a8f1: 85 bc       ..
+    lda l0f04,y                                                       ; a8f3: b9 04 0f    ...
+    beq ca8fa                                                         ; a8f6: f0 02       ..
+    lda #1                                                            ; a8f8: a9 01       ..
+; $a8fa referenced 1 time by $a8f6
+ca8fa
+    clc                                                               ; a8fa: 18          .
+    adc l0f05,y                                                       ; a8fb: 79 05 0f    y..
+    bcc ca902                                                         ; a8fe: 90 02       ..
+    inc l00bc                                                         ; a900: e6 bc       ..
+; $a902 referenced 1 time by $a8fe
+ca902
+    clc                                                               ; a902: 18          .
+    adc l0f07,y                                                       ; a903: 79 07 0f    y..
+    sta l00bb                                                         ; a906: 85 bb       ..
+    bcc ca90c                                                         ; a908: 90 02       ..
+    inc l00bc                                                         ; a90a: e6 bc       ..
+; $a90c referenced 1 time by $a908
+ca90c
+    rts                                                               ; a90c: 60          `
+
+; $a90d referenced 2 times by $a898, $a8b1
+sub_ca90d
+    jsr sub_c81c0                                                     ; a90d: 20 c0 81     ..
+    jsr sub_ca9bf                                                     ; a910: 20 bf a9     ..
+    jsr print_inline_osasci_top_bit_clear                             ; a913: 20 9c a9     ..
+    !text " Files "                                                   ; a916: 20 46 69...  Fi
+
+    stx l00bc                                                         ; a91d: 86 bc       ..
+    sty l00bd                                                         ; a91f: 84 bd       ..
+    tya                                                               ; a921: 98          .
+    jsr sub_ca9ca                                                     ; a922: 20 ca a9     ..
+    txa                                                               ; a925: 8a          .
+    jsr sub_ca9c2                                                     ; a926: 20 c2 a9     ..
+    jsr print_inline_osasci_top_bit_clear                             ; a929: 20 9c a9     ..
+    !text " Sectors "                                                 ; a92c: 20 53 65...  Se
+
+    lda #0                                                            ; a935: a9 00       ..
+    sta l00bb                                                         ; a937: 85 bb       ..
+    sta l00be                                                         ; a939: 85 be       ..
+    ldx #$1f                                                          ; a93b: a2 1f       ..
+    stx l00c1                                                         ; a93d: 86 c1       ..
+    ldx #9                                                            ; a93f: a2 09       ..
+; $a941 referenced 1 time by $a945
+loop_ca941
+    sta l1000,x                                                       ; a941: 9d 00 10    ...
+    dex                                                               ; a944: ca          .
+    bpl loop_ca941                                                    ; a945: 10 fa       ..
+; $a947 referenced 1 time by $a966
+loop_ca947
+    asl l00bb                                                         ; a947: 06 bb       ..
+    rol l00bc                                                         ; a949: 26 bc       &.
+    rol l00bd                                                         ; a94b: 26 bd       &.
+    rol l00be                                                         ; a94d: 26 be       &.
+    ldx #0                                                            ; a94f: a2 00       ..
+    ldy #9                                                            ; a951: a0 09       ..
+; $a953 referenced 1 time by $a962
+loop_ca953
+    lda l1000,x                                                       ; a953: bd 00 10    ...
+    rol                                                               ; a956: 2a          *
+    cmp #$0a                                                          ; a957: c9 0a       ..
+    bcc ca95d                                                         ; a959: 90 02       ..
+    sbc #$0a                                                          ; a95b: e9 0a       ..
+; $a95d referenced 1 time by $a959
+ca95d
+    sta l1000,x                                                       ; a95d: 9d 00 10    ...
+    inx                                                               ; a960: e8          .
+    dey                                                               ; a961: 88          .
+    bpl loop_ca953                                                    ; a962: 10 ef       ..
+    dec l00c1                                                         ; a964: c6 c1       ..
+    bpl loop_ca947                                                    ; a966: 10 df       ..
+    ldy #$20 ; ' '                                                    ; a968: a0 20       .
+    ldx #5                                                            ; a96a: a2 05       ..
+; $a96c referenced 1 time by $a98e
+ca96c
+    bne ca970                                                         ; a96c: d0 02       ..
+    ldy #$2c ; ','                                                    ; a96e: a0 2c       .,
+; $a970 referenced 1 time by $a96c
+ca970
+    lda l1000,x                                                       ; a970: bd 00 10    ...
+    bne ca97d                                                         ; a973: d0 08       ..
+    cpy #$2c ; ','                                                    ; a975: c0 2c       .,
+    beq ca97d                                                         ; a977: f0 04       ..
+    lda #$20 ; ' '                                                    ; a979: a9 20       .
+    bne ca982                                                         ; a97b: d0 05       ..
+; $a97d referenced 2 times by $a973, $a977
+ca97d
+    ldy #$2c ; ','                                                    ; a97d: a0 2c       .,
+    clc                                                               ; a97f: 18          .
+    adc #'0'                                                          ; a980: 69 30       i0
+; $a982 referenced 1 time by $a97b
+ca982
+    jsr osasci                                                        ; a982: 20 e3 ff     ..
+    cpx #3                                                            ; a985: e0 03       ..
+    bne ca98d                                                         ; a987: d0 04       ..
+    tya                                                               ; a989: 98          .
+    jsr osasci                                                        ; a98a: 20 e3 ff     ..
+; $a98d referenced 1 time by $a987
+ca98d
+    dex                                                               ; a98d: ca          .
+    bpl ca96c                                                         ; a98e: 10 dc       ..
+    jsr print_inline_osasci_top_bit_clear                             ; a990: 20 9c a9     ..
+    !text " Bytes "                                                   ; a993: 20 42 79...  By
+
+    nop                                                               ; a99a: ea          .
+    rts                                                               ; a99b: 60          `
+
+; $a99c referenced 7 times by $a803, $a89b, $a8b4, $a8c8, $a913, $a929, $a990
+print_inline_osasci_top_bit_clear
+    sta l00b3                                                         ; a99c: 85 b3       ..
+    pla                                                               ; a99e: 68          h
+    sta l00ae                                                         ; a99f: 85 ae       ..
+    pla                                                               ; a9a1: 68          h
+    sta l00af                                                         ; a9a2: 85 af       ..
+    lda l00b3                                                         ; a9a4: a5 b3       ..
+    pha                                                               ; a9a6: 48          H
+    tya                                                               ; a9a7: 98          .
+    pha                                                               ; a9a8: 48          H
+    ldy #0                                                            ; a9a9: a0 00       ..
+; $a9ab referenced 1 time by $a9b5
+loop_ca9ab
+    jsr inc16_ae                                                      ; a9ab: 20 dc 83     ..
+    lda (l00ae),y                                                     ; a9ae: b1 ae       ..
+    bmi ca9b8                                                         ; a9b0: 30 06       0.
+    jsr osasci                                                        ; a9b2: 20 e3 ff     ..
+    jmp loop_ca9ab                                                    ; a9b5: 4c ab a9    L..
+
+; $a9b8 referenced 1 time by $a9b0
+ca9b8
+    pla                                                               ; a9b8: 68          h
+    tay                                                               ; a9b9: a8          .
+    pla                                                               ; a9ba: 68          h
+    clc                                                               ; a9bb: 18          .
+    jmp (l00ae)                                                       ; a9bc: 6c ae 00    l..
+
+; $a9bf referenced 1 time by $a910
+sub_ca9bf
+    jsr sub_c841b                                                     ; a9bf: 20 1b 84     ..
+; $a9c2 referenced 3 times by $a8c5, $a8da, $a926
+sub_ca9c2
+    pha                                                               ; a9c2: 48          H
+    jsr sub_c81bf                                                     ; a9c3: 20 bf 81     ..
+    jsr sub_ca9ca                                                     ; a9c6: 20 ca a9     ..
+    pla                                                               ; a9c9: 68          h
+; $a9ca referenced 4 times by $a8c0, $a8d5, $a922, $a9c6
+sub_ca9ca
+    jsr sub_c80c8                                                     ; a9ca: 20 c8 80     ..
+    jmp osasci                                                        ; a9cd: 4c e3 ff    L..
+
+sub_ca9d0
+    lda #0                                                            ; a9d0: a9 00       ..
+    sta l00a8                                                         ; a9d2: 85 a8       ..
+    jsr sub_caaea                                                     ; a9d4: 20 ea aa     ..
+    lda #$0f                                                          ; a9d7: a9 0f       ..
+    sta l00aa                                                         ; a9d9: 85 aa       ..
+    jsr sub_caadd                                                     ; a9db: 20 dd aa     ..
+    sec                                                               ; a9de: 38          8
+    jsr gsinit                                                        ; a9df: 20 c2 ff     ..
+    sty l00ab                                                         ; a9e2: 84 ab       ..
+    clc                                                               ; a9e4: 18          .
+    beq ca9ff                                                         ; a9e5: f0 18       ..
+; $a9e7 referenced 1 time by $a9fc
+loop_ca9e7
+    jsr sub_c8456                                                     ; a9e7: 20 56 84     V.
+    bcs ca9ff                                                         ; a9ea: b0 13       ..
+    sty l00ab                                                         ; a9ec: 84 ab       ..
+    and #$0f                                                          ; a9ee: 29 0f       ).
+    sta l00aa                                                         ; a9f0: 85 aa       ..
+    jsr sub_caa53                                                     ; a9f2: 20 53 aa     S.
+    ldy l00ab                                                         ; a9f5: a4 ab       ..
+    jsr clc_jmp_gsinit                                                ; a9f7: 20 4c 87     L.
+    sty l00ab                                                         ; a9fa: 84 ab       ..
+    bne loop_ca9e7                                                    ; a9fc: d0 e9       ..
+    rts                                                               ; a9fe: 60          `
+
+; $a9ff referenced 2 times by $a9e5, $a9ea
+ca9ff
+    ror l00a8                                                         ; a9ff: 66 a8       f.
+; $aa01 referenced 1 time by $aa0f
+loop_caa01
+    bit l00a8                                                         ; aa01: 24 a8       $.
+    bpl caa0a                                                         ; aa03: 10 05       ..
+    jsr sub_caa12                                                     ; aa05: 20 12 aa     ..
+    bcc caa0d                                                         ; aa08: 90 03       ..
+; $aa0a referenced 1 time by $aa03
+caa0a
+    jsr sub_caa53                                                     ; aa0a: 20 53 aa     S.
+; $aa0d referenced 1 time by $aa08
+caa0d
+    dec l00aa                                                         ; aa0d: c6 aa       ..
+    bpl loop_caa01                                                    ; aa0f: 10 f0       ..
+    rts                                                               ; aa11: 60          `
+
+; $aa12 referenced 1 time by $aa05
+sub_caa12
+    lda #9                                                            ; aa12: a9 09       ..
+    sta osrdsc_ptr                                                    ; aa14: 85 f6       ..
+    lda #$80                                                          ; aa16: a9 80       ..
+    sta l00f7                                                         ; aa18: 85 f7       ..
+    ldy l00ab                                                         ; aa1a: a4 ab       ..
+; $aa1c referenced 2 times by $aa39, $aa40
+caa1c
+    lda (os_text_ptr),y                                               ; aa1c: b1 f2       ..
+    cmp #$0d                                                          ; aa1e: c9 0d       ..
+    beq caa44                                                         ; aa20: f0 22       ."
+    cmp #$22 ; '"'                                                    ; aa22: c9 22       ."
+    beq caa44                                                         ; aa24: f0 1e       ..
+    iny                                                               ; aa26: c8          .
+    cmp #$2a ; '*'                                                    ; aa27: c9 2a       .*
+    beq caa51                                                         ; aa29: f0 26       .&
+    jsr sub_c82fe                                                     ; aa2b: 20 fe 82     ..
+    sta l00ae                                                         ; aa2e: 85 ae       ..
+    jsr sub_caacf                                                     ; aa30: 20 cf aa     ..
+    beq caa42                                                         ; aa33: f0 0d       ..
+    ldx l00ae                                                         ; aa35: a6 ae       ..
+    cpx #$23 ; '#'                                                    ; aa37: e0 23       .#
+    beq caa1c                                                         ; aa39: f0 e1       ..
+    jsr sub_c82fe                                                     ; aa3b: 20 fe 82     ..
+    cmp l00ae                                                         ; aa3e: c5 ae       ..
+    beq caa1c                                                         ; aa40: f0 da       ..
+; $aa42 referenced 3 times by $aa33, $aa4f, $aa57
+caa42
+    clc                                                               ; aa42: 18          .
+    rts                                                               ; aa43: 60          `
+
+; $aa44 referenced 3 times by $aa20, $aa24, $aa4b
+caa44
+    jsr sub_caacf                                                     ; aa44: 20 cf aa     ..
+    beq caa51                                                         ; aa47: f0 08       ..
+    cmp #$20 ; ' '                                                    ; aa49: c9 20       .
+    beq caa44                                                         ; aa4b: f0 f7       ..
+    cmp #$0d                                                          ; aa4d: c9 0d       ..
+    bne caa42                                                         ; aa4f: d0 f1       ..
+; $aa51 referenced 2 times by $aa29, $aa47
+caa51
+    sec                                                               ; aa51: 38          8
+    rts                                                               ; aa52: 60          `
+
+; $aa53 referenced 2 times by $a9f2, $aa0a
+sub_caa53
+    ldy l00aa                                                         ; aa53: a4 aa       ..
+    lda (l00b4),y                                                     ; aa55: b1 b4       ..
+    beq caa42                                                         ; aa57: f0 e9       ..
+    pha                                                               ; aa59: 48          H
+    jsr print_inline_l809f_top_bit_clear                              ; aa5a: 20 77 80     w.
+    !text "Rom "                                                      ; aa5d: 52 6f 6d... Rom
+
+    tya                                                               ; aa61: 98          .
+    jsr sub_c80b8                                                     ; aa62: 20 b8 80     ..
+    jsr print_inline_l809f_top_bit_clear                              ; aa65: 20 77 80     w.
+    !text " : "                                                       ; aa68: 20 3a 20     :
+
+    lda #$28 ; '('                                                    ; aa6b: a9 28       .(
+    jsr c809f                                                         ; aa6d: 20 9f 80     ..
+    pla                                                               ; aa70: 68          h
+    pha                                                               ; aa71: 48          H
+    bmi caa78                                                         ; aa72: 30 04       0.
+    ldy #$20 ; ' '                                                    ; aa74: a0 20       .
+    bne caa7a                                                         ; aa76: d0 02       ..
+; $aa78 referenced 1 time by $aa72
+caa78
+    ldy #$53 ; 'S'                                                    ; aa78: a0 53       .S
+; $aa7a referenced 1 time by $aa76
+caa7a
+    tya                                                               ; aa7a: 98          .
+    jsr c809f                                                         ; aa7b: 20 9f 80     ..
+    pla                                                               ; aa7e: 68          h
+    ldy #$20 ; ' '                                                    ; aa7f: a0 20       .
+    asl                                                               ; aa81: 0a          .
+    bpl caa86                                                         ; aa82: 10 02       ..
+    ldy #$4c ; 'L'                                                    ; aa84: a0 4c       .L
+; $aa86 referenced 1 time by $aa82
+caa86
+    tya                                                               ; aa86: 98          .
+    jsr c809f                                                         ; aa87: 20 9f 80     ..
+    lda #$29 ; ')'                                                    ; aa8a: a9 29       .)
+    jsr c809f                                                         ; aa8c: 20 9f 80     ..
+    jsr cac0f                                                         ; aa8f: 20 0f ac     ..
+    jsr sub_caa9a                                                     ; aa92: 20 9a aa     ..
+    jsr ca3dc                                                         ; aa95: 20 dc a3     ..
+    sec                                                               ; aa98: 38          8
+    rts                                                               ; aa99: 60          `
+
+; $aa9a referenced 1 time by $aa92
+sub_caa9a
+    lda #7                                                            ; aa9a: a9 07       ..
+    sta osrdsc_ptr                                                    ; aa9c: 85 f6       ..
+    lda #$80                                                          ; aa9e: a9 80       ..
+    sta l00f7                                                         ; aaa0: 85 f7       ..
+    jsr sub_caacf                                                     ; aaa2: 20 cf aa     ..
+    sta l00ae                                                         ; aaa5: 85 ae       ..
+    inc osrdsc_ptr                                                    ; aaa7: e6 f6       ..
+    ldy #$1e                                                          ; aaa9: a0 1e       ..
+    jsr sub_caac2                                                     ; aaab: 20 c2 aa     ..
+    bcs caab7                                                         ; aaae: b0 07       ..
+    jsr cac0f                                                         ; aab0: 20 0f ac     ..
+    dey                                                               ; aab3: 88          .
+    jsr sub_caac2                                                     ; aab4: 20 c2 aa     ..
+; $aab7 referenced 1 time by $aaae
+caab7
+    rts                                                               ; aab7: 60          `
+
+; $aab8 referenced 1 time by $aacb
+loop_caab8
+    cmp #$20 ; ' '                                                    ; aab8: c9 20       .
+    bcs caabe                                                         ; aaba: b0 02       ..
+    lda #$20 ; ' '                                                    ; aabc: a9 20       .
+; $aabe referenced 1 time by $aaba
+caabe
+    jsr c809f                                                         ; aabe: 20 9f 80     ..
+    dey                                                               ; aac1: 88          .
+; $aac2 referenced 2 times by $aaab, $aab4
+sub_caac2
+    lda osrdsc_ptr                                                    ; aac2: a5 f6       ..
+    cmp l00ae                                                         ; aac4: c5 ae       ..
+    bcs caace                                                         ; aac6: b0 06       ..
+    jsr sub_caacf                                                     ; aac8: 20 cf aa     ..
+    bne loop_caab8                                                    ; aacb: d0 eb       ..
+    clc                                                               ; aacd: 18          .
+; $aace referenced 1 time by $aac6
+caace
+    rts                                                               ; aace: 60          `
+
+; $aacf referenced 4 times by $aa30, $aa44, $aaa2, $aac8
+sub_caacf
+    tya                                                               ; aacf: 98          .
+    pha                                                               ; aad0: 48          H
+    ldy l00aa                                                         ; aad1: a4 aa       ..
+    jsr osrdsc                                                        ; aad3: 20 b9 ff     ..
+    inc osrdsc_ptr                                                    ; aad6: e6 f6       ..
+    tax                                                               ; aad8: aa          .
+    pla                                                               ; aad9: 68          h
+    tay                                                               ; aada: a8          .
+    txa                                                               ; aadb: 8a          .
+    rts                                                               ; aadc: 60          `
+
+; $aadd referenced 1 time by $a9db
+sub_caadd
+    jsr sub_c840c                                                     ; aadd: 20 0c 84     ..
+    lda #$aa                                                          ; aae0: a9 aa       ..
+    jsr osbyte_read                                                   ; aae2: 20 e5 9a     ..
+    stx l00b4                                                         ; aae5: 86 b4       ..
+    sty l00b5                                                         ; aae7: 84 b5       ..
+    rts                                                               ; aae9: 60          `
+
+; $aaea referenced 1 time by $a9d4
+sub_caaea
+    tsx                                                               ; aaea: ba          .
+    lda #0                                                            ; aaeb: a9 00       ..
+    sta l0107,x                                                       ; aaed: 9d 07 01    ...
+    rts                                                               ; aaf0: 60          `
+
+; $aaf1 referenced 2 times by $ab51, $abd5
+sub_caaf1
+    ldx romsel_copy                                                   ; aaf1: a6 f4       ..
+    lda l0df0,x                                                       ; aaf3: bd f0 0d    ...
+    and #$3f ; '?'                                                    ; aaf6: 29 3f       )?
+    sta l00ad                                                         ; aaf8: 85 ad       ..
+    inc l00ad                                                         ; aafa: e6 ad       ..
+    rts                                                               ; aafc: 60          `
+
+sub_caafd
+    jsr sub_cac18                                                     ; aafd: 20 18 ac     ..
+    lda #0                                                            ; ab00: a9 00       ..
+    beq cab09                                                         ; ab02: f0 05       ..
+sub_cab04
+    jsr sub_cac18                                                     ; ab04: 20 18 ac     ..
+    lda #$ff                                                          ; ab07: a9 ff       ..
+; $ab09 referenced 1 time by $ab02
+cab09
+    sta l00ab                                                         ; ab09: 85 ab       ..
+    lda #$40 ; '@'                                                    ; ab0b: a9 40       .@
+    jsr osfind                                                        ; ab0d: 20 ce ff     ..
+    tay                                                               ; ab10: a8          .
+    lda #$0d                                                          ; ab11: a9 0d       ..
+    cpy #0                                                            ; ab13: c0 00       ..
+    bne cab35                                                         ; ab15: d0 1e       ..
+; $ab17 referenced 1 time by $ab4f
+cab17
+    jmp c822a                                                         ; ab17: 4c 2a 82    L*.
+
+; $ab1a referenced 2 times by $ab21, $ab3a
+cab1a
+    jsr osbget                                                        ; ab1a: 20 d7 ff     ..
+    bcs cab3d                                                         ; ab1d: b0 1e       ..
+    cmp #$0a                                                          ; ab1f: c9 0a       ..
+    beq cab1a                                                         ; ab21: f0 f7       ..
+    plp                                                               ; ab23: 28          (
+    bne cab2e                                                         ; ab24: d0 08       ..
+    pha                                                               ; ab26: 48          H
+    jsr sub_cac4e                                                     ; ab27: 20 4e ac     N.
+    jsr cac0f                                                         ; ab2a: 20 0f ac     ..
+    pla                                                               ; ab2d: 68          h
+; $ab2e referenced 1 time by $ab24
+cab2e
+    jsr osasci                                                        ; ab2e: 20 e3 ff     ..
+    bit l00ff                                                         ; ab31: 24 ff       $.
+    bmi cab54                                                         ; ab33: 30 1f       0.
+; $ab35 referenced 1 time by $ab15
+cab35
+    and l00ab                                                         ; ab35: 25 ab       %.
+    cmp #$0d                                                          ; ab37: c9 0d       ..
+    php                                                               ; ab39: 08          .
+    jmp cab1a                                                         ; ab3a: 4c 1a ab    L..
+
+; $ab3d referenced 1 time by $ab1d
+cab3d
+    plp                                                               ; ab3d: 28          (
+    jsr osnewl                                                        ; ab3e: 20 e7 ff     ..
+; $ab41 referenced 2 times by $aba5, $abbf
+cab41
+    lda #0                                                            ; ab41: a9 00       ..
+    jmp osfind                                                        ; ab43: 4c ce ff    L..
+
+sub_cab46
+    jsr sub_cac18                                                     ; ab46: 20 18 ac     ..
+    lda #$40 ; '@'                                                    ; ab49: a9 40       .@
+    jsr osfind                                                        ; ab4b: 20 ce ff     ..
+    tay                                                               ; ab4e: a8          .
+    beq cab17                                                         ; ab4f: f0 c6       ..
+    jsr sub_caaf1                                                     ; ab51: 20 f1 aa     ..
+; $ab54 referenced 2 times by $ab33, $aba7
+cab54
+    bit l00ff                                                         ; ab54: 24 ff       $.
+    bmi cabbc                                                         ; ab56: 30 64       0d
+    lda l00a9                                                         ; ab58: a5 a9       ..
+    jsr sub_cac62                                                     ; ab5a: 20 62 ac     b.
+    lda l00a8                                                         ; ab5d: a5 a8       ..
+    jsr sub_cac62                                                     ; ab5f: 20 62 ac     b.
+    jsr cac0f                                                         ; ab62: 20 0f ac     ..
+    lda #8                                                            ; ab65: a9 08       ..
+    sta l00ac                                                         ; ab67: 85 ac       ..
+    ldx #0                                                            ; ab69: a2 00       ..
+; $ab6b referenced 1 time by $ab7a
+loop_cab6b
+    jsr osbget                                                        ; ab6b: 20 d7 ff     ..
+    bcs cab7d                                                         ; ab6e: b0 0d       ..
+    sta (l00ac,x)                                                     ; ab70: 81 ac       ..
+    jsr sub_cac62                                                     ; ab72: 20 62 ac     b.
+    jsr cac0f                                                         ; ab75: 20 0f ac     ..
+    dec l00ac                                                         ; ab78: c6 ac       ..
+    bne loop_cab6b                                                    ; ab7a: d0 ef       ..
+    clc                                                               ; ab7c: 18          .
+; $ab7d referenced 1 time by $ab6e
+cab7d
+    php                                                               ; ab7d: 08          .
+    bcc cab93                                                         ; ab7e: 90 13       ..
+; $ab80 referenced 1 time by $ab91
+loop_cab80
+    lda #$2a ; '*'                                                    ; ab80: a9 2a       .*
+    jsr osasci                                                        ; ab82: 20 e3 ff     ..
+    jsr osasci                                                        ; ab85: 20 e3 ff     ..
+    jsr cac0f                                                         ; ab88: 20 0f ac     ..
+    lda #0                                                            ; ab8b: a9 00       ..
+    sta (l00ac,x)                                                     ; ab8d: 81 ac       ..
+    dec l00ac                                                         ; ab8f: c6 ac       ..
+    bne loop_cab80                                                    ; ab91: d0 ed       ..
+; $ab93 referenced 1 time by $ab7e
+cab93
+    jsr sub_caba9                                                     ; ab93: 20 a9 ab     ..
+    jsr osnewl                                                        ; ab96: 20 e7 ff     ..
+    lda #8                                                            ; ab99: a9 08       ..
+    clc                                                               ; ab9b: 18          .
+    adc l00a8                                                         ; ab9c: 65 a8       e.
+    sta l00a8                                                         ; ab9e: 85 a8       ..
+    bcc caba4                                                         ; aba0: 90 02       ..
+    inc l00a9                                                         ; aba2: e6 a9       ..
+; $aba4 referenced 1 time by $aba0
+caba4
+    plp                                                               ; aba4: 28          (
+    bcs cab41                                                         ; aba5: b0 9a       ..
+    bcc cab54                                                         ; aba7: 90 ab       ..
+; $aba9 referenced 1 time by $ab93
+sub_caba9
+    lda #8                                                            ; aba9: a9 08       ..
+    sta l00ac                                                         ; abab: 85 ac       ..
+; $abad referenced 1 time by $abb9
+loop_cabad
+    ldx #0                                                            ; abad: a2 00       ..
+    lda (l00ac,x)                                                     ; abaf: a1 ac       ..
+    jsr sub_c842c                                                     ; abb1: 20 2c 84     ,.
+    jsr osasci                                                        ; abb4: 20 e3 ff     ..
+    dec l00ac                                                         ; abb7: c6 ac       ..
+    bne loop_cabad                                                    ; abb9: d0 f2       ..
+    rts                                                               ; abbb: 60          `
+
+; $abbc referenced 2 times by $ab56, $ac02
+cabbc
+    jsr sub_c9ad8                                                     ; abbc: 20 d8 9a     ..
+    jsr cab41                                                         ; abbf: 20 41 ab     A.
+    jmp c9436                                                         ; abc2: 4c 36 94    L6.
+
+sub_cabc5
+    jsr sub_cac18                                                     ; abc5: 20 18 ac     ..
+    lda #$80                                                          ; abc8: a9 80       ..
+    jsr osfind                                                        ; abca: 20 ce ff     ..
+    sta l00ab                                                         ; abcd: 85 ab       ..
+; $abcf referenced 1 time by $ac09
+cabcf
+    jsr sub_cac4e                                                     ; abcf: 20 4e ac     N.
+    jsr cac0f                                                         ; abd2: 20 0f ac     ..
+    jsr sub_caaf1                                                     ; abd5: 20 f1 aa     ..
+    ldx #$ac                                                          ; abd8: a2 ac       ..
+    ldy #$ff                                                          ; abda: a0 ff       ..
+    sty l00ae                                                         ; abdc: 84 ae       ..
+    sty l00b0                                                         ; abde: 84 b0       ..
+    iny                                                               ; abe0: c8          .
+    sty l00ac                                                         ; abe1: 84 ac       ..
+    lda #$20 ; ' '                                                    ; abe3: a9 20       .
+    sta l00af                                                         ; abe5: 85 af       ..
+    tya                                                               ; abe7: 98          .
+    jsr osword                                                        ; abe8: 20 f1 ff     ..
+    php                                                               ; abeb: 08          .
+    sty l00aa                                                         ; abec: 84 aa       ..
+    ldy l00ab                                                         ; abee: a4 ab       ..
+    ldx #0                                                            ; abf0: a2 00       ..
+    beq cabfb                                                         ; abf2: f0 07       ..
+; $abf4 referenced 1 time by $abff
+loop_cabf4
+    lda (l00ac,x)                                                     ; abf4: a1 ac       ..
+    jsr osbput                                                        ; abf6: 20 d4 ff     ..
+    inc l00ac                                                         ; abf9: e6 ac       ..
+; $abfb referenced 1 time by $abf2
+cabfb
+    lda l00ac                                                         ; abfb: a5 ac       ..
+    cmp l00aa                                                         ; abfd: c5 aa       ..
+    bne loop_cabf4                                                    ; abff: d0 f3       ..
+    plp                                                               ; ac01: 28          (
+    bcs cabbc                                                         ; ac02: b0 b8       ..
+    lda #$0d                                                          ; ac04: a9 0d       ..
+    jsr osbput                                                        ; ac06: 20 d4 ff     ..
+    jmp cabcf                                                         ; ac09: 4c cf ab    L..
+
+; $ac0c referenced 3 times by $817f, $8198, $85ca
+sub_cac0c
+    jsr cac0f                                                         ; ac0c: 20 0f ac     ..
+; $ac0f referenced 11 times by $81a7, $834f, $837d, $aa8f, $aab0, $ab2a, $ab62, $ab75, $ab88, $abd2, $ac0c
+cac0f
+    pha                                                               ; ac0f: 48          H
+    lda #$20 ; ' '                                                    ; ac10: a9 20       .
+    jsr osasci                                                        ; ac12: 20 e3 ff     ..
+    pla                                                               ; ac15: 68          h
+    clc                                                               ; ac16: 18          .
+    rts                                                               ; ac17: 60          `
+
+; $ac18 referenced 4 times by $aafd, $ab04, $ab46, $abc5
+sub_cac18
+    tsx                                                               ; ac18: ba          .
+    lda #0                                                            ; ac19: a9 00       ..
+    sta l0107,x                                                       ; ac1b: 9d 07 01    ...
+    jsr sub_cac47                                                     ; ac1e: 20 47 ac     G.
+    cmp #$0d                                                          ; ac21: c9 0d       ..
+    bne cac28                                                         ; ac23: d0 03       ..
+    jmp ca14f                                                         ; ac25: 4c 4f a1    LO.
+
+; $ac28 referenced 1 time by $ac23
+cac28
+    lda #0                                                            ; ac28: a9 00       ..
+    sta l00a8                                                         ; ac2a: 85 a8       ..
+    sta l00a9                                                         ; ac2c: 85 a9       ..
+    pha                                                               ; ac2e: 48          H
+    tya                                                               ; ac2f: 98          .
+    clc                                                               ; ac30: 18          .
+    adc os_text_ptr                                                   ; ac31: 65 f2       e.
+    tax                                                               ; ac33: aa          .
+    lda l00f3                                                         ; ac34: a5 f3       ..
+    adc #0                                                            ; ac36: 69 00       i.
+    tay                                                               ; ac38: a8          .
+    pla                                                               ; ac39: 68          h
+    rts                                                               ; ac3a: 60          `
+
+    tya                                                               ; ac3b: 98          .
+    clc                                                               ; ac3c: 18          .
+    adc os_text_ptr                                                   ; ac3d: 65 f2       e.
+    sta os_text_ptr                                                   ; ac3f: 85 f2       ..
+    bcc cac45                                                         ; ac41: 90 02       ..
+    inc os_text_ptr                                                   ; ac43: e6 f2       ..
+; $ac45 referenced 1 time by $ac41
+cac45
+    rts                                                               ; ac45: 60          `
+
+; $ac46 referenced 1 time by $ac4b
+loop_cac46
+    iny                                                               ; ac46: c8          .
+; $ac47 referenced 1 time by $ac1e
+sub_cac47
+    lda (os_text_ptr),y                                               ; ac47: b1 f2       ..
+    cmp #$20 ; ' '                                                    ; ac49: c9 20       .
+    beq loop_cac46                                                    ; ac4b: f0 f9       ..
+    rts                                                               ; ac4d: 60          `
+
+; $ac4e referenced 2 times by $ab27, $abcf
+sub_cac4e
+    sed                                                               ; ac4e: f8          .
+    clc                                                               ; ac4f: 18          .
+    lda l00a8                                                         ; ac50: a5 a8       ..
+    adc #1                                                            ; ac52: 69 01       i.
+    sta l00a8                                                         ; ac54: 85 a8       ..
+    lda l00a9                                                         ; ac56: a5 a9       ..
+    adc #0                                                            ; ac58: 69 00       i.
+    sta l00a9                                                         ; ac5a: 85 a9       ..
+    cld                                                               ; ac5c: d8          .
+    jsr sub_cac62                                                     ; ac5d: 20 62 ac     b.
+    lda l00a8                                                         ; ac60: a5 a8       ..
+; $ac62 referenced 4 times by $ab5a, $ab5f, $ab72, $ac5d
+sub_cac62
+    pha                                                               ; ac62: 48          H
+    jsr sub_c81bf                                                     ; ac63: 20 bf 81     ..
+    jsr sub_cac6a                                                     ; ac66: 20 6a ac     j.
+    pla                                                               ; ac69: 68          h
+; $ac6a referenced 1 time by $ac66
+sub_cac6a
+    jsr sub_c80c8                                                     ; ac6a: 20 c8 80     ..
+    jsr osasci                                                        ; ac6d: 20 e3 ff     ..
+    sec                                                               ; ac70: 38          8
+    rts                                                               ; ac71: 60          `
+
+; $ac72 referenced 1 time by $96e1
+sub_cac72
+    jsr sub_c83e3                                                     ; ac72: 20 e3 83     ..
+    lda #$40 ; '@'                                                    ; ac75: a9 40       .@
+    sta l10de                                                         ; ac77: 8d de 10    ...
+    lda #$a8                                                          ; ac7a: a9 a8       ..
+    jsr osbyte_read                                                   ; ac7c: 20 e5 9a     ..
+    stx l00b0                                                         ; ac7f: 86 b0       ..
+    sty l00b1                                                         ; ac81: 84 b1       ..
+    ldy #$0f                                                          ; ac83: a0 0f       ..
+    lda #$4c ; 'L'                                                    ; ac85: a9 4c       .L
+    sta l10e2                                                         ; ac87: 8d e2 10    ...
+    lda bytev                                                         ; ac8a: ad 0a 02    ...
+    sta l10e3                                                         ; ac8d: 8d e3 10    ...
+    lda bytev+1                                                       ; ac90: ad 0b 02    ...
+    sta l10e4                                                         ; ac93: 8d e4 10    ...
+    php                                                               ; ac96: 08          .
+    sei                                                               ; ac97: 78          x
+    lda #$0f                                                          ; ac98: a9 0f       ..
+    sta bytev                                                         ; ac9a: 8d 0a 02    ...
+    lda #$ff                                                          ; ac9d: a9 ff       ..
+    sta bytev+1                                                       ; ac9f: 8d 0b 02    ...
+    lda #$b2                                                          ; aca2: a9 b2       ..
+    sta (l00b0),y                                                     ; aca4: 91 b0       ..
+    iny                                                               ; aca6: c8          .
+    lda #$ac                                                          ; aca7: a9 ac       ..
+    sta (l00b0),y                                                     ; aca9: 91 b0       ..
+    iny                                                               ; acab: c8          .
+    lda romsel_copy                                                   ; acac: a5 f4       ..
+    sta (l00b0),y                                                     ; acae: 91 b0       ..
+    plp                                                               ; acb0: 28          (
+    rts                                                               ; acb1: 60          `
+
+    cmp #0                                                            ; acb2: c9 00       ..
+    beq cacc7                                                         ; acb4: f0 11       ..
+    cmp #$81                                                          ; acb6: c9 81       ..
+    bne cacc4                                                         ; acb8: d0 0a       ..
+    cpy #$ff                                                          ; acba: c0 ff       ..
+    bne cacc4                                                         ; acbc: d0 06       ..
+    cpx #0                                                            ; acbe: e0 00       ..
+    bne cacc4                                                         ; acc0: d0 02       ..
+    dex                                                               ; acc2: ca          .
+    rts                                                               ; acc3: 60          `
+
+; $acc4 referenced 3 times by $acb8, $acbc, $acc0
+cacc4
+    jmp l10e2                                                         ; acc4: 4c e2 10    L..
+
+; $acc7 referenced 1 time by $acb4
+cacc7
+    php                                                               ; acc7: 08          .
+    sei                                                               ; acc8: 78          x
+    lda l10e3                                                         ; acc9: ad e3 10    ...
+    sta bytev                                                         ; accc: 8d 0a 02    ...
+    lda l10e4                                                         ; accf: ad e4 10    ...
+    sta bytev+1                                                       ; acd2: 8d 0b 02    ...
+    lda #0                                                            ; acd5: a9 00       ..
+    ldx #1                                                            ; acd7: a2 01       ..
+    plp                                                               ; acd9: 28          (
+    rts                                                               ; acda: 60          `
+
+; $acdb referenced 3 times by $50, $af19, $af1c
+tube_host_code2
+; $acdb referenced 3 times by $50, $af19, $af1c
+
+!pseudopc $0500 {
+; $acdb referenced 3 times by $50, $af19, $af1c
+l0500
+    !word          sub_c0537,          sub_c0596,          sub_c05f2  ; acdb: 37 05 96... 7.. :0500[2]
+    !word          sub_c0607,          sub_c0627, tube_host_osword_0  ; ace1: 07 06 27... ..' :0506[2]
+    !word          sub_c055e,          sub_c052d,          sub_c0520  ; ace7: 5e 05 2d... ^.- :050c[2]
+    !word          sub_c0542,          sub_c05a9,          sub_c05d1  ; aced: 42 05 a9... B.. :0512[2]
+; Table of flags used by tube_entry_small_a to set up registers 1/4
+; for the
+; selected operation.
+; $acf3 referenced 1 time by $0453
+tube_entry_flags
+    !byte $86, $88, $96, $98, $18, $18, $82, $18                      ; acf3: 86 88 96... ... :0518[2]
+
+sub_c0520
+    jsr read_tube_r2_data                                             ; acfb: 20 c5 06     .. :0520[2]
+    tay                                                               ; acfe: a8          .   :0523[2]
+    jsr read_tube_r2_data                                             ; acff: 20 c5 06     .. :0524[2]
+    jsr osbput                                                        ; ad02: 20 d4 ff     .. :0527[2]
+    jmp c059c                                                         ; ad05: 4c 9c 05    L.. :052a[2]
+
+sub_c052d
+    jsr read_tube_r2_data                                             ; ad08: 20 c5 06     .. :052d[2]
+    tay                                                               ; ad0b: a8          .   :0530[2]
+    jsr osbget                                                        ; ad0c: 20 d7 ff     .. :0531[2]
+    jmp c053a                                                         ; ad0f: 4c 3a 05    L:. :0534[2]
+
+sub_c0537
+    jsr osrdch                                                        ; ad12: 20 e0 ff     .. :0537[2]
+; $ad15 referenced 2 times by $0534, $05ef
+c053a
+    ror                                                               ; ad15: 6a          j   :053a[2]
+    jsr write_tube_r2_data                                            ; ad16: 20 95 06     .. :053b[2]
+    rol                                                               ; ad19: 2a          *   :053e[2]
+    jmp c059e                                                         ; ad1a: 4c 9e 05    L.. :053f[2]
+
+sub_c0542
+    jsr read_tube_r2_data                                             ; ad1d: 20 c5 06     .. :0542[2]
+    beq c0552                                                         ; ad20: f0 0b       ..  :0545[2]
+    pha                                                               ; ad22: 48          H   :0547[2]
+    jsr sub_c0582                                                     ; ad23: 20 82 05     .. :0548[2]
+    pla                                                               ; ad26: 68          h   :054b[2]
+    jsr osfind                                                        ; ad27: 20 ce ff     .. :054c[2]
+    jmp c059e                                                         ; ad2a: 4c 9e 05    L.. :054f[2]
+
+; $ad2d referenced 1 time by $0545
+c0552
+    jsr read_tube_r2_data                                             ; ad2d: 20 c5 06     .. :0552[2]
+    tay                                                               ; ad30: a8          .   :0555[2]
+    lda #0                                                            ; ad31: a9 00       ..  :0556[2]
+    jsr osfind                                                        ; ad33: 20 ce ff     .. :0558[2]
+    jmp c059c                                                         ; ad36: 4c 9c 05    L.. :055b[2]
+
+sub_c055e
+    jsr read_tube_r2_data                                             ; ad39: 20 c5 06     .. :055e[2]
+    tay                                                               ; ad3c: a8          .   :0561[2]
+    ldx #4                                                            ; ad3d: a2 04       ..  :0562[2]
+; $ad3f referenced 1 time by $056a
+loop_c0564
+    jsr read_tube_r2_data                                             ; ad3f: 20 c5 06     .. :0564[2]
+    sta l00ff,x                                                       ; ad42: 95 ff       ..  :0567[2]
+    dex                                                               ; ad44: ca          .   :0569[2]
+    bne loop_c0564                                                    ; ad45: d0 f8       ..  :056a[2]
+    jsr read_tube_r2_data                                             ; ad47: 20 c5 06     .. :056c[2]
+    jsr osargs                                                        ; ad4a: 20 da ff     .. :056f[2]
+    jsr write_tube_r2_data                                            ; ad4d: 20 95 06     .. :0572[2]
+    ldx #3                                                            ; ad50: a2 03       ..  :0575[2]
+; $ad52 referenced 1 time by $057d
+loop_c0577
+    lda l0000,x                                                       ; ad52: b5 00       ..  :0577[2]
+    jsr write_tube_r2_data                                            ; ad54: 20 95 06     .. :0579[2]
+    dex                                                               ; ad57: ca          .   :057c[2]
+    bpl loop_c0577                                                    ; ad58: 10 f8       ..  :057d[2]
+    jmp c0036                                                         ; ad5a: 4c 36 00    L6. :057f[2]
+
+; $ad5d referenced 3 times by $0548, $0596, $05b3
+sub_c0582
+    ldx #0                                                            ; ad5d: a2 00       ..  :0582[2]
+    ldy #0                                                            ; ad5f: a0 00       ..  :0584[2]
+; $ad61 referenced 1 time by $0591
+loop_c0586
+    jsr read_tube_r2_data                                             ; ad61: 20 c5 06     .. :0586[2]
+    sta l0700,y                                                       ; ad64: 99 00 07    ... :0589[2]
+    iny                                                               ; ad67: c8          .   :058c[2]
+    beq c0593                                                         ; ad68: f0 04       ..  :058d[2]
+    cmp #$0d                                                          ; ad6a: c9 0d       ..  :058f[2]
+    bne loop_c0586                                                    ; ad6c: d0 f3       ..  :0591[2]
+; $ad6e referenced 1 time by $058d
+c0593
+    ldy #7                                                            ; ad6e: a0 07       ..  :0593[2]
+    rts                                                               ; ad70: 60          `   :0595[2]
+
+sub_c0596
+    jsr sub_c0582                                                     ; ad71: 20 82 05     .. :0596[2]
+    jsr oscli                                                         ; ad74: 20 f7 ff     .. :0599[2]
+; $ad77 referenced 3 times by $0489, $052a, $055b
+c059c
+    lda #$7f                                                          ; ad77: a9 7f       ..  :059c[2]
+; $ad79 referenced 4 times by $053f, $054f, $05a1, $067d
+c059e
+    bit tube_host_r2_status                                           ; ad79: 2c e2 fe    ,.. :059e[2]
+    bvc c059e                                                         ; ad7c: 50 fb       P.  :05a1[2]
+    sta tube_host_r2_data                                             ; ad7e: 8d e3 fe    ... :05a3[2]
+; $ad81 referenced 1 time by $05cf
+c05a6
+    jmp c0036                                                         ; ad81: 4c 36 00    L6. :05a6[2]
+
+sub_c05a9
+    ldx #$10                                                          ; ad84: a2 10       ..  :05a9[2]
+; $ad86 referenced 1 time by $05b1
+loop_c05ab
+    jsr read_tube_r2_data                                             ; ad86: 20 c5 06     .. :05ab[2]
+    sta l0001,x                                                       ; ad89: 95 01       ..  :05ae[2]
+    dex                                                               ; ad8b: ca          .   :05b0[2]
+    bne loop_c05ab                                                    ; ad8c: d0 f8       ..  :05b1[2]
+    jsr sub_c0582                                                     ; ad8e: 20 82 05     .. :05b3[2]
+    stx l0000                                                         ; ad91: 86 00       ..  :05b6[2]
+    sty l0001                                                         ; ad93: 84 01       ..  :05b8[2]
+    ldy #0                                                            ; ad95: a0 00       ..  :05ba[2]
+    jsr read_tube_r2_data                                             ; ad97: 20 c5 06     .. :05bc[2]
+    jsr osfile                                                        ; ad9a: 20 dd ff     .. :05bf[2]
+    jsr write_tube_r2_data                                            ; ad9d: 20 95 06     .. :05c2[2]
+    ldx #$10                                                          ; ada0: a2 10       ..  :05c5[2]
+; $ada2 referenced 1 time by $05cd
+loop_c05c7
+    lda l0001,x                                                       ; ada2: b5 01       ..  :05c7[2]
+    jsr write_tube_r2_data                                            ; ada4: 20 95 06     .. :05c9[2]
+    dex                                                               ; ada7: ca          .   :05cc[2]
+    bne loop_c05c7                                                    ; ada8: d0 f8       ..  :05cd[2]
+    beq c05a6                                                         ; adaa: f0 d5       ..  :05cf[2]
+sub_c05d1
+    ldx #$0d                                                          ; adac: a2 0d       ..  :05d1[2]
+; $adae referenced 1 time by $05d9
+loop_c05d3
+    jsr read_tube_r2_data                                             ; adae: 20 c5 06     .. :05d3[2]
+    sta l00ff,x                                                       ; adb1: 95 ff       ..  :05d6[2]
+    dex                                                               ; adb3: ca          .   :05d8[2]
+    bne loop_c05d3                                                    ; adb4: d0 f8       ..  :05d9[2]
+    jsr read_tube_r2_data                                             ; adb6: 20 c5 06     .. :05db[2]
+    ldy #0                                                            ; adb9: a0 00       ..  :05de[2]
+    jsr osgbpb                                                        ; adbb: 20 d1 ff     .. :05e0[2]
+    pha                                                               ; adbe: 48          H   :05e3[2]
+    ldx #$0c                                                          ; adbf: a2 0c       ..  :05e4[2]
+; $adc1 referenced 1 time by $05ec
+loop_c05e6
+    lda l0000,x                                                       ; adc1: b5 00       ..  :05e6[2]
+    jsr write_tube_r2_data                                            ; adc3: 20 95 06     .. :05e8[2]
+    dex                                                               ; adc6: ca          .   :05eb[2]
+    bpl loop_c05e6                                                    ; adc7: 10 f8       ..  :05ec[2]
+    pla                                                               ; adc9: 68          h   :05ee[2]
+    jmp c053a                                                         ; adca: 4c 3a 05    L:. :05ef[2]
+
+sub_c05f2
+    jsr read_tube_r2_data                                             ; adcd: 20 c5 06     .. :05f2[2]
+    tax                                                               ; add0: aa          .   :05f5[2]
+    jsr read_tube_r2_data                                             ; add1: 20 c5 06     .. :05f6[2]
+    jsr osbyte                                                        ; add4: 20 f4 ff     .. :05f9[2]
+; $add7 referenced 2 times by $05ff, $0625
+c05fc
+    bit tube_host_r2_status                                           ; add7: 2c e2 fe    ,.. :05fc[2]
+sub_c05ff
+l0600 = sub_c05ff+1
+    bvc c05fc                                                         ; adda: 50 fb       P.  :05ff[2]
+; $addb referenced 2 times by $af1f, $af22
+    stx tube_host_r2_data                                             ; addc: 8e e3 fe    ... :0601[2]
+; $addf referenced 1 time by $0617
+loop_c0604
+    jmp c0036                                                         ; addf: 4c 36 00    L6. :0604[2]
+
+sub_c0607
+    jsr read_tube_r2_data                                             ; ade2: 20 c5 06     .. :0607[2]
+    tax                                                               ; ade5: aa          .   :060a[2]
+    jsr read_tube_r2_data                                             ; ade6: 20 c5 06     .. :060b[2]
+    tay                                                               ; ade9: a8          .   :060e[2]
+    jsr read_tube_r2_data                                             ; adea: 20 c5 06     .. :060f[2]
+    jsr osbyte                                                        ; aded: 20 f4 ff     .. :0612[2]
+    eor #$9d                                                          ; adf0: 49 9d       I.  :0615[2]
+    beq loop_c0604                                                    ; adf2: f0 eb       ..  :0617[2]
+    ror                                                               ; adf4: 6a          j   :0619[2]
+    jsr write_tube_r2_data                                            ; adf5: 20 95 06     .. :061a[2]
+; $adf8 referenced 1 time by $0620
+loop_c061d
+    bit tube_host_r2_status                                           ; adf8: 2c e2 fe    ,.. :061d[2]
+    bvc loop_c061d                                                    ; adfb: 50 fb       P.  :0620[2]
+    sty tube_host_r2_data                                             ; adfd: 8c e3 fe    ... :0622[2]
+    bvs c05fc                                                         ; ae00: 70 d5       p.  :0625[2]
+sub_c0627
+    jsr read_tube_r2_data                                             ; ae02: 20 c5 06     .. :0627[2]
+    tay                                                               ; ae05: a8          .   :062a[2]
+; $ae06 referenced 1 time by $062e
+loop_c062b
+    bit tube_host_r2_status                                           ; ae06: 2c e2 fe    ,.. :062b[2]
+    bpl loop_c062b                                                    ; ae09: 10 fb       ..  :062e[2]
+    ldx tube_host_r2_data                                             ; ae0b: ae e3 fe    ... :0630[2]
+    dex                                                               ; ae0e: ca          .   :0633[2]
+    bmi c0645                                                         ; ae0f: 30 0f       0.  :0634[2]
+; $ae11 referenced 2 times by $0639, $0642
+c0636
+    bit tube_host_r2_status                                           ; ae11: 2c e2 fe    ,.. :0636[2]
+    bpl c0636                                                         ; ae14: 10 fb       ..  :0639[2]
+    lda tube_host_r2_data                                             ; ae16: ad e3 fe    ... :063b[2]
+    sta l0128,x                                                       ; ae19: 9d 28 01    .(. :063e[2]
+    dex                                                               ; ae1c: ca          .   :0641[2]
+    bpl c0636                                                         ; ae1d: 10 f2       ..  :0642[2]
+    tya                                                               ; ae1f: 98          .   :0644[2]
+; $ae20 referenced 1 time by $0634
+c0645
+    ldx #<(l0128)                                                     ; ae20: a2 28       .(  :0645[2]
+    ldy #>(l0128)                                                     ; ae22: a0 01       ..  :0647[2]
+    jsr osword                                                        ; ae24: 20 f1 ff     .. :0649[2]
+; $ae27 referenced 1 time by $064f
+loop_c064c
+    bit tube_host_r2_status                                           ; ae27: 2c e2 fe    ,.. :064c[2]
+    bpl loop_c064c                                                    ; ae2a: 10 fb       ..  :064f[2]
+    ldx tube_host_r2_data                                             ; ae2c: ae e3 fe    ... :0651[2]
+    dex                                                               ; ae2f: ca          .   :0654[2]
+    bmi c0665                                                         ; ae30: 30 0e       0.  :0655[2]
+; $ae32 referenced 1 time by $0663
+loop_c0657
+    ldy l0128,x                                                       ; ae32: bc 28 01    .(. :0657[2]
+; $ae35 referenced 1 time by $065d
+loop_c065a
+    bit tube_host_r2_status                                           ; ae35: 2c e2 fe    ,.. :065a[2]
+    bvc loop_c065a                                                    ; ae38: 50 fb       P.  :065d[2]
+    sty tube_host_r2_data                                             ; ae3a: 8c e3 fe    ... :065f[2]
+    dex                                                               ; ae3d: ca          .   :0662[2]
+    bpl loop_c0657                                                    ; ae3e: 10 f2       ..  :0663[2]
+; $ae40 referenced 1 time by $0655
+c0665
+    jmp c0036                                                         ; ae40: 4c 36 00    L6. :0665[2]
+
+tube_host_osword_0
+    ldx #4                                                            ; ae43: a2 04       ..  :0668[2]
+; $ae45 referenced 1 time by $0670
+tube_host_osword_0_loop
+    jsr read_tube_r2_data                                             ; ae45: 20 c5 06     .. :066a[2]
+    sta l0000,x                                                       ; ae48: 95 00       ..  :066d[2]
+    dex                                                               ; ae4a: ca          .   :066f[2]
+    bpl tube_host_osword_0_loop                                       ; ae4b: 10 f8       ..  :0670[2]
+    inx                                                               ; ae4d: e8          .   :0672[2]
+    ldy #0                                                            ; ae4e: a0 00       ..  :0673[2]
+    txa                                                               ; ae50: 8a          .   :0675[2]
+    jsr osword                                                        ; ae51: 20 f1 ff     .. :0676[2]
+    bcc tube_host_osword_0_no_escape                                  ; ae54: 90 05       ..  :0679[2]
+    lda #$ff                                                          ; ae56: a9 ff       ..  :067b[2]
+    jmp c059e                                                         ; ae58: 4c 9e 05    L.. :067d[2]
+
+; $ae5b referenced 1 time by $0679
+tube_host_osword_0_no_escape
+    ldx #0                                                            ; ae5b: a2 00       ..  :0680[2]
+    lda #$7f                                                          ; ae5d: a9 7f       ..  :0682[2]
+    jsr write_tube_r2_data                                            ; ae5f: 20 95 06     .. :0684[2]
+; $ae62 referenced 1 time by $0690
+tube_host_osword_0_no_escape_loop
+    lda l0700,x                                                       ; ae62: bd 00 07    ... :0687[2]
+    jsr write_tube_r2_data                                            ; ae65: 20 95 06     .. :068a[2]
+    inx                                                               ; ae68: e8          .   :068d[2]
+    cmp #$0d                                                          ; ae69: c9 0d       ..  :068e[2]
+    bne tube_host_osword_0_no_escape_loop                             ; ae6b: d0 f5       ..  :0690[2]
+    jmp c0036                                                         ; ae6d: 4c 36 00    L6. :0692[2]
+
+; Wait for register 2 to have space and write A to it.
+; $ae70 referenced 14 times by $0474, $053b, $0572, $0579, $05c2, $05c9, $05e8, $061a, $0684, $068a, $0698, $20, $26, $2c
+write_tube_r2_data
+    bit tube_host_r2_status                                           ; ae70: 2c e2 fe    ,.. :0695[2]
+    bvc write_tube_r2_data                                            ; ae73: 50 fb       P.  :0698[2]
+    sta tube_host_r2_data                                             ; ae75: 8d e3 fe    ... :069a[2]
+    rts                                                               ; ae78: 60          `   :069d[2]
+
+; Wait for register 4 to have space and write A to it.
+; $ae79 referenced 8 times by $0418, $041d, $043b, $0443, $0448, $0463, $06a1, $18
+write_tube_r4_data
+    bit tube_host_r4_status                                           ; ae79: 2c e6 fe    ,.. :069e[2]
+    bvc write_tube_r4_data                                            ; ae7c: 50 fb       P.  :06a1[2]
+    sta tube_host_r4_data                                             ; ae7e: 8d e7 fe    ... :06a3[2]
+    rts                                                               ; ae81: 60          `   :06a6[2]
+
+; $ae82 referenced 1 time by $0403
+c06a7
+    lda l00ff                                                         ; ae82: a5 ff       ..  :06a7[2]
+    sec                                                               ; ae84: 38          8   :06a9[2]
+    ror                                                               ; ae85: 6a          j   :06aa[2]
+    bmi write_tube_r1_data                                            ; ae86: 30 0f       0.  :06ab[2]
+tube_evntv_handler
+    pha                                                               ; ae88: 48          H   :06ad[2]
+    lda #0                                                            ; ae89: a9 00       ..  :06ae[2]
+    jsr write_tube_r1_data                                            ; ae8b: 20 bc 06     .. :06b0[2]
+    tya                                                               ; ae8e: 98          .   :06b3[2]
+    jsr write_tube_r1_data                                            ; ae8f: 20 bc 06     .. :06b4[2]
+    txa                                                               ; ae92: 8a          .   :06b7[2]
+    jsr write_tube_r1_data                                            ; ae93: 20 bc 06     .. :06b8[2]
+    pla                                                               ; ae96: 68          h   :06bb[2]
+; Wait for register 1 to have space and write A to it.
+; $ae97 referenced 5 times by $06ab, $06b0, $06b4, $06b8, $06bf
+write_tube_r1_data
+    bit tube_host_r1_status                                           ; ae97: 2c e0 fe    ,.. :06bc[2]
+    bvc write_tube_r1_data                                            ; ae9a: 50 fb       P.  :06bf[2]
+    sta tube_host_r1_data                                             ; ae9c: 8d e1 fe    ... :06c1[2]
+    rts                                                               ; ae9f: 60          `   :06c4[2]
+
+; Wait for register 2 to have data and read A from it.
+; $aea0 referenced 21 times by $0520, $0524, $052d, $0542, $0552, $055e, $0564, $056c, $0586, $05ab, $05bc, $05d3, $05db, $05f2, $05f6, $0607, $060b, $060f, $0627, $066a, $06c8
+read_tube_r2_data
+    bit tube_host_r2_status                                           ; aea0: 2c e2 fe    ,.. :06c5[2]
+    bpl read_tube_r2_data                                             ; aea3: 10 fb       ..  :06c8[2]
+    lda tube_host_r2_data                                             ; aea5: ad e3 fe    ... :06ca[2]
+    rts                                                               ; aea8: 60          `   :06cd[2]
+
+; $aea9 referenced 1 time by $965d
+}
+
+; $aea9 referenced 1 time by $965d
+service_handler_help_and_tube
+; $aea9 referenced 1 time by $965d
+    cmp #service_help                                                 ; aea9: c9 09       ..
+    bne caed7                                                         ; aeab: d0 2a       .*
+    tya                                                               ; aead: 98          .
+    pha                                                               ; aeae: 48          H
+    lda (os_text_ptr),y                                               ; aeaf: b1 f2       ..
+    cmp #$0d                                                          ; aeb1: c9 0d       ..
+    bne caed3                                                         ; aeb3: d0 1e       ..
+    lda #$e9                                                          ; aeb5: a9 e9       ..
+    jsr osbyte_read                                                   ; aeb7: 20 e5 9a     ..
+    ldx romsel_copy                                                   ; aeba: a6 f4       ..
+    tya                                                               ; aebc: 98          .
+    beq caed3                                                         ; aebd: f0 14       ..
+    jsr print_inline_l809f_top_bit_clear                              ; aebf: 20 77 80     w.
+    !text $0d, "TUBE HOST 2.30", $0d                                  ; aec2: 0d 54 55... .TU
+
+    nop                                                               ; aed2: ea          .
+; $aed3 referenced 2 times by $aeb3, $aebd
+caed3
+    pla                                                               ; aed3: 68          h
+    tay                                                               ; aed4: a8          .
+    lda #9                                                            ; aed5: a9 09       ..
+; $aed7 referenced 1 time by $aeab
+caed7
+    cmp #service_tube_post_init                                       ; aed7: c9 fe       ..
+    bcc just_rts                                                      ; aed9: 90 5c       .\
+    bne service_handler_tube_main_init                                ; aedb: d0 1b       ..
+    cpy #0                                                            ; aedd: c0 00       ..
+    beq just_rts                                                      ; aedf: f0 56       .V
+    ldx #6                                                            ; aee1: a2 06       ..
+    lda #osbyte_explode_chars                                         ; aee3: a9 14       ..
+    jsr osbyte                                                        ; aee5: 20 f4 ff     ..
+; $aee8 referenced 2 times by $aeeb, $aef5
+tube_banner_loop
+    bit tube_host_r1_status                                           ; aee8: 2c e0 fe    ,..
+    bpl tube_banner_loop                                              ; aeeb: 10 fb       ..
+    lda tube_host_r1_data                                             ; aeed: ad e1 fe    ...
+    beq lda_0_rts                                                     ; aef0: f0 43       .C
+    jsr oswrch                                                        ; aef2: 20 ee ff     ..
+    jmp tube_banner_loop                                              ; aef5: 4c e8 ae    L..
+
+; $aef8 referenced 1 time by $aedb
+service_handler_tube_main_init
+    lda #<tube_evntv_handler                                          ; aef8: a9 ad       ..
+    sta evntv                                                         ; aefa: 8d 20 02    . .
+    lda #>tube_evntv_handler                                          ; aefd: a9 06       ..
+    sta evntv+1                                                       ; aeff: 8d 21 02    .!.
+    lda #<tube_brkv_handler                                           ; af02: a9 16       ..
+    sta brkv                                                          ; af04: 8d 02 02    ...
+    lda #>tube_brkv_handler                                           ; af07: a9 00       ..
+    sta brkv+1                                                        ; af09: 8d 03 02    ...
+    lda #$8e                                                          ; af0c: a9 8e       ..
+    sta tube_host_r1_status                                           ; af0e: 8d e0 fe    ...
+    ldy #0                                                            ; af11: a0 00       ..
+; $af13 referenced 1 time by $af26
+loop_caf13
+    lda tube_host_code1,y                                             ; af13: b9 79 af    .y.
+    sta c0400,y                                                       ; af16: 99 00 04    ...
+    lda tube_host_code2,y                                             ; af19: b9 db ac    ...
+    sta l0500,y                                                       ; af1c: 99 00 05    ...
+    lda tube_host_code2+256,y                                         ; af1f: b9 db ad    ...
+    sta l0600,y                                                       ; af22: 99 00 06    ...
+    dey                                                               ; af25: 88          .
+    bne loop_caf13                                                    ; af26: d0 eb       ..
+    jsr sub_c0421                                                     ; af28: 20 21 04     !.
+    ldx #$41 ; 'A'                                                    ; af2b: a2 41       .A
+; $af2d referenced 1 time by $af33
+loop_caf2d
+    lda tube_host_code3,x                                             ; af2d: bd 38 af    .8.
+    sta tube_brkv_handler_fwd,x                                       ; af30: 95 16       ..
+    dex                                                               ; af32: ca          .
+    bpl loop_caf2d                                                    ; af33: 10 f8       ..
+; $af35 referenced 1 time by $aef0
+lda_0_rts
+    lda #0                                                            ; af35: a9 00       ..
+; $af37 referenced 2 times by $aed9, $aedf
+just_rts
+    rts                                                               ; af37: 60          `
+
+; $af38 referenced 2 times by $af2d, $af30
+tube_host_code3
+; $af38 referenced 2 times by $af2d, $af30
+
+!pseudopc $16 {
+; $af38 referenced 2 times by $af2d, $af30
+tube_brkv_handler
+    lda #$ff                                                          ; af38: a9 ff       ..  :0016[3]
+    jsr write_tube_r4_data                                            ; af3a: 20 9e 06     .. :0018[3]
+    lda tube_host_r2_data                                             ; af3d: ad e3 fe    ... :001b[3]
+    lda #0                                                            ; af40: a9 00       ..  :001e[3]
+    jsr write_tube_r2_data                                            ; af42: 20 95 06     .. :0020[3]
+    tay                                                               ; af45: a8          .   :0023[3]
+    lda (l00fd),y                                                     ; af46: b1 fd       ..  :0024[3]
+    jsr write_tube_r2_data                                            ; af48: 20 95 06     .. :0026[3]
+; $af4b referenced 1 time by $30
+loop_c0029
+    iny                                                               ; af4b: c8          .   :0029[3]
+    lda (l00fd),y                                                     ; af4c: b1 fd       ..  :002a[3]
+    jsr write_tube_r2_data                                            ; af4e: 20 95 06     .. :002c[3]
+    tax                                                               ; af51: aa          .   :002f[3]
+    bne loop_c0029                                                    ; af52: d0 f7       ..  :0030[3]
+; $af54 referenced 1 time by $0477
+c0032
+    ldx #$ff                                                          ; af54: a2 ff       ..  :0032[3]
+    txs                                                               ; af56: 9a          .   :0034[3]
+    cli                                                               ; af57: 58          X   :0035[3]
+; $af58 referenced 6 times by $057f, $05a6, $0604, $0665, $0692, $44
+c0036
+    bit tube_host_r1_status                                           ; af58: 2c e0 fe    ,.. :0036[3]
+    bpl c0041                                                         ; af5b: 10 06       ..  :0039[3]
+; $af5d referenced 1 time by $49
+loop_c003b
+    lda tube_host_r1_data                                             ; af5d: ad e1 fe    ... :003b[3]
+    jsr oswrch                                                        ; af60: 20 ee ff     .. :003e[3]
+; $af63 referenced 1 time by $39
+c0041
+    bit tube_host_r2_status                                           ; af63: 2c e2 fe    ,.. :0041[3]
+    bpl c0036                                                         ; af66: 10 f0       ..  :0044[3]
+    bit tube_host_r1_status                                           ; af68: 2c e0 fe    ,.. :0046[3]
+    bmi loop_c003b                                                    ; af6b: 30 f0       0.  :0049[3]
+    ldx tube_host_r2_data                                             ; af6d: ae e3 fe    ... :004b[3]
+; Patch the following JMP so we effectively do JMP (&500,X)
+
+; Extra comment after a blank line
+; manually-created comment
+    stx <jump_address_low                                             ; af70: 86 51       .Q  :004e[3]
+sub_c0050
+jump_address_low = sub_c0050+1
+    jmp (l0500)                                                       ; af72: 6c 00 05    l.. :0050[3]
+
+; $af73 referenced 1 time by $4e
+; $af75 referenced 2 times by $04da, $04ea
+l0053
+    !byte 0                                                           ; af75: 00          .   :0053[3]
+; $af76 referenced 3 times by $04b2, $04d0, $04ef
+l0054
+    !byte $80                                                         ; af76: 80          .   :0054[3]
+; $af77 referenced 2 times by $04b6, $04f9
+l0055
+    !byte 0                                                           ; af77: 00          .   :0055[3]
+; $af78 referenced 2 times by $04ba, $04f7
+l0056
+    !byte 0                                                           ; af78: 00          .   :0056[3]
+; $af79 referenced 2 times by $af13, $af16
+}
+
+; $af79 referenced 2 times by $af13, $af16
+tube_host_code1
+; $af79 referenced 2 times by $af13, $af16
+
+!pseudopc $0400 {
+; $af79 referenced 2 times by $af13, $af16
+c0400
+    jmp c0484                                                         ; af79: 4c 84 04    L.. :0400[1]
+
+    jmp c06a7                                                         ; af7c: 4c a7 06    L.. :0403[1]
+
+; $af7f referenced 14 times by $0493, $04cb, $892a, $8cae, $8f6e, $8f7d, $9346, $982b, $bd64, $bd91, $be09, $be2c, $be7d, $be85
+tube_entry
+    cmp #$80                                                          ; af7f: c9 80       ..  :0406[1]
+    bcc tube_entry_small_a                                            ; af81: 90 2b       .+  :0408[1]
+    cmp #$c0                                                          ; af83: c9 c0       ..  :040a[1]
+    bcs tube_entry_claim_tube                                         ; af85: b0 1a       ..  :040c[1]
+; This is a call to release the tube.
+    ora #$40 ; '@'                                                    ; af87: 09 40       .@  :040e[1]
+    cmp l0015                                                         ; af89: c5 15       ..  :0410[1]
+    bne c0434                                                         ; af8b: d0 20       .   :0412[1]
+; $af8d referenced 1 time by $0471
+sub_c0414
+    php                                                               ; af8d: 08          .   :0414[1]
+    sei                                                               ; af8e: 78          x   :0415[1]
+    lda #5                                                            ; af8f: a9 05       ..  :0416[1]
+    jsr write_tube_r4_data                                            ; af91: 20 9e 06     .. :0418[1]
+    lda l0015                                                         ; af94: a5 15       ..  :041b[1]
+    jsr write_tube_r4_data                                            ; af96: 20 9e 06     .. :041d[1]
+    plp                                                               ; af99: 28          (   :0420[1]
+; $af9a referenced 1 time by $af28
+sub_c0421
+    lda #$80                                                          ; af9a: a9 80       ..  :0421[1]
+    sta l0015                                                         ; af9c: 85 15       ..  :0423[1]
+    sta l0014                                                         ; af9e: 85 14       ..  :0425[1]
+    rts                                                               ; afa0: 60          `   :0427[1]
+
+; $afa1 referenced 1 time by $040c
+tube_entry_claim_tube
+    asl l0014                                                         ; afa1: 06 14       ..  :0428[1]
+    bcs c0432                                                         ; afa3: b0 06       ..  :042a[1]
+    cmp l0015                                                         ; afa5: c5 15       ..  :042c[1]
+    beq c0434                                                         ; afa7: f0 04       ..  :042e[1]
+    clc                                                               ; afa9: 18          .   :0430[1]
+    rts                                                               ; afaa: 60          `   :0431[1]
+
+; $afab referenced 1 time by $042a
+c0432
+    sta l0015                                                         ; afab: 85 15       ..  :0432[1]
+; $afad referenced 2 times by $0412, $042e
+c0434
+    rts                                                               ; afad: 60          `   :0434[1]
+
+; $afae referenced 1 time by $0408
+tube_entry_small_a
+    php                                                               ; afae: 08          .   :0435[1]
+    sei                                                               ; afaf: 78          x   :0436[1]
+    sty l0013                                                         ; afb0: 84 13       ..  :0437[1]
+    stx l0012                                                         ; afb2: 86 12       ..  :0439[1]
+    jsr write_tube_r4_data                                            ; afb4: 20 9e 06     .. :043b[1]
+    tax                                                               ; afb7: aa          .   :043e[1]
+    ldy #3                                                            ; afb8: a0 03       ..  :043f[1]
+    lda l0015                                                         ; afba: a5 15       ..  :0441[1]
+    jsr write_tube_r4_data                                            ; afbc: 20 9e 06     .. :0443[1]
+; $afbf referenced 1 time by $044c
+loop_c0446
+    lda (l0012),y                                                     ; afbf: b1 12       ..  :0446[1]
+    jsr write_tube_r4_data                                            ; afc1: 20 9e 06     .. :0448[1]
+    dey                                                               ; afc4: 88          .   :044b[1]
+    bpl loop_c0446                                                    ; afc5: 10 f8       ..  :044c[1]
+    ldy #$18                                                          ; afc7: a0 18       ..  :044e[1]
+    sty tube_host_r1_status                                           ; afc9: 8c e0 fe    ... :0450[1]
+    lda tube_entry_flags,x                                            ; afcc: bd 18 05    ... :0453[1]
+    sta tube_host_r1_status                                           ; afcf: 8d e0 fe    ... :0456[1]
+    lsr                                                               ; afd2: 4a          J   :0459[1]
+    lsr                                                               ; afd3: 4a          J   :045a[1]
+    bcc c0463                                                         ; afd4: 90 06       ..  :045b[1]
+    bit tube_host_r3_data                                             ; afd6: 2c e5 fe    ,.. :045d[1]
+    bit tube_host_r3_data                                             ; afd9: 2c e5 fe    ,.. :0460[1]
+; $afdc referenced 1 time by $045b
+c0463
+    jsr write_tube_r4_data                                            ; afdc: 20 9e 06     .. :0463[1]
+; $afdf referenced 1 time by $0469
+loop_c0466
+    bit tube_host_r4_status                                           ; afdf: 2c e6 fe    ,.. :0466[1]
+    bvc loop_c0466                                                    ; afe2: 50 fb       P.  :0469[1]
+    bcs c047a                                                         ; afe4: b0 0d       ..  :046b[1]
+    cpx #4                                                            ; afe6: e0 04       ..  :046d[1]
+    bne c0482                                                         ; afe8: d0 11       ..  :046f[1]
+; $afea referenced 1 time by $048f
+loop_c0471
+    jsr sub_c0414                                                     ; afea: 20 14 04     .. :0471[1]
+    jsr write_tube_r2_data                                            ; afed: 20 95 06     .. :0474[1]
+    jmp c0032                                                         ; aff0: 4c 32 00    L2. :0477[1]
+
+; $aff3 referenced 1 time by $046b
+c047a
+    lsr                                                               ; aff3: 4a          J   :047a[1]
+    bcc c0482                                                         ; aff4: 90 05       ..  :047b[1]
+    ldy #$88                                                          ; aff6: a0 88       ..  :047d[1]
+    sty tube_host_r1_status                                           ; aff8: 8c e0 fe    ... :047f[1]
+; $affb referenced 2 times by $046f, $047b
+c0482
+    plp                                                               ; affb: 28          (   :0482[1]
+    rts                                                               ; affc: 60          `   :0483[1]
+
+; $affd referenced 1 time by $0400
+c0484
+    cli                                                               ; affd: 58          X   :0484[1]
+    bcs c0491                                                         ; affe: b0 0a       ..  :0485[1]
+    bne c048c                                                         ; b000: d0 03       ..  :0487[1]
+    jmp c059c                                                         ; b002: 4c 9c 05    L.. :0489[1]
+
+; $b005 referenced 1 time by $0487
+c048c
+    ldx l028d                                                         ; b005: ae 8d 02    ... :048c[1]
+    beq loop_c0471                                                    ; b008: f0 e0       ..  :048f[1]
+; $b00a referenced 2 times by $0485, $0496
+c0491
+    lda #$ff                                                          ; b00a: a9 ff       ..  :0491[1]
+    jsr tube_entry                                                    ; b00c: 20 06 04     .. :0493[1]
+    bcc c0491                                                         ; b00f: 90 f9       ..  :0496[1]
+    jsr sub_c04ce                                                     ; b011: 20 ce 04     .. :0498[1]
+; $b014 referenced 1 time by $04c0
+c049b
+    php                                                               ; b014: 08          .   :049b[1]
+    sei                                                               ; b015: 78          x   :049c[1]
+    lda #7                                                            ; b016: a9 07       ..  :049d[1]
+    jsr sub_c04c7                                                     ; b018: 20 c7 04     .. :049f[1]
+    ldy #0                                                            ; b01b: a0 00       ..  :04a2[1]
+    sty l0000                                                         ; b01d: 84 00       ..  :04a4[1]
+; $b01f referenced 1 time by $04af
+loop_c04a6
+    lda (l0000),y                                                     ; b01f: b1 00       ..  :04a6[1]
+    sta tube_host_r3_data                                             ; b021: 8d e5 fe    ... :04a8[1]
+    nop                                                               ; b024: ea          .   :04ab[1]
+    nop                                                               ; b025: ea          .   :04ac[1]
+    nop                                                               ; b026: ea          .   :04ad[1]
+    iny                                                               ; b027: c8          .   :04ae[1]
+    bne loop_c04a6                                                    ; b028: d0 f5       ..  :04af[1]
+    plp                                                               ; b02a: 28          (   :04b1[1]
+    inc l0054                                                         ; b02b: e6 54       .T  :04b2[1]
+    bne c04bc                                                         ; b02d: d0 06       ..  :04b4[1]
+    inc l0055                                                         ; b02f: e6 55       .U  :04b6[1]
+    bne c04bc                                                         ; b031: d0 02       ..  :04b8[1]
+    inc l0056                                                         ; b033: e6 56       .V  :04ba[1]
+; $b035 referenced 2 times by $04b4, $04b8
+c04bc
+    inc l0001                                                         ; b035: e6 01       ..  :04bc[1]
+    bit l0001                                                         ; b037: 24 01       $.  :04be[1]
+    bvc c049b                                                         ; b039: 50 d9       P.  :04c0[1]
+    jsr sub_c04ce                                                     ; b03b: 20 ce 04     .. :04c2[1]
+    lda #4                                                            ; b03e: a9 04       ..  :04c5[1]
+; $b040 referenced 1 time by $049f
+sub_c04c7
+    ldy #0                                                            ; b040: a0 00       ..  :04c7[1]
+    ldx #$53 ; 'S'                                                    ; b042: a2 53       .S  :04c9[1]
+    jmp tube_entry                                                    ; b044: 4c 06 04    L.. :04cb[1]
+
+; $b047 referenced 2 times by $0498, $04c2
+sub_c04ce
+    lda #$80                                                          ; b047: a9 80       ..  :04ce[1]
+    sta l0054                                                         ; b049: 85 54       .T  :04d0[1]
+    sta l0001                                                         ; b04b: 85 01       ..  :04d2[1]
+    lda #$20 ; ' '                                                    ; b04d: a9 20       .   :04d4[1]
+    and rom_type                                                      ; b04f: 2d 06 80    -.. :04d6[1]
+    tay                                                               ; b052: a8          .   :04d9[1]
+    sty l0053                                                         ; b053: 84 53       .S  :04da[1]
+    beq c04f7                                                         ; b055: f0 19       ..  :04dc[1]
+    ldx copyright_offset                                              ; b057: ae 07 80    ... :04de[1]
+; $b05a referenced 1 time by $04e5
+loop_c04e1
+    inx                                                               ; b05a: e8          .   :04e1[1]
+    lda rom_header,x                                                  ; b05b: bd 00 80    ... :04e2[1]
+    bne loop_c04e1                                                    ; b05e: d0 fa       ..  :04e5[1]
+    lda l8001,x                                                       ; b060: bd 01 80    ... :04e7[1]
+    sta l0053                                                         ; b063: 85 53       .S  :04ea[1]
+    lda l8002,x                                                       ; b065: bd 02 80    ... :04ec[1]
+    sta l0054                                                         ; b068: 85 54       .T  :04ef[1]
+    ldy service_entry,x                                               ; b06a: bc 03 80    ... :04f1[1]
+    lda l8004,x                                                       ; b06d: bd 04 80    ... :04f4[1]
+; $b070 referenced 1 time by $04dc
+c04f7
+    sta l0056                                                         ; b070: 85 56       .V  :04f7[1]
+    sty l0055                                                         ; b072: 84 55       .U  :04f9[1]
+    rts                                                               ; b074: 60          `   :04fb[1]
+
+; $b075 referenced 1 time by $b2b4
+}
+
+; $b075 referenced 1 time by $b2b4
+lb075
+; $b075 referenced 1 time by $b2b4
+    !byte $0a                                                         ; b075: 0a          .
+    !text "SRAM 1.05"                                                 ; b076: 53 52 41... SRA
+    !byte $0d, $0a                                                    ; b07f: 0d 0a       ..
+    !text "  SRDATA  <id.>"                                           ; b081: 20 20 53...   S
+    !byte $0d, $0a                                                    ; b090: 0d 0a       ..
+    !text "  SRLOAD  <filename> <sram address> (<id.>) (Q)"           ; b092: 20 20 53...   S
+    !byte $0d, $0a                                                    ; b0c1: 0d 0a       ..
+    !text "  SRREAD  <dest. start> <dest. end> <sram start> (<id.>"   ; b0c3: 20 20 53...   S
+    !text ")"                                                         ; b0fa: 29          )
+    !byte $0d, $0a                                                    ; b0fb: 0d 0a       ..
+    !text "  SRROM   <id.>"                                           ; b0fd: 20 20 53...   S
+    !byte $0d, $0a                                                    ; b10c: 0d 0a       ..
+    !text "  SRSAVE  <filename> <sram start> <sram end> (<id.>) (Q"   ; b10e: 20 20 53...   S
+    !text ")"                                                         ; b145: 29          )
+    !byte $0d, $0a                                                    ; b146: 0d 0a       ..
+    !text "  SRWRITE <source start> <source end> <sram s"             ; b148: 20 20 53...   S
+; $b175 referenced 1 time by $b2bd
+lb175
+    !text "tart> (<id.>)"                                             ; b175: 74 61 72... tar
+    !byte $0d, $0a                                                    ; b182: 0d 0a       ..
+    !text "End addresses may be replaced by +<length>"                ; b184: 45 6e 64... End
+    !byte $0d, $0a,   0                                               ; b1ae: 0d 0a 00    ...
+
+; $b1b1 referenced 1 time by $bedd
+general_service_handler
+    jsr sub_c965d                                                     ; b1b1: 20 5d 96     ].
+    pha                                                               ; b1b4: 48          H
+    tax                                                               ; b1b5: aa          .
+    lda l00b8                                                         ; b1b6: a5 b8       ..
+    pha                                                               ; b1b8: 48          H
+    lda l00b9                                                         ; b1b9: a5 b9       ..
+    pha                                                               ; b1bb: 48          H
+    tya                                                               ; b1bc: 98          .
+    pha                                                               ; b1bd: 48          H
+    txa                                                               ; b1be: 8a          .
+    ldx romsel_copy                                                   ; b1bf: a6 f4       ..
+    jsr cb82b                                                         ; b1c1: 20 2b b8     +.
+    bit l00b9                                                         ; b1c4: 24 b9       $.
+    bmi cb203                                                         ; b1c6: 30 3b       0;
+    cmp #8                                                            ; b1c8: c9 08       ..
+    bne cb1fc                                                         ; b1ca: d0 30       .0
+    lda l00ef                                                         ; b1cc: a5 ef       ..
+    cmp #$43 ; 'C'                                                    ; b1ce: c9 43       .C
+    bne cb1dd                                                         ; b1d0: d0 0b       ..
+    jsr sub_cb2c8                                                     ; b1d2: 20 c8 b2     ..
+; $b1d5 referenced 3 times by $b1f9, $b231, $b25d
+cb1d5
+    tsx                                                               ; b1d5: ba          .
+    lda #0                                                            ; b1d6: a9 00       ..
+    sta l0104,x                                                       ; b1d8: 9d 04 01    ...
+    beq cb203                                                         ; b1db: f0 26       .&
+; $b1dd referenced 1 time by $b1d0
+cb1dd
+    cmp #$42 ; 'B'                                                    ; b1dd: c9 42       .B
+    bne cb203                                                         ; b1df: d0 22       ."
+    ldy #9                                                            ; b1e1: a0 09       ..
+; $b1e3 referenced 1 time by $b1eb
+loop_cb1e3
+    lda (l00f0),y                                                     ; b1e3: b1 f0       ..
+    sta l00b4,y                                                       ; b1e5: 99 b4 00    ...
+    dey                                                               ; b1e8: 88          .
+    cpy #8                                                            ; b1e9: c0 08       ..
+    bcs loop_cb1e3                                                    ; b1eb: b0 f6       ..
+; $b1ed referenced 1 time by $b1f3
+loop_cb1ed
+    lda (l00f0),y                                                     ; b1ed: b1 f0       ..
+    sta l00b0,y                                                       ; b1ef: 99 b0 00    ...
+    dey                                                               ; b1f2: 88          .
+    bpl loop_cb1ed                                                    ; b1f3: 10 f8       ..
+    cli                                                               ; b1f5: 58          X
+    jsr cbcb9                                                         ; b1f6: 20 b9 bc     ..
+    jmp cb1d5                                                         ; b1f9: 4c d5 b1    L..
+
+; $b1fc referenced 1 time by $b1ca
+cb1fc
+    cmp #2                                                            ; b1fc: c9 02       ..
+    bne cb20f                                                         ; b1fe: d0 0f       ..
+    jsr sub_cb882                                                     ; b200: 20 82 b8     ..
+; $b203 referenced 10 times by $b1c6, $b1db, $b1df, $b219, $b21e, $b228, $b22c, $b262, $b26a, $b280
+cb203
+    pla                                                               ; b203: 68          h
+    tay                                                               ; b204: a8          .
+    pla                                                               ; b205: 68          h
+    sta l00b9                                                         ; b206: 85 b9       ..
+    pla                                                               ; b208: 68          h
+    sta l00b8                                                         ; b209: 85 b8       ..
+    pla                                                               ; b20b: 68          h
+    ldx romsel_copy                                                   ; b20c: a6 f4       ..
+    rts                                                               ; b20e: 60          `
+
+; $b20f referenced 1 time by $b1fe
+cb20f
+    cmp #6                                                            ; b20f: c9 06       ..
+    bne cb221                                                         ; b211: d0 0e       ..
+    ldy #$ff                                                          ; b213: a0 ff       ..
+    lda (l00b8),y                                                     ; b215: b1 b8       ..
+    cmp #$4e ; 'N'                                                    ; b217: c9 4e       .N
+    bne cb203                                                         ; b219: d0 e8       ..
+    jsr sub_cb5f2                                                     ; b21b: 20 f2 b5     ..
+    jmp cb203                                                         ; b21e: 4c 03 b2    L..
+
+; $b221 referenced 1 time by $b211
+cb221
+    cmp #4                                                            ; b221: c9 04       ..
+    bne cb23d                                                         ; b223: d0 18       ..
+    jsr sub_cb9f5                                                     ; b225: 20 f5 b9     ..
+    bcs cb203                                                         ; b228: b0 d9       ..
+    cpx #4                                                            ; b22a: e0 04       ..
+    beq cb203                                                         ; b22c: f0 d5       ..
+    jsr sub_cb234                                                     ; b22e: 20 34 b2     4.
+    jmp cb1d5                                                         ; b231: 4c d5 b1    L..
+
+; $b234 referenced 1 time by $b22e
+sub_cb234
+    lda sram_table,x                                                  ; b234: bd 30 ba    .0.
+    pha                                                               ; b237: 48          H
+    lda sram_table+1,x                                                ; b238: bd 31 ba    .1.
+    pha                                                               ; b23b: 48          H
+    rts                                                               ; b23c: 60          `
+
+; $b23d referenced 1 time by $b223
+cb23d
+    cmp #7                                                            ; b23d: c9 07       ..
+    bne cb268                                                         ; b23f: d0 27       .'
+    lda l00ef                                                         ; b241: a5 ef       ..
+    cmp #$44 ; 'D'                                                    ; b243: c9 44       .D
+    bne cb260                                                         ; b245: d0 19       ..
+    ldy #$ee                                                          ; b247: a0 ee       ..
+; $b249 referenced 1 time by $b266
+loop_cb249
+    lda (l00b8),y                                                     ; b249: b1 b8       ..
+    and #$3f ; '?'                                                    ; b24b: 29 3f       )?
+    sta l00b0                                                         ; b24d: 85 b0       ..
+    ldy #$fe                                                          ; b24f: a0 fe       ..
+    lda (l00b8),y                                                     ; b251: b1 b8       ..
+    and #8                                                            ; b253: 29 08       ).
+    asl                                                               ; b255: 0a          .
+    asl                                                               ; b256: 0a          .
+    asl                                                               ; b257: 0a          .
+    asl                                                               ; b258: 0a          .
+    ora l00b0                                                         ; b259: 05 b0       ..
+    sta l00f0                                                         ; b25b: 85 f0       ..
+    jmp cb1d5                                                         ; b25d: 4c d5 b1    L..
+
+; $b260 referenced 1 time by $b245
+cb260
+    cmp #$45 ; 'E'                                                    ; b260: c9 45       .E
+    bne cb203                                                         ; b262: d0 9f       ..
+    ldy #$fd                                                          ; b264: a0 fd       ..
+    bne loop_cb249                                                    ; b266: d0 e1       ..
+; $b268 referenced 1 time by $b23f
+cb268
+    cmp #9                                                            ; b268: c9 09       ..
+    bne cb203                                                         ; b26a: d0 97       ..
+    lda #$0d                                                          ; b26c: a9 0d       ..
+    jsr sub_cbac4                                                     ; b26e: 20 c4 ba     ..
+    bcs cb297                                                         ; b271: b0 24       .$
+    ldx #0                                                            ; b273: a2 00       ..
+; $b275 referenced 1 time by $b27e
+loop_cb275
+    lda lb283,x                                                       ; b275: bd 83 b2    ...
+    jsr oswrch                                                        ; b278: 20 ee ff     ..
+    inx                                                               ; b27b: e8          .
+    cpx #$14                                                          ; b27c: e0 14       ..
+    bne loop_cb275                                                    ; b27e: d0 f5       ..
+; $b280 referenced 2 times by $b2a6, $b2c0
+cb280
+    jmp cb203                                                         ; b280: 4c 03 b2    L..
+
+; $b283 referenced 1 time by $b275
+lb283
+    !byte $0a                                                         ; b283: 0a          .
+    !text "SRAM 1.05"                                                 ; b284: 53 52 41... SRA
+    !byte $0d, $0a                                                    ; b28d: 0d 0a       ..
+    !text "  SRAM"                                                    ; b28f: 20 20 53...   S
+    !byte $0d, $0a                                                    ; b295: 0d 0a       ..
+
+; $b297 referenced 2 times by $b271, $b2b0
+cb297
+    jsr sub_cb9f5                                                     ; b297: 20 f5 b9     ..
+    cpx #4                                                            ; b29a: e0 04       ..
+    beq cb2b2                                                         ; b29c: f0 14       ..
+    lda #0                                                            ; b29e: a9 00       ..
+; $b2a0 referenced 2 times by $b2aa, $b2ae
+cb2a0
+    tax                                                               ; b2a0: aa          .
+    iny                                                               ; b2a1: c8          .
+    lda (os_text_ptr),y                                               ; b2a2: b1 f2       ..
+    cmp #$0d                                                          ; b2a4: c9 0d       ..
+    beq cb280                                                         ; b2a6: f0 d8       ..
+    cmp #$20 ; ' '                                                    ; b2a8: c9 20       .
+    beq cb2a0                                                         ; b2aa: f0 f4       ..
+    cpx #$20 ; ' '                                                    ; b2ac: e0 20       .
+    bne cb2a0                                                         ; b2ae: d0 f0       ..
+    beq cb297                                                         ; b2b0: f0 e5       ..
+; $b2b2 referenced 1 time by $b29c
+cb2b2
+    ldy #0                                                            ; b2b2: a0 00       ..
+; $b2b4 referenced 1 time by $b2bb
+loop_cb2b4
+    lda lb075,y                                                       ; b2b4: b9 75 b0    .u.
+    jsr oswrch                                                        ; b2b7: 20 ee ff     ..
+    iny                                                               ; b2ba: c8          .
+    bne loop_cb2b4                                                    ; b2bb: d0 f7       ..
+; $b2bd referenced 1 time by $b2c6
+loop_cb2bd
+    lda lb175,y                                                       ; b2bd: b9 75 b1    .u.
+    beq cb280                                                         ; b2c0: f0 be       ..
+    jsr oswrch                                                        ; b2c2: 20 ee ff     ..
+    iny                                                               ; b2c5: c8          .
+    bne loop_cb2bd                                                    ; b2c6: d0 f5       ..
+; $b2c8 referenced 1 time by $b1d2
+sub_cb2c8
+    jsr cb82b                                                         ; b2c8: 20 2b b8     +.
+    lda #$ee                                                          ; b2cb: a9 ee       ..
+    sta l00b8                                                         ; b2cd: 85 b8       ..
+    ldy #$0b                                                          ; b2cf: a0 0b       ..
+; $b2d1 referenced 1 time by $b2e4
+loop_cb2d1
+    lda (l00f0),y                                                     ; b2d1: b1 f0       ..
+    cpy #0                                                            ; b2d3: c0 00       ..
+    bne cb2e1                                                         ; b2d5: d0 0a       ..
+    and #$c0                                                          ; b2d7: 29 c0       ).
+    sta l00bc                                                         ; b2d9: 85 bc       ..
+    lda (l00b8),y                                                     ; b2db: b1 b8       ..
+    and #$3f ; '?'                                                    ; b2dd: 29 3f       )?
+    ora l00bc                                                         ; b2df: 05 bc       ..
+; $b2e1 referenced 1 time by $b2d5
+cb2e1
+    sta (l00b8),y                                                     ; b2e1: 91 b8       ..
+    dey                                                               ; b2e3: 88          .
+    bpl loop_cb2d1                                                    ; b2e4: 10 eb       ..
+    cli                                                               ; b2e6: 58          X
+; $b2e7 referenced 1 time by $bbcd
+cb2e7
+    jsr cb82b                                                         ; b2e7: 20 2b b8     +.
+    ldy #$f2                                                          ; b2ea: a0 f2       ..
+    lda (l00b8),y                                                     ; b2ec: b1 b8       ..
+    tax                                                               ; b2ee: aa          .
+    iny                                                               ; b2ef: c8          .
+    lda (l00b8),y                                                     ; b2f0: b1 b8       ..
+    jsr sub_cb85d                                                     ; b2f2: 20 5d b8     ].
+    bvs cb305                                                         ; b2f5: 70 0e       p.
+    ldy #$f1                                                          ; b2f7: a0 f1       ..
+    lda (l00b8),y                                                     ; b2f9: b1 b8       ..
+    tay                                                               ; b2fb: a8          .
+    cpy #$14                                                          ; b2fc: c0 14       ..
+    bcc cb314                                                         ; b2fe: 90 14       ..
+; $b300 referenced 2 times by $b324, $bcd3
+cb300
+    ldx #0                                                            ; b300: a2 00       ..
+    jmp cb8fb                                                         ; b302: 4c fb b8    L..
+
+; $b305 referenced 1 time by $b2f5
+cb305
+    jsr sub_cb6b1                                                     ; b305: 20 b1 b6     ..
+    sty l00ba                                                         ; b308: 84 ba       ..
+    ldy #$f3                                                          ; b30a: a0 f3       ..
+    sta (l00b8),y                                                     ; b30c: 91 b8       ..
+    txa                                                               ; b30e: 8a          .
+    dey                                                               ; b30f: 88          .
+    sta (l00b8),y                                                     ; b310: 91 b8       ..
+    ldy l00ba                                                         ; b312: a4 ba       ..
+; $b314 referenced 1 time by $b2fe
+cb314
+    jsr sub_cb6fe                                                     ; b314: 20 fe b6     ..
+    tax                                                               ; b317: aa          .
+    tya                                                               ; b318: 98          .
+    ldy #$f1                                                          ; b319: a0 f1       ..
+    sta (l00b8),y                                                     ; b31b: 91 b8       ..
+    txa                                                               ; b31d: 8a          .
+    ldy #$ee                                                          ; b31e: a0 ee       ..
+    eor (l00b8),y                                                     ; b320: 51 b8       Q.
+    and #$40 ; '@'                                                    ; b322: 29 40       )@
+    bne cb300                                                         ; b324: d0 da       ..
+    tay                                                               ; b326: a8          .
+    ldx #$ba                                                          ; b327: a2 ba       ..
+    jsr osargs                                                        ; b329: 20 da ff     ..
+    jsr cb82b                                                         ; b32c: 20 2b b8     +.
+    tax                                                               ; b32f: aa          .
+    bne cb337                                                         ; b330: d0 05       ..
+    ldx #2                                                            ; b332: a2 02       ..
+    jmp cb8fb                                                         ; b334: 4c fb b8    L..
+
+; $b337 referenced 1 time by $b330
+cb337
+    pha                                                               ; b337: 48          H
+    jsr sub_cbe9d                                                     ; b338: 20 9d be     ..
+    pla                                                               ; b33b: 68          h
+    cmp #4                                                            ; b33c: c9 04       ..
+    bcs cb3ba                                                         ; b33e: b0 7a       .z
+    jsr sub_cb85d                                                     ; b340: 20 5d b8     ].
+    bpl cb375                                                         ; b343: 10 30       .0
+    jsr sub_cb5ce                                                     ; b345: 20 ce b5     ..
+    jsr sub_cb607                                                     ; b348: 20 07 b6     ..
+    bne cb371                                                         ; b34b: d0 24       .$
+    beq cb352                                                         ; b34d: f0 03       ..
+; $b34f referenced 1 time by $b36f
+cb34f
+    jsr sub_cb65f                                                     ; b34f: 20 5f b6     _.
+; $b352 referenced 1 time by $b34d
+cb352
+    ldy #$fa                                                          ; b352: a0 fa       ..
+    lda (l00b8),y                                                     ; b354: b1 b8       ..
+    tay                                                               ; b356: a8          .
+    jsr osbget                                                        ; b357: 20 d7 ff     ..
+    jsr cb82b                                                         ; b35a: 20 2b b8     +.
+    ldy #$f2                                                          ; b35d: a0 f2       ..
+    jsr sub_cb83f                                                     ; b35f: 20 3f b8     ?.
+    tax                                                               ; b362: aa          .
+    ldy #$f1                                                          ; b363: a0 f1       ..
+    lda (l00b8),y                                                     ; b365: b1 b8       ..
+    tay                                                               ; b367: a8          .
+    txa                                                               ; b368: 8a          .
+    jsr sub_cb745                                                     ; b369: 20 45 b7     E.
+    jsr sub_cb607                                                     ; b36c: 20 07 b6     ..
+    beq cb34f                                                         ; b36f: f0 de       ..
+; $b371 referenced 3 times by $b34b, $b37b, $b3b8
+cb371
+    jsr sub_cb5f2                                                     ; b371: 20 f2 b5     ..
+    rts                                                               ; b374: 60          `
+
+; $b375 referenced 1 time by $b343
+cb375
+    jsr sub_cb5ee                                                     ; b375: 20 ee b5     ..
+    jsr sub_cb616                                                     ; b378: 20 16 b6     ..
+    beq cb371                                                         ; b37b: f0 f4       ..
+    bne cb382                                                         ; b37d: d0 03       ..
+; $b37f referenced 1 time by $b3b6
+cb37f
+    jsr sub_cb65f                                                     ; b37f: 20 5f b6     _.
+; $b382 referenced 1 time by $b37d
+cb382
+    ldy #$f4                                                          ; b382: a0 f4       ..
+    lda (l00b8),y                                                     ; b384: b1 b8       ..
+    sec                                                               ; b386: 38          8
+    sbc #1                                                            ; b387: e9 01       ..
+    sta (l00b8),y                                                     ; b389: 91 b8       ..
+    cmp #$ff                                                          ; b38b: c9 ff       ..
+    bne cb397                                                         ; b38d: d0 08       ..
+    iny                                                               ; b38f: c8          .
+    lda (l00b8),y                                                     ; b390: b1 b8       ..
+    sec                                                               ; b392: 38          8
+    sbc #1                                                            ; b393: e9 01       ..
+    sta (l00b8),y                                                     ; b395: 91 b8       ..
+; $b397 referenced 1 time by $b38d
+cb397
+    ldx #$f6                                                          ; b397: a2 f6       ..
+    ldy #$f2                                                          ; b399: a0 f2       ..
+    jsr sub_cb841                                                     ; b39b: 20 41 b8     A.
+    ldy #$f1                                                          ; b39e: a0 f1       ..
+    lda (l00b8),y                                                     ; b3a0: b1 b8       ..
+    tay                                                               ; b3a2: a8          .
+    jsr osrdsc                                                        ; b3a3: 20 b9 ff     ..
+    tax                                                               ; b3a6: aa          .
+    ldy #$fa                                                          ; b3a7: a0 fa       ..
+    lda (l00b8),y                                                     ; b3a9: b1 b8       ..
+    tay                                                               ; b3ab: a8          .
+    txa                                                               ; b3ac: 8a          .
+    jsr osbput                                                        ; b3ad: 20 d4 ff     ..
+    jsr cb82b                                                         ; b3b0: 20 2b b8     +.
+    jsr sub_cb616                                                     ; b3b3: 20 16 b6     ..
+    bne cb37f                                                         ; b3b6: d0 c7       ..
+    beq cb371                                                         ; b3b8: f0 b7       ..
+; $b3ba referenced 1 time by $b33e
+cb3ba
+    ldy #$f9                                                          ; b3ba: a0 f9       ..
+    lda (l00b8),y                                                     ; b3bc: b1 b8       ..
+    bmi cb3de                                                         ; b3be: 30 1e       0.
+    dey                                                               ; b3c0: 88          .
+    ora (l00b8),y                                                     ; b3c1: 11 b8       ..
+    bne cb406                                                         ; b3c3: d0 41       .A
+    lda #0                                                            ; b3c5: a9 00       ..
+    sta (l00b8),y                                                     ; b3c7: 91 b8       ..
+    lda #1                                                            ; b3c9: a9 01       ..
+    iny                                                               ; b3cb: c8          .
+    sta (l00b8),y                                                     ; b3cc: 91 b8       ..
+    ldy #$f6                                                          ; b3ce: a0 f6       ..
+    lda #0                                                            ; b3d0: a9 00       ..
+    sta (l00b8),y                                                     ; b3d2: 91 b8       ..
+    ldx l00b9                                                         ; b3d4: a6 b9       ..
+    inx                                                               ; b3d6: e8          .
+    txa                                                               ; b3d7: 8a          .
+    iny                                                               ; b3d8: c8          .
+    sta (l00b8),y                                                     ; b3d9: 91 b8       ..
+    jmp cb406                                                         ; b3db: 4c 06 b4    L..
+
+; $b3de referenced 1 time by $b3be
+cb3de
+    lda #osbyte_read_himem                                            ; b3de: a9 84       ..
+    jsr osbyte                                                        ; b3e0: 20 f4 ff     ..
+    tya                                                               ; b3e3: 98          .
+    pha                                                               ; b3e4: 48          H
+    txa                                                               ; b3e5: 8a          .
+    pha                                                               ; b3e6: 48          H
+    lda #osbyte_read_oshwm                                            ; b3e7: a9 83       ..
+    jsr osbyte                                                        ; b3e9: 20 f4 ff     ..
+    jsr cb82b                                                         ; b3ec: 20 2b b8     +.
+    stx l00ba                                                         ; b3ef: 86 ba       ..
+    sty l00bb                                                         ; b3f1: 84 bb       ..
+    ldy #$f6                                                          ; b3f3: a0 f6       ..
+    jsr sub_cb84e                                                     ; b3f5: 20 4e b8     N.
+    pla                                                               ; b3f8: 68          h
+    sec                                                               ; b3f9: 38          8
+    sbc l00ba                                                         ; b3fa: e5 ba       ..
+    ldy #$f8                                                          ; b3fc: a0 f8       ..
+    sta (l00b8),y                                                     ; b3fe: 91 b8       ..
+    pla                                                               ; b400: 68          h
+    sbc l00bb                                                         ; b401: e5 bb       ..
+    iny                                                               ; b403: c8          .
+    sta (l00b8),y                                                     ; b404: 91 b8       ..
+; $b406 referenced 2 times by $b3c3, $b3db
+cb406
+    jsr sub_cb85d                                                     ; b406: 20 5d b8     ].
+    bmi cb40e                                                         ; b409: 30 03       0.
+    jmp cb4d8                                                         ; b40b: 4c d8 b4    L..
+
+; $b40e referenced 1 time by $b409
+cb40e
+    jsr sub_cb5ce                                                     ; b40e: 20 ce b5     ..
+    tsx                                                               ; b411: ba          .
+    txa                                                               ; b412: 8a          .
+    sec                                                               ; b413: 38          8
+    sbc #$10                                                          ; b414: e9 10       ..
+    tax                                                               ; b416: aa          .
+    txs                                                               ; b417: 9a          .
+    ldy #$f0                                                          ; b418: a0 f0       ..
+    lda (l00b8),y                                                     ; b41a: b1 b8       ..
+    pha                                                               ; b41c: 48          H
+    dey                                                               ; b41d: 88          .
+    lda (l00b8),y                                                     ; b41e: b1 b8       ..
+    pha                                                               ; b420: 48          H
+    dex                                                               ; b421: ca          .
+    ldy #1                                                            ; b422: a0 01       ..
+    lda #osfile_read_catalogue_info                                   ; b424: a9 05       ..
+    jsr osfile                                                        ; b426: 20 dd ff     ..
+    jsr cb82b                                                         ; b429: 20 2b b8     +.
+    tsx                                                               ; b42c: ba          .
+    lda l010b,x                                                       ; b42d: bd 0b 01    ...
+    ldy #$f4                                                          ; b430: a0 f4       ..
+    sta (l00b8),y                                                     ; b432: 91 b8       ..
+    sta l00ba                                                         ; b434: 85 ba       ..
+    lda l010c,x                                                       ; b436: bd 0c 01    ...
+    iny                                                               ; b439: c8          .
+    sta (l00b8),y                                                     ; b43a: 91 b8       ..
+    sta l00bb                                                         ; b43c: 85 bb       ..
+    lda l010d,x                                                       ; b43e: bd 0d 01    ...
+    ora l010e,x                                                       ; b441: 1d 0e 01    ...
+    beq cb44b                                                         ; b444: f0 05       ..
+; $b446 referenced 4 times by $b68c, $b6c7, $b715, $bc10
+cb446
+    ldx #1                                                            ; b446: a2 01       ..
+    jmp cb8fb                                                         ; b448: 4c fb b8    L..
+
+; $b44b referenced 1 time by $b444
+cb44b
+    ldx #$12                                                          ; b44b: a2 12       ..
+; $b44d referenced 1 time by $b44f
+loop_cb44d
+    pla                                                               ; b44d: 68          h
+    dex                                                               ; b44e: ca          .
+    bne loop_cb44d                                                    ; b44f: d0 fc       ..
+    bit lb57f                                                         ; b451: 2c 7f b5    ,..
+    lda l00ba                                                         ; b454: a5 ba       ..
+    ora l00bb                                                         ; b456: 05 bb       ..
+    bne cb45e                                                         ; b458: d0 04       ..
+; $b45a referenced 1 time by $b4d2
+cb45a
+    jsr sub_cb5f2                                                     ; b45a: 20 f2 b5     ..
+    rts                                                               ; b45d: 60          `
+
+; $b45e referenced 2 times by $b458, $b4d5
+cb45e
+    ldx #$bc                                                          ; b45e: a2 bc       ..
+    ldy #$f8                                                          ; b460: a0 f8       ..
+    jsr sub_cb841                                                     ; b462: 20 41 b8     A.
+    ldy #$ba                                                          ; b465: a0 ba       ..
+    jsr sub_cb58b                                                     ; b467: 20 8b b5     ..
+    bcs cb470                                                         ; b46a: b0 04       ..
+    jsr sub_cb580                                                     ; b46c: 20 80 b5     ..
+    clv                                                               ; b46f: b8          .
+; $b470 referenced 1 time by $b46a
+cb470
+    ldy #$fb                                                          ; b470: a0 fb       ..
+    jsr sub_cb84e                                                     ; b472: 20 4e b8     N.
+    bvc cb4af                                                         ; b475: 50 38       P8
+    jsr sub_cb5f2                                                     ; b477: 20 f2 b5     ..
+    tsx                                                               ; b47a: ba          .
+    txa                                                               ; b47b: 8a          .
+    sec                                                               ; b47c: 38          8
+    sbc #$0b                                                          ; b47d: e9 0b       ..
+    tax                                                               ; b47f: aa          .
+    txs                                                               ; b480: 9a          .
+    lda #0                                                            ; b481: a9 00       ..
+    pha                                                               ; b483: 48          H
+    lda #$ff                                                          ; b484: a9 ff       ..
+    pha                                                               ; b486: 48          H
+    pha                                                               ; b487: 48          H
+    ldy #$f7                                                          ; b488: a0 f7       ..
+    lda (l00b8),y                                                     ; b48a: b1 b8       ..
+    pha                                                               ; b48c: 48          H
+    dey                                                               ; b48d: 88          .
+    lda (l00b8),y                                                     ; b48e: b1 b8       ..
+    pha                                                               ; b490: 48          H
+    ldy #$f0                                                          ; b491: a0 f0       ..
+    lda (l00b8),y                                                     ; b493: b1 b8       ..
+    pha                                                               ; b495: 48          H
+    dey                                                               ; b496: 88          .
+    lda (l00b8),y                                                     ; b497: b1 b8       ..
+    pha                                                               ; b499: 48          H
+    tsx                                                               ; b49a: ba          .
+    inx                                                               ; b49b: e8          .
+    ldy #1                                                            ; b49c: a0 01       ..
+    lda #osfile_load                                                  ; b49e: a9 ff       ..
+    jsr osfile                                                        ; b4a0: 20 dd ff     ..
+    jsr cb82b                                                         ; b4a3: 20 2b b8     +.
+    ldx #$12                                                          ; b4a6: a2 12       ..
+; $b4a8 referenced 1 time by $b4aa
+loop_cb4a8
+    pla                                                               ; b4a8: 68          h
+    dex                                                               ; b4a9: ca          .
+    bne loop_cb4a8                                                    ; b4aa: d0 fc       ..
+    jmp cb4b4                                                         ; b4ac: 4c b4 b4    L..
+
+; $b4af referenced 1 time by $b475
+cb4af
+    lda #4                                                            ; b4af: a9 04       ..
+    jsr sub_cb598                                                     ; b4b1: 20 98 b5     ..
+; $b4b4 referenced 1 time by $b4ac
+cb4b4
+    ldx #$b1                                                          ; b4b4: a2 b1       ..
+    ldy #$f6                                                          ; b4b6: a0 f6       ..
+    jsr sub_cb841                                                     ; b4b8: 20 41 b8     A.
+    ldx #$b3                                                          ; b4bb: a2 b3       ..
+    ldy #$f2                                                          ; b4bd: a0 f2       ..
+    jsr sub_cb841                                                     ; b4bf: 20 41 b8     A.
+    ldx #$be                                                          ; b4c2: a2 be       ..
+    ldy #$fb                                                          ; b4c4: a0 fb       ..
+    jsr sub_cb841                                                     ; b4c6: 20 41 b8     A.
+    sec                                                               ; b4c9: 38          8
+    jsr cb795                                                         ; b4ca: 20 95 b7     ..
+    ldx #$b3                                                          ; b4cd: a2 b3       ..
+    jsr sub_cb61e                                                     ; b4cf: 20 1e b6     ..
+    beq cb45a                                                         ; b4d2: f0 86       ..
+    clv                                                               ; b4d4: b8          .
+    jmp cb45e                                                         ; b4d5: 4c 5e b4    L^.
+
+; $b4d8 referenced 1 time by $b40b
+cb4d8
+    jsr sub_cb5ee                                                     ; b4d8: 20 ee b5     ..
+    bit lb57f                                                         ; b4db: 2c 7f b5    ,..
+    php                                                               ; b4de: 08          .
+; $b4df referenced 1 time by $b531
+cb4df
+    ldy #$f4                                                          ; b4df: a0 f4       ..
+    jsr sub_cb83f                                                     ; b4e1: 20 3f b8     ?.
+    jsr sub_cb616                                                     ; b4e4: 20 16 b6     ..
+    bne cb4ee                                                         ; b4e7: d0 05       ..
+; $b4e9 referenced 1 time by $b57c
+cb4e9
+    plp                                                               ; b4e9: 28          (
+    jsr sub_cb5f2                                                     ; b4ea: 20 f2 b5     ..
+    rts                                                               ; b4ed: 60          `
+
+; $b4ee referenced 1 time by $b4e7
+cb4ee
+    ldx #$bc                                                          ; b4ee: a2 bc       ..
+    ldy #$f8                                                          ; b4f0: a0 f8       ..
+    jsr sub_cb841                                                     ; b4f2: 20 41 b8     A.
+    ldy #$ba                                                          ; b4f5: a0 ba       ..
+    jsr sub_cb58b                                                     ; b4f7: 20 8b b5     ..
+    bcs cb502                                                         ; b4fa: b0 06       ..
+    jsr sub_cb580                                                     ; b4fc: 20 80 b5     ..
+    plp                                                               ; b4ff: 28          (
+    clv                                                               ; b500: b8          .
+    php                                                               ; b501: 08          .
+; $b502 referenced 1 time by $b4fa
+cb502
+    ldy #$fb                                                          ; b502: a0 fb       ..
+    jsr sub_cb84e                                                     ; b504: 20 4e b8     N.
+    ldx #$b1                                                          ; b507: a2 b1       ..
+    ldy #$f2                                                          ; b509: a0 f2       ..
+    jsr sub_cb841                                                     ; b50b: 20 41 b8     A.
+    ldx #$b3                                                          ; b50e: a2 b3       ..
+    ldy #$f6                                                          ; b510: a0 f6       ..
+    jsr sub_cb841                                                     ; b512: 20 41 b8     A.
+    ldx #$be                                                          ; b515: a2 be       ..
+    ldy #$fb                                                          ; b517: a0 fb       ..
+    jsr sub_cb841                                                     ; b519: 20 41 b8     A.
+    clc                                                               ; b51c: 18          .
+    jsr cb795                                                         ; b51d: 20 95 b7     ..
+    ldx #$b1                                                          ; b520: a2 b1       ..
+    jsr sub_cb61e                                                     ; b522: 20 1e b6     ..
+    plp                                                               ; b525: 28          (
+    php                                                               ; b526: 08          .
+    bvs cb534                                                         ; b527: 70 0b       p.
+    lda #2                                                            ; b529: a9 02       ..
+    jsr sub_cb598                                                     ; b52b: 20 98 b5     ..
+    plp                                                               ; b52e: 28          (
+    clv                                                               ; b52f: b8          .
+    php                                                               ; b530: 08          .
+    jmp cb4df                                                         ; b531: 4c df b4    L..
+
+; $b534 referenced 1 time by $b527
+cb534
+    jsr sub_cb5f2                                                     ; b534: 20 f2 b5     ..
+    lda #$ff                                                          ; b537: a9 ff       ..
+    pha                                                               ; b539: 48          H
+    pha                                                               ; b53a: 48          H
+    ldy #$f6                                                          ; b53b: a0 f6       ..
+    jsr sub_cb83f                                                     ; b53d: 20 3f b8     ?.
+    ldy #$fb                                                          ; b540: a0 fb       ..
+    lda l00ba                                                         ; b542: a5 ba       ..
+    clc                                                               ; b544: 18          .
+    adc (l00b8),y                                                     ; b545: 71 b8       q.
+    tax                                                               ; b547: aa          .
+    lda l00bb                                                         ; b548: a5 bb       ..
+    iny                                                               ; b54a: c8          .
+    adc (l00b8),y                                                     ; b54b: 71 b8       q.
+    pha                                                               ; b54d: 48          H
+    txa                                                               ; b54e: 8a          .
+    pha                                                               ; b54f: 48          H
+    lda #$ff                                                          ; b550: a9 ff       ..
+    pha                                                               ; b552: 48          H
+    pha                                                               ; b553: 48          H
+    lda l00bb                                                         ; b554: a5 bb       ..
+    pha                                                               ; b556: 48          H
+    lda l00ba                                                         ; b557: a5 ba       ..
+    pha                                                               ; b559: 48          H
+    lda #$ff                                                          ; b55a: a9 ff       ..
+    ldx #8                                                            ; b55c: a2 08       ..
+; $b55e referenced 1 time by $b560
+loop_cb55e
+    pha                                                               ; b55e: 48          H
+    dex                                                               ; b55f: ca          .
+    bne loop_cb55e                                                    ; b560: d0 fc       ..
+    ldy #$f0                                                          ; b562: a0 f0       ..
+    lda (l00b8),y                                                     ; b564: b1 b8       ..
+    pha                                                               ; b566: 48          H
+    dey                                                               ; b567: 88          .
+    tsx                                                               ; b568: ba          .
+    lda (l00b8),y                                                     ; b569: b1 b8       ..
+    pha                                                               ; b56b: 48          H
+    ldy #1                                                            ; b56c: a0 01       ..
+    lda #osfile_save                                                  ; b56e: a9 00       ..
+    jsr osfile                                                        ; b570: 20 dd ff     ..
+    jsr cb82b                                                         ; b573: 20 2b b8     +.
+    ldx #$12                                                          ; b576: a2 12       ..
+; $b578 referenced 1 time by $b57a
+loop_cb578
+    pla                                                               ; b578: 68          h
+    dex                                                               ; b579: ca          .
+    bne loop_cb578                                                    ; b57a: d0 fc       ..
+    jmp cb4e9                                                         ; b57c: 4c e9 b4    L..
+
+; $b57f referenced 4 times by $b451, $b4db, $bae7, $bbda
+lb57f
+    !byte $40                                                         ; b57f: 40          @
+
+; $b580 referenced 7 times by $b46c, $b4fc, $bcfd, $bd08, $bd12, $bdaa, $bde4
+sub_cb580
+    lda l0000,x                                                       ; b580: b5 00       ..
+    sta l0000,y                                                       ; b582: 99 00 00    ...
+    lda l0001,x                                                       ; b585: b5 01       ..
+    sta l0001,y                                                       ; b587: 99 01 00    ...
+    rts                                                               ; b58a: 60          `
+
+; $b58b referenced 3 times by $b467, $b4f7, $b800
+sub_cb58b
+    lda l0001,x                                                       ; b58b: b5 01       ..
+    cmp l0001,y                                                       ; b58d: d9 01 00    ...
+    bne cb597                                                         ; b590: d0 05       ..
+    lda l0000,x                                                       ; b592: b5 00       ..
+    cmp l0000,y                                                       ; b594: d9 00 00    ...
+; $b597 referenced 1 time by $b590
+cb597
+    rts                                                               ; b597: 60          `
+
+; $b598 referenced 2 times by $b4b1, $b52b
+sub_cb598
+    pha                                                               ; b598: 48          H
+    pha                                                               ; b599: 48          H
+    pha                                                               ; b59a: 48          H
+    pha                                                               ; b59b: 48          H
+    lda #0                                                            ; b59c: a9 00       ..
+    pha                                                               ; b59e: 48          H
+    pha                                                               ; b59f: 48          H
+    ldy #$fc                                                          ; b5a0: a0 fc       ..
+    lda (l00b8),y                                                     ; b5a2: b1 b8       ..
+    pha                                                               ; b5a4: 48          H
+    dey                                                               ; b5a5: 88          .
+    lda (l00b8),y                                                     ; b5a6: b1 b8       ..
+    pha                                                               ; b5a8: 48          H
+    lda #$ff                                                          ; b5a9: a9 ff       ..
+    pha                                                               ; b5ab: 48          H
+    pha                                                               ; b5ac: 48          H
+    ldy #$f7                                                          ; b5ad: a0 f7       ..
+    lda (l00b8),y                                                     ; b5af: b1 b8       ..
+    pha                                                               ; b5b1: 48          H
+    dey                                                               ; b5b2: 88          .
+    lda (l00b8),y                                                     ; b5b3: b1 b8       ..
+    pha                                                               ; b5b5: 48          H
+    tsx                                                               ; b5b6: ba          .
+    ldy #$fa                                                          ; b5b7: a0 fa       ..
+    lda (l00b8),y                                                     ; b5b9: b1 b8       ..
+    pha                                                               ; b5bb: 48          H
+    lda l0109,x                                                       ; b5bc: bd 09 01    ...
+    ldy #1                                                            ; b5bf: a0 01       ..
+    jsr osgbpb                                                        ; b5c1: 20 d1 ff     ..
+    ldx #$0d                                                          ; b5c4: a2 0d       ..
+; $b5c6 referenced 1 time by $b5c8
+loop_cb5c6
+    pla                                                               ; b5c6: 68          h
+    dex                                                               ; b5c7: ca          .
+    bne loop_cb5c6                                                    ; b5c8: d0 fc       ..
+    jsr cb82b                                                         ; b5ca: 20 2b b8     +.
+    rts                                                               ; b5cd: 60          `
+
+; $b5ce referenced 2 times by $b345, $b40e
+sub_cb5ce
+    lda #$40 ; '@'                                                    ; b5ce: a9 40       .@
+; $b5d0 referenced 1 time by $b5f0
+cb5d0
+    pha                                                               ; b5d0: 48          H
+    ldy #$ef                                                          ; b5d1: a0 ef       ..
+    lda (l00b8),y                                                     ; b5d3: b1 b8       ..
+    tax                                                               ; b5d5: aa          .
+    iny                                                               ; b5d6: c8          .
+    lda (l00b8),y                                                     ; b5d7: b1 b8       ..
+    tay                                                               ; b5d9: a8          .
+    pla                                                               ; b5da: 68          h
+    jsr osfind                                                        ; b5db: 20 ce ff     ..
+    tax                                                               ; b5de: aa          .
+    bne cb5e6                                                         ; b5df: d0 05       ..
+    ldx #4                                                            ; b5e1: a2 04       ..
+    jmp cb8fb                                                         ; b5e3: 4c fb b8    L..
+
+; $b5e6 referenced 1 time by $b5df
+cb5e6
+    ldy #$fa                                                          ; b5e6: a0 fa       ..
+    jsr cb82b                                                         ; b5e8: 20 2b b8     +.
+    sta (l00b8),y                                                     ; b5eb: 91 b8       ..
+; $b5ed referenced 1 time by $b5f6
+loop_cb5ed
+    rts                                                               ; b5ed: 60          `
+
+; $b5ee referenced 2 times by $b375, $b4d8
+sub_cb5ee
+    lda #$80                                                          ; b5ee: a9 80       ..
+    bne cb5d0                                                         ; b5f0: d0 de       ..
+; $b5f2 referenced 6 times by $b21b, $b371, $b45a, $b477, $b4ea, $b534
+sub_cb5f2
+    ldy #$fa                                                          ; b5f2: a0 fa       ..
+    lda (l00b8),y                                                     ; b5f4: b1 b8       ..
+    beq loop_cb5ed                                                    ; b5f6: f0 f5       ..
+    pha                                                               ; b5f8: 48          H
+    lda #0                                                            ; b5f9: a9 00       ..
+    sta (l00b8),y                                                     ; b5fb: 91 b8       ..
+    pla                                                               ; b5fd: 68          h
+    tay                                                               ; b5fe: a8          .
+    lda #0                                                            ; b5ff: a9 00       ..
+    jsr osfind                                                        ; b601: 20 ce ff     ..
+    jmp cb82b                                                         ; b604: 4c 2b b8    L+.
+
+; $b607 referenced 2 times by $b348, $b36c
+sub_cb607
+    ldy #$fa                                                          ; b607: a0 fa       ..
+    lda (l00b8),y                                                     ; b609: b1 b8       ..
+    tax                                                               ; b60b: aa          .
+    lda #1                                                            ; b60c: a9 01       ..
+    jsr sub_cb86f                                                     ; b60e: 20 6f b8     o.
+    jsr cb82b                                                         ; b611: 20 2b b8     +.
+    txa                                                               ; b614: 8a          .
+    rts                                                               ; b615: 60          `
+
+; $b616 referenced 4 times by $b378, $b3b3, $b4e4, $be5d
+sub_cb616
+    ldy #$f4                                                          ; b616: a0 f4       ..
+    lda (l00b8),y                                                     ; b618: b1 b8       ..
+    iny                                                               ; b61a: c8          .
+    ora (l00b8),y                                                     ; b61b: 11 b8       ..
+    rts                                                               ; b61d: 60          `
+
+; $b61e referenced 2 times by $b4cf, $b522
+sub_cb61e
+    stx l00bc                                                         ; b61e: 86 bc       ..
+    ldy #$fb                                                          ; b620: a0 fb       ..
+    jsr sub_cb83f                                                     ; b622: 20 3f b8     ?.
+    ldy #$f4                                                          ; b625: a0 f4       ..
+    lda (l00b8),y                                                     ; b627: b1 b8       ..
+    sec                                                               ; b629: 38          8
+    sbc l00ba                                                         ; b62a: e5 ba       ..
+    sta (l00b8),y                                                     ; b62c: 91 b8       ..
+    sta l00ba                                                         ; b62e: 85 ba       ..
+    iny                                                               ; b630: c8          .
+    lda (l00b8),y                                                     ; b631: b1 b8       ..
+    sbc l00bb                                                         ; b633: e5 bb       ..
+    sta (l00b8),y                                                     ; b635: 91 b8       ..
+    sta l00bb                                                         ; b637: 85 bb       ..
+    ora l00ba                                                         ; b639: 05 ba       ..
+    beq cb65e                                                         ; b63b: f0 21       .!
+    ldx l00bc                                                         ; b63d: a6 bc       ..
+    jsr sub_cb85d                                                     ; b63f: 20 5d b8     ].
+    bvc cb655                                                         ; b642: 50 11       P.
+    lda l0001,x                                                       ; b644: b5 01       ..
+    cmp #$c0                                                          ; b646: c9 c0       ..
+    bcc cb655                                                         ; b648: 90 0b       ..
+    lda #$10                                                          ; b64a: a9 10       ..
+    sta l0000,x                                                       ; b64c: 95 00       ..
+    lda #$80                                                          ; b64e: a9 80       ..
+    sta l0001,x                                                       ; b650: 95 01       ..
+    jsr sub_cb68f                                                     ; b652: 20 8f b6     ..
+; $b655 referenced 2 times by $b642, $b648
+cb655
+    ldx l00bc                                                         ; b655: a6 bc       ..
+    ldy #$f2                                                          ; b657: a0 f2       ..
+    jsr sub_cb850                                                     ; b659: 20 50 b8     P.
+    lda #$ff                                                          ; b65c: a9 ff       ..
+; $b65e referenced 1 time by $b63b
+cb65e
+    rts                                                               ; b65e: 60          `
+
+; $b65f referenced 2 times by $b34f, $b37f
+sub_cb65f
+    ldx #$bd                                                          ; b65f: a2 bd       ..
+    ldy #$f2                                                          ; b661: a0 f2       ..
+    jsr sub_cb841                                                     ; b663: 20 41 b8     A.
+    inc l00bd                                                         ; b666: e6 bd       ..
+    bne cb684                                                         ; b668: d0 1a       ..
+    inc l00be                                                         ; b66a: e6 be       ..
+    beq cb68c                                                         ; b66c: f0 1e       ..
+    jsr sub_cb85d                                                     ; b66e: 20 5d b8     ].
+    bvc cb684                                                         ; b671: 50 11       P.
+    lda l00be                                                         ; b673: a5 be       ..
+    cmp #$c0                                                          ; b675: c9 c0       ..
+    bne cb684                                                         ; b677: d0 0b       ..
+    jsr sub_cb68f                                                     ; b679: 20 8f b6     ..
+    lda #$10                                                          ; b67c: a9 10       ..
+    sta l00bd                                                         ; b67e: 85 bd       ..
+    lda #$80                                                          ; b680: a9 80       ..
+    sta l00be                                                         ; b682: 85 be       ..
+; $b684 referenced 3 times by $b668, $b671, $b677
+cb684
+    ldx #$bd                                                          ; b684: a2 bd       ..
+    ldy #$f2                                                          ; b686: a0 f2       ..
+    jsr sub_cb850                                                     ; b688: 20 50 b8     P.
+    rts                                                               ; b68b: 60          `
+
+; $b68c referenced 4 times by $b66c, $b698, $b69c, $b6ae
+cb68c
+    jmp cb446                                                         ; b68c: 4c 46 b4    LF.
+
+; $b68f referenced 4 times by $b652, $b679, $b81f, $be77
+sub_cb68f
+    ldy #$f1                                                          ; b68f: a0 f1       ..
+    lda (l00b8),y                                                     ; b691: b1 b8       ..
+    clc                                                               ; b693: 18          .
+    adc #1                                                            ; b694: 69 01       i.
+    cmp #$10                                                          ; b696: c9 10       ..
+    bcs cb68c                                                         ; b698: b0 f2       ..
+    cmp #2                                                            ; b69a: c9 02       ..
+    beq cb68c                                                         ; b69c: f0 ee       ..
+    cmp #$0e                                                          ; b69e: c9 0e       ..
+    bne cb6a6                                                         ; b6a0: d0 04       ..
+    ldy #$fe                                                          ; b6a2: a0 fe       ..
+    and (l00b8),y                                                     ; b6a4: 31 b8       1.
+; $b6a6 referenced 1 time by $b6a0
+cb6a6
+    ldy #$f1                                                          ; b6a6: a0 f1       ..
+    sta (l00b8),y                                                     ; b6a8: 91 b8       ..
+    tay                                                               ; b6aa: a8          .
+    jsr sub_cb6fe                                                     ; b6ab: 20 fe b6     ..
+    beq cb68c                                                         ; b6ae: f0 dc       ..
+    rts                                                               ; b6b0: 60          `
+
+; $b6b1 referenced 2 times by $b305, $bcda
+sub_cb6b1
+    ldy #$10                                                          ; b6b1: a0 10       ..
+; $b6b3 referenced 1 time by $b6c5
+loop_cb6b3
+    cmp cb6ca,y                                                       ; b6b3: d9 ca b6    ...
+    bcc cb6ca                                                         ; b6b6: 90 12       ..
+    bne cb6c2                                                         ; b6b8: d0 08       ..
+    pha                                                               ; b6ba: 48          H
+    txa                                                               ; b6bb: 8a          .
+    cmp lb6c6,y                                                       ; b6bc: d9 c6 b6    ...
+    pla                                                               ; b6bf: 68          h
+    bcc cb6ca                                                         ; b6c0: 90 08       ..
+; $b6c2 referenced 1 time by $b6b8
+cb6c2
+    iny                                                               ; b6c2: c8          .
+    cpy #$14                                                          ; b6c3: c0 14       ..
+sub_cb6c5
+lb6c6 = sub_cb6c5+1
+    bcc loop_cb6b3                                                    ; b6c5: 90 ec       ..
+; $b6c6 referenced 1 time by $b6bc
+    jmp cb446                                                         ; b6c7: 4c 46 b4    LF.
+
+; $b6ca referenced 3 times by $b6b3, $b6b6, $b6c0
+cb6ca
+    pha                                                               ; b6ca: 48          H
+    txa                                                               ; b6cb: 8a          .
+    clc                                                               ; b6cc: 18          .
+sub_cb6cd
+lb6ce = sub_cb6cd+1
+    adc lb6ce,y                                                       ; b6cd: 79 ce b6    y..
+; $b6ce referenced 1 time by $b6cd
+    tax                                                               ; b6d0: aa          .
+    pla                                                               ; b6d1: 68          h
+; $b6d2 referenced 1 time by $b6d2
+cb6d2
+    adc cb6d2,y                                                       ; b6d2: 79 d2 b6    y..
+    rts                                                               ; b6d5: 60          `
+
+    !byte $f0, $e0, $d0, $c0, $3f, $7f, $bf, $ff, $10                 ; b6d6: f0 e0 d0... ...
+    !text " 0@"                                                       ; b6df: 20 30 40     0@
+    !byte $80, $40,   0, $c0                                          ; b6e2: 80 40 00... .@.
+
+; $b6e6 referenced 1 time by $b6fe
+sub_cb6e6
+    cpy #$10                                                          ; b6e6: c0 10       ..
+    bcs cb6eb                                                         ; b6e8: b0 01       ..
+    rts                                                               ; b6ea: 60          `
+
+; $b6eb referenced 1 time by $b6e8
+cb6eb
+    tya                                                               ; b6eb: 98          .
+    sec                                                               ; b6ec: 38          8
+    sbc #4                                                            ; b6ed: e9 04       ..
+    tay                                                               ; b6ef: a8          .
+    cpy #$0e                                                          ; b6f0: c0 0e       ..
+    bcs cb6f5                                                         ; b6f2: b0 01       ..
+    rts                                                               ; b6f4: 60          `
+
+; $b6f5 referenced 1 time by $b6f2
+cb6f5
+    tya                                                               ; b6f5: 98          .
+    and #1                                                            ; b6f6: 29 01       ).
+    ldy #$fe                                                          ; b6f8: a0 fe       ..
+    ora (l00b8),y                                                     ; b6fa: 11 b8       ..
+    tay                                                               ; b6fc: a8          .
+    rts                                                               ; b6fd: 60          `
+
+; $b6fe referenced 5 times by $b314, $b6ab, $bc44, $bc8e, $bce1
+sub_cb6fe
+    jsr sub_cb6e6                                                     ; b6fe: 20 e6 b6     ..
+    tya                                                               ; b701: 98          .
+    tax                                                               ; b702: aa          .
+    lda lb726,y                                                       ; b703: b9 26 b7    .&.
+    pha                                                               ; b706: 48          H
+    ldy #$ee                                                          ; b707: a0 ee       ..
+    and (l00b8),y                                                     ; b709: 31 b8       1.
+    bne cb718                                                         ; b70b: d0 0b       ..
+    lda (l00b8),y                                                     ; b70d: b1 b8       ..
+    and #$c0                                                          ; b70f: 29 c0       ).
+    cmp #$80                                                          ; b711: c9 80       ..
+    beq cb718                                                         ; b713: f0 03       ..
+    jmp cb446                                                         ; b715: 4c 46 b4    LF.
+
+; $b718 referenced 2 times by $b70b, $b713
+cb718
+    pla                                                               ; b718: 68          h
+    ldy #$fd                                                          ; b719: a0 fd       ..
+    and (l00b8),y                                                     ; b71b: 31 b8       1.
+    pha                                                               ; b71d: 48          H
+    txa                                                               ; b71e: 8a          .
+    tay                                                               ; b71f: a8          .
+    pla                                                               ; b720: 68          h
+    beq cb725                                                         ; b721: f0 02       ..
+    lda #$ff                                                          ; b723: a9 ff       ..
+; $b725 referenced 1 time by $b721
+cb725
+    rts                                                               ; b725: 60          `
+
+; $b726 referenced 6 times by $b703, $b898, $b8c8, $b8db, $bc56, $bca1
+lb726
+    !byte   4,   8,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0  ; b726: 04 08 00... ...
+    !byte   1,   2, $10, $20                                          ; b732: 01 02 10... ...
+
+; $b736 referenced 1 time by $b75a
+cb736
+    sty romsel_copy                                                   ; b736: 84 f4       ..
+    sty romsel                                                        ; b738: 8c 30 fe    .0.
+    ldy #0                                                            ; b73b: a0 00       ..
+    sta (l00ba),y                                                     ; b73d: 91 ba       ..
+    stx romsel_copy                                                   ; b73f: 86 f4       ..
+    stx romsel                                                        ; b741: 8e 30 fe    .0.
+    rts                                                               ; b744: 60          `
+
+; $b745 referenced 5 times by $b369, $b8b7, $b8d1, $bc78, $bc9e
+sub_cb745
+    sta l00bf                                                         ; b745: 85 bf       ..
+    txa                                                               ; b747: 8a          .
+    pha                                                               ; b748: 48          H
+    tya                                                               ; b749: 98          .
+    pha                                                               ; b74a: 48          H
+    ldx romsel_copy                                                   ; b74b: a6 f4       ..
+    lda l0df0,x                                                       ; b74d: bd f0 0d    ...
+    sta l00b1                                                         ; b750: 85 b1       ..
+    inc l00b1                                                         ; b752: e6 b1       ..
+    lda #0                                                            ; b754: a9 00       ..
+    sta l00b0                                                         ; b756: 85 b0       ..
+    ldy #$0e                                                          ; b758: a0 0e       ..
+; $b75a referenced 1 time by $b760
+loop_cb75a
+    lda cb736,y                                                       ; b75a: b9 36 b7    .6.
+    sta (l00b0),y                                                     ; b75d: 91 b0       ..
+    dey                                                               ; b75f: 88          .
+    bpl loop_cb75a                                                    ; b760: 10 f8       ..
+    pla                                                               ; b762: 68          h
+    pha                                                               ; b763: 48          H
+    tay                                                               ; b764: a8          .
+    lda l00bf                                                         ; b765: a5 bf       ..
+    jsr sub_cb771                                                     ; b767: 20 71 b7     q.
+    pla                                                               ; b76a: 68          h
+    tay                                                               ; b76b: a8          .
+    pla                                                               ; b76c: 68          h
+    tax                                                               ; b76d: aa          .
+    lda l00bf                                                         ; b76e: a5 bf       ..
+    rts                                                               ; b770: 60          `
+
+; $b771 referenced 1 time by $b767
+sub_cb771
+    jmp (l00b0)                                                       ; b771: 6c b0 00    l..
+
+; $b774 referenced 1 time by $b7be
+lb774
+    !byte $85, $f4, $8d, $30, $fe, $b1, $b1, $91, $b3, $c8, $d0,   5  ; b774: 85 f4 8d... ...
+    !byte $e6, $b2, $e6, $b4, $ca, $c4, $b5, $d0, $f0, $8a, $d0, $ed  ; b780: e6 b2 e6... ...
+    !byte $68, $85, $f4, $8d, $30, $fe, $4c, $d5, $b7                 ; b78c: 68 85 f4... h..
+
+; $b795 referenced 5 times by $b4ca, $b51d, $bd0b, $bdb0, $bded
+cb795
+    ldy #$f1                                                          ; b795: a0 f1       ..
+    lda (l00b8),y                                                     ; b797: b1 b8       ..
+    sta l00b0                                                         ; b799: 85 b0       ..
+    ldx l00be                                                         ; b79b: a6 be       ..
+    ldy l00bf                                                         ; b79d: a4 bf       ..
+    lda #0                                                            ; b79f: a9 00       ..
+    rol                                                               ; b7a1: 2a          *
+    asl                                                               ; b7a2: 0a          .
+    sta l00b7                                                         ; b7a3: 85 b7       ..
+    inc l00b7                                                         ; b7a5: e6 b7       ..
+    jsr sub_cb85d                                                     ; b7a7: 20 5d b8     ].
+    bvs cb7ed                                                         ; b7aa: 70 41       pA
+    bvc cb7b2                                                         ; b7ac: 50 04       P.
+; $b7ae referenced 1 time by $b803
+cb7ae
+    ldx l00be                                                         ; b7ae: a6 be       ..
+    ldy l00bf                                                         ; b7b0: a4 bf       ..
+; $b7b2 referenced 1 time by $b7ac
+cb7b2
+    stx l00b5                                                         ; b7b2: 86 b5       ..
+    sty l00b6                                                         ; b7b4: 84 b6       ..
+; $b7b6 referenced 1 time by $b812
+sub_cb7b6
+    lda l00b5                                                         ; b7b6: a5 b5       ..
+    ora l00b6                                                         ; b7b8: 05 b6       ..
+    beq cb7ec                                                         ; b7ba: f0 30       .0
+    ldx #$20 ; ' '                                                    ; b7bc: a2 20       .
+; $b7be referenced 1 time by $b7c3
+loop_cb7be
+    lda lb774,x                                                       ; b7be: bd 74 b7    .t.
+    pha                                                               ; b7c1: 48          H
+    dex                                                               ; b7c2: ca          .
+    bpl loop_cb7be                                                    ; b7c3: 10 f9       ..
+    tsx                                                               ; b7c5: ba          .
+    lda romsel_copy                                                   ; b7c6: a5 f4       ..
+    pha                                                               ; b7c8: 48          H
+    lda #1                                                            ; b7c9: a9 01       ..
+    pha                                                               ; b7cb: 48          H
+    txa                                                               ; b7cc: 8a          .
+    pha                                                               ; b7cd: 48          H
+    lda l00b0                                                         ; b7ce: a5 b0       ..
+    ldx l00b6                                                         ; b7d0: a6 b6       ..
+    ldy #0                                                            ; b7d2: a0 00       ..
+    rts                                                               ; b7d4: 60          `
+
+    ldx #$21 ; '!'                                                    ; b7d5: a2 21       .!
+; $b7d7 referenced 1 time by $b7d9
+loop_cb7d7
+    pla                                                               ; b7d7: 68          h
+    dex                                                               ; b7d8: ca          .
+    bne loop_cb7d7                                                    ; b7d9: d0 fc       ..
+    ldx #2                                                            ; b7db: a2 02       ..
+; $b7dd referenced 1 time by $b7ea
+loop_cb7dd
+    lda l00b1,x                                                       ; b7dd: b5 b1       ..
+    clc                                                               ; b7df: 18          .
+    adc l00b5                                                         ; b7e0: 65 b5       e.
+    sta l00b1,x                                                       ; b7e2: 95 b1       ..
+    bcc cb7e8                                                         ; b7e4: 90 02       ..
+    inc l00b2,x                                                       ; b7e6: f6 b2       ..
+; $b7e8 referenced 1 time by $b7e4
+cb7e8
+    dex                                                               ; b7e8: ca          .
+    dex                                                               ; b7e9: ca          .
+    bpl loop_cb7dd                                                    ; b7ea: 10 f1       ..
+; $b7ec referenced 1 time by $b7ba
+cb7ec
+    rts                                                               ; b7ec: 60          `
+
+; $b7ed referenced 2 times by $b7aa, $b828
+cb7ed
+    lda #0                                                            ; b7ed: a9 00       ..
+    sec                                                               ; b7ef: 38          8
+    ldx l00b7                                                         ; b7f0: a6 b7       ..
+    sbc l00b0,x                                                       ; b7f2: f5 b0       ..
+    sta l00b5                                                         ; b7f4: 85 b5       ..
+    lda #$c0                                                          ; b7f6: a9 c0       ..
+    sbc l00b1,x                                                       ; b7f8: f5 b1       ..
+    sta l00b6                                                         ; b7fa: 85 b6       ..
+    ldx #$b5                                                          ; b7fc: a2 b5       ..
+    ldy #$be                                                          ; b7fe: a0 be       ..
+    jsr sub_cb58b                                                     ; b800: 20 8b b5     ..
+    bcs cb7ae                                                         ; b803: b0 a9       ..
+    lda l00be                                                         ; b805: a5 be       ..
+    sec                                                               ; b807: 38          8
+    sbc l00b5                                                         ; b808: e5 b5       ..
+    sta l00be                                                         ; b80a: 85 be       ..
+    lda l00bf                                                         ; b80c: a5 bf       ..
+    sbc l00b6                                                         ; b80e: e5 b6       ..
+    sta l00bf                                                         ; b810: 85 bf       ..
+    jsr sub_cb7b6                                                     ; b812: 20 b6 b7     ..
+    lda #$10                                                          ; b815: a9 10       ..
+    ldx l00b7                                                         ; b817: a6 b7       ..
+    sta l00b0,x                                                       ; b819: 95 b0       ..
+    lda #$80                                                          ; b81b: a9 80       ..
+    sta l00b1,x                                                       ; b81d: 95 b1       ..
+    jsr sub_cb68f                                                     ; b81f: 20 8f b6     ..
+    ldy #$f1                                                          ; b822: a0 f1       ..
+    lda (l00b8),y                                                     ; b824: b1 b8       ..
+    sta l00b0                                                         ; b826: 85 b0       ..
+    jmp cb7ed                                                         ; b828: 4c ed b7    L..
+
+; $b82b referenced 16 times by $b1c1, $b2c8, $b2e7, $b32c, $b35a, $b3b0, $b3ec, $b429, $b4a3, $b573, $b5ca, $b5e8, $b604, $b611, $b86b, $beb5
+cb82b
+    php                                                               ; b82b: 08          .
+    pha                                                               ; b82c: 48          H
+    txa                                                               ; b82d: 8a          .
+    pha                                                               ; b82e: 48          H
+    lda #0                                                            ; b82f: a9 00       ..
+    sta l00b8                                                         ; b831: 85 b8       ..
+    ldx romsel_copy                                                   ; b833: a6 f4       ..
+    lda l0df0,x                                                       ; b835: bd f0 0d    ...
+    sta l00b9                                                         ; b838: 85 b9       ..
+    pla                                                               ; b83a: 68          h
+    tax                                                               ; b83b: aa          .
+    pla                                                               ; b83c: 68          h
+    plp                                                               ; b83d: 28          (
+    rts                                                               ; b83e: 60          `
+
+; $b83f referenced 4 times by $b35f, $b4e1, $b53d, $b622
+sub_cb83f
+    ldx #$ba                                                          ; b83f: a2 ba       ..
+; $b841 referenced 12 times by $b39b, $b462, $b4b8, $b4bf, $b4c6, $b4f2, $b50b, $b512, $b519, $b663, $bd4a, $bdc4
+sub_cb841
+    pha                                                               ; b841: 48          H
+    lda (l00b8),y                                                     ; b842: b1 b8       ..
+    sta l0000,x                                                       ; b844: 95 00       ..
+    iny                                                               ; b846: c8          .
+    lda (l00b8),y                                                     ; b847: b1 b8       ..
+    sta l0001,x                                                       ; b849: 95 01       ..
+    dey                                                               ; b84b: 88          .
+    pla                                                               ; b84c: 68          h
+    rts                                                               ; b84d: 60          `
+
+; $b84e referenced 3 times by $b3f5, $b472, $b504
+sub_cb84e
+    ldx #$ba                                                          ; b84e: a2 ba       ..
+; $b850 referenced 5 times by $b659, $b688, $bb5c, $bb8d, $bd36
+sub_cb850
+    pha                                                               ; b850: 48          H
+    lda l0000,x                                                       ; b851: b5 00       ..
+    sta (l00b8),y                                                     ; b853: 91 b8       ..
+    iny                                                               ; b855: c8          .
+    lda l0001,x                                                       ; b856: b5 01       ..
+    sta (l00b8),y                                                     ; b858: 91 b8       ..
+    dey                                                               ; b85a: 88          .
+    pla                                                               ; b85b: 68          h
+    rts                                                               ; b85c: 60          `
+
+; $b85d referenced 8 times by $b2f2, $b340, $b406, $b63f, $b66e, $b7a7, $be64, $be9d
+sub_cb85d
+    pha                                                               ; b85d: 48          H
+    tya                                                               ; b85e: 98          .
+    pha                                                               ; b85f: 48          H
+    ldy #$ee                                                          ; b860: a0 ee       ..
+    lda (l00b8),y                                                     ; b862: b1 b8       ..
+    sta l00b8                                                         ; b864: 85 b8       ..
+    pla                                                               ; b866: 68          h
+    tay                                                               ; b867: a8          .
+    pla                                                               ; b868: 68          h
+    bit l00b8                                                         ; b869: 24 b8       $.
+    jsr cb82b                                                         ; b86b: 20 2b b8     +.
+    rts                                                               ; b86e: 60          `
+
+; $b86f referenced 1 time by $b60e
+sub_cb86f
+    jmp (fscv)                                                        ; b86f: 6c 1e 02    l..
+
+; $b872 referenced 2 times by $b9c7, $bc70
+lb872
+    !byte $60,   0,   0, $60,   0,   0,   2, $0c, $ff                 ; b872: 60 00 00... `..
+    !text "RAM"                                                       ; b87b: 52 41 4d    RAM
+; $b87e referenced 1 time by $b9a3
+lb87e
+    !byte 0                                                           ; b87e: 00          .
+    !text "(C)"                                                       ; b87f: 28 43 29    (C)
+
+; $b882 referenced 1 time by $b200
+sub_cb882
+    lda #0                                                            ; b882: a9 00       ..
+    ldy #$fd                                                          ; b884: a0 fd       ..
+    sta (l00b8),y                                                     ; b886: 91 b8       ..
+    ldy #$ee                                                          ; b888: a0 ee       ..
+    sta (l00b8),y                                                     ; b88a: 91 b8       ..
+    ldy #$fa                                                          ; b88c: a0 fa       ..
+    sta (l00b8),y                                                     ; b88e: 91 b8       ..
+    ldy #$ff                                                          ; b890: a0 ff       ..
+    lda #$4e ; 'N'                                                    ; b892: a9 4e       .N
+    sta (l00b8),y                                                     ; b894: 91 b8       ..
+    ldy #$0f                                                          ; b896: a0 0f       ..
+; $b898 referenced 1 time by $b8e7
+cb898
+    lda lb726,y                                                       ; b898: b9 26 b7    .&.
+    beq cb8e6                                                         ; b89b: f0 49       .I
+    tya                                                               ; b89d: 98          .
+    pha                                                               ; b89e: 48          H
+    lda #8                                                            ; b89f: a9 08       ..
+    sta osrdsc_ptr                                                    ; b8a1: 85 f6       ..
+    sta l00ba                                                         ; b8a3: 85 ba       ..
+    lda #$80                                                          ; b8a5: a9 80       ..
+    sta l00f7                                                         ; b8a7: 85 f7       ..
+    sta l00bb                                                         ; b8a9: 85 bb       ..
+    jsr osrdsc                                                        ; b8ab: 20 b9 ff     ..
+    sta l00bd                                                         ; b8ae: 85 bd       ..
+    pla                                                               ; b8b0: 68          h
+    pha                                                               ; b8b1: 48          H
+    tay                                                               ; b8b2: a8          .
+    lda l00bd                                                         ; b8b3: a5 bd       ..
+    eor #$ff                                                          ; b8b5: 49 ff       I.
+    jsr sub_cb745                                                     ; b8b7: 20 45 b7     E.
+    jsr osrdsc                                                        ; b8ba: 20 b9 ff     ..
+    cmp l00bd                                                         ; b8bd: c5 bd       ..
+    beq cb8e4                                                         ; b8bf: f0 23       .#
+    pla                                                               ; b8c1: 68          h
+    pha                                                               ; b8c2: 48          H
+    tax                                                               ; b8c3: aa          .
+    ldy #$ee                                                          ; b8c4: a0 ee       ..
+    lda (l00b8),y                                                     ; b8c6: b1 b8       ..
+    ora lb726,x                                                       ; b8c8: 1d 26 b7    .&.
+    sta (l00b8),y                                                     ; b8cb: 91 b8       ..
+    txa                                                               ; b8cd: 8a          .
+    tay                                                               ; b8ce: a8          .
+    lda l00bd                                                         ; b8cf: a5 bd       ..
+    jsr sub_cb745                                                     ; b8d1: 20 45 b7     E.
+    jsr sub_cb986                                                     ; b8d4: 20 86 b9     ..
+    cmp #2                                                            ; b8d7: c9 02       ..
+    bne cb8e4                                                         ; b8d9: d0 09       ..
+    lda lb726,y                                                       ; b8db: b9 26 b7    .&.
+    ldy #$fd                                                          ; b8de: a0 fd       ..
+    ora (l00b8),y                                                     ; b8e0: 11 b8       ..
+    sta (l00b8),y                                                     ; b8e2: 91 b8       ..
+; $b8e4 referenced 2 times by $b8bf, $b8d9
+cb8e4
+    pla                                                               ; b8e4: 68          h
+    tay                                                               ; b8e5: a8          .
+; $b8e6 referenced 1 time by $b89b
+cb8e6
+    dey                                                               ; b8e6: 88          .
+    bpl cb898                                                         ; b8e7: 10 af       ..
+    ldy #$ee                                                          ; b8e9: a0 ee       ..
+    lda (l00b8),y                                                     ; b8eb: b1 b8       ..
+    ldx #0                                                            ; b8ed: a2 00       ..
+    and #$0c                                                          ; b8ef: 29 0c       ).
+    bne cb8f5                                                         ; b8f1: d0 02       ..
+    ldx #$0e                                                          ; b8f3: a2 0e       ..
+; $b8f5 referenced 1 time by $b8f1
+cb8f5
+    txa                                                               ; b8f5: 8a          .
+    ldy #$fe                                                          ; b8f6: a0 fe       ..
+    sta (l00b8),y                                                     ; b8f8: 91 b8       ..
+    rts                                                               ; b8fa: 60          `
+
+; $b8fb referenced 6 times by $b302, $b334, $b448, $b5e3, $bafa, $bc51
+cb8fb
+    lda #0                                                            ; b8fb: a9 00       ..
+    sta l0100                                                         ; b8fd: 8d 00 01    ...
+    lda lb980,x                                                       ; b900: bd 80 b9    ...
+    sta l0101                                                         ; b903: 8d 01 01    ...
+    lda lb97a,x                                                       ; b906: bd 7a b9    .z.
+    sta l00bf                                                         ; b909: 85 bf       ..
+    ldy lb979,x                                                       ; b90b: bc 79 b9    .y.
+    ldx #0                                                            ; b90e: a2 00       ..
+; $b910 referenced 1 time by $b91a
+loop_cb910
+    lda lb924,y                                                       ; b910: b9 24 b9    .$.
+    sta l0102,x                                                       ; b913: 9d 02 01    ...
+    inx                                                               ; b916: e8          .
+    iny                                                               ; b917: c8          .
+    cpy l00bf                                                         ; b918: c4 bf       ..
+    bcc loop_cb910                                                    ; b91a: 90 f4       ..
+    lda #0                                                            ; b91c: a9 00       ..
+    sta l0102,x                                                       ; b91e: 9d 02 01    ...
+    jmp l0100                                                         ; b921: 4c 00 01    L..
+
+; $b924 referenced 1 time by $b910
+lb924
+    !text "Illegal parameterIllegal addressNo filing systemBad com"   ; b924: 49 6c 6c... Ill
+    !text "mandFile not foundRAM occupied"                            ; b95b: 6d 61 6e... man
+; $b979 referenced 1 time by $b90b
+lb979
+    !byte 0                                                           ; b979: 00          .
+; $b97a referenced 1 time by $b906
+lb97a
+    !byte $11                                                         ; b97a: 11          .
+    !text " 0;IU"                                                     ; b97b: 20 30 3b...  0;
+; $b980 referenced 1 time by $b900
+lb980
+    !byte $80, $81, $82, $fe, $d6, $83                                ; b980: 80 81 82... ...
+
+; $b986 referenced 3 times by $b8d4, $bc49, $bcb2
+sub_cb986
+    txa                                                               ; b986: 8a          .
+    pha                                                               ; b987: 48          H
+    tya                                                               ; b988: 98          .
+    pha                                                               ; b989: 48          H
+    ldx #7                                                            ; b98a: a2 07       ..
+    stx osrdsc_ptr                                                    ; b98c: 86 f6       ..
+    lda #$80                                                          ; b98e: a9 80       ..
+    sta l00f7                                                         ; b990: 85 f7       ..
+    jsr osrdsc                                                        ; b992: 20 b9 ff     ..
+    sta osrdsc_ptr                                                    ; b995: 85 f6       ..
+    ldx #0                                                            ; b997: a2 00       ..
+; $b999 referenced 1 time by $b9b1
+loop_cb999
+    stx l00bf                                                         ; b999: 86 bf       ..
+    pla                                                               ; b99b: 68          h
+    pha                                                               ; b99c: 48          H
+    tay                                                               ; b99d: a8          .
+    jsr osrdsc                                                        ; b99e: 20 b9 ff     ..
+    ldx l00bf                                                         ; b9a1: a6 bf       ..
+    cmp lb87e,x                                                       ; b9a3: dd 7e b8    .~.
+    bne cb9ee                                                         ; b9a6: d0 46       .F
+    inc osrdsc_ptr                                                    ; b9a8: e6 f6       ..
+    bne cb9ae                                                         ; b9aa: d0 02       ..
+    inc l00f7                                                         ; b9ac: e6 f7       ..
+; $b9ae referenced 1 time by $b9aa
+cb9ae
+    inx                                                               ; b9ae: e8          .
+    cpx #4                                                            ; b9af: e0 04       ..
+    bcc loop_cb999                                                    ; b9b1: 90 e6       ..
+    lda #2                                                            ; b9b3: a9 02       ..
+    sta l00bf                                                         ; b9b5: 85 bf       ..
+    ldx #$0f                                                          ; b9b7: a2 0f       ..
+    lda #$80                                                          ; b9b9: a9 80       ..
+    sta l00f7                                                         ; b9bb: 85 f7       ..
+; $b9bd referenced 1 time by $b9cf
+loop_cb9bd
+    stx osrdsc_ptr                                                    ; b9bd: 86 f6       ..
+    pla                                                               ; b9bf: 68          h
+    pha                                                               ; b9c0: 48          H
+    tay                                                               ; b9c1: a8          .
+    jsr osrdsc                                                        ; b9c2: 20 b9 ff     ..
+    ldx osrdsc_ptr                                                    ; b9c5: a6 f6       ..
+    cmp lb872,x                                                       ; b9c7: dd 72 b8    .r.
+    bne cb9d9                                                         ; b9ca: d0 0d       ..
+; $b9cc referenced 1 time by $b9e5
+loop_cb9cc
+    dex                                                               ; b9cc: ca          .
+    cpx #6                                                            ; b9cd: e0 06       ..
+    bcs loop_cb9bd                                                    ; b9cf: b0 ec       ..
+; $b9d1 referenced 1 time by $b9ec
+loop_cb9d1
+    clc                                                               ; b9d1: 18          .
+; $b9d2 referenced 1 time by $b9f3
+cb9d2
+    pla                                                               ; b9d2: 68          h
+    tay                                                               ; b9d3: a8          .
+    pla                                                               ; b9d4: 68          h
+    tax                                                               ; b9d5: aa          .
+    lda l00bf                                                         ; b9d6: a5 bf       ..
+    rts                                                               ; b9d8: 60          `
+
+; $b9d9 referenced 1 time by $b9ca
+cb9d9
+    cpx #$0a                                                          ; b9d9: e0 0a       ..
+    bne cb9e8                                                         ; b9db: d0 0b       ..
+    cmp #$4f ; 'O'                                                    ; b9dd: c9 4f       .O
+    bne cb9e8                                                         ; b9df: d0 07       ..
+    lda #1                                                            ; b9e1: a9 01       ..
+    sta l00bf                                                         ; b9e3: 85 bf       ..
+    jmp loop_cb9cc                                                    ; b9e5: 4c cc b9    L..
+
+; $b9e8 referenced 2 times by $b9db, $b9df
+cb9e8
+    lda #0                                                            ; b9e8: a9 00       ..
+    sta l00bf                                                         ; b9ea: 85 bf       ..
+    beq loop_cb9d1                                                    ; b9ec: f0 e3       ..
+; $b9ee referenced 1 time by $b9a6
+cb9ee
+    lda #$ff                                                          ; b9ee: a9 ff       ..
+    sta l00bf                                                         ; b9f0: 85 bf       ..
+    sec                                                               ; b9f2: 38          8
+    bcs cb9d2                                                         ; b9f3: b0 dd       ..
+; $b9f5 referenced 2 times by $b225, $b297
+sub_cb9f5
+    ldx #0                                                            ; b9f5: a2 00       ..
+; $b9f7 referenced 1 time by $ba25
+cb9f7
+    tya                                                               ; b9f7: 98          .
+    pha                                                               ; b9f8: 48          H
+; $b9f9 referenced 1 time by $ba0e
+loop_cb9f9
+    lda (os_text_ptr),y                                               ; b9f9: b1 f2       ..
+    bmi cba10                                                         ; b9fb: 30 13       0.
+    cmp #$2e ; '.'                                                    ; b9fd: c9 2e       ..
+    beq cba19                                                         ; b9ff: f0 18       ..
+    cmp #$41 ; 'A'                                                    ; ba01: c9 41       .A
+    bcc cba10                                                         ; ba03: 90 0b       ..
+    eor sram_table,x                                                  ; ba05: 5d 30 ba    ]0.
+    and #$df                                                          ; ba08: 29 df       ).
+    bne cba15                                                         ; ba0a: d0 09       ..
+    iny                                                               ; ba0c: c8          .
+    inx                                                               ; ba0d: e8          .
+    bne loop_cb9f9                                                    ; ba0e: d0 e9       ..
+; $ba10 referenced 2 times by $b9fb, $ba03
+cba10
+    lda sram_table,x                                                  ; ba10: bd 30 ba    .0.
+    bmi cba28                                                         ; ba13: 30 13       0.
+; $ba15 referenced 1 time by $ba0a
+cba15
+    clc                                                               ; ba15: 18          .
+    pla                                                               ; ba16: 68          h
+    tay                                                               ; ba17: a8          .
+    dey                                                               ; ba18: 88          .
+; $ba19 referenced 1 time by $b9ff
+cba19
+    iny                                                               ; ba19: c8          .
+; $ba1a referenced 1 time by $ba20
+loop_cba1a
+    inx                                                               ; ba1a: e8          .
+    lda cba2f,x                                                       ; ba1b: bd 2f ba    ./.
+    beq cba2e                                                         ; ba1e: f0 0e       ..
+    bpl loop_cba1a                                                    ; ba20: 10 f8       ..
+    bcs cba27                                                         ; ba22: b0 03       ..
+    inx                                                               ; ba24: e8          .
+    bcc cb9f7                                                         ; ba25: 90 d0       ..
+; $ba27 referenced 1 time by $ba22
+cba27
+    dex                                                               ; ba27: ca          .
+; $ba28 referenced 1 time by $ba13
+cba28
+    pla                                                               ; ba28: 68          h
+    jsr sub_cbab9                                                     ; ba29: 20 b9 ba     ..
+    clc                                                               ; ba2c: 18          .
+    rts                                                               ; ba2d: 60          `
+
+; $ba2e referenced 1 time by $ba1e
+cba2e
+    sec                                                               ; ba2e: 38          8
+; $ba2f referenced 1 time by $ba1b
+cba2f
+    rts                                                               ; ba2f: 60          `
+
+; $ba30 referenced 3 times by $b234, $ba05, $ba10
+sram_table
+    !text "SRAM"                                                      ; ba30: 53 52 41... SRA
+; $ba31 referenced 1 time by $b238
+    !byte $ff, $ff                                                    ; ba34: ff ff       ..
+    !text "SRLOAD"                                                    ; ba36: 53 52 4c... SRL
+    !byte >(sub_cbb46-1)                                              ; ba3c: bb          .
+    !byte <(sub_cbb46-1)                                              ; ba3d: 45          E
+    !text "SRSAVE"                                                    ; ba3e: 53 52 53... SRS
+    !byte >(sub_cbb4a-1)                                              ; ba44: bb          .
+    !byte <(sub_cbb4a-1)                                              ; ba45: 49          I
+    !text "SRWRITE"                                                   ; ba46: 53 52 57... SRW
+    !byte >(sub_cbbd3-1)                                              ; ba4d: bb          .
+    !byte <(sub_cbbd3-1)                                              ; ba4e: d2          .
+    !text "SRREAD"                                                    ; ba4f: 53 52 52... SRR
+    !byte >(sub_cbbd7-1)                                              ; ba55: bb          .
+    !byte <(sub_cbbd7-1)                                              ; ba56: d6          .
+    !text "SRDATA"                                                    ; ba57: 53 52 44... SRD
+    !byte >(sub_cbc37-1)                                              ; ba5d: bc          .
+    !byte <(sub_cbc37-1)                                              ; ba5e: 36          6
+    !text "SRROM"                                                     ; ba5f: 53 52 52... SRR
+    !byte >(sub_cbc81-1)                                              ; ba64: bc          .
+    !byte <(sub_cbc81-1)                                              ; ba65: 80          .
+    !byte 0                                                           ; ba66: 00          .
+
+; $ba67 referenced 5 times by $bb51, $bb6c, $bbdd, $bbf3, $bc1c
+sub_cba67
+    txa                                                               ; ba67: 8a          .
+    pha                                                               ; ba68: 48          H
+    jsr sub_cbab9                                                     ; ba69: 20 b9 ba     ..
+    lda #0                                                            ; ba6c: a9 00       ..
+    sta l00bc                                                         ; ba6e: 85 bc       ..
+    sta l00bd                                                         ; ba70: 85 bd       ..
+    sta l00be                                                         ; ba72: 85 be       ..
+    sta l00bf                                                         ; ba74: 85 bf       ..
+    sec                                                               ; ba76: 38          8
+    php                                                               ; ba77: 08          .
+; $ba78 referenced 1 time by $baae
+cba78
+    lda (os_text_ptr),y                                               ; ba78: b1 f2       ..
+    cmp #$30 ; '0'                                                    ; ba7a: c9 30       .0
+    bcc cbab4                                                         ; ba7c: 90 36       .6
+    cmp #$3a ; ':'                                                    ; ba7e: c9 3a       .:
+    bcc cba8c                                                         ; ba80: 90 0a       ..
+    cmp #$47 ; 'G'                                                    ; ba82: c9 47       .G
+    bcs cbab4                                                         ; ba84: b0 2e       ..
+    cmp #$41 ; 'A'                                                    ; ba86: c9 41       .A
+    bcc cbab4                                                         ; ba88: 90 2a       .*
+    sbc #7                                                            ; ba8a: e9 07       ..
+; $ba8c referenced 1 time by $ba80
+cba8c
+    sec                                                               ; ba8c: 38          8
+    sbc #$30 ; '0'                                                    ; ba8d: e9 30       .0
+    plp                                                               ; ba8f: 28          (
+    php                                                               ; ba90: 08          .
+    pha                                                               ; ba91: 48          H
+    ldx #4                                                            ; ba92: a2 04       ..
+; $ba94 referenced 1 time by $baa1
+loop_cba94
+    asl l00bc                                                         ; ba94: 06 bc       ..
+    rol l00bd                                                         ; ba96: 26 bd       &.
+    bvc cba9e                                                         ; ba98: 50 04       P.
+    rol l00be                                                         ; ba9a: 26 be       &.
+    rol l00bf                                                         ; ba9c: 26 bf       &.
+; $ba9e referenced 1 time by $ba98
+cba9e
+    bcs cbab0                                                         ; ba9e: b0 10       ..
+    dex                                                               ; baa0: ca          .
+    bne loop_cba94                                                    ; baa1: d0 f1       ..
+    pla                                                               ; baa3: 68          h
+    ora l00bc                                                         ; baa4: 05 bc       ..
+    sta l00bc                                                         ; baa6: 85 bc       ..
+    plp                                                               ; baa8: 28          (
+    clc                                                               ; baa9: 18          .
+    php                                                               ; baaa: 08          .
+    iny                                                               ; baab: c8          .
+    beq cbab1                                                         ; baac: f0 03       ..
+    bcc cba78                                                         ; baae: 90 c8       ..
+; $bab0 referenced 1 time by $ba9e
+cbab0
+    pla                                                               ; bab0: 68          h
+; $bab1 referenced 1 time by $baac
+cbab1
+    plp                                                               ; bab1: 28          (
+    sec                                                               ; bab2: 38          8
+    php                                                               ; bab3: 08          .
+; $bab4 referenced 3 times by $ba7c, $ba84, $ba88
+cbab4
+    plp                                                               ; bab4: 28          (
+    pla                                                               ; bab5: 68          h
+    tax                                                               ; bab6: aa          .
+    rts                                                               ; bab7: 60          `
+
+; $bab8 referenced 1 time by $babd
+loop_cbab8
+    iny                                                               ; bab8: c8          .
+; $bab9 referenced 7 times by $ba29, $ba69, $bac5, $bad2, $bb02, $bb2b, $bbb0
+sub_cbab9
+    lda (os_text_ptr),y                                               ; bab9: b1 f2       ..
+    cmp #$20 ; ' '                                                    ; babb: c9 20       .
+    beq loop_cbab8                                                    ; babd: f0 f9       ..
+    cmp #$0d                                                          ; babf: c9 0d       ..
+    rts                                                               ; bac1: 60          `
+
+; $bac2 referenced 4 times by $bbbe, $bc2c, $bc3d, $bc87
+sub_cbac2
+    lda #$0d                                                          ; bac2: a9 0d       ..
+; $bac4 referenced 3 times by $b26e, $bb67, $bbed
+sub_cbac4
+    pha                                                               ; bac4: 48          H
+    jsr sub_cbab9                                                     ; bac5: 20 b9 ba     ..
+    pla                                                               ; bac8: 68          h
+    cmp (os_text_ptr),y                                               ; bac9: d1 f2       ..
+    bne cbad0                                                         ; bacb: d0 03       ..
+    clc                                                               ; bacd: 18          .
+    iny                                                               ; bace: c8          .
+    rts                                                               ; bacf: 60          `
+
+; $bad0 referenced 1 time by $bacb
+cbad0
+    sec                                                               ; bad0: 38          8
+    rts                                                               ; bad1: 60          `
+
+; $bad2 referenced 1 time by $bb4d
+sub_cbad2
+    jsr sub_cbab9                                                     ; bad2: 20 b9 ba     ..
+    tya                                                               ; bad5: 98          .
+    pha                                                               ; bad6: 48          H
+    clc                                                               ; bad7: 18          .
+    adc os_text_ptr                                                   ; bad8: 65 f2       e.
+    ldy #$ef                                                          ; bada: a0 ef       ..
+    sta (l00b8),y                                                     ; badc: 91 b8       ..
+    lda l00f3                                                         ; bade: a5 f3       ..
+    adc #0                                                            ; bae0: 69 00       i.
+    iny                                                               ; bae2: c8          .
+    sta (l00b8),y                                                     ; bae3: 91 b8       ..
+    pla                                                               ; bae5: 68          h
+    tay                                                               ; bae6: a8          .
+    bit lb57f                                                         ; bae7: 2c 7f b5    ,..
+; $baea referenced 1 time by $baf6
+loop_cbaea
+    lda (os_text_ptr),y                                               ; baea: b1 f2       ..
+    cmp #$20 ; ' '                                                    ; baec: c9 20       .
+    beq cbafd                                                         ; baee: f0 0d       ..
+    cmp #$0d                                                          ; baf0: c9 0d       ..
+    beq cbafd                                                         ; baf2: f0 09       ..
+    clv                                                               ; baf4: b8          .
+    iny                                                               ; baf5: c8          .
+    bne loop_cbaea                                                    ; baf6: d0 f2       ..
+; $baf8 referenced 2 times by $bafd, $bbd0
+cbaf8
+    ldx #3                                                            ; baf8: a2 03       ..
+    jmp cb8fb                                                         ; bafa: 4c fb b8    L..
+
+; $bafd referenced 2 times by $baee, $baf2
+cbafd
+    bvs cbaf8                                                         ; bafd: 70 f9       p.
+    rts                                                               ; baff: 60          `
+
+; $bb00 referenced 4 times by $bb92, $bc21, $bc37, $bc81
+sub_cbb00
+    stx l00bf                                                         ; bb00: 86 bf       ..
+    jsr sub_cbab9                                                     ; bb02: 20 b9 ba     ..
+    ldx #3                                                            ; bb05: a2 03       ..
+; $bb07 referenced 1 time by $bb34
+cbb07
+    cmp lbb3e,x                                                       ; bb07: dd 3e bb    .>.
+    bcs cbb36                                                         ; bb0a: b0 2a       .*
+    cmp lbb3a,x                                                       ; bb0c: dd 3a bb    .:.
+    bcc cbb33                                                         ; bb0f: 90 22       ."
+    sbc lbb42,x                                                       ; bb11: fd 42 bb    .B.
+    iny                                                               ; bb14: c8          .
+    cmp #1                                                            ; bb15: c9 01       ..
+    bne cbb2a                                                         ; bb17: d0 11       ..
+    lda (os_text_ptr),y                                               ; bb19: b1 f2       ..
+    cmp #$36 ; '6'                                                    ; bb1b: c9 36       .6
+    bcs cbb28                                                         ; bb1d: b0 09       ..
+    cmp #$30 ; '0'                                                    ; bb1f: c9 30       .0
+    bcc cbb28                                                         ; bb21: 90 05       ..
+    sbc #$26 ; '&'                                                    ; bb23: e9 26       .&
+    iny                                                               ; bb25: c8          .
+    bne cbb2a                                                         ; bb26: d0 02       ..
+; $bb28 referenced 2 times by $bb1d, $bb21
+cbb28
+    lda #1                                                            ; bb28: a9 01       ..
+; $bb2a referenced 2 times by $bb17, $bb26
+cbb2a
+    pha                                                               ; bb2a: 48          H
+    jsr sub_cbab9                                                     ; bb2b: 20 b9 ba     ..
+    pla                                                               ; bb2e: 68          h
+    ldx l00bf                                                         ; bb2f: a6 bf       ..
+    clc                                                               ; bb31: 18          .
+    rts                                                               ; bb32: 60          `
+
+; $bb33 referenced 1 time by $bb0f
+cbb33
+    dex                                                               ; bb33: ca          .
+    bpl cbb07                                                         ; bb34: 10 d1       ..
+; $bb36 referenced 1 time by $bb0a
+cbb36
+    ldx l00bf                                                         ; bb36: a6 bf       ..
+    sec                                                               ; bb38: 38          8
+    rts                                                               ; bb39: 60          `
+
+; $bb3a referenced 1 time by $bb0c
+lbb3a
+    !text "0AWw"                                                      ; bb3a: 30 41 57... 0AW
+; $bb3e referenced 1 time by $bb07
+lbb3e
+    !text ":G[{"                                                      ; bb3e: 3a 47 5b... :G[
+; $bb42 referenced 1 time by $bb11
+lbb42
+    !text "07Gg"                                                      ; bb42: 30 37 47... 07G
+
+sub_cbb46
+    lda #$c0                                                          ; bb46: a9 c0       ..
+    bne cbb4c                                                         ; bb48: d0 02       ..
+sub_cbb4a
+    lda #$40 ; '@'                                                    ; bb4a: a9 40       .@
+; $bb4c referenced 1 time by $bb48
+cbb4c
+    pha                                                               ; bb4c: 48          H
+    jsr sub_cbad2                                                     ; bb4d: 20 d2 ba     ..
+    clv                                                               ; bb50: b8          .
+    jsr sub_cba67                                                     ; bb51: 20 67 ba     g.
+    bcs cbb6f                                                         ; bb54: b0 19       ..
+    sty l00ba                                                         ; bb56: 84 ba       ..
+    ldx #$bc                                                          ; bb58: a2 bc       ..
+    ldy #$f2                                                          ; bb5a: a0 f2       ..
+    jsr sub_cb850                                                     ; bb5c: 20 50 b8     P.
+    ldy l00ba                                                         ; bb5f: a4 ba       ..
+    pla                                                               ; bb61: 68          h
+    pha                                                               ; bb62: 48          H
+    bmi cbb90                                                         ; bb63: 30 2b       0+
+    lda #$2b ; '+'                                                    ; bb65: a9 2b       .+
+    jsr sub_cbac4                                                     ; bb67: 20 c4 ba     ..
+    php                                                               ; bb6a: 08          .
+    clv                                                               ; bb6b: b8          .
+    jsr sub_cba67                                                     ; bb6c: 20 67 ba     g.
+; $bb6f referenced 1 time by $bb54
+cbb6f
+    bcs cbbd0                                                         ; bb6f: b0 5f       ._
+    sty l00ba                                                         ; bb71: 84 ba       ..
+    plp                                                               ; bb73: 28          (
+    bcc cbb89                                                         ; bb74: 90 13       ..
+    ldy #$f2                                                          ; bb76: a0 f2       ..
+    sec                                                               ; bb78: 38          8
+    lda l00bc                                                         ; bb79: a5 bc       ..
+    sec                                                               ; bb7b: 38          8
+    sbc (l00b8),y                                                     ; bb7c: f1 b8       ..
+    sta l00bc                                                         ; bb7e: 85 bc       ..
+    iny                                                               ; bb80: c8          .
+    lda l00bd                                                         ; bb81: a5 bd       ..
+    sbc (l00b8),y                                                     ; bb83: f1 b8       ..
+    bcc cbbd0                                                         ; bb85: 90 49       .I
+    sta l00bd                                                         ; bb87: 85 bd       ..
+; $bb89 referenced 1 time by $bb74
+cbb89
+    ldx #$bc                                                          ; bb89: a2 bc       ..
+    ldy #$f4                                                          ; bb8b: a0 f4       ..
+    jsr sub_cb850                                                     ; bb8d: 20 50 b8     P.
+; $bb90 referenced 1 time by $bb63
+cbb90
+    ldy l00ba                                                         ; bb90: a4 ba       ..
+    jsr sub_cbb00                                                     ; bb92: 20 00 bb     ..
+    sty l00ba                                                         ; bb95: 84 ba       ..
+    bcs cbba1                                                         ; bb97: b0 08       ..
+    ldy #$f1                                                          ; bb99: a0 f1       ..
+    sta (l00b8),y                                                     ; bb9b: 91 b8       ..
+    pla                                                               ; bb9d: 68          h
+    and #$80                                                          ; bb9e: 29 80       ).
+    pha                                                               ; bba0: 48          H
+; $bba1 referenced 1 time by $bb97
+cbba1
+    pla                                                               ; bba1: 68          h
+    sta l00bb                                                         ; bba2: 85 bb       ..
+    ldy #$ee                                                          ; bba4: a0 ee       ..
+    lda (l00b8),y                                                     ; bba6: b1 b8       ..
+    and #$3f ; '?'                                                    ; bba8: 29 3f       )?
+    ora l00bb                                                         ; bbaa: 05 bb       ..
+    sta (l00b8),y                                                     ; bbac: 91 b8       ..
+    ldy l00ba                                                         ; bbae: a4 ba       ..
+    jsr sub_cbab9                                                     ; bbb0: 20 b9 ba     ..
+    and #$df                                                          ; bbb3: 29 df       ).
+    ldx #0                                                            ; bbb5: a2 00       ..
+    cmp #$51 ; 'Q'                                                    ; bbb7: c9 51       .Q
+    bne cbbbe                                                         ; bbb9: d0 03       ..
+    iny                                                               ; bbbb: c8          .
+    ldx #$ff                                                          ; bbbc: a2 ff       ..
+; $bbbe referenced 1 time by $bbb9
+cbbbe
+    jsr sub_cbac2                                                     ; bbbe: 20 c2 ba     ..
+    bcs cbbd0                                                         ; bbc1: b0 0d       ..
+    ldy #$f8                                                          ; bbc3: a0 f8       ..
+    lda #0                                                            ; bbc5: a9 00       ..
+    sta (l00b8),y                                                     ; bbc7: 91 b8       ..
+    iny                                                               ; bbc9: c8          .
+    txa                                                               ; bbca: 8a          .
+    sta (l00b8),y                                                     ; bbcb: 91 b8       ..
+    jmp cb2e7                                                         ; bbcd: 4c e7 b2    L..
+
+; $bbd0 referenced 9 times by $bb6f, $bb85, $bbc1, $bbe0, $bbf6, $bc1f, $bc2f, $bc3a, $bc40
+cbbd0
+    jmp cbaf8                                                         ; bbd0: 4c f8 ba    L..
+
+sub_cbbd3
+    lda #$c0                                                          ; bbd3: a9 c0       ..
+    bne cbbd9                                                         ; bbd5: d0 02       ..
+sub_cbbd7
+    lda #$40 ; '@'                                                    ; bbd7: a9 40       .@
+; $bbd9 referenced 1 time by $bbd5
+cbbd9
+    pha                                                               ; bbd9: 48          H
+    bit lb57f                                                         ; bbda: 2c 7f b5    ,..
+    jsr sub_cba67                                                     ; bbdd: 20 67 ba     g.
+    bcs cbbd0                                                         ; bbe0: b0 ee       ..
+    ldx #3                                                            ; bbe2: a2 03       ..
+; $bbe4 referenced 1 time by $bbe9
+loop_cbbe4
+    lda l00bc,x                                                       ; bbe4: b5 bc       ..
+    sta l00b1,x                                                       ; bbe6: 95 b1       ..
+    dex                                                               ; bbe8: ca          .
+    bpl loop_cbbe4                                                    ; bbe9: 10 f9       ..
+    lda #$2b ; '+'                                                    ; bbeb: a9 2b       .+
+    jsr sub_cbac4                                                     ; bbed: 20 c4 ba     ..
+    bcs cbbf3                                                         ; bbf0: b0 01       ..
+    clv                                                               ; bbf2: b8          .
+; $bbf3 referenced 1 time by $bbf0
+cbbf3
+    jsr sub_cba67                                                     ; bbf3: 20 67 ba     g.
+    bcs cbbd0                                                         ; bbf6: b0 d8       ..
+    bvc cbc13                                                         ; bbf8: 50 19       P.
+    sec                                                               ; bbfa: 38          8
+    ldx #0                                                            ; bbfb: a2 00       ..
+    sec                                                               ; bbfd: 38          8
+; $bbfe referenced 1 time by $bc08
+loop_cbbfe
+    lda l00bc,x                                                       ; bbfe: b5 bc       ..
+    sbc l00b1,x                                                       ; bc00: f5 b1       ..
+    sta l00bc,x                                                       ; bc02: 95 bc       ..
+    inx                                                               ; bc04: e8          .
+    txa                                                               ; bc05: 8a          .
+    and #4                                                            ; bc06: 29 04       ).
+    beq loop_cbbfe                                                    ; bc08: f0 f4       ..
+    lda l00be                                                         ; bc0a: a5 be       ..
+    ora l00bf                                                         ; bc0c: 05 bf       ..
+    beq cbc13                                                         ; bc0e: f0 03       ..
+    jmp cb446                                                         ; bc10: 4c 46 b4    LF.
+
+; $bc13 referenced 2 times by $bbf8, $bc0e
+cbc13
+    lda l00bc                                                         ; bc13: a5 bc       ..
+    sta l00b5                                                         ; bc15: 85 b5       ..
+    lda l00bd                                                         ; bc17: a5 bd       ..
+    sta l00b6                                                         ; bc19: 85 b6       ..
+    clv                                                               ; bc1b: b8          .
+    jsr sub_cba67                                                     ; bc1c: 20 67 ba     g.
+    bcs cbbd0                                                         ; bc1f: b0 af       ..
+    jsr sub_cbb00                                                     ; bc21: 20 00 bb     ..
+    bcs cbc2c                                                         ; bc24: b0 06       ..
+    sta l00b7                                                         ; bc26: 85 b7       ..
+    pla                                                               ; bc28: 68          h
+    and #$bf                                                          ; bc29: 29 bf       ).
+    pha                                                               ; bc2b: 48          H
+; $bc2c referenced 1 time by $bc24
+cbc2c
+    jsr sub_cbac2                                                     ; bc2c: 20 c2 ba     ..
+    bcs cbbd0                                                         ; bc2f: b0 9f       ..
+    pla                                                               ; bc31: 68          h
+    sta l00b0                                                         ; bc32: 85 b0       ..
+    jmp cbcb9                                                         ; bc34: 4c b9 bc    L..
+
+sub_cbc37
+    jsr sub_cbb00                                                     ; bc37: 20 00 bb     ..
+; $bc3a referenced 2 times by $bc84, $bc8a
+cbc3a
+    bcs cbbd0                                                         ; bc3a: b0 94       ..
+    pha                                                               ; bc3c: 48          H
+    jsr sub_cbac2                                                     ; bc3d: 20 c2 ba     ..
+    bcs cbbd0                                                         ; bc40: b0 8e       ..
+    pla                                                               ; bc42: 68          h
+    tay                                                               ; bc43: a8          .
+    jsr sub_cb6fe                                                     ; bc44: 20 fe b6     ..
+    bne cbc64                                                         ; bc47: d0 1b       ..
+    jsr sub_cb986                                                     ; bc49: 20 86 b9     ..
+    tax                                                               ; bc4c: aa          .
+    bne cbc54                                                         ; bc4d: d0 05       ..
+    ldx #5                                                            ; bc4f: a2 05       ..
+    jmp cb8fb                                                         ; bc51: 4c fb b8    L..
+
+; $bc54 referenced 1 time by $bc4d
+cbc54
+    sty l00bf                                                         ; bc54: 84 bf       ..
+    lda lb726,y                                                       ; bc56: b9 26 b7    .&.
+    ldy #$fd                                                          ; bc59: a0 fd       ..
+    ora (l00b8),y                                                     ; bc5b: 11 b8       ..
+    sta (l00b8),y                                                     ; bc5d: 91 b8       ..
+    ldy l00bf                                                         ; bc5f: a4 bf       ..
+    jsr sub_cbc68                                                     ; bc61: 20 68 bc     h.
+; $bc64 referenced 1 time by $bc47
+cbc64
+    jsr sub_cbec2                                                     ; bc64: 20 c2 be     ..
+    rts                                                               ; bc67: 60          `
+
+; $bc68 referenced 2 times by $bc61, $bc95
+sub_cbc68
+    ldx #$0f                                                          ; bc68: a2 0f       ..
+    stx l00ba                                                         ; bc6a: 86 ba       ..
+    lda #$80                                                          ; bc6c: a9 80       ..
+    sta l00bb                                                         ; bc6e: 85 bb       ..
+; $bc70 referenced 1 time by $bc7e
+loop_cbc70
+    lda lb872,x                                                       ; bc70: bd 72 b8    .r.
+    cpx #1                                                            ; bc73: e0 01       ..
+    bne cbc78                                                         ; bc75: d0 01       ..
+    tya                                                               ; bc77: 98          .
+; $bc78 referenced 1 time by $bc75
+cbc78
+    jsr sub_cb745                                                     ; bc78: 20 45 b7     E.
+    dex                                                               ; bc7b: ca          .
+    stx l00ba                                                         ; bc7c: 86 ba       ..
+    bpl loop_cbc70                                                    ; bc7e: 10 f0       ..
+    rts                                                               ; bc80: 60          `
+
+sub_cbc81
+    jsr sub_cbb00                                                     ; bc81: 20 00 bb     ..
+    bcs cbc3a                                                         ; bc84: b0 b4       ..
+    pha                                                               ; bc86: 48          H
+    jsr sub_cbac2                                                     ; bc87: 20 c2 ba     ..
+    bcs cbc3a                                                         ; bc8a: b0 ae       ..
+    pla                                                               ; bc8c: 68          h
+    tay                                                               ; bc8d: a8          .
+    jsr sub_cb6fe                                                     ; bc8e: 20 fe b6     ..
+    beq cbcb2                                                         ; bc91: f0 1f       ..
+; $bc93 referenced 1 time by $bcb6
+cbc93
+    sty l00bc                                                         ; bc93: 84 bc       ..
+    jsr sub_cbc68                                                     ; bc95: 20 68 bc     h.
+    lda #$0a                                                          ; bc98: a9 0a       ..
+    sta l00ba                                                         ; bc9a: 85 ba       ..
+    lda #$4f ; 'O'                                                    ; bc9c: a9 4f       .O
+    jsr sub_cb745                                                     ; bc9e: 20 45 b7     E.
+    lda lb726,y                                                       ; bca1: b9 26 b7    .&.
+    eor #$ff                                                          ; bca4: 49 ff       I.
+    ldy #$fd                                                          ; bca6: a0 fd       ..
+    and (l00b8),y                                                     ; bca8: 31 b8       1.
+    sta (l00b8),y                                                     ; bcaa: 91 b8       ..
+    ldy l00bc                                                         ; bcac: a4 bc       ..
+    jsr sub_cbec2                                                     ; bcae: 20 c2 be     ..
+    rts                                                               ; bcb1: 60          `
+
+; $bcb2 referenced 1 time by $bc91
+cbcb2
+    jsr sub_cb986                                                     ; bcb2: 20 86 b9     ..
+    tax                                                               ; bcb5: aa          .
+    bne cbc93                                                         ; bcb6: d0 db       ..
+    rts                                                               ; bcb8: 60          `
+
+; $bcb9 referenced 2 times by $b1f6, $bc34
+cbcb9
+    lda l00b0                                                         ; bcb9: a5 b0       ..
+    and #$c0                                                          ; bcbb: 29 c0       ).
+    sta l00be                                                         ; bcbd: 85 be       ..
+    ldy #$ee                                                          ; bcbf: a0 ee       ..
+    lda (l00b8),y                                                     ; bcc1: b1 b8       ..
+    and #$3f ; '?'                                                    ; bcc3: 29 3f       )?
+    ora l00be                                                         ; bcc5: 05 be       ..
+    sta (l00b8),y                                                     ; bcc7: 91 b8       ..
+    bit l00b0                                                         ; bcc9: 24 b0       $.
+    bvs cbcd6                                                         ; bccb: 70 09       p.
+    ldy l00b7                                                         ; bccd: a4 b7       ..
+    cpy #$14                                                          ; bccf: c0 14       ..
+    bcc cbce1                                                         ; bcd1: 90 0e       ..
+; $bcd3 referenced 1 time by $bcef
+loop_cbcd3
+    jmp cb300                                                         ; bcd3: 4c 00 b3    L..
+
+; $bcd6 referenced 1 time by $bccb
+cbcd6
+    ldx l00bc                                                         ; bcd6: a6 bc       ..
+    lda l00bd                                                         ; bcd8: a5 bd       ..
+    jsr sub_cb6b1                                                     ; bcda: 20 b1 b6     ..
+    stx l00bc                                                         ; bcdd: 86 bc       ..
+    sta l00bd                                                         ; bcdf: 85 bd       ..
+; $bce1 referenced 1 time by $bcd1
+cbce1
+    jsr sub_cb6fe                                                     ; bce1: 20 fe b6     ..
+    pha                                                               ; bce4: 48          H
+    tya                                                               ; bce5: 98          .
+    ldy #$f1                                                          ; bce6: a0 f1       ..
+    sta (l00b8),y                                                     ; bce8: 91 b8       ..
+    pla                                                               ; bcea: 68          h
+    eor l00b0                                                         ; bceb: 45 b0       E.
+    and #$40 ; '@'                                                    ; bced: 29 40       )@
+    bne loop_cbcd3                                                    ; bcef: d0 e2       ..
+    jsr sub_cbe9d                                                     ; bcf1: 20 9d be     ..
+    jsr sub_cbe91                                                     ; bcf4: 20 91 be     ..
+    bcs cbd1b                                                         ; bcf7: b0 22       ."
+; $bcf9 referenced 1 time by $bd21
+cbcf9
+    ldx #$b5                                                          ; bcf9: a2 b5       ..
+    ldy #$be                                                          ; bcfb: a0 be       ..
+    jsr sub_cb580                                                     ; bcfd: 20 80 b5     ..
+    rol l00b0                                                         ; bd00: 26 b0       &.
+    bcc cbd0e                                                         ; bd02: 90 0a       ..
+    ldx #$bc                                                          ; bd04: a2 bc       ..
+    ldy #$b3                                                          ; bd06: a0 b3       ..
+; $bd08 referenced 1 time by $bd19
+loop_cbd08
+    jsr sub_cb580                                                     ; bd08: 20 80 b5     ..
+    jmp cb795                                                         ; bd0b: 4c 95 b7    L..
+
+; $bd0e referenced 1 time by $bd02
+cbd0e
+    ldx #$b1                                                          ; bd0e: a2 b1       ..
+    ldy #$b3                                                          ; bd10: a0 b3       ..
+    jsr sub_cb580                                                     ; bd12: 20 80 b5     ..
+    ldx #$bc                                                          ; bd15: a2 bc       ..
+    ldy #$b1                                                          ; bd17: a0 b1       ..
+    bne loop_cbd08                                                    ; bd19: d0 ed       ..
+; $bd1b referenced 1 time by $bcf7
+cbd1b
+    lda l00b3                                                         ; bd1b: a5 b3       ..
+    and l00b4                                                         ; bd1d: 25 b4       %.
+    cmp #$ff                                                          ; bd1f: c9 ff       ..
+    beq cbcf9                                                         ; bd21: f0 d6       ..
+    lda l00bc                                                         ; bd23: a5 bc       ..
+    pha                                                               ; bd25: 48          H
+    lda l00bd                                                         ; bd26: a5 bd       ..
+    pha                                                               ; bd28: 48          H
+    ldx #3                                                            ; bd29: a2 03       ..
+; $bd2b referenced 1 time by $bd30
+loop_cbd2b
+    lda l00b1,x                                                       ; bd2b: b5 b1       ..
+    sta l00ba,x                                                       ; bd2d: 95 ba       ..
+    dex                                                               ; bd2f: ca          .
+    bpl loop_cbd2b                                                    ; bd30: 10 f9       ..
+    ldx #$b5                                                          ; bd32: a2 b5       ..
+    ldy #$f4                                                          ; bd34: a0 f4       ..
+    jsr sub_cb850                                                     ; bd36: 20 50 b8     P.
+    bit l00b0                                                         ; bd39: 24 b0       $.
+    bmi cbd40                                                         ; bd3b: 30 03       0.
+    jmp cbdba                                                         ; bd3d: 4c ba bd    L..
+
+; $bd40 referenced 1 time by $bd3b
+cbd40
+    pla                                                               ; bd40: 68          h
+    sta l00b4                                                         ; bd41: 85 b4       ..
+    pla                                                               ; bd43: 68          h
+    sta l00b3                                                         ; bd44: 85 b3       ..
+; $bd46 referenced 1 time by $bdb6
+cbd46
+    ldx #$be                                                          ; bd46: a2 be       ..
+    ldy #$f4                                                          ; bd48: a0 f4       ..
+    jsr sub_cb841                                                     ; bd4a: 20 41 b8     A.
+    lda l00bf                                                         ; bd4d: a5 bf       ..
+    bne cbd7e                                                         ; bd4f: d0 2d       .-
+    ldx l00be                                                         ; bd51: a6 be       ..
+    beq cbdb9                                                         ; bd53: f0 64       .d
+    lda #0                                                            ; bd55: a9 00       ..
+    sta (l00b8),y                                                     ; bd57: 91 b8       ..
+    inc l00b9                                                         ; bd59: e6 b9       ..
+    jsr cbe7b                                                         ; bd5b: 20 7b be     {.
+    lda #0                                                            ; bd5e: a9 00       ..
+    ldx #$ba                                                          ; bd60: a2 ba       ..
+    ldy #0                                                            ; bd62: a0 00       ..
+    jsr tube_entry                                                    ; bd64: 20 06 04     ..
+    ldy #7                                                            ; bd67: a0 07       ..
+    jsr cbe89                                                         ; bd69: 20 89 be     ..
+; $bd6c referenced 1 time by $bd7a
+loop_cbd6c
+    lda tube_host_r3_data                                             ; bd6c: ad e5 fe    ...
+    sta (l00b8),y                                                     ; bd6f: 91 b8       ..
+    ldx #3                                                            ; bd71: a2 03       ..
+    jsr cbe8d                                                         ; bd73: 20 8d be     ..
+    nop                                                               ; bd76: ea          .
+    iny                                                               ; bd77: c8          .
+    cpy l00be                                                         ; bd78: c4 be       ..
+    bne loop_cbd6c                                                    ; bd7a: d0 f0       ..
+    beq cbda3                                                         ; bd7c: f0 25       .%
+; $bd7e referenced 1 time by $bd4f
+cbd7e
+    lda #0                                                            ; bd7e: a9 00       ..
+    sta l00be                                                         ; bd80: 85 be       ..
+    lda #1                                                            ; bd82: a9 01       ..
+    sta l00bf                                                         ; bd84: 85 bf       ..
+    inc l00b9                                                         ; bd86: e6 b9       ..
+    jsr cbe7b                                                         ; bd88: 20 7b be     {.
+    lda #6                                                            ; bd8b: a9 06       ..
+    ldx #$ba                                                          ; bd8d: a2 ba       ..
+    ldy #0                                                            ; bd8f: a0 00       ..
+    jsr tube_entry                                                    ; bd91: 20 06 04     ..
+    ldy #5                                                            ; bd94: a0 05       ..
+    jsr cbe89                                                         ; bd96: 20 89 be     ..
+; $bd99 referenced 1 time by $bda1
+loop_cbd99
+    lda tube_host_r3_data                                             ; bd99: ad e5 fe    ...
+    sta (l00b8),y                                                     ; bd9c: 91 b8       ..
+    lda (l00b8),y                                                     ; bd9e: b1 b8       ..
+    iny                                                               ; bda0: c8          .
+    bne loop_cbd99                                                    ; bda1: d0 f6       ..
+; $bda3 referenced 1 time by $bd7c
+cbda3
+    jsr sub_cbe83                                                     ; bda3: 20 83 be     ..
+    ldx #$b8                                                          ; bda6: a2 b8       ..
+    ldy #$b1                                                          ; bda8: a0 b1       ..
+    jsr sub_cb580                                                     ; bdaa: 20 80 b5     ..
+    dec l00b9                                                         ; bdad: c6 b9       ..
+    sec                                                               ; bdaf: 38          8
+    jsr cb795                                                         ; bdb0: 20 95 b7     ..
+    jsr cbe47                                                         ; bdb3: 20 47 be     G.
+    jmp cbd46                                                         ; bdb6: 4c 46 bd    LF.
+
+; $bdb9 referenced 2 times by $bd53, $bdcd
+cbdb9
+    rts                                                               ; bdb9: 60          `
+
+; $bdba referenced 1 time by $bd3d
+cbdba
+    pla                                                               ; bdba: 68          h
+    sta l00b2                                                         ; bdbb: 85 b2       ..
+    pla                                                               ; bdbd: 68          h
+    sta l00b1                                                         ; bdbe: 85 b1       ..
+; $bdc0 referenced 1 time by $be44
+cbdc0
+    ldx #$be                                                          ; bdc0: a2 be       ..
+    ldy #$f4                                                          ; bdc2: a0 f4       ..
+    jsr sub_cb841                                                     ; bdc4: 20 41 b8     A.
+    lda l00bf                                                         ; bdc7: a5 bf       ..
+    bne cbdd3                                                         ; bdc9: d0 08       ..
+    ldx l00be                                                         ; bdcb: a6 be       ..
+    beq cbdb9                                                         ; bdcd: f0 ea       ..
+    lda #1                                                            ; bdcf: a9 01       ..
+    bne cbddd                                                         ; bdd1: d0 0a       ..
+; $bdd3 referenced 1 time by $bdc9
+cbdd3
+    lda #0                                                            ; bdd3: a9 00       ..
+    sta l00be                                                         ; bdd5: 85 be       ..
+    lda #1                                                            ; bdd7: a9 01       ..
+    sta l00bf                                                         ; bdd9: 85 bf       ..
+    lda #7                                                            ; bddb: a9 07       ..
+; $bddd referenced 1 time by $bdd1
+cbddd
+    pha                                                               ; bddd: 48          H
+    inc l00b9                                                         ; bdde: e6 b9       ..
+    ldx #$b8                                                          ; bde0: a2 b8       ..
+    ldy #$b3                                                          ; bde2: a0 b3       ..
+    jsr sub_cb580                                                     ; bde4: 20 80 b5     ..
+    lda l00be                                                         ; bde7: a5 be       ..
+    pha                                                               ; bde9: 48          H
+    dec l00b9                                                         ; bdea: c6 b9       ..
+    clc                                                               ; bdec: 18          .
+    jsr cb795                                                         ; bded: 20 95 b7     ..
+    pla                                                               ; bdf0: 68          h
+    sta l00be                                                         ; bdf1: 85 be       ..
+    pla                                                               ; bdf3: 68          h
+    cmp #1                                                            ; bdf4: c9 01       ..
+    bne cbe21                                                         ; bdf6: d0 29       .)
+    lda #0                                                            ; bdf8: a9 00       ..
+    ldy #$f4                                                          ; bdfa: a0 f4       ..
+    sta (l00b8),y                                                     ; bdfc: 91 b8       ..
+    inc l00b9                                                         ; bdfe: e6 b9       ..
+    jsr cbe7b                                                         ; be00: 20 7b be     {.
+    lda #1                                                            ; be03: a9 01       ..
+    ldx #$ba                                                          ; be05: a2 ba       ..
+    ldy #0                                                            ; be07: a0 00       ..
+    jsr tube_entry                                                    ; be09: 20 06 04     ..
+    ldy #0                                                            ; be0c: a0 00       ..
+; $be0e referenced 1 time by $be1d
+loop_cbe0e
+    lda (l00b8),y                                                     ; be0e: b1 b8       ..
+    sta tube_host_r3_data                                             ; be10: 8d e5 fe    ...
+    ldx #3                                                            ; be13: a2 03       ..
+    jsr cbe8d                                                         ; be15: 20 8d be     ..
+    iny                                                               ; be18: c8          .
+    cpy l00be                                                         ; be19: c4 be       ..
+    cpy l00be                                                         ; be1b: c4 be       ..
+    bne loop_cbe0e                                                    ; be1d: d0 ef       ..
+    beq cbe3c                                                         ; be1f: f0 1b       ..
+; $be21 referenced 1 time by $bdf6
+cbe21
+    inc l00b9                                                         ; be21: e6 b9       ..
+    jsr cbe7b                                                         ; be23: 20 7b be     {.
+    lda #7                                                            ; be26: a9 07       ..
+    ldx #$ba                                                          ; be28: a2 ba       ..
+    ldy #0                                                            ; be2a: a0 00       ..
+    jsr tube_entry                                                    ; be2c: 20 06 04     ..
+    ldy #0                                                            ; be2f: a0 00       ..
+; $be31 referenced 1 time by $be3a
+loop_cbe31
+    lda (l00b8),y                                                     ; be31: b1 b8       ..
+    sta tube_host_r3_data                                             ; be33: 8d e5 fe    ...
+    nop                                                               ; be36: ea          .
+    nop                                                               ; be37: ea          .
+    nop                                                               ; be38: ea          .
+    iny                                                               ; be39: c8          .
+    bne loop_cbe31                                                    ; be3a: d0 f5       ..
+; $be3c referenced 1 time by $be1f
+cbe3c
+    jsr sub_cbe83                                                     ; be3c: 20 83 be     ..
+    dec l00b9                                                         ; be3f: c6 b9       ..
+    jsr cbe47                                                         ; be41: 20 47 be     G.
+    jmp cbdc0                                                         ; be44: 4c c0 bd    L..
+
+; $be47 referenced 3 times by $bdb3, $be41, $be50
+cbe47
+    ldx #1                                                            ; be47: a2 01       ..
+    inc l00ba,x                                                       ; be49: f6 ba       ..
+    bne cbe52                                                         ; be4b: d0 05       ..
+    inx                                                               ; be4d: e8          .
+    cpx #4                                                            ; be4e: e0 04       ..
+    bcc cbe47                                                         ; be50: 90 f5       ..
+; $be52 referenced 1 time by $be4b
+cbe52
+    ldy #$f5                                                          ; be52: a0 f5       ..
+    lda (l00b8),y                                                     ; be54: b1 b8       ..
+    sec                                                               ; be56: 38          8
+    sbc #1                                                            ; be57: e9 01       ..
+    bcc cbe7a                                                         ; be59: 90 1f       ..
+    sta (l00b8),y                                                     ; be5b: 91 b8       ..
+    jsr sub_cb616                                                     ; be5d: 20 16 b6     ..
+    beq cbe7a                                                         ; be60: f0 18       ..
+    ldx l00b7                                                         ; be62: a6 b7       ..
+    jsr sub_cb85d                                                     ; be64: 20 5d b8     ].
+    bvc cbe7a                                                         ; be67: 50 11       P.
+    lda l00b1,x                                                       ; be69: b5 b1       ..
+    cmp #$c0                                                          ; be6b: c9 c0       ..
+    bcc cbe7a                                                         ; be6d: 90 0b       ..
+    lda #$10                                                          ; be6f: a9 10       ..
+    sta l00b0,x                                                       ; be71: 95 b0       ..
+    lda #$80                                                          ; be73: a9 80       ..
+    sta l00b1,x                                                       ; be75: 95 b1       ..
+    jsr sub_cb68f                                                     ; be77: 20 8f b6     ..
+; $be7a referenced 4 times by $be59, $be60, $be67, $be6d
+cbe7a
+    rts                                                               ; be7a: 60          `
+
+; $be7b referenced 5 times by $bd5b, $bd88, $be00, $be23, $be80
+cbe7b
+    lda #$c8                                                          ; be7b: a9 c8       ..
+    jsr tube_entry                                                    ; be7d: 20 06 04     ..
+    bcc cbe7b                                                         ; be80: 90 f9       ..
+    rts                                                               ; be82: 60          `
+
+; $be83 referenced 2 times by $bda3, $be3c
+sub_cbe83
+    lda #$88                                                          ; be83: a9 88       ..
+    jsr tube_entry                                                    ; be85: 20 06 04     ..
+    rts                                                               ; be88: 60          `
+
+; $be89 referenced 3 times by $bd69, $bd96, $be8a
+cbe89
+    dey                                                               ; be89: 88          .
+    bne cbe89                                                         ; be8a: d0 fd       ..
+    rts                                                               ; be8c: 60          `
+
+; $be8d referenced 3 times by $bd73, $be15, $be8e
+cbe8d
+    dex                                                               ; be8d: ca          .
+    bne cbe8d                                                         ; be8e: d0 fd       ..
+    rts                                                               ; be90: 60          `
+
+; $be91 referenced 1 time by $bcf4
+sub_cbe91
+    lda #osbyte_read_tube_presence                                    ; be91: a9 ea       ..
+    ldx #0                                                            ; be93: a2 00       ..
+    ldy #$ff                                                          ; be95: a0 ff       ..
+    jsr osbyte                                                        ; be97: 20 f4 ff     ..
+    cpx #$ff                                                          ; be9a: e0 ff       ..
+    rts                                                               ; be9c: 60          `
+
+; $be9d referenced 2 times by $b338, $bcf1
+sub_cbe9d
+    jsr sub_cb85d                                                     ; be9d: 20 5d b8     ].
+    bpl cbec1                                                         ; bea0: 10 1f       ..
+    bvs cbec1                                                         ; bea2: 70 1d       p.
+    lda #0                                                            ; bea4: a9 00       ..
+    pha                                                               ; bea6: 48          H
+    ldy #$f1                                                          ; bea7: a0 f1       ..
+    lda (l00b8),y                                                     ; bea9: b1 b8       ..
+; $beab referenced 1 time by $bec6
+loop_cbeab
+    pha                                                               ; beab: 48          H
+    lda #osbyte_read_rom_info_table_low                               ; beac: a9 aa       ..
+    ldx #0                                                            ; beae: a2 00       ..
+    ldy #$ff                                                          ; beb0: a0 ff       ..
+    jsr osbyte                                                        ; beb2: 20 f4 ff     ..
+    jsr cb82b                                                         ; beb5: 20 2b b8     +.
+    stx l00ba                                                         ; beb8: 86 ba       ..
+    sty l00bb                                                         ; beba: 84 bb       ..
+    pla                                                               ; bebc: 68          h
+    tay                                                               ; bebd: a8          .
+    pla                                                               ; bebe: 68          h
+    sta (l00ba),y                                                     ; bebf: 91 ba       ..
+; $bec1 referenced 2 times by $bea0, $bea2
+cbec1
+    rts                                                               ; bec1: 60          `
+
+; $bec2 referenced 2 times by $bc64, $bcae
+sub_cbec2
+    lda #2                                                            ; bec2: a9 02       ..
+    pha                                                               ; bec4: 48          H
+    tya                                                               ; bec5: 98          .
+    bpl loop_cbeab                                                    ; bec6: 10 e3       ..
+; $bec8 referenced 1 time by $8003
+service_handler
+    cmp #service_claim_absolute_workspace                             ; bec8: c9 01       ..
+    bne cbee0                                                         ; beca: d0 14       ..
+    pha                                                               ; becc: 48          H
+    tya                                                               ; becd: 98          .
+    pha                                                               ; bece: 48          H
+    lda #osbyte_issue_service_request                                 ; becf: a9 8f       ..
+    ldx #service_check_swr_presence                                   ; bed1: a2 2b       .+
+    ldy romsel_copy                                                   ; bed3: a4 f4       ..
+    jsr osbyte                                                        ; bed5: 20 f4 ff     ..
+    pla                                                               ; bed8: 68          h
+    tay                                                               ; bed9: a8          .
+    ldx romsel_copy                                                   ; beda: a6 f4       ..
+    pla                                                               ; bedc: 68          h
+; $bedd referenced 2 times by $bee2, $beec
+general_service_handler_indirect
+    jmp general_service_handler                                       ; bedd: 4c b1 b1    L..
+
+; $bee0 referenced 1 time by $beca
+cbee0
+    cmp #service_check_swr_presence                                   ; bee0: c9 2b       .+
+    bne general_service_handler_indirect                              ; bee2: d0 f9       ..
+    cpy romsel_copy                                                   ; bee4: c4 f4       ..
+    beq cbeee                                                         ; bee6: f0 06       ..
+; $bee8 referenced 4 times by $bef8, $beff, $bf08, $bf4c
+cbee8
+    ldx romsel_copy                                                   ; bee8: a6 f4       ..
+    lda #0                                                            ; beea: a9 00       ..
+    beq general_service_handler_indirect                              ; beec: f0 ef       ..
+; $beee referenced 1 time by $bee6
+cbeee
+    lda #$72 ; 'r'                                                    ; beee: a9 72       .r
+    ldx #0                                                            ; bef0: a2 00       ..
+    jsr osbyte                                                        ; bef2: 20 f4 ff     ..
+    jsr osbyte                                                        ; bef5: 20 f4 ff     ..
+    bvs cbee8                                                         ; bef8: 70 ee       p.
+    lda #$ea                                                          ; befa: a9 ea       ..
+    jsr sub_cbf82                                                     ; befc: 20 82 bf     ..
+    bne cbee8                                                         ; beff: d0 e7       ..
+    lda #$d7                                                          ; bf01: a9 d7       ..
+    ldy #$7f                                                          ; bf03: a0 7f       ..
+    jsr sub_cbf84                                                     ; bf05: 20 84 bf     ..
+    bpl cbee8                                                         ; bf08: 10 de       ..
+    jsr osnewl                                                        ; bf0a: 20 e7 ff     ..
+    ldx #0                                                            ; bf0d: a2 00       ..
+    jsr sub_cbf7c                                                     ; bf0f: 20 7c bf     |.
+    lda #$fd                                                          ; bf12: a9 fd       ..
+    jsr sub_cbf82                                                     ; bf14: 20 82 bf     ..
+    beq cbf46                                                         ; bf17: f0 2d       .-
+    tsx                                                               ; bf19: ba          .
+    ldy #$30 ; '0'                                                    ; bf1a: a0 30       .0
+; $bf1c referenced 1 time by $bf21
+loop_cbf1c
+    lda cbf8a,y                                                       ; bf1c: b9 8a bf    ...
+    pha                                                               ; bf1f: 48          H
+    dey                                                               ; bf20: 88          .
+    bne loop_cbf1c                                                    ; bf21: d0 f9       ..
+    txa                                                               ; bf23: 8a          .
+    tay                                                               ; bf24: a8          .
+    lda #1                                                            ; bf25: a9 01       ..
+    pha                                                               ; bf27: 48          H
+    tsx                                                               ; bf28: ba          .
+    inx                                                               ; bf29: e8          .
+    txa                                                               ; bf2a: 8a          .
+    pha                                                               ; bf2b: 48          H
+    ldx #$0f                                                          ; bf2c: a2 0f       ..
+    lda #0                                                            ; bf2e: a9 00       ..
+    sta l00b0                                                         ; bf30: 85 b0       ..
+    rts                                                               ; bf32: 60          `
+
+; $bf33 referenced 1 time by $bfb8
+cbf33
+    tya                                                               ; bf33: 98          .
+    tax                                                               ; bf34: aa          .
+    txs                                                               ; bf35: 9a          .
+    lda l00b0                                                         ; bf36: a5 b0       ..
+    asl                                                               ; bf38: 0a          .
+    asl                                                               ; bf39: 0a          .
+    clc                                                               ; bf3a: 18          .
+    adc #$0d                                                          ; bf3b: 69 0d       i.
+    tax                                                               ; bf3d: aa          .
+    jsr sub_cbf7c                                                     ; bf3e: 20 7c bf     |.
+    ldx #$0a                                                          ; bf41: a2 0a       ..
+    jsr sub_cbf7c                                                     ; bf43: 20 7c bf     |.
+; $bf46 referenced 1 time by $bf17
+cbf46
+    jsr osnewl                                                        ; bf46: 20 e7 ff     ..
+    jsr osnewl                                                        ; bf49: 20 e7 ff     ..
+    jmp cbee8                                                         ; bf4c: 4c e8 be    L..
+
+; $bf4f referenced 1 time by $bf7c
+lbf4f
+    !text "Acorn OS "                                                 ; bf4f: 41 63 6f... Aco
+    !byte   0, $4b,   7,   0, $36, $34,   0,   0, $38, $30,   0,   0  ; bf58: 00 4b 07... .K.
+    !byte $39, $36,   0,   0                                          ; bf64: 39 36 00... 96.
+    !text "112"                                                       ; bf68: 31 31 32    112
+    !byte 0                                                           ; bf6b: 00          .
+    !text "128"                                                       ; bf6c: 31 32 38    128
+    !byte 0                                                           ; bf6f: 00          .
+    !text "144"                                                       ; bf70: 31 34 34    144
+    !byte 0                                                           ; bf73: 00          .
+    !text "160"                                                       ; bf74: 31 36 30    160
+    !byte 0                                                           ; bf77: 00          .
+
+; $bf78 referenced 1 time by $bf7f
+loop_cbf78
+    jsr oswrch                                                        ; bf78: 20 ee ff     ..
+    inx                                                               ; bf7b: e8          .
+; $bf7c referenced 3 times by $bf0f, $bf3e, $bf43
+sub_cbf7c
+    lda lbf4f,x                                                       ; bf7c: bd 4f bf    .O.
+    bne loop_cbf78                                                    ; bf7f: d0 f7       ..
+    rts                                                               ; bf81: 60          `
+
+; $bf82 referenced 2 times by $befc, $bf14
+sub_cbf82
+    ldy #$ff                                                          ; bf82: a0 ff       ..
+; $bf84 referenced 1 time by $bf05
+sub_cbf84
+    ldx #0                                                            ; bf84: a2 00       ..
+    jsr osbyte                                                        ; bf86: 20 f4 ff     ..
+    txa                                                               ; bf89: 8a          .
+; $bf8a referenced 1 time by $bf1c
+cbf8a
+    rts                                                               ; bf8a: 60          `
+
+    lda romsel_copy                                                   ; bf8b: a5 f4       ..
+    pha                                                               ; bf8d: 48          H
+; $bf8e referenced 2 times by $bfac, $bfb0
+cbf8e
+    stx romsel_copy                                                   ; bf8e: 86 f4       ..
+    stx romsel                                                        ; bf90: 8e 30 fe    .0.
+    lda lbfff                                                         ; bf93: ad ff bf    ...
+    pha                                                               ; bf96: 48          H
+    eor #$a5                                                          ; bf97: 49 a5       I.
+    sta lbfff                                                         ; bf99: 8d ff bf    ...
+    cmp lbfff                                                         ; bf9c: cd ff bf    ...
+    bne cbfa3                                                         ; bf9f: d0 02       ..
+    inc l00b0                                                         ; bfa1: e6 b0       ..
+; $bfa3 referenced 1 time by $bf9f
+cbfa3
+    pla                                                               ; bfa3: 68          h
+    sta lbfff                                                         ; bfa4: 8d ff bf    ...
+    dex                                                               ; bfa7: ca          .
+    bmi cbfb2                                                         ; bfa8: 30 08       0.
+    cpx #$0b                                                          ; bfaa: e0 0b       ..
+    bne cbf8e                                                         ; bfac: d0 e0       ..
+    ldx #1                                                            ; bfae: a2 01       ..
+    bne cbf8e                                                         ; bfb0: d0 dc       ..
+; $bfb2 referenced 1 time by $bfa8
+cbfb2
+    pla                                                               ; bfb2: 68          h
+    sta romsel_copy                                                   ; bfb3: 85 f4       ..
+    sta romsel                                                        ; bfb5: 8d 30 fe    .0.
+    jmp cbf33                                                         ; bfb8: 4c 33 bf    L3.
+
+    !byte $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff  ; bfbb: ff ff ff... ...
+    !byte $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff  ; bfc7: ff ff ff... ...
+    !byte $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff  ; bfd3: ff ff ff... ...
+    !byte $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff  ; bfdf: ff ff ff... ...
+    !byte $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff  ; bfeb: ff ff ff... ...
+    !byte $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff                      ; bff7: ff ff ff... ...
+; $bfff referenced 4 times by $bf93, $bf99, $bf9c, $bfa4
+lbfff
+    !byte $ff                                                         ; bfff: ff          .
+pydis_end
+
+; Label references by decreasing frequency:
+;     l00b8:                                125
+;     l00b0:                                105
+;     l00ba:                                 44
+;     l00bf:                                 42
+;     l00bc:                                 41
+;     l00b6:                                 35
+;     l00be:                                 31
+;     l00cd:                                 31
+;     print_inline_l809f_top_bit_clear:      31
+;     l00c2:                                 30
+;     l00b1:                                 29
+;     sub_c83e3:                             29
+;     l00b9:                                 28
+;     l00bb:                                 28
+;     l00b5:                                 26
+;     l00bd:                                 26
+;     l00b4:                                 25
+;     l00b3:                                 23
+;     l00c1:                                 23
+;     os_text_ptr:                           23
+;     osbyte:                                22
+;     romsel_copy:                           21
+;     l0f0e:                                 21
+;     caea0:                                 21
+;     l00c4:                                 20
+;     c809f:                                 20
+;     l00b2:                                 19
+;     l10c2:                                 19
+;     l0001:                                 18
+;     l00a8:                                 18
+;     l00aa:                                 18
+;     l00c5:                                 18
+;     l00c9:                                 18
+;     l10de:                                 18
+;     l0000:                                 17
+;     l00b7:                                 17
+;     l0e0f:                                 17
+;     l0f06:                                 17
+;     l1000:                                 17
+;     l00a2:                                 16
+;     l00ab:                                 16
+;     l00ae:                                 16
+;     ca3dc:                                 16
+;     cb82b:                                 16
+;     l00c0:                                 15
+;     l00c3:                                 15
+;     l00c7:                                 15
+;     l0f05:                                 15
+;     l00cc:                                 14
+;     l1117:                                 14
+;     cae70:                                 14
+;     caf7f:                                 14
+;     l00a1:                                 13
+;     l00a5:                                 13
+;     l00c8:                                 13
+;     l0f07:                                 13
+;     sub_ca14a:                             13
+;     tube_host_r3_data:                     13
+;     l00ac:                                 12
+;     clc_jmp_gsinit:                        12
+;     sub_cb841:                             12
+;     osasci:                                12
+;     l00c6:                                 11
+;     osrdsc_ptr:                            11
+;     l0e08:                                 11
+;     generate_error_precheck:               11
+;     sub_c8149:                             11
+;     c996e:                                 11
+;     cac0f:                                 11
+;     lfe84:                                 11
+;     tube_host_r2_data:                     11
+;     l00a9:                                 10
+;     l1111:                                 10
+;     l1112:                                 10
+;     sub_c80c3:                             10
+;     c93e6:                                 10
+;     cb203:                                 10
+;     lfe87:                                 10
+;     tube_host_r2_status:                   10
+;     l00ca:                                  9
+;     l1074:                                  9
+;     l108a:                                  9
+;     l1097:                                  9
+;     l10c0:                                  9
+;     l1110:                                  9
+;     cbbd0:                                  9
+;     l00ce:                                  8
+;     l00ff:                                  8
+;     l0100:                                  8
+;     l0df0:                                  8
+;     l0f04:                                  8
+;     l1060:                                  8
+;     l1082:                                  8
+;     l108b:                                  8
+;     l1090:                                  8
+;     l1096:                                  8
+;     l10ca:                                  8
+;     l10cf:                                  8
+;     l10d1:                                  8
+;     sub_c81b0:                              8
+;     sub_c81bf:                              8
+;     c8816:                                  8
+;     sub_c8b7b:                              8
+;     osbyte_read:                            8
+;     cae79:                                  8
+;     sub_cb85d:                              8
+;     tube_host_r1_status:                    8
+;     osfind:                                 8
+;     l00a7:                                  7
+;     l00cf:                                  7
+;     l0f08:                                  7
+;     l1075:                                  7
+;     l10c9:                                  7
+;     l10d2:                                  7
+;     l1114:                                  7
+;     generate_error2:                        7
+;     sub_c8284:                              7
+;     sub_c8380:                              7
+;     c8b8b:                                  7
+;     print_inline_osasci_top_bit_clear:      7
+;     sub_cb580:                              7
+;     sub_cbab9:                              7
+;     osrdsc:                                 7
+;     l0015:                                  6
+;     l00f3:                                  6
+;     l00f7:                                  6
+;     l0f0f:                                  6
+;     l1100:                                  6
+;     generate_error_precheck_bad:            6
+;     sub_c8280:                              6
+;     sub_c82fe:                              6
+;     command_table:                          6
+;     sub_c87da:                              6
+;     c940c:                                  6
+;     sub_c99ac:                              6
+;     zero_stacked_XXX:                       6
+;     sub_c9e75:                              6
+;     caf58:                                  6
+;     sub_cb5f2:                              6
+;     lb726:                                  6
+;     cb8fb:                                  6
+;     oswrch:                                 6
+;     l00a6:                                  5
+;     l00af:                                  5
+;     l00f0:                                  5
+;     l1087:                                  5
+;     l1088:                                  5
+;     l1099:                                  5
+;     l10c7:                                  5
+;     l10dd:                                  5
+;     l110c:                                  5
+;     l1115:                                  5
+;     l1116:                                  5
+;     sub_c80bb:                              5
+;     sub_c80ed:                              5
+;     sub_c80f3:                              5
+;     c8125:                                  5
+;     sub_c830a:                              5
+;     sub_c8335:                              5
+;     sub_c8386:                              5
+;     sub_c840c:                              5
+;     c8ba2:                                  5
+;     sub_c8f3f:                              5
+;     c9257:                                  5
+;     c99a3:                                  5
+;     sub_c9a6e:                              5
+;     sub_c9ab8:                              5
+;     sub_ca0de:                              5
+;     sub_ca1b4:                              5
+;     cae97:                                  5
+;     sub_cb6fe:                              5
+;     sub_cb745:                              5
+;     cb795:                                  5
+;     sub_cb850:                              5
+;     sub_cba67:                              5
+;     cbe7b:                                  5
+;     osnewl:                                 5
+;     l0002:                                  4
+;     l0e00:                                  4
+;     l0f0c:                                  4
+;     l0f0d:                                  4
+;     l1069:                                  4
+;     l1076:                                  4
+;     l1077:                                  4
+;     l1081:                                  4
+;     l1086:                                  4
+;     l1095:                                  4
+;     l10c4:                                  4
+;     l10cb:                                  4
+;     l10cc:                                  4
+;     l10ce:                                  4
+;     l10d9:                                  4
+;     l10da:                                  4
+;     l110d:                                  4
+;     l1113:                                  4
+;     l111a:                                  4
+;     l111d:                                  4
+;     generate_error_precheck_disc:           4
+;     generate_error:                         4
+;     sub_c80c8:                              4
+;     sub_c8174:                              4
+;     c81a7:                                  4
+;     sub_c821d:                              4
+;     c8225:                                  4
+;     sub_c82b2:                              4
+;     sub_c8327:                              4
+;     inc16_ae:                               4
+;     c8d74:                                  4
+;     c8d91:                                  4
+;     c8e0e:                                  4
+;     c8e12:                                  4
+;     c8e64:                                  4
+;     sub_c8f6b:                              4
+;     c940e:                                  4
+;     c9436:                                  4
+;     c993b:                                  4
+;     sub_c9965:                              4
+;     sub_c9a8d:                              4
+;     c9adf:                                  4
+;     c9ae9:                                  4
+;     sub_ca379:                              4
+;     ca5e5:                                  4
+;     sub_ca9ca:                              4
+;     sub_caacf:                              4
+;     sub_cac18:                              4
+;     sub_cac62:                              4
+;     cad79:                                  4
+;     cb446:                                  4
+;     lb57f:                                  4
+;     sub_cb616:                              4
+;     cb68c:                                  4
+;     sub_cb68f:                              4
+;     sub_cb83f:                              4
+;     sub_cbac2:                              4
+;     sub_cbb00:                              4
+;     cbe7a:                                  4
+;     cbee8:                                  4
+;     lbfff:                                  4
+;     romsel:                                 4
+;     lfe85:                                  4
+;     lfe86:                                  4
+;     osbput:                                 4
+;     osbget:                                 4
+;     osfile:                                 4
+;     osrdch:                                 4
+;     l00ef:                                  3
+;     l0107:                                  3
+;     l0109:                                  3
+;     bytev:                                  3
+;     bytev+1:                                3
+;     l0ef8:                                  3
+;     l1092:                                  3
+;     l1093:                                  3
+;     l1094:                                  3
+;     l1098:                                  3
+;     l109d:                                  3
+;     l109f:                                  3
+;     l10c3:                                  3
+;     l10c5:                                  3
+;     l10c6:                                  3
+;     l10d0:                                  3
+;     l10d3:                                  3
+;     l10d6:                                  3
+;     l10d7:                                  3
+;     l1119:                                  3
+;     l111c:                                  3
+;     c8103:                                  3
+;     sub_c81be:                              3
+;     c8290:                                  3
+;     c82e6:                                  3
+;     sub_c833a:                              3
+;     sub_c836e:                              3
+;     c8454:                                  3
+;     sub_c8456:                              3
+;     c89d7:                                  3
+;     sub_c8b86:                              3
+;     c8d41:                                  3
+;     c8e53:                                  3
+;     c8ecc:                                  3
+;     c8f2a:                                  3
+;     sub_c8f7a:                              3
+;     nmi_handler2_rom_end:                   3
+;     c91af:                                  3
+;     c9214:                                  3
+;     sub_c93fd:                              3
+;     c9444:                                  3
+;     c94bc:                                  3
+;     sub_c9526:                              3
+;     c9738:                                  3
+;     sub_c9940:                              3
+;     c99ed:                                  3
+;     c9a8c:                                  3
+;     sub_c9be5:                              3
+;     generate_error_precheck_open:           3
+;     c9d5d:                                  3
+;     sub_c9e30:                              3
+;     sub_c9f0f:                              3
+;     sub_c9f16:                              3
+;     sub_c9f1e:                              3
+;     ca06b:                                  3
+;     ca14f:                                  3
+;     ca1c0:                                  3
+;     sub_ca315:                              3
+;     sub_ca384:                              3
+;     sub_ca530:                              3
+;     ca660:                                  3
+;     sub_ca9c2:                              3
+;     caa42:                                  3
+;     caa44:                                  3
+;     sub_cac0c:                              3
+;     cacc4:                                  3
+;     tube_host_code2:                        3
+;     sub_cad5d:                              3
+;     cad77:                                  3
+;     laf76:                                  3
+;     cb1d5:                                  3
+;     cb371:                                  3
+;     sub_cb58b:                              3
+;     cb684:                                  3
+;     cb6ca:                                  3
+;     sub_cb84e:                              3
+;     sub_cb986:                              3
+;     sram_table:                             3
+;     cbab4:                                  3
+;     sub_cbac4:                              3
+;     cbe47:                                  3
+;     cbe89:                                  3
+;     cbe8d:                                  3
+;     sub_cbf7c:                              3
+;     lfe80:                                  3
+;     tube_host_r1_data:                      3
+;     osword:                                 3
+;     oscli:                                  3
+;     l0003:                                  2
+;     l0012:                                  2
+;     l0014:                                  2
+;     l00a0:                                  2
+;     l00a3:                                  2
+;     l00a4:                                  2
+;     l00ad:                                  2
+;     l00fd:                                  2
+;     l0101:                                  2
+;     l0102:                                  2
+;     l0105:                                  2
+;     l010b:                                  2
+;     l0128:                                  2
+;     fscv:                                   2
+;     l0700:                                  2
+;     l0e07:                                  2
+;     l0f0a:                                  2
+;     l0f0b:                                  2
+;     l1045:                                  2
+;     l1062:                                  2
+;     l1065:                                  2
+;     l1067:                                  2
+;     l1078:                                  2
+;     l107d:                                  2
+;     l107e:                                  2
+;     l107f:                                  2
+;     l1089:                                  2
+;     l108c:                                  2
+;     l1091:                                  2
+;     l109a:                                  2
+;     l109b:                                  2
+;     l109e:                                  2
+;     l10c1:                                  2
+;     l10cd:                                  2
+;     l10d8:                                  2
+;     l10db:                                  2
+;     l10dc:                                  2
+;     l10e2:                                  2
+;     l10e3:                                  2
+;     l10e4:                                  2
+;     l1109:                                  2
+;     l110b:                                  2
+;     l110e:                                  2
+;     l110f:                                  2
+;     l111b:                                  2
+;     sub_c809a:                              2
+;     sub_c80e3:                              2
+;     c815d:                                  2
+;     sub_c81ae:                              2
+;     sub_c81c5:                              2
+;     c822a:                                  2
+;     c825d:                                  2
+;     sub_c8266:                              2
+;     sub_c826d:                              2
+;     sub_c82bb:                              2
+;     sub_c82e8:                              2
+;     c82fd:                                  2
+;     sub_c841b:                              2
+;     sub_c8439:                              2
+;     c8543:                                  2
+;     sub_c8555:                              2
+;     c8560:                                  2
+;     c85bc:                                  2
+;     c8703:                                  2
+;     c8705:                                  2
+;     c873b:                                  2
+;     sub_c8745:                              2
+;     sub_c87db:                              2
+;     sub_c87e3:                              2
+;     c8808:                                  2
+;     c883f:                                  2
+;     sub_c8855:                              2
+;     sub_c8862:                              2
+;     c88a6:                                  2
+;     c88f4:                                  2
+;     sub_c8951:                              2
+;     c898a:                                  2
+;     c89a5:                                  2
+;     c89b4:                                  2
+;     sub_c89da:                              2
+;     c8a00:                                  2
+;     c8a6e:                                  2
+;     sub_c8a77:                              2
+;     sub_c8ab3:                              2
+;     sub_c8b4d:                              2
+;     sub_c8b64:                              2
+;     c8be3:                                  2
+;     c8c12:                                  2
+;     c8cb2:                                  2
+;     c8d0d:                                  2
+;     c8d13:                                  2
+;     c8e0d:                                  2
+;     c8e32:                                  2
+;     c8e9f:                                  2
+;     c8ea5:                                  2
+;     c8eb7:                                  2
+;     c8eeb:                                  2
+;     c8f3e:                                  2
+;     c90c7:                                  2
+;     c91df:                                  2
+;     sub_c9279:                              2
+;     c9289:                                  2
+;     sub_c928a:                              2
+;     c9367:                                  2
+;     sub_c93c5:                              2
+;     sub_c93d3:                              2
+;     sub_c93f5:                              2
+;     sub_c9432:                              2
+;     sub_c9445:                              2
+;     c94a9:                                  2
+;     c94c6:                                  2
+;     sub_c9516:                              2
+;     sub_c952e:                              2
+;     c95fd:                                  2
+;     c9628:                                  2
+;     c965a:                                  2
+;     c96b7:                                  2
+;     c97b3:                                  2
+;     sub_c992c:                              2
+;     invert_l1065:                           2
+;     sub_c995a:                              2
+;     sub_c99f3:                              2
+;     sub_c9a0f:                              2
+;     sub_c9a50:                              2
+;     sub_c9a60:                              2
+;     sub_c9a63:                              2
+;     sub_c9a78:                              2
+;     sub_c9a82:                              2
+;     sub_c9aa3:                              2
+;     sub_c9ac8:                              2
+;     sub_c9ad8:                              2
+;     c9b6e:                                  2
+;     sub_c9b79:                              2
+;     c9bc5:                                  2
+;     sub_c9bf2:                              2
+;     sub_c9d1e:                              2
+;     c9dcd:                                  2
+;     c9dd5:                                  2
+;     sub_c9df4:                              2
+;     sub_c9e1e:                              2
+;     c9e41:                                  2
+;     sub_c9e54:                              2
+;     sub_c9ef4:                              2
+;     sub_c9f14:                              2
+;     sub_c9f26:                              2
+;     ca01d:                                  2
+;     ca021:                                  2
+;     ca06c:                                  2
+;     ca0f5:                                  2
+;     ca10b:                                  2
+;     sub_ca168:                              2
+;     ca19f:                                  2
+;     sub_ca1c6:                              2
+;     la1d3:                                  2
+;     ca2f2:                                  2
+;     sub_ca324:                              2
+;     ca38b:                                  2
+;     sub_ca3ec:                              2
+;     ca411:                                  2
+;     ca414:                                  2
+;     sub_ca51f:                              2
+;     ca5ab:                                  2
+;     sub_ca5b2:                              2
+;     ca637:                                  2
+;     ca845:                                  2
+;     ca86b:                                  2
+;     ca87a:                                  2
+;     sub_ca90d:                              2
+;     ca97d:                                  2
+;     ca9ff:                                  2
+;     caa1c:                                  2
+;     caa51:                                  2
+;     sub_caa53:                              2
+;     sub_caac2:                              2
+;     sub_caaf1:                              2
+;     cab1a:                                  2
+;     cab41:                                  2
+;     cab54:                                  2
+;     cabbc:                                  2
+;     sub_cac4e:                              2
+;     cad15:                                  2
+;     cadd7:                                  2
+;     tube_host_code2+256:                    2
+;     cae11:                                  2
+;     caed3:                                  2
+;     tube_banner_loop:                       2
+;     just_rts:                               2
+;     tube_host_code3:                        2
+;     laf75:                                  2
+;     laf77:                                  2
+;     laf78:                                  2
+;     tube_host_code1:                        2
+;     cafad:                                  2
+;     caffb:                                  2
+;     cb00a:                                  2
+;     cb035:                                  2
+;     sub_cb047:                              2
+;     cb280:                                  2
+;     cb297:                                  2
+;     cb2a0:                                  2
+;     cb300:                                  2
+;     cb406:                                  2
+;     cb45e:                                  2
+;     sub_cb598:                              2
+;     sub_cb5ce:                              2
+;     sub_cb5ee:                              2
+;     sub_cb607:                              2
+;     sub_cb61e:                              2
+;     cb655:                                  2
+;     sub_cb65f:                              2
+;     sub_cb6b1:                              2
+;     cb718:                                  2
+;     cb7ed:                                  2
+;     lb872:                                  2
+;     cb8e4:                                  2
+;     cb9e8:                                  2
+;     sub_cb9f5:                              2
+;     cba10:                                  2
+;     cbaf8:                                  2
+;     cbafd:                                  2
+;     cbb28:                                  2
+;     cbb2a:                                  2
+;     cbc13:                                  2
+;     cbc3a:                                  2
+;     sub_cbc68:                              2
+;     cbcb9:                                  2
+;     cbdb9:                                  2
+;     sub_cbe83:                              2
+;     sub_cbe9d:                              2
+;     cbec1:                                  2
+;     sub_cbec2:                              2
+;     general_service_handler_indirect:       2
+;     sub_cbf82:                              2
+;     cbf8e:                                  2
+;     tube_host_r4_status:                    2
+;     gsinit:                                 2
+;     gsread:                                 2
+;     osgbpb:                                 2
+;     osargs:                                 2
+;     l0013:                                  1
+;     l00f1:                                  1
+;     l0103:                                  1
+;     l0104:                                  1
+;     l010c:                                  1
+;     l010d:                                  1
+;     l010e:                                  1
+;     brkv:                                   1
+;     brkv+1:                                 1
+;     filev:                                  1
+;     evntv:                                  1
+;     evntv+1:                                1
+;     l028d:                                  1
+;     l0cff:                                  1
+;     l0e0e:                                  1
+;     l0e10:                                  1
+;     l0f00:                                  1
+;     l0f09:                                  1
+;     l0f10:                                  1
+;     l1001:                                  1
+;     l1002:                                  1
+;     l1003:                                  1
+;     l1004:                                  1
+;     l1005:                                  1
+;     l1006:                                  1
+;     l1007:                                  1
+;     l100e:                                  1
+;     l1047:                                  1
+;     l104d:                                  1
+;     l104e:                                  1
+;     l1050:                                  1
+;     l1058:                                  1
+;     l105f:                                  1
+;     l1061:                                  1
+;     l1063:                                  1
+;     l1064:                                  1
+;     l1072:                                  1
+;     l1079:                                  1
+;     l107a:                                  1
+;     l1083:                                  1
+;     l108f:                                  1
+;     rom_header:                             1
+;     l8001:                                  1
+;     l8002:                                  1
+;     service_entry:                          1
+;     l8004:                                  1
+;     rom_type:                               1
+;     copyright_offset:                       1
+;     sub_c8020:                              1
+;     c8040:                                  1
+;     loop_c8064:                             1
+;     loop_c8086:                             1
+;     c8093:                                  1
+;     c8096:                                  1
+;     sub_c809d:                              1
+;     sub_c80b8:                              1
+;     c80d0:                                  1
+;     sub_c80d3:                              1
+;     sub_c80db:                              1
+;     sub_c80e6:                              1
+;     sub_c80f6:                              1
+;     c8111:                                  1
+;     c8115:                                  1
+;     c812e:                                  1
+;     loop_c813a:                             1
+;     c815b:                                  1
+;     c815f:                                  1
+;     loop_c8161:                             1
+;     loop_c816b:                             1
+;     c8184:                                  1
+;     c818a:                                  1
+;     loop_c818c:                             1
+;     c81a2:                                  1
+;     sub_c81b7:                              1
+;     c81bd:                                  1
+;     sub_c81c0:                              1
+;     sub_c81c4:                              1
+;     sub_c81ca:                              1
+;     loop_c820c:                             1
+;     loop_c820d:                             1
+;     loop_c821c:                             1
+;     sub_c8222:                              1
+;     c8243:                                  1
+;     loop_c826f:                             1
+;     c8286:                                  1
+;     c828b:                                  1
+;     c82be:                                  1
+;     loop_c82c7:                             1
+;     loop_c82d1:                             1
+;     c82d9:                                  1
+;     c82e7:                                  1
+;     c82fb:                                  1
+;     c8306:                                  1
+;     loop_c830d:                             1
+;     loop_c8326:                             1
+;     c8332:                                  1
+;     c8333:                                  1
+;     loop_c8370:                             1
+;     loop_c8390:                             1
+;     loop_c8397:                             1
+;     c83ab:                                  1
+;     sub_c83bf:                              1
+;     c83cd:                                  1
+;     sub_c83d1:                              1
+;     sub_c83d4:                              1
+;     c83e2:                                  1
+;     sub_c83ee:                              1
+;     loop_c83f0:                             1
+;     loop_c83fa:                             1
+;     loop_c8406:                             1
+;     loop_c8425:                             1
+;     c842b:                                  1
+;     sub_c842c:                              1
+;     c8436:                                  1
+;     c8438:                                  1
+;     c8453:                                  1
+;     loop_c8463:                             1
+;     c8477:                                  1
+;     c8481:                                  1
+;     c8482:                                  1
+;     loop_c8493:                             1
+;     c849d:                                  1
+;     loop_c84e7:                             1
+;     loop_c8527:                             1
+;     c853e:                                  1
+;     loop_c8552:                             1
+;     c855f:                                  1
+;     loop_c8564:                             1
+;     c8573:                                  1
+;     loop_c857b:                             1
+;     c859b:                                  1
+;     loop_c85b5:                             1
+;     c85c5:                                  1
+;     opt4_table:                             1
+;     sub_c85e3:                              1
+;     sub_c8602:                              1
+;     command_table+1:                        1
+;     loop_c8717:                             1
+;     loop_c8725:                             1
+;     c8734:                                  1
+;     c8759:                                  1
+;     c8779:                                  1
+;     c877c:                                  1
+;     loop_c87a0:                             1
+;     c87ab:                                  1
+;     c87b8:                                  1
+;     loop_c87be:                             1
+;     c87c6:                                  1
+;     c8815:                                  1
+;     sub_c8826:                              1
+;     c8837:                                  1
+;     c8864:                                  1
+;     c8867:                                  1
+;     loop_c88bc:                             1
+;     c892d:                                  1
+;     sub_c8932:                              1
+;     c8945:                                  1
+;     loop_c895f:                             1
+;     c8968:                                  1
+;     c896b:                                  1
+;     sub_c8979:                              1
+;     loop_c8990:                             1
+;     c89ad:                                  1
+;     loop_c89c4:                             1
+;     loop_c89ca:                             1
+;     c89e2:                                  1
+;     c89f6:                                  1
+;     loop_c8a17:                             1
+;     c8a19:                                  1
+;     c8a49:                                  1
+;     c8a50:                                  1
+;     c8a54:                                  1
+;     c8a82:                                  1
+;     loop_c8ac8:                             1
+;     c8ad0:                                  1
+;     loop_c8ad8:                             1
+;     c8aeb:                                  1
+;     loop_c8af0:                             1
+;     loop_c8afb:                             1
+;     c8b18:                                  1
+;     sub_c8b25:                              1
+;     c8b60:                                  1
+;     c8b77:                                  1
+;     loop_c8b80:                             1
+;     loop_c8bea:                             1
+;     sub_c8bf6:                              1
+;     sub_c8bf9:                              1
+;     c8bfb:                                  1
+;     c8c2e:                                  1
+;     c8c3a:                                  1
+;     c8c4e:                                  1
+;     sub_c8c56:                              1
+;     loop_c8c58:                             1
+;     c8c61:                                  1
+;     sub_c8c65:                              1
+;     loop_c8c71:                             1
+;     c8c87:                                  1
+;     c8cae:                                  1
+;     c8cc1:                                  1
+;     c8cd6:                                  1
+;     c8ce7:                                  1
+;     c8cfc:                                  1
+;     c8d03:                                  1
+;     loop_c8d14:                             1
+;     loop_c8d17:                             1
+;     sub_c8d1a:                              1
+;     c8d5d:                                  1
+;     c8d92:                                  1
+;     loop_c8dac:                             1
+;     loop_c8dba:                             1
+;     sub_c8dc6:                              1
+;     c8dd2:                                  1
+;     c8de2:                                  1
+;     loop_c8de9:                             1
+;     loop_c8df0:                             1
+;     c8e03:                                  1
+;     loop_c8e14:                             1
+;     c8e4d:                                  1
+;     c8e6f:                                  1
+;     c8e72:                                  1
+;     loop_c8e85:                             1
+;     c8e9e:                                  1
+;     c8eaf:                                  1
+;     c8ecb:                                  1
+;     c8edf:                                  1
+;     sub_c8eec:                              1
+;     c8ef8:                                  1
+;     sub_c8efa:                              1
+;     sub_c8eff:                              1
+;     c8f12:                                  1
+;     loop_c8f17:                             1
+;     c8f21:                                  1
+;     sub_c8f33:                              1
+;     sub_c8f37:                              1
+;     sub_c8f4f:                              1
+;     sub_c8f5e:                              1
+;     loop_c8f6c:                             1
+;     sub_c8f75:                              1
+;     c8f81:                                  1
+;     sub_c8f82:                              1
+;     sub_c8f94:                              1
+;     loop_c8f96:                             1
+;     loop_c8fac:                             1
+;     c8fb5:                                  1
+;     c8fc7:                                  1
+;     nmi_handler_rom_start:                  1
+;     nmi3_handler_rom_start-1:               1
+;     nmi3_handler_rom_end:                   1
+;     loop_c9047:                             1
+;     c9060:                                  1
+;     nmi_handler2_rom_start-1:               1
+;     c90db:                                  1
+;     c90e7:                                  1
+;     set_c_iff_have_fdc:                     1
+;     loop_c9108:                             1
+;     loop_c9113:                             1
+;     c9115:                                  1
+;     l911d:                                  1
+;     l9121:                                  1
+;     nmi_and_table:                          1
+;     l9139:                                  1
+;     l913f:                                  1
+;     l9145:                                  1
+;     l9146:                                  1
+;     l9191:                                  1
+;     l91a0:                                  1
+;     loop_c91ba:                             1
+;     c91cc:                                  1
+;     loop_c91e7:                             1
+;     c91eb:                                  1
+;     c91f3:                                  1
+;     c91f9:                                  1
+;     c9201:                                  1
+;     c920d:                                  1
+;     c921f:                                  1
+;     c922b:                                  1
+;     c9238:                                  1
+;     c923b:                                  1
+;     c923f:                                  1
+;     c9249:                                  1
+;     c925a:                                  1
+;     c926a:                                  1
+;     c9276:                                  1
+;     c929c:                                  1
+;     sub_c929d:                              1
+;     c92bd:                                  1
+;     c92c4:                                  1
+;     c92c7:                                  1
+;     c92d6:                                  1
+;     c92e3:                                  1
+;     loop_c92ef:                             1
+;     c9302:                                  1
+;     loop_c9355:                             1
+;     loop_c9357:                             1
+;     c936b:                                  1
+;     loop_c936f:                             1
+;     c9379:                                  1
+;     loop_c9382:                             1
+;     c938d:                                  1
+;     c9390:                                  1
+;     c93a8:                                  1
+;     c93b1:                                  1
+;     sub_c93b4:                              1
+;     loop_c93bd:                             1
+;     c93c4:                                  1
+;     sub_c93d8:                              1
+;     loop_c93da:                             1
+;     c93e2:                                  1
+;     c93e5:                                  1
+;     sub_c93f1:                              1
+;     sub_c93f9:                              1
+;     c93ff:                                  1
+;     c9450:                                  1
+;     c945c:                                  1
+;     c948d:                                  1
+;     c94c1:                                  1
+;     c94c2:                                  1
+;     c94d4:                                  1
+;     c9504:                                  1
+;     c9535:                                  1
+;     sub_c9536:                              1
+;     loop_c953a:                             1
+;     c9556:                                  1
+;     c956d:                                  1
+;     c956f:                                  1
+;     loop_c957d:                             1
+;     loop_c9593:                             1
+;     loop_c95b6:                             1
+;     loop_c95d9:                             1
+;     c95e4:                                  1
+;     c95e7:                                  1
+;     loop_c95ec:                             1
+;     loop_c9618:                             1
+;     c9649:                                  1
+;     c964a:                                  1
+;     c9658:                                  1
+;     sub_c965d:                              1
+;     c967a:                                  1
+;     c9682:                                  1
+;     c9683:                                  1
+;     c969e:                                  1
+;     pla_rts:                                1
+;     loop_c96c2:                             1
+;     c96c3:                                  1
+;     c96e4:                                  1
+;     c96e9:                                  1
+;     c96ec:                                  1
+;     loop_c96f2:                             1
+;     c96f5:                                  1
+;     c9700:                                  1
+;     c9714:                                  1
+;     c9736:                                  1
+;     c973c:                                  1
+;     c973d:                                  1
+;     c975b:                                  1
+;     c976c:                                  1
+;     loop_c979d:                             1
+;     loop_c97c8:                             1
+;     c97e6:                                  1
+;     sub_c97e8:                              1
+;     loop_c9803:                             1
+;     c981f:                                  1
+;     c982e:                                  1
+;     sub_c9832:                              1
+;     c9835:                                  1
+;     loop_c9837:                             1
+;     c984c:                                  1
+;     loop_c9851:                             1
+;     c9859:                                  1
+;     loop_c985e:                             1
+;     c986b:                                  1
+;     c9873:                                  1
+;     loop_c9881:                             1
+;     loop_c98a0:                             1
+;     c98b1:                                  1
+;     c98ba:                                  1
+;     loop_c98c1:                             1
+;     c98cd:                                  1
+;     loop_c98e4:                             1
+;     c98ed:                                  1
+;     c98f0:                                  1
+;     loop_c9942:                             1
+;     c994b:                                  1
+;     loop_c994e:                             1
+;     loop_c9964:                             1
+;     c9978:                                  1
+;     sub_c9988:                              1
+;     c9993:                                  1
+;     loop_c99a8:                             1
+;     c99ea:                                  1
+;     c9a2a:                                  1
+;     sub_c9a32:                              1
+;     c9a3f:                                  1
+;     sub_c9a4b:                              1
+;     generate_error_precheck_locked:         1
+;     c9a73:                                  1
+;     c9a77:                                  1
+;     sub_c9ad3:                              1
+;     c9ad4:                                  1
+;     l9aec:                                  1
+;     l9b0f:                                  1
+;     l9b18:                                  1
+;     l9b21:                                  1
+;     l9b29:                                  1
+;     l9b31:                                  1
+;     l9b3a:                                  1
+;     l9b43:                                  1
+;     loop_c9b50:                             1
+;     sub_c9b51:                              1
+;     loop_c9b5e:                             1
+;     sub_c9b61:                              1
+;     loop_c9b63:                             1
+;     c9bc2:                                  1
+;     sub_c9bca:                              1
+;     sub_c9bcd:                              1
+;     loop_c9bcf:                             1
+;     loop_c9be4:                             1
+;     generate_error_precheck_disc_changed:   1
+;     c9c16:                                  1
+;     c9c33:                                  1
+;     loop_c9c38:                             1
+;     c9c51:                                  1
+;     c9c58:                                  1
+;     loop_c9c5d:                             1
+;     c9c6b:                                  1
+;     c9c8b:                                  1
+;     loop_c9c90:                             1
+;     loop_c9ca8:                             1
+;     c9cee:                                  1
+;     loop_c9d03:                             1
+;     c9d12:                                  1
+;     sub_c9d19:                              1
+;     c9d2b:                                  1
+;     loop_c9d43:                             1
+;     c9d57:                                  1
+;     c9d67:                                  1
+;     c9d71:                                  1
+;     c9d72:                                  1
+;     sub_c9d75:                              1
+;     c9d86:                                  1
+;     c9d89:                                  1
+;     c9db4:                                  1
+;     c9dce:                                  1
+;     loop_c9e07:                             1
+;     c9e13:                                  1
+;     c9e16:                                  1
+;     c9e28:                                  1
+;     c9e2a:                                  1
+;     osbyte_write_0:                         1
+;     c9e5c:                                  1
+;     c9e6f:                                  1
+;     c9e71:                                  1
+;     loop_c9e74:                             1
+;     loop_c9e8c:                             1
+;     sub_c9e94:                              1
+;     c9eb3:                                  1
+;     c9ec2:                                  1
+;     c9ef1:                                  1
+;     c9f0d:                                  1
+;     c9f19:                                  1
+;     c9f5e:                                  1
+;     c9f64:                                  1
+;     c9f6a:                                  1
+;     c9f6b:                                  1
+;     loop_c9f6e:                             1
+;     sub_c9f7c:                              1
+;     sub_c9f82:                              1
+;     c9f88:                                  1
+;     c9fd9:                                  1
+;     c9ff4:                                  1
+;     ca005:                                  1
+;     ca054:                                  1
+;     loop_ca061:                             1
+;     ca075:                                  1
+;     ca0a9:                                  1
+;     sub_ca0b8:                              1
+;     sub_ca0f6:                              1
+;     loop_ca11d:                             1
+;     loop_ca132:                             1
+;     loop_ca143:                             1
+;     loop_ca16e:                             1
+;     ca17a:                                  1
+;     ca183:                                  1
+;     sub_ca190:                              1
+;     loop_ca1aa:                             1
+;     ca1c1:                                  1
+;     loop_ca1cc:                             1
+;     ca1d2:                                  1
+;     ca27a:                                  1
+;     ca2ab:                                  1
+;     ca30d:                                  1
+;     ca321:                                  1
+;     ca34a:                                  1
+;     ca378:                                  1
+;     ca38c:                                  1
+;     ca38e:                                  1
+;     ca3ae:                                  1
+;     ca3bd:                                  1
+;     sub_ca3e4:                              1
+;     ca3fb:                                  1
+;     ca40c:                                  1
+;     ca45d:                                  1
+;     ca47b:                                  1
+;     loop_ca487:                             1
+;     sub_ca4e1:                              1
+;     ca4fa:                                  1
+;     loop_ca521:                             1
+;     ca538:                                  1
+;     ca547:                                  1
+;     ca574:                                  1
+;     ca595:                                  1
+;     ca5a0:                                  1
+;     ca5c4:                                  1
+;     ca5e2:                                  1
+;     ca5fb:                                  1
+;     ca605:                                  1
+;     ca63a:                                  1
+;     ca647:                                  1
+;     ca652:                                  1
+;     ca65d:                                  1
+;     sub_ca663:                              1
+;     ca675:                                  1
+;     ca68a:                                  1
+;     ca6b3:                                  1
+;     ca6b6:                                  1
+;     ca6bb:                                  1
+;     ca6ce:                                  1
+;     ca6e2:                                  1
+;     ca70a:                                  1
+;     ca712:                                  1
+;     ca721:                                  1
+;     ca728:                                  1
+;     ca73a:                                  1
+;     sub_ca73d:                              1
+;     sub_ca76c:                              1
+;     loop_ca76f:                             1
+;     sub_ca779:                              1
+;     ca787:                                  1
+;     sub_ca788:                              1
+;     ca7a4:                                  1
+;     loop_ca7a7:                             1
+;     sub_ca7c4:                              1
+;     sub_ca7c5:                              1
+;     loop_ca7c6:                             1
+;     sub_ca7ce:                              1
+;     loop_ca7e0:                             1
+;     loop_ca7e1:                             1
+;     ca7f2:                                  1
+;     ca7f7:                                  1
+;     ca818:                                  1
+;     ca82f:                                  1
+;     ca856:                                  1
+;     ca8bd:                                  1
+;     sub_ca8be:                              1
+;     sub_ca8e2:                              1
+;     ca8fa:                                  1
+;     ca902:                                  1
+;     ca90c:                                  1
+;     loop_ca941:                             1
+;     loop_ca947:                             1
+;     loop_ca953:                             1
+;     ca95d:                                  1
+;     ca96c:                                  1
+;     ca970:                                  1
+;     ca982:                                  1
+;     ca98d:                                  1
+;     loop_ca9ab:                             1
+;     ca9b8:                                  1
+;     sub_ca9bf:                              1
+;     loop_ca9e7:                             1
+;     loop_caa01:                             1
+;     caa0a:                                  1
+;     caa0d:                                  1
+;     sub_caa12:                              1
+;     caa78:                                  1
+;     caa7a:                                  1
+;     caa86:                                  1
+;     sub_caa9a:                              1
+;     caab7:                                  1
+;     loop_caab8:                             1
+;     caabe:                                  1
+;     caace:                                  1
+;     sub_caadd:                              1
+;     sub_caaea:                              1
+;     cab09:                                  1
+;     cab17:                                  1
+;     cab2e:                                  1
+;     cab35:                                  1
+;     cab3d:                                  1
+;     loop_cab6b:                             1
+;     cab7d:                                  1
+;     loop_cab80:                             1
+;     cab93:                                  1
+;     caba4:                                  1
+;     sub_caba9:                              1
+;     loop_cabad:                             1
+;     cabcf:                                  1
+;     loop_cabf4:                             1
+;     cabfb:                                  1
+;     cac28:                                  1
+;     cac45:                                  1
+;     loop_cac46:                             1
+;     sub_cac47:                              1
+;     sub_cac6a:                              1
+;     sub_cac72:                              1
+;     cacc7:                                  1
+;     lacf3:                                  1
+;     cad2d:                                  1
+;     cad3f:                                  1
+;     cad52:                                  1
+;     cad61:                                  1
+;     cad6e:                                  1
+;     cad81:                                  1
+;     cad86:                                  1
+;     cada2:                                  1
+;     cadae:                                  1
+;     cadc1:                                  1
+;     caddf:                                  1
+;     cadf8:                                  1
+;     cae06:                                  1
+;     cae20:                                  1
+;     cae27:                                  1
+;     cae32:                                  1
+;     cae35:                                  1
+;     cae40:                                  1
+;     cae45:                                  1
+;     cae5b:                                  1
+;     cae62:                                  1
+;     cae82:                                  1
+;     service_handler_help_and_tube:          1
+;     caed7:                                  1
+;     service_handler_tube_main_init:         1
+;     loop_caf13:                             1
+;     loop_caf2d:                             1
+;     lda_0_rts:                              1
+;     caf4b:                                  1
+;     caf54:                                  1
+;     caf5d:                                  1
+;     caf63:                                  1
+;     laf73:                                  1
+;     sub_caf8d:                              1
+;     sub_caf9a:                              1
+;     cafa1:                                  1
+;     cafab:                                  1
+;     cafae:                                  1
+;     cafbf:                                  1
+;     cafdc:                                  1
+;     cafdf:                                  1
+;     cafea:                                  1
+;     caff3:                                  1
+;     caffd:                                  1
+;     cb005:                                  1
+;     cb014:                                  1
+;     cb01f:                                  1
+;     sub_cb040:                              1
+;     cb05a:                                  1
+;     cb070:                                  1
+;     lb075:                                  1
+;     lb175:                                  1
+;     general_service_handler:                1
+;     cb1dd:                                  1
+;     loop_cb1e3:                             1
+;     loop_cb1ed:                             1
+;     cb1fc:                                  1
+;     cb20f:                                  1
+;     cb221:                                  1
+;     sub_cb234:                              1
+;     cb23d:                                  1
+;     loop_cb249:                             1
+;     cb260:                                  1
+;     cb268:                                  1
+;     loop_cb275:                             1
+;     lb283:                                  1
+;     cb2b2:                                  1
+;     loop_cb2b4:                             1
+;     loop_cb2bd:                             1
+;     sub_cb2c8:                              1
+;     loop_cb2d1:                             1
+;     cb2e1:                                  1
+;     cb2e7:                                  1
+;     cb305:                                  1
+;     cb314:                                  1
+;     cb337:                                  1
+;     cb34f:                                  1
+;     cb352:                                  1
+;     cb375:                                  1
+;     cb37f:                                  1
+;     cb382:                                  1
+;     cb397:                                  1
+;     cb3ba:                                  1
+;     cb3de:                                  1
+;     cb40e:                                  1
+;     cb44b:                                  1
+;     loop_cb44d:                             1
+;     cb45a:                                  1
+;     cb470:                                  1
+;     loop_cb4a8:                             1
+;     cb4af:                                  1
+;     cb4b4:                                  1
+;     cb4d8:                                  1
+;     cb4df:                                  1
+;     cb4e9:                                  1
+;     cb4ee:                                  1
+;     cb502:                                  1
+;     cb534:                                  1
+;     loop_cb55e:                             1
+;     loop_cb578:                             1
+;     cb597:                                  1
+;     loop_cb5c6:                             1
+;     cb5d0:                                  1
+;     cb5e6:                                  1
+;     loop_cb5ed:                             1
+;     cb65e:                                  1
+;     cb6a6:                                  1
+;     loop_cb6b3:                             1
+;     cb6c2:                                  1
+;     lb6c6:                                  1
+;     lb6ce:                                  1
+;     cb6d2:                                  1
+;     sub_cb6e6:                              1
+;     cb6eb:                                  1
+;     cb6f5:                                  1
+;     cb725:                                  1
+;     cb736:                                  1
+;     loop_cb75a:                             1
+;     sub_cb771:                              1
+;     lb774:                                  1
+;     cb7ae:                                  1
+;     cb7b2:                                  1
+;     sub_cb7b6:                              1
+;     loop_cb7be:                             1
+;     loop_cb7d7:                             1
+;     loop_cb7dd:                             1
+;     cb7e8:                                  1
+;     cb7ec:                                  1
+;     sub_cb86f:                              1
+;     lb87e:                                  1
+;     sub_cb882:                              1
+;     cb898:                                  1
+;     cb8e6:                                  1
+;     cb8f5:                                  1
+;     loop_cb910:                             1
+;     lb924:                                  1
+;     lb979:                                  1
+;     lb97a:                                  1
+;     lb980:                                  1
+;     loop_cb999:                             1
+;     cb9ae:                                  1
+;     loop_cb9bd:                             1
+;     loop_cb9cc:                             1
+;     loop_cb9d1:                             1
+;     cb9d2:                                  1
+;     cb9d9:                                  1
+;     cb9ee:                                  1
+;     cb9f7:                                  1
+;     loop_cb9f9:                             1
+;     cba15:                                  1
+;     cba19:                                  1
+;     loop_cba1a:                             1
+;     cba27:                                  1
+;     cba28:                                  1
+;     cba2e:                                  1
+;     cba2f:                                  1
+;     sram_table+1:                           1
+;     cba78:                                  1
+;     cba8c:                                  1
+;     loop_cba94:                             1
+;     cba9e:                                  1
+;     cbab0:                                  1
+;     cbab1:                                  1
+;     loop_cbab8:                             1
+;     cbad0:                                  1
+;     sub_cbad2:                              1
+;     loop_cbaea:                             1
+;     cbb07:                                  1
+;     cbb33:                                  1
+;     cbb36:                                  1
+;     lbb3a:                                  1
+;     lbb3e:                                  1
+;     lbb42:                                  1
+;     cbb4c:                                  1
+;     cbb6f:                                  1
+;     cbb89:                                  1
+;     cbb90:                                  1
+;     cbba1:                                  1
+;     cbbbe:                                  1
+;     cbbd9:                                  1
+;     loop_cbbe4:                             1
+;     cbbf3:                                  1
+;     loop_cbbfe:                             1
+;     cbc2c:                                  1
+;     cbc54:                                  1
+;     cbc64:                                  1
+;     loop_cbc70:                             1
+;     cbc78:                                  1
+;     cbc93:                                  1
+;     cbcb2:                                  1
+;     loop_cbcd3:                             1
+;     cbcd6:                                  1
+;     cbce1:                                  1
+;     cbcf9:                                  1
+;     loop_cbd08:                             1
+;     cbd0e:                                  1
+;     cbd1b:                                  1
+;     loop_cbd2b:                             1
+;     cbd40:                                  1
+;     cbd46:                                  1
+;     loop_cbd6c:                             1
+;     cbd7e:                                  1
+;     loop_cbd99:                             1
+;     cbda3:                                  1
+;     cbdba:                                  1
+;     cbdc0:                                  1
+;     cbdd3:                                  1
+;     cbddd:                                  1
+;     loop_cbe0e:                             1
+;     cbe21:                                  1
+;     loop_cbe31:                             1
+;     cbe3c:                                  1
+;     cbe52:                                  1
+;     sub_cbe91:                              1
+;     loop_cbeab:                             1
+;     service_handler:                        1
+;     cbee0:                                  1
+;     cbeee:                                  1
+;     loop_cbf1c:                             1
+;     cbf33:                                  1
+;     cbf46:                                  1
+;     lbf4f:                                  1
+;     loop_cbf78:                             1
+;     sub_cbf84:                              1
+;     cbf8a:                                  1
+;     cbfa3:                                  1
+;     cbfb2:                                  1
+;     tube_host_r4_data:                      1
+
+; Automatically generated labels:
+;     c0032
+;     c0036
+;     c0041
+;     c0400
+;     c0432
+;     c0434
+;     c0463
+;     c047a
+;     c0482
+;     c0484
+;     c048c
+;     c0491
+;     c049b
+;     c04bc
+;     c04f7
+;     c053a
+;     c0552
+;     c0593
+;     c059c
+;     c059e
+;     c05a6
+;     c05fc
+;     c0636
+;     c0645
+;     c0665
+;     c06a7
+;     c0d60
+;     c0d74
+;     c0d80
+;     c8040
+;     c8093
+;     c8096
+;     c809f
+;     c80d0
+;     c8103
+;     c8111
+;     c8115
+;     c8125
+;     c812e
+;     c815b
+;     c815d
+;     c815f
+;     c8184
+;     c818a
+;     c81a2
+;     c81a7
+;     c81bd
+;     c8225
+;     c822a
+;     c8243
+;     c825d
+;     c8286
+;     c828b
+;     c8290
+;     c82be
+;     c82d9
+;     c82e6
+;     c82e7
+;     c82fb
+;     c82fd
+;     c8306
+;     c8332
+;     c8333
+;     c83ab
+;     c83cd
+;     c83e2
+;     c842b
+;     c8436
+;     c8438
+;     c8453
+;     c8454
+;     c8477
+;     c8481
+;     c8482
+;     c849d
+;     c853e
+;     c8543
+;     c855f
+;     c8560
+;     c8573
+;     c859b
+;     c85bc
+;     c85c5
+;     c8703
+;     c8705
+;     c8734
+;     c873b
+;     c8759
+;     c8779
+;     c877c
+;     c87ab
+;     c87b8
+;     c87c6
+;     c8808
+;     c8815
+;     c8816
+;     c8837
+;     c883f
+;     c8864
+;     c8867
+;     c88a6
+;     c88f4
+;     c892d
+;     c8945
+;     c8968
+;     c896b
+;     c898a
+;     c89a5
+;     c89ad
+;     c89b4
+;     c89d7
+;     c89e2
+;     c89f6
+;     c8a00
+;     c8a19
+;     c8a49
+;     c8a50
+;     c8a54
+;     c8a6e
+;     c8a82
+;     c8ad0
+;     c8aeb
+;     c8b18
+;     c8b60
+;     c8b77
+;     c8b8b
+;     c8ba2
+;     c8be3
+;     c8bfb
+;     c8c12
+;     c8c2e
+;     c8c3a
+;     c8c4e
+;     c8c61
+;     c8c87
+;     c8cae
+;     c8cb2
+;     c8cc1
+;     c8cd6
+;     c8ce7
+;     c8cfc
+;     c8d03
+;     c8d0d
+;     c8d13
+;     c8d41
+;     c8d5d
+;     c8d74
+;     c8d91
+;     c8d92
+;     c8dd2
+;     c8de2
+;     c8e03
+;     c8e0d
+;     c8e0e
+;     c8e12
+;     c8e32
+;     c8e4d
+;     c8e53
+;     c8e64
+;     c8e6f
+;     c8e72
+;     c8e9e
+;     c8e9f
+;     c8ea5
+;     c8eaf
+;     c8eb7
+;     c8ecb
+;     c8ecc
+;     c8edf
+;     c8eeb
+;     c8ef8
+;     c8f12
+;     c8f21
+;     c8f2a
+;     c8f3e
+;     c8f81
+;     c8fb5
+;     c8fc7
+;     c9060
+;     c90c7
+;     c90db
+;     c90e7
+;     c9115
+;     c91af
+;     c91cc
+;     c91df
+;     c91eb
+;     c91f3
+;     c91f9
+;     c9201
+;     c920d
+;     c9214
+;     c921f
+;     c922b
+;     c9238
+;     c923b
+;     c923f
+;     c9249
+;     c9257
+;     c925a
+;     c926a
+;     c9276
+;     c9289
+;     c929c
+;     c92bd
+;     c92c4
+;     c92c7
+;     c92d6
+;     c92e3
+;     c9302
+;     c9367
+;     c936b
+;     c9379
+;     c938d
+;     c9390
+;     c93a8
+;     c93b1
+;     c93c4
+;     c93e2
+;     c93e5
+;     c93e6
+;     c93ff
+;     c940c
+;     c940e
+;     c9436
+;     c9444
+;     c9450
+;     c945c
+;     c948d
+;     c94a9
+;     c94bc
+;     c94c1
+;     c94c2
+;     c94c6
+;     c94d4
+;     c9504
+;     c9535
+;     c9556
+;     c956d
+;     c956f
+;     c95e4
+;     c95e7
+;     c95fd
+;     c9628
+;     c9649
+;     c964a
+;     c9658
+;     c965a
+;     c967a
+;     c9682
+;     c9683
+;     c969e
+;     c96b7
+;     c96c3
+;     c96e4
+;     c96e9
+;     c96ec
+;     c96f5
+;     c9700
+;     c9714
+;     c9736
+;     c9738
+;     c973c
+;     c973d
+;     c975b
+;     c976c
+;     c97b3
+;     c97e6
+;     c981f
+;     c982e
+;     c9835
+;     c984c
+;     c9859
+;     c986b
+;     c9873
+;     c98b1
+;     c98ba
+;     c98cd
+;     c98ed
+;     c98f0
+;     c993b
+;     c994b
+;     c996e
+;     c9978
+;     c9993
+;     c99a3
+;     c99ea
+;     c99ed
+;     c9a2a
+;     c9a3f
+;     c9a73
+;     c9a77
+;     c9a8c
+;     c9ad4
+;     c9adf
+;     c9ae9
+;     c9b6e
+;     c9bc2
+;     c9bc5
+;     c9c16
+;     c9c33
+;     c9c51
+;     c9c58
+;     c9c6b
+;     c9c8b
+;     c9cee
+;     c9d12
+;     c9d2b
+;     c9d57
+;     c9d5d
+;     c9d67
+;     c9d71
+;     c9d72
+;     c9d86
+;     c9d89
+;     c9db4
+;     c9dcd
+;     c9dce
+;     c9dd5
+;     c9e13
+;     c9e16
+;     c9e28
+;     c9e2a
+;     c9e41
+;     c9e5c
+;     c9e6f
+;     c9e71
+;     c9eb3
+;     c9ec2
+;     c9ef1
+;     c9f0d
+;     c9f19
+;     c9f5e
+;     c9f64
+;     c9f6a
+;     c9f6b
+;     c9f88
+;     c9fd9
+;     c9ff4
+;     ca005
+;     ca01d
+;     ca021
+;     ca054
+;     ca06b
+;     ca06c
+;     ca075
+;     ca0a9
+;     ca0f5
+;     ca10b
+;     ca14f
+;     ca17a
+;     ca183
+;     ca19f
+;     ca1c0
+;     ca1c1
+;     ca1d2
+;     ca27a
+;     ca2ab
+;     ca2f2
+;     ca30d
+;     ca321
+;     ca34a
+;     ca378
+;     ca38b
+;     ca38c
+;     ca38e
+;     ca3ae
+;     ca3bd
+;     ca3dc
+;     ca3fb
+;     ca40c
+;     ca411
+;     ca414
+;     ca45d
+;     ca47b
+;     ca4fa
+;     ca538
+;     ca547
+;     ca574
+;     ca595
+;     ca5a0
+;     ca5ab
+;     ca5c4
+;     ca5e2
+;     ca5e5
+;     ca5fb
+;     ca605
+;     ca637
+;     ca63a
+;     ca647
+;     ca652
+;     ca65d
+;     ca660
+;     ca675
+;     ca68a
+;     ca6b3
+;     ca6b6
+;     ca6bb
+;     ca6ce
+;     ca6e2
+;     ca70a
+;     ca712
+;     ca721
+;     ca728
+;     ca73a
+;     ca787
+;     ca7a4
+;     ca7f2
+;     ca7f7
+;     ca818
+;     ca82f
+;     ca845
+;     ca856
+;     ca86b
+;     ca87a
+;     ca8bd
+;     ca8fa
+;     ca902
+;     ca90c
+;     ca95d
+;     ca96c
+;     ca970
+;     ca97d
+;     ca982
+;     ca98d
+;     ca9b8
+;     ca9ff
+;     caa0a
+;     caa0d
+;     caa1c
+;     caa42
+;     caa44
+;     caa51
+;     caa78
+;     caa7a
+;     caa86
+;     caab7
+;     caabe
+;     caace
+;     cab09
+;     cab17
+;     cab1a
+;     cab2e
+;     cab35
+;     cab3d
+;     cab41
+;     cab54
+;     cab7d
+;     cab93
+;     caba4
+;     cabbc
+;     cabcf
+;     cabfb
+;     cac0f
+;     cac28
+;     cac45
+;     cacc4
+;     cacc7
+;     cad15
+;     cad2d
+;     cad3f
+;     cad52
+;     cad61
+;     cad6e
+;     cad77
+;     cad79
+;     cad81
+;     cad86
+;     cada2
+;     cadae
+;     cadc1
+;     cadd7
+;     caddf
+;     cadf8
+;     cae06
+;     cae11
+;     cae20
+;     cae27
+;     cae32
+;     cae35
+;     cae40
+;     cae45
+;     cae5b
+;     cae62
+;     cae70
+;     cae79
+;     cae82
+;     cae97
+;     caea0
+;     caed3
+;     caed7
+;     caf4b
+;     caf54
+;     caf58
+;     caf5d
+;     caf63
+;     caf7f
+;     cafa1
+;     cafab
+;     cafad
+;     cafae
+;     cafbf
+;     cafdc
+;     cafdf
+;     cafea
+;     caff3
+;     caffb
+;     caffd
+;     cb005
+;     cb00a
+;     cb014
+;     cb01f
+;     cb035
+;     cb05a
+;     cb070
+;     cb1d5
+;     cb1dd
+;     cb1fc
+;     cb203
+;     cb20f
+;     cb221
+;     cb23d
+;     cb260
+;     cb268
+;     cb280
+;     cb297
+;     cb2a0
+;     cb2b2
+;     cb2e1
+;     cb2e7
+;     cb300
+;     cb305
+;     cb314
+;     cb337
+;     cb34f
+;     cb352
+;     cb371
+;     cb375
+;     cb37f
+;     cb382
+;     cb397
+;     cb3ba
+;     cb3de
+;     cb406
+;     cb40e
+;     cb446
+;     cb44b
+;     cb45a
+;     cb45e
+;     cb470
+;     cb4af
+;     cb4b4
+;     cb4d8
+;     cb4df
+;     cb4e9
+;     cb4ee
+;     cb502
+;     cb534
+;     cb597
+;     cb5d0
+;     cb5e6
+;     cb655
+;     cb65e
+;     cb684
+;     cb68c
+;     cb6a6
+;     cb6c2
+;     cb6ca
+;     cb6d2
+;     cb6eb
+;     cb6f5
+;     cb718
+;     cb725
+;     cb736
+;     cb795
+;     cb7ae
+;     cb7b2
+;     cb7e8
+;     cb7ec
+;     cb7ed
+;     cb82b
+;     cb898
+;     cb8e4
+;     cb8e6
+;     cb8f5
+;     cb8fb
+;     cb9ae
+;     cb9d2
+;     cb9d9
+;     cb9e8
+;     cb9ee
+;     cb9f7
+;     cba10
+;     cba15
+;     cba19
+;     cba27
+;     cba28
+;     cba2e
+;     cba2f
+;     cba78
+;     cba8c
+;     cba9e
+;     cbab0
+;     cbab1
+;     cbab4
+;     cbad0
+;     cbaf8
+;     cbafd
+;     cbb07
+;     cbb28
+;     cbb2a
+;     cbb33
+;     cbb36
+;     cbb4c
+;     cbb6f
+;     cbb89
+;     cbb90
+;     cbba1
+;     cbbbe
+;     cbbd0
+;     cbbd9
+;     cbbf3
+;     cbc13
+;     cbc2c
+;     cbc3a
+;     cbc54
+;     cbc64
+;     cbc78
+;     cbc93
+;     cbcb2
+;     cbcb9
+;     cbcd6
+;     cbce1
+;     cbcf9
+;     cbd0e
+;     cbd1b
+;     cbd40
+;     cbd46
+;     cbd7e
+;     cbda3
+;     cbdb9
+;     cbdba
+;     cbdc0
+;     cbdd3
+;     cbddd
+;     cbe21
+;     cbe3c
+;     cbe47
+;     cbe52
+;     cbe7a
+;     cbe7b
+;     cbe89
+;     cbe8d
+;     cbec1
+;     cbee0
+;     cbee8
+;     cbeee
+;     cbf33
+;     cbf46
+;     cbf8a
+;     cbf8e
+;     cbfa3
+;     cbfb2
+;     l0000
+;     l0001
+;     l0002
+;     l0003
+;     l0012
+;     l0013
+;     l0014
+;     l0015
+;     l0053
+;     l0054
+;     l0055
+;     l0056
+;     l00a0
+;     l00a1
+;     l00a2
+;     l00a3
+;     l00a4
+;     l00a5
+;     l00a6
+;     l00a7
+;     l00a8
+;     l00a9
+;     l00aa
+;     l00ab
+;     l00ac
+;     l00ad
+;     l00ae
+;     l00af
+;     l00b0
+;     l00b1
+;     l00b2
+;     l00b3
+;     l00b4
+;     l00b5
+;     l00b6
+;     l00b7
+;     l00b8
+;     l00b9
+;     l00ba
+;     l00bb
+;     l00bc
+;     l00bd
+;     l00be
+;     l00bf
+;     l00c0
+;     l00c1
+;     l00c2
+;     l00c3
+;     l00c4
+;     l00c5
+;     l00c6
+;     l00c7
+;     l00c8
+;     l00c9
+;     l00ca
+;     l00cc
+;     l00cd
+;     l00ce
+;     l00cf
+;     l00ef
+;     l00f0
+;     l00f1
+;     l00f3
+;     l00f7
+;     l00fd
+;     l00ff
+;     l0100
+;     l0101
+;     l0102
+;     l0103
+;     l0104
+;     l0105
+;     l0107
+;     l0109
+;     l010b
+;     l010c
+;     l010d
+;     l010e
+;     l0128
+;     l028d
+;     l0500
+;     l0600
+;     l0700
+;     l0cff
+;     l0d0f
+;     l0d12
+;     l0d1f
+;     l0d26
+;     l0d2a
+;     l0d30
+;     l0d3d
+;     l0d50
+;     l0df0
+;     l0e00
+;     l0e07
+;     l0e08
+;     l0e0e
+;     l0e0f
+;     l0e10
+;     l0ef8
+;     l0f00
+;     l0f04
+;     l0f05
+;     l0f06
+;     l0f07
+;     l0f08
+;     l0f09
+;     l0f0a
+;     l0f0b
+;     l0f0c
+;     l0f0d
+;     l0f0e
+;     l0f0f
+;     l0f10
+;     l1000
+;     l1001
+;     l1002
+;     l1003
+;     l1004
+;     l1005
+;     l1006
+;     l1007
+;     l100e
+;     l1045
+;     l1047
+;     l104d
+;     l104e
+;     l1050
+;     l1058
+;     l105f
+;     l1060
+;     l1061
+;     l1062
+;     l1063
+;     l1064
+;     l1065
+;     l1067
+;     l1069
+;     l1072
+;     l1074
+;     l1075
+;     l1076
+;     l1077
+;     l1078
+;     l1079
+;     l107a
+;     l107d
+;     l107e
+;     l107f
+;     l1081
+;     l1082
+;     l1083
+;     l1086
+;     l1087
+;     l1088
+;     l1089
+;     l108a
+;     l108b
+;     l108c
+;     l108f
+;     l1090
+;     l1091
+;     l1092
+;     l1093
+;     l1094
+;     l1095
+;     l1096
+;     l1097
+;     l1098
+;     l1099
+;     l109a
+;     l109b
+;     l109d
+;     l109e
+;     l109f
+;     l10c0
+;     l10c1
+;     l10c2
+;     l10c3
+;     l10c4
+;     l10c5
+;     l10c6
+;     l10c7
+;     l10c9
+;     l10ca
+;     l10cb
+;     l10cc
+;     l10cd
+;     l10ce
+;     l10cf
+;     l10d0
+;     l10d1
+;     l10d2
+;     l10d3
+;     l10d6
+;     l10d7
+;     l10d8
+;     l10d9
+;     l10da
+;     l10db
+;     l10dc
+;     l10dd
+;     l10de
+;     l10e2
+;     l10e3
+;     l10e4
+;     l1100
+;     l1109
+;     l110b
+;     l110c
+;     l110d
+;     l110e
+;     l110f
+;     l1110
+;     l1111
+;     l1112
+;     l1113
+;     l1114
+;     l1115
+;     l1116
+;     l1117
+;     l1119
+;     l111a
+;     l111b
+;     l111c
+;     l111d
+;     l8001
+;     l8002
+;     l8004
+;     l911d
+;     l9121
+;     l9139
+;     l913f
+;     l9145
+;     l9146
+;     l9191
+;     l91a0
+;     l9aec
+;     l9b0f
+;     l9b18
+;     l9b21
+;     l9b29
+;     l9b31
+;     l9b3a
+;     l9b43
+;     la1d3
+;     lacf3
+;     laf73
+;     laf75
+;     laf76
+;     laf77
+;     laf78
+;     lb075
+;     lb175
+;     lb283
+;     lb57f
+;     lb6c6
+;     lb6ce
+;     lb726
+;     lb774
+;     lb872
+;     lb87e
+;     lb924
+;     lb979
+;     lb97a
+;     lb980
+;     lbb3a
+;     lbb3e
+;     lbb42
+;     lbf4f
+;     lbfff
+;     lfe80
+;     lfe84
+;     lfe85
+;     lfe86
+;     lfe87
+;     loop_c0029
+;     loop_c003b
+;     loop_c0446
+;     loop_c0466
+;     loop_c0471
+;     loop_c04a6
+;     loop_c04e1
+;     loop_c0564
+;     loop_c0577
+;     loop_c0586
+;     loop_c05ab
+;     loop_c05c7
+;     loop_c05d3
+;     loop_c05e6
+;     loop_c0604
+;     loop_c061d
+;     loop_c062b
+;     loop_c064c
+;     loop_c0657
+;     loop_c065a
+;     loop_c8064
+;     loop_c8086
+;     loop_c813a
+;     loop_c8161
+;     loop_c816b
+;     loop_c818c
+;     loop_c820c
+;     loop_c820d
+;     loop_c821c
+;     loop_c826f
+;     loop_c82c7
+;     loop_c82d1
+;     loop_c830d
+;     loop_c8326
+;     loop_c8370
+;     loop_c8390
+;     loop_c8397
+;     loop_c83f0
+;     loop_c83fa
+;     loop_c8406
+;     loop_c8425
+;     loop_c8463
+;     loop_c8493
+;     loop_c84e7
+;     loop_c8527
+;     loop_c8552
+;     loop_c8564
+;     loop_c857b
+;     loop_c85b5
+;     loop_c8717
+;     loop_c8725
+;     loop_c87a0
+;     loop_c87be
+;     loop_c88bc
+;     loop_c895f
+;     loop_c8990
+;     loop_c89c4
+;     loop_c89ca
+;     loop_c8a17
+;     loop_c8ac8
+;     loop_c8ad8
+;     loop_c8af0
+;     loop_c8afb
+;     loop_c8b80
+;     loop_c8bea
+;     loop_c8c58
+;     loop_c8c71
+;     loop_c8d14
+;     loop_c8d17
+;     loop_c8dac
+;     loop_c8dba
+;     loop_c8de9
+;     loop_c8df0
+;     loop_c8e14
+;     loop_c8e85
+;     loop_c8f17
+;     loop_c8f6c
+;     loop_c8f96
+;     loop_c8fac
+;     loop_c9047
+;     loop_c9108
+;     loop_c9113
+;     loop_c91ba
+;     loop_c91e7
+;     loop_c92ef
+;     loop_c9355
+;     loop_c9357
+;     loop_c936f
+;     loop_c9382
+;     loop_c93bd
+;     loop_c93da
+;     loop_c953a
+;     loop_c957d
+;     loop_c9593
+;     loop_c95b6
+;     loop_c95d9
+;     loop_c95ec
+;     loop_c9618
+;     loop_c96c2
+;     loop_c96f2
+;     loop_c979d
+;     loop_c97c8
+;     loop_c9803
+;     loop_c9837
+;     loop_c9851
+;     loop_c985e
+;     loop_c9881
+;     loop_c98a0
+;     loop_c98c1
+;     loop_c98e4
+;     loop_c9942
+;     loop_c994e
+;     loop_c9964
+;     loop_c99a8
+;     loop_c9b50
+;     loop_c9b5e
+;     loop_c9b63
+;     loop_c9bcf
+;     loop_c9be4
+;     loop_c9c38
+;     loop_c9c5d
+;     loop_c9c90
+;     loop_c9ca8
+;     loop_c9d03
+;     loop_c9d43
+;     loop_c9e07
+;     loop_c9e74
+;     loop_c9e8c
+;     loop_c9f6e
+;     loop_ca061
+;     loop_ca11d
+;     loop_ca132
+;     loop_ca143
+;     loop_ca16e
+;     loop_ca1aa
+;     loop_ca1cc
+;     loop_ca487
+;     loop_ca521
+;     loop_ca76f
+;     loop_ca7a7
+;     loop_ca7c6
+;     loop_ca7e0
+;     loop_ca7e1
+;     loop_ca941
+;     loop_ca947
+;     loop_ca953
+;     loop_ca9ab
+;     loop_ca9e7
+;     loop_caa01
+;     loop_caab8
+;     loop_cab6b
+;     loop_cab80
+;     loop_cabad
+;     loop_cabf4
+;     loop_cac46
+;     loop_caf13
+;     loop_caf2d
+;     loop_cb1e3
+;     loop_cb1ed
+;     loop_cb249
+;     loop_cb275
+;     loop_cb2b4
+;     loop_cb2bd
+;     loop_cb2d1
+;     loop_cb44d
+;     loop_cb4a8
+;     loop_cb55e
+;     loop_cb578
+;     loop_cb5c6
+;     loop_cb5ed
+;     loop_cb6b3
+;     loop_cb75a
+;     loop_cb7be
+;     loop_cb7d7
+;     loop_cb7dd
+;     loop_cb910
+;     loop_cb999
+;     loop_cb9bd
+;     loop_cb9cc
+;     loop_cb9d1
+;     loop_cb9f9
+;     loop_cba1a
+;     loop_cba94
+;     loop_cbab8
+;     loop_cbaea
+;     loop_cbbe4
+;     loop_cbbfe
+;     loop_cbc70
+;     loop_cbcd3
+;     loop_cbd08
+;     loop_cbd2b
+;     loop_cbd6c
+;     loop_cbd99
+;     loop_cbe0e
+;     loop_cbe31
+;     loop_cbeab
+;     loop_cbf1c
+;     loop_cbf78
+;     sub_c0050
+;     sub_c0414
+;     sub_c0421
+;     sub_c04c7
+;     sub_c04ce
+;     sub_c0520
+;     sub_c052d
+;     sub_c0537
+;     sub_c0542
+;     sub_c055e
+;     sub_c0582
+;     sub_c0596
+;     sub_c05a9
+;     sub_c05d1
+;     sub_c05f2
+;     sub_c05ff
+;     sub_c0607
+;     sub_c0627
+;     sub_c8020
+;     sub_c809a
+;     sub_c809d
+;     sub_c80b8
+;     sub_c80bb
+;     sub_c80c3
+;     sub_c80c8
+;     sub_c80d3
+;     sub_c80db
+;     sub_c80e3
+;     sub_c80e6
+;     sub_c80ed
+;     sub_c80f3
+;     sub_c80f6
+;     sub_c8149
+;     sub_c8174
+;     sub_c81ae
+;     sub_c81b0
+;     sub_c81b7
+;     sub_c81be
+;     sub_c81bf
+;     sub_c81c0
+;     sub_c81c4
+;     sub_c81c5
+;     sub_c81ca
+;     sub_c821d
+;     sub_c8222
+;     sub_c8238
+;     sub_c8254
+;     sub_c8266
+;     sub_c826d
+;     sub_c8280
+;     sub_c8284
+;     sub_c82b2
+;     sub_c82bb
+;     sub_c82e8
+;     sub_c82fe
+;     sub_c830a
+;     sub_c8327
+;     sub_c8335
+;     sub_c833a
+;     sub_c836e
+;     sub_c8380
+;     sub_c8386
+;     sub_c83bf
+;     sub_c83d1
+;     sub_c83d4
+;     sub_c83e3
+;     sub_c83ee
+;     sub_c840c
+;     sub_c841b
+;     sub_c842c
+;     sub_c8439
+;     sub_c8456
+;     sub_c8555
+;     sub_c85e3
+;     sub_c8602
+;     sub_c8745
+;     sub_c8750
+;     sub_c8782
+;     sub_c8794
+;     sub_c87da
+;     sub_c87db
+;     sub_c87e3
+;     sub_c87ee
+;     sub_c8826
+;     sub_c8855
+;     sub_c8862
+;     sub_c8932
+;     sub_c893f
+;     sub_c8943
+;     sub_c8951
+;     sub_c8979
+;     sub_c89b7
+;     sub_c89da
+;     sub_c89e6
+;     sub_c8a77
+;     sub_c8ab3
+;     sub_c8b25
+;     sub_c8b47
+;     sub_c8b4d
+;     sub_c8b64
+;     sub_c8b7b
+;     sub_c8b86
+;     sub_c8bac
+;     sub_c8bf6
+;     sub_c8bf9
+;     sub_c8c56
+;     sub_c8c65
+;     sub_c8d1a
+;     sub_c8dc6
+;     sub_c8eec
+;     sub_c8efa
+;     sub_c8eff
+;     sub_c8f33
+;     sub_c8f37
+;     sub_c8f3f
+;     sub_c8f4f
+;     sub_c8f5e
+;     sub_c8f6b
+;     sub_c8f75
+;     sub_c8f7a
+;     sub_c8f82
+;     sub_c8f94
+;     sub_c9279
+;     sub_c928a
+;     sub_c929d
+;     sub_c93b4
+;     sub_c93c5
+;     sub_c93d3
+;     sub_c93d8
+;     sub_c93f1
+;     sub_c93f5
+;     sub_c93f9
+;     sub_c93fd
+;     sub_c9432
+;     sub_c9445
+;     sub_c9516
+;     sub_c9526
+;     sub_c952e
+;     sub_c9536
+;     sub_c965d
+;     sub_c9785
+;     sub_c97b6
+;     sub_c97c9
+;     sub_c97e8
+;     sub_c9832
+;     sub_c992c
+;     sub_c9940
+;     sub_c995a
+;     sub_c9965
+;     sub_c9988
+;     sub_c99ac
+;     sub_c99f3
+;     sub_c9a0f
+;     sub_c9a32
+;     sub_c9a4b
+;     sub_c9a50
+;     sub_c9a60
+;     sub_c9a63
+;     sub_c9a6e
+;     sub_c9a78
+;     sub_c9a82
+;     sub_c9a8d
+;     sub_c9aa3
+;     sub_c9ab8
+;     sub_c9ac8
+;     sub_c9ad3
+;     sub_c9ad8
+;     sub_c9b51
+;     sub_c9b59
+;     sub_c9b61
+;     sub_c9b79
+;     sub_c9bca
+;     sub_c9bcd
+;     sub_c9be5
+;     sub_c9bf2
+;     sub_c9c0c
+;     sub_c9d19
+;     sub_c9d1e
+;     sub_c9d75
+;     sub_c9d9b
+;     sub_c9df4
+;     sub_c9e1e
+;     sub_c9e30
+;     sub_c9e54
+;     sub_c9e75
+;     sub_c9e94
+;     sub_c9ef4
+;     sub_c9f0f
+;     sub_c9f14
+;     sub_c9f16
+;     sub_c9f1e
+;     sub_c9f26
+;     sub_c9f7c
+;     sub_c9f82
+;     sub_ca0b8
+;     sub_ca0de
+;     sub_ca0f6
+;     sub_ca106
+;     sub_ca137
+;     sub_ca14a
+;     sub_ca168
+;     sub_ca190
+;     sub_ca1b4
+;     sub_ca1c6
+;     sub_ca244
+;     sub_ca315
+;     sub_ca324
+;     sub_ca379
+;     sub_ca384
+;     sub_ca3e4
+;     sub_ca3ec
+;     sub_ca417
+;     sub_ca463
+;     sub_ca4e1
+;     sub_ca51f
+;     sub_ca530
+;     sub_ca5b2
+;     sub_ca5bb
+;     sub_ca5bf
+;     sub_ca663
+;     sub_ca73d
+;     sub_ca76c
+;     sub_ca779
+;     sub_ca788
+;     sub_ca7c4
+;     sub_ca7c5
+;     sub_ca7ce
+;     sub_ca7f3
+;     sub_ca7f6
+;     sub_ca8be
+;     sub_ca8e2
+;     sub_ca90d
+;     sub_ca9bf
+;     sub_ca9c2
+;     sub_ca9ca
+;     sub_ca9d0
+;     sub_caa12
+;     sub_caa53
+;     sub_caa9a
+;     sub_caac2
+;     sub_caacf
+;     sub_caadd
+;     sub_caaea
+;     sub_caaf1
+;     sub_caafd
+;     sub_cab04
+;     sub_cab46
+;     sub_caba9
+;     sub_cabc5
+;     sub_cac0c
+;     sub_cac18
+;     sub_cac47
+;     sub_cac4e
+;     sub_cac62
+;     sub_cac6a
+;     sub_cac72
+;     sub_cad5d
+;     sub_caf8d
+;     sub_caf9a
+;     sub_cb040
+;     sub_cb047
+;     sub_cb234
+;     sub_cb2c8
+;     sub_cb580
+;     sub_cb58b
+;     sub_cb598
+;     sub_cb5ce
+;     sub_cb5ee
+;     sub_cb5f2
+;     sub_cb607
+;     sub_cb616
+;     sub_cb61e
+;     sub_cb65f
+;     sub_cb68f
+;     sub_cb6b1
+;     sub_cb6c5
+;     sub_cb6cd
+;     sub_cb6e6
+;     sub_cb6fe
+;     sub_cb745
+;     sub_cb771
+;     sub_cb7b6
+;     sub_cb83f
+;     sub_cb841
+;     sub_cb84e
+;     sub_cb850
+;     sub_cb85d
+;     sub_cb86f
+;     sub_cb882
+;     sub_cb986
+;     sub_cb9f5
+;     sub_cba67
+;     sub_cbab9
+;     sub_cbac2
+;     sub_cbac4
+;     sub_cbad2
+;     sub_cbb00
+;     sub_cbb46
+;     sub_cbb4a
+;     sub_cbbd3
+;     sub_cbbd7
+;     sub_cbc37
+;     sub_cbc68
+;     sub_cbc81
+;     sub_cbe83
+;     sub_cbe91
+;     sub_cbe9d
+;     sub_cbec2
+;     sub_cbf7c
+;     sub_cbf82
+;     sub_cbf84
+!if (<(c956d-1)) != $6c {
+    !error "Assertion failed: <(c956d-1) == $6c"
+}
+!if (<(c956d-1)) != $6c {
+    !error "Assertion failed: <(c956d-1) == $6c"
+}
+!if (<(l0128)) != $28 {
+    !error "Assertion failed: <(l0128) == $28"
+}
+!if (<(l1000)) != $00 {
+    !error "Assertion failed: <(l1000) == $00"
+}
+!if (<(sub_c8238-1)) != $37 {
+    !error "Assertion failed: <(sub_c8238-1) == $37"
+}
+!if (<(sub_c8254-1)) != $53 {
+    !error "Assertion failed: <(sub_c8254-1) == $53"
+}
+!if (<(sub_c8750-1)) != $4f {
+    !error "Assertion failed: <(sub_c8750-1) == $4f"
+}
+!if (<(sub_c8782-1)) != $81 {
+    !error "Assertion failed: <(sub_c8782-1) == $81"
+}
+!if (<(sub_c8794-1)) != $93 {
+    !error "Assertion failed: <(sub_c8794-1) == $93"
+}
+!if (<(sub_c87ee-1)) != $ed {
+    !error "Assertion failed: <(sub_c87ee-1) == $ed"
+}
+!if (<(sub_c893f-1)) != $3e {
+    !error "Assertion failed: <(sub_c893f-1) == $3e"
+}
+!if (<(sub_c8943-1)) != $42 {
+    !error "Assertion failed: <(sub_c8943-1) == $42"
+}
+!if (<(sub_c89b7-1)) != $b6 {
+    !error "Assertion failed: <(sub_c89b7-1) == $b6"
+}
+!if (<(sub_c89e6-1)) != $e5 {
+    !error "Assertion failed: <(sub_c89e6-1) == $e5"
+}
+!if (<(sub_c8b47-1)) != $46 {
+    !error "Assertion failed: <(sub_c8b47-1) == $46"
+}
+!if (<(sub_c8bac-1)) != $ab {
+    !error "Assertion failed: <(sub_c8bac-1) == $ab"
+}
+!if (<(sub_c9b59-1)) != $58 {
+    !error "Assertion failed: <(sub_c9b59-1) == $58"
+}
+!if (<(sub_ca106-1)) != $05 {
+    !error "Assertion failed: <(sub_ca106-1) == $05"
+}
+!if (<(sub_ca137-1)) != $36 {
+    !error "Assertion failed: <(sub_ca137-1) == $36"
+}
+!if (<(sub_ca244-1)) != $43 {
+    !error "Assertion failed: <(sub_ca244-1) == $43"
+}
+!if (<(sub_ca417-1)) != $16 {
+    !error "Assertion failed: <(sub_ca417-1) == $16"
+}
+!if (<(sub_ca463-1)) != $62 {
+    !error "Assertion failed: <(sub_ca463-1) == $62"
+}
+!if (<(sub_ca5bb-1)) != $ba {
+    !error "Assertion failed: <(sub_ca5bb-1) == $ba"
+}
+!if (<(sub_ca5bf-1)) != $be {
+    !error "Assertion failed: <(sub_ca5bf-1) == $be"
+}
+!if (<(sub_ca7f3-1)) != $f2 {
+    !error "Assertion failed: <(sub_ca7f3-1) == $f2"
+}
+!if (<(sub_ca7f6-1)) != $f5 {
+    !error "Assertion failed: <(sub_ca7f6-1) == $f5"
+}
+!if (<(sub_ca9d0-1)) != $cf {
+    !error "Assertion failed: <(sub_ca9d0-1) == $cf"
+}
+!if (<(sub_caafd-1)) != $fc {
+    !error "Assertion failed: <(sub_caafd-1) == $fc"
+}
+!if (<(sub_cab04-1)) != $03 {
+    !error "Assertion failed: <(sub_cab04-1) == $03"
+}
+!if (<(sub_cab46-1)) != $45 {
+    !error "Assertion failed: <(sub_cab46-1) == $45"
+}
+!if (<(sub_cabc5-1)) != $c4 {
+    !error "Assertion failed: <(sub_cabc5-1) == $c4"
+}
+!if (<(sub_cbb46-1)) != $45 {
+    !error "Assertion failed: <(sub_cbb46-1) == $45"
+}
+!if (<(sub_cbb4a-1)) != $49 {
+    !error "Assertion failed: <(sub_cbb4a-1) == $49"
+}
+!if (<(sub_cbbd3-1)) != $d2 {
+    !error "Assertion failed: <(sub_cbbd3-1) == $d2"
+}
+!if (<(sub_cbbd7-1)) != $d6 {
+    !error "Assertion failed: <(sub_cbbd7-1) == $d6"
+}
+!if (<(sub_cbc37-1)) != $36 {
+    !error "Assertion failed: <(sub_cbc37-1) == $36"
+}
+!if (<(sub_cbc81-1)) != $80 {
+    !error "Assertion failed: <(sub_cbc81-1) == $80"
+}
+!if (<jump_address_low) != $51 {
+    !error "Assertion failed: <jump_address_low == $51"
+}
+!if (<tube_brkv_handler) != $16 {
+    !error "Assertion failed: <tube_brkv_handler == $16"
+}
+!if (<tube_evntv_handler) != $ad {
+    !error "Assertion failed: <tube_evntv_handler == $ad"
+}
+!if (>(c956d-1)) != $95 {
+    !error "Assertion failed: >(c956d-1) == $95"
+}
+!if (>(c956d-1)) != $95 {
+    !error "Assertion failed: >(c956d-1) == $95"
+}
+!if (>(l0128)) != $01 {
+    !error "Assertion failed: >(l0128) == $01"
+}
+!if (>(l1000)) != $10 {
+    !error "Assertion failed: >(l1000) == $10"
+}
+!if (>(sub_c8238-1)) != $82 {
+    !error "Assertion failed: >(sub_c8238-1) == $82"
+}
+!if (>(sub_c8254-1)) != $82 {
+    !error "Assertion failed: >(sub_c8254-1) == $82"
+}
+!if (>(sub_c8750-1)) != $87 {
+    !error "Assertion failed: >(sub_c8750-1) == $87"
+}
+!if (>(sub_c8782-1)) != $87 {
+    !error "Assertion failed: >(sub_c8782-1) == $87"
+}
+!if (>(sub_c8794-1)) != $87 {
+    !error "Assertion failed: >(sub_c8794-1) == $87"
+}
+!if (>(sub_c87ee-1)) != $87 {
+    !error "Assertion failed: >(sub_c87ee-1) == $87"
+}
+!if (>(sub_c893f-1)) != $89 {
+    !error "Assertion failed: >(sub_c893f-1) == $89"
+}
+!if (>(sub_c8943-1)) != $89 {
+    !error "Assertion failed: >(sub_c8943-1) == $89"
+}
+!if (>(sub_c89b7-1)) != $89 {
+    !error "Assertion failed: >(sub_c89b7-1) == $89"
+}
+!if (>(sub_c89e6-1)) != $89 {
+    !error "Assertion failed: >(sub_c89e6-1) == $89"
+}
+!if (>(sub_c8b47-1)) != $8b {
+    !error "Assertion failed: >(sub_c8b47-1) == $8b"
+}
+!if (>(sub_c8bac-1)) != $8b {
+    !error "Assertion failed: >(sub_c8bac-1) == $8b"
+}
+!if (>(sub_c9b59-1)) != $9b {
+    !error "Assertion failed: >(sub_c9b59-1) == $9b"
+}
+!if (>(sub_ca106-1)) != $a1 {
+    !error "Assertion failed: >(sub_ca106-1) == $a1"
+}
+!if (>(sub_ca137-1)) != $a1 {
+    !error "Assertion failed: >(sub_ca137-1) == $a1"
+}
+!if (>(sub_ca244-1)) != $a2 {
+    !error "Assertion failed: >(sub_ca244-1) == $a2"
+}
+!if (>(sub_ca417-1)) != $a4 {
+    !error "Assertion failed: >(sub_ca417-1) == $a4"
+}
+!if (>(sub_ca463-1)) != $a4 {
+    !error "Assertion failed: >(sub_ca463-1) == $a4"
+}
+!if (>(sub_ca5bb-1)) != $a5 {
+    !error "Assertion failed: >(sub_ca5bb-1) == $a5"
+}
+!if (>(sub_ca5bf-1)) != $a5 {
+    !error "Assertion failed: >(sub_ca5bf-1) == $a5"
+}
+!if (>(sub_ca7f3-1)) != $a7 {
+    !error "Assertion failed: >(sub_ca7f3-1) == $a7"
+}
+!if (>(sub_ca7f6-1)) != $a7 {
+    !error "Assertion failed: >(sub_ca7f6-1) == $a7"
+}
+!if (>(sub_ca9d0-1)) != $a9 {
+    !error "Assertion failed: >(sub_ca9d0-1) == $a9"
+}
+!if (>(sub_caafd-1)) != $aa {
+    !error "Assertion failed: >(sub_caafd-1) == $aa"
+}
+!if (>(sub_cab04-1)) != $ab {
+    !error "Assertion failed: >(sub_cab04-1) == $ab"
+}
+!if (>(sub_cab46-1)) != $ab {
+    !error "Assertion failed: >(sub_cab46-1) == $ab"
+}
+!if (>(sub_cabc5-1)) != $ab {
+    !error "Assertion failed: >(sub_cabc5-1) == $ab"
+}
+!if (>(sub_cbb46-1)) != $bb {
+    !error "Assertion failed: >(sub_cbb46-1) == $bb"
+}
+!if (>(sub_cbb4a-1)) != $bb {
+    !error "Assertion failed: >(sub_cbb4a-1) == $bb"
+}
+!if (>(sub_cbbd3-1)) != $bb {
+    !error "Assertion failed: >(sub_cbbd3-1) == $bb"
+}
+!if (>(sub_cbbd7-1)) != $bb {
+    !error "Assertion failed: >(sub_cbbd7-1) == $bb"
+}
+!if (>(sub_cbc37-1)) != $bc {
+    !error "Assertion failed: >(sub_cbc37-1) == $bc"
+}
+!if (>(sub_cbc81-1)) != $bc {
+    !error "Assertion failed: >(sub_cbc81-1) == $bc"
+}
+!if (>tube_brkv_handler) != $00 {
+    !error "Assertion failed: >tube_brkv_handler == $00"
+}
+!if (>tube_evntv_handler) != $06 {
+    !error "Assertion failed: >tube_evntv_handler == $06"
+}
+!if (copyright - rom_header) != $11 {
+    !error "Assertion failed: copyright - rom_header == $11"
+}
+!if (nmi3_handler_rom_end-nmi3_handler_rom_start) != $0e {
+    !error "Assertion failed: nmi3_handler_rom_end-nmi3_handler_rom_start == $0e"
+}
+!if (nmi_XXX1-(nmi_beq+2)) != $48 {
+    !error "Assertion failed: nmi_XXX1-(nmi_beq+2) == $48"
+}
+!if (nmi_XXX10-(nmi_bcs+2)) != $32 {
+    !error "Assertion failed: nmi_XXX10-(nmi_bcs+2) == $32"
+}
+!if (nmi_XXX11-(nmi_bcs+2)) != $3b {
+    !error "Assertion failed: nmi_XXX11-(nmi_bcs+2) == $3b"
+}
+!if (nmi_XXX12-(nmi_bcs+2)) != $3f {
+    !error "Assertion failed: nmi_XXX12-(nmi_bcs+2) == $3f"
+}
+!if (nmi_XXX13-(nmi_bcs+2)) != $49 {
+    !error "Assertion failed: nmi_XXX13-(nmi_bcs+2) == $49"
+}
+!if (nmi_XXX14-(nmi_bcs+2)) != $4d {
+    !error "Assertion failed: nmi_XXX14-(nmi_bcs+2) == $4d"
+}
+!if (nmi_XXX15-(nmi_bcs+2)) != $55 {
+    !error "Assertion failed: nmi_XXX15-(nmi_bcs+2) == $55"
+}
+!if (nmi_XXX16-(nmi_bcs+2)) != $5d {
+    !error "Assertion failed: nmi_XXX16-(nmi_bcs+2) == $5d"
+}
+!if (nmi_XXX17-(nmi_bcs+2)) != $06 {
+    !error "Assertion failed: nmi_XXX17-(nmi_bcs+2) == $06"
+}
+!if (nmi_XXX18-(nmi_bcs+2)) != $11 {
+    !error "Assertion failed: nmi_XXX18-(nmi_bcs+2) == $11"
+}
+!if (nmi_XXX19-(nmi_bcs+2)) != $7b {
+    !error "Assertion failed: nmi_XXX19-(nmi_bcs+2) == $7b"
+}
+!if (nmi_XXX2-(nmi_beq+2)) != $2f {
+    !error "Assertion failed: nmi_XXX2-(nmi_beq+2) == $2f"
+}
+!if (nmi_XXX2-1) != $0d38 {
+    !error "Assertion failed: nmi_XXX2-1 == $0d38"
+}
+!if (nmi_XXX20-(nmi_bcs+2)) != $7f {
+    !error "Assertion failed: nmi_XXX20-(nmi_bcs+2) == $7f"
+}
+!if (nmi_XXX21-(nmi_bcs+2)) != $26 {
+    !error "Assertion failed: nmi_XXX21-(nmi_bcs+2) == $26"
+}
+!if (nmi_XXX22-(nmi_bcs+2)) != $77 {
+    !error "Assertion failed: nmi_XXX22-(nmi_bcs+2) == $77"
+}
+!if (nmi_XXX23-(nmi_bcs+2)) != $24 {
+    !error "Assertion failed: nmi_XXX23-(nmi_bcs+2) == $24"
+}
+!if (nmi_XXX5-(nmi_cmp_imm_or_bcs+2)) != $06 {
+    !error "Assertion failed: nmi_XXX5-(nmi_cmp_imm_or_bcs+2) == $06"
+}
+!if (nmi_XXX7-(nmi_XXX6+2)) != $06 {
+    !error "Assertion failed: nmi_XXX7-(nmi_XXX6+2) == $06"
+}
+!if (nmi_XXX8-(nmi_beq+2)) != $4d {
+    !error "Assertion failed: nmi_XXX8-(nmi_beq+2) == $4d"
+}
+!if (nmi_handler2_rom_end-nmi_handler2_rom_start) != $94 {
+    !error "Assertion failed: nmi_handler2_rom_end-nmi_handler2_rom_start == $94"
+}
+!if (nmi_handler_rom_end-nmi_handler_rom_start-1) != $5d {
+    !error "Assertion failed: nmi_handler_rom_end-nmi_handler_rom_start-1 == $5d"
+}
+!if (opcode_bcs) != $b0 {
+    !error "Assertion failed: opcode_bcs == $b0"
+}
+!if (opcode_rti) != $40 {
+    !error "Assertion failed: opcode_rti == $40"
+}
+!if (osbyte_close_spool_exec) != $77 {
+    !error "Assertion failed: osbyte_close_spool_exec == $77"
+}
+!if (osbyte_explode_chars) != $14 {
+    !error "Assertion failed: osbyte_explode_chars == $14"
+}
+!if (osbyte_issue_service_request) != $8f {
+    !error "Assertion failed: osbyte_issue_service_request == $8f"
+}
+!if (osbyte_read_himem) != $84 {
+    !error "Assertion failed: osbyte_read_himem == $84"
+}
+!if (osbyte_read_oshwm) != $83 {
+    !error "Assertion failed: osbyte_read_oshwm == $83"
+}
+!if (osbyte_read_rom_info_table_low) != $aa {
+    !error "Assertion failed: osbyte_read_rom_info_table_low == $aa"
+}
+!if (osbyte_read_tube_presence) != $ea {
+    !error "Assertion failed: osbyte_read_tube_presence == $ea"
+}
+!if (osbyte_read_write_spool_file_handle) != $c7 {
+    !error "Assertion failed: osbyte_read_write_spool_file_handle == $c7"
+}
+!if (osbyte_read_write_startup_options) != $ff {
+    !error "Assertion failed: osbyte_read_write_startup_options == $ff"
+}
+!if (osbyte_rw_exec_handle) != $c6 {
+    !error "Assertion failed: osbyte_rw_exec_handle == $c6"
+}
+!if (osbyte_scan_keyboard_from_16) != $7a {
+    !error "Assertion failed: osbyte_scan_keyboard_from_16 == $7a"
+}
+!if (osbyte_write_keys_pressed) != $78 {
+    !error "Assertion failed: osbyte_write_keys_pressed == $78"
+}
+!if (osfile_load) != $ff {
+    !error "Assertion failed: osfile_load == $ff"
+}
+!if (osfile_read_catalogue_info) != $05 {
+    !error "Assertion failed: osfile_read_catalogue_info == $05"
+}
+!if (osfile_save) != $00 {
+    !error "Assertion failed: osfile_save == $00"
+}
+!if (service_absolute_workspace_claimed) != $0a {
+    !error "Assertion failed: service_absolute_workspace_claimed == $0a"
+}
+!if (service_boot) != $03 {
+    !error "Assertion failed: service_boot == $03"
+}
+!if (service_check_swr_presence) != $2b {
+    !error "Assertion failed: service_check_swr_presence == $2b"
+}
+!if (service_claim_absolute_workspace) != $01 {
+    !error "Assertion failed: service_claim_absolute_workspace == $01"
+}
+!if (service_claim_private_workspace) != $02 {
+    !error "Assertion failed: service_claim_private_workspace == $02"
+}
+!if (service_help) != $09 {
+    !error "Assertion failed: service_help == $09"
+}
+!if (service_select_filing_system) != $12 {
+    !error "Assertion failed: service_select_filing_system == $12"
+}
+!if (service_tube_post_init) != $fe {
+    !error "Assertion failed: service_tube_post_init == $fe"
+}
+!if (service_unrecognised_command) != $04 {
+    !error "Assertion failed: service_unrecognised_command == $04"
+}
+!if (service_unrecognised_osword) != $08 {
+    !error "Assertion failed: service_unrecognised_osword == $08"
+}
+!if (sub_c0520) != $0520 {
+    !error "Assertion failed: sub_c0520 == $0520"
+}
+!if (sub_c052d) != $052d {
+    !error "Assertion failed: sub_c052d == $052d"
+}
+!if (sub_c0537) != $0537 {
+    !error "Assertion failed: sub_c0537 == $0537"
+}
+!if (sub_c0542) != $0542 {
+    !error "Assertion failed: sub_c0542 == $0542"
+}
+!if (sub_c055e) != $055e {
+    !error "Assertion failed: sub_c055e == $055e"
+}
+!if (sub_c0596) != $0596 {
+    !error "Assertion failed: sub_c0596 == $0596"
+}
+!if (sub_c05a9) != $05a9 {
+    !error "Assertion failed: sub_c05a9 == $05a9"
+}
+!if (sub_c05d1) != $05d1 {
+    !error "Assertion failed: sub_c05d1 == $05d1"
+}
+!if (sub_c05f2) != $05f2 {
+    !error "Assertion failed: sub_c05f2 == $05f2"
+}
+!if (sub_c0607) != $0607 {
+    !error "Assertion failed: sub_c0607 == $0607"
+}
+!if (sub_c0627) != $0627 {
+    !error "Assertion failed: sub_c0627 == $0627"
+}
+!if (sub_c9785) != $9785 {
+    !error "Assertion failed: sub_c9785 == $9785"
+}
+!if (sub_c97b6) != $97b6 {
+    !error "Assertion failed: sub_c97b6 == $97b6"
+}
+!if (sub_c97c9) != $97c9 {
+    !error "Assertion failed: sub_c97c9 == $97c9"
+}
+!if (sub_c9c0c) != $9c0c {
+    !error "Assertion failed: sub_c9c0c == $9c0c"
+}
+!if (sub_c9d9b) != $9d9b {
+    !error "Assertion failed: sub_c9d9b == $9d9b"
+}
+!if (sub_c9e94) != $9e94 {
+    !error "Assertion failed: sub_c9e94 == $9e94"
+}
+!if (sub_c9f82) != $9f82 {
+    !error "Assertion failed: sub_c9f82 == $9f82"
+}
+!if (tube_brkv_handler_fwd) != $16 {
+    !error "Assertion failed: tube_brkv_handler_fwd == $16"
+}
+!if (tube_host_osword_0) != $0668 {
+    !error "Assertion failed: tube_host_osword_0 == $0668"
+}

--- a/examples/known_good/dfs226_beebasm.asm
+++ b/examples/known_good/dfs226_beebasm.asm
@@ -1,0 +1,13722 @@
+; Constants
+opcode_bcs                            = 176
+opcode_rti                            = 64
+osbyte_close_spool_exec               = 119
+osbyte_explode_chars                  = 20
+osbyte_issue_service_request          = 143
+osbyte_read_himem                     = 132
+osbyte_read_oshwm                     = 131
+osbyte_read_rom_info_table_low        = 170
+osbyte_read_tube_presence             = 234
+osbyte_read_write_spool_file_handle   = 199
+osbyte_read_write_startup_options     = 255
+osbyte_rw_exec_handle                 = 198
+osbyte_scan_keyboard_from_16          = 122
+osbyte_write_keys_pressed             = 120
+osfile_load                           = 255
+osfile_read_catalogue_info            = 5
+osfile_save                           = 0
+service_absolute_workspace_claimed    = 10
+service_boot                          = 3
+service_check_swr_presence            = 43
+service_claim_absolute_workspace      = 1
+service_claim_private_workspace       = 2
+service_help                          = 9
+service_select_filing_system          = 18
+service_tube_post_init                = 254
+service_unrecognised_command          = 4
+service_unrecognised_osword           = 8
+tube_brkv_handler_fwd                 = 22
+
+; Memory locations
+l0000               = &0000
+l0001               = &0001
+l0002               = &0002
+l0003               = &0003
+l0012               = &0012
+l0013               = &0013
+l0014               = &0014
+l0015               = &0015
+l0057               = &0057
+l00a0               = &00a0
+l00a1               = &00a1
+l00a2               = &00a2
+l00a3               = &00a3
+l00a4               = &00a4
+l00a5               = &00a5
+l00a6               = &00a6
+l00a7               = &00a7
+l00a8               = &00a8
+l00a9               = &00a9
+l00aa               = &00aa
+l00ab               = &00ab
+l00ac               = &00ac
+l00ad               = &00ad
+l00ae               = &00ae
+l00af               = &00af
+l00b0               = &00b0
+l00b1               = &00b1
+l00b2               = &00b2
+l00b3               = &00b3
+l00b4               = &00b4
+l00b5               = &00b5
+l00b6               = &00b6
+l00b7               = &00b7
+l00b8               = &00b8
+l00b9               = &00b9
+l00ba               = &00ba
+l00bb               = &00bb
+l00bc               = &00bc
+l00bd               = &00bd
+l00be               = &00be
+l00bf               = &00bf
+l00c0               = &00c0
+l00c1               = &00c1
+l00c2               = &00c2
+l00c3               = &00c3
+l00c4               = &00c4
+l00c5               = &00c5
+l00c6               = &00c6
+l00c7               = &00c7
+l00c8               = &00c8
+l00c9               = &00c9
+l00ca               = &00ca
+l00cc               = &00cc
+l00cd               = &00cd
+l00ce               = &00ce
+l00cf               = &00cf
+l00ef               = &00ef
+l00f0               = &00f0
+l00f1               = &00f1
+os_text_ptr         = &00f2
+l00f3               = &00f3
+romsel_copy         = &00f4
+osrdsc_ptr          = &00f6
+l00f7               = &00f7
+l00fd               = &00fd
+l00ff               = &00ff
+l0100               = &0100
+l0101               = &0101
+l0102               = &0102
+l0103               = &0103
+l0104               = &0104
+l0105               = &0105
+l0107               = &0107
+l0109               = &0109
+l010b               = &010b
+l010c               = &010c
+l010d               = &010d
+l010e               = &010e
+l0128               = &0128
+brkv                = &0202
+bytev               = &020a
+filev               = &0212
+fscv                = &021e
+evntv               = &0220
+l028d               = &028d
+l04fc               = &04fc
+l06ce               = &06ce
+l0700               = &0700
+l0cff               = &0cff
+l0d00               = &0d00
+l0d47               = &0d47
+sub_c0d5e           = &0d5e
+l0d94               = &0d94
+l0df0               = &0df0
+l0e00               = &0e00
+l0e07               = &0e07
+l0e08               = &0e08
+l0e0e               = &0e0e
+l0e0f               = &0e0f
+l0e10               = &0e10
+l0ef8               = &0ef8
+l0f00               = &0f00
+l0f04               = &0f04
+l0f05               = &0f05
+l0f06               = &0f06
+l0f07               = &0f07
+l0f08               = &0f08
+l0f09               = &0f09
+l0f0a               = &0f0a
+l0f0b               = &0f0b
+l0f0c               = &0f0c
+l0f0d               = &0f0d
+l0f0e               = &0f0e
+l0f0f               = &0f0f
+l0f10               = &0f10
+l1000               = &1000
+l1001               = &1001
+l1002               = &1002
+l1003               = &1003
+l1004               = &1004
+l1005               = &1005
+l1006               = &1006
+l1007               = &1007
+l100e               = &100e
+l1045               = &1045
+l1047               = &1047
+l104d               = &104d
+l104e               = &104e
+l1050               = &1050
+l1058               = &1058
+l105f               = &105f
+l1060               = &1060
+l1061               = &1061
+l1062               = &1062
+l1063               = &1063
+l1064               = &1064
+l1065               = &1065
+l1067               = &1067
+l1069               = &1069
+l1072               = &1072
+l1074               = &1074
+l1075               = &1075
+l1076               = &1076
+l1077               = &1077
+l1078               = &1078
+l1079               = &1079
+l107a               = &107a
+l107d               = &107d
+l107e               = &107e
+l107f               = &107f
+l1081               = &1081
+l1082               = &1082
+l1083               = &1083
+l1086               = &1086
+l1087               = &1087
+l1088               = &1088
+l1089               = &1089
+l108a               = &108a
+l108b               = &108b
+l108c               = &108c
+l108f               = &108f
+l1090               = &1090
+l1091               = &1091
+l1092               = &1092
+l1093               = &1093
+l1094               = &1094
+l1095               = &1095
+l1096               = &1096
+l1097               = &1097
+l1098               = &1098
+l1099               = &1099
+l109a               = &109a
+l109b               = &109b
+l109d               = &109d
+l109e               = &109e
+l109f               = &109f
+l10c0               = &10c0
+l10c1               = &10c1
+l10c2               = &10c2
+l10c3               = &10c3
+l10c4               = &10c4
+l10c5               = &10c5
+l10c6               = &10c6
+l10c7               = &10c7
+l10c9               = &10c9
+l10ca               = &10ca
+l10cb               = &10cb
+l10cc               = &10cc
+l10cd               = &10cd
+l10ce               = &10ce
+l10cf               = &10cf
+l10d0               = &10d0
+l10d1               = &10d1
+l10d2               = &10d2
+l10d3               = &10d3
+l10d6               = &10d6
+l10d7               = &10d7
+l10d8               = &10d8
+l10d9               = &10d9
+l10da               = &10da
+l10db               = &10db
+l10dc               = &10dc
+l10dd               = &10dd
+l10de               = &10de
+l10e2               = &10e2
+l10e3               = &10e3
+l10e4               = &10e4
+l1100               = &1100
+l1109               = &1109
+l110b               = &110b
+l110c               = &110c
+l110d               = &110d
+l110e               = &110e
+l110f               = &110f
+l1110               = &1110
+l1111               = &1111
+l1112               = &1112
+l1113               = &1113
+l1114               = &1114
+l1115               = &1115
+l1116               = &1116
+l1117               = &1117
+l1119               = &1119
+l111a               = &111a
+l111b               = &111b
+l111c               = &111c
+l111d               = &111d
+romsel              = &fe30
+lfe80               = &fe80
+lfe84               = &fe84
+lfe85               = &fe85
+lfe86               = &fe86
+lfe87               = &fe87
+tube_host_r1_status = &fee0
+tube_host_r1_data   = &fee1
+tube_host_r2_status = &fee2
+tube_host_r2_data   = &fee3
+tube_host_r3_data   = &fee5
+tube_host_r4_status = &fee6
+tube_host_r4_data   = &fee7
+osrdsc              = &ffb9
+gsinit              = &ffc2
+gsread              = &ffc5
+osfind              = &ffce
+osgbpb              = &ffd1
+osbput              = &ffd4
+osbget              = &ffd7
+osargs              = &ffda
+osfile              = &ffdd
+osrdch              = &ffe0
+osasci              = &ffe3
+osnewl              = &ffe7
+oswrch              = &ffee
+osword              = &fff1
+osbyte              = &fff4
+oscli               = &fff7
+
+    org &8000
+
+; Sideways ROM header
+; &8000 referenced 1 time by &04e2
+.rom_header
+.language_entry
+.pydis_start
+l8001 = rom_header+1
+l8002 = rom_header+2
+    equb 0, 0, 0                                                      ; 8000: 00 00 00    ...
+; &8001 referenced 1 time by &04e7
+; &8002 referenced 1 time by &04ec
+
+; &8003 referenced 1 time by &04f1
+.service_entry
+l8004 = service_entry+1
+    jmp service_handler                                               ; 8003: 4c c8 be    L..
+
+; &8004 referenced 1 time by &04f4
+; &8006 referenced 1 time by &04d6
+.rom_type
+    equb &82                                                          ; 8006: 82          .
+; &8007 referenced 1 time by &04de
+.copyright_offset
+    equb copyright - rom_header                                       ; 8007: 11          .
+.binary_version
+    equb &7b                                                          ; 8008: 7b          {
+.title
+    equs "DFS"                                                        ; 8009: 44 46 53    DFS
+.version
+    equb 0                                                            ; 800c: 00          .
+    equs "2.26"                                                       ; 800d: 32 2e 32... 2.2
+.copyright
+    equb 0                                                            ; 8011: 00          .
+    equs "(C)1985 Acorn", 0                                           ; 8012: 28 43 29... (C)
+
+; &8020 referenced 1 time by &9575
+.sub_c8020
+    jmp (fscv)                                                        ; 8020: 6c 1e 02    l..
+
+; &8023 referenced 4 times by &8a6e, &94c6, &94d5, &9c00
+.generate_error_precheck_disc
+    jsr generate_error_precheck                                       ; 8023: 20 38 80     8.
+    equb 0                                                            ; 8026: 00          .
+    equs "Disc "                                                      ; 8027: 44 69 73... Dis
+
+    bcc generate_error2                                               ; 802c: 90 21       .!
+; &802e referenced 6 times by &8125, &889a, &89a5, &8a24, &8a3e, &8ba2
+.generate_error_precheck_bad
+    jsr generate_error_precheck                                       ; 802e: 20 38 80     8.
+    equb 0                                                            ; 8031: 00          .
+    equs "Bad "                                                       ; 8032: 42 61 64... Bad
+
+    bcc generate_error2                                               ; 8036: 90 17       ..
+; &8038 referenced 11 times by &8023, &802e, &8b18, &8bd8, &9a55, &9c70, &9c82, &9e80, &9e8c, &9f6e, &9fc8
+.generate_error_precheck
+    lda l10dd                                                         ; 8038: ad dd 10    ...
+    bne c8040                                                         ; 803b: d0 03       ..
+    jsr sub_c9e30                                                     ; 803d: 20 30 9e     0.
+; &8040 referenced 1 time by &803b
+.c8040
+    lda #%11111111                                                    ; 8040: a9 ff       ..
+    sta l1082                                                         ; 8042: 8d 82 10    ...
+    sta l10dd                                                         ; 8045: 8d dd 10    ...
+; Generate an OS error using inline data. Called as either:
+;     jsr XXX:equb errnum, "error message", 0
+; to actually generate an error now, or as:
+;     jsr XXX:equb errnum, "partial error message", instruction...
+; to partially construct an error (on the stack) and continue executing
+; 'instruction' afterwards; its opcode must have its top bit set. Carry is
+; always clear on exit.
+; &8048 referenced 4 times by &822a, &9439, &947c, &a14f
+.generate_error
+    ldx #2                                                            ; 8048: a2 02       ..
+    lda #0                                                            ; 804a: a9 00       ..
+    sta l0100                                                         ; 804c: 8d 00 01    ...
+; &804f referenced 7 times by &802c, &8036, &94da, &94e9, &94f7, &9507, &9511
+.generate_error2
+    sta l00b3                                                         ; 804f: 85 b3       ..
+    pla                                                               ; 8051: 68          h
+    sta l00ae                                                         ; 8052: 85 ae       ..
+    pla                                                               ; 8054: 68          h
+    sta l00af                                                         ; 8055: 85 af       ..
+; XXX: Redundant lda l00b3? Is sta l00b3 above redundant too?
+    lda l00b3                                                         ; 8057: a5 b3       ..
+    ldy #0                                                            ; 8059: a0 00       ..
+    jsr inc16_ae                                                      ; 805b: 20 dc 83     ..
+    lda (l00ae),y                                                     ; 805e: b1 ae       ..
+    sta l0101                                                         ; 8060: 8d 01 01    ...
+    dex                                                               ; 8063: ca          .
+; &8064 referenced 1 time by &806f
+.loop_c8064
+    jsr inc16_ae                                                      ; 8064: 20 dc 83     ..
+    inx                                                               ; 8067: e8          .
+    lda (l00ae),y                                                     ; 8068: b1 ae       ..
+    sta l0100,x                                                       ; 806a: 9d 00 01    ...
+    bmi c8096                                                         ; 806d: 30 27       0'
+    bne loop_c8064                                                    ; 806f: d0 f3       ..
+    jsr sub_c8f75                                                     ; 8071: 20 75 8f     u.
+    jmp l0100                                                         ; 8074: 4c 00 01    L..
+
+; Print (XXX: using l809f, which seems to be quite fancy) an inline
+; string terminated by a top-bit set instruction to execute after
+; printing the string. Carry is always clear on exit.
+; &8077 referenced 31 times by &84a5, &84b0, &84c8, &84dc, &84f1, &850d, &87ce, &9558, &a10c, &a247, &a298, &a34d, &a364, &a394, &a3a3, &a3ae, &a3bd, &a3e4, &a3ec, &a5f0, &a5fb, &a605, &a667, &a678, &a68a, &a699, &a70a, &a719, &aa5a, &aa65, &aebf
+.print_inline_l809f_top_bit_clear
+    sta l00b3                                                         ; 8077: 85 b3       ..
+    pla                                                               ; 8079: 68          h
+    sta l00ae                                                         ; 807a: 85 ae       ..
+    pla                                                               ; 807c: 68          h
+    sta l00af                                                         ; 807d: 85 af       ..
+    lda l00b3                                                         ; 807f: a5 b3       ..
+    pha                                                               ; 8081: 48          H
+    tya                                                               ; 8082: 98          .
+    pha                                                               ; 8083: 48          H
+    ldy #0                                                            ; 8084: a0 00       ..
+; &8086 referenced 1 time by &8090
+.loop_c8086
+    jsr inc16_ae                                                      ; 8086: 20 dc 83     ..
+    lda (l00ae),y                                                     ; 8089: b1 ae       ..
+    bmi c8093                                                         ; 808b: 30 06       0.
+    jsr c809f                                                         ; 808d: 20 9f 80     ..
+    jmp loop_c8086                                                    ; 8090: 4c 86 80    L..
+
+; &8093 referenced 1 time by &808b
+.c8093
+    pla                                                               ; 8093: 68          h
+    tay                                                               ; 8094: a8          .
+    pla                                                               ; 8095: 68          h
+; &8096 referenced 1 time by &806d
+.c8096
+    clc                                                               ; 8096: 18          .
+    jmp (l00ae)                                                       ; 8097: 6c ae 00    l..
+
+; &809a referenced 2 times by &84ff, &8519
+.sub_c809a
+    jsr sub_c80c3                                                     ; 809a: 20 c3 80     ..
+; &809d referenced 1 time by &8187
+.sub_c809d
+    lda #&2e ; '.'                                                    ; 809d: a9 2e       ..
+; &809f referenced 20 times by &808d, &80c6, &8184, &8191, &81a2, &849d, &84ea, &8505, &851f, &a1c3, &a3df, &a40c, &a621, &a6bd, &a6c0, &aa6d, &aa7b, &aa87, &aa8c, &aabe
+.c809f
+    jsr sub_c83e3                                                     ; 809f: 20 e3 83     ..
+    pha                                                               ; 80a2: 48          H
+    lda #&ec                                                          ; 80a3: a9 ec       ..
+    jsr osbyte_read                                                   ; 80a5: 20 e5 9a     ..
+    txa                                                               ; 80a8: 8a          .
+    pha                                                               ; 80a9: 48          H
+    ora #&10                                                          ; 80aa: 09 10       ..
+    jsr sub_c9ad3                                                     ; 80ac: 20 d3 9a     ..
+    pla                                                               ; 80af: 68          h
+    tax                                                               ; 80b0: aa          .
+    pla                                                               ; 80b1: 68          h
+    jsr osasci                                                        ; 80b2: 20 e3 ff     ..
+    jmp c9ad4                                                         ; 80b5: 4c d4 9a    L..
+
+; &80b8 referenced 1 time by &aa62
+.sub_c80b8
+    jsr sub_c841b                                                     ; 80b8: 20 1b 84     ..
+; &80bb referenced 5 times by &8368, &8373, &84ad, &a295, &a6c6
+.sub_c80bb
+    pha                                                               ; 80bb: 48          H
+    jsr sub_c81bf                                                     ; 80bc: 20 bf 81     ..
+    jsr sub_c80c3                                                     ; 80bf: 20 c3 80     ..
+    pla                                                               ; 80c2: 68          h
+; &80c3 referenced 10 times by &809a, &80bf, &8362, &84c0, &84d9, &a25c, &a291, &a361, &a36f, &a696
+.sub_c80c3
+    jsr sub_c80c8                                                     ; 80c3: 20 c8 80     ..
+    bne c809f                                                         ; 80c6: d0 d7       ..
+; &80c8 referenced 4 times by &80c3, &952e, &a9ca, &ac6a
+.sub_c80c8
+    and #&0f                                                          ; 80c8: 29 0f       ).
+    cmp #&0a                                                          ; 80ca: c9 0a       ..
+    bcc c80d0                                                         ; 80cc: 90 02       ..
+    adc #6                                                            ; 80ce: 69 06       i.
+; &80d0 referenced 1 time by &80cc
+.c80d0
+    adc #'0'                                                          ; 80d0: 69 30       i0
+    rts                                                               ; 80d2: 60          `
+
+; &80d3 referenced 1 time by &979d
+.sub_c80d3
+    jsr sub_c80e3                                                     ; 80d3: 20 e3 80     ..
+    dex                                                               ; 80d6: ca          .
+    dex                                                               ; 80d7: ca          .
+    jsr sub_c80db                                                     ; 80d8: 20 db 80     ..
+; &80db referenced 1 time by &80d8
+.sub_c80db
+    lda (l00b0),y                                                     ; 80db: b1 b0       ..
+    sta l1072,x                                                       ; 80dd: 9d 72 10    .r.
+    inx                                                               ; 80e0: e8          .
+    iny                                                               ; 80e1: c8          .
+    rts                                                               ; 80e2: 60          `
+
+; &80e3 referenced 2 times by &80d3, &979a
+.sub_c80e3
+    jsr sub_c80e6                                                     ; 80e3: 20 e6 80     ..
+; &80e6 referenced 1 time by &80e3
+.sub_c80e6
+    lda (l00b0),y                                                     ; 80e6: b1 b0       ..
+    sta l00ba,x                                                       ; 80e8: 95 ba       ..
+    inx                                                               ; 80ea: e8          .
+    iny                                                               ; 80eb: c8          .
+    rts                                                               ; 80ec: 60          `
+
+; &80ed referenced 5 times by &821d, &89ec, &8bb2, &8bc7, &a46c
+.sub_c80ed
+    jsr sub_c8b7b                                                     ; 80ed: 20 7b 8b     {.
+    jmp c8103                                                         ; 80f0: 4c 03 81    L..
+
+; &80f3 referenced 5 times by &8222, &8879, &8a77, &9a78, &9c22
+.sub_c80f3
+    jsr sub_c8b7b                                                     ; 80f3: 20 7b 8b     {.
+; &80f6 referenced 1 time by &8892
+.sub_c80f6
+    lda l00ba                                                         ; 80f6: a5 ba       ..
+    sta os_text_ptr                                                   ; 80f8: 85 f2       ..
+    lda l00bb                                                         ; 80fa: a5 bb       ..
+    sta l00f3                                                         ; 80fc: 85 f3       ..
+    ldy #0                                                            ; 80fe: a0 00       ..
+    jsr clc_jmp_gsinit                                                ; 8100: 20 4c 87     L.
+; &8103 referenced 3 times by &80f0, &8113, &8123
+.c8103
+    ldx #&20                                                          ; 8103: a2 20       .
+    jsr sub_c8149                                                     ; 8105: 20 49 81     I.
+    bcs c8125                                                         ; 8108: b0 1b       ..
+    sta l1000                                                         ; 810a: 8d 00 10    ...
+    cmp #'.'                                                          ; 810d: c9 2e       ..
+    bne c8115                                                         ; 810f: d0 04       ..
+; &8111 referenced 1 time by &8136
+.c8111
+    stx l00cc                                                         ; 8111: 86 cc       ..
+    beq c8103                                                         ; 8113: f0 ee       ..
+; &8115 referenced 1 time by &810f
+.c8115
+    cmp #&3a ; ':'                                                    ; 8115: c9 3a       .:
+    bne c812e                                                         ; 8117: d0 15       ..
+    jsr c8b8b                                                         ; 8119: 20 8b 8b     ..
+    jsr sub_c8149                                                     ; 811c: 20 49 81     I.
+    bcs c8125                                                         ; 811f: b0 04       ..
+    cmp #&2e ; '.'                                                    ; 8121: c9 2e       ..
+    beq c8103                                                         ; 8123: f0 de       ..
+; &8125 referenced 5 times by &8108, &811f, &8147, &8155, &8159
+.c8125
+    jsr generate_error_precheck_bad                                   ; 8125: 20 2e 80     ..
+    equb &cc                                                          ; 8128: cc          .
+    equs "name"                                                       ; 8129: 6e 61 6d... nam
+    equb 0                                                            ; 812d: 00          .
+
+; &812e referenced 1 time by &8117
+.c812e
+    tax                                                               ; 812e: aa          .
+    jsr sub_c8149                                                     ; 812f: 20 49 81     I.
+    bcs c815d                                                         ; 8132: b0 29       .)
+    cmp #&2e ; '.'                                                    ; 8134: c9 2e       ..
+    beq c8111                                                         ; 8136: f0 d9       ..
+    ldx #1                                                            ; 8138: a2 01       ..
+; &813a referenced 1 time by &8145
+.loop_c813a
+    sta l1000,x                                                       ; 813a: 9d 00 10    ...
+    inx                                                               ; 813d: e8          .
+    jsr sub_c8149                                                     ; 813e: 20 49 81     I.
+    bcs c815f                                                         ; 8141: b0 1c       ..
+    cpx #7                                                            ; 8143: e0 07       ..
+    bne loop_c813a                                                    ; 8145: d0 f3       ..
+    beq c8125                                                         ; 8147: f0 dc       ..
+; &8149 referenced 11 times by &8105, &811c, &812f, &813e, &8990, &899c, &89af, &89cb, &8a19, &8b8b, &a143
+.sub_c8149
+    jsr gsread                                                        ; 8149: 20 c5 ff     ..
+    php                                                               ; 814c: 08          .
+    and #&7f                                                          ; 814d: 29 7f       ).
+    cmp #13                                                           ; 814f: c9 0d       ..
+    beq c815b                                                         ; 8151: f0 08       ..
+    cmp #&20 ; ' '                                                    ; 8153: c9 20       .
+    bcc c8125                                                         ; 8155: 90 ce       ..
+    cmp #&7f                                                          ; 8157: c9 7f       ..
+    beq c8125                                                         ; 8159: f0 ca       ..
+; &815b referenced 1 time by &8151
+.c815b
+    plp                                                               ; 815b: 28          (
+    rts                                                               ; 815c: 60          `
+
+; &815d referenced 2 times by &8132, &8248
+.c815d
+    ldx #1                                                            ; 815d: a2 01       ..
+; &815f referenced 1 time by &8141
+.c815f
+    lda #&20 ; ' '                                                    ; 815f: a9 20       .
+; &8161 referenced 1 time by &8167
+.loop_c8161
+    sta l1000,x                                                       ; 8161: 9d 00 10    ...
+    inx                                                               ; 8164: e8          .
+    cpx #&40 ; '@'                                                    ; 8165: e0 40       .@
+    bne loop_c8161                                                    ; 8167: d0 f8       ..
+    ldx #6                                                            ; 8169: a2 06       ..
+; &816b referenced 1 time by &8171
+.loop_c816b
+    lda l1000,x                                                       ; 816b: bd 00 10    ...
+    sta l00c5,x                                                       ; 816e: 95 c5       ..
+    dex                                                               ; 8170: ca          .
+    bpl loop_c816b                                                    ; 8171: 10 f8       ..
+    rts                                                               ; 8173: 60          `
+
+; &8174 referenced 4 times by &833d, &85cd, &875e, &87a5
+.sub_c8174
+    jsr sub_c83e3                                                     ; 8174: 20 e3 83     ..
+    lda l0e0f,y                                                       ; 8177: b9 0f 0e    ...
+    php                                                               ; 817a: 08          .
+    and #&7f                                                          ; 817b: 29 7f       ).
+    bne c8184                                                         ; 817d: d0 05       ..
+    jsr sub_cac0c                                                     ; 817f: 20 0c ac     ..
+    beq c818a                                                         ; 8182: f0 06       ..
+; &8184 referenced 1 time by &817d
+.c8184
+    jsr c809f                                                         ; 8184: 20 9f 80     ..
+    jsr sub_c809d                                                     ; 8187: 20 9d 80     ..
+; &818a referenced 1 time by &8182
+.c818a
+    ldx #6                                                            ; 818a: a2 06       ..
+; &818c referenced 1 time by &8196
+.loop_c818c
+    lda l0e08,y                                                       ; 818c: b9 08 0e    ...
+    and #&7f                                                          ; 818f: 29 7f       ).
+    jsr c809f                                                         ; 8191: 20 9f 80     ..
+    iny                                                               ; 8194: c8          .
+    dex                                                               ; 8195: ca          .
+    bpl loop_c818c                                                    ; 8196: 10 f4       ..
+    jsr sub_cac0c                                                     ; 8198: 20 0c ac     ..
+    lda #&20 ; ' '                                                    ; 819b: a9 20       .
+    plp                                                               ; 819d: 28          (
+    bpl c81a2                                                         ; 819e: 10 02       ..
+    lda #&4c ; 'L'                                                    ; 81a0: a9 4c       .L
+; &81a2 referenced 1 time by &819e
+.c81a2
+    jsr c809f                                                         ; 81a2: 20 9f 80     ..
+    ldy #1                                                            ; 81a5: a0 01       ..
+; &81a7 referenced 4 times by &81ab, &84c5, &850a, &85c2
+.c81a7
+    jsr cac0f                                                         ; 81a7: 20 0f ac     ..
+    dey                                                               ; 81aa: 88          .
+    bne c81a7                                                         ; 81ab: d0 fa       ..
+    rts                                                               ; 81ad: 60          `
+
+; &81ae referenced 2 times by &88a9, &8b6b
+.sub_c81ae
+    lsr a                                                             ; 81ae: 4a          J
+    lsr a                                                             ; 81af: 4a          J
+; &81b0 referenced 8 times by &81f5, &85e6, &9cdb, &9cfd, &a2c6, &a49f, &a505, &a8e6
+.sub_c81b0
+    lsr a                                                             ; 81b0: 4a          J
+    lsr a                                                             ; 81b1: 4a          J
+    lsr a                                                             ; 81b2: 4a          J
+    lsr a                                                             ; 81b3: 4a          J
+    and #3                                                            ; 81b4: 29 03       ).
+    rts                                                               ; 81b6: 60          `
+
+; &81b7 referenced 1 time by &8b54
+.sub_c81b7
+    and #8                                                            ; 81b7: 29 08       ).
+    beq c81bd                                                         ; 81b9: f0 02       ..
+    lda #3                                                            ; 81bb: a9 03       ..
+; &81bd referenced 1 time by &81b9
+.c81bd
+    rts                                                               ; 81bd: 60          `
+
+; &81be referenced 3 times by &9cb3, &9d0c, &9e00
+.sub_c81be
+    lsr a                                                             ; 81be: 4a          J
+; &81bf referenced 8 times by &80bc, &84d5, &9527, &9644, &98fb, &a18d, &a9c3, &ac63
+.sub_c81bf
+    lsr a                                                             ; 81bf: 4a          J
+; &81c0 referenced 1 time by &a90d
+.sub_c81c0
+    lsr a                                                             ; 81c0: 4a          J
+    lsr a                                                             ; 81c1: 4a          J
+    lsr a                                                             ; 81c2: 4a          J
+    rts                                                               ; 81c3: 60          `
+
+; &81c4 referenced 1 time by &9e2a
+.sub_c81c4
+    asl a                                                             ; 81c4: 0a          .
+; &81c5 referenced 2 times by &8a5d, &9bae
+.sub_c81c5
+    asl a                                                             ; 81c5: 0a          .
+    asl a                                                             ; 81c6: 0a          .
+    asl a                                                             ; 81c7: 0a          .
+    asl a                                                             ; 81c8: 0a          .
+    rts                                                               ; 81c9: 60          `
+
+; &81ca referenced 1 time by &8867
+.sub_c81ca
+    lda #5                                                            ; 81ca: a9 05       ..
+    sta l1095                                                         ; 81cc: 8d 95 10    ...
+    lda l00cd                                                         ; 81cf: a5 cd       ..
+    sta l1090                                                         ; 81d1: 8d 90 10    ...
+    lda #&0a                                                          ; 81d4: a9 0a       ..
+    sta l00b0                                                         ; 81d6: 85 b0       ..
+    lda l00bc                                                         ; 81d8: a5 bc       ..
+    sta l1091                                                         ; 81da: 8d 91 10    ...
+    lda l00bd                                                         ; 81dd: a5 bd       ..
+    sta l1092                                                         ; 81df: 8d 92 10    ...
+    lda l1074                                                         ; 81e2: ad 74 10    .t.
+    sta l1093                                                         ; 81e5: 8d 93 10    ...
+    lda l1075                                                         ; 81e8: ad 75 10    .u.
+    sta l1094                                                         ; 81eb: 8d 94 10    ...
+    lda #&ff                                                          ; 81ee: a9 ff       ..
+    sta l1097                                                         ; 81f0: 8d 97 10    ...
+    lda l00c2                                                         ; 81f3: a5 c2       ..
+    jsr sub_c81b0                                                     ; 81f5: 20 b0 81     ..
+    sta l109a                                                         ; 81f8: 8d 9a 10    ...
+    lda l00c0                                                         ; 81fb: a5 c0       ..
+    sta l109b                                                         ; 81fd: 8d 9b 10    ...
+    lda l00c1                                                         ; 8200: a5 c1       ..
+    sta l1099                                                         ; 8202: 8d 99 10    ...
+    lda l00c2                                                         ; 8205: a5 c2       ..
+    and #&03                                                          ; 8207: 29 03       ).
+    tax                                                               ; 8209: aa          .
+    lda l00c3                                                         ; 820a: a5 c3       ..
+; &820c referenced 1 time by &8215
+.loop_c820c
+    sec                                                               ; 820c: 38          8
+; &820d referenced 1 time by &8212
+.loop_c820d
+    inc l1097                                                         ; 820d: ee 97 10    ...
+    sbc l00b0                                                         ; 8210: e5 b0       ..
+    bcs loop_c820d                                                    ; 8212: b0 f9       ..
+    dex                                                               ; 8214: ca          .
+    bpl loop_c820c                                                    ; 8215: 10 f5       ..
+    adc l00b0                                                         ; 8217: 65 b0       e.
+    sta l1098                                                         ; 8219: 8d 98 10    ...
+; &821c referenced 1 time by &8228
+.loop_c821c
+    rts                                                               ; 821c: 60          `
+
+; &821d referenced 4 times by &825a, &8756, &8788, &879d
+.sub_c821d
+    jsr sub_c80ed                                                     ; 821d: 20 ed 80     ..
+    bmi c8225                                                         ; 8220: 30 03       0.
+; &8222 referenced 1 time by &881b
+.sub_c8222
+    jsr sub_c80f3                                                     ; 8222: 20 f3 80     ..
+; &8225 referenced 4 times by &8220, &824e, &8bb7, &a478
+.c8225
+    jsr sub_c8284                                                     ; 8225: 20 84 82     ..
+    bcs loop_c821c                                                    ; 8228: b0 f2       ..
+; &822a referenced 2 times by &89fd, &ab17
+.c822a
+    jsr generate_error                                                ; 822a: 20 48 80     H.
+    equb &d6                                                          ; 822d: d6          .
+    equs "Not found"                                                  ; 822e: 4e 6f 74... Not
+    equb 0                                                            ; 8237: 00          .
+
+.sub_c8238
+    jsr sub_c8b7b                                                     ; 8238: 20 7b 8b     {.
+    jsr clc_jmp_gsinit                                                ; 823b: 20 4c 87     L.
+    beq c8243                                                         ; 823e: f0 03       ..
+    jsr c898a                                                         ; 8240: 20 8a 89     ..
+; &8243 referenced 1 time by &823e
+.c8243
+    lda #&2a ; '*'                                                    ; 8243: a9 2a       .*
+    sta l1000                                                         ; 8245: 8d 00 10    ...
+    jsr c815d                                                         ; 8248: 20 5d 81     ].
+    jsr sub_c99ac                                                     ; 824b: 20 ac 99     ..
+    jsr c8225                                                         ; 824e: 20 25 82     %.
+    jmp c825d                                                         ; 8251: 4c 5d 82    L].
+
+.sub_c8254
+    jsr sub_c99ac                                                     ; 8254: 20 ac 99     ..
+    jsr sub_ca14a                                                     ; 8257: 20 4a a1     J.
+    jsr sub_c821d                                                     ; 825a: 20 1d 82     ..
+; &825d referenced 2 times by &8251, &8263
+.c825d
+    jsr sub_c833a                                                     ; 825d: 20 3a 83     :.
+    jsr sub_c8280                                                     ; 8260: 20 80 82     ..
+    bcs c825d                                                         ; 8263: b0 f8       ..
+    rts                                                               ; 8265: 60          `
+
+; &8266 referenced 2 times by &887f, &8895
+.sub_c8266
+    jsr sub_c93f9                                                     ; 8266: 20 f9 93     ..
+    lda #0                                                            ; 8269: a9 00       ..
+    beq c828b                                                         ; 826b: f0 1e       ..
+; &826d referenced 2 times by &9bd9, &a4f2
+.sub_c826d
+    ldx #6                                                            ; 826d: a2 06       ..
+; &826f referenced 1 time by &8275
+.loop_c826f
+    lda l00c5,x                                                       ; 826f: b5 c5       ..
+    sta l1058,x                                                       ; 8271: 9d 58 10    .X.
+    dex                                                               ; 8274: ca          .
+    bpl loop_c826f                                                    ; 8275: 10 f8       ..
+    lda #&20 ; ' '                                                    ; 8277: a9 20       .
+    sta l105f                                                         ; 8279: 8d 5f 10    ._.
+    lda #&58 ; 'X'                                                    ; 827c: a9 58       .X
+    bne c8286                                                         ; 827e: d0 06       ..
+; &8280 referenced 6 times by &8260, &877c, &87ab, &87c6, &8a10, &a4db
+.sub_c8280
+    ldx #0                                                            ; 8280: a2 00       ..
+    beq c8290                                                         ; 8282: f0 0c       ..
+; &8284 referenced 7 times by &8225, &87bb, &89f8, &8a7a, &8bcf, &9a7b, &9c28
+.sub_c8284
+    lda #0                                                            ; 8284: a9 00       ..
+; &8286 referenced 1 time by &827e
+.c8286
+    pha                                                               ; 8286: 48          H
+    jsr sub_c93fd                                                     ; 8287: 20 fd 93     ..
+    pla                                                               ; 828a: 68          h
+; &828b referenced 1 time by &826b
+.c828b
+    tax                                                               ; 828b: aa          .
+    lda #0                                                            ; 828c: a9 00       ..
+    sta l00b6                                                         ; 828e: 85 b6       ..
+; &8290 referenced 3 times by &8282, &82a4, &82ad
+.c8290
+    ldy #0                                                            ; 8290: a0 00       ..
+    lda #&0e                                                          ; 8292: a9 0e       ..
+    sta l00b7                                                         ; 8294: 85 b7       ..
+    lda l00b6                                                         ; 8296: a5 b6       ..
+    cmp l0f05                                                         ; 8298: cd 05 0f    ...
+    bcs c82e6                                                         ; 829b: b0 49       .I
+    adc #8                                                            ; 829d: 69 08       i.
+    sta l00b6                                                         ; 829f: 85 b6       ..
+    jsr sub_c82bb                                                     ; 82a1: 20 bb 82     ..
+    bcc c8290                                                         ; 82a4: 90 ea       ..
+    lda l00cc                                                         ; 82a6: a5 cc       ..
+    ldy #7                                                            ; 82a8: a0 07       ..
+    jsr sub_c82e8                                                     ; 82aa: 20 e8 82     ..
+    bne c8290                                                         ; 82ad: d0 e1       ..
+    ldy l00b6                                                         ; 82af: a4 b6       ..
+    sec                                                               ; 82b1: 38          8
+; &82b2 referenced 4 times by &87e8, &8aca, &a27c, &a848
+.sub_c82b2
+    dey                                                               ; 82b2: 88          .
+    dey                                                               ; 82b3: 88          .
+    dey                                                               ; 82b4: 88          .
+    dey                                                               ; 82b5: 88          .
+    dey                                                               ; 82b6: 88          .
+    dey                                                               ; 82b7: 88          .
+    dey                                                               ; 82b8: 88          .
+    dey                                                               ; 82b9: 88          .
+    rts                                                               ; 82ba: 60          `
+
+; &82bb referenced 2 times by &82a1, &82c7
+.sub_c82bb
+    jsr sub_c83e3                                                     ; 82bb: 20 e3 83     ..
+; &82be referenced 1 time by &82e4
+.c82be
+    lda l1000,x                                                       ; 82be: bd 00 10    ...
+    cmp l10ce                                                         ; 82c1: cd ce 10    ...
+    bne c82d9                                                         ; 82c4: d0 13       ..
+    inx                                                               ; 82c6: e8          .
+; &82c7 referenced 1 time by &82cf
+.loop_c82c7
+    jsr sub_c82bb                                                     ; 82c7: 20 bb 82     ..
+    bcs c82e7                                                         ; 82ca: b0 1b       ..
+    iny                                                               ; 82cc: c8          .
+    cpy #7                                                            ; 82cd: c0 07       ..
+    bcc loop_c82c7                                                    ; 82cf: 90 f6       ..
+; &82d1 referenced 1 time by &82db
+.loop_c82d1
+    lda l1000,x                                                       ; 82d1: bd 00 10    ...
+    cmp #&20 ; ' '                                                    ; 82d4: c9 20       .
+    bne c82e6                                                         ; 82d6: d0 0e       ..
+    rts                                                               ; 82d8: 60          `
+
+; &82d9 referenced 1 time by &82c4
+.c82d9
+    cpy #7                                                            ; 82d9: c0 07       ..
+    bcs loop_c82d1                                                    ; 82db: b0 f4       ..
+    jsr sub_c82e8                                                     ; 82dd: 20 e8 82     ..
+    bne c82e6                                                         ; 82e0: d0 04       ..
+    inx                                                               ; 82e2: e8          .
+    iny                                                               ; 82e3: c8          .
+    bne c82be                                                         ; 82e4: d0 d8       ..
+; &82e6 referenced 3 times by &829b, &82d6, &82e0
+.c82e6
+    clc                                                               ; 82e6: 18          .
+; &82e7 referenced 1 time by &82ca
+.c82e7
+    rts                                                               ; 82e7: 60          `
+
+; &82e8 referenced 2 times by &82aa, &82dd
+.sub_c82e8
+    cmp l10ce                                                         ; 82e8: cd ce 10    ...
+    beq c82fd                                                         ; 82eb: f0 10       ..
+    cmp l10cd                                                         ; 82ed: cd cd 10    ...
+    beq c82fd                                                         ; 82f0: f0 0b       ..
+    jsr sub_c8327                                                     ; 82f2: 20 27 83     '.
+    eor (l00b6),y                                                     ; 82f5: 51 b6       Q.
+    bcs c82fb                                                         ; 82f7: b0 02       ..
+    and #%01011111                                                    ; 82f9: 29 5f       )_
+; &82fb referenced 1 time by &82f7
+.c82fb
+    and #&7f                                                          ; 82fb: 29 7f       ).
+; &82fd referenced 2 times by &82eb, &82f0
+.c82fd
+    rts                                                               ; 82fd: 60          `
+
+; &82fe referenced 6 times by &8441, &8567, &857e, &858e, &aa2b, &aa3b
+.sub_c82fe
+    php                                                               ; 82fe: 08          .
+    jsr sub_c8327                                                     ; 82ff: 20 27 83     '.
+    bcs c8306                                                         ; 8302: b0 02       ..
+    and #&5f ; '_'                                                    ; 8304: 29 5f       )_
+; &8306 referenced 1 time by &8302
+.c8306
+    and #&7f                                                          ; 8306: 29 7f       ).
+    plp                                                               ; 8308: 28          (
+    rts                                                               ; 8309: 60          `
+
+; &830a referenced 5 times by &878e, &87e3, &8a7f, &99c4, &a4f7
+.sub_c830a
+    jsr sub_c9a60                                                     ; 830a: 20 60 9a     `.
+; &830d referenced 1 time by &831d
+.loop_c830d
+    lda l0e10,y                                                       ; 830d: b9 10 0e    ...
+    sta l0e08,y                                                       ; 8310: 99 08 0e    ...
+    lda l0f10,y                                                       ; 8313: b9 10 0f    ...
+    sta l0f08,y                                                       ; 8316: 99 08 0f    ...
+    iny                                                               ; 8319: c8          .
+    cpy l0f05                                                         ; 831a: cc 05 0f    ...
+    bcc loop_c830d                                                    ; 831d: 90 ee       ..
+    tya                                                               ; 831f: 98          .
+    sbc #8                                                            ; 8320: e9 08       ..
+    sta l0f05                                                         ; 8322: 8d 05 0f    ...
+    clc                                                               ; 8325: 18          .
+; &8326 referenced 1 time by &8338
+.loop_c8326
+    rts                                                               ; 8326: 60          `
+
+; &8327 referenced 4 times by &82f2, &82ff, &8736, &98a8
+.sub_c8327
+    pha                                                               ; 8327: 48          H
+    and #&5f ; '_'                                                    ; 8328: 29 5f       )_
+    cmp #&41 ; 'A'                                                    ; 832a: c9 41       .A
+    bcc c8332                                                         ; 832c: 90 04       ..
+    cmp #&5b ; '['                                                    ; 832e: c9 5b       .[
+    bcc c8333                                                         ; 8330: 90 01       ..
+; &8332 referenced 1 time by &832c
+.c8332
+    sec                                                               ; 8332: 38          8
+; &8333 referenced 1 time by &8330
+.c8333
+    pla                                                               ; 8333: 68          h
+    rts                                                               ; 8334: 60          `
+
+; &8335 referenced 5 times by &878b, &884f, &8a0d, &8b04, &a2ad
+.sub_c8335
+    bit l10c6                                                         ; 8335: 2c c6 10    ,..
+    bmi loop_c8326                                                    ; 8338: 30 ec       0.
+; &833a referenced 3 times by &825d, &a30f, &a482
+.sub_c833a
+    jsr sub_c83e3                                                     ; 833a: 20 e3 83     ..
+    jsr sub_c8174                                                     ; 833d: 20 74 81     t.
+    tya                                                               ; 8340: 98          .
+    pha                                                               ; 8341: 48          H
+    lda #&60 ; '`'                                                    ; 8342: a9 60       .`
+    sta l00b0                                                         ; 8344: 85 b0       ..
+    lda #&10                                                          ; 8346: a9 10       ..
+    sta l00b1                                                         ; 8348: 85 b1       ..
+    jsr sub_c8386                                                     ; 834a: 20 86 83     ..
+    ldy #2                                                            ; 834d: a0 02       ..
+    jsr cac0f                                                         ; 834f: 20 0f ac     ..
+    jsr sub_c836e                                                     ; 8352: 20 6e 83     n.
+    jsr sub_c836e                                                     ; 8355: 20 6e 83     n.
+    jsr sub_c836e                                                     ; 8358: 20 6e 83     n.
+    pla                                                               ; 835b: 68          h
+    tay                                                               ; 835c: a8          .
+    lda l0f0e,y                                                       ; 835d: b9 0e 0f    ...
+    and #3                                                            ; 8360: 29 03       ).
+    jsr sub_c80c3                                                     ; 8362: 20 c3 80     ..
+    lda l0f0f,y                                                       ; 8365: b9 0f 0f    ...
+    jsr sub_c80bb                                                     ; 8368: 20 bb 80     ..
+    jmp ca3dc                                                         ; 836b: 4c dc a3    L..
+
+; &836e referenced 3 times by &8352, &8355, &8358
+.sub_c836e
+    ldx #3                                                            ; 836e: a2 03       ..
+; &8370 referenced 1 time by &8378
+.loop_c8370
+    lda l1062,y                                                       ; 8370: b9 62 10    .b.
+    jsr sub_c80bb                                                     ; 8373: 20 bb 80     ..
+    dey                                                               ; 8376: 88          .
+    dex                                                               ; 8377: ca          .
+    bne loop_c8370                                                    ; 8378: d0 f6       ..
+    jsr sub_c87db                                                     ; 837a: 20 db 87     ..
+    jmp cac0f                                                         ; 837d: 4c 0f ac    L..
+
+; &8380 referenced 7 times by &89bd, &975e, &9bf8, &a26a, &a4d1, &a4ef, &a7fc
+.sub_c8380
+    jsr sub_c83e3                                                     ; 8380: 20 e3 83     ..
+    jmp c940c                                                         ; 8383: 4c 0c 94    L..
+
+; &8386 referenced 5 times by &834a, &8821, &885f, &99b8, &99c1
+.sub_c8386
+    jsr sub_c83e3                                                     ; 8386: 20 e3 83     ..
+    tya                                                               ; 8389: 98          .
+    pha                                                               ; 838a: 48          H
+    tax                                                               ; 838b: aa          .
+    ldy #&12                                                          ; 838c: a0 12       ..
+    lda #0                                                            ; 838e: a9 00       ..
+; &8390 referenced 1 time by &8395
+.loop_c8390
+    dey                                                               ; 8390: 88          .
+    sta (l00b0),y                                                     ; 8391: 91 b0       ..
+    cpy #2                                                            ; 8393: c0 02       ..
+    bne loop_c8390                                                    ; 8395: d0 f9       ..
+; &8397 referenced 1 time by &839e
+.loop_c8397
+    jsr sub_c83d1                                                     ; 8397: 20 d1 83     ..
+    iny                                                               ; 839a: c8          .
+    iny                                                               ; 839b: c8          .
+    cpy #&0e                                                          ; 839c: c0 0e       ..
+    bne loop_c8397                                                    ; 839e: d0 f7       ..
+    pla                                                               ; 83a0: 68          h
+    tax                                                               ; 83a1: aa          .
+    lda l0e0f,x                                                       ; 83a2: bd 0f 0e    ...
+    bpl c83ab                                                         ; 83a5: 10 04       ..
+    lda #8                                                            ; 83a7: a9 08       ..
+    sta (l00b0),y                                                     ; 83a9: 91 b0       ..
+; &83ab referenced 1 time by &83a5
+.c83ab
+    lda l0f0e,x                                                       ; 83ab: bd 0e 0f    ...
+    ldy #4                                                            ; 83ae: a0 04       ..
+    jsr sub_c83bf                                                     ; 83b0: 20 bf 83     ..
+    ldy #&0c                                                          ; 83b3: a0 0c       ..
+    lsr a                                                             ; 83b5: 4a          J
+    lsr a                                                             ; 83b6: 4a          J
+    pha                                                               ; 83b7: 48          H
+    and #3                                                            ; 83b8: 29 03       ).
+    sta (l00b0),y                                                     ; 83ba: 91 b0       ..
+    pla                                                               ; 83bc: 68          h
+    ldy #8                                                            ; 83bd: a0 08       ..
+; &83bf referenced 1 time by &83b0
+.sub_c83bf
+    lsr a                                                             ; 83bf: 4a          J
+    lsr a                                                             ; 83c0: 4a          J
+    pha                                                               ; 83c1: 48          H
+    and #3                                                            ; 83c2: 29 03       ).
+    cmp #3                                                            ; 83c4: c9 03       ..
+    bne c83cd                                                         ; 83c6: d0 05       ..
+    lda #&ff                                                          ; 83c8: a9 ff       ..
+    sta (l00b0),y                                                     ; 83ca: 91 b0       ..
+    iny                                                               ; 83cc: c8          .
+; &83cd referenced 1 time by &83c6
+.c83cd
+    sta (l00b0),y                                                     ; 83cd: 91 b0       ..
+    pla                                                               ; 83cf: 68          h
+    rts                                                               ; 83d0: 60          `
+
+; &83d1 referenced 1 time by &8397
+.sub_c83d1
+    jsr sub_c83d4                                                     ; 83d1: 20 d4 83     ..
+; &83d4 referenced 1 time by &83d1
+.sub_c83d4
+    lda l0f08,x                                                       ; 83d4: bd 08 0f    ...
+    sta (l00b0),y                                                     ; 83d7: 91 b0       ..
+    inx                                                               ; 83d9: e8          .
+    iny                                                               ; 83da: c8          .
+    rts                                                               ; 83db: 60          `
+
+; &83dc referenced 4 times by &805b, &8064, &8086, &a9ab
+.inc16_ae
+    inc l00ae                                                         ; 83dc: e6 ae       ..
+    bne c83e2                                                         ; 83de: d0 02       ..
+    inc l00af                                                         ; 83e0: e6 af       ..
+; &83e2 referenced 1 time by &83de
+.c83e2
+    rts                                                               ; 83e2: 60          `
+
+; &83e3 referenced 29 times by &809f, &8174, &82bb, &833a, &8380, &8386, &8951, &8a32, &96c3, &97cd, &993b, &99f3, &9a0f, &9a32, &9a63, &9ac8, &9ad8, &9b51, &9bf2, &9c10, &9d9b, &9f7c, &9f82, &a06c, &a190, &a1b4, &a379, &a384, &ac72
+.sub_c83e3
+    pha                                                               ; 83e3: 48          H
+    txa                                                               ; 83e4: 8a          .
+    pha                                                               ; 83e5: 48          H
+    tya                                                               ; 83e6: 98          .
+    pha                                                               ; 83e7: 48          H
+    lda #&84                                                          ; 83e8: a9 84       ..
+    pha                                                               ; 83ea: 48          H
+    lda #5                                                            ; 83eb: a9 05       ..
+    pha                                                               ; 83ed: 48          H
+; &83ee referenced 1 time by &8411
+.sub_c83ee
+    ldy #5                                                            ; 83ee: a0 05       ..
+; &83f0 referenced 1 time by &83f6
+.loop_c83f0
+    tsx                                                               ; 83f0: ba          .
+    lda l0107,x                                                       ; 83f1: bd 07 01    ...
+    pha                                                               ; 83f4: 48          H
+    dey                                                               ; 83f5: 88          .
+    bne loop_c83f0                                                    ; 83f6: d0 f8       ..
+    ldy #&0a                                                          ; 83f8: a0 0a       ..
+; &83fa referenced 1 time by &8402
+.loop_c83fa
+    lda l0109,x                                                       ; 83fa: bd 09 01    ...
+    sta l010b,x                                                       ; 83fd: 9d 0b 01    ...
+    dex                                                               ; 8400: ca          .
+    dey                                                               ; 8401: 88          .
+    bne loop_c83fa                                                    ; 8402: d0 f6       ..
+    pla                                                               ; 8404: 68          h
+    pla                                                               ; 8405: 68          h
+; &8406 referenced 1 time by &8418
+.loop_c8406
+    pla                                                               ; 8406: 68          h
+    tay                                                               ; 8407: a8          .
+    pla                                                               ; 8408: 68          h
+    tax                                                               ; 8409: aa          .
+    pla                                                               ; 840a: 68          h
+    rts                                                               ; 840b: 60          `
+
+; &840c referenced 5 times by &841b, &9785, &9c16, &9e94, &aadd
+.sub_c840c
+    pha                                                               ; 840c: 48          H
+    txa                                                               ; 840d: 8a          .
+    pha                                                               ; 840e: 48          H
+    tya                                                               ; 840f: 98          .
+    pha                                                               ; 8410: 48          H
+    jsr sub_c83ee                                                     ; 8411: 20 ee 83     ..
+    tsx                                                               ; 8414: ba          .
+    sta l0103,x                                                       ; 8415: 9d 03 01    ...
+    jmp loop_c8406                                                    ; 8418: 4c 06 84    L..
+
+; &841b referenced 2 times by &80b8, &a9bf
+.sub_c841b
+    jsr sub_c840c                                                     ; 841b: 20 0c 84     ..
+    tay                                                               ; 841e: a8          .
+    beq c842b                                                         ; 841f: f0 0a       ..
+    clc                                                               ; 8421: 18          .
+    sed                                                               ; 8422: f8          .
+    lda #0                                                            ; 8423: a9 00       ..
+; &8425 referenced 1 time by &8428
+.loop_c8425
+    adc #1                                                            ; 8425: 69 01       i.
+    dey                                                               ; 8427: 88          .
+    bne loop_c8425                                                    ; 8428: d0 fb       ..
+    cld                                                               ; 842a: d8          .
+; &842b referenced 1 time by &841f
+.c842b
+    rts                                                               ; 842b: 60          `
+
+; &842c referenced 1 time by &abb1
+.sub_c842c
+    and #&7f                                                          ; 842c: 29 7f       ).
+    cmp #&7f                                                          ; 842e: c9 7f       ..
+    beq c8436                                                         ; 8430: f0 04       ..
+    cmp #&20 ; ' '                                                    ; 8432: c9 20       .
+    bcs c8438                                                         ; 8434: b0 02       ..
+; &8436 referenced 1 time by &8430
+.c8436
+    lda #&2e ; '.'                                                    ; 8436: a9 2e       ..
+; &8438 referenced 1 time by &8434
+.c8438
+    rts                                                               ; 8438: 60          `
+
+; &8439 referenced 2 times by &8444, &8463
+.sub_c8439
+    sec                                                               ; 8439: 38          8
+    sbc #&30 ; '0'                                                    ; 843a: e9 30       .0
+    bcc c8454                                                         ; 843c: 90 16       ..
+    cmp #&0a                                                          ; 843e: c9 0a       ..
+    rts                                                               ; 8440: 60          `
+
+    jsr sub_c82fe                                                     ; 8441: 20 fe 82     ..
+    jsr sub_c8439                                                     ; 8444: 20 39 84     9.
+    bcc c8453                                                         ; 8447: 90 0a       ..
+    sbc #7                                                            ; 8449: e9 07       ..
+    bcc c8454                                                         ; 844b: 90 07       ..
+    cmp #&0a                                                          ; 844d: c9 0a       ..
+    bcc c8454                                                         ; 844f: 90 03       ..
+    cmp #&10                                                          ; 8451: c9 10       ..
+; &8453 referenced 1 time by &8447
+.c8453
+    rts                                                               ; 8453: 60          `
+
+; &8454 referenced 3 times by &843c, &844b, &844f
+.c8454
+    sec                                                               ; 8454: 38          8
+    rts                                                               ; 8455: 60          `
+
+; &8456 referenced 3 times by &87f7, &a5ce, &a9e7
+.sub_c8456
+    jsr clc_jmp_gsinit                                                ; 8456: 20 4c 87     L.
+    sec                                                               ; 8459: 38          8
+    beq c8482                                                         ; 845a: f0 26       .&
+    php                                                               ; 845c: 08          .
+    lda #0                                                            ; 845d: a9 00       ..
+    sta l00b9                                                         ; 845f: 85 b9       ..
+    beq c8477                                                         ; 8461: f0 14       ..
+; &8463 referenced 1 time by &847a
+.loop_c8463
+    jsr sub_c8439                                                     ; 8463: 20 39 84     9.
+    bcs c8481                                                         ; 8466: b0 19       ..
+    sta l00b8                                                         ; 8468: 85 b8       ..
+    lda l00b9                                                         ; 846a: a5 b9       ..
+    asl a                                                             ; 846c: 0a          .
+    sta l00b9                                                         ; 846d: 85 b9       ..
+    asl a                                                             ; 846f: 0a          .
+    asl a                                                             ; 8470: 0a          .
+    adc l00b9                                                         ; 8471: 65 b9       e.
+    adc l00b8                                                         ; 8473: 65 b8       e.
+    sta l00b9                                                         ; 8475: 85 b9       ..
+; &8477 referenced 1 time by &8461
+.c8477
+    jsr gsread                                                        ; 8477: 20 c5 ff     ..
+    bcc loop_c8463                                                    ; 847a: 90 e7       ..
+    lda l00b9                                                         ; 847c: a5 b9       ..
+    plp                                                               ; 847e: 28          (
+    clc                                                               ; 847f: 18          .
+    rts                                                               ; 8480: 60          `
+
+; &8481 referenced 1 time by &8466
+.c8481
+    plp                                                               ; 8481: 28          (
+; &8482 referenced 1 time by &845a
+.c8482
+    rts                                                               ; 8482: 60          `
+
+    jsr sub_c8745                                                     ; 8483: 20 45 87     E.
+    jsr sub_c8b86                                                     ; 8486: 20 86 8b     ..
+    jsr c940c                                                         ; 8489: 20 0c 94     ..
+    ldy #&ff                                                          ; 848c: a0 ff       ..
+    sty l00a8                                                         ; 848e: 84 a8       ..
+    iny                                                               ; 8490: c8          .
+    sty l00aa                                                         ; 8491: 84 aa       ..
+; &8493 referenced 1 time by &84a3
+.loop_c8493
+    lda l0e00,y                                                       ; 8493: b9 00 0e    ...
+    cpy #8                                                            ; 8496: c0 08       ..
+    bcc c849d                                                         ; 8498: 90 03       ..
+    lda l0ef8,y                                                       ; 849a: b9 f8 0e    ...
+; &849d referenced 1 time by &8498
+.c849d
+    jsr c809f                                                         ; 849d: 20 9f 80     ..
+    iny                                                               ; 84a0: c8          .
+    cpy #&0c                                                          ; 84a1: c0 0c       ..
+    bne loop_c8493                                                    ; 84a3: d0 ee       ..
+    jsr print_inline_l809f_top_bit_clear                              ; 84a5: 20 77 80     w.
+    equs " ("                                                         ; 84a8: 20 28        (
+
+    lda l0f04                                                         ; 84aa: ad 04 0f    ...
+    jsr sub_c80bb                                                     ; 84ad: 20 bb 80     ..
+    jsr print_inline_l809f_top_bit_clear                              ; 84b0: 20 77 80     w.
+    equs ") FM", &0d, "Drive "                                        ; 84b3: 29 20 46... ) F
+
+    lda l00cd                                                         ; 84be: a5 cd       ..
+    jsr sub_c80c3                                                     ; 84c0: 20 c3 80     ..
+    ldy #&0d                                                          ; 84c3: a0 0d       ..
+    jsr c81a7                                                         ; 84c5: 20 a7 81     ..
+    jsr print_inline_l809f_top_bit_clear                              ; 84c8: 20 77 80     w.
+    equs "Option "                                                    ; 84cb: 4f 70 74... Opt
+
+    lda l0f06                                                         ; 84d2: ad 06 0f    ...
+    jsr sub_c81bf                                                     ; 84d5: 20 bf 81     ..
+    pha                                                               ; 84d8: 48          H
+    jsr sub_c80c3                                                     ; 84d9: 20 c3 80     ..
+    jsr print_inline_l809f_top_bit_clear                              ; 84dc: 20 77 80     w.
+    equs " ("                                                         ; 84df: 20 28        (
+
+    ldy #3                                                            ; 84e1: a0 03       ..
+    pla                                                               ; 84e3: 68          h
+    asl a                                                             ; 84e4: 0a          .
+    asl a                                                             ; 84e5: 0a          .
+    tax                                                               ; 84e6: aa          .
+; &84e7 referenced 1 time by &84ef
+.loop_c84e7
+    lda opt4_table,x                                                  ; 84e7: bd d3 85    ...
+    jsr c809f                                                         ; 84ea: 20 9f 80     ..
+    inx                                                               ; 84ed: e8          .
+    dey                                                               ; 84ee: 88          .
+    bpl loop_c84e7                                                    ; 84ef: 10 f6       ..
+    jsr print_inline_l809f_top_bit_clear                              ; 84f1: 20 77 80     w.
+    equs ")", &0d, "Dir. :"                                           ; 84f4: 29 0d 44... ).D
+
+    lda l10ca                                                         ; 84fc: ad ca 10    ...
+    jsr sub_c809a                                                     ; 84ff: 20 9a 80     ..
+    lda l10c9                                                         ; 8502: ad c9 10    ...
+    jsr c809f                                                         ; 8505: 20 9f 80     ..
+    ldy #&0b                                                          ; 8508: a0 0b       ..
+    jsr c81a7                                                         ; 850a: 20 a7 81     ..
+    jsr print_inline_l809f_top_bit_clear                              ; 850d: 20 77 80     w.
+    equs "Lib. :"                                                     ; 8510: 4c 69 62... Lib
+
+    lda l10cc                                                         ; 8516: ad cc 10    ...
+    jsr sub_c809a                                                     ; 8519: 20 9a 80     ..
+    lda l10cb                                                         ; 851c: ad cb 10    ...
+    jsr c809f                                                         ; 851f: 20 9f 80     ..
+    jsr ca3dc                                                         ; 8522: 20 dc a3     ..
+    ldy #0                                                            ; 8525: a0 00       ..
+; &8527 referenced 1 time by &8541
+.loop_c8527
+    cpy l0f05                                                         ; 8527: cc 05 0f    ...
+    bcs c8543                                                         ; 852a: b0 17       ..
+    lda l0e0f,y                                                       ; 852c: b9 0f 0e    ...
+    eor l10c9                                                         ; 852f: 4d c9 10    M..
+    and #&5f ; '_'                                                    ; 8532: 29 5f       )_
+    bne c853e                                                         ; 8534: d0 08       ..
+    lda l0e0f,y                                                       ; 8536: b9 0f 0e    ...
+    and #&80                                                          ; 8539: 29 80       ).
+    sta l0e0f,y                                                       ; 853b: 99 0f 0e    ...
+; &853e referenced 1 time by &8534
+.c853e
+    jsr sub_c87da                                                     ; 853e: 20 da 87     ..
+    bcc loop_c8527                                                    ; 8541: 90 e4       ..
+; &8543 referenced 2 times by &852a, &85d0
+.c8543
+    ldy #0                                                            ; 8543: a0 00       ..
+    jsr sub_c8555                                                     ; 8545: 20 55 85     U.
+    bcc c8560                                                         ; 8548: 90 16       ..
+    lda #&ff                                                          ; 854a: a9 ff       ..
+    sta l1082                                                         ; 854c: 8d 82 10    ...
+    jmp ca3dc                                                         ; 854f: 4c dc a3    L..
+
+; &8552 referenced 1 time by &855d
+.loop_c8552
+    jsr sub_c87da                                                     ; 8552: 20 da 87     ..
+; &8555 referenced 2 times by &8545, &8573
+.sub_c8555
+    cpy l0f05                                                         ; 8555: cc 05 0f    ...
+    bcs c855f                                                         ; 8558: b0 05       ..
+    lda l0e08,y                                                       ; 855a: b9 08 0e    ...
+    bmi loop_c8552                                                    ; 855d: 30 f3       0.
+; &855f referenced 1 time by &8558
+.c855f
+    rts                                                               ; 855f: 60          `
+
+; &8560 referenced 2 times by &8548, &8594
+.c8560
+    sty l00ab                                                         ; 8560: 84 ab       ..
+    ldx #0                                                            ; 8562: a2 00       ..
+; &8564 referenced 1 time by &8571
+.loop_c8564
+    lda l0e08,y                                                       ; 8564: b9 08 0e    ...
+    jsr sub_c82fe                                                     ; 8567: 20 fe 82     ..
+    sta l1060,x                                                       ; 856a: 9d 60 10    .`.
+    iny                                                               ; 856d: c8          .
+    inx                                                               ; 856e: e8          .
+    cpx #8                                                            ; 856f: e0 08       ..
+    bne loop_c8564                                                    ; 8571: d0 f1       ..
+; &8573 referenced 1 time by &8599
+.c8573
+    jsr sub_c8555                                                     ; 8573: 20 55 85     U.
+    bcs c859b                                                         ; 8576: b0 23       .#
+    sec                                                               ; 8578: 38          8
+    ldx #6                                                            ; 8579: a2 06       ..
+; &857b referenced 1 time by &8586
+.loop_c857b
+    lda l0e0e,y                                                       ; 857b: b9 0e 0e    ...
+    jsr sub_c82fe                                                     ; 857e: 20 fe 82     ..
+    sbc l1060,x                                                       ; 8581: fd 60 10    .`.
+    dey                                                               ; 8584: 88          .
+    dex                                                               ; 8585: ca          .
+    bpl loop_c857b                                                    ; 8586: 10 f3       ..
+    jsr sub_c87db                                                     ; 8588: 20 db 87     ..
+    lda l0e0f,y                                                       ; 858b: b9 0f 0e    ...
+    jsr sub_c82fe                                                     ; 858e: 20 fe 82     ..
+    sbc l1067                                                         ; 8591: ed 67 10    .g.
+    bcc c8560                                                         ; 8594: 90 ca       ..
+    jsr sub_c87da                                                     ; 8596: 20 da 87     ..
+    bcs c8573                                                         ; 8599: b0 d8       ..
+; &859b referenced 1 time by &8576
+.c859b
+    ldy l00ab                                                         ; 859b: a4 ab       ..
+    lda l0e08,y                                                       ; 859d: b9 08 0e    ...
+    ora #&80                                                          ; 85a0: 09 80       ..
+    sta l0e08,y                                                       ; 85a2: 99 08 0e    ...
+    lda l1067                                                         ; 85a5: ad 67 10    .g.
+    cmp l00aa                                                         ; 85a8: c5 aa       ..
+    beq c85bc                                                         ; 85aa: f0 10       ..
+    ldx l00aa                                                         ; 85ac: a6 aa       ..
+    sta l00aa                                                         ; 85ae: 85 aa       ..
+    bne c85bc                                                         ; 85b0: d0 0a       ..
+    jsr ca3dc                                                         ; 85b2: 20 dc a3     ..
+; &85b5 referenced 1 time by &85be
+.loop_c85b5
+    jsr ca3dc                                                         ; 85b5: 20 dc a3     ..
+    ldy #&ff                                                          ; 85b8: a0 ff       ..
+    bne c85c5                                                         ; 85ba: d0 09       ..
+; &85bc referenced 2 times by &85aa, &85b0
+.c85bc
+    ldy l00a8                                                         ; 85bc: a4 a8       ..
+    bne loop_c85b5                                                    ; 85be: d0 f5       ..
+    ldy #5                                                            ; 85c0: a0 05       ..
+    jsr c81a7                                                         ; 85c2: 20 a7 81     ..
+; &85c5 referenced 1 time by &85ba
+.c85c5
+    iny                                                               ; 85c5: c8          .
+    sty l00a8                                                         ; 85c6: 84 a8       ..
+    ldy l00ab                                                         ; 85c8: a4 ab       ..
+    jsr sub_cac0c                                                     ; 85ca: 20 0c ac     ..
+    jsr sub_c8174                                                     ; 85cd: 20 74 81     t.
+    jmp c8543                                                         ; 85d0: 4c 43 85    LC.
+
+; &85d3 referenced 1 time by &84e7
+.opt4_table
+    equs "off", 0                                                     ; 85d3: 6f 66 66... off
+    equs "LOAD"                                                       ; 85d7: 4c 4f 41... LOA
+    equs "RUN", 0                                                     ; 85db: 52 55 4e... RUN
+    equs "EXEC"                                                       ; 85df: 45 58 45... EXE
+
+; &85e3 referenced 1 time by &8acd
+.sub_c85e3
+    lda l0f0e,y                                                       ; 85e3: b9 0e 0f    ...
+    jsr sub_c81b0                                                     ; 85e6: 20 b0 81     ..
+    sta l00c2                                                         ; 85e9: 85 c2       ..
+    clc                                                               ; 85eb: 18          .
+    lda #&ff                                                          ; 85ec: a9 ff       ..
+    adc l0f0c,y                                                       ; 85ee: 79 0c 0f    y..
+    lda l0f0f,y                                                       ; 85f1: b9 0f 0f    ...
+    adc l0f0d,y                                                       ; 85f4: 79 0d 0f    y..
+    sta l00c3                                                         ; 85f7: 85 c3       ..
+    lda l0f0e,y                                                       ; 85f9: b9 0e 0f    ...
+    and #3                                                            ; 85fc: 29 03       ).
+    adc l00c2                                                         ; 85fe: 65 c2       e.
+    sta l00c2                                                         ; 8600: 85 c2       ..
+; &8602 referenced 1 time by &8ac2
+.sub_c8602
+    sec                                                               ; 8602: 38          8
+    lda l0f07,y                                                       ; 8603: b9 07 0f    ...
+    sbc l00c3                                                         ; 8606: e5 c3       ..
+    pha                                                               ; 8608: 48          H
+    lda l0f06,y                                                       ; 8609: b9 06 0f    ...
+    and #3                                                            ; 860c: 29 03       ).
+    sbc l00c2                                                         ; 860e: e5 c2       ..
+    tax                                                               ; 8610: aa          .
+    lda #0                                                            ; 8611: a9 00       ..
+    cmp l00c0                                                         ; 8613: c5 c0       ..
+    pla                                                               ; 8615: 68          h
+    sbc l00c1                                                         ; 8616: e5 c1       ..
+    txa                                                               ; 8618: 8a          .
+    sbc l00c4                                                         ; 8619: e5 c4       ..
+    rts                                                               ; 861b: 60          `
+
+; &861c referenced 6 times by &870e, &8719, &8726, &873c, &a16f, &a187
+.command_table
+    equs "ACCESS"                                                     ; 861c: 41 43 43... ACC
+; &861d referenced 1 time by &8740
+    equb >(sub_c89e6-1)                                               ; 8622: 89          .
+    equb <(sub_c89e6-1)                                               ; 8623: e5          .
+    equb &32                                                          ; 8624: 32          2
+    equs "BACKUP"                                                     ; 8625: 42 41 43... BAC
+    equb >(sub_ca417-1)                                               ; 862b: a4          .
+    equb <(sub_ca417-1)                                               ; 862c: 16          .
+    equb 4                                                            ; 862d: 04          .
+    equs "CLOSE"                                                      ; 862e: 43 4c 4f... CLO
+    equb >(sub_c9b59-1)                                               ; 8633: 9b          .
+    equb <(sub_c9b59-1)                                               ; 8634: 58          X
+    equb 0                                                            ; 8635: 00          .
+    equs "COMPACT"                                                    ; 8636: 43 4f 4d... COM
+    equb >(sub_ca244-1)                                               ; 863d: a2          .
+    equb <(sub_ca244-1)                                               ; 863e: 43          C
+    equb 7                                                            ; 863f: 07          .
+    equs "COPY"                                                       ; 8640: 43 4f 50... COP
+    equb >(sub_ca463-1)                                               ; 8644: a4          .
+    equb <(sub_ca463-1)                                               ; 8645: 62          b
+    equb &24                                                          ; 8646: 24          $
+    equs "DELETE"                                                     ; 8647: 44 45 4c... DEL
+    equb >(sub_c8782-1)                                               ; 864d: 87          .
+    equb <(sub_c8782-1)                                               ; 864e: 81          .
+    equb 1                                                            ; 864f: 01          .
+    equs "DESTROY"                                                    ; 8650: 44 45 53... DES
+    equb >(sub_c8794-1)                                               ; 8657: 87          .
+    equb <(sub_c8794-1)                                               ; 8658: 93          .
+    equb 2                                                            ; 8659: 02          .
+    equs "DIR"                                                        ; 865a: 44 49 52    DIR
+    equb >(sub_c893f-1)                                               ; 865d: 89          .
+    equb <(sub_c893f-1)                                               ; 865e: 3e          >
+    equb 6                                                            ; 865f: 06          .
+    equs "DRIVE"                                                      ; 8660: 44 52 49... DRI
+    equb >(sub_c87ee-1)                                               ; 8665: 87          .
+    equb <(sub_c87ee-1)                                               ; 8666: ed          .
+    equb 9                                                            ; 8667: 09          .
+    equs "ENABLE"                                                     ; 8668: 45 4e 41... ENA
+    equb >(sub_c8b47-1)                                               ; 866e: 8b          .
+    equb <(sub_c8b47-1)                                               ; 866f: 46          F
+    equb 0                                                            ; 8670: 00          .
+    equs "EX"                                                         ; 8671: 45 58       EX
+    equb >(sub_c8238-1)                                               ; 8673: 82          .
+    equb <(sub_c8238-1)                                               ; 8674: 37          7
+    equb 6                                                            ; 8675: 06          .
+    equs "FORM"                                                       ; 8676: 46 4f 52... FOR
+    equb >(sub_ca5bf-1)                                               ; 867a: a5          .
+    equb <(sub_ca5bf-1)                                               ; 867b: be          .
+    equb &ba                                                          ; 867c: ba          .
+    equs "FREE"                                                       ; 867d: 46 52 45... FRE
+    equb >(sub_ca7f3-1)                                               ; 8681: a7          .
+    equb <(sub_ca7f3-1)                                               ; 8682: f2          .
+    equb 7                                                            ; 8683: 07          .
+    equs "INFO"                                                       ; 8684: 49 4e 46... INF
+    equb >(sub_c8254-1)                                               ; 8688: 82          .
+    equb <(sub_c8254-1)                                               ; 8689: 53          S
+    equb 2                                                            ; 868a: 02          .
+    equs "LIB"                                                        ; 868b: 4c 49 42    LIB
+    equb >(sub_c8943-1)                                               ; 868e: 89          .
+    equb <(sub_c8943-1)                                               ; 868f: 42          B
+    equb 6                                                            ; 8690: 06          .
+    equs "MAP"                                                        ; 8691: 4d 41 50    MAP
+    equb >(sub_ca7f6-1)                                               ; 8694: a7          .
+    equb <(sub_ca7f6-1)                                               ; 8695: f5          .
+    equb 7                                                            ; 8696: 07          .
+    equs "RENAME"                                                     ; 8697: 52 45 4e... REN
+    equb >(sub_c8bac-1)                                               ; 869d: 8b          .
+    equb <(sub_c8bac-1)                                               ; 869e: ab          .
+    equb 5                                                            ; 869f: 05          .
+    equs "TITLE"                                                      ; 86a0: 54 49 54... TIT
+    equb >(sub_c89b7-1)                                               ; 86a5: 89          .
+    equb <(sub_c89b7-1)                                               ; 86a6: b6          .
+    equb 8                                                            ; 86a7: 08          .
+    equs "VERIFY"                                                     ; 86a8: 56 45 52... VER
+    equb >(sub_ca5bb-1)                                               ; 86ae: a5          .
+    equb <(sub_ca5bb-1)                                               ; 86af: ba          .
+    equb &0b                                                          ; 86b0: 0b          .
+    equs "WIPE"                                                       ; 86b1: 57 49 50... WIP
+    equb >(sub_c8750-1)                                               ; 86b5: 87          .
+    equb <(sub_c8750-1)                                               ; 86b6: 4f          O
+    equb   2, &88, &72                                                ; 86b7: 02 88 72    ..r
+    equs "BUILD"                                                      ; 86ba: 42 55 49... BUI
+    equb >(sub_cabc5-1)                                               ; 86bf: ab          .
+    equb <(sub_cabc5-1)                                               ; 86c0: c4          .
+    equb 1                                                            ; 86c1: 01          .
+    equs "DISC"                                                       ; 86c2: 44 49 53... DIS
+    equb >(c956d-1)                                                   ; 86c6: 95          .
+    equb <(c956d-1)                                                   ; 86c7: 6c          l
+    equb 0                                                            ; 86c8: 00          .
+    equs "DUMP"                                                       ; 86c9: 44 55 4d... DUM
+    equb >(sub_cab46-1)                                               ; 86cd: ab          .
+    equb <(sub_cab46-1)                                               ; 86ce: 45          E
+    equb 1                                                            ; 86cf: 01          .
+    equs "LIST"                                                       ; 86d0: 4c 49 53... LIS
+    equb >(sub_cab04-1)                                               ; 86d4: ab          .
+    equb <(sub_cab04-1)                                               ; 86d5: 03          .
+    equb 1                                                            ; 86d6: 01          .
+    equs "ROMS"                                                       ; 86d7: 52 4f 4d... ROM
+    equb >(sub_ca9d0-1)                                               ; 86db: a9          .
+    equb <(sub_ca9d0-1)                                               ; 86dc: cf          .
+    equb &0c                                                          ; 86dd: 0c          .
+    equs "TYPE"                                                       ; 86de: 54 59 50... TYP
+    equb >(sub_caafd-1)                                               ; 86e2: aa          .
+    equb <(sub_caafd-1)                                               ; 86e3: fc          .
+    equb 1                                                            ; 86e4: 01          .
+    equs "DISK"                                                       ; 86e5: 44 49 53... DIS
+    equb >(c956d-1)                                                   ; 86e9: 95          .
+    equb <(c956d-1)                                                   ; 86ea: 6c          l
+    equb   0, &86, &1a                                                ; 86eb: 00 86 1a    ...
+    equs "DFS"                                                        ; 86ee: 44 46 53    DFS
+    equb >(sub_ca106-1)                                               ; 86f1: a1          .
+    equb <(sub_ca106-1)                                               ; 86f2: 05          .
+    equb 0                                                            ; 86f3: 00          .
+    equs "UTILS"                                                      ; 86f4: 55 54 49... UTI
+    equb >(sub_ca137-1)                                               ; 86f9: a1          .
+    equb <(sub_ca137-1)                                               ; 86fa: 36          6
+    equb   0, &a1                                                     ; 86fb: 00 a1       ..
+    equs "= E"                                                        ; 86fd: 3d 20 45    = E
+    equb &87, &a2, &fd                                                ; 8700: 87 a2 fd    ...
+
+; &8703 referenced 2 times by &96f2, &a134
+.c8703
+    tya                                                               ; 8703: 98          .
+    pha                                                               ; 8704: 48          H
+; &8705 referenced 2 times by &872f, &8739
+.c8705
+    inx                                                               ; 8705: e8          .
+    inx                                                               ; 8706: e8          .
+    pla                                                               ; 8707: 68          h
+    pha                                                               ; 8708: 48          H
+    tay                                                               ; 8709: a8          .
+    jsr clc_jmp_gsinit                                                ; 870a: 20 4c 87     L.
+    inx                                                               ; 870d: e8          .
+    lda command_table,x                                               ; 870e: bd 1c 86    ...
+    bmi c873b                                                         ; 8711: 30 28       0(
+    dex                                                               ; 8713: ca          .
+    dey                                                               ; 8714: 88          .
+    stx l00bf                                                         ; 8715: 86 bf       ..
+; &8717 referenced 1 time by &8722
+.loop_c8717
+    inx                                                               ; 8717: e8          .
+    iny                                                               ; 8718: c8          .
+    lda command_table,x                                               ; 8719: bd 1c 86    ...
+    bmi c8734                                                         ; 871c: 30 16       0.
+    eor (os_text_ptr),y                                               ; 871e: 51 f2       Q.
+    and #&5f ; '_'                                                    ; 8720: 29 5f       )_
+    beq loop_c8717                                                    ; 8722: f0 f3       ..
+    dex                                                               ; 8724: ca          .
+; &8725 referenced 1 time by &8729
+.loop_c8725
+    inx                                                               ; 8725: e8          .
+    lda command_table,x                                               ; 8726: bd 1c 86    ...
+    bpl loop_c8725                                                    ; 8729: 10 fa       ..
+    lda (os_text_ptr),y                                               ; 872b: b1 f2       ..
+    cmp #&2e ; '.'                                                    ; 872d: c9 2e       ..
+    bne c8705                                                         ; 872f: d0 d4       ..
+    iny                                                               ; 8731: c8          .
+    bcs c873b                                                         ; 8732: b0 07       ..
+; &8734 referenced 1 time by &871c
+.c8734
+    lda (os_text_ptr),y                                               ; 8734: b1 f2       ..
+    jsr sub_c8327                                                     ; 8736: 20 27 83     '.
+    bcc c8705                                                         ; 8739: 90 ca       ..
+; &873b referenced 2 times by &8711, &8732
+.c873b
+    pla                                                               ; 873b: 68          h
+    lda command_table,x                                               ; 873c: bd 1c 86    ...
+    pha                                                               ; 873f: 48          H
+    lda command_table+1,x                                             ; 8740: bd 1d 86    ...
+    pha                                                               ; 8743: 48          H
+    rts                                                               ; 8744: 60          `
+
+; &8745 referenced 2 times by &8483, &8870
+.sub_c8745
+    stx os_text_ptr                                                   ; 8745: 86 f2       ..
+    sty l00f3                                                         ; 8747: 84 f3       ..
+    ldy #0                                                            ; 8749: a0 00       ..
+    rts                                                               ; 874b: 60          `
+
+; &874c referenced 12 times by &8100, &823b, &8456, &870a, &897e, &89f1, &8b86, &a13e, &a14a, &a5e5, &a657, &a9f7
+.clc_jmp_gsinit
+    clc                                                               ; 874c: 18          .
+    jmp gsinit                                                        ; 874d: 4c c2 ff    L..
+
+.sub_c8750
+    jsr sub_c99ac                                                     ; 8750: 20 ac 99     ..
+    jsr sub_ca14a                                                     ; 8753: 20 4a a1     J.
+    jsr sub_c821d                                                     ; 8756: 20 1d 82     ..
+; &8759 referenced 1 time by &877f
+.c8759
+    lda l0e0f,y                                                       ; 8759: b9 0f 0e    ...
+    bmi c877c                                                         ; 875c: 30 1e       0.
+    jsr sub_c8174                                                     ; 875e: 20 74 81     t.
+    jsr sub_ca3e4                                                     ; 8761: 20 e4 a3     ..
+    bne c8779                                                         ; 8764: d0 13       ..
+    ldx l00b6                                                         ; 8766: a6 b6       ..
+    jsr sub_c9bf2                                                     ; 8768: 20 f2 9b     ..
+    stx l00b6                                                         ; 876b: 86 b6       ..
+    jsr sub_c87e3                                                     ; 876d: 20 e3 87     ..
+    sty l00ab                                                         ; 8770: 84 ab       ..
+    jsr c93e6                                                         ; 8772: 20 e6 93     ..
+    lda l00ab                                                         ; 8775: a5 ab       ..
+    sta l00b6                                                         ; 8777: 85 b6       ..
+; &8779 referenced 1 time by &8764
+.c8779
+    jsr ca3dc                                                         ; 8779: 20 dc a3     ..
+; &877c referenced 1 time by &875c
+.c877c
+    jsr sub_c8280                                                     ; 877c: 20 80 82     ..
+    bcs c8759                                                         ; 877f: b0 d8       ..
+    rts                                                               ; 8781: 60          `
+
+.sub_c8782
+    jsr c99a3                                                         ; 8782: 20 a3 99     ..
+    jsr sub_ca14a                                                     ; 8785: 20 4a a1     J.
+    jsr sub_c821d                                                     ; 8788: 20 1d 82     ..
+    jsr sub_c8335                                                     ; 878b: 20 35 83     5.
+    jsr sub_c830a                                                     ; 878e: 20 0a 83     ..
+    jmp c93e6                                                         ; 8791: 4c e6 93    L..
+
+.sub_c8794
+    jsr sub_ca315                                                     ; 8794: 20 15 a3     ..
+    jsr sub_c99ac                                                     ; 8797: 20 ac 99     ..
+    jsr sub_ca14a                                                     ; 879a: 20 4a a1     J.
+    jsr sub_c821d                                                     ; 879d: 20 1d 82     ..
+; &87a0 referenced 1 time by &87ae
+.loop_c87a0
+    lda l0e0f,y                                                       ; 87a0: b9 0f 0e    ...
+    bmi c87ab                                                         ; 87a3: 30 06       0.
+    jsr sub_c8174                                                     ; 87a5: 20 74 81     t.
+    jsr ca3dc                                                         ; 87a8: 20 dc a3     ..
+; &87ab referenced 1 time by &87a3
+.c87ab
+    jsr sub_c8280                                                     ; 87ab: 20 80 82     ..
+    bcs loop_c87a0                                                    ; 87ae: b0 f0       ..
+    jsr sub_ca3ec                                                     ; 87b0: 20 ec a3     ..
+    beq c87b8                                                         ; 87b3: f0 03       ..
+    jmp ca3dc                                                         ; 87b5: 4c dc a3    L..
+
+; &87b8 referenced 1 time by &87b3
+.c87b8
+    jsr sub_c9bf2                                                     ; 87b8: 20 f2 9b     ..
+    jsr sub_c8284                                                     ; 87bb: 20 84 82     ..
+; &87be referenced 1 time by &87c9
+.loop_c87be
+    lda l0e0f,y                                                       ; 87be: b9 0f 0e    ...
+    bmi c87c6                                                         ; 87c1: 30 03       0.
+    jsr sub_c87e3                                                     ; 87c3: 20 e3 87     ..
+; &87c6 referenced 1 time by &87c1
+.c87c6
+    jsr sub_c8280                                                     ; 87c6: 20 80 82     ..
+    bcs loop_c87be                                                    ; 87c9: b0 f3       ..
+    jsr c93e6                                                         ; 87cb: 20 e6 93     ..
+    jsr print_inline_l809f_top_bit_clear                              ; 87ce: 20 77 80     w.
+    equs &0d, "Deleted", &0d                                          ; 87d1: 0d 44 65... .De
+
+; &87da referenced 6 times by &853e, &8552, &8596, &8b0c, &8be5, &98b5
+.sub_c87da
+    iny                                                               ; 87da: c8          .
+; &87db referenced 2 times by &837a, &8588
+.sub_c87db
+    iny                                                               ; 87db: c8          .
+    iny                                                               ; 87dc: c8          .
+    iny                                                               ; 87dd: c8          .
+    iny                                                               ; 87de: c8          .
+    iny                                                               ; 87df: c8          .
+    iny                                                               ; 87e0: c8          .
+    iny                                                               ; 87e1: c8          .
+    rts                                                               ; 87e2: 60          `
+
+; &87e3 referenced 2 times by &876d, &87c3
+.sub_c87e3
+    jsr sub_c830a                                                     ; 87e3: 20 0a 83     ..
+    ldy l00b6                                                         ; 87e6: a4 b6       ..
+    jsr sub_c82b2                                                     ; 87e8: 20 b2 82     ..
+    sty l00b6                                                         ; 87eb: 84 b6       ..
+    rts                                                               ; 87ed: 60          `
+
+.sub_c87ee
+    jsr sub_ca14a                                                     ; 87ee: 20 4a a1     J.
+    jsr c8b8b                                                         ; 87f1: 20 8b 8b     ..
+    sta l10ca                                                         ; 87f4: 8d ca 10    ...
+    jsr sub_c8456                                                     ; 87f7: 20 56 84     V.
+    beq c8815                                                         ; 87fa: f0 19       ..
+    cmp #&28 ; '('                                                    ; 87fc: c9 28       .(
+    beq c8808                                                         ; 87fe: f0 08       ..
+    cmp #&50 ; 'P'                                                    ; 8800: c9 50       .P
+    clc                                                               ; 8802: 18          .
+    beq c8808                                                         ; 8803: f0 03       ..
+    jmp ca14f                                                         ; 8805: 4c 4f a1    LO.
+
+; &8808 referenced 2 times by &87fe, &8803
+.c8808
+    php                                                               ; 8808: 08          .
+    ldx l10ca                                                         ; 8809: ae ca 10    ...
+    lda l10de,x                                                       ; 880c: bd de 10    ...
+    rol a                                                             ; 880f: 2a          *
+    plp                                                               ; 8810: 28          (
+    ror a                                                             ; 8811: 6a          j
+    sta l10de,x                                                       ; 8812: 9d de 10    ...
+; &8815 referenced 1 time by &87fa
+.c8815
+    rts                                                               ; 8815: 60          `
+
+; &8816 referenced 8 times by &888f, &8985, &898d, &8b83, &8b9d, &9bef, &a475, &a4ce
+.c8816
+    and #3                                                            ; 8816: 29 03       ).
+    sta l00cd                                                         ; 8818: 85 cd       ..
+    rts                                                               ; 881a: 60          `
+
+    jsr sub_c8222                                                     ; 881b: 20 22 82     ".
+    jsr sub_c9a82                                                     ; 881e: 20 82 9a     ..
+    jsr sub_c8386                                                     ; 8821: 20 86 83     ..
+    lda #&80                                                          ; 8824: a9 80       ..
+; &8826 referenced 1 time by &88f6
+.sub_c8826
+    sta l1096                                                         ; 8826: 8d 96 10    ...
+    sty l00ba                                                         ; 8829: 84 ba       ..
+    ldx #0                                                            ; 882b: a2 00       ..
+    lda l00be                                                         ; 882d: a5 be       ..
+    bne c8837                                                         ; 882f: d0 06       ..
+    iny                                                               ; 8831: c8          .
+    iny                                                               ; 8832: c8          .
+    ldx #2                                                            ; 8833: a2 02       ..
+    bne c883f                                                         ; 8835: d0 08       ..
+; &8837 referenced 1 time by &882f
+.c8837
+    lda l0f0e,y                                                       ; 8837: b9 0e 0f    ...
+    sta l00c2                                                         ; 883a: 85 c2       ..
+    jsr sub_c8b4d                                                     ; 883c: 20 4d 8b     M.
+; &883f referenced 2 times by &8835, &8848
+.c883f
+    lda l0f08,y                                                       ; 883f: b9 08 0f    ...
+    sta l00bc,x                                                       ; 8842: 95 bc       ..
+    iny                                                               ; 8844: c8          .
+    inx                                                               ; 8845: e8          .
+    cpx #8                                                            ; 8846: e0 08       ..
+    bne c883f                                                         ; 8848: d0 f5       ..
+    jsr sub_c8b64                                                     ; 884a: 20 64 8b     d.
+    ldy l00ba                                                         ; 884d: a4 ba       ..
+    jsr sub_c8335                                                     ; 884f: 20 35 83     5.
+    jmp c8867                                                         ; 8852: 4c 67 88    Lg.
+
+; &8855 referenced 2 times by &9f61, &a561
+.sub_c8855
+    lda #&80                                                          ; 8855: a9 80       ..
+    bne c8864                                                         ; 8857: d0 0b       ..
+    jsr sub_c8a77                                                     ; 8859: 20 77 8a     w.
+    jsr sub_c9a82                                                     ; 885c: 20 82 9a     ..
+    jsr sub_c8386                                                     ; 885f: 20 86 83     ..
+; &8862 referenced 2 times by &9f51, &a587
+.sub_c8862
+    lda #&a0                                                          ; 8862: a9 a0       ..
+; &8864 referenced 1 time by &8857
+.c8864
+    sta l1096                                                         ; 8864: 8d 96 10    ...
+; &8867 referenced 1 time by &8852
+.c8867
+    jsr sub_c81ca                                                     ; 8867: 20 ca 81     ..
+    jsr sub_c9445                                                     ; 886a: 20 45 94     E.
+    lda #1                                                            ; 886d: a9 01       ..
+    rts                                                               ; 886f: 60          `
+
+    jsr sub_c8745                                                     ; 8870: 20 45 87     E.
+    jsr sub_c8932                                                     ; 8873: 20 32 89     2.
+    sty l10da                                                         ; 8876: 8c da 10    ...
+    jsr sub_c80f3                                                     ; 8879: 20 f3 80     ..
+    sty l10d9                                                         ; 887c: 8c d9 10    ...
+    jsr sub_c8266                                                     ; 887f: 20 66 82     f.
+    bcs c88a6                                                         ; 8882: b0 22       ."
+    ldy l10da                                                         ; 8884: ac da 10    ...
+    lda l10cb                                                         ; 8887: ad cb 10    ...
+    sta l00cc                                                         ; 888a: 85 cc       ..
+    lda l10cc                                                         ; 888c: ad cc 10    ...
+    jsr c8816                                                         ; 888f: 20 16 88     ..
+    jsr sub_c80f6                                                     ; 8892: 20 f6 80     ..
+    jsr sub_c8266                                                     ; 8895: 20 66 82     f.
+    bcs c88a6                                                         ; 8898: b0 0c       ..
+    jsr generate_error_precheck_bad                                   ; 889a: 20 2e 80     ..
+    equb &fe                                                          ; 889d: fe          .
+    equs "command"                                                    ; 889e: 63 6f 6d... com
+    equb 0                                                            ; 88a5: 00          .
+
+; &88a6 referenced 2 times by &8882, &8898
+.c88a6
+    lda l0f0e,y                                                       ; 88a6: b9 0e 0f    ...
+    jsr sub_c81ae                                                     ; 88a9: 20 ae 81     ..
+    cmp #3                                                            ; 88ac: c9 03       ..
+    bne c88f4                                                         ; 88ae: d0 44       .D
+    lda l0f0a,y                                                       ; 88b0: b9 0a 0f    ...
+    and l0f0b,y                                                       ; 88b3: 39 0b 0f    9..
+    cmp #&ff                                                          ; 88b6: c9 ff       ..
+    bne c88f4                                                         ; 88b8: d0 3a       .:
+    ldx #6                                                            ; 88ba: a2 06       ..
+; &88bc referenced 1 time by &88c3
+.loop_c88bc
+    lda l1000,x                                                       ; 88bc: bd 00 10    ...
+    sta l1007,x                                                       ; 88bf: 9d 07 10    ...
+    dex                                                               ; 88c2: ca          .
+    bpl loop_c88bc                                                    ; 88c3: 10 f7       ..
+    lda #&0d                                                          ; 88c5: a9 0d       ..
+    sta l100e                                                         ; 88c7: 8d 0e 10    ...
+    lda #&45 ; 'E'                                                    ; 88ca: a9 45       .E
+    sta l1000                                                         ; 88cc: 8d 00 10    ...
+    lda #&2e ; '.'                                                    ; 88cf: a9 2e       ..
+    sta l1001                                                         ; 88d1: 8d 01 10    ...
+    lda #&3a ; ':'                                                    ; 88d4: a9 3a       .:
+    sta l1002                                                         ; 88d6: 8d 02 10    ...
+    lda l00cd                                                         ; 88d9: a5 cd       ..
+    ora #&30 ; '0'                                                    ; 88db: 09 30       .0
+    sta l1003                                                         ; 88dd: 8d 03 10    ...
+    lda #&2e ; '.'                                                    ; 88e0: a9 2e       ..
+    sta l1004                                                         ; 88e2: 8d 04 10    ...
+    sta l1006                                                         ; 88e5: 8d 06 10    ...
+    lda l00cc                                                         ; 88e8: a5 cc       ..
+    sta l1005                                                         ; 88ea: 8d 05 10    ...
+    ldx #<(l1000)                                                     ; 88ed: a2 00       ..
+    ldy #>(l1000)                                                     ; 88ef: a0 10       ..
+    jmp oscli                                                         ; 88f1: 4c f7 ff    L..
+
+; &88f4 referenced 2 times by &88ae, &88b8
+.c88f4
+    lda #&81                                                          ; 88f4: a9 81       ..
+    jsr sub_c8826                                                     ; 88f6: 20 26 88     &.
+    clc                                                               ; 88f9: 18          .
+    lda l10d9                                                         ; 88fa: ad d9 10    ...
+    tay                                                               ; 88fd: a8          .
+    adc os_text_ptr                                                   ; 88fe: 65 f2       e.
+    sta l10d9                                                         ; 8900: 8d d9 10    ...
+    lda l00f3                                                         ; 8903: a5 f3       ..
+    adc #0                                                            ; 8905: 69 00       i.
+    sta l10da                                                         ; 8907: 8d da 10    ...
+    lda l1076                                                         ; 890a: ad 76 10    .v.
+    and l1077                                                         ; 890d: 2d 77 10    -w.
+    ora l10d6                                                         ; 8910: 0d d6 10    ...
+    cmp #&ff                                                          ; 8913: c9 ff       ..
+    beq c892d                                                         ; 8915: f0 16       ..
+    lda l00be                                                         ; 8917: a5 be       ..
+    sta l1074                                                         ; 8919: 8d 74 10    .t.
+    lda l00bf                                                         ; 891c: a5 bf       ..
+    sta l1075                                                         ; 891e: 8d 75 10    .u.
+    jsr sub_c8f6b                                                     ; 8921: 20 6b 8f     k.
+    ldx #&74 ; 't'                                                    ; 8924: a2 74       .t
+    ldy #&10                                                          ; 8926: a0 10       ..
+    lda #4                                                            ; 8928: a9 04       ..
+    jmp tube_entry                                                    ; 892a: 4c 06 04    L..
+
+; &892d referenced 1 time by &8915
+.c892d
+    lda #1                                                            ; 892d: a9 01       ..
+    jmp (l00be)                                                       ; 892f: 6c be 00    l..
+
+; &8932 referenced 1 time by &8873
+.sub_c8932
+    lda #&ff                                                          ; 8932: a9 ff       ..
+    sta l00be                                                         ; 8934: 85 be       ..
+    lda os_text_ptr                                                   ; 8936: a5 f2       ..
+    sta l00ba                                                         ; 8938: 85 ba       ..
+    lda l00f3                                                         ; 893a: a5 f3       ..
+    sta l00bb                                                         ; 893c: 85 bb       ..
+    rts                                                               ; 893e: 60          `
+
+.sub_c893f
+    ldx #0                                                            ; 893f: a2 00       ..
+    beq c8945                                                         ; 8941: f0 02       ..
+.sub_c8943
+    ldx #2                                                            ; 8943: a2 02       ..
+; &8945 referenced 1 time by &8941
+.c8945
+    jsr sub_c8979                                                     ; 8945: 20 79 89     y.
+    sta l10ca,x                                                       ; 8948: 9d ca 10    ...
+    lda l00cc                                                         ; 894b: a5 cc       ..
+    sta l10c9,x                                                       ; 894d: 9d c9 10    ...
+    rts                                                               ; 8950: 60          `
+
+; &8951 referenced 2 times by &96b4, &9729
+.sub_c8951
+    jsr sub_c83e3                                                     ; 8951: 20 e3 83     ..
+    lda l00b0                                                         ; 8954: a5 b0       ..
+    pha                                                               ; 8956: 48          H
+    lda l00b1                                                         ; 8957: a5 b1       ..
+    pha                                                               ; 8959: 48          H
+    jsr sub_c9ab8                                                     ; 895a: 20 b8 9a     ..
+    ldy #0                                                            ; 895d: a0 00       ..
+; &895f referenced 1 time by &8970
+.loop_c895f
+    cpy #&c0                                                          ; 895f: c0 c0       ..
+    bcc c8968                                                         ; 8961: 90 05       ..
+    lda l1000,y                                                       ; 8963: b9 00 10    ...
+    bcs c896b                                                         ; 8966: b0 03       ..
+; &8968 referenced 1 time by &8961
+.c8968
+    lda l1100,y                                                       ; 8968: b9 00 11    ...
+; &896b referenced 1 time by &8966
+.c896b
+    sta (l00b0),y                                                     ; 896b: 91 b0       ..
+    iny                                                               ; 896d: c8          .
+    cpy #&ee                                                          ; 896e: c0 ee       ..
+    bne loop_c895f                                                    ; 8970: d0 ed       ..
+    pla                                                               ; 8972: 68          h
+    sta l00b1                                                         ; 8973: 85 b1       ..
+    pla                                                               ; 8975: 68          h
+    sta l00b0                                                         ; 8976: 85 b0       ..
+    rts                                                               ; 8978: 60          `
+
+; &8979 referenced 1 time by &8945
+.sub_c8979
+    lda l10c9                                                         ; 8979: ad c9 10    ...
+    sta l00cc                                                         ; 897c: 85 cc       ..
+    jsr clc_jmp_gsinit                                                ; 897e: 20 4c 87     L.
+    bne c898a                                                         ; 8981: d0 07       ..
+    lda #0                                                            ; 8983: a9 00       ..
+    jsr c8816                                                         ; 8985: 20 16 88     ..
+    beq c89b4                                                         ; 8988: f0 2a       .*
+; &898a referenced 2 times by &8240, &8981
+.c898a
+    lda l10ca                                                         ; 898a: ad ca 10    ...
+    jsr c8816                                                         ; 898d: 20 16 88     ..
+; &8990 referenced 1 time by &89a3
+.loop_c8990
+    jsr sub_c8149                                                     ; 8990: 20 49 81     I.
+    bcs c89a5                                                         ; 8993: b0 10       ..
+    cmp #&3a ; ':'                                                    ; 8995: c9 3a       .:
+    bne c89ad                                                         ; 8997: d0 14       ..
+    jsr c8b8b                                                         ; 8999: 20 8b 8b     ..
+    jsr sub_c8149                                                     ; 899c: 20 49 81     I.
+    bcs c89b4                                                         ; 899f: b0 13       ..
+    cmp #&2e ; '.'                                                    ; 89a1: c9 2e       ..
+    beq loop_c8990                                                    ; 89a3: f0 eb       ..
+; &89a5 referenced 2 times by &8993, &89b2
+.c89a5
+    jsr generate_error_precheck_bad                                   ; 89a5: 20 2e 80     ..
+    equb &ce                                                          ; 89a8: ce          .
+    equs "dir"                                                        ; 89a9: 64 69 72    dir
+    equb 0                                                            ; 89ac: 00          .
+
+; &89ad referenced 1 time by &8997
+.c89ad
+    sta l00cc                                                         ; 89ad: 85 cc       ..
+    jsr sub_c8149                                                     ; 89af: 20 49 81     I.
+    bcc c89a5                                                         ; 89b2: 90 f1       ..
+; &89b4 referenced 2 times by &8988, &899f
+.c89b4
+    lda l00cd                                                         ; 89b4: a5 cd       ..
+    rts                                                               ; 89b6: 60          `
+
+.sub_c89b7
+    jsr sub_ca14a                                                     ; 89b7: 20 4a a1     J.
+    jsr sub_c8b7b                                                     ; 89ba: 20 7b 8b     {.
+    jsr sub_c8380                                                     ; 89bd: 20 80 83     ..
+    ldx #&0b                                                          ; 89c0: a2 0b       ..
+    lda #0                                                            ; 89c2: a9 00       ..
+; &89c4 referenced 1 time by &89c8
+.loop_c89c4
+    jsr sub_c89da                                                     ; 89c4: 20 da 89     ..
+    dex                                                               ; 89c7: ca          .
+    bpl loop_c89c4                                                    ; 89c8: 10 fa       ..
+; &89ca referenced 1 time by &89d5
+.loop_c89ca
+    inx                                                               ; 89ca: e8          .
+    jsr sub_c8149                                                     ; 89cb: 20 49 81     I.
+    bcs c89d7                                                         ; 89ce: b0 07       ..
+    jsr sub_c89da                                                     ; 89d0: 20 da 89     ..
+    cpx #&0b                                                          ; 89d3: e0 0b       ..
+    bcc loop_c89ca                                                    ; 89d5: 90 f3       ..
+; &89d7 referenced 3 times by &89ce, &8a15, &99ed
+.c89d7
+    jmp c93e6                                                         ; 89d7: 4c e6 93    L..
+
+; &89da referenced 2 times by &89c4, &89d0
+.sub_c89da
+    cpx #8                                                            ; 89da: e0 08       ..
+    bcc c89e2                                                         ; 89dc: 90 04       ..
+    sta l0ef8,x                                                       ; 89de: 9d f8 0e    ...
+    rts                                                               ; 89e1: 60          `
+
+; &89e2 referenced 1 time by &89dc
+.c89e2
+    sta l0e00,x                                                       ; 89e2: 9d 00 0e    ...
+    rts                                                               ; 89e5: 60          `
+
+.sub_c89e6
+    jsr sub_c99ac                                                     ; 89e6: 20 ac 99     ..
+    jsr sub_ca14a                                                     ; 89e9: 20 4a a1     J.
+    jsr sub_c80ed                                                     ; 89ec: 20 ed 80     ..
+    ldx #0                                                            ; 89ef: a2 00       ..
+    jsr clc_jmp_gsinit                                                ; 89f1: 20 4c 87     L.
+    bne c8a19                                                         ; 89f4: d0 23       .#
+; &89f6 referenced 1 time by &8a1c
+.c89f6
+    stx l00aa                                                         ; 89f6: 86 aa       ..
+    jsr sub_c8284                                                     ; 89f8: 20 84 82     ..
+    bcs c8a00                                                         ; 89fb: b0 03       ..
+    jmp c822a                                                         ; 89fd: 4c 2a 82    L*.
+
+; &8a00 referenced 2 times by &89fb, &8a13
+.c8a00
+    jsr sub_c9a63                                                     ; 8a00: 20 63 9a     c.
+    lda l0e0f,y                                                       ; 8a03: b9 0f 0e    ...
+    and #&7f                                                          ; 8a06: 29 7f       ).
+    ora l00aa                                                         ; 8a08: 05 aa       ..
+    sta l0e0f,y                                                       ; 8a0a: 99 0f 0e    ...
+    jsr sub_c8335                                                     ; 8a0d: 20 35 83     5.
+    jsr sub_c8280                                                     ; 8a10: 20 80 82     ..
+    bcs c8a00                                                         ; 8a13: b0 eb       ..
+    bcc c89d7                                                         ; 8a15: 90 c0       ..
+; &8a17 referenced 1 time by &8a22
+.loop_c8a17
+    ldx #&80                                                          ; 8a17: a2 80       ..
+; &8a19 referenced 1 time by &89f4
+.c8a19
+    jsr sub_c8149                                                     ; 8a19: 20 49 81     I.
+    bcs c89f6                                                         ; 8a1c: b0 d8       ..
+    and #&5f ; '_'                                                    ; 8a1e: 29 5f       )_
+    cmp #&4c ; 'L'                                                    ; 8a20: c9 4c       .L
+    beq loop_c8a17                                                    ; 8a22: f0 f3       ..
+    jsr generate_error_precheck_bad                                   ; 8a24: 20 2e 80     ..
+    equb &cf                                                          ; 8a27: cf          .
+    equs "attribute"                                                  ; 8a28: 61 74 74... att
+    equb 0                                                            ; 8a31: 00          .
+
+    jsr sub_c83e3                                                     ; 8a32: 20 e3 83     ..
+    txa                                                               ; 8a35: 8a          .
+    cmp #4                                                            ; 8a36: c9 04       ..
+    beq c8a54                                                         ; 8a38: f0 1a       ..
+    cmp #2                                                            ; 8a3a: c9 02       ..
+    bcc c8a49                                                         ; 8a3c: 90 0b       ..
+    jsr generate_error_precheck_bad                                   ; 8a3e: 20 2e 80     ..
+    equb &cb                                                          ; 8a41: cb          .
+    equs "option"                                                     ; 8a42: 6f 70 74... opt
+    equb 0                                                            ; 8a48: 00          .
+
+; &8a49 referenced 1 time by &8a3c
+.c8a49
+    ldx #&ff                                                          ; 8a49: a2 ff       ..
+    tya                                                               ; 8a4b: 98          .
+    beq c8a50                                                         ; 8a4c: f0 02       ..
+    ldx #0                                                            ; 8a4e: a2 00       ..
+; &8a50 referenced 1 time by &8a4c
+.c8a50
+    stx l10c6                                                         ; 8a50: 8e c6 10    ...
+    rts                                                               ; 8a53: 60          `
+
+; &8a54 referenced 1 time by &8a38
+.c8a54
+    tya                                                               ; 8a54: 98          .
+    pha                                                               ; 8a55: 48          H
+    jsr sub_c8b7b                                                     ; 8a56: 20 7b 8b     {.
+    jsr c940c                                                         ; 8a59: 20 0c 94     ..
+    pla                                                               ; 8a5c: 68          h
+    jsr sub_c81c5                                                     ; 8a5d: 20 c5 81     ..
+    eor l0f06                                                         ; 8a60: 4d 06 0f    M..
+    and #&30 ; '0'                                                    ; 8a63: 29 30       )0
+    eor l0f06                                                         ; 8a65: 4d 06 0f    M..
+    sta l0f06                                                         ; 8a68: 8d 06 0f    ...
+    jmp c93e6                                                         ; 8a6b: 4c e6 93    L..
+
+; &8a6e referenced 2 times by &8ac8, &a414
+.c8a6e
+    jsr generate_error_precheck_disc                                  ; 8a6e: 20 23 80     #.
+    equb &c6                                                          ; 8a71: c6          .
+    equs "full"                                                       ; 8a72: 66 75 6c... ful
+    equb 0                                                            ; 8a76: 00          .
+
+; &8a77 referenced 2 times by &8859, &9c4e
+.sub_c8a77
+    jsr sub_c80f3                                                     ; 8a77: 20 f3 80     ..
+    jsr sub_c8284                                                     ; 8a7a: 20 84 82     ..
+    bcc c8a82                                                         ; 8a7d: 90 03       ..
+    jsr sub_c830a                                                     ; 8a7f: 20 0a 83     ..
+; &8a82 referenced 1 time by &8a7d
+.c8a82
+    lda l00c0                                                         ; 8a82: a5 c0       ..
+    pha                                                               ; 8a84: 48          H
+    lda l00c1                                                         ; 8a85: a5 c1       ..
+    pha                                                               ; 8a87: 48          H
+    sec                                                               ; 8a88: 38          8
+    lda l00c2                                                         ; 8a89: a5 c2       ..
+    sbc l00c0                                                         ; 8a8b: e5 c0       ..
+    sta l00c0                                                         ; 8a8d: 85 c0       ..
+    lda l00c3                                                         ; 8a8f: a5 c3       ..
+    sbc l00c1                                                         ; 8a91: e5 c1       ..
+    sta l00c1                                                         ; 8a93: 85 c1       ..
+    lda l107a                                                         ; 8a95: ad 7a 10    .z.
+    sbc l1078                                                         ; 8a98: ed 78 10    .x.
+    sta l00c4                                                         ; 8a9b: 85 c4       ..
+    jsr sub_c8ab3                                                     ; 8a9d: 20 b3 8a     ..
+    lda l1079                                                         ; 8aa0: ad 79 10    .y.
+    sta l1075                                                         ; 8aa3: 8d 75 10    .u.
+    lda l1078                                                         ; 8aa6: ad 78 10    .x.
+    sta l1074                                                         ; 8aa9: 8d 74 10    .t.
+    pla                                                               ; 8aac: 68          h
+    sta l00bd                                                         ; 8aad: 85 bd       ..
+    pla                                                               ; 8aaf: 68          h
+    sta l00bc                                                         ; 8ab0: 85 bc       ..
+    rts                                                               ; 8ab2: 60          `
+
+; &8ab3 referenced 2 times by &8a9d, &a50a
+.sub_c8ab3
+    lda #0                                                            ; 8ab3: a9 00       ..
+    sta l00c2                                                         ; 8ab5: 85 c2       ..
+    lda #2                                                            ; 8ab7: a9 02       ..
+    sta l00c3                                                         ; 8ab9: 85 c3       ..
+    ldy l0f05                                                         ; 8abb: ac 05 0f    ...
+    cpy #&f8                                                          ; 8abe: c0 f8       ..
+    bcs c8b18                                                         ; 8ac0: b0 56       .V
+    jsr sub_c8602                                                     ; 8ac2: 20 02 86     ..
+    jmp c8ad0                                                         ; 8ac5: 4c d0 8a    L..
+
+; &8ac8 referenced 1 time by &8ad1
+.loop_c8ac8
+    beq c8a6e                                                         ; 8ac8: f0 a4       ..
+    jsr sub_c82b2                                                     ; 8aca: 20 b2 82     ..
+    jsr sub_c85e3                                                     ; 8acd: 20 e3 85     ..
+; &8ad0 referenced 1 time by &8ac5
+.c8ad0
+    tya                                                               ; 8ad0: 98          .
+    bcc loop_c8ac8                                                    ; 8ad1: 90 f5       ..
+    sty l00b0                                                         ; 8ad3: 84 b0       ..
+    ldy l0f05                                                         ; 8ad5: ac 05 0f    ...
+; &8ad8 referenced 1 time by &8ae9
+.loop_c8ad8
+    cpy l00b0                                                         ; 8ad8: c4 b0       ..
+    beq c8aeb                                                         ; 8ada: f0 0f       ..
+    lda l0e07,y                                                       ; 8adc: b9 07 0e    ...
+    sta l0e0f,y                                                       ; 8adf: 99 0f 0e    ...
+    lda l0f07,y                                                       ; 8ae2: b9 07 0f    ...
+    sta l0f0f,y                                                       ; 8ae5: 99 0f 0f    ...
+    dey                                                               ; 8ae8: 88          .
+    bcs loop_c8ad8                                                    ; 8ae9: b0 ed       ..
+; &8aeb referenced 1 time by &8ada
+.c8aeb
+    ldx #0                                                            ; 8aeb: a2 00       ..
+    jsr sub_c8b25                                                     ; 8aed: 20 25 8b     %.
+; &8af0 referenced 1 time by &8af9
+.loop_c8af0
+    lda l00c5,x                                                       ; 8af0: b5 c5       ..
+    sta l0e08,y                                                       ; 8af2: 99 08 0e    ...
+    iny                                                               ; 8af5: c8          .
+    inx                                                               ; 8af6: e8          .
+    cpx #8                                                            ; 8af7: e0 08       ..
+    bne loop_c8af0                                                    ; 8af9: d0 f5       ..
+; &8afb referenced 1 time by &8b02
+.loop_c8afb
+    lda l00bb,x                                                       ; 8afb: b5 bb       ..
+    dey                                                               ; 8afd: 88          .
+    sta l0f08,y                                                       ; 8afe: 99 08 0f    ...
+    dex                                                               ; 8b01: ca          .
+    bne loop_c8afb                                                    ; 8b02: d0 f7       ..
+    jsr sub_c8335                                                     ; 8b04: 20 35 83     5.
+    tya                                                               ; 8b07: 98          .
+    pha                                                               ; 8b08: 48          H
+    ldy l0f05                                                         ; 8b09: ac 05 0f    ...
+    jsr sub_c87da                                                     ; 8b0c: 20 da 87     ..
+    sty l0f05                                                         ; 8b0f: 8c 05 0f    ...
+    jsr c93e6                                                         ; 8b12: 20 e6 93     ..
+    pla                                                               ; 8b15: 68          h
+    tay                                                               ; 8b16: a8          .
+    rts                                                               ; 8b17: 60          `
+
+; &8b18 referenced 1 time by &8ac0
+.c8b18
+    jsr generate_error_precheck                                       ; 8b18: 20 38 80     8.
+    equb &be                                                          ; 8b1b: be          .
+    equs "Cat full"                                                   ; 8b1c: 43 61 74... Cat
+    equb 0                                                            ; 8b24: 00          .
+
+; &8b25 referenced 1 time by &8aed
+.sub_c8b25
+    lda l1076                                                         ; 8b25: ad 76 10    .v.
+    and #3                                                            ; 8b28: 29 03       ).
+    asl a                                                             ; 8b2a: 0a          .
+    asl a                                                             ; 8b2b: 0a          .
+    eor l00c4                                                         ; 8b2c: 45 c4       E.
+    and #&fc                                                          ; 8b2e: 29 fc       ).
+    eor l00c4                                                         ; 8b30: 45 c4       E.
+    asl a                                                             ; 8b32: 0a          .
+    asl a                                                             ; 8b33: 0a          .
+    eor l1074                                                         ; 8b34: 4d 74 10    Mt.
+    and #&fc                                                          ; 8b37: 29 fc       ).
+    eor l1074                                                         ; 8b39: 4d 74 10    Mt.
+    asl a                                                             ; 8b3c: 0a          .
+    asl a                                                             ; 8b3d: 0a          .
+    eor l00c2                                                         ; 8b3e: 45 c2       E.
+    and #&fc                                                          ; 8b40: 29 fc       ).
+    eor l00c2                                                         ; 8b42: 45 c2       E.
+    sta l00c2                                                         ; 8b44: 85 c2       ..
+    rts                                                               ; 8b46: 60          `
+
+.sub_c8b47
+    lda #1                                                            ; 8b47: a9 01       ..
+    sta l10c7                                                         ; 8b49: 8d c7 10    ...
+    rts                                                               ; 8b4c: 60          `
+
+; &8b4d referenced 2 times by &883c, &a4fd
+.sub_c8b4d
+    lda #0                                                            ; 8b4d: a9 00       ..
+    sta l1075                                                         ; 8b4f: 8d 75 10    .u.
+    lda l00c2                                                         ; 8b52: a5 c2       ..
+    jsr sub_c81b7                                                     ; 8b54: 20 b7 81     ..
+    cmp #3                                                            ; 8b57: c9 03       ..
+    bne c8b60                                                         ; 8b59: d0 05       ..
+    lda #&ff                                                          ; 8b5b: a9 ff       ..
+    sta l1075                                                         ; 8b5d: 8d 75 10    .u.
+; &8b60 referenced 1 time by &8b59
+.c8b60
+    sta l1074                                                         ; 8b60: 8d 74 10    .t.
+    rts                                                               ; 8b63: 60          `
+
+; &8b64 referenced 2 times by &884a, &a500
+.sub_c8b64
+    lda #0                                                            ; 8b64: a9 00       ..
+    sta l1077                                                         ; 8b66: 8d 77 10    .w.
+    lda l00c2                                                         ; 8b69: a5 c2       ..
+    jsr sub_c81ae                                                     ; 8b6b: 20 ae 81     ..
+    cmp #3                                                            ; 8b6e: c9 03       ..
+    bne c8b77                                                         ; 8b70: d0 05       ..
+    lda #&ff                                                          ; 8b72: a9 ff       ..
+    sta l1077                                                         ; 8b74: 8d 77 10    .w.
+; &8b77 referenced 1 time by &8b70
+.c8b77
+    sta l1076                                                         ; 8b77: 8d 76 10    .v.
+    rts                                                               ; 8b7a: 60          `
+
+; &8b7b referenced 8 times by &80ed, &80f3, &8238, &89ba, &8a56, &975b, &988b, &98d7
+.sub_c8b7b
+    lda l10c9                                                         ; 8b7b: ad c9 10    ...
+    sta l00cc                                                         ; 8b7e: 85 cc       ..
+; &8b80 referenced 1 time by &8b89
+.loop_c8b80
+    lda l10ca                                                         ; 8b80: ad ca 10    ...
+    jmp c8816                                                         ; 8b83: 4c 16 88    L..
+
+; &8b86 referenced 3 times by &8486, &a244, &a7f9
+.sub_c8b86
+    jsr clc_jmp_gsinit                                                ; 8b86: 20 4c 87     L.
+    beq loop_c8b80                                                    ; 8b89: f0 f5       ..
+; &8b8b referenced 7 times by &8119, &87f1, &8999, &8b92, &a327, &a330, &a637
+.c8b8b
+    jsr sub_c8149                                                     ; 8b8b: 20 49 81     I.
+    bcs c8ba2                                                         ; 8b8e: b0 12       ..
+    cmp #&3a ; ':'                                                    ; 8b90: c9 3a       .:
+    beq c8b8b                                                         ; 8b92: f0 f7       ..
+    sec                                                               ; 8b94: 38          8
+    sbc #&30 ; '0'                                                    ; 8b95: e9 30       .0
+    bcc c8ba2                                                         ; 8b97: 90 09       ..
+    cmp #4                                                            ; 8b99: c9 04       ..
+    bcs c8ba2                                                         ; 8b9b: b0 05       ..
+    jsr c8816                                                         ; 8b9d: 20 16 88     ..
+    clc                                                               ; 8ba0: 18          .
+    rts                                                               ; 8ba1: 60          `
+
+; &8ba2 referenced 5 times by &8b8e, &8b97, &8b9b, &8bcd, &a660
+.c8ba2
+    jsr generate_error_precheck_bad                                   ; 8ba2: 20 2e 80     ..
+    equb &cd                                                          ; 8ba5: cd          .
+    equs "drive"                                                      ; 8ba6: 64 72 69... dri
+    equb 0                                                            ; 8bab: 00          .
+
+.sub_c8bac
+    jsr c99a3                                                         ; 8bac: 20 a3 99     ..
+    jsr sub_ca14a                                                     ; 8baf: 20 4a a1     J.
+    jsr sub_c80ed                                                     ; 8bb2: 20 ed 80     ..
+    tya                                                               ; 8bb5: 98          .
+    pha                                                               ; 8bb6: 48          H
+    jsr c8225                                                         ; 8bb7: 20 25 82     %.
+    jsr sub_c9a60                                                     ; 8bba: 20 60 9a     `.
+    sty l00c4                                                         ; 8bbd: 84 c4       ..
+    pla                                                               ; 8bbf: 68          h
+    tay                                                               ; 8bc0: a8          .
+    jsr sub_ca14a                                                     ; 8bc1: 20 4a a1     J.
+    lda l00cd                                                         ; 8bc4: a5 cd       ..
+    pha                                                               ; 8bc6: 48          H
+    jsr sub_c80ed                                                     ; 8bc7: 20 ed 80     ..
+    pla                                                               ; 8bca: 68          h
+    cmp l00cd                                                         ; 8bcb: c5 cd       ..
+    bne c8ba2                                                         ; 8bcd: d0 d3       ..
+    jsr sub_c8284                                                     ; 8bcf: 20 84 82     ..
+    bcc c8be3                                                         ; 8bd2: 90 0f       ..
+    cpy l00c4                                                         ; 8bd4: c4 c4       ..
+    beq c8be3                                                         ; 8bd6: f0 0b       ..
+    jsr generate_error_precheck                                       ; 8bd8: 20 38 80     8.
+    equb &c4                                                          ; 8bdb: c4          .
+    equs "Exists"                                                     ; 8bdc: 45 78 69... Exi
+    equb 0                                                            ; 8be2: 00          .
+
+; &8be3 referenced 2 times by &8bd2, &8bd6
+.c8be3
+    ldy l00c4                                                         ; 8be3: a4 c4       ..
+    jsr sub_c87da                                                     ; 8be5: 20 da 87     ..
+    ldx #7                                                            ; 8be8: a2 07       ..
+; &8bea referenced 1 time by &8bf1
+.loop_c8bea
+    lda l00c5,x                                                       ; 8bea: b5 c5       ..
+    sta l0e07,y                                                       ; 8bec: 99 07 0e    ...
+    dey                                                               ; 8bef: 88          .
+    dex                                                               ; 8bf0: ca          .
+    bpl loop_c8bea                                                    ; 8bf1: 10 f7       ..
+    jmp c93e6                                                         ; 8bf3: 4c e6 93    L..
+
+; &8bf6 referenced 1 time by &9466
+.sub_c8bf6
+    clc                                                               ; 8bf6: 18          .
+    bcc c8bfb                                                         ; 8bf7: 90 02       ..
+; &8bf9 referenced 1 time by &9211
+.sub_c8bf9
+    cli                                                               ; 8bf9: 58          X
+    sec                                                               ; 8bfa: 38          8
+; &8bfb referenced 1 time by &8bf7
+.c8bfb
+    ror l00b2                                                         ; 8bfb: 66 b2       f.
+    stx l00b0                                                         ; 8bfd: 86 b0       ..
+    sty l00b1                                                         ; 8bff: 84 b1       ..
+    cld                                                               ; 8c01: d8          .
+    jsr sub_c8c65                                                     ; 8c02: 20 65 8c     e.
+    lda l00a2                                                         ; 8c05: a5 a2       ..
+    bne c8c12                                                         ; 8c07: d0 09       ..
+    ldy #5                                                            ; 8c09: a0 05       ..
+    lda (l00b0),y                                                     ; 8c0b: b1 b0       ..
+    beq c8c12                                                         ; 8c0d: f0 03       ..
+    jsr sub_c8d1a                                                     ; 8c0f: 20 1a 8d     ..
+; &8c12 referenced 2 times by &8c07, &8c0d
+.c8c12
+    ldy #5                                                            ; 8c12: a0 05       ..
+    lda (l00b0),y                                                     ; 8c14: b1 b0       ..
+    clc                                                               ; 8c16: 18          .
+    adc #7                                                            ; 8c17: 69 07       i.
+    tay                                                               ; 8c19: a8          .
+    lda l00a2                                                         ; 8c1a: a5 a2       ..
+    jsr sub_c8c56                                                     ; 8c1c: 20 56 8c     V.
+    sta (l00b0),y                                                     ; 8c1f: 91 b0       ..
+    ldx l00a7                                                         ; 8c21: a6 a7       ..
+    cpx #&80                                                          ; 8c23: e0 80       ..
+    bne c8c2e                                                         ; 8c25: d0 07       ..
+    lda lfe84                                                         ; 8c27: ad 84 fe    ...
+    and #&20 ; ' '                                                    ; 8c2a: 29 20       )
+    ora (l00b0),y                                                     ; 8c2c: 11 b0       ..
+; &8c2e referenced 1 time by &8c25
+.c8c2e
+    pha                                                               ; 8c2e: 48          H
+    and #&df                                                          ; 8c2f: 29 df       ).
+    cmp #&18                                                          ; 8c31: c9 18       ..
+    bne c8c3a                                                         ; 8c33: d0 05       ..
+    lda #&ff                                                          ; 8c35: a9 ff       ..
+    sta l1087                                                         ; 8c37: 8d 87 10    ...
+; &8c3a referenced 1 time by &8c33
+.c8c3a
+    lda l00cd                                                         ; 8c3a: a5 cd       ..
+    and #1                                                            ; 8c3c: 29 01       ).
+    tay                                                               ; 8c3e: a8          .
+    lda l00ce                                                         ; 8c3f: a5 ce       ..
+    sta l1088,y                                                       ; 8c41: 99 88 10    ...
+    jsr c8f2a                                                         ; 8c44: 20 2a 8f     *.
+    bit l00a1                                                         ; 8c47: 24 a1       $.
+    bpl c8c4e                                                         ; 8c49: 10 03       ..
+    jsr sub_c8f7a                                                     ; 8c4b: 20 7a 8f     z.
+; &8c4e referenced 1 time by &8c49
+.c8c4e
+    jsr sub_c8f5e                                                     ; 8c4e: 20 5e 8f     ^.
+    lda lfe87                                                         ; 8c51: ad 87 fe    ...
+    pla                                                               ; 8c54: 68          h
+    rts                                                               ; 8c55: 60          `
+
+; &8c56 referenced 1 time by &8c1c
+.sub_c8c56
+    ldx #5                                                            ; 8c56: a2 05       ..
+; &8c58 referenced 1 time by &8c5e
+.loop_c8c58
+    cmp l9139,x                                                       ; 8c58: dd 39 91    .9.
+    beq c8c61                                                         ; 8c5b: f0 04       ..
+    dex                                                               ; 8c5d: ca          .
+    bpl loop_c8c58                                                    ; 8c5e: 10 f8       ..
+    rts                                                               ; 8c60: 60          `
+
+; &8c61 referenced 1 time by &8c5b
+.c8c61
+    lda l913f,x                                                       ; 8c61: bd 3f 91    .?.
+    rts                                                               ; 8c64: 60          `
+
+; &8c65 referenced 1 time by &8c02
+.sub_c8c65
+    jsr sub_c8f4f                                                     ; 8c65: 20 4f 8f     O.
+    jsr sub_c8f82                                                     ; 8c68: 20 82 8f     ..
+    lda #0                                                            ; 8c6b: a9 00       ..
+    sta l00a1                                                         ; 8c6d: 85 a1       ..
+    ldy #9                                                            ; 8c6f: a0 09       ..
+; &8c71 referenced 1 time by &8c79
+.loop_c8c71
+    lda (l00b0),y                                                     ; 8c71: b1 b0       ..
+    sta l00aa,y                                                       ; 8c73: 99 aa 00    ...
+    iny                                                               ; 8c76: c8          .
+    cpy #&0c                                                          ; 8c77: c0 0c       ..
+    bne loop_c8c71                                                    ; 8c79: d0 f6       ..
+    ldy #6                                                            ; 8c7b: a0 06       ..
+    lda (l00b0),y                                                     ; 8c7d: b1 b0       ..
+    and #&f0                                                          ; 8c7f: 29 f0       ).
+    cmp #&a0                                                          ; 8c81: c9 a0       ..
+    beq c8c87                                                         ; 8c83: f0 02       ..
+    cmp #&f0                                                          ; 8c85: c9 f0       ..
+; &8c87 referenced 1 time by &8c83
+.c8c87
+    ror l00a1                                                         ; 8c87: 66 a1       f.
+    ldy #3                                                            ; 8c89: a0 03       ..
+    lda (l00b0),y                                                     ; 8c8b: b1 b0       ..
+    iny                                                               ; 8c8d: c8          .
+    and (l00b0),y                                                     ; 8c8e: 31 b0       1.
+    cmp #&ff                                                          ; 8c90: c9 ff       ..
+    clc                                                               ; 8c92: 18          .
+    beq c8cb2                                                         ; 8c93: f0 1d       ..
+    jsr sub_c8f3f                                                     ; 8c95: 20 3f 8f     ?.
+    clc                                                               ; 8c98: 18          .
+    bmi c8cb2                                                         ; 8c99: 30 17       0.
+    jsr sub_c8f6b                                                     ; 8c9b: 20 6b 8f     k.
+    lda l00a1                                                         ; 8c9e: a5 a1       ..
+    rol a                                                             ; 8ca0: 2a          *
+    rol a                                                             ; 8ca1: 2a          *
+    and #1                                                            ; 8ca2: 29 01       ).
+    eor #1                                                            ; 8ca4: 49 01       I.
+    ldx l00b0                                                         ; 8ca6: a6 b0       ..
+    ldy l00b1                                                         ; 8ca8: a4 b1       ..
+    inx                                                               ; 8caa: e8          .
+    bne c8cae                                                         ; 8cab: d0 01       ..
+    iny                                                               ; 8cad: c8          .
+; &8cae referenced 1 time by &8cab
+.c8cae
+    jsr tube_entry                                                    ; 8cae: 20 06 04     ..
+    sec                                                               ; 8cb1: 38          8
+; &8cb2 referenced 2 times by &8c93, &8c99
+.c8cb2
+    ror l00a1                                                         ; 8cb2: 66 a1       f.
+    jsr sub_c8f94                                                     ; 8cb4: 20 94 8f     ..
+    ldy #0                                                            ; 8cb7: a0 00       ..
+    lda (l00b0),y                                                     ; 8cb9: b1 b0       ..
+    bmi c8cc1                                                         ; 8cbb: 30 04       0.
+    and #&0f                                                          ; 8cbd: 29 0f       ).
+    sta l00cd                                                         ; 8cbf: 85 cd       ..
+; &8cc1 referenced 1 time by &8cbb
+.c8cc1
+    lda l00cd                                                         ; 8cc1: a5 cd       ..
+    and #3                                                            ; 8cc3: 29 03       ).
+    tax                                                               ; 8cc5: aa          .
+    lda l10de,x                                                       ; 8cc6: bd de 10    ...
+    sta l108a                                                         ; 8cc9: 8d 8a 10    ...
+    lda l00cd                                                         ; 8ccc: a5 cd       ..
+    ldy #&0a                                                          ; 8cce: a0 0a       ..
+    and #8                                                            ; 8cd0: 29 08       ).
+    beq c8cd6                                                         ; 8cd2: f0 02       ..
+    ldy #&10                                                          ; 8cd4: a0 10       ..
+; &8cd6 referenced 1 time by &8cd2
+.c8cd6
+    sty l00a3                                                         ; 8cd6: 84 a3       ..
+    eor l911d,x                                                       ; 8cd8: 5d 1d 91    ]..
+    sta lfe80                                                         ; 8cdb: 8d 80 fe    ...
+    lsr a                                                             ; 8cde: 4a          J
+    ldx l1088                                                         ; 8cdf: ae 88 10    ...
+    bcs c8ce7                                                         ; 8ce2: b0 03       ..
+    ldx l1089                                                         ; 8ce4: ae 89 10    ...
+; &8ce7 referenced 1 time by &8ce2
+.c8ce7
+    ldy #0                                                            ; 8ce7: a0 00       ..
+    sty l00a2                                                         ; 8ce9: 84 a2       ..
+    lda l1087                                                         ; 8ceb: ad 87 10    ...
+    bit l1087                                                         ; 8cee: 2c 87 10    ,..
+    bcc c8cfc                                                         ; 8cf1: 90 09       ..
+    bpl c8d0d                                                         ; 8cf3: 10 18       ..
+    sty l1088                                                         ; 8cf5: 8c 88 10    ...
+    and #&7f                                                          ; 8cf8: 29 7f       ).
+    bpl c8d03                                                         ; 8cfa: 10 07       ..
+; &8cfc referenced 1 time by &8cf1
+.c8cfc
+    bvc c8d0d                                                         ; 8cfc: 50 0f       P.
+    sty l1089                                                         ; 8cfe: 8c 89 10    ...
+    and #&bf                                                          ; 8d01: 29 bf       ).
+; &8d03 referenced 1 time by &8cfa
+.c8d03
+    sta l1087                                                         ; 8d03: 8d 87 10    ...
+    lda #0                                                            ; 8d06: a9 00       ..
+    jsr c8e12                                                         ; 8d08: 20 12 8e     ..
+    ldx #0                                                            ; 8d0b: a2 00       ..
+; &8d0d referenced 2 times by &8cf3, &8cfc
+.c8d0d
+    txa                                                               ; 8d0d: 8a          .
+    sta l00ce                                                         ; 8d0e: 85 ce       ..
+    jsr c8f2a                                                         ; 8d10: 20 2a 8f     *.
+; &8d13 referenced 2 times by &8d1d, &8d25
+.c8d13
+    rts                                                               ; 8d13: 60          `
+
+; &8d14 referenced 1 time by &8d29
+.loop_c8d14
+    jmp c8eaf                                                         ; 8d14: 4c af 8e    L..
+
+; &8d17 referenced 1 time by &8d2d
+.loop_c8d17
+    jmp c8e12                                                         ; 8d17: 4c 12 8e    L..
+
+; &8d1a referenced 1 time by &8c0f
+.sub_c8d1a
+    jsr sub_c8eff                                                     ; 8d1a: 20 ff 8e     ..
+    bne c8d13                                                         ; 8d1d: d0 f4       ..
+    ldy #6                                                            ; 8d1f: a0 06       ..
+    lda (l00b0),y                                                     ; 8d21: b1 b0       ..
+    cmp #&10                                                          ; 8d23: c9 10       ..
+    beq c8d13                                                         ; 8d25: f0 ec       ..
+    cmp #&c0                                                          ; 8d27: c9 c0       ..
+    beq loop_c8d14                                                    ; 8d29: f0 e9       ..
+    cmp #&e0                                                          ; 8d2b: c9 e0       ..
+    bcs loop_c8d17                                                    ; 8d2d: b0 e8       ..
+    ldy #8                                                            ; 8d2f: a0 08       ..
+    lda (l00b0),y                                                     ; 8d31: b1 b0       ..
+    bit l00b2                                                         ; 8d33: 24 b2       $.
+    bmi c8d92                                                         ; 8d35: 30 5b       0[
+    ldx l00b5                                                         ; 8d37: a6 b5       ..
+    beq c8d41                                                         ; 8d39: f0 06       ..
+    inc l00b3                                                         ; 8d3b: e6 b3       ..
+    bne c8d41                                                         ; 8d3d: d0 02       ..
+    inc l00b4                                                         ; 8d3f: e6 b4       ..
+; &8d41 referenced 3 times by &8d39, &8d3d, &8d8f
+.c8d41
+    jsr nmi_handler2_rom_end                                          ; 8d41: 20 fb 90     ..
+    sta l00cf                                                         ; 8d44: 85 cf       ..
+    sbc l00a3                                                         ; 8d46: e5 a3       ..
+    eor #&ff                                                          ; 8d48: 49 ff       I.
+    clc                                                               ; 8d4a: 18          .
+    adc #1                                                            ; 8d4b: 69 01       i.
+    sta l00a5                                                         ; 8d4d: 85 a5       ..
+    lda l00b4                                                         ; 8d4f: a5 b4       ..
+    bne c8d74                                                         ; 8d51: d0 21       .!
+    lda l00b3                                                         ; 8d53: a5 b3       ..
+    beq c8d91                                                         ; 8d55: f0 3a       .:
+    cmp l00a5                                                         ; 8d57: c5 a5       ..
+    beq c8d5d                                                         ; 8d59: f0 02       ..
+    bcs c8d74                                                         ; 8d5b: b0 17       ..
+; &8d5d referenced 1 time by &8d59
+.c8d5d
+    sta l00a5                                                         ; 8d5d: 85 a5       ..
+    ldx l00b5                                                         ; 8d5f: a6 b5       ..
+    beq c8d74                                                         ; 8d61: f0 11       ..
+    stx l00a6                                                         ; 8d63: 86 a6       ..
+    ror l00a1                                                         ; 8d65: 66 a1       f.
+    sec                                                               ; 8d67: 38          8
+    rol l00a1                                                         ; 8d68: 26 a1       &.
+    cmp #1                                                            ; 8d6a: c9 01       ..
+    bne c8d74                                                         ; 8d6c: d0 06       ..
+    lda nmi_lda_immXXX4+1                                             ; 8d6e: ad 22 0d    .".
+    sta nmi_lda_immXXX3+1                                             ; 8d71: 8d 4c 0d    .L.
+; &8d74 referenced 4 times by &8d51, &8d5b, &8d61, &8d6c
+.c8d74
+    lda l00b3                                                         ; 8d74: a5 b3       ..
+    sec                                                               ; 8d76: 38          8
+    sbc l00a5                                                         ; 8d77: e5 a5       ..
+    sta l00b3                                                         ; 8d79: 85 b3       ..
+    lda l00b4                                                         ; 8d7b: a5 b4       ..
+    sbc #0                                                            ; 8d7d: e9 00       ..
+    sta l00b4                                                         ; 8d7f: 85 b4       ..
+    jsr c8e0e                                                         ; 8d81: 20 0e 8e     ..
+    bne c8d91                                                         ; 8d84: d0 0b       ..
+    lda l00b3                                                         ; 8d86: a5 b3       ..
+    ora l00b4                                                         ; 8d88: 05 b4       ..
+    beq c8d91                                                         ; 8d8a: f0 05       ..
+    jsr c8ecc                                                         ; 8d8c: 20 cc 8e     ..
+    beq c8d41                                                         ; 8d8f: f0 b0       ..
+; &8d91 referenced 4 times by &8d55, &8d84, &8d8a, &8d9d
+.c8d91
+    rts                                                               ; 8d91: 60          `
+
+; &8d92 referenced 1 time by &8d35
+.c8d92
+    jsr nmi_handler2_rom_end                                          ; 8d92: 20 fb 90     ..
+    sta l00cf                                                         ; 8d95: 85 cf       ..
+    ldy #9                                                            ; 8d97: a0 09       ..
+    lda (l00b0),y                                                     ; 8d99: b1 b0       ..
+    and #&1f                                                          ; 8d9b: 29 1f       ).
+    beq c8d91                                                         ; 8d9d: f0 f2       ..
+    sta l00a5                                                         ; 8d9f: 85 a5       ..
+    bit l00a1                                                         ; 8da1: 24 a1       $.
+    bvs c8e0e                                                         ; 8da3: 70 69       pi
+    bit l108a                                                         ; 8da5: 2c 8a 10    ,..
+    bvc c8e0e                                                         ; 8da8: 50 64       Pd
+    ldx #&33 ; '3'                                                    ; 8daa: a2 33       .3
+; &8dac referenced 1 time by &8db3
+.loop_c8dac
+    lda c0d60,x                                                       ; 8dac: bd 60 0d    .`.
+    sta l1000,x                                                       ; 8daf: 9d 00 10    ...
+    dex                                                               ; 8db2: ca          .
+    bpl loop_c8dac                                                    ; 8db3: 10 f7       ..
+    jsr sub_c8dc6                                                     ; 8db5: 20 c6 8d     ..
+    ldx #&33 ; '3'                                                    ; 8db8: a2 33       .3
+; &8dba referenced 1 time by &8dc1
+.loop_c8dba
+    lda l1000,x                                                       ; 8dba: bd 00 10    ...
+    sta c0d60,x                                                       ; 8dbd: 9d 60 0d    .`.
+    dex                                                               ; 8dc0: ca          .
+    bpl loop_c8dba                                                    ; 8dc1: 10 f7       ..
+    lda l00a2                                                         ; 8dc3: a5 a2       ..
+    rts                                                               ; 8dc5: 60          `
+
+; &8dc6 referenced 1 time by &8db5
+.sub_c8dc6
+    lda #0                                                            ; 8dc6: a9 00       ..
+    sta l00b4                                                         ; 8dc8: 85 b4       ..
+    lda (l00b0),y                                                     ; 8dca: b1 b0       ..
+    and #&e0                                                          ; 8dcc: 29 e0       ).
+    bne c8dd2                                                         ; 8dce: d0 02       ..
+    lda #&10                                                          ; 8dd0: a9 10       ..
+; &8dd2 referenced 1 time by &8dce
+.c8dd2
+    asl a                                                             ; 8dd2: 0a          .
+    rol l00b4                                                         ; 8dd3: 26 b4       &.
+    asl a                                                             ; 8dd5: 0a          .
+    rol l00b4                                                         ; 8dd6: 26 b4       &.
+    asl a                                                             ; 8dd8: 0a          .
+    rol l00b4                                                         ; 8dd9: 26 b4       &.
+    sta l00b3                                                         ; 8ddb: 85 b3       ..
+    tax                                                               ; 8ddd: aa          .
+    beq c8de2                                                         ; 8dde: f0 02       ..
+    inc l00b4                                                         ; 8de0: e6 b4       ..
+; &8de2 referenced 1 time by &8dde
+.c8de2
+    jsr nmi3_handler_rom_end                                          ; 8de2: 20 3e 90     >.
+    lda #&14                                                          ; 8de5: a9 14       ..
+    sta l00b7                                                         ; 8de7: 85 b7       ..
+; &8de9 referenced 1 time by &8dfc
+.loop_c8de9
+    lda #&e0                                                          ; 8de9: a9 e0       ..
+    sta l00a2                                                         ; 8deb: 85 a2       ..
+    sta lfe84                                                         ; 8ded: 8d 84 fe    ...
+; &8df0 referenced 1 time by &8df2
+.loop_c8df0
+    lda l00a2                                                         ; 8df0: a5 a2       ..
+    bmi loop_c8df0                                                    ; 8df2: 30 fc       0.
+    bne c8e0d                                                         ; 8df4: d0 17       ..
+    lda l00a5                                                         ; 8df6: a5 a5       ..
+    beq c8e03                                                         ; 8df8: f0 09       ..
+    dec l00b7                                                         ; 8dfa: c6 b7       ..
+    bne loop_c8de9                                                    ; 8dfc: d0 eb       ..
+    lda #&10                                                          ; 8dfe: a9 10       ..
+    sta l00a2                                                         ; 8e00: 85 a2       ..
+    rts                                                               ; 8e02: 60          `
+
+; &8e03 referenced 1 time by &8df8
+.c8e03
+    lda l00b6                                                         ; 8e03: a5 b6       ..
+    eor #&fb                                                          ; 8e05: 49 fb       I.
+    beq c8e0d                                                         ; 8e07: f0 04       ..
+    lda #&20 ; ' '                                                    ; 8e09: a9 20       .
+    sta l00a2                                                         ; 8e0b: 85 a2       ..
+; &8e0d referenced 2 times by &8df4, &8e07
+.c8e0d
+    rts                                                               ; 8e0d: 60          `
+
+; &8e0e referenced 4 times by &8d81, &8da3, &8da8, &8ec2
+.c8e0e
+    ldy #6                                                            ; 8e0e: a0 06       ..
+    lda (l00b0),y                                                     ; 8e10: b1 b0       ..
+; &8e12 referenced 4 times by &8d08, &8d17, &8efc, &8f21
+.c8e12
+    ldy #&ff                                                          ; 8e12: a0 ff       ..
+; &8e14 referenced 1 time by &8e18
+.loop_c8e14
+    iny                                                               ; 8e14: c8          .
+    cmp l9121,y                                                       ; 8e15: d9 21 91    .!.
+    bne loop_c8e14                                                    ; 8e18: d0 fa       ..
+    pha                                                               ; 8e1a: 48          H
+    lda nmi_and_table,y                                               ; 8e1b: b9 2d 91    .-.
+    sta nmi_and_imm+1                                                 ; 8e1e: 8d 05 0d    ...
+    ror l00a2                                                         ; 8e21: 66 a2       f.
+    pla                                                               ; 8e23: 68          h
+    bpl c8e72                                                         ; 8e24: 10 4c       .L
+    bit l00a1                                                         ; 8e26: 24 a1       $.
+    bvc c8e32                                                         ; 8e28: 50 08       P.
+    ldy l00ce                                                         ; 8e2a: a4 ce       ..
+    cpy #&14                                                          ; 8e2c: c0 14       ..
+    bcc c8e32                                                         ; 8e2e: 90 02       ..
+    ora #2                                                            ; 8e30: 09 02       ..
+; &8e32 referenced 2 times by &8e28, &8e2e
+.c8e32
+    sta l00a7                                                         ; 8e32: 85 a7       ..
+    ldy #1                                                            ; 8e34: a0 01       ..
+    cmp #&c0                                                          ; 8e36: c9 c0       ..
+    beq c8e53                                                         ; 8e38: f0 19       ..
+    ora #4                                                            ; 8e3a: 09 04       ..
+    bcs c8e53                                                         ; 8e3c: b0 15       ..
+    ldy l00a5                                                         ; 8e3e: a4 a5       ..
+    cmp #&85                                                          ; 8e40: c9 85       ..
+    beq c8e4d                                                         ; 8e42: f0 09       ..
+    cmp #&87                                                          ; 8e44: c9 87       ..
+    bne c8e53                                                         ; 8e46: d0 0b       ..
+    lda #nmi_XXX1-(nmi_beq+2)                                         ; 8e48: a9 48       .H
+    sta nmi_beq+1                                                     ; 8e4a: 8d 09 0d    ...
+; &8e4d referenced 1 time by &8e42
+.c8e4d
+    lda #&80                                                          ; 8e4d: a9 80       ..
+    sta l00a7                                                         ; 8e4f: 85 a7       ..
+    lda #&84                                                          ; 8e51: a9 84       ..
+; &8e53 referenced 3 times by &8e38, &8e3c, &8e46
+.c8e53
+    sty l00a5                                                         ; 8e53: 84 a5       ..
+    sta lfe84                                                         ; 8e55: 8d 84 fe    ...
+    cmp #&f0                                                          ; 8e58: c9 f0       ..
+    bcc c8e64                                                         ; 8e5a: 90 08       ..
+    jsr c8e9f                                                         ; 8e5c: 20 9f 8e     ..
+    and #&5c ; '\'                                                    ; 8e5f: 29 5c       )\
+    sta l00a2                                                         ; 8e61: 85 a2       ..
+    rts                                                               ; 8e63: 60          `
+
+; &8e64 referenced 4 times by &8e5a, &8e66, &8e7f, &8e83
+.c8e64
+    lda l00a2                                                         ; 8e64: a5 a2       ..
+    bmi c8e64                                                         ; 8e66: 30 fc       0.
+    cmp #&20 ; ' '                                                    ; 8e68: c9 20       .
+    bne c8e6f                                                         ; 8e6a: d0 03       ..
+    jsr c8ea5                                                         ; 8e6c: 20 a5 8e     ..
+; &8e6f referenced 1 time by &8e6a
+.c8e6f
+    lda l00a2                                                         ; 8e6f: a5 a2       ..
+    rts                                                               ; 8e71: 60          `
+
+; &8e72 referenced 1 time by &8e24
+.c8e72
+    ldy #1                                                            ; 8e72: a0 01       ..
+    sty l00a5                                                         ; 8e74: 84 a5       ..
+    ora l00a4                                                         ; 8e76: 05 a4       ..
+    sta l00a7                                                         ; 8e78: 85 a7       ..
+    sta lfe84                                                         ; 8e7a: 8d 84 fe    ...
+    bit l00b2                                                         ; 8e7d: 24 b2       $.
+    bmi c8e64                                                         ; 8e7f: 30 e3       0.
+    cmp #&20 ; ' '                                                    ; 8e81: c9 20       .
+    bcs c8e64                                                         ; 8e83: b0 df       ..
+; &8e85 referenced 1 time by &8e8b
+.loop_c8e85
+    lda l00a2                                                         ; 8e85: a5 a2       ..
+    bpl c8e9e                                                         ; 8e87: 10 15       ..
+    lda l00ff                                                         ; 8e89: a5 ff       ..
+    bpl loop_c8e85                                                    ; 8e8b: 10 f8       ..
+    lda #opcode_rti                                                   ; 8e8d: a9 40       .@
+    sta nmi_handler_ram                                               ; 8e8f: 8d 00 0d    ...
+    lda #0                                                            ; 8e92: a9 00       ..
+    sta lfe80                                                         ; 8e94: 8d 80 fe    ...
+    lda l00ff                                                         ; 8e97: a5 ff       ..
+    sta l1082                                                         ; 8e99: 8d 82 10    ...
+    sta l00a2                                                         ; 8e9c: 85 a2       ..
+; &8e9e referenced 1 time by &8e87
+.c8e9e
+    rts                                                               ; 8e9e: 60          `
+
+; &8e9f referenced 2 times by &8e5c, &8ea3
+.c8e9f
+    lda lfe84                                                         ; 8e9f: ad 84 fe    ...
+    ror a                                                             ; 8ea2: 6a          j
+    bcc c8e9f                                                         ; 8ea3: 90 fa       ..
+; &8ea5 referenced 2 times by &8e6c, &8ea9
+.c8ea5
+    lda lfe84                                                         ; 8ea5: ad 84 fe    ...
+    ror a                                                             ; 8ea8: 6a          j
+    bcs c8ea5                                                         ; 8ea9: b0 fa       ..
+    lda lfe84                                                         ; 8eab: ad 84 fe    ...
+    rts                                                               ; 8eae: 60          `
+
+; &8eaf referenced 1 time by &8d14
+.c8eaf
+    lda #nmi_XXX1-(nmi_beq+2)                                         ; 8eaf: a9 48       .H
+    sta nmi_lda_immXXX3+1                                             ; 8eb1: 8d 4c 0d    .L.
+    ldx nmi_beq+1                                                     ; 8eb4: ae 09 0d    ...
+; &8eb7 referenced 2 times by &8eb9, &8ec9
+.c8eb7
+    sbc #1                                                            ; 8eb7: e9 01       ..
+    bne c8eb7                                                         ; 8eb9: d0 fc       ..
+    stx nmi_beq+1                                                     ; 8ebb: 8e 09 0d    ...
+    lda #4                                                            ; 8ebe: a9 04       ..
+    sta l00a6                                                         ; 8ec0: 85 a6       ..
+    jsr c8e0e                                                         ; 8ec2: 20 0e 8e     ..
+    bne c8ecb                                                         ; 8ec5: d0 04       ..
+    dec l00b3                                                         ; 8ec7: c6 b3       ..
+    bne c8eb7                                                         ; 8ec9: d0 ec       ..
+; &8ecb referenced 1 time by &8ec5
+.c8ecb
+    rts                                                               ; 8ecb: 60          `
+
+; &8ecc referenced 3 times by &8d8c, &8ee2, &8ee7
+.c8ecc
+    jsr sub_c8eec                                                     ; 8ecc: 20 ec 8e     ..
+    bne c8eeb                                                         ; 8ecf: d0 1a       ..
+    lda l00cd                                                         ; 8ed1: a5 cd       ..
+    and #1                                                            ; 8ed3: 29 01       ).
+    asl a                                                             ; 8ed5: 0a          .
+    tay                                                               ; 8ed6: a8          .
+    lda l00ce                                                         ; 8ed7: a5 ce       ..
+    bit l108a                                                         ; 8ed9: 2c 8a 10    ,..
+    bpl c8edf                                                         ; 8edc: 10 01       ..
+    lsr a                                                             ; 8ede: 4a          J
+; &8edf referenced 1 time by &8edc
+.c8edf
+    cmp l108b,y                                                       ; 8edf: d9 8b 10    ...
+    beq c8ecc                                                         ; 8ee2: f0 e8       ..
+    cmp l108c,y                                                       ; 8ee4: d9 8c 10    ...
+    beq c8ecc                                                         ; 8ee7: f0 e3       ..
+    lda #0                                                            ; 8ee9: a9 00       ..
+; &8eeb referenced 2 times by &8ecf, &8ef6
+.c8eeb
+    rts                                                               ; 8eeb: 60          `
+
+; &8eec referenced 1 time by &8ecc
+.sub_c8eec
+    bit l108a                                                         ; 8eec: 2c 8a 10    ,..
+    bpl c8ef8                                                         ; 8eef: 10 07       ..
+    lda #&40 ; '@'                                                    ; 8ef1: a9 40       .@
+    jsr sub_c8efa                                                     ; 8ef3: 20 fa 8e     ..
+    bne c8eeb                                                         ; 8ef6: d0 f3       ..
+; &8ef8 referenced 1 time by &8eef
+.c8ef8
+    lda #&50 ; 'P'                                                    ; 8ef8: a9 50       .P
+; &8efa referenced 1 time by &8ef3
+.sub_c8efa
+    inc l00ce                                                         ; 8efa: e6 ce       ..
+    jmp c8e12                                                         ; 8efc: 4c 12 8e    L..
+
+; &8eff referenced 1 time by &8d1a
+.sub_c8eff
+    lda l00cd                                                         ; 8eff: a5 cd       ..
+    and #1                                                            ; 8f01: 29 01       ).
+    asl a                                                             ; 8f03: 0a          .
+    tax                                                               ; 8f04: aa          .
+    ldy #7                                                            ; 8f05: a0 07       ..
+    lda (l00b0),y                                                     ; 8f07: b1 b0       ..
+    jsr sub_c8f33                                                     ; 8f09: 20 33 8f     3.
+    bit l108a                                                         ; 8f0c: 2c 8a 10    ,..
+    bpl c8f12                                                         ; 8f0f: 10 01       ..
+    asl a                                                             ; 8f11: 0a          .
+; &8f12 referenced 1 time by &8f0f
+.c8f12
+    sta l00ce                                                         ; 8f12: 85 ce       ..
+    tay                                                               ; 8f14: a8          .
+    beq c8f21                                                         ; 8f15: f0 0a       ..
+; &8f17 referenced 1 time by &8f1d
+.loop_c8f17
+    sta lfe87                                                         ; 8f17: 8d 87 fe    ...
+    cmp lfe87                                                         ; 8f1a: cd 87 fe    ...
+    bne loop_c8f17                                                    ; 8f1d: d0 f8       ..
+    lda #&10                                                          ; 8f1f: a9 10       ..
+; &8f21 referenced 1 time by &8f15
+.c8f21
+    jsr c8e12                                                         ; 8f21: 20 12 8e     ..
+    bne c8f3e                                                         ; 8f24: d0 18       ..
+    ldy #7                                                            ; 8f26: a0 07       ..
+    lda (l00b0),y                                                     ; 8f28: b1 b0       ..
+; &8f2a referenced 3 times by &8c44, &8d10, &8f30
+.c8f2a
+    sta lfe85                                                         ; 8f2a: 8d 85 fe    ...
+    cmp lfe85                                                         ; 8f2d: cd 85 fe    ...
+    bne c8f2a                                                         ; 8f30: d0 f8       ..
+    rts                                                               ; 8f32: 60          `
+
+; &8f33 referenced 1 time by &8f09
+.sub_c8f33
+    jsr sub_c8f37                                                     ; 8f33: 20 37 8f     7.
+    inx                                                               ; 8f36: e8          .
+; &8f37 referenced 1 time by &8f33
+.sub_c8f37
+    cmp l108b,x                                                       ; 8f37: dd 8b 10    ...
+    bcc c8f3e                                                         ; 8f3a: 90 02       ..
+    adc #0                                                            ; 8f3c: 69 00       i.
+; &8f3e referenced 2 times by &8f24, &8f3a
+.c8f3e
+    rts                                                               ; 8f3e: 60          `
+
+; &8f3f referenced 5 times by &8c95, &8f75, &92b0, &932b, &9628
+.sub_c8f3f
+    lda #osbyte_read_tube_presence                                    ; 8f3f: a9 ea       ..
+    ldx #0                                                            ; 8f41: a2 00       ..
+    ldy #&ff                                                          ; 8f43: a0 ff       ..
+    jsr osbyte                                                        ; 8f45: 20 f4 ff     ..
+    txa                                                               ; 8f48: 8a          .
+    eor #&ff                                                          ; 8f49: 49 ff       I.
+    sta l10d6                                                         ; 8f4b: 8d d6 10    ...
+    rts                                                               ; 8f4e: 60          `
+
+; &8f4f referenced 1 time by &8c65
+.sub_c8f4f
+    lda #osbyte_issue_service_request                                 ; 8f4f: a9 8f       ..
+    ldx #&0c                                                          ; 8f51: a2 0c       ..
+    ldy #&ff                                                          ; 8f53: a0 ff       ..
+    jsr osbyte                                                        ; 8f55: 20 f4 ff     ..
+    sty l00a0                                                         ; 8f58: 84 a0       ..
+    inc l10d3                                                         ; 8f5a: ee d3 10    ...
+    rts                                                               ; 8f5d: 60          `
+
+; &8f5e referenced 1 time by &8c4e
+.sub_c8f5e
+    ldy l00a0                                                         ; 8f5e: a4 a0       ..
+    lda #osbyte_issue_service_request                                 ; 8f60: a9 8f       ..
+    ldx #&0b                                                          ; 8f62: a2 0b       ..
+    jsr osbyte                                                        ; 8f64: 20 f4 ff     ..
+    dec l10d3                                                         ; 8f67: ce d3 10    ...
+    rts                                                               ; 8f6a: 60          `
+
+; &8f6b referenced 4 times by &8921, &8c9b, &933e, &9819
+.sub_c8f6b
+    pha                                                               ; 8f6b: 48          H
+; &8f6c referenced 1 time by &8f71
+.loop_c8f6c
+    lda #&c1                                                          ; 8f6c: a9 c1       ..
+    jsr tube_entry                                                    ; 8f6e: 20 06 04     ..
+    bcc loop_c8f6c                                                    ; 8f71: 90 f9       ..
+    pla                                                               ; 8f73: 68          h
+    rts                                                               ; 8f74: 60          `
+
+; &8f75 referenced 1 time by &8071
+.sub_c8f75
+    jsr sub_c8f3f                                                     ; 8f75: 20 3f 8f     ?.
+    bmi c8f81                                                         ; 8f78: 30 07       0.
+; &8f7a referenced 3 times by &8c4b, &9364, &97e3
+.sub_c8f7a
+    pha                                                               ; 8f7a: 48          H
+    lda #&81                                                          ; 8f7b: a9 81       ..
+    jsr tube_entry                                                    ; 8f7d: 20 06 04     ..
+    pla                                                               ; 8f80: 68          h
+; &8f81 referenced 1 time by &8f78
+.c8f81
+    rts                                                               ; 8f81: 60          `
+
+; &8f82 referenced 1 time by &8c68
+.sub_c8f82
+    lda #osbyte_read_write_startup_options                            ; 8f82: a9 ff       ..
+    ldx #0                                                            ; 8f84: a2 00       ..
+    tay                                                               ; 8f86: a8          .
+    jsr osbyte                                                        ; 8f87: 20 f4 ff     ..
+    txa                                                               ; 8f8a: 8a          .
+    lsr a                                                             ; 8f8b: 4a          J
+    lsr a                                                             ; 8f8c: 4a          J
+    lsr a                                                             ; 8f8d: 4a          J
+    lsr a                                                             ; 8f8e: 4a          J
+    and #3                                                            ; 8f8f: 29 03       ).
+    sta l00a4                                                         ; 8f91: 85 a4       ..
+    rts                                                               ; 8f93: 60          `
+
+; &8f94 referenced 1 time by &8cb4
+.sub_c8f94
+    ldx #nmi_handler_rom_end-nmi_handler_rom_start-1                  ; 8f94: a2 5d       .]
+; &8f96 referenced 1 time by &8f9d
+.loop_c8f96
+    lda nmi_handler_rom_start,x                                       ; 8f96: bd d2 8f    ...
+    sta nmi_handler_ram,x                                             ; 8f99: 9d 00 0d    ...
+    dex                                                               ; 8f9c: ca          .
+    bpl loop_c8f96                                                    ; 8f9d: 10 f7       ..
+    ldx #3                                                            ; 8f9f: a2 03       ..
+    bit l00a1                                                         ; 8fa1: 24 a1       $.
+    bvc c8fb5                                                         ; 8fa3: 50 10       P.
+    lda #nmi_XXX8-(nmi_beq+2)                                         ; 8fa5: a9 4d       .M
+    sta nmi_lda_immXXX4+1                                             ; 8fa7: 8d 22 0d    .".
+    ldx #nmi3_handler_rom_end-nmi3_handler_rom_start                  ; 8faa: a2 0e       ..
+; &8fac referenced 1 time by &8fb3
+.loop_c8fac
+    lda nmi3_handler_rom_start-1,x                                    ; 8fac: bd 2f 90    ./.
+    sta nmi_XXX2-1,x                                                  ; 8faf: 9d 38 0d    .8.
+    dex                                                               ; 8fb2: ca          .
+    bne loop_c8fac                                                    ; 8fb3: d0 f7       ..
+; &8fb5 referenced 1 time by &8fa3
+.c8fb5
+    bit l00a1                                                         ; 8fb5: 24 a1       $.
+    bmi c8fc7                                                         ; 8fb7: 30 0e       0.
+    ldy #1                                                            ; 8fb9: a0 01       ..
+    lda (l00b0),y                                                     ; 8fbb: b1 b0       ..
+    sta nmi_lda_abs+1,x                                               ; 8fbd: 9d 3a 0d    .:.
+    iny                                                               ; 8fc0: c8          .
+    lda (l00b0),y                                                     ; 8fc1: b1 b0       ..
+    sta nmi_lda_abs+2,x                                               ; 8fc3: 9d 3b 0d    .;.
+    rts                                                               ; 8fc6: 60          `
+
+; &8fc7 referenced 1 time by &8fb7
+.c8fc7
+    lda #opcode_bcs                                                   ; 8fc7: a9 b0       ..
+    sta nmi_XXX6                                                      ; 8fc9: 8d 3f 0d    .?.
+    lda #nmi_XXX7-(nmi_XXX6+2)                                        ; 8fcc: a9 06       ..
+    sta nmi_XXX6+1                                                    ; 8fce: 8d 40 0d    .@.
+    rts                                                               ; 8fd1: 60          `
+
+; &8fd2 referenced 1 time by &8f96
+.nmi_handler_rom_start
+; &8fd2 referenced 1 time by &8f96
+
+    org &0d00
+; &8fd2 referenced 1 time by &8f96
+.nmi_handler_ram
+    pha                                                               ; 8fd2: 48          H   :0d00[4]
+    lda lfe84                                                         ; 8fd3: ad 84 fe    ... :0d01[4]
+; The operand of this and is modified at runtime.
+.nmi_and_imm
+    and #&18                                                          ; 8fd6: 29 18       ).  :0d04[4]
+    cmp #3                                                            ; 8fd8: c9 03       ..  :0d06[4]
+; The operand of this "beq" is modified at runtime.
+.nmi_beq
+    beq nmi_XXX2                                                      ; 8fda: f0 2f       ./  :0d08[4]
+    and #&fc                                                          ; 8fdc: 29 fc       ).  :0d0a[4]
+    bne l0d12                                                         ; 8fde: d0 04       ..  :0d0c[4]
+    dec l00a5                                                         ; 8fe0: c6 a5       ..  :0d0e[4]
+    bne nmi_lda_zp                                                    ; 8fe2: d0 04       ..  :0d10[4]
+.l0d12
+    sta l00a2                                                         ; 8fe4: 85 a2       ..  :0d12[4]
+    pla                                                               ; 8fe6: 68          h   :0d14[4]
+    rti                                                               ; 8fe7: 40          @   :0d15[4]
+
+; The operand of this lda is modified at runtime.
+.nmi_lda_zp
+    lda l00a5                                                         ; 8fe8: a5 a5       ..  :0d16[4]
+; This instruction is patched at runtime to toggle between cmp #/bcs.
+.nmi_cmp_imm_or_bcs
+    cmp #1                                                            ; 8fea: c9 01       ..  :0d18[4]
+    bne l0d26                                                         ; 8fec: d0 0a       ..  :0d1a[4]
+    lda l00a1                                                         ; 8fee: a5 a1       ..  :0d1c[4]
+    ror a                                                             ; 8ff0: 6a          j   :0d1e[4]
+.l0d1f
+nmi_XXX5 = l0d1f+1
+    bcc l0d26                                                         ; 8ff1: 90 05       ..  :0d1f[4]
+; One patched variant of the code transfers control to nmi_XXX5, which
+; is the
+; second byte of the following bcc instruction. That is always &05,
+; which is
+; ORA #. XXX: correct?
+; The operand of this lda is modified at runtime.
+.nmi_lda_immXXX4
+    lda #nmi_XXX1-(nmi_beq+2)                                         ; 8ff3: a9 48       .H  :0d21[4]
+    sta nmi_lda_immXXX3+1                                             ; 8ff5: 8d 4c 0d    .L. :0d23[4]
+.l0d26
+    inc l00cf                                                         ; 8ff8: e6 cf       ..  :0d26[4]
+    lda l00cf                                                         ; 8ffa: a5 cf       ..  :0d28[4]
+.l0d2a
+    sta lfe86                                                         ; 8ffc: 8d 86 fe    ... :0d2a[4]
+    cmp lfe86                                                         ; 8fff: cd 86 fe    ... :0d2d[4]
+    bne l0d2a                                                         ; 9002: d0 f8       ..  :0d30[4]
+    lda l00a7                                                         ; 9004: a5 a7       ..  :0d32[4]
+    sta lfe84                                                         ; 9006: 8d 84 fe    ... :0d34[4]
+    pla                                                               ; 9009: 68          h   :0d37[4]
+    rti                                                               ; 900a: 40          @   :0d38[4]
+
+.nmi_XXX2
+    lda lfe87                                                         ; 900b: ad 87 fe    ... :0d39[4]
+; The operand of this sta is modified at runtime.
+.nmi_sta_abs
+    sta tube_host_r3_data                                             ; 900e: 8d e5 fe    ... :0d3c[4]
+; The first two bytes of the following instruction may be patched at
+; runtime.
+.nmi_XXX6
+    inc nmi_sta_abs+1                                                 ; 9011: ee 3d 0d    .=. :0d3f[4]
+    bne nmi_XXX7                                                      ; 9014: d0 03       ..  :0d42[4]
+    inc nmi_sta_abs+2                                                 ; 9016: ee 3e 0d    .>. :0d44[4]
+.nmi_XXX7
+    dec l00a6                                                         ; 9019: c6 a6       ..  :0d47[4]
+    bne l0d50                                                         ; 901b: d0 05       ..  :0d49[4]
+; The operand of this lda is modified at runtime.
+.nmi_lda_immXXX3
+    lda #nmi_XXX2-(nmi_beq+2)                                         ; 901d: a9 2f       ./  :0d4b[4]
+    sta nmi_beq+1                                                     ; 901f: 8d 09 0d    ... :0d4d[4]
+.l0d50
+    pla                                                               ; 9022: 68          h   :0d50[4]
+    rti                                                               ; 9023: 40          @   :0d51[4]
+
+.nmi_XXX1
+    lda lfe87                                                         ; 9024: ad 87 fe    ... :0d52[4]
+    pla                                                               ; 9027: 68          h   :0d55[4]
+    rti                                                               ; 9028: 40          @   :0d56[4]
+
+.nmi_XXX8
+    lda #0                                                            ; 9029: a9 00       ..  :0d57[4]
+    sta lfe87                                                         ; 902b: 8d 87 fe    ... :0d59[4]
+    pla                                                               ; 902e: 68          h   :0d5c[4]
+; &902f referenced 1 time by &8fac
+    rti                                                               ; 902f: 40          @   :0d5d[4]
+
+; The operand of this lda is modified at runtime.
+    org nmi_handler_rom_start + (sub_c0d5e - nmi_handler_ram)
+    copyblock nmi_handler_ram, sub_c0d5e, nmi_handler_rom_start
+    clear nmi_handler_ram, sub_c0d5e
+
+; The operand of this lda is modified at runtime.
+.nmi_handler_rom_end
+.nmi3_handler_rom_start
+; The operand of this lda is modified at runtime.
+
+    org &0d39
+; The operand of this lda is modified at runtime.
+.nmi_lda_abs
+    lda tube_host_r3_data                                             ; 9030: ad e5 fe    ... :0d39[5]
+    sta lfe87                                                         ; 9033: 8d 87 fe    ... :0d3c[5]
+    inc nmi_lda_abs+1                                                 ; 9036: ee 3a 0d    .:. :0d3f[5]
+    bne nmi_XXX7                                                      ; 9039: d0 03       ..  :0d42[5]
+    inc nmi_lda_abs+2                                                 ; 903b: ee 3b 0d    .;. :0d44[5]
+; &903e referenced 1 time by &8de2
+    org nmi_handler_rom_end + (l0d47 - nmi_lda_abs)
+    copyblock nmi_lda_abs, l0d47, nmi_handler_rom_end
+    clear nmi_lda_abs, l0d47
+
+; &903e referenced 1 time by &8de2
+.nmi3_handler_rom_end
+; &903e referenced 1 time by &8de2
+    ldx nmi_sta_abs+1                                                 ; 903e: ae 3d 0d    .=.
+    lda nmi_sta_abs+2                                                 ; 9041: ad 3e 0d    .>.
+    pha                                                               ; 9044: 48          H
+    ldy #nmi_handler2_rom_end-nmi_handler2_rom_start                  ; 9045: a0 94       ..
+; &9047 referenced 1 time by &904e
+.loop_c9047
+    lda nmi_handler2_rom_start-1,y                                    ; 9047: b9 66 90    .f.
+    sta l0cff,y                                                       ; 904a: 99 ff 0c    ...
+    dey                                                               ; 904d: 88          .
+    bne loop_c9047                                                    ; 904e: d0 f7       ..
+    pla                                                               ; 9050: 68          h
+    bit l00a1                                                         ; 9051: 24 a1       $.
+    bpl c9060                                                         ; 9053: 10 0b       ..
+    lda #opcode_bcs                                                   ; 9055: a9 b0       ..
+    sta nmi_cmp_imm_or_bcs                                            ; 9057: 8d 18 0d    ...
+    lda #nmi_XXX5-(nmi_cmp_imm_or_bcs+2)                              ; 905a: a9 06       ..
+    sta nmi_cmp_imm_or_bcs+1                                          ; 905c: 8d 19 0d    ...
+    rts                                                               ; 905f: 60          `
+
+; &9060 referenced 1 time by &9053
+.c9060
+    stx nmi_lda_zp                                                    ; 9060: 8e 16 0d    ...
+    sta nmi_lda_zp+1                                                  ; 9063: 8d 17 0d    ...
+; &9066 referenced 1 time by &9047
+    rts                                                               ; 9066: 60          `
+
+.nmi_handler2_rom_start
+
+    org &0d00
+    pha                                                               ; 9067: 48          H   :0d00[6]
+    lda lfe84                                                         ; 9068: ad 84 fe    ... :0d01[6]
+    and #&1b                                                          ; 906b: 29 1b       ).  :0d04[6]
+    cmp #3                                                            ; 906d: c9 03       ..  :0d06[6]
+    bne l0d0f                                                         ; 906f: d0 05       ..  :0d08[6]
+    lda lfe87                                                         ; 9071: ad 87 fe    ... :0d0a[6]
+; The operand of this bcs is modified at runtime
+.nmi_bcs
+    bcs nmi_XXX21                                                     ; 9074: b0 26       .&  :0d0d[6]
+.l0d0f
+    and #&fc                                                          ; 9076: 29 fc       ).  :0d0f[6]
+    sta l00a2                                                         ; 9078: 85 a2       ..  :0d11[6]
+    pla                                                               ; 907a: 68          h   :0d13[6]
+    rti                                                               ; 907b: 40          @   :0d14[6]
+
+; The operand of this sta is modified at runtime.
+.nmi_XXX17
+.nmi_sta_abs2
+    sta tube_host_r3_data                                             ; 907c: 8d e5 fe    ... :0d15[6]
+    inc nmi_sta_abs2+1                                                ; 907f: ee 16 0d    ... :0d18[6]
+    bne nmi_XXX18                                                     ; 9082: d0 03       ..  :0d1b[6]
+    inc nmi_sta_abs2+2                                                ; 9084: ee 17 0d    ... :0d1d[6]
+.nmi_XXX18
+    dec l00a6                                                         ; 9087: c6 a6       ..  :0d20[6]
+    bne nmi_XXX23                                                     ; 9089: d0 0f       ..  :0d22[6]
+    dec l00a7                                                         ; 908b: c6 a7       ..  :0d24[6]
+    bne nmi_XXX23                                                     ; 908d: d0 0b       ..  :0d26[6]
+    lda #nmi_XXX22-(nmi_bcs+2)                                        ; 908f: a9 77       .w  :0d28[6]
+    dec l00a5                                                         ; 9091: c6 a5       ..  :0d2a[6]
+    bne l0d30                                                         ; 9093: d0 02       ..  :0d2c[6]
+    lda #nmi_XXX23-(nmi_bcs+2)                                        ; 9095: a9 24       .$  :0d2e[6]
+.l0d30
+    sta nmi_bcs+1                                                     ; 9097: 8d 0e 0d    ... :0d30[6]
+.nmi_XXX23
+    pla                                                               ; 909a: 68          h   :0d33[6]
+    rti                                                               ; 909b: 40          @   :0d34[6]
+
+.nmi_XXX21
+    cmp #&fe                                                          ; 909c: c9 fe       ..  :0d35[6]
+    beq l0d3d                                                         ; 909e: f0 04       ..  :0d37[6]
+    cmp #&ce                                                          ; 90a0: c9 ce       ..  :0d39[6]
+    bne nmi_XXX23                                                     ; 90a2: d0 f6       ..  :0d3b[6]
+.l0d3d
+    lda #nmi_XXX10-(nmi_bcs+2)                                        ; 90a4: a9 32       .2  :0d3d[6]
+    bne l0d30                                                         ; 90a6: d0 ef       ..  :0d3f[6]
+.nmi_XXX10
+    sbc lfe87                                                         ; 90a8: ed 87 fe    ... :0d41[6]
+    sta l00b5                                                         ; 90ab: 85 b5       ..  :0d44[6]
+    lda #nmi_XXX11-(nmi_bcs+2)                                        ; 90ad: a9 3b       .;  :0d46[6]
+    bne l0d30                                                         ; 90af: d0 e6       ..  :0d48[6]
+.nmi_XXX11
+    lda #nmi_XXX12-(nmi_bcs+2)                                        ; 90b1: a9 3f       .?  :0d4a[6]
+    bne l0d30                                                         ; 90b3: d0 e2       ..  :0d4c[6]
+.nmi_XXX12
+    sbc l00cf                                                         ; 90b5: e5 cf       ..  :0d4e[6]
+    ora l00b5                                                         ; 90b7: 05 b5       ..  :0d50[6]
+    sta l00b5                                                         ; 90b9: 85 b5       ..  :0d52[6]
+    lda #nmi_XXX13-(nmi_bcs+2)                                        ; 90bb: a9 49       .I  :0d54[6]
+    bne l0d30                                                         ; 90bd: d0 d8       ..  :0d56[6]
+.nmi_XXX13
+    lda #nmi_XXX14-(nmi_bcs+2)                                        ; 90bf: a9 4d       .M  :0d58[6]
+    bne l0d30                                                         ; 90c1: d0 d4       ..  :0d5a[6]
+.nmi_XXX14
+    lda l00b3                                                         ; 90c3: a5 b3       ..  :0d5c[6]
+    sta l00a6                                                         ; 90c5: 85 a6       ..  :0d5e[6]
+; &90c7 referenced 2 times by &8dac, &8dbd
+.c0d60
+    lda #nmi_XXX15-(nmi_bcs+2)                                        ; 90c7: a9 55       .U  :0d60[6]
+    bne l0d30                                                         ; 90c9: d0 cc       ..  :0d62[6]
+.nmi_XXX15
+    lda l00b4                                                         ; 90cb: a5 b4       ..  :0d64[6]
+    sta l00a7                                                         ; 90cd: 85 a7       ..  :0d66[6]
+    lda #nmi_XXX16-(nmi_bcs+2)                                        ; 90cf: a9 5d       .]  :0d68[6]
+    bne l0d30                                                         ; 90d1: d0 c4       ..  :0d6a[6]
+.nmi_XXX16
+    cmp #&fb                                                          ; 90d3: c9 fb       ..  :0d6c[6]
+    beq c0d74                                                         ; 90d5: f0 04       ..  :0d6e[6]
+    cmp #&f8                                                          ; 90d7: c9 f8       ..  :0d70[6]
+    bne nmi_XXX23                                                     ; 90d9: d0 bf       ..  :0d72[6]
+; &90db referenced 1 time by &0d6e
+.c0d74
+    sta l00b6                                                         ; 90db: 85 b6       ..  :0d74[6]
+    lda l00b5                                                         ; 90dd: a5 b5       ..  :0d76[6]
+    bne c0d80                                                         ; 90df: d0 06       ..  :0d78[6]
+    inc l00cf                                                         ; 90e1: e6 cf       ..  :0d7a[6]
+    lda #nmi_XXX17-(nmi_bcs+2)                                        ; 90e3: a9 06       ..  :0d7c[6]
+    bne l0d30                                                         ; 90e5: d0 b0       ..  :0d7e[6]
+; &90e7 referenced 1 time by &0d78
+.c0d80
+    inc l00a5                                                         ; 90e7: e6 a5       ..  :0d80[6]
+    lda #nmi_XXX18-(nmi_bcs+2)                                        ; 90e9: a9 11       ..  :0d82[6]
+    bne l0d30                                                         ; 90eb: d0 aa       ..  :0d84[6]
+.nmi_XXX22
+    lda #nmi_XXX19-(nmi_bcs+2)                                        ; 90ed: a9 7b       .{  :0d86[6]
+    bne l0d30                                                         ; 90ef: d0 a6       ..  :0d88[6]
+.nmi_XXX19
+    lda #nmi_XXX20-(nmi_bcs+2)                                        ; 90f1: a9 7f       ..  :0d8a[6]
+    bne l0d30                                                         ; 90f3: d0 a2       ..  :0d8c[6]
+.nmi_XXX20
+    bne nmi_XXX23                                                     ; 90f5: d0 a3       ..  :0d8e[6]
+    lda #nmi_XXX21-(nmi_bcs+2)                                        ; 90f7: a9 26       .&  :0d90[6]
+    bne l0d30                                                         ; 90f9: d0 9c       ..  :0d92[6]
+; &90fb referenced 3 times by &8d41, &8d92, &9101
+    org nmi_handler2_rom_start + (l0d94 - l0d00)
+    copyblock l0d00, l0d94, nmi_handler2_rom_start
+    clear l0d00, l0d94
+
+; &90fb referenced 3 times by &8d41, &8d92, &9101
+.nmi_handler2_rom_end
+; &90fb referenced 3 times by &8d41, &8d92, &9101
+    sta lfe86                                                         ; 90fb: 8d 86 fe    ...
+    cmp lfe86                                                         ; 90fe: cd 86 fe    ...
+    bne nmi_handler2_rom_end                                          ; 9101: d0 f8       ..
+    rts                                                               ; 9103: 60          `
+
+; &9104 referenced 1 time by &966b
+.set_c_iff_have_fdc
+    ldx #0                                                            ; 9104: a2 00       ..
+    lda #&5a ; 'Z'                                                    ; 9106: a9 5a       .Z
+; &9108 referenced 1 time by &9111
+.loop_c9108
+    sta lfe85                                                         ; 9108: 8d 85 fe    ...
+    cmp lfe85                                                         ; 910b: cd 85 fe    ...
+    beq c9115                                                         ; 910e: f0 05       ..
+    dex                                                               ; 9110: ca          .
+    bne loop_c9108                                                    ; 9111: d0 f5       ..
+; &9113 referenced 1 time by &911a
+.loop_c9113
+    clc                                                               ; 9113: 18          .
+    rts                                                               ; 9114: 60          `
+
+; &9115 referenced 1 time by &910e
+.c9115
+    lda lfe80                                                         ; 9115: ad 80 fe    ...
+    and #3                                                            ; 9118: 29 03       ).
+    beq loop_c9113                                                    ; 911a: f0 f7       ..
+    rts                                                               ; 911c: 60          `
+
+; &911d referenced 1 time by &8cd8
+.l911d
+    equs ")*-."                                                       ; 911d: 29 2a 2d... )*-
+; &9121 referenced 1 time by &8e15
+.l9121
+    equb   0, &10, &40, &50, &80, &81, &83, &a0, &a1, &c0, &e0, &f0   ; 9121: 00 10 40... ..@
+; &912d referenced 1 time by &8e1b
+.nmi_and_table
+    equb &18, &18, &18, &18, &3f, &1f, &1f, &5f, &5f, &17, &1b, &5f   ; 912d: 18 18 18... ...
+; &9139 referenced 1 time by &8c58
+.l9139
+    equb   8, &10, &18, &20, &40,   0                                 ; 9139: 08 10 18... ...
+; &913f referenced 1 time by &8c61
+.l913f
+    equb &0e, &18, &0c, &20, &12,   0                                 ; 913f: 0e 18 0c... ...
+; &9145 referenced 1 time by &92e3
+.l9145
+    equb &6d                                                          ; 9145: 6d          m
+; &9146 referenced 1 time by &92e8
+.l9146
+    equb &91, &49, &91                                                ; 9146: 91 49 91    .I.
+    equb &3c, &0c,   3                                                ; 9149: 3c 0c 03    <..
+    equb   1,   1,   1                                                ; 914c: 01 01 01    ...
+    equb   1,   1,   1                                                ; 914f: 01 01 01    ...
+    equb &16, &0c,   3                                                ; 9152: 16 0c 03    ...
+    equb   1, &ff,   1                                                ; 9155: 01 ff 01    ...
+    equb   1, &18,   4                                                ; 9158: 01 18 04    ...
+    equb &4e,   0, &f5                                                ; 915b: 4e 00 f5    N..
+    equb &fe,   0,   0                                                ; 915e: fe 00 00    ...
+    equb   0,   0, &f7                                                ; 9161: 00 00 f7    ...
+    equb &4e,   0                                                     ; 9164: 4e 00       N.
+    equb &f5, &fb, &5a, &5a, &f7, &4e, &4e, &10,   6,   0,   1,   1   ; 9166: f5 fb 5a... ..Z
+    equb   1,   1,   1,   1, &0b,   6,   0,   1, &ff,   1,   1, &13   ; 9172: 01 01 01... ...
+    equb   3, &ff,   0,   0, &fe,   0,   0,   0,   0, &f7, &ff,   0   ; 917e: 03 ff 00... ...
+    equb   0, &fb, &e5, &e5, &f7, &ff, &ff                            ; 918a: 00 fb e5... ...
+; &9191 referenced 1 time by &91df
+.l9191
+    equb &0a, &0b, &0e, &0f, &12, &13, &16, &17, &1b, &1e, &1f        ; 9191: 0a 0b 0e... ...
+    equs "#) 0"                                                       ; 919c: 23 29 20... #)
+; &91a0 referenced 1 time by &9201
+.l91a0
+    equb &a0, &a0, &a1, &a1, &80, &80, &81, &81, &c0, &83, &83, &f0   ; 91a0: a0 a0 a1... ...
+    equb &10, &e0, &f0                                                ; 91ac: 10 e0 f0    ...
+
+; &91af referenced 3 times by &9758, &a6dc, &a700
+.c91af
+    lda #&ff                                                          ; 91af: a9 ff       ..
+    sta l1082                                                         ; 91b1: 8d 82 10    ...
+    stx l00c7                                                         ; 91b4: 86 c7       ..
+    sty l00c8                                                         ; 91b6: 84 c8       ..
+    ldy #&0c                                                          ; 91b8: a0 0c       ..
+; &91ba referenced 1 time by &91c0
+.loop_c91ba
+    lda (l00c7),y                                                     ; 91ba: b1 c7       ..
+    sta l00ba,y                                                       ; 91bc: 99 ba 00    ...
+    dey                                                               ; 91bf: 88          .
+    bpl loop_c91ba                                                    ; 91c0: 10 f8       ..
+    ldx #&0c                                                          ; 91c2: a2 0c       ..
+    lda l00bf                                                         ; 91c4: a5 bf       ..
+    cmp #&0a                                                          ; 91c6: c9 0a       ..
+    bne c91cc                                                         ; 91c8: d0 02       ..
+    ldx #&0e                                                          ; 91ca: a2 0e       ..
+; &91cc referenced 1 time by &91c8
+.c91cc
+    lda l00c0                                                         ; 91cc: a5 c0       ..
+    and #&3f ; '?'                                                    ; 91ce: 29 3f       )?
+    cmp #&3a ; ':'                                                    ; 91d0: c9 3a       .:
+    beq c921f                                                         ; 91d2: f0 4b       .K
+    cmp #&3d ; '='                                                    ; 91d4: c9 3d       .=
+    beq c923f                                                         ; 91d6: f0 67       .g
+    cmp #&35 ; '5'                                                    ; 91d8: c9 35       .5
+    bne c91df                                                         ; 91da: d0 03       ..
+    jmp c925a                                                         ; 91dc: 4c 5a 92    LZ.
+
+; &91df referenced 2 times by &91da, &91e5
+.c91df
+    cmp l9191,x                                                       ; 91df: dd 91 91    ...
+    beq c91eb                                                         ; 91e2: f0 07       ..
+    dex                                                               ; 91e4: ca          .
+    bpl c91df                                                         ; 91e5: 10 f8       ..
+; &91e7 referenced 1 time by &91ff
+.loop_c91e7
+    lda #&fe                                                          ; 91e7: a9 fe       ..
+    bmi c9214                                                         ; 91e9: 30 29       0)
+; &91eb referenced 1 time by &91e2
+.c91eb
+    cmp #&23 ; '#'                                                    ; 91eb: c9 23       .#
+    beq c91f3                                                         ; 91ed: f0 04       ..
+    cpx #4                                                            ; 91ef: e0 04       ..
+    bcs c9201                                                         ; 91f1: b0 0e       ..
+; &91f3 referenced 1 time by &91ed
+.c91f3
+    lda l00ba                                                         ; 91f3: a5 ba       ..
+    bpl c91f9                                                         ; 91f5: 10 02       ..
+    lda l00cd                                                         ; 91f7: a5 cd       ..
+; &91f9 referenced 1 time by &91f5
+.c91f9
+    and #3                                                            ; 91f9: 29 03       ).
+    tay                                                               ; 91fb: a8          .
+    lda l10de,y                                                       ; 91fc: b9 de 10    ...
+    bmi loop_c91e7                                                    ; 91ff: 30 e6       0.
+; &9201 referenced 1 time by &91f1
+.c9201
+    ldy l91a0,x                                                       ; 9201: bc a0 91    ...
+    sty l00c0                                                         ; 9204: 84 c0       ..
+    cpy #&f0                                                          ; 9206: c0 f0       ..
+    bne c920d                                                         ; 9208: d0 03       ..
+    jsr sub_c929d                                                     ; 920a: 20 9d 92     ..
+; &920d referenced 1 time by &9208
+.c920d
+    ldx #&ba                                                          ; 920d: a2 ba       ..
+    ldy #0                                                            ; 920f: a0 00       ..
+    jsr sub_c8bf9                                                     ; 9211: 20 f9 8b     ..
+; &9214 referenced 3 times by &91e9, &9257, &9276
+.c9214
+    pha                                                               ; 9214: 48          H
+    lda l00bf                                                         ; 9215: a5 bf       ..
+    clc                                                               ; 9217: 18          .
+    adc #7                                                            ; 9218: 69 07       i.
+    tay                                                               ; 921a: a8          .
+    pla                                                               ; 921b: 68          h
+    sta (l00c7),y                                                     ; 921c: 91 c7       ..
+    rts                                                               ; 921e: 60          `
+
+; &921f referenced 1 time by &91d2
+.c921f
+    jsr sub_c928a                                                     ; 921f: 20 8a 92     ..
+    bcs c922b                                                         ; 9222: b0 07       ..
+    lda l00c2                                                         ; 9224: a5 c2       ..
+    sta l108b,x                                                       ; 9226: 9d 8b 10    ...
+    bcc c923b                                                         ; 9229: 90 10       ..
+; &922b referenced 1 time by &9222
+.c922b
+    jsr sub_c9279                                                     ; 922b: 20 79 92     y.
+    bcc c9257                                                         ; 922e: 90 27       .'
+    lda l00c2                                                         ; 9230: a5 c2       ..
+    ldy l10de,x                                                       ; 9232: bc de 10    ...
+    bpl c9238                                                         ; 9235: 10 01       ..
+    asl a                                                             ; 9237: 0a          .
+; &9238 referenced 1 time by &9235
+.c9238
+    sta l1088,x                                                       ; 9238: 9d 88 10    ...
+; &923b referenced 1 time by &9229
+.c923b
+    lda #0                                                            ; 923b: a9 00       ..
+    beq c9257                                                         ; 923d: f0 18       ..
+; &923f referenced 1 time by &91d6
+.c923f
+    jsr sub_c928a                                                     ; 923f: 20 8a 92     ..
+    bcs c9249                                                         ; 9242: b0 05       ..
+    lda l108b,x                                                       ; 9244: bd 8b 10    ...
+    bcc c9257                                                         ; 9247: 90 0e       ..
+; &9249 referenced 1 time by &9242
+.c9249
+    jsr sub_c9279                                                     ; 9249: 20 79 92     y.
+    bcc c9257                                                         ; 924c: 90 09       ..
+    lda l1088,x                                                       ; 924e: bd 88 10    ...
+    ldy l10de,x                                                       ; 9251: bc de 10    ...
+    bpl c9257                                                         ; 9254: 10 01       ..
+    lsr a                                                             ; 9256: 4a          J
+; &9257 referenced 5 times by &922e, &923d, &9247, &924c, &9254
+.c9257
+    jmp c9214                                                         ; 9257: 4c 14 92    L..
+
+; &925a referenced 1 time by &91dc
+.c925a
+    lda #&ff                                                          ; 925a: a9 ff       ..
+    ldx #0                                                            ; 925c: a2 00       ..
+    ldy l00c1                                                         ; 925e: a4 c1       ..
+    cpy #&10                                                          ; 9260: c0 10       ..
+    beq c926a                                                         ; 9262: f0 06       ..
+    cpy #&18                                                          ; 9264: c0 18       ..
+    bne c9276                                                         ; 9266: d0 0e       ..
+    inx                                                               ; 9268: e8          .
+    inx                                                               ; 9269: e8          .
+; &926a referenced 1 time by &9262
+.c926a
+    lda l00c2                                                         ; 926a: a5 c2       ..
+    sta l108b,x                                                       ; 926c: 9d 8b 10    ...
+    lda l00c3                                                         ; 926f: a5 c3       ..
+    sta l108c,x                                                       ; 9271: 9d 8c 10    ...
+    lda #0                                                            ; 9274: a9 00       ..
+; &9276 referenced 1 time by &9266
+.c9276
+    jmp c9214                                                         ; 9276: 4c 14 92    L..
+
+; &9279 referenced 2 times by &922b, &9249
+.sub_c9279
+    ldx #0                                                            ; 9279: a2 00       ..
+    lda l00c1                                                         ; 927b: a5 c1       ..
+    cmp #&12                                                          ; 927d: c9 12       ..
+    beq c9289                                                         ; 927f: f0 08       ..
+    inx                                                               ; 9281: e8          .
+    cmp #&1a                                                          ; 9282: c9 1a       ..
+    beq c9289                                                         ; 9284: f0 03       ..
+    lda #&fe                                                          ; 9286: a9 fe       ..
+    clc                                                               ; 9288: 18          .
+; &9289 referenced 2 times by &927f, &9284
+.c9289
+    rts                                                               ; 9289: 60          `
+
+; &928a referenced 2 times by &921f, &923f
+.sub_c928a
+    lda l00c1                                                         ; 928a: a5 c1       ..
+    and #&f6                                                          ; 928c: 29 f6       ).
+    cmp #&10                                                          ; 928e: c9 10       ..
+    sec                                                               ; 9290: 38          8
+    bne c929c                                                         ; 9291: d0 09       ..
+    lda l00c1                                                         ; 9293: a5 c1       ..
+    lsr a                                                             ; 9295: 4a          J
+    lsr a                                                             ; 9296: 4a          J
+    ora l00c1                                                         ; 9297: 05 c1       ..
+    and #3                                                            ; 9299: 29 03       ).
+    tax                                                               ; 929b: aa          .
+; &929c referenced 1 time by &9291
+.c929c
+    rts                                                               ; 929c: 60          `
+
+; &929d referenced 1 time by &920a
+.sub_c929d
+    jsr sub_c9a8d                                                     ; 929d: 20 8d 9a     ..
+    lda l00bb                                                         ; 92a0: a5 bb       ..
+    sta l00b0                                                         ; 92a2: 85 b0       ..
+    sta l00b4                                                         ; 92a4: 85 b4       ..
+    clc                                                               ; 92a6: 18          .
+    adc #&80                                                          ; 92a7: 69 80       i.
+    sta l00b2                                                         ; 92a9: 85 b2       ..
+    lda l00bc                                                         ; 92ab: a5 bc       ..
+    sta l00b1                                                         ; 92ad: 85 b1       ..
+    php                                                               ; 92af: 08          .
+    jsr sub_c8f3f                                                     ; 92b0: 20 3f 8f     ?.
+    bmi c92bd                                                         ; 92b3: 30 08       0.
+    lda l00bd                                                         ; 92b5: a5 bd       ..
+    ora l00be                                                         ; 92b7: 05 be       ..
+    cmp #&ff                                                          ; 92b9: c9 ff       ..
+    bne c92c4                                                         ; 92bb: d0 07       ..
+; &92bd referenced 1 time by &92b3
+.c92bd
+    lda l00b1                                                         ; 92bd: a5 b1       ..
+    cmp l10cf                                                         ; 92bf: cd cf 10    ...
+    bcs c92c7                                                         ; 92c2: b0 03       ..
+; &92c4 referenced 1 time by &92bb
+.c92c4
+    lda l10cf                                                         ; 92c4: ad cf 10    ...
+; &92c7 referenced 1 time by &92c2
+.c92c7
+    plp                                                               ; 92c7: 28          (
+    sta l00b5                                                         ; 92c8: 85 b5       ..
+    adc #0                                                            ; 92ca: 69 00       i.
+    sta l00b3                                                         ; 92cc: 85 b3       ..
+    inc l00b5                                                         ; 92ce: e6 b5       ..
+    lda l00ba                                                         ; 92d0: a5 ba       ..
+    bpl c92d6                                                         ; 92d2: 10 02       ..
+    lda #0                                                            ; 92d4: a9 00       ..
+; &92d6 referenced 1 time by &92d2
+.c92d6
+    rol a                                                             ; 92d6: 2a          *
+    rol a                                                             ; 92d7: 2a          *
+    rol a                                                             ; 92d8: 2a          *
+    sta l108a                                                         ; 92d9: 8d 8a 10    ...
+    ldx #2                                                            ; 92dc: a2 02       ..
+    rol a                                                             ; 92de: 2a          *
+    bmi c92e3                                                         ; 92df: 30 02       0.
+    ldx #0                                                            ; 92e1: a2 00       ..
+; &92e3 referenced 1 time by &92df
+.c92e3
+    lda l9145,x                                                       ; 92e3: bd 45 91    .E.
+    sta l00b6                                                         ; 92e6: 85 b6       ..
+    lda l9146,x                                                       ; 92e8: bd 46 91    .F.
+    sta l00b7                                                         ; 92eb: 85 b7       ..
+    ldy #&23 ; '#'                                                    ; 92ed: a0 23       .#
+; &92ef referenced 1 time by &92f4
+.loop_c92ef
+    lda (l00b6),y                                                     ; 92ef: b1 b6       ..
+    sta (l00b2),y                                                     ; 92f1: 91 b2       ..
+    dey                                                               ; 92f3: 88          .
+    bpl loop_c92ef                                                    ; 92f4: 10 f9       ..
+    iny                                                               ; 92f6: c8          .
+    sty l00b6                                                         ; 92f7: 84 b6       ..
+    lda l00c3                                                         ; 92f9: a5 c3       ..
+    pha                                                               ; 92fb: 48          H
+    and #&e0                                                          ; 92fc: 29 e0       ).
+    bne c9302                                                         ; 92fe: d0 02       ..
+    lda #&10                                                          ; 9300: a9 10       ..
+; &9302 referenced 1 time by &92fe
+.c9302
+    asl a                                                             ; 9302: 0a          .
+    rol l00b6                                                         ; 9303: 26 b6       &.
+    asl a                                                             ; 9305: 0a          .
+    rol l00b6                                                         ; 9306: 26 b6       &.
+    asl a                                                             ; 9308: 0a          .
+    rol l00b6                                                         ; 9309: 26 b6       &.
+    ldy #&0d                                                          ; 930b: a0 0d       ..
+    sta (l00b2),y                                                     ; 930d: 91 b2       ..
+    lda l00b6                                                         ; 930f: a5 b6       ..
+    iny                                                               ; 9311: c8          .
+    sta (l00b2),y                                                     ; 9312: 91 b2       ..
+    pla                                                               ; 9314: 68          h
+    and #&1f                                                          ; 9315: 29 1f       ).
+    sta l00b9                                                         ; 9317: 85 b9       ..
+    lda l00c2                                                         ; 9319: a5 c2       ..
+    ldy #&10                                                          ; 931b: a0 10       ..
+    sta (l00b2),y                                                     ; 931d: 91 b2       ..
+    lda l00c5                                                         ; 931f: a5 c5       ..
+    ldy #0                                                            ; 9321: a0 00       ..
+    sta (l00b2),y                                                     ; 9323: 91 b2       ..
+    tya                                                               ; 9325: 98          .
+    sta l00b8                                                         ; 9326: 85 b8       ..
+    jsr sub_c93d3                                                     ; 9328: 20 d3 93     ..
+    jsr sub_c8f3f                                                     ; 932b: 20 3f 8f     ?.
+    bmi c9367                                                         ; 932e: 30 37       07
+    lda l00bd                                                         ; 9330: a5 bd       ..
+    and l00be                                                         ; 9332: 25 be       %.
+    cmp #&ff                                                          ; 9334: c9 ff       ..
+    beq c9367                                                         ; 9336: f0 2f       ./
+    lda #&ff                                                          ; 9338: a9 ff       ..
+    sta l00bd                                                         ; 933a: 85 bd       ..
+    sta l00be                                                         ; 933c: 85 be       ..
+    jsr sub_c8f6b                                                     ; 933e: 20 6b 8f     k.
+    ldx #&bb                                                          ; 9341: a2 bb       ..
+    ldy #0                                                            ; 9343: a0 00       ..
+    tya                                                               ; 9345: 98          .
+    jsr tube_entry                                                    ; 9346: 20 06 04     ..
+    ldx l00b5                                                         ; 9349: a6 b5       ..
+    dex                                                               ; 934b: ca          .
+    stx l00b1                                                         ; 934c: 86 b1       ..
+    lda l00b9                                                         ; 934e: a5 b9       ..
+    asl a                                                             ; 9350: 0a          .
+    asl a                                                             ; 9351: 0a          .
+    tax                                                               ; 9352: aa          .
+    ldy #0                                                            ; 9353: a0 00       ..
+; &9355 referenced 1 time by &9362
+.loop_c9355
+    lda #7                                                            ; 9355: a9 07       ..
+; &9357 referenced 1 time by &9359
+.loop_c9357
+    sbc #1                                                            ; 9357: e9 01       ..
+    bne loop_c9357                                                    ; 9359: d0 fc       ..
+    lda tube_host_r3_data                                             ; 935b: ad e5 fe    ...
+    sta (l00b0),y                                                     ; 935e: 91 b0       ..
+    iny                                                               ; 9360: c8          .
+    dex                                                               ; 9361: ca          .
+    bpl loop_c9355                                                    ; 9362: 10 f1       ..
+    jsr sub_c8f7a                                                     ; 9364: 20 7a 8f     z.
+; &9367 referenced 2 times by &932e, &9336
+.c9367
+    lda l00b5                                                         ; 9367: a5 b5       ..
+    sta l00bc                                                         ; 9369: 85 bc       ..
+; &936b referenced 1 time by &939c
+.c936b
+    ldy #&16                                                          ; 936b: a0 16       ..
+    ldx #0                                                            ; 936d: a2 00       ..
+; &936f referenced 1 time by &937c
+.loop_c936f
+    lda (l00b0,x)                                                     ; 936f: a1 b0       ..
+    sta (l00b2),y                                                     ; 9371: 91 b2       ..
+    inc l00b0                                                         ; 9373: e6 b0       ..
+    bne c9379                                                         ; 9375: d0 02       ..
+    inc l00b1                                                         ; 9377: e6 b1       ..
+; &9379 referenced 1 time by &9375
+.c9379
+    iny                                                               ; 9379: c8          .
+    cpy #&1a                                                          ; 937a: c0 1a       ..
+    bne loop_c936f                                                    ; 937c: d0 f1       ..
+    lda #1                                                            ; 937e: a9 01       ..
+    sta l00b6                                                         ; 9380: 85 b6       ..
+; &9382 referenced 1 time by &9396
+.loop_c9382
+    lda l00b6                                                         ; 9382: a5 b6       ..
+    cmp #&0e                                                          ; 9384: c9 0e       ..
+    bne c938d                                                         ; 9386: d0 05       ..
+    jsr sub_c93b4                                                     ; 9388: 20 b4 93     ..
+    beq c9390                                                         ; 938b: f0 03       ..
+; &938d referenced 1 time by &9386
+.c938d
+    jsr sub_c93d3                                                     ; 938d: 20 d3 93     ..
+; &9390 referenced 1 time by &938b
+.c9390
+    inc l00b6                                                         ; 9390: e6 b6       ..
+    lda l00b6                                                         ; 9392: a5 b6       ..
+    cmp #&11                                                          ; 9394: c9 11       ..
+    bne loop_c9382                                                    ; 9396: d0 ea       ..
+    inc l00b8                                                         ; 9398: e6 b8       ..
+    dec l00b9                                                         ; 939a: c6 b9       ..
+    bne c936b                                                         ; 939c: d0 cd       ..
+    tay                                                               ; 939e: a8          .
+    lda #&0e                                                          ; 939f: a9 0e       ..
+    bit l108a                                                         ; 93a1: 2c 8a 10    ,..
+    bvc c93a8                                                         ; 93a4: 50 02       P.
+    lda #&1a                                                          ; 93a6: a9 1a       ..
+; &93a8 referenced 1 time by &93a4
+.c93a8
+    clc                                                               ; 93a8: 18          .
+    adc l00bc                                                         ; 93a9: 65 bc       e.
+    sbc l00b5                                                         ; 93ab: e5 b5       ..
+    bcs c93b1                                                         ; 93ad: b0 02       ..
+    lda #1                                                            ; 93af: a9 01       ..
+; &93b1 referenced 1 time by &93ad
+.c93b1
+    sta (l00b2),y                                                     ; 93b1: 91 b2       ..
+    tya                                                               ; 93b3: 98          .
+; &93b4 referenced 1 time by &9388
+.sub_c93b4
+    jsr sub_c93c5                                                     ; 93b4: 20 c5 93     ..
+    beq c93c4                                                         ; 93b7: f0 0b       ..
+    stx l00b7                                                         ; 93b9: 86 b7       ..
+    ldx #0                                                            ; 93bb: a2 00       ..
+; &93bd referenced 1 time by &93c2
+.loop_c93bd
+    jsr sub_c93d8                                                     ; 93bd: 20 d8 93     ..
+    dec l00b7                                                         ; 93c0: c6 b7       ..
+    bne loop_c93bd                                                    ; 93c2: d0 f9       ..
+; &93c4 referenced 1 time by &93b7
+.c93c4
+    rts                                                               ; 93c4: 60          `
+
+; &93c5 referenced 2 times by &93b4, &93d3
+.sub_c93c5
+    tay                                                               ; 93c5: a8          .
+    lda (l00b2),y                                                     ; 93c6: b1 b2       ..
+    tax                                                               ; 93c8: aa          .
+    tya                                                               ; 93c9: 98          .
+    clc                                                               ; 93ca: 18          .
+    adc #&12                                                          ; 93cb: 69 12       i.
+    tay                                                               ; 93cd: a8          .
+    lda (l00b2),y                                                     ; 93ce: b1 b2       ..
+    cpx #0                                                            ; 93d0: e0 00       ..
+    rts                                                               ; 93d2: 60          `
+
+; &93d3 referenced 2 times by &9328, &938d
+.sub_c93d3
+    jsr sub_c93c5                                                     ; 93d3: 20 c5 93     ..
+    beq c93e5                                                         ; 93d6: f0 0d       ..
+; &93d8 referenced 1 time by &93bd
+.sub_c93d8
+    ldy #0                                                            ; 93d8: a0 00       ..
+; &93da referenced 1 time by &93e3
+.loop_c93da
+    sta (l00b4),y                                                     ; 93da: 91 b4       ..
+    inc l00b4                                                         ; 93dc: e6 b4       ..
+    bne c93e2                                                         ; 93de: d0 02       ..
+    inc l00b5                                                         ; 93e0: e6 b5       ..
+; &93e2 referenced 1 time by &93de
+.c93e2
+    dex                                                               ; 93e2: ca          .
+    bne loop_c93da                                                    ; 93e3: d0 f5       ..
+; &93e5 referenced 1 time by &93d6
+.c93e5
+    rts                                                               ; 93e5: 60          `
+
+; &93e6 referenced 10 times by &8772, &8791, &87cb, &89d7, &8a6b, &8b12, &8bf3, &9bbc, &9fff, &a30a
+.c93e6
+    lda l0f04                                                         ; 93e6: ad 04 0f    ...
+    clc                                                               ; 93e9: 18          .
+    sed                                                               ; 93ea: f8          .
+    adc #1                                                            ; 93eb: 69 01       i.
+    sta l0f04                                                         ; 93ed: 8d 04 0f    ...
+    cld                                                               ; 93f0: d8          .
+; &93f1 referenced 1 time by &a737
+.sub_c93f1
+    ldy #&a0                                                          ; 93f1: a0 a0       ..
+    bne c940e                                                         ; 93f3: d0 19       ..
+; &93f5 referenced 2 times by &9636, &a7ce
+.sub_c93f5
+    ldy #&81                                                          ; 93f5: a0 81       ..
+    bne c940e                                                         ; 93f7: d0 15       ..
+; &93f9 referenced 1 time by &8266
+.sub_c93f9
+    ldy #&81                                                          ; 93f9: a0 81       ..
+    bne c93ff                                                         ; 93fb: d0 02       ..
+; &93fd referenced 3 times by &8287, &988e, &98da
+.sub_c93fd
+    ldy #&80                                                          ; 93fd: a0 80       ..
+; &93ff referenced 1 time by &93fb
+.c93ff
+    bit lfe84                                                         ; 93ff: 2c 84 fe    ,..
+    bpl c940e                                                         ; 9402: 10 0a       ..
+    lda l1082                                                         ; 9404: ad 82 10    ...
+    cmp l00cd                                                         ; 9407: c5 cd       ..
+    bne c940e                                                         ; 9409: d0 03       ..
+    rts                                                               ; 940b: 60          `
+
+; &940c referenced 6 times by &8383, &8489, &8a59, &a431, &a448, &a460
+.c940c
+    ldy #&80                                                          ; 940c: a0 80       ..
+; &940e referenced 4 times by &93f3, &93f7, &9402, &9409
+.c940e
+    jsr sub_c9536                                                     ; 940e: 20 36 95     6.
+    sty l1096                                                         ; 9411: 8c 96 10    ...
+    lda l00cd                                                         ; 9414: a5 cd       ..
+    sta l1090                                                         ; 9416: 8d 90 10    ...
+    lda #2                                                            ; 9419: a9 02       ..
+    sta l1099                                                         ; 941b: 8d 99 10    ...
+    lda #&0e                                                          ; 941e: a9 0e       ..
+    sta l1092                                                         ; 9420: 8d 92 10    ...
+    dec l1093                                                         ; 9423: ce 93 10    ...
+    dec l1094                                                         ; 9426: ce 94 10    ...
+    jsr sub_c9445                                                     ; 9429: 20 45 94     E.
+    lda l00cd                                                         ; 942c: a5 cd       ..
+    sta l1082                                                         ; 942e: 8d 82 10    ...
+    rts                                                               ; 9431: 60          `
+
+; &9432 referenced 2 times by &944d, &a6f9
+.sub_c9432
+    bit l00ff                                                         ; 9432: 24 ff       $.
+    bpl c9444                                                         ; 9434: 10 0e       ..
+; &9436 referenced 4 times by &946c, &a411, &a65d, &abc2
+.c9436
+    jsr sub_c9ad8                                                     ; 9436: 20 d8 9a     ..
+    jsr generate_error                                                ; 9439: 20 48 80     H.
+    equb &11                                                          ; 943c: 11          .
+    equs "Escape"                                                     ; 943d: 45 73 63... Esc
+    equb 0                                                            ; 9443: 00          .
+
+; &9444 referenced 3 times by &9434, &946a, &947a
+.c9444
+    rts                                                               ; 9444: 60          `
+
+; &9445 referenced 2 times by &886a, &9429
+.sub_c9445
+    jsr sub_c9516                                                     ; 9445: 20 16 95     ..
+    lda #6                                                            ; 9448: a9 06       ..
+    sta l109e                                                         ; 944a: 8d 9e 10    ...
+    jsr sub_c9432                                                     ; 944d: 20 32 94     2.
+; &9450 referenced 1 time by &94bf
+.c9450
+    lda l1097                                                         ; 9450: ad 97 10    ...
+    ldx l1090                                                         ; 9453: ae 90 10    ...
+    ldy l10de,x                                                       ; 9456: bc de 10    ...
+    bpl c945c                                                         ; 9459: 10 01       ..
+    asl a                                                             ; 945b: 0a          .
+; &945c referenced 1 time by &9459
+.c945c
+    ldy #&18                                                          ; 945c: a0 18       ..
+    cmp #&50 ; 'P'                                                    ; 945e: c9 50       .P
+    bcs c94c1                                                         ; 9460: b0 5f       ._
+    ldx #&90                                                          ; 9462: a2 90       ..
+    ldy #&10                                                          ; 9464: a0 10       ..
+    jsr sub_c8bf6                                                     ; 9466: 20 f6 8b     ..
+    tay                                                               ; 9469: a8          .
+    beq c9444                                                         ; 946a: f0 d8       ..
+    bmi c9436                                                         ; 946c: 30 c8       0.
+    cmp #&12                                                          ; 946e: c9 12       ..
+    beq c94c6                                                         ; 9470: f0 54       .T
+    cmp #&20 ; ' '                                                    ; 9472: c9 20       .
+    bne c948d                                                         ; 9474: d0 17       ..
+    lda l1096                                                         ; 9476: ad 96 10    ...
+    ror a                                                             ; 9479: 6a          j
+    bcs c9444                                                         ; 947a: b0 c8       ..
+    jsr generate_error                                                ; 947c: 20 48 80     H.
+    equb &bc                                                          ; 947f: bc          .
+    equs "Execute only"                                               ; 9480: 45 78 65... Exe
+    equb 0                                                            ; 948c: 00          .
+
+; &948d referenced 1 time by &9474
+.c948d
+    cmp #&18                                                          ; 948d: c9 18       ..
+    bne c94bc                                                         ; 948f: d0 2b       .+
+    lda l108a                                                         ; 9491: ad 8a 10    ...
+    cmp #4                                                            ; 9494: c9 04       ..
+    bne c94a9                                                         ; 9496: d0 11       ..
+    ldx l1096                                                         ; 9498: ae 96 10    ...
+    cpx #&81                                                          ; 949b: e0 81       ..
+    bne c94a9                                                         ; 949d: d0 0a       ..
+    lda #&ff                                                          ; 949f: a9 ff       ..
+    eor l108b                                                         ; 94a1: 4d 8b 10    M..
+    sta l108b                                                         ; 94a4: 8d 8b 10    ...
+    bcs c94bc                                                         ; 94a7: b0 13       ..
+; &94a9 referenced 2 times by &9496, &949d
+.c94a9
+    ldx l00ce                                                         ; 94a9: a6 ce       ..
+    beq c94bc                                                         ; 94ab: f0 0f       ..
+    rol a                                                             ; 94ad: 2a          *
+    and #&80                                                          ; 94ae: 29 80       ).
+    ldx l1090                                                         ; 94b0: ae 90 10    ...
+    eor l10de,x                                                       ; 94b3: 5d de 10    ]..
+    sta l10de,x                                                       ; 94b6: 9d de 10    ...
+    jsr sub_c9516                                                     ; 94b9: 20 16 95     ..
+; &94bc referenced 3 times by &948f, &94a7, &94ab
+.c94bc
+    dec l109e                                                         ; 94bc: ce 9e 10    ...
+    bne c9450                                                         ; 94bf: d0 8f       ..
+; &94c1 referenced 1 time by &9460
+.c94c1
+    tya                                                               ; 94c1: 98          .
+; &94c2 referenced 1 time by &a70f
+.c94c2
+    cmp #&12                                                          ; 94c2: c9 12       ..
+    bne c94d4                                                         ; 94c4: d0 0e       ..
+; &94c6 referenced 2 times by &9470, &9523
+.c94c6
+    jsr generate_error_precheck_disc                                  ; 94c6: 20 23 80     #.
+    equb &c9                                                          ; 94c9: c9          .
+    equs "read only"                                                  ; 94ca: 72 65 61... rea
+    equb 0                                                            ; 94d3: 00          .
+
+; &94d4 referenced 1 time by &94c4
+.c94d4
+    pha                                                               ; 94d4: 48          H
+    jsr generate_error_precheck_disc                                  ; 94d5: 20 23 80     #.
+    equb 0                                                            ; 94d8: 00          .
+
+    nop                                                               ; 94d9: ea          .
+    jsr generate_error2                                               ; 94da: 20 4f 80     O.
+    equb &c7                                                          ; 94dd: c7          .
+    equs "fault "                                                     ; 94de: 66 61 75... fau
+
+    nop                                                               ; 94e4: ea          .
+    pla                                                               ; 94e5: 68          h
+    jsr sub_c9526                                                     ; 94e6: 20 26 95     &.
+    jsr generate_error2                                               ; 94e9: 20 4f 80     O.
+    equb 0                                                            ; 94ec: 00          .
+    equs " at :"                                                      ; 94ed: 20 61 74...  at
+
+    lda l00cd                                                         ; 94f2: a5 cd       ..
+    jsr sub_c952e                                                     ; 94f4: 20 2e 95     ..
+    jsr generate_error2                                               ; 94f7: 20 4f 80     O.
+    equb 0                                                            ; 94fa: 00          .
+    equs " "                                                          ; 94fb: 20
+
+    lda l00ce                                                         ; 94fc: a5 ce       ..
+    bit l108a                                                         ; 94fe: 2c 8a 10    ,..
+    bpl c9504                                                         ; 9501: 10 01       ..
+    lsr a                                                             ; 9503: 4a          J
+; &9504 referenced 1 time by &9501
+.c9504
+    jsr sub_c9526                                                     ; 9504: 20 26 95     &.
+    jsr generate_error2                                               ; 9507: 20 4f 80     O.
+    equb 0                                                            ; 950a: 00          .
+    equs "/"                                                          ; 950b: 2f          /
+
+    lda l00cf                                                         ; 950c: a5 cf       ..
+    jsr sub_c9526                                                     ; 950e: 20 26 95     &.
+    jsr generate_error2                                               ; 9511: 20 4f 80     O.
+    equb &c7,   0                                                     ; 9514: c7 00       ..
+
+; &9516 referenced 2 times by &9445, &94b9
+.sub_c9516
+    lda l1096                                                         ; 9516: ad 96 10    ...
+    cmp #&a0                                                          ; 9519: c9 a0       ..
+    bcc c9535                                                         ; 951b: 90 18       ..
+    ldx l1090                                                         ; 951d: ae 90 10    ...
+    lda l10de,x                                                       ; 9520: bd de 10    ...
+    bmi c94c6                                                         ; 9523: 30 a1       0.
+    rts                                                               ; 9525: 60          `
+
+; &9526 referenced 3 times by &94e6, &9504, &950e
+.sub_c9526
+    pha                                                               ; 9526: 48          H
+    jsr sub_c81bf                                                     ; 9527: 20 bf 81     ..
+    jsr sub_c952e                                                     ; 952a: 20 2e 95     ..
+    pla                                                               ; 952d: 68          h
+; &952e referenced 2 times by &94f4, &952a
+.sub_c952e
+    jsr sub_c80c8                                                     ; 952e: 20 c8 80     ..
+    sta l0100,x                                                       ; 9531: 9d 00 01    ...
+    inx                                                               ; 9534: e8          .
+; &9535 referenced 1 time by &951b
+.c9535
+    rts                                                               ; 9535: 60          `
+
+; &9536 referenced 1 time by &940e
+.sub_c9536
+    ldx #&0d                                                          ; 9536: a2 0d       ..
+    lda #0                                                            ; 9538: a9 00       ..
+; &953a referenced 1 time by &953e
+.loop_c953a
+    sta l108f,x                                                       ; 953a: 9d 8f 10    ...
+    dex                                                               ; 953d: ca          .
+    bne loop_c953a                                                    ; 953e: d0 fa       ..
+    lda #5                                                            ; 9540: a9 05       ..
+    sta l1095                                                         ; 9542: 8d 95 10    ...
+    rts                                                               ; 9545: 60          `
+
+    equs "L.!BOOT", &0d                                               ; 9546: 4c 2e 21... L.!
+    equs "E.!BOOT", &0d                                               ; 954e: 45 2e 21... E.!
+
+; &9556 referenced 1 time by &96e9
+.c9556
+    lda l00b3                                                         ; 9556: a5 b3       ..
+    jsr print_inline_l809f_top_bit_clear                              ; 9558: 20 77 80     w.
+    equs "Acorn 1770 DFS", &0d, &0d                                   ; 955b: 41 63 6f... Aco
+
+    bcc c956f                                                         ; 956b: 90 02       ..
+; &956d referenced 1 time by &96fd
+.c956d
+    lda #&ff                                                          ; 956d: a9 ff       ..
+; &956f referenced 1 time by &956b
+.c956f
+    jsr zero_stacked_XXX                                              ; 956f: 20 8e 9d     ..
+    pha                                                               ; 9572: 48          H
+    lda #6                                                            ; 9573: a9 06       ..
+    jsr sub_c8020                                                     ; 9575: 20 20 80      .
+    lda lfe87                                                         ; 9578: ad 87 fe    ...
+    ldx #&0d                                                          ; 957b: a2 0d       ..
+; &957d referenced 1 time by &9584
+.loop_c957d
+    lda l9aec,x                                                       ; 957d: bd ec 9a    ...
+    sta filev,x                                                       ; 9580: 9d 12 02    ...
+    dex                                                               ; 9583: ca          .
+    bpl loop_c957d                                                    ; 9584: 10 f7       ..
+    lda #&a8                                                          ; 9586: a9 a8       ..
+    jsr osbyte_read                                                   ; 9588: 20 e5 9a     ..
+    sty l00b1                                                         ; 958b: 84 b1       ..
+    stx l00b0                                                         ; 958d: 86 b0       ..
+    ldx #7                                                            ; 958f: a2 07       ..
+    ldy #&1b                                                          ; 9591: a0 1b       ..
+; &9593 referenced 1 time by &95a5
+.loop_c9593
+    lda c9adf,y                                                       ; 9593: b9 df 9a    ...
+    sta (l00b0),y                                                     ; 9596: 91 b0       ..
+    iny                                                               ; 9598: c8          .
+    lda c9adf,y                                                       ; 9599: b9 df 9a    ...
+    sta (l00b0),y                                                     ; 959c: 91 b0       ..
+    iny                                                               ; 959e: c8          .
+    lda romsel_copy                                                   ; 959f: a5 f4       ..
+    sta (l00b0),y                                                     ; 95a1: 91 b0       ..
+    iny                                                               ; 95a3: c8          .
+    dex                                                               ; 95a4: ca          .
+    bne loop_c9593                                                    ; 95a5: d0 ec       ..
+    sty l1082                                                         ; 95a7: 8c 82 10    ...
+    sty l1083                                                         ; 95aa: 8c 83 10    ...
+    stx l00cd                                                         ; 95ad: 86 cd       ..
+    lda #&ff                                                          ; 95af: a9 ff       ..
+    sta l1087                                                         ; 95b1: 8d 87 10    ...
+    ldy #3                                                            ; 95b4: a0 03       ..
+; &95b6 referenced 1 time by &95ba
+.loop_c95b6
+    sta l108b,y                                                       ; 95b6: 99 8b 10    ...
+    dey                                                               ; 95b9: 88          .
+    bpl loop_c95b6                                                    ; 95ba: 10 fa       ..
+    ldx #&0f                                                          ; 95bc: a2 0f       ..
+    jsr c9adf                                                         ; 95be: 20 df 9a     ..
+    jsr sub_c9ab8                                                     ; 95c1: 20 b8 9a     ..
+    ldy #&d3                                                          ; 95c4: a0 d3       ..
+    lda (l00b0),y                                                     ; 95c6: b1 b0       ..
+    bpl c95fd                                                         ; 95c8: 10 33       .3
+    pla                                                               ; 95ca: 68          h
+    pha                                                               ; 95cb: 48          H
+    beq c95fd                                                         ; 95cc: f0 2f       ./
+    ldy #&d4                                                          ; 95ce: a0 d4       ..
+    lda (l00b0),y                                                     ; 95d0: b1 b0       ..
+    bmi c9628                                                         ; 95d2: 30 54       0T
+    jsr sub_c9aa3                                                     ; 95d4: 20 a3 9a     ..
+    ldy #0                                                            ; 95d7: a0 00       ..
+; &95d9 referenced 1 time by &95e8
+.loop_c95d9
+    lda (l00b0),y                                                     ; 95d9: b1 b0       ..
+    cpy #&c0                                                          ; 95db: c0 c0       ..
+    bcc c95e4                                                         ; 95dd: 90 05       ..
+    sta l1000,y                                                       ; 95df: 99 00 10    ...
+    bcs c95e7                                                         ; 95e2: b0 03       ..
+; &95e4 referenced 1 time by &95dd
+.c95e4
+    sta l1100,y                                                       ; 95e4: 99 00 11    ...
+; &95e7 referenced 1 time by &95e2
+.c95e7
+    dey                                                               ; 95e7: 88          .
+    bne loop_c95d9                                                    ; 95e8: d0 ef       ..
+    lda #&a0                                                          ; 95ea: a9 a0       ..
+; &95ec referenced 1 time by &95f9
+.loop_c95ec
+    tay                                                               ; 95ec: a8          .
+    pha                                                               ; 95ed: 48          H
+    lda #&3f ; '?'                                                    ; 95ee: a9 3f       .?
+    jsr sub_c9f16                                                     ; 95f0: 20 16 9f     ..
+    pla                                                               ; 95f3: 68          h
+    sta l111d,y                                                       ; 95f4: 99 1d 11    ...
+    sbc #&1f                                                          ; 95f7: e9 1f       ..
+    bne loop_c95ec                                                    ; 95f9: d0 f1       ..
+    beq c9628                                                         ; 95fb: f0 2b       .+
+; &95fd referenced 2 times by &95c8, &95cc
+.c95fd
+    jsr sub_c9aa3                                                     ; 95fd: 20 a3 9a     ..
+    lda #&24 ; '$'                                                    ; 9600: a9 24       .$
+    sta l10c9                                                         ; 9602: 8d c9 10    ...
+    sta l10cb                                                         ; 9605: 8d cb 10    ...
+    ldy #0                                                            ; 9608: a0 00       ..
+    sty l10ca                                                         ; 960a: 8c ca 10    ...
+    sty l10cc                                                         ; 960d: 8c cc 10    ...
+    ldy #0                                                            ; 9610: a0 00       ..
+    sty l10c0                                                         ; 9612: 8c c0 10    ...
+    ldx #3                                                            ; 9615: a2 03       ..
+    tya                                                               ; 9617: 98          .
+; &9618 referenced 1 time by &961c
+.loop_c9618
+    sta l10de,x                                                       ; 9618: 9d de 10    ...
+    dex                                                               ; 961b: ca          .
+    bne loop_c9618                                                    ; 961c: d0 fa       ..
+    dey                                                               ; 961e: 88          .
+    sty l10c7                                                         ; 961f: 8c c7 10    ...
+    sty l10c6                                                         ; 9622: 8c c6 10    ...
+    sty l10dd                                                         ; 9625: 8c dd 10    ...
+; &9628 referenced 2 times by &95d2, &95fb
+.c9628
+    jsr sub_c8f3f                                                     ; 9628: 20 3f 8f     ?.
+    pla                                                               ; 962b: 68          h
+    bne c9649                                                         ; 962c: d0 1b       ..
+    lda #4                                                            ; 962e: a9 04       ..
+    ora l10de                                                         ; 9630: 0d de 10    ...
+    sta l10de                                                         ; 9633: 8d de 10    ...
+    jsr sub_c93f5                                                     ; 9636: 20 f5 93     ..
+    lda #&fb                                                          ; 9639: a9 fb       ..
+    and l10de                                                         ; 963b: 2d de 10    -..
+    sta l10de                                                         ; 963e: 8d de 10    ...
+    lda l0f06                                                         ; 9641: ad 06 0f    ...
+    jsr sub_c81bf                                                     ; 9644: 20 bf 81     ..
+    bne c964a                                                         ; 9647: d0 01       ..
+; &9649 referenced 1 time by &962c
+.c9649
+    rts                                                               ; 9649: 60          `
+
+; &964a referenced 1 time by &9647
+.c964a
+    ldy #&95                                                          ; 964a: a0 95       ..
+    ldx #&46 ; 'F'                                                    ; 964c: a2 46       .F
+    cmp #2                                                            ; 964e: c9 02       ..
+    bcc c965a                                                         ; 9650: 90 08       ..
+    beq c9658                                                         ; 9652: f0 04       ..
+    ldx #&4e ; 'N'                                                    ; 9654: a2 4e       .N
+    bne c965a                                                         ; 9656: d0 02       ..
+; &9658 referenced 1 time by &9652
+.c9658
+    ldx #&50 ; 'P'                                                    ; 9658: a2 50       .P
+; &965a referenced 2 times by &9650, &9656
+.c965a
+    jmp oscli                                                         ; 965a: 4c f7 ff    L..
+
+; &965d referenced 1 time by &b1b1
+.sub_c965d
+    jsr service_handler_help_and_tube                                 ; 965d: 20 a9 ae     ..
+    pha                                                               ; 9660: 48          H
+    lda l0df0,x                                                       ; 9661: bd f0 0d    ...
+    bmi pla_rts                                                       ; 9664: 30 5b       0[
+    pla                                                               ; 9666: 68          h
+    cmp #service_claim_absolute_workspace                             ; 9667: c9 01       ..
+    bne c9683                                                         ; 9669: d0 18       ..
+    jsr set_c_iff_have_fdc                                            ; 966b: 20 04 91     ..
+    ldx romsel_copy                                                   ; 966e: a6 f4       ..
+    bcs c967a                                                         ; 9670: b0 08       ..
+    lda #&80                                                          ; 9672: a9 80       ..
+    sta l0df0,x                                                       ; 9674: 9d f0 0d    ...
+    lda #1                                                            ; 9677: a9 01       ..
+    rts                                                               ; 9679: 60          `
+
+; &967a referenced 1 time by &9670
+.c967a
+    lda #service_claim_absolute_workspace                             ; 967a: a9 01       ..
+    cpy #&17                                                          ; 967c: c0 17       ..
+    bcs c9682                                                         ; 967e: b0 02       ..
+    ldy #&17                                                          ; 9680: a0 17       ..
+; &9682 referenced 1 time by &967e
+.c9682
+    rts                                                               ; 9682: 60          `
+
+; &9683 referenced 1 time by &9669
+.c9683
+    cmp #service_claim_private_workspace                              ; 9683: c9 02       ..
+    bne c96c3                                                         ; 9685: d0 3c       .<
+    pha                                                               ; 9687: 48          H
+    tya                                                               ; 9688: 98          .
+    pha                                                               ; 9689: 48          H
+    sta l00b1                                                         ; 968a: 85 b1       ..
+    ldy l0df0,x                                                       ; 968c: bc f0 0d    ...
+    sta l0df0,x                                                       ; 968f: 9d f0 0d    ...
+    lda #0                                                            ; 9692: a9 00       ..
+    sta l00b0                                                         ; 9694: 85 b0       ..
+    cpy l00b1                                                         ; 9696: c4 b1       ..
+    beq c969e                                                         ; 9698: f0 04       ..
+    ldy #&d3                                                          ; 969a: a0 d3       ..
+    sta (l00b0),y                                                     ; 969c: 91 b0       ..
+; &969e referenced 1 time by &9698
+.c969e
+    lda #&fd                                                          ; 969e: a9 fd       ..
+    jsr osbyte_read                                                   ; 96a0: 20 e5 9a     ..
+    dex                                                               ; 96a3: ca          .
+    txa                                                               ; 96a4: 8a          .
+    ldy #&d3                                                          ; 96a5: a0 d3       ..
+    and (l00b0),y                                                     ; 96a7: 31 b0       1.
+    sta (l00b0),y                                                     ; 96a9: 91 b0       ..
+    php                                                               ; 96ab: 08          .
+    iny                                                               ; 96ac: c8          .
+    plp                                                               ; 96ad: 28          (
+    bpl c96b7                                                         ; 96ae: 10 07       ..
+    lda (l00b0),y                                                     ; 96b0: b1 b0       ..
+    bpl c96b7                                                         ; 96b2: 10 03       ..
+    jsr sub_c8951                                                     ; 96b4: 20 51 89     Q.
+; &96b7 referenced 2 times by &96ae, &96b2
+.c96b7
+    lda #0                                                            ; 96b7: a9 00       ..
+    sta (l00b0),y                                                     ; 96b9: 91 b0       ..
+    ldx romsel_copy                                                   ; 96bb: a6 f4       ..
+    pla                                                               ; 96bd: 68          h
+    tay                                                               ; 96be: a8          .
+    iny                                                               ; 96bf: c8          .
+    iny                                                               ; 96c0: c8          .
+; &96c1 referenced 1 time by &9664
+.pla_rts
+    pla                                                               ; 96c1: 68          h
+; &96c2 referenced 1 time by &96df
+.loop_c96c2
+    rts                                                               ; 96c2: 60          `
+
+; &96c3 referenced 1 time by &9685
+.c96c3
+    jsr sub_c83e3                                                     ; 96c3: 20 e3 83     ..
+    cmp #service_boot                                                 ; 96c6: c9 03       ..
+    bne c96ec                                                         ; 96c8: d0 22       ."
+    sty l00b3                                                         ; 96ca: 84 b3       ..
+    lda #0                                                            ; 96cc: a9 00       ..
+    sta l10de                                                         ; 96ce: 8d de 10    ...
+    lda #osbyte_scan_keyboard_from_16                                 ; 96d1: a9 7a       .z
+    jsr osbyte                                                        ; 96d3: 20 f4 ff     ..
+    txa                                                               ; 96d6: 8a          .
+    bmi c96e9                                                         ; 96d7: 30 10       0.
+    cmp #&32 ; '2'                                                    ; 96d9: c9 32       .2
+    beq c96e4                                                         ; 96db: f0 07       ..
+    cmp #&61 ; 'a'                                                    ; 96dd: c9 61       .a
+    bne loop_c96c2                                                    ; 96df: d0 e1       ..
+    jsr sub_cac72                                                     ; 96e1: 20 72 ac     r.
+; &96e4 referenced 1 time by &96db
+.c96e4
+    lda #osbyte_write_keys_pressed                                    ; 96e4: a9 78       .x
+    jsr osbyte                                                        ; 96e6: 20 f4 ff     ..
+; &96e9 referenced 1 time by &96d7
+.c96e9
+    jmp c9556                                                         ; 96e9: 4c 56 95    LV.
+
+; &96ec referenced 1 time by &96c8
+.c96ec
+    cmp #service_unrecognised_command                                 ; 96ec: c9 04       ..
+    bne c96f5                                                         ; 96ee: d0 05       ..
+    ldx #&9b                                                          ; 96f0: a2 9b       ..
+; &96f2 referenced 1 time by &970a
+.loop_c96f2
+    jmp c8703                                                         ; 96f2: 4c 03 87    L..
+
+; &96f5 referenced 1 time by &96ee
+.c96f5
+    cmp #service_select_filing_system                                 ; 96f5: c9 12       ..
+    bne c9700                                                         ; 96f7: d0 07       ..
+    cpy #4                                                            ; 96f9: c0 04       ..
+    bne c973c                                                         ; 96fb: d0 3f       .?
+    jmp c956d                                                         ; 96fd: 4c 6d 95    Lm.
+
+; &9700 referenced 1 time by &96f7
+.c9700
+    cmp #service_help                                                 ; 9700: c9 09       ..
+    bne c9714                                                         ; 9702: d0 10       ..
+    lda (os_text_ptr),y                                               ; 9704: b1 f2       ..
+    ldx #&cf                                                          ; 9706: a2 cf       ..
+    cmp #&0d                                                          ; 9708: c9 0d       ..
+    bne loop_c96f2                                                    ; 970a: d0 e6       ..
+    tya                                                               ; 970c: 98          .
+    inx                                                               ; 970d: e8          .
+    inx                                                               ; 970e: e8          .
+    ldy #2                                                            ; 970f: a0 02       ..
+    jmp ca10b                                                         ; 9711: 4c 0b a1    L..
+
+; &9714 referenced 1 time by &9702
+.c9714
+    jsr zero_stacked_XXX                                              ; 9714: 20 8e 9d     ..
+    cmp #service_absolute_workspace_claimed                           ; 9717: c9 0a       ..
+    bne c973d                                                         ; 9719: d0 22       ."
+    jsr sub_c9ab8                                                     ; 971b: 20 b8 9a     ..
+    ldy #&d4                                                          ; 971e: a0 d4       ..
+    lda (l00b0),y                                                     ; 9720: b1 b0       ..
+    bpl c9736                                                         ; 9722: 10 12       ..
+    ldy #0                                                            ; 9724: a0 00       ..
+    jsr sub_c9d75                                                     ; 9726: 20 75 9d     u.
+    jsr sub_c8951                                                     ; 9729: 20 51 89     Q.
+    jsr sub_c9ab8                                                     ; 972c: 20 b8 9a     ..
+    ldy #&d4                                                          ; 972f: a0 d4       ..
+    lda #0                                                            ; 9731: a9 00       ..
+    sta (l00b0),y                                                     ; 9733: 91 b0       ..
+    rts                                                               ; 9735: 60          `
+
+; &9736 referenced 1 time by &9722
+.c9736
+    lda #&0a                                                          ; 9736: a9 0a       ..
+; &9738 referenced 3 times by &973f, &9743, &9747
+.c9738
+    tsx                                                               ; 9738: ba          .
+    sta l0105,x                                                       ; 9739: 9d 05 01    ...
+; &973c referenced 1 time by &96fb
+.c973c
+    rts                                                               ; 973c: 60          `
+
+; &973d referenced 1 time by &9719
+.c973d
+    cmp #service_unrecognised_osword                                  ; 973d: c9 08       ..
+    bne c9738                                                         ; 973f: d0 f7       ..
+    ldy l00ef                                                         ; 9741: a4 ef       ..
+    bmi c9738                                                         ; 9743: 30 f3       0.
+    cpy #&7d ; '}'                                                    ; 9745: c0 7d       .}
+    bcc c9738                                                         ; 9747: 90 ef       ..
+    ldx l00f0                                                         ; 9749: a6 f0       ..
+    stx l00c7                                                         ; 974b: 86 c7       ..
+    ldx l00f1                                                         ; 974d: a6 f1       ..
+    stx l00c8                                                         ; 974f: 86 c8       ..
+    iny                                                               ; 9751: c8          .
+    bpl c975b                                                         ; 9752: 10 07       ..
+    ldx l00c7                                                         ; 9754: a6 c7       ..
+    ldy l00c8                                                         ; 9756: a4 c8       ..
+    jmp c91af                                                         ; 9758: 4c af 91    L..
+
+; &975b referenced 1 time by &9752
+.c975b
+    jsr sub_c8b7b                                                     ; 975b: 20 7b 8b     {.
+    jsr sub_c8380                                                     ; 975e: 20 80 83     ..
+    iny                                                               ; 9761: c8          .
+    bmi c976c                                                         ; 9762: 30 08       0.
+    ldy #0                                                            ; 9764: a0 00       ..
+    lda l0f04                                                         ; 9766: ad 04 0f    ...
+    sta (l00c7),y                                                     ; 9769: 91 c7       ..
+    rts                                                               ; 976b: 60          `
+
+; &976c referenced 1 time by &9762
+.c976c
+    lda #0                                                            ; 976c: a9 00       ..
+    tay                                                               ; 976e: a8          .
+    sta (l00c7),y                                                     ; 976f: 91 c7       ..
+    iny                                                               ; 9771: c8          .
+    lda l0f07                                                         ; 9772: ad 07 0f    ...
+    sta (l00c7),y                                                     ; 9775: 91 c7       ..
+    iny                                                               ; 9777: c8          .
+    lda l0f06                                                         ; 9778: ad 06 0f    ...
+    and #3                                                            ; 977b: 29 03       ).
+    sta (l00c7),y                                                     ; 977d: 91 c7       ..
+    iny                                                               ; 977f: c8          .
+    lda #0                                                            ; 9780: a9 00       ..
+    sta (l00c7),y                                                     ; 9782: 91 c7       ..
+    rts                                                               ; 9784: 60          `
+
+.sub_c9785
+    jsr sub_c840c                                                     ; 9785: 20 0c 84     ..
+    pha                                                               ; 9788: 48          H
+    jsr c99a3                                                         ; 9789: 20 a3 99     ..
+    stx l00b0                                                         ; 978c: 86 b0       ..
+    stx l10db                                                         ; 978e: 8e db 10    ...
+    sty l00b1                                                         ; 9791: 84 b1       ..
+    sty l10dc                                                         ; 9793: 8c dc 10    ...
+    ldx #0                                                            ; 9796: a2 00       ..
+    ldy #0                                                            ; 9798: a0 00       ..
+    jsr sub_c80e3                                                     ; 979a: 20 e3 80     ..
+; &979d referenced 1 time by &97a2
+.loop_c979d
+    jsr sub_c80d3                                                     ; 979d: 20 d3 80     ..
+    cpy #&12                                                          ; 97a0: c0 12       ..
+    bne loop_c979d                                                    ; 97a2: d0 f9       ..
+    pla                                                               ; 97a4: 68          h
+    tax                                                               ; 97a5: aa          .
+    inx                                                               ; 97a6: e8          .
+    cpx #8                                                            ; 97a7: e0 08       ..
+    bcs c97b3                                                         ; 97a9: b0 08       ..
+    lda l9b29,x                                                       ; 97ab: bd 29 9b    .).
+    pha                                                               ; 97ae: 48          H
+    lda l9b21,x                                                       ; 97af: bd 21 9b    .!.
+    pha                                                               ; 97b2: 48          H
+; &97b3 referenced 2 times by &97a9, &97b8
+.c97b3
+    lda #0                                                            ; 97b3: a9 00       ..
+    rts                                                               ; 97b5: 60          `
+
+.sub_c97b6
+    cmp #9                                                            ; 97b6: c9 09       ..
+    bcs c97b3                                                         ; 97b8: b0 f9       ..
+    stx l00b5                                                         ; 97ba: 86 b5       ..
+    tax                                                               ; 97bc: aa          .
+    lda l9b18,x                                                       ; 97bd: bd 18 9b    ...
+    pha                                                               ; 97c0: 48          H
+    lda l9b0f,x                                                       ; 97c1: bd 0f 9b    ...
+    pha                                                               ; 97c4: 48          H
+    txa                                                               ; 97c5: 8a          .
+    ldx l00b5                                                         ; 97c6: a6 b5       ..
+; &97c8 referenced 1 time by &97cb
+.loop_c97c8
+    rts                                                               ; 97c8: 60          `
+
+.sub_c97c9
+    cmp #9                                                            ; 97c9: c9 09       ..
+    bcs loop_c97c8                                                    ; 97cb: b0 fb       ..
+    jsr sub_c83e3                                                     ; 97cd: 20 e3 83     ..
+    jsr zero_stacked_XXX                                              ; 97d0: 20 8e 9d     ..
+    stx l107d                                                         ; 97d3: 8e 7d 10    .}.
+    sty l107e                                                         ; 97d6: 8c 7e 10    .~.
+    tay                                                               ; 97d9: a8          .
+    jsr sub_c97e8                                                     ; 97da: 20 e8 97     ..
+    php                                                               ; 97dd: 08          .
+    bit l1081                                                         ; 97de: 2c 81 10    ,..
+    bpl c97e6                                                         ; 97e1: 10 03       ..
+    jsr sub_c8f7a                                                     ; 97e3: 20 7a 8f     z.
+; &97e6 referenced 1 time by &97e1
+.c97e6
+    plp                                                               ; 97e6: 28          (
+    rts                                                               ; 97e7: 60          `
+
+; &97e8 referenced 1 time by &97da
+.sub_c97e8
+    lda l9b31,y                                                       ; 97e8: b9 31 9b    .1.
+    sta l10d7                                                         ; 97eb: 8d d7 10    ...
+    lda l9b3a,y                                                       ; 97ee: b9 3a 9b    .:.
+    sta l10d8                                                         ; 97f1: 8d d8 10    ...
+    lda l9b43,y                                                       ; 97f4: b9 43 9b    .C.
+    lsr a                                                             ; 97f7: 4a          J
+    php                                                               ; 97f8: 08          .
+    lsr a                                                             ; 97f9: 4a          J
+    php                                                               ; 97fa: 08          .
+    sta l107f                                                         ; 97fb: 8d 7f 10    ...
+    jsr sub_c995a                                                     ; 97fe: 20 5a 99     Z.
+    ldy #&0c                                                          ; 9801: a0 0c       ..
+; &9803 referenced 1 time by &9809
+.loop_c9803
+    lda (l00b4),y                                                     ; 9803: b1 b4       ..
+    sta l1060,y                                                       ; 9805: 99 60 10    .`.
+    dey                                                               ; 9808: 88          .
+    bpl loop_c9803                                                    ; 9809: 10 f8       ..
+    lda l1063                                                         ; 980b: ad 63 10    .c.
+    and l1064                                                         ; 980e: 2d 64 10    -d.
+    ora l10d6                                                         ; 9811: 0d d6 10    ...
+    clc                                                               ; 9814: 18          .
+    adc #1                                                            ; 9815: 69 01       i.
+    beq c981f                                                         ; 9817: f0 06       ..
+    jsr sub_c8f6b                                                     ; 9819: 20 6b 8f     k.
+    clc                                                               ; 981c: 18          .
+    lda #&ff                                                          ; 981d: a9 ff       ..
+; &981f referenced 1 time by &9817
+.c981f
+    sta l1081                                                         ; 981f: 8d 81 10    ...
+    lda l107f                                                         ; 9822: ad 7f 10    ...
+    bcs c982e                                                         ; 9825: b0 07       ..
+    ldx #&61 ; 'a'                                                    ; 9827: a2 61       .a
+    ldy #&10                                                          ; 9829: a0 10       ..
+    jsr tube_entry                                                    ; 982b: 20 06 04     ..
+; &982e referenced 1 time by &9825
+.c982e
+    plp                                                               ; 982e: 28          (
+    bcs c9835                                                         ; 982f: b0 04       ..
+    plp                                                               ; 9831: 28          (
+; &9832 referenced 1 time by &9861
+.sub_c9832
+    jmp (l10d7)                                                       ; 9832: 6c d7 10    l..
+
+; &9835 referenced 1 time by &982f
+.c9835
+    ldx #3                                                            ; 9835: a2 03       ..
+; &9837 referenced 1 time by &983d
+.loop_c9837
+    lda l1069,x                                                       ; 9837: bd 69 10    .i.
+    sta l00b6,x                                                       ; 983a: 95 b6       ..
+    dex                                                               ; 983c: ca          .
+    bpl loop_c9837                                                    ; 983d: 10 f8       ..
+    ldx #&b6                                                          ; 983f: a2 b6       ..
+    ldy l1060                                                         ; 9841: ac 60 10    .`.
+    lda #0                                                            ; 9844: a9 00       ..
+    plp                                                               ; 9846: 28          (
+    bcs c984c                                                         ; 9847: b0 03       ..
+    jsr ca06c                                                         ; 9849: 20 6c a0     l.
+; &984c referenced 1 time by &9847
+.c984c
+    jsr c9dd5                                                         ; 984c: 20 d5 9d     ..
+    ldx #3                                                            ; 984f: a2 03       ..
+; &9851 referenced 1 time by &9857
+.loop_c9851
+    lda l00b6,x                                                       ; 9851: b5 b6       ..
+    sta l1069,x                                                       ; 9853: 9d 69 10    .i.
+    dex                                                               ; 9856: ca          .
+    bpl loop_c9851                                                    ; 9857: 10 f8       ..
+; &9859 referenced 1 time by &989b
+.c9859
+    jsr invert_l1065                                                  ; 9859: 20 4c 99     L.
+    bmi c986b                                                         ; 985c: 30 0d       0.
+; &985e referenced 1 time by &9870
+.loop_c985e
+    ldy l1060                                                         ; 985e: ac 60 10    .`.
+    jsr sub_c9832                                                     ; 9861: 20 32 98     2.
+    bcs c9873                                                         ; 9864: b0 0d       ..
+    ldx #9                                                            ; 9866: a2 09       ..
+    jsr sub_c9940                                                     ; 9868: 20 40 99     @.
+; &986b referenced 1 time by &985c
+.c986b
+    ldx #5                                                            ; 986b: a2 05       ..
+    jsr sub_c9940                                                     ; 986d: 20 40 99     @.
+    bne loop_c985e                                                    ; 9870: d0 ec       ..
+    clc                                                               ; 9872: 18          .
+; &9873 referenced 1 time by &9864
+.c9873
+    php                                                               ; 9873: 08          .
+    jsr invert_l1065                                                  ; 9874: 20 4c 99     L.
+    ldx #5                                                            ; 9877: a2 05       ..
+    jsr sub_c9940                                                     ; 9879: 20 40 99     @.
+    ldy #&0c                                                          ; 987c: a0 0c       ..
+    jsr sub_c995a                                                     ; 987e: 20 5a 99     Z.
+; &9881 referenced 1 time by &9887
+.loop_c9881
+    lda l1060,y                                                       ; 9881: b9 60 10    .`.
+    sta (l00b4),y                                                     ; 9884: 91 b4       ..
+    dey                                                               ; 9886: 88          .
+    bpl loop_c9881                                                    ; 9887: 10 f8       ..
+    plp                                                               ; 9889: 28          (
+    rts                                                               ; 988a: 60          `
+
+    jsr sub_c8b7b                                                     ; 988b: 20 7b 8b     {.
+    jsr sub_c93fd                                                     ; 988e: 20 fd 93     ..
+    lda #&9d                                                          ; 9891: a9 9d       ..
+    sta l10d7                                                         ; 9893: 8d d7 10    ...
+    lda #&98                                                          ; 9896: a9 98       ..
+    sta l10d8                                                         ; 9898: 8d d8 10    ...
+    bne c9859                                                         ; 989b: d0 bc       ..
+    ldy l1069                                                         ; 989d: ac 69 10    .i.
+; &98a0 referenced 1 time by &98b8
+.loop_c98a0
+    cpy l0f05                                                         ; 98a0: cc 05 0f    ...
+    bcs c98cd                                                         ; 98a3: b0 28       .(
+    lda l0e0f,y                                                       ; 98a5: b9 0f 0e    ...
+    jsr sub_c8327                                                     ; 98a8: 20 27 83     '.
+    eor l00cc                                                         ; 98ab: 45 cc       E.
+    bcs c98b1                                                         ; 98ad: b0 02       ..
+    and #&df                                                          ; 98af: 29 df       ).
+; &98b1 referenced 1 time by &98ad
+.c98b1
+    and #&7f                                                          ; 98b1: 29 7f       ).
+    beq c98ba                                                         ; 98b3: f0 05       ..
+    jsr sub_c87da                                                     ; 98b5: 20 da 87     ..
+    bne loop_c98a0                                                    ; 98b8: d0 e6       ..
+; &98ba referenced 1 time by &98b3
+.c98ba
+    lda #7                                                            ; 98ba: a9 07       ..
+    jsr c996e                                                         ; 98bc: 20 6e 99     n.
+    sta l00b0                                                         ; 98bf: 85 b0       ..
+; &98c1 referenced 1 time by &98ca
+.loop_c98c1
+    lda l0e08,y                                                       ; 98c1: b9 08 0e    ...
+    jsr c996e                                                         ; 98c4: 20 6e 99     n.
+    iny                                                               ; 98c7: c8          .
+    dec l00b0                                                         ; 98c8: c6 b0       ..
+    bne loop_c98c1                                                    ; 98ca: d0 f5       ..
+    clc                                                               ; 98cc: 18          .
+; &98cd referenced 1 time by &98a3
+.c98cd
+    sty l1069                                                         ; 98cd: 8c 69 10    .i.
+    lda l0f04                                                         ; 98d0: ad 04 0f    ...
+    sta l1060                                                         ; 98d3: 8d 60 10    .`.
+    rts                                                               ; 98d6: 60          `
+
+    jsr sub_c8b7b                                                     ; 98d7: 20 7b 8b     {.
+    jsr sub_c93fd                                                     ; 98da: 20 fd 93     ..
+    lda #&0c                                                          ; 98dd: a9 0c       ..
+    jsr c996e                                                         ; 98df: 20 6e 99     n.
+    ldy #0                                                            ; 98e2: a0 00       ..
+; &98e4 referenced 1 time by &98f6
+.loop_c98e4
+    cpy #8                                                            ; 98e4: c0 08       ..
+    bcs c98ed                                                         ; 98e6: b0 05       ..
+    lda l0e00,y                                                       ; 98e8: b9 00 0e    ...
+    bcc c98f0                                                         ; 98eb: 90 03       ..
+; &98ed referenced 1 time by &98e6
+.c98ed
+    lda l0ef8,y                                                       ; 98ed: b9 f8 0e    ...
+; &98f0 referenced 1 time by &98eb
+.c98f0
+    jsr c996e                                                         ; 98f0: 20 6e 99     n.
+    iny                                                               ; 98f3: c8          .
+    cpy #&0c                                                          ; 98f4: c0 0c       ..
+    bne loop_c98e4                                                    ; 98f6: d0 ec       ..
+    lda l0f06                                                         ; 98f8: ad 06 0f    ...
+    jsr sub_c81bf                                                     ; 98fb: 20 bf 81     ..
+    jsr c996e                                                         ; 98fe: 20 6e 99     n.
+    lda l00cd                                                         ; 9901: a5 cd       ..
+    jmp c996e                                                         ; 9903: 4c 6e 99    Ln.
+
+    jsr sub_c9965                                                     ; 9906: 20 65 99     e.
+    lda l10ca                                                         ; 9909: ad ca 10    ...
+    ora #&30 ; '0'                                                    ; 990c: 09 30       .0
+    jsr c996e                                                         ; 990e: 20 6e 99     n.
+    jsr sub_c9965                                                     ; 9911: 20 65 99     e.
+    lda l10c9                                                         ; 9914: ad c9 10    ...
+    bne c996e                                                         ; 9917: d0 55       .U
+    jsr sub_c9965                                                     ; 9919: 20 65 99     e.
+    lda l10cc                                                         ; 991c: ad cc 10    ...
+    ora #&30 ; '0'                                                    ; 991f: 09 30       .0
+    jsr c996e                                                         ; 9921: 20 6e 99     n.
+    jsr sub_c9965                                                     ; 9924: 20 65 99     e.
+    lda l10cb                                                         ; 9927: ad cb 10    ...
+    bne c996e                                                         ; 992a: d0 42       .B
+; &992c referenced 2 times by &9978, &9993
+.sub_c992c
+    pha                                                               ; 992c: 48          H
+    lda l1061                                                         ; 992d: ad 61 10    .a.
+    sta l00b8                                                         ; 9930: 85 b8       ..
+    lda l1062                                                         ; 9932: ad 62 10    .b.
+    sta l00b9                                                         ; 9935: 85 b9       ..
+    ldx #0                                                            ; 9937: a2 00       ..
+    pla                                                               ; 9939: 68          h
+    rts                                                               ; 993a: 60          `
+
+; &993b referenced 4 times by &9976, &997d, &9990, &9998
+.c993b
+    jsr sub_c83e3                                                     ; 993b: 20 e3 83     ..
+    ldx #1                                                            ; 993e: a2 01       ..
+; &9940 referenced 3 times by &9868, &986d, &9879
+.sub_c9940
+    ldy #4                                                            ; 9940: a0 04       ..
+; &9942 referenced 1 time by &9949
+.loop_c9942
+    inc l1060,x                                                       ; 9942: fe 60 10    .`.
+    bne c994b                                                         ; 9945: d0 04       ..
+    inx                                                               ; 9947: e8          .
+    dey                                                               ; 9948: 88          .
+    bne loop_c9942                                                    ; 9949: d0 f7       ..
+; &994b referenced 1 time by &9945
+.c994b
+    rts                                                               ; 994b: 60          `
+
+; Invert the 32-bit value at l1065
+; &994c referenced 2 times by &9859, &9874
+.invert_l1065
+    ldx #3                                                            ; 994c: a2 03       ..
+; &994e referenced 1 time by &9957
+.loop_c994e
+    lda #&ff                                                          ; 994e: a9 ff       ..
+    eor l1065,x                                                       ; 9950: 5d 65 10    ]e.
+    sta l1065,x                                                       ; 9953: 9d 65 10    .e.
+    dex                                                               ; 9956: ca          .
+    bpl loop_c994e                                                    ; 9957: 10 f5       ..
+    rts                                                               ; 9959: 60          `
+
+; &995a referenced 2 times by &97fe, &987e
+.sub_c995a
+    lda l107d                                                         ; 995a: ad 7d 10    .}.
+    sta l00b4                                                         ; 995d: 85 b4       ..
+    lda l107e                                                         ; 995f: ad 7e 10    .~.
+    sta l00b5                                                         ; 9962: 85 b5       ..
+; &9964 referenced 1 time by &996c
+.loop_c9964
+    rts                                                               ; 9964: 60          `
+
+; &9965 referenced 4 times by &9906, &9911, &9919, &9924
+.sub_c9965
+    lda #1                                                            ; 9965: a9 01       ..
+    bne c996e                                                         ; 9967: d0 05       ..
+    jsr sub_c9e94                                                     ; 9969: 20 94 9e     ..
+    bcs loop_c9964                                                    ; 996c: b0 f6       ..
+; &996e referenced 11 times by &98bc, &98c4, &98df, &98f0, &98fe, &9903, &990e, &9917, &9921, &992a, &9967
+.c996e
+    bit l1081                                                         ; 996e: 2c 81 10    ,..
+    bpl c9978                                                         ; 9971: 10 05       ..
+    sta tube_host_r3_data                                             ; 9973: 8d e5 fe    ...
+    bmi c993b                                                         ; 9976: 30 c3       0.
+; &9978 referenced 1 time by &9971
+.c9978
+    jsr sub_c992c                                                     ; 9978: 20 2c 99     ,.
+    sta (l00b8,x)                                                     ; 997b: 81 b8       ..
+    jmp c993b                                                         ; 997d: 4c 3b 99    L;.
+
+    jsr sub_c9988                                                     ; 9980: 20 88 99     ..
+    jsr sub_c9f82                                                     ; 9983: 20 82 9f     ..
+    clc                                                               ; 9986: 18          .
+    rts                                                               ; 9987: 60          `
+
+; &9988 referenced 1 time by &9980
+.sub_c9988
+    bit l1081                                                         ; 9988: 2c 81 10    ,..
+    bpl c9993                                                         ; 998b: 10 06       ..
+    lda tube_host_r3_data                                             ; 998d: ad e5 fe    ...
+    jmp c993b                                                         ; 9990: 4c 3b 99    L;.
+
+; &9993 referenced 1 time by &998b
+.c9993
+    jsr sub_c992c                                                     ; 9993: 20 2c 99     ,.
+    lda (l00b8,x)                                                     ; 9996: a1 b8       ..
+    jmp c993b                                                         ; 9998: 4c 3b 99    L;.
+
+    bit l10c7                                                         ; 999b: 2c c7 10    ,..
+    bmi c99a3                                                         ; 999e: 30 03       0.
+    dec l10c7                                                         ; 99a0: ce c7 10    ...
+; &99a3 referenced 5 times by &8782, &8bac, &9789, &999e, &9c25
+.c99a3
+    lda #&ff                                                          ; 99a3: a9 ff       ..
+    sta l10ce                                                         ; 99a5: 8d ce 10    ...
+; &99a8 referenced 1 time by &99b3
+.loop_c99a8
+    sta l10cd                                                         ; 99a8: 8d cd 10    ...
+    rts                                                               ; 99ab: 60          `
+
+; &99ac referenced 6 times by &824b, &8254, &8750, &8797, &89e6, &a463
+.sub_c99ac
+    lda #&2a ; '*'                                                    ; 99ac: a9 2a       .*
+    sta l10ce                                                         ; 99ae: 8d ce 10    ...
+    lda #&23 ; '#'                                                    ; 99b1: a9 23       .#
+    bne loop_c99a8                                                    ; 99b3: d0 f3       ..
+    jsr sub_c9a6e                                                     ; 99b5: 20 6e 9a     n.
+    jsr sub_c8386                                                     ; 99b8: 20 86 83     ..
+    lda #1                                                            ; 99bb: a9 01       ..
+    rts                                                               ; 99bd: 60          `
+
+    jsr sub_c9a4b                                                     ; 99be: 20 4b 9a     K.
+    jsr sub_c8386                                                     ; 99c1: 20 86 83     ..
+    jsr sub_c830a                                                     ; 99c4: 20 0a 83     ..
+    bcc c99ed                                                         ; 99c7: 90 24       .$
+    jsr sub_c9a6e                                                     ; 99c9: 20 6e 9a     n.
+    jsr sub_c99f3                                                     ; 99cc: 20 f3 99     ..
+    jsr sub_c9a0f                                                     ; 99cf: 20 0f 9a     ..
+    bvc c99ea                                                         ; 99d2: 50 16       P.
+    jsr sub_c9a6e                                                     ; 99d4: 20 6e 9a     n.
+    jsr sub_c9a0f                                                     ; 99d7: 20 0f 9a     ..
+    bvc c99ed                                                         ; 99da: 50 11       P.
+    jsr sub_c9a6e                                                     ; 99dc: 20 6e 9a     n.
+    jsr sub_c99f3                                                     ; 99df: 20 f3 99     ..
+    bvc c99ed                                                         ; 99e2: 50 09       P.
+    jsr sub_c9a6e                                                     ; 99e4: 20 6e 9a     n.
+    jsr sub_c9a63                                                     ; 99e7: 20 63 9a     c.
+; &99ea referenced 1 time by &99d2
+.c99ea
+    jsr sub_c9a32                                                     ; 99ea: 20 32 9a     2.
+; &99ed referenced 3 times by &99c7, &99da, &99e2
+.c99ed
+    jsr c89d7                                                         ; 99ed: 20 d7 89     ..
+    lda #1                                                            ; 99f0: a9 01       ..
+    rts                                                               ; 99f2: 60          `
+
+; &99f3 referenced 2 times by &99cc, &99df
+.sub_c99f3
+    jsr sub_c83e3                                                     ; 99f3: 20 e3 83     ..
+    ldy #2                                                            ; 99f6: a0 02       ..
+    lda (l00b0),y                                                     ; 99f8: b1 b0       ..
+    sta l0f08,x                                                       ; 99fa: 9d 08 0f    ...
+    iny                                                               ; 99fd: c8          .
+    lda (l00b0),y                                                     ; 99fe: b1 b0       ..
+    sta l0f09,x                                                       ; 9a00: 9d 09 0f    ...
+    iny                                                               ; 9a03: c8          .
+    lda (l00b0),y                                                     ; 9a04: b1 b0       ..
+    asl a                                                             ; 9a06: 0a          .
+    asl a                                                             ; 9a07: 0a          .
+    eor l0f0e,x                                                       ; 9a08: 5d 0e 0f    ]..
+    and #&0c                                                          ; 9a0b: 29 0c       ).
+    bpl c9a2a                                                         ; 9a0d: 10 1b       ..
+; &9a0f referenced 2 times by &99cf, &99d7
+.sub_c9a0f
+    jsr sub_c83e3                                                     ; 9a0f: 20 e3 83     ..
+    ldy #6                                                            ; 9a12: a0 06       ..
+    lda (l00b0),y                                                     ; 9a14: b1 b0       ..
+    sta l0f0a,x                                                       ; 9a16: 9d 0a 0f    ...
+    iny                                                               ; 9a19: c8          .
+    lda (l00b0),y                                                     ; 9a1a: b1 b0       ..
+    sta l0f0b,x                                                       ; 9a1c: 9d 0b 0f    ...
+    iny                                                               ; 9a1f: c8          .
+    lda (l00b0),y                                                     ; 9a20: b1 b0       ..
+    ror a                                                             ; 9a22: 6a          j
+    ror a                                                             ; 9a23: 6a          j
+    ror a                                                             ; 9a24: 6a          j
+    eor l0f0e,x                                                       ; 9a25: 5d 0e 0f    ]..
+    and #&c0                                                          ; 9a28: 29 c0       ).
+; &9a2a referenced 1 time by &9a0d
+.c9a2a
+    eor l0f0e,x                                                       ; 9a2a: 5d 0e 0f    ]..
+    sta l0f0e,x                                                       ; 9a2d: 9d 0e 0f    ...
+    clv                                                               ; 9a30: b8          .
+    rts                                                               ; 9a31: 60          `
+
+; &9a32 referenced 1 time by &99ea
+.sub_c9a32
+    jsr sub_c83e3                                                     ; 9a32: 20 e3 83     ..
+    ldy #&0e                                                          ; 9a35: a0 0e       ..
+    lda (l00b0),y                                                     ; 9a37: b1 b0       ..
+    and #&0a                                                          ; 9a39: 29 0a       ).
+    beq c9a3f                                                         ; 9a3b: f0 02       ..
+    lda #&80                                                          ; 9a3d: a9 80       ..
+; &9a3f referenced 1 time by &9a3b
+.c9a3f
+    eor l0e0f,x                                                       ; 9a3f: 5d 0f 0e    ]..
+    and #&80                                                          ; 9a42: 29 80       ).
+    eor l0e0f,x                                                       ; 9a44: 5d 0f 0e    ]..
+    sta l0e0f,x                                                       ; 9a47: 9d 0f 0e    ...
+    rts                                                               ; 9a4a: 60          `
+
+; &9a4b referenced 1 time by &99be
+.sub_c9a4b
+    jsr sub_c9a78                                                     ; 9a4b: 20 78 9a     x.
+    bcc c9a73                                                         ; 9a4e: 90 23       .#
+; &9a50 referenced 2 times by &9a60, &9c55
+.sub_c9a50
+    lda l0e0f,y                                                       ; 9a50: b9 0f 0e    ...
+    bpl c9a77                                                         ; 9a53: 10 22       ."
+; &9a55 referenced 1 time by &9f6b
+.generate_error_precheck_locked
+    jsr generate_error_precheck                                       ; 9a55: 20 38 80     8.
+    equb &c3                                                          ; 9a58: c3          .
+    equs "Locked"                                                     ; 9a59: 4c 6f 63... Loc
+    equb 0                                                            ; 9a5f: 00          .
+
+; &9a60 referenced 2 times by &830a, &8bba
+.sub_c9a60
+    jsr sub_c9a50                                                     ; 9a60: 20 50 9a     P.
+; &9a63 referenced 2 times by &8a00, &99e7
+.sub_c9a63
+    jsr sub_c83e3                                                     ; 9a63: 20 e3 83     ..
+    jsr sub_c9d1e                                                     ; 9a66: 20 1e 9d     ..
+    bcc c9a8c                                                         ; 9a69: 90 21       .!
+    jmp generate_error_precheck_open                                  ; 9a6b: 4c 82 9c    L..
+
+; &9a6e referenced 5 times by &99b5, &99c9, &99d4, &99dc, &99e4
+.sub_c9a6e
+    jsr sub_c9a78                                                     ; 9a6e: 20 78 9a     x.
+    bcs c9a8c                                                         ; 9a71: b0 19       ..
+; &9a73 referenced 1 time by &9a4e
+.c9a73
+    pla                                                               ; 9a73: 68          h
+    pla                                                               ; 9a74: 68          h
+    lda #0                                                            ; 9a75: a9 00       ..
+; &9a77 referenced 1 time by &9a53
+.c9a77
+    rts                                                               ; 9a77: 60          `
+
+; &9a78 referenced 2 times by &9a4b, &9a6e
+.sub_c9a78
+    jsr sub_c80f3                                                     ; 9a78: 20 f3 80     ..
+    jsr sub_c8284                                                     ; 9a7b: 20 84 82     ..
+    bcc c9a8c                                                         ; 9a7e: 90 0c       ..
+    tya                                                               ; 9a80: 98          .
+    tax                                                               ; 9a81: aa          .
+; &9a82 referenced 2 times by &881e, &885c
+.sub_c9a82
+    lda l10db                                                         ; 9a82: ad db 10    ...
+    sta l00b0                                                         ; 9a85: 85 b0       ..
+    lda l10dc                                                         ; 9a87: ad dc 10    ...
+    sta l00b1                                                         ; 9a8a: 85 b1       ..
+; &9a8c referenced 3 times by &9a69, &9a71, &9a7e
+.c9a8c
+    rts                                                               ; 9a8c: 60          `
+
+; &9a8d referenced 4 times by &929d, &a267, &a34a, &a64f
+.sub_c9a8d
+    lda #osbyte_read_oshwm                                            ; 9a8d: a9 83       ..
+    jsr osbyte                                                        ; 9a8f: 20 f4 ff     ..
+    sty l10cf                                                         ; 9a92: 8c cf 10    ...
+    lda #osbyte_read_himem                                            ; 9a95: a9 84       ..
+    jsr osbyte                                                        ; 9a97: 20 f4 ff     ..
+    tya                                                               ; 9a9a: 98          .
+    sec                                                               ; 9a9b: 38          8
+    sbc l10cf                                                         ; 9a9c: ed cf 10    ...
+    sta l10d0                                                         ; 9a9f: 8d d0 10    ...
+    rts                                                               ; 9aa2: 60          `
+
+; &9aa3 referenced 2 times by &95d4, &95fd
+.sub_c9aa3
+    ldx #&0a                                                          ; 9aa3: a2 0a       ..
+    jsr c9adf                                                         ; 9aa5: 20 df 9a     ..
+    jsr sub_c9ab8                                                     ; 9aa8: 20 b8 9a     ..
+    ldy #&d3                                                          ; 9aab: a0 d3       ..
+    lda #&ff                                                          ; 9aad: a9 ff       ..
+    sta (l00b0),y                                                     ; 9aaf: 91 b0       ..
+    sta l10d3                                                         ; 9ab1: 8d d3 10    ...
+    iny                                                               ; 9ab4: c8          .
+    sta (l00b0),y                                                     ; 9ab5: 91 b0       ..
+    rts                                                               ; 9ab7: 60          `
+
+; &9ab8 referenced 5 times by &895a, &95c1, &971b, &972c, &9aa8
+.sub_c9ab8
+    pha                                                               ; 9ab8: 48          H
+    ldx romsel_copy                                                   ; 9ab9: a6 f4       ..
+    lda #0                                                            ; 9abb: a9 00       ..
+    sta l00b0                                                         ; 9abd: 85 b0       ..
+    lda l0df0,x                                                       ; 9abf: bd f0 0d    ...
+    and #&3f ; '?'                                                    ; 9ac2: 29 3f       )?
+    sta l00b1                                                         ; 9ac4: 85 b1       ..
+    pla                                                               ; 9ac6: 68          h
+    rts                                                               ; 9ac7: 60          `
+
+; &9ac8 referenced 2 times by &a3d4, &a3fb
+.sub_c9ac8
+    jsr sub_c83e3                                                     ; 9ac8: 20 e3 83     ..
+    lda #&0f                                                          ; 9acb: a9 0f       ..
+    ldx #1                                                            ; 9acd: a2 01       ..
+    ldy #0                                                            ; 9acf: a0 00       ..
+    beq c9ae9                                                         ; 9ad1: f0 16       ..
+; &9ad3 referenced 1 time by &80ac
+.sub_c9ad3
+    tax                                                               ; 9ad3: aa          .
+; &9ad4 referenced 1 time by &80b5
+.c9ad4
+    lda #3                                                            ; 9ad4: a9 03       ..
+    bne c9ae9                                                         ; 9ad6: d0 11       ..
+; &9ad8 referenced 2 times by &9436, &abbc
+.sub_c9ad8
+    jsr sub_c83e3                                                     ; 9ad8: 20 e3 83     ..
+    lda #&7e ; '~'                                                    ; 9adb: a9 7e       .~
+    bne c9ae9                                                         ; 9add: d0 0a       ..
+; &9adf referenced 4 times by &9593, &9599, &95be, &9aa5
+.c9adf
+    lda #&8f                                                          ; 9adf: a9 8f       ..
+    bne c9ae9                                                         ; 9ae1: d0 06       ..
+    lda #osbyte_read_write_startup_options                            ; 9ae3: a9 ff       ..
+; &9ae5 referenced 8 times by &80a5, &9588, &96a0, &9e32, &9e43, &aae2, &ac7c, &aeb7
+.osbyte_read
+    ldx #0                                                            ; 9ae5: a2 00       ..
+    ldy #&ff                                                          ; 9ae7: a0 ff       ..
+; &9ae9 referenced 4 times by &9ad1, &9ad6, &9add, &9ae1
+.c9ae9
+    jmp osbyte                                                        ; 9ae9: 4c f4 ff    L..
+
+; &9aec referenced 1 time by &957d
+.l9aec
+    equb &1b, &ff, &1e, &ff, &21, &ff, &24, &ff, &27, &ff, &2a, &ff   ; 9aec: 1b ff 1e... ...
+    equb &2d, &ff                                                     ; 9af8: 2d ff       -.
+    equw sub_c9785                                                    ; 9afa: 85 97       ..
+    equb 0                                                            ; 9afc: 00          .
+    equw sub_c9d9b                                                    ; 9afd: 9b 9d       ..
+    equb 0                                                            ; 9aff: 00          .
+    equw sub_c9e94                                                    ; 9b00: 94 9e       ..
+    equb 0                                                            ; 9b02: 00          .
+    equw sub_c9f82                                                    ; 9b03: 82 9f       ..
+    equb 0                                                            ; 9b05: 00          .
+    equw sub_c97c9                                                    ; 9b06: c9 97       ..
+    equb 0                                                            ; 9b08: 00          .
+    equw sub_c9c0c                                                    ; 9b09: 0c 9c       ..
+    equb 0                                                            ; 9b0b: 00          .
+    equw sub_c97b6                                                    ; 9b0c: b6 97       ..
+    equb 0                                                            ; 9b0e: 00          .
+; &9b0f referenced 1 time by &97c1
+.l9b0f
+    equs "1\o"                                                        ; 9b0f: 31 5c 6f    1\o
+    equb &fd, &6f, &82, &50, &4b, &9a                                 ; 9b12: fd 6f 82... .o.
+; &9b18 referenced 1 time by &97bd
+.l9b18
+    equb &8a, &9e, &88, &86, &88, &84, &9b, &9b, &99                  ; 9b18: 8a 9e 88... ...
+; &9b21 referenced 1 time by &97af
+.l9b21
+    equb &1a, &58, &c8, &db, &d3, &e3, &b4, &bd                       ; 9b21: 1a 58 c8... .X.
+; &9b29 referenced 1 time by &97ab
+.l9b29
+    equb &88, &88, &99, &99, &99, &99, &99, &99                       ; 9b29: 88 88 99... ...
+; &9b31 referenced 1 time by &97e8
+.l9b31
+    equb &1b, &80, &80, &69, &69, &d7,   6, &19, &8b                  ; 9b31: 1b 80 80... ...
+; &9b3a referenced 1 time by &97ee
+.l9b3a
+    equb &86, &99, &99, &99, &99, &98, &99, &99, &98                  ; 9b3a: 86 99 99... ...
+; &9b43 referenced 1 time by &97f4
+.l9b43
+    equb   4,   2,   3,   6,   7,   4,   4,   4,   4, &a2, &11, &a0   ; 9b43: 04 02 03... ...
+    equb &15                                                          ; 9b4f: 15          .
+
+; &9b50 referenced 1 time by &9b66
+.loop_c9b50
+    rts                                                               ; 9b50: 60          `
+
+; &9b51 referenced 1 time by &9b5e
+.sub_c9b51
+    jsr sub_c83e3                                                     ; 9b51: 20 e3 83     ..
+    lda #osbyte_close_spool_exec                                      ; 9b54: a9 77       .w
+    jmp osbyte                                                        ; 9b56: 4c f4 ff    L..
+
+.sub_c9b59
+    lda #&20 ; ' '                                                    ; 9b59: a9 20       .
+    sta l1086                                                         ; 9b5b: 8d 86 10    ...
+; &9b5e referenced 1 time by &9b74
+.loop_c9b5e
+    jsr sub_c9b51                                                     ; 9b5e: 20 51 9b     Q.
+; &9b61 referenced 1 time by &9d81
+.sub_c9b61
+    lda #0                                                            ; 9b61: a9 00       ..
+; &9b63 referenced 1 time by &9b6c
+.loop_c9b63
+    clc                                                               ; 9b63: 18          .
+    adc #&20 ; ' '                                                    ; 9b64: 69 20       i
+    beq loop_c9b50                                                    ; 9b66: f0 e8       ..
+    tay                                                               ; 9b68: a8          .
+    jsr sub_c9b79                                                     ; 9b69: 20 79 9b     y.
+    bne loop_c9b63                                                    ; 9b6c: d0 f5       ..
+; &9b6e referenced 2 times by &9c13, &9d86
+.c9b6e
+    lda #&20 ; ' '                                                    ; 9b6e: a9 20       .
+    sta l1086                                                         ; 9b70: 8d 86 10    ...
+    tya                                                               ; 9b73: 98          .
+    beq loop_c9b5e                                                    ; 9b74: f0 e8       ..
+    jsr sub_c9e75                                                     ; 9b76: 20 75 9e     u.
+; &9b79 referenced 2 times by &9b69, &a264
+.sub_c9b79
+    pha                                                               ; 9b79: 48          H
+    jsr sub_c9df4                                                     ; 9b7a: 20 f4 9d     ..
+    bcs c9bc5                                                         ; 9b7d: b0 46       .F
+    lda l111b,y                                                       ; 9b7f: b9 1b 11    ...
+    eor #&ff                                                          ; 9b82: 49 ff       I.
+    and l10c0                                                         ; 9b84: 2d c0 10    -..
+    sta l10c0                                                         ; 9b87: 8d c0 10    ...
+    lda l1117,y                                                       ; 9b8a: b9 17 11    ...
+    and #&60 ; '`'                                                    ; 9b8d: 29 60       )`
+    beq c9bc5                                                         ; 9b8f: f0 34       .4
+    jsr sub_c9bca                                                     ; 9b91: 20 ca 9b     ..
+    lda l1117,y                                                       ; 9b94: b9 17 11    ...
+    and l1086                                                         ; 9b97: 2d 86 10    -..
+    beq c9bc2                                                         ; 9b9a: f0 26       .&
+    ldx l10c3                                                         ; 9b9c: ae c3 10    ...
+    lda l1114,y                                                       ; 9b9f: b9 14 11    ...
+    sta l0f0c,x                                                       ; 9ba2: 9d 0c 0f    ...
+    lda l1115,y                                                       ; 9ba5: b9 15 11    ...
+    sta l0f0d,x                                                       ; 9ba8: 9d 0d 0f    ...
+    lda l1116,y                                                       ; 9bab: b9 16 11    ...
+    jsr sub_c81c5                                                     ; 9bae: 20 c5 81     ..
+    eor l0f0e,x                                                       ; 9bb1: 5d 0e 0f    ]..
+    and #&30 ; '0'                                                    ; 9bb4: 29 30       )0
+    eor l0f0e,x                                                       ; 9bb6: 5d 0e 0f    ]..
+    sta l0f0e,x                                                       ; 9bb9: 9d 0e 0f    ...
+    jsr c93e6                                                         ; 9bbc: 20 e6 93     ..
+    ldy l10c2                                                         ; 9bbf: ac c2 10    ...
+; &9bc2 referenced 1 time by &9b9a
+.c9bc2
+    jsr sub_c9f1e                                                     ; 9bc2: 20 1e 9f     ..
+; &9bc5 referenced 2 times by &9b7d, &9b8f
+.c9bc5
+    ldx l10c5                                                         ; 9bc5: ae c5 10    ...
+    pla                                                               ; 9bc8: 68          h
+    rts                                                               ; 9bc9: 60          `
+
+; &9bca referenced 1 time by &9b91
+.sub_c9bca
+    jsr sub_c9be5                                                     ; 9bca: 20 e5 9b     ..
+; &9bcd referenced 1 time by &9f9f
+.sub_c9bcd
+    ldx #6                                                            ; 9bcd: a2 06       ..
+; &9bcf referenced 1 time by &9bd7
+.loop_c9bcf
+    lda l110c,y                                                       ; 9bcf: b9 0c 11    ...
+    sta l00c5,x                                                       ; 9bd2: 95 c5       ..
+    dey                                                               ; 9bd4: 88          .
+    dey                                                               ; 9bd5: 88          .
+    dex                                                               ; 9bd6: ca          .
+    bpl loop_c9bcf                                                    ; 9bd7: 10 f6       ..
+    jsr sub_c826d                                                     ; 9bd9: 20 6d 82     m.
+    bcc generate_error_precheck_disc_changed                          ; 9bdc: 90 22       ."
+    sty l10c3                                                         ; 9bde: 8c c3 10    ...
+    ldy l10c2                                                         ; 9be1: ac c2 10    ...
+; &9be4 referenced 1 time by &9bfe
+.loop_c9be4
+    rts                                                               ; 9be4: 60          `
+
+; &9be5 referenced 3 times by &9bca, &9eb8, &9f93
+.sub_c9be5
+    lda l110e,y                                                       ; 9be5: b9 0e 11    ...
+    and #&7f                                                          ; 9be8: 29 7f       ).
+    sta l00cc                                                         ; 9bea: 85 cc       ..
+    lda l1117,y                                                       ; 9bec: b9 17 11    ...
+    jmp c8816                                                         ; 9bef: 4c 16 88    L..
+
+; &9bf2 referenced 2 times by &8768, &87b8
+.sub_c9bf2
+    jsr sub_c83e3                                                     ; 9bf2: 20 e3 83     ..
+    lda l0f04                                                         ; 9bf5: ad 04 0f    ...
+    jsr sub_c8380                                                     ; 9bf8: 20 80 83     ..
+    cmp l0f04                                                         ; 9bfb: cd 04 0f    ...
+    beq loop_c9be4                                                    ; 9bfe: f0 e4       ..
+; &9c00 referenced 1 time by &9bdc
+.generate_error_precheck_disc_changed
+    jsr generate_error_precheck_disc                                  ; 9c00: 20 23 80     #.
+    equb &c8                                                          ; 9c03: c8          .
+    equs "changed"                                                    ; 9c04: 63 68 61... cha
+    equb 0                                                            ; 9c0b: 00          .
+
+.sub_c9c0c
+    and #&c0                                                          ; 9c0c: 29 c0       ).
+    bne c9c16                                                         ; 9c0e: d0 06       ..
+    jsr sub_c83e3                                                     ; 9c10: 20 e3 83     ..
+    jmp c9b6e                                                         ; 9c13: 4c 6e 9b    Ln.
+
+; &9c16 referenced 1 time by &9c0e
+.c9c16
+    jsr sub_c840c                                                     ; 9c16: 20 0c 84     ..
+    stx l00ba                                                         ; 9c19: 86 ba       ..
+    sty l00bb                                                         ; 9c1b: 84 bb       ..
+    sta l00b4                                                         ; 9c1d: 85 b4       ..
+    bit l00b4                                                         ; 9c1f: 24 b4       $.
+    php                                                               ; 9c21: 08          .
+    jsr sub_c80f3                                                     ; 9c22: 20 f3 80     ..
+    jsr c99a3                                                         ; 9c25: 20 a3 99     ..
+    jsr sub_c8284                                                     ; 9c28: 20 84 82     ..
+    bcs c9c51                                                         ; 9c2b: b0 24       .$
+    plp                                                               ; 9c2d: 28          (
+    bvc c9c33                                                         ; 9c2e: 50 03       P.
+    lda #0                                                            ; 9c30: a9 00       ..
+    rts                                                               ; 9c32: 60          `
+
+; &9c33 referenced 1 time by &9c2e
+.c9c33
+    php                                                               ; 9c33: 08          .
+    lda #0                                                            ; 9c34: a9 00       ..
+    ldx #7                                                            ; 9c36: a2 07       ..
+; &9c38 referenced 1 time by &9c3e
+.loop_c9c38
+    sta l00bc,x                                                       ; 9c38: 95 bc       ..
+    sta l1074,x                                                       ; 9c3a: 9d 74 10    .t.
+    dex                                                               ; 9c3d: ca          .
+    bpl loop_c9c38                                                    ; 9c3e: 10 f8       ..
+    dec l00be                                                         ; 9c40: c6 be       ..
+    dec l00bf                                                         ; 9c42: c6 bf       ..
+    dec l1076                                                         ; 9c44: ce 76 10    .v.
+    dec l1077                                                         ; 9c47: ce 77 10    .w.
+    lda #&40 ; '@'                                                    ; 9c4a: a9 40       .@
+    sta l00c3                                                         ; 9c4c: 85 c3       ..
+    jsr sub_c8a77                                                     ; 9c4e: 20 77 8a     w.
+; &9c51 referenced 1 time by &9c2b
+.c9c51
+    plp                                                               ; 9c51: 28          (
+    php                                                               ; 9c52: 08          .
+    bvs c9c58                                                         ; 9c53: 70 03       p.
+    jsr sub_c9a50                                                     ; 9c55: 20 50 9a     P.
+; &9c58 referenced 1 time by &9c53
+.c9c58
+    jsr sub_c9d1e                                                     ; 9c58: 20 1e 9d     ..
+    bcc c9c6b                                                         ; 9c5b: 90 0e       ..
+; &9c5d referenced 1 time by &9c69
+.loop_c9c5d
+    lda l110c,y                                                       ; 9c5d: b9 0c 11    ...
+    bpl generate_error_precheck_open                                  ; 9c60: 10 20       .
+    plp                                                               ; 9c62: 28          (
+    php                                                               ; 9c63: 08          .
+    bmi generate_error_precheck_open                                  ; 9c64: 30 1c       0.
+    jsr sub_c9d19                                                     ; 9c66: 20 19 9d     ..
+    bcs loop_c9c5d                                                    ; 9c69: b0 f2       ..
+; &9c6b referenced 1 time by &9c5b
+.c9c6b
+    ldy l10c2                                                         ; 9c6b: ac c2 10    ...
+    bne c9c8b                                                         ; 9c6e: d0 1b       ..
+    jsr generate_error_precheck                                       ; 9c70: 20 38 80     8.
+    equb &c0                                                          ; 9c73: c0          .
+    equs "Too many open"                                              ; 9c74: 54 6f 6f... Too
+    equb 0                                                            ; 9c81: 00          .
+
+; &9c82 referenced 3 times by &9a6b, &9c60, &9c64
+.generate_error_precheck_open
+    jsr generate_error_precheck                                       ; 9c82: 20 38 80     8.
+    equb &c2                                                          ; 9c85: c2          .
+    equs "Open"                                                       ; 9c86: 4f 70 65... Ope
+    equb 0                                                            ; 9c8a: 00          .
+
+; &9c8b referenced 1 time by &9c6e
+.c9c8b
+    lda #8                                                            ; 9c8b: a9 08       ..
+    sta l10c4                                                         ; 9c8d: 8d c4 10    ...
+; &9c90 referenced 1 time by &9ca2
+.loop_c9c90
+    lda l0e08,x                                                       ; 9c90: bd 08 0e    ...
+    sta l1100,y                                                       ; 9c93: 99 00 11    ...
+    iny                                                               ; 9c96: c8          .
+    lda l0f08,x                                                       ; 9c97: bd 08 0f    ...
+    sta l1100,y                                                       ; 9c9a: 99 00 11    ...
+    iny                                                               ; 9c9d: c8          .
+    inx                                                               ; 9c9e: e8          .
+    dec l10c4                                                         ; 9c9f: ce c4 10    ...
+    bne loop_c9c90                                                    ; 9ca2: d0 ec       ..
+    ldx #&10                                                          ; 9ca4: a2 10       ..
+    lda #0                                                            ; 9ca6: a9 00       ..
+; &9ca8 referenced 1 time by &9cad
+.loop_c9ca8
+    sta l1100,y                                                       ; 9ca8: 99 00 11    ...
+    iny                                                               ; 9cab: c8          .
+    dex                                                               ; 9cac: ca          .
+    bne loop_c9ca8                                                    ; 9cad: d0 f9       ..
+    lda l10c2                                                         ; 9caf: ad c2 10    ...
+    tay                                                               ; 9cb2: a8          .
+    jsr sub_c81be                                                     ; 9cb3: 20 be 81     ..
+    adc #&11                                                          ; 9cb6: 69 11       i.
+    sta l1113,y                                                       ; 9cb8: 99 13 11    ...
+    lda l10c1                                                         ; 9cbb: ad c1 10    ...
+    sta l111b,y                                                       ; 9cbe: 99 1b 11    ...
+    ora l10c0                                                         ; 9cc1: 0d c0 10    ...
+    sta l10c0                                                         ; 9cc4: 8d c0 10    ...
+    lda l1109,y                                                       ; 9cc7: b9 09 11    ...
+    adc #&ff                                                          ; 9cca: 69 ff       i.
+    lda l110b,y                                                       ; 9ccc: b9 0b 11    ...
+    adc #0                                                            ; 9ccf: 69 00       i.
+    sta l1119,y                                                       ; 9cd1: 99 19 11    ...
+    lda l110d,y                                                       ; 9cd4: b9 0d 11    ...
+    ora #&0f                                                          ; 9cd7: 09 0f       ..
+    adc #0                                                            ; 9cd9: 69 00       i.
+    jsr sub_c81b0                                                     ; 9cdb: 20 b0 81     ..
+    sta l111a,y                                                       ; 9cde: 99 1a 11    ...
+    plp                                                               ; 9ce1: 28          (
+    bvc c9d12                                                         ; 9ce2: 50 2e       P.
+    bmi c9cee                                                         ; 9ce4: 30 08       0.
+    lda #&80                                                          ; 9ce6: a9 80       ..
+    ora l110c,y                                                       ; 9ce8: 19 0c 11    ...
+    sta l110c,y                                                       ; 9ceb: 99 0c 11    ...
+; &9cee referenced 1 time by &9ce4
+.c9cee
+    lda l1109,y                                                       ; 9cee: b9 09 11    ...
+    sta l1114,y                                                       ; 9cf1: 99 14 11    ...
+    lda l110b,y                                                       ; 9cf4: b9 0b 11    ...
+    sta l1115,y                                                       ; 9cf7: 99 15 11    ...
+    lda l110d,y                                                       ; 9cfa: b9 0d 11    ...
+    jsr sub_c81b0                                                     ; 9cfd: 20 b0 81     ..
+    sta l1116,y                                                       ; 9d00: 99 16 11    ...
+; &9d03 referenced 1 time by &9d17
+.loop_c9d03
+    lda l00cd                                                         ; 9d03: a5 cd       ..
+    ora l1117,y                                                       ; 9d05: 19 17 11    ...
+    sta l1117,y                                                       ; 9d08: 99 17 11    ...
+    tya                                                               ; 9d0b: 98          .
+    jsr sub_c81be                                                     ; 9d0c: 20 be 81     ..
+    ora #&10                                                          ; 9d0f: 09 10       ..
+    rts                                                               ; 9d11: 60          `
+
+; &9d12 referenced 1 time by &9ce2
+.c9d12
+    lda #&20 ; ' '                                                    ; 9d12: a9 20       .
+    sta l1117,y                                                       ; 9d14: 99 17 11    ...
+    bne loop_c9d03                                                    ; 9d17: d0 ea       ..
+; &9d19 referenced 1 time by &9c66
+.sub_c9d19
+    txa                                                               ; 9d19: 8a          .
+    pha                                                               ; 9d1a: 48          H
+    jmp c9d5d                                                         ; 9d1b: 4c 5d 9d    L].
+
+; &9d1e referenced 2 times by &9a66, &9c58
+.sub_c9d1e
+    lda #0                                                            ; 9d1e: a9 00       ..
+    sta l10c2                                                         ; 9d20: 8d c2 10    ...
+    lda #8                                                            ; 9d23: a9 08       ..
+    sta l00b5                                                         ; 9d25: 85 b5       ..
+    tya                                                               ; 9d27: 98          .
+    tax                                                               ; 9d28: aa          .
+    ldy #&a0                                                          ; 9d29: a0 a0       ..
+; &9d2b referenced 1 time by &9d6f
+.c9d2b
+    sty l00b3                                                         ; 9d2b: 84 b3       ..
+    txa                                                               ; 9d2d: 8a          .
+    pha                                                               ; 9d2e: 48          H
+    lda #8                                                            ; 9d2f: a9 08       ..
+    sta l00b2                                                         ; 9d31: 85 b2       ..
+    lda l00b5                                                         ; 9d33: a5 b5       ..
+    bit l10c0                                                         ; 9d35: 2c c0 10    ,..
+    beq c9d57                                                         ; 9d38: f0 1d       ..
+    lda l1117,y                                                       ; 9d3a: b9 17 11    ...
+    eor l00cd                                                         ; 9d3d: 45 cd       E.
+    and #3                                                            ; 9d3f: 29 03       ).
+    bne c9d5d                                                         ; 9d41: d0 1a       ..
+; &9d43 referenced 1 time by &9d52
+.loop_c9d43
+    lda l0e08,x                                                       ; 9d43: bd 08 0e    ...
+    eor l1100,y                                                       ; 9d46: 59 00 11    Y..
+    and #&7f                                                          ; 9d49: 29 7f       ).
+    bne c9d5d                                                         ; 9d4b: d0 10       ..
+    inx                                                               ; 9d4d: e8          .
+    iny                                                               ; 9d4e: c8          .
+    iny                                                               ; 9d4f: c8          .
+    dec l00b2                                                         ; 9d50: c6 b2       ..
+    bne loop_c9d43                                                    ; 9d52: d0 ef       ..
+    sec                                                               ; 9d54: 38          8
+    bcs c9d67                                                         ; 9d55: b0 10       ..
+; &9d57 referenced 1 time by &9d38
+.c9d57
+    sty l10c2                                                         ; 9d57: 8c c2 10    ...
+    sta l10c1                                                         ; 9d5a: 8d c1 10    ...
+; &9d5d referenced 3 times by &9d1b, &9d41, &9d4b
+.c9d5d
+    sec                                                               ; 9d5d: 38          8
+    lda l00b3                                                         ; 9d5e: a5 b3       ..
+    sbc #&20 ; ' '                                                    ; 9d60: e9 20       .
+    sta l00b3                                                         ; 9d62: 85 b3       ..
+    asl l00b5                                                         ; 9d64: 06 b5       ..
+    clc                                                               ; 9d66: 18          .
+; &9d67 referenced 1 time by &9d55
+.c9d67
+    pla                                                               ; 9d67: 68          h
+    tax                                                               ; 9d68: aa          .
+    ldy l00b3                                                         ; 9d69: a4 b3       ..
+    lda l00b5                                                         ; 9d6b: a5 b5       ..
+    bcs c9d71                                                         ; 9d6d: b0 02       ..
+    bne c9d2b                                                         ; 9d6f: d0 ba       ..
+; &9d71 referenced 1 time by &9d6d
+.c9d71
+    rts                                                               ; 9d71: 60          `
+
+; &9d72 referenced 1 time by &9da0
+.c9d72
+    jsr zero_stacked_XXX                                              ; 9d72: 20 8e 9d     ..
+; &9d75 referenced 1 time by &9726
+.sub_c9d75
+    lda l10c0                                                         ; 9d75: ad c0 10    ...
+    pha                                                               ; 9d78: 48          H
+    lda #0                                                            ; 9d79: a9 00       ..
+    sta l1086                                                         ; 9d7b: 8d 86 10    ...
+    tya                                                               ; 9d7e: 98          .
+    bne c9d86                                                         ; 9d7f: d0 05       ..
+    jsr sub_c9b61                                                     ; 9d81: 20 61 9b     a.
+    beq c9d89                                                         ; 9d84: f0 03       ..
+; &9d86 referenced 1 time by &9d7f
+.c9d86
+    jsr c9b6e                                                         ; 9d86: 20 6e 9b     n.
+; &9d89 referenced 1 time by &9d84
+.c9d89
+    pla                                                               ; 9d89: 68          h
+    sta l10c0                                                         ; 9d8a: 8d c0 10    ...
+    rts                                                               ; 9d8d: 60          `
+
+; &9d8e referenced 6 times by &956f, &9714, &97d0, &9d72, &9daa, &9db8
+.zero_stacked_XXX
+    pha                                                               ; 9d8e: 48          H
+    txa                                                               ; 9d8f: 8a          .
+    pha                                                               ; 9d90: 48          H
+    lda #0                                                            ; 9d91: a9 00       ..
+    tsx                                                               ; 9d93: ba          .
+    sta l0109,x                                                       ; 9d94: 9d 09 01    ...
+    pla                                                               ; 9d97: 68          h
+    tax                                                               ; 9d98: aa          .
+    pla                                                               ; 9d99: 68          h
+    rts                                                               ; 9d9a: 60          `
+
+.sub_c9d9b
+    jsr sub_c83e3                                                     ; 9d9b: 20 e3 83     ..
+    cmp #&ff                                                          ; 9d9e: c9 ff       ..
+    beq c9d72                                                         ; 9da0: f0 d0       ..
+    cpy #0                                                            ; 9da2: c0 00       ..
+    beq c9db4                                                         ; 9da4: f0 0e       ..
+    cmp #3                                                            ; 9da6: c9 03       ..
+    bcs c9dcd                                                         ; 9da8: b0 23       .#
+    jsr zero_stacked_XXX                                              ; 9daa: 20 8e 9d     ..
+    cmp #1                                                            ; 9dad: c9 01       ..
+    bne c9dd5                                                         ; 9daf: d0 24       .$
+    jmp ca06c                                                         ; 9db1: 4c 6c a0    Ll.
+
+; &9db4 referenced 1 time by &9da4
+.c9db4
+    cmp #2                                                            ; 9db4: c9 02       ..
+    bcs c9dcd                                                         ; 9db6: b0 15       ..
+    jsr zero_stacked_XXX                                              ; 9db8: 20 8e 9d     ..
+    beq c9dce                                                         ; 9dbb: f0 11       ..
+    lda #&ff                                                          ; 9dbd: a9 ff       ..
+    sta l0002,x                                                       ; 9dbf: 95 02       ..
+    sta l0003,x                                                       ; 9dc1: 95 03       ..
+    lda l10d9                                                         ; 9dc3: ad d9 10    ...
+    sta l0000,x                                                       ; 9dc6: 95 00       ..
+    lda l10da                                                         ; 9dc8: ad da 10    ...
+    sta l0001,x                                                       ; 9dcb: 95 01       ..
+; &9dcd referenced 2 times by &9da8, &9db6
+.c9dcd
+    rts                                                               ; 9dcd: 60          `
+
+; &9dce referenced 1 time by &9dbb
+.c9dce
+    lda #4                                                            ; 9dce: a9 04       ..
+    tsx                                                               ; 9dd0: ba          .
+    sta l0105,x                                                       ; 9dd1: 9d 05 01    ...
+    rts                                                               ; 9dd4: 60          `
+
+; &9dd5 referenced 2 times by &984c, &9daf
+.c9dd5
+    jsr sub_c9e75                                                     ; 9dd5: 20 75 9e     u.
+    sty l10c2                                                         ; 9dd8: 8c c2 10    ...
+    asl a                                                             ; 9ddb: 0a          .
+    adc l10c2                                                         ; 9ddc: 6d c2 10    m..
+    tay                                                               ; 9ddf: a8          .
+    lda l1110,y                                                       ; 9de0: b9 10 11    ...
+    sta l0000,x                                                       ; 9de3: 95 00       ..
+    lda l1111,y                                                       ; 9de5: b9 11 11    ...
+    sta l0001,x                                                       ; 9de8: 95 01       ..
+    lda l1112,y                                                       ; 9dea: b9 12 11    ...
+    sta l0002,x                                                       ; 9ded: 95 02       ..
+    lda #0                                                            ; 9def: a9 00       ..
+    sta l0003,x                                                       ; 9df1: 95 03       ..
+    rts                                                               ; 9df3: 60          `
+
+; &9df4 referenced 2 times by &9b7a, &9e78
+.sub_c9df4
+    pha                                                               ; 9df4: 48          H
+    stx l10c5                                                         ; 9df5: 8e c5 10    ...
+    tya                                                               ; 9df8: 98          .
+    and #&e0                                                          ; 9df9: 29 e0       ).
+    sta l10c2                                                         ; 9dfb: 8d c2 10    ...
+    beq c9e13                                                         ; 9dfe: f0 13       ..
+    jsr sub_c81be                                                     ; 9e00: 20 be 81     ..
+    tay                                                               ; 9e03: a8          .
+    lda #0                                                            ; 9e04: a9 00       ..
+    sec                                                               ; 9e06: 38          8
+; &9e07 referenced 1 time by &9e09
+.loop_c9e07
+    ror a                                                             ; 9e07: 6a          j
+    dey                                                               ; 9e08: 88          .
+    bne loop_c9e07                                                    ; 9e09: d0 fc       ..
+    ldy l10c2                                                         ; 9e0b: ac c2 10    ...
+    bit l10c0                                                         ; 9e0e: 2c c0 10    ,..
+    bne c9e16                                                         ; 9e11: d0 03       ..
+; &9e13 referenced 1 time by &9dfe
+.c9e13
+    pla                                                               ; 9e13: 68          h
+    sec                                                               ; 9e14: 38          8
+    rts                                                               ; 9e15: 60          `
+
+; &9e16 referenced 1 time by &9e11
+.c9e16
+    pla                                                               ; 9e16: 68          h
+    clc                                                               ; 9e17: 18          .
+    rts                                                               ; 9e18: 60          `
+
+    equb &48, &8a, &4c, &20, &9e                                      ; 9e19: 48 8a 4c... H.L
+
+; &9e1e referenced 2 times by &9e56, &9e75
+.sub_c9e1e
+    pha                                                               ; 9e1e: 48          H
+    tya                                                               ; 9e1f: 98          .
+    cmp #&10                                                          ; 9e20: c9 10       ..
+    bcc c9e28                                                         ; 9e22: 90 04       ..
+    cmp #&18                                                          ; 9e24: c9 18       ..
+    bcc c9e2a                                                         ; 9e26: 90 02       ..
+; &9e28 referenced 1 time by &9e22
+.c9e28
+    lda #8                                                            ; 9e28: a9 08       ..
+; &9e2a referenced 1 time by &9e26
+.c9e2a
+    jsr sub_c81c4                                                     ; 9e2a: 20 c4 81     ..
+    tay                                                               ; 9e2d: a8          .
+    pla                                                               ; 9e2e: 68          h
+    rts                                                               ; 9e2f: 60          `
+
+; &9e30 referenced 3 times by &803d, &9e7d, &9fc5
+.sub_c9e30
+    lda #osbyte_rw_exec_handle                                        ; 9e30: a9 c6       ..
+    jsr osbyte_read                                                   ; 9e32: 20 e5 9a     ..
+    txa                                                               ; 9e35: 8a          .
+    beq c9e41                                                         ; 9e36: f0 09       ..
+    jsr sub_c9e54                                                     ; 9e38: 20 54 9e     T.
+    bne c9e41                                                         ; 9e3b: d0 04       ..
+    lda #osbyte_rw_exec_handle                                        ; 9e3d: a9 c6       ..
+    bne osbyte_write_0                                                ; 9e3f: d0 0c       ..
+; &9e41 referenced 2 times by &9e36, &9e3b
+.c9e41
+    lda #osbyte_read_write_spool_file_handle                          ; 9e41: a9 c7       ..
+    jsr osbyte_read                                                   ; 9e43: 20 e5 9a     ..
+    jsr sub_c9e54                                                     ; 9e46: 20 54 9e     T.
+    bne c9e5c                                                         ; 9e49: d0 11       ..
+    lda #osbyte_read_write_spool_file_handle                          ; 9e4b: a9 c7       ..
+; &9e4d referenced 1 time by &9e3f
+.osbyte_write_0
+    ldx #0                                                            ; 9e4d: a2 00       ..
+    ldy #0                                                            ; 9e4f: a0 00       ..
+    jmp osbyte                                                        ; 9e51: 4c f4 ff    L..
+
+; &9e54 referenced 2 times by &9e38, &9e46
+.sub_c9e54
+    txa                                                               ; 9e54: 8a          .
+    tay                                                               ; 9e55: a8          .
+    jsr sub_c9e1e                                                     ; 9e56: 20 1e 9e     ..
+    cpy l10c2                                                         ; 9e59: cc c2 10    ...
+; &9e5c referenced 1 time by &9e49
+.c9e5c
+    rts                                                               ; 9e5c: 60          `
+
+    pha                                                               ; 9e5d: 48          H
+    tya                                                               ; 9e5e: 98          .
+    pha                                                               ; 9e5f: 48          H
+    txa                                                               ; 9e60: 8a          .
+    tay                                                               ; 9e61: a8          .
+    jsr sub_c9e75                                                     ; 9e62: 20 75 9e     u.
+    tya                                                               ; 9e65: 98          .
+    jsr sub_ca0de                                                     ; 9e66: 20 de a0     ..
+    bne c9e6f                                                         ; 9e69: d0 04       ..
+    ldx #&ff                                                          ; 9e6b: a2 ff       ..
+    bne c9e71                                                         ; 9e6d: d0 02       ..
+; &9e6f referenced 1 time by &9e69
+.c9e6f
+    ldx #0                                                            ; 9e6f: a2 00       ..
+; &9e71 referenced 1 time by &9e6d
+.c9e71
+    pla                                                               ; 9e71: 68          h
+    tay                                                               ; 9e72: a8          .
+    pla                                                               ; 9e73: 68          h
+; &9e74 referenced 1 time by &9e7b
+.loop_c9e74
+    rts                                                               ; 9e74: 60          `
+
+; &9e75 referenced 6 times by &9b76, &9dd5, &9e62, &9e97, &9f85, &a06f
+.sub_c9e75
+    jsr sub_c9e1e                                                     ; 9e75: 20 1e 9e     ..
+    jsr sub_c9df4                                                     ; 9e78: 20 f4 9d     ..
+    bcc loop_c9e74                                                    ; 9e7b: 90 f7       ..
+    jsr sub_c9e30                                                     ; 9e7d: 20 30 9e     0.
+    jsr generate_error_precheck                                       ; 9e80: 20 38 80     8.
+    equb &de                                                          ; 9e83: de          .
+    equs "Channel"                                                    ; 9e84: 43 68 61... Cha
+    equb 0                                                            ; 9e8b: 00          .
+
+; &9e8c referenced 1 time by &9ea5
+.loop_c9e8c
+    jsr generate_error_precheck                                       ; 9e8c: 20 38 80     8.
+    equb &df                                                          ; 9e8f: df          .
+    equs "EOF"                                                        ; 9e90: 45 4f 46    EOF
+    equb 0                                                            ; 9e93: 00          .
+
+; &9e94 referenced 1 time by &9969
+.sub_c9e94
+    jsr sub_c840c                                                     ; 9e94: 20 0c 84     ..
+    jsr sub_c9e75                                                     ; 9e97: 20 75 9e     u.
+    tya                                                               ; 9e9a: 98          .
+    jsr sub_ca0de                                                     ; 9e9b: 20 de a0     ..
+    bne c9eb3                                                         ; 9e9e: d0 13       ..
+    lda l1117,y                                                       ; 9ea0: b9 17 11    ...
+    and #&10                                                          ; 9ea3: 29 10       ).
+    bne loop_c9e8c                                                    ; 9ea5: d0 e5       ..
+    lda #&10                                                          ; 9ea7: a9 10       ..
+    jsr sub_c9f0f                                                     ; 9ea9: 20 0f 9f     ..
+    ldx l10c5                                                         ; 9eac: ae c5 10    ...
+    lda #&fe                                                          ; 9eaf: a9 fe       ..
+    sec                                                               ; 9eb1: 38          8
+    rts                                                               ; 9eb2: 60          `
+
+; &9eb3 referenced 1 time by &9e9e
+.c9eb3
+    lda l1117,y                                                       ; 9eb3: b9 17 11    ...
+    bmi c9ec2                                                         ; 9eb6: 30 0a       0.
+    jsr sub_c9be5                                                     ; 9eb8: 20 e5 9b     ..
+    jsr sub_c9f1e                                                     ; 9ebb: 20 1e 9f     ..
+    sec                                                               ; 9ebe: 38          8
+    jsr sub_c9f26                                                     ; 9ebf: 20 26 9f     &.
+; &9ec2 referenced 1 time by &9eb6
+.c9ec2
+    lda l1110,y                                                       ; 9ec2: b9 10 11    ...
+    sta l00ba                                                         ; 9ec5: 85 ba       ..
+    lda l1113,y                                                       ; 9ec7: b9 13 11    ...
+    sta l00bb                                                         ; 9eca: 85 bb       ..
+    ldy #0                                                            ; 9ecc: a0 00       ..
+    lda (l00ba),y                                                     ; 9ece: b1 ba       ..
+    pha                                                               ; 9ed0: 48          H
+    ldy l10c2                                                         ; 9ed1: ac c2 10    ...
+    ldx l00ba                                                         ; 9ed4: a6 ba       ..
+    inx                                                               ; 9ed6: e8          .
+    txa                                                               ; 9ed7: 8a          .
+    sta l1110,y                                                       ; 9ed8: 99 10 11    ...
+    bne c9ef1                                                         ; 9edb: d0 14       ..
+    clc                                                               ; 9edd: 18          .
+    lda l1111,y                                                       ; 9ede: b9 11 11    ...
+    adc #1                                                            ; 9ee1: 69 01       i.
+    sta l1111,y                                                       ; 9ee3: 99 11 11    ...
+    lda l1112,y                                                       ; 9ee6: b9 12 11    ...
+    adc #0                                                            ; 9ee9: 69 00       i.
+    sta l1112,y                                                       ; 9eeb: 99 12 11    ...
+    jsr sub_c9f14                                                     ; 9eee: 20 14 9f     ..
+; &9ef1 referenced 1 time by &9edb
+.c9ef1
+    clc                                                               ; 9ef1: 18          .
+    pla                                                               ; 9ef2: 68          h
+    rts                                                               ; 9ef3: 60          `
+
+; &9ef4 referenced 2 times by &9f5e, &a018
+.sub_c9ef4
+    clc                                                               ; 9ef4: 18          .
+    lda l110f,y                                                       ; 9ef5: b9 0f 11    ...
+    adc l1111,y                                                       ; 9ef8: 79 11 11    y..
+    sta l00c3                                                         ; 9efb: 85 c3       ..
+    sta l111c,y                                                       ; 9efd: 99 1c 11    ...
+    lda l110d,y                                                       ; 9f00: b9 0d 11    ...
+    and #3                                                            ; 9f03: 29 03       ).
+    adc l1112,y                                                       ; 9f05: 79 12 11    y..
+    sta l00c2                                                         ; 9f08: 85 c2       ..
+    sta l111d,y                                                       ; 9f0a: 99 1d 11    ...
+; &9f0d referenced 1 time by &a0db
+.c9f0d
+    lda #&80                                                          ; 9f0d: a9 80       ..
+; &9f0f referenced 3 times by &9ea9, &a035, &a05c
+.sub_c9f0f
+    ora l1117,y                                                       ; 9f0f: 19 17 11    ...
+    bne c9f19                                                         ; 9f12: d0 05       ..
+; &9f14 referenced 2 times by &9eee, &a041
+.sub_c9f14
+    lda #&7f                                                          ; 9f14: a9 7f       ..
+; &9f16 referenced 3 times by &95f0, &9f59, &a0ba
+.sub_c9f16
+    and l1117,y                                                       ; 9f16: 39 17 11    9..
+; &9f19 referenced 1 time by &9f12
+.c9f19
+    sta l1117,y                                                       ; 9f19: 99 17 11    ...
+    clc                                                               ; 9f1c: 18          .
+    rts                                                               ; 9f1d: 60          `
+
+; &9f1e referenced 3 times by &9bc2, &9ebb, &a00a
+.sub_c9f1e
+    lda l1117,y                                                       ; 9f1e: b9 17 11    ...
+    and #&40 ; '@'                                                    ; 9f21: 29 40       )@
+    beq c9f6a                                                         ; 9f23: f0 45       .E
+    clc                                                               ; 9f25: 18          .
+; &9f26 referenced 2 times by &9ebf, &a01e
+.sub_c9f26
+    php                                                               ; 9f26: 08          .
+    inc l10dd                                                         ; 9f27: ee dd 10    ...
+    ldy l10c2                                                         ; 9f2a: ac c2 10    ...
+    lda l1113,y                                                       ; 9f2d: b9 13 11    ...
+    sta l00bd                                                         ; 9f30: 85 bd       ..
+    lda #&ff                                                          ; 9f32: a9 ff       ..
+    sta l1074                                                         ; 9f34: 8d 74 10    .t.
+    sta l1075                                                         ; 9f37: 8d 75 10    .u.
+    lda #0                                                            ; 9f3a: a9 00       ..
+    sta l00bc                                                         ; 9f3c: 85 bc       ..
+    sta l00c0                                                         ; 9f3e: 85 c0       ..
+    lda #1                                                            ; 9f40: a9 01       ..
+    sta l00c1                                                         ; 9f42: 85 c1       ..
+    plp                                                               ; 9f44: 28          (
+    bcs c9f5e                                                         ; 9f45: b0 17       ..
+    lda l111c,y                                                       ; 9f47: b9 1c 11    ...
+    sta l00c3                                                         ; 9f4a: 85 c3       ..
+    lda l111d,y                                                       ; 9f4c: b9 1d 11    ...
+    sta l00c2                                                         ; 9f4f: 85 c2       ..
+    jsr sub_c8862                                                     ; 9f51: 20 62 88     b.
+    ldy l10c2                                                         ; 9f54: ac c2 10    ...
+    lda #&bf                                                          ; 9f57: a9 bf       ..
+    jsr sub_c9f16                                                     ; 9f59: 20 16 9f     ..
+    bcc c9f64                                                         ; 9f5c: 90 06       ..
+; &9f5e referenced 1 time by &9f45
+.c9f5e
+    jsr sub_c9ef4                                                     ; 9f5e: 20 f4 9e     ..
+    jsr sub_c8855                                                     ; 9f61: 20 55 88     U.
+; &9f64 referenced 1 time by &9f5c
+.c9f64
+    dec l10dd                                                         ; 9f64: ce dd 10    ...
+    ldy l10c2                                                         ; 9f67: ac c2 10    ...
+; &9f6a referenced 1 time by &9f23
+.c9f6a
+    rts                                                               ; 9f6a: 60          `
+
+; &9f6b referenced 1 time by &9f91
+.c9f6b
+    jmp generate_error_precheck_locked                                ; 9f6b: 4c 55 9a    LU.
+
+; &9f6e referenced 1 time by &9f8c
+.loop_c9f6e
+    jsr generate_error_precheck                                       ; 9f6e: 20 38 80     8.
+    equb &c1                                                          ; 9f71: c1          .
+    equs "Read only"                                                  ; 9f72: 52 65 61... Rea
+    equb 0                                                            ; 9f7b: 00          .
+
+; &9f7c referenced 1 time by &a09a
+.sub_c9f7c
+    jsr sub_c83e3                                                     ; 9f7c: 20 e3 83     ..
+    jmp c9f88                                                         ; 9f7f: 4c 88 9f    L..
+
+; &9f82 referenced 1 time by &9983
+.sub_c9f82
+    jsr sub_c83e3                                                     ; 9f82: 20 e3 83     ..
+    jsr sub_c9e75                                                     ; 9f85: 20 75 9e     u.
+; &9f88 referenced 1 time by &9f7f
+.c9f88
+    pha                                                               ; 9f88: 48          H
+    lda l110c,y                                                       ; 9f89: b9 0c 11    ...
+    bmi loop_c9f6e                                                    ; 9f8c: 30 e0       0.
+    lda l110e,y                                                       ; 9f8e: b9 0e 11    ...
+    bmi c9f6b                                                         ; 9f91: 30 d8       0.
+    jsr sub_c9be5                                                     ; 9f93: 20 e5 9b     ..
+    tya                                                               ; 9f96: 98          .
+    clc                                                               ; 9f97: 18          .
+    adc #4                                                            ; 9f98: 69 04       i.
+    jsr sub_ca0de                                                     ; 9f9a: 20 de a0     ..
+    bne ca005                                                         ; 9f9d: d0 66       .f
+    jsr sub_c9bcd                                                     ; 9f9f: 20 cd 9b     ..
+    ldx l10c3                                                         ; 9fa2: ae c3 10    ...
+    sec                                                               ; 9fa5: 38          8
+    lda l0f07,x                                                       ; 9fa6: bd 07 0f    ...
+    sbc l0f0f,x                                                       ; 9fa9: fd 0f 0f    ...
+    pha                                                               ; 9fac: 48          H
+    lda l0f06,x                                                       ; 9fad: bd 06 0f    ...
+    sbc l0f0e,x                                                       ; 9fb0: fd 0e 0f    ...
+    and #3                                                            ; 9fb3: 29 03       ).
+    cmp l111a,y                                                       ; 9fb5: d9 1a 11    ...
+    bne c9fd9                                                         ; 9fb8: d0 1f       ..
+    pla                                                               ; 9fba: 68          h
+    cmp l1119,y                                                       ; 9fbb: d9 19 11    ...
+    bne c9ff4                                                         ; 9fbe: d0 34       .4
+    sty l00b4                                                         ; 9fc0: 84 b4       ..
+    sty l10c2                                                         ; 9fc2: 8c c2 10    ...
+    jsr sub_c9e30                                                     ; 9fc5: 20 30 9e     0.
+    jsr generate_error_precheck                                       ; 9fc8: 20 38 80     8.
+    equb &bf                                                          ; 9fcb: bf          .
+    equs "Can't extend"                                               ; 9fcc: 43 61 6e... Can
+    equb 0                                                            ; 9fd8: 00          .
+
+; &9fd9 referenced 1 time by &9fb8
+.c9fd9
+    lda l111a,y                                                       ; 9fd9: b9 1a 11    ...
+    clc                                                               ; 9fdc: 18          .
+    adc #1                                                            ; 9fdd: 69 01       i.
+    sta l111a,y                                                       ; 9fdf: 99 1a 11    ...
+    asl a                                                             ; 9fe2: 0a          .
+    asl a                                                             ; 9fe3: 0a          .
+    asl a                                                             ; 9fe4: 0a          .
+    asl a                                                             ; 9fe5: 0a          .
+    eor l0f0e,x                                                       ; 9fe6: 5d 0e 0f    ]..
+    and #&30 ; '0'                                                    ; 9fe9: 29 30       )0
+    eor l0f0e,x                                                       ; 9feb: 5d 0e 0f    ]..
+    sta l0f0e,x                                                       ; 9fee: 9d 0e 0f    ...
+    pla                                                               ; 9ff1: 68          h
+    lda #0                                                            ; 9ff2: a9 00       ..
+; &9ff4 referenced 1 time by &9fbe
+.c9ff4
+    sta l0f0d,x                                                       ; 9ff4: 9d 0d 0f    ...
+    sta l1119,y                                                       ; 9ff7: 99 19 11    ...
+    lda #0                                                            ; 9ffa: a9 00       ..
+    sta l0f0c,x                                                       ; 9ffc: 9d 0c 0f    ...
+    jsr c93e6                                                         ; 9fff: 20 e6 93     ..
+    ldy l10c2                                                         ; a002: ac c2 10    ...
+; &a005 referenced 1 time by &9f9d
+.ca005
+    lda l1117,y                                                       ; a005: b9 17 11    ...
+    bmi ca021                                                         ; a008: 30 17       0.
+    jsr sub_c9f1e                                                     ; a00a: 20 1e 9f     ..
+    lda l1114,y                                                       ; a00d: b9 14 11    ...
+    bne ca01d                                                         ; a010: d0 0b       ..
+    tya                                                               ; a012: 98          .
+    jsr sub_ca0de                                                     ; a013: 20 de a0     ..
+    bne ca01d                                                         ; a016: d0 05       ..
+    jsr sub_c9ef4                                                     ; a018: 20 f4 9e     ..
+    bne ca021                                                         ; a01b: d0 04       ..
+; &a01d referenced 2 times by &a010, &a016
+.ca01d
+    sec                                                               ; a01d: 38          8
+    jsr sub_c9f26                                                     ; a01e: 20 26 9f     &.
+; &a021 referenced 2 times by &a008, &a01b
+.ca021
+    lda l1110,y                                                       ; a021: b9 10 11    ...
+    sta l00ba                                                         ; a024: 85 ba       ..
+    lda l1113,y                                                       ; a026: b9 13 11    ...
+    sta l00bb                                                         ; a029: 85 bb       ..
+    pla                                                               ; a02b: 68          h
+    ldy #0                                                            ; a02c: a0 00       ..
+    sta (l00ba),y                                                     ; a02e: 91 ba       ..
+    ldy l10c2                                                         ; a030: ac c2 10    ...
+    lda #&40 ; '@'                                                    ; a033: a9 40       .@
+    jsr sub_c9f0f                                                     ; a035: 20 0f 9f     ..
+    inc l00ba                                                         ; a038: e6 ba       ..
+    lda l00ba                                                         ; a03a: a5 ba       ..
+    sta l1110,y                                                       ; a03c: 99 10 11    ...
+    bne ca054                                                         ; a03f: d0 13       ..
+    jsr sub_c9f14                                                     ; a041: 20 14 9f     ..
+    lda l1111,y                                                       ; a044: b9 11 11    ...
+    adc #1                                                            ; a047: 69 01       i.
+    sta l1111,y                                                       ; a049: 99 11 11    ...
+    lda l1112,y                                                       ; a04c: b9 12 11    ...
+    adc #0                                                            ; a04f: 69 00       i.
+    sta l1112,y                                                       ; a051: 99 12 11    ...
+; &a054 referenced 1 time by &a03f
+.ca054
+    tya                                                               ; a054: 98          .
+    jsr sub_ca0de                                                     ; a055: 20 de a0     ..
+    bcc ca06b                                                         ; a058: 90 11       ..
+    lda #&20 ; ' '                                                    ; a05a: a9 20       .
+    jsr sub_c9f0f                                                     ; a05c: 20 0f 9f     ..
+    ldx #2                                                            ; a05f: a2 02       ..
+; &a061 referenced 1 time by &a069
+.loop_ca061
+    lda l1110,y                                                       ; a061: b9 10 11    ...
+    sta l1114,y                                                       ; a064: 99 14 11    ...
+    iny                                                               ; a067: c8          .
+    dex                                                               ; a068: ca          .
+    bpl loop_ca061                                                    ; a069: 10 f6       ..
+; &a06b referenced 3 times by &a058, &a0d1, &a0d9
+.ca06b
+    rts                                                               ; a06b: 60          `
+
+; &a06c referenced 2 times by &9849, &9db1
+.ca06c
+    jsr sub_c83e3                                                     ; a06c: 20 e3 83     ..
+    jsr sub_c9e75                                                     ; a06f: 20 75 9e     u.
+    ldy l10c2                                                         ; a072: ac c2 10    ...
+; &a075 referenced 1 time by &a0a6
+.ca075
+    jsr sub_ca0f6                                                     ; a075: 20 f6 a0     ..
+    bcs ca0a9                                                         ; a078: b0 2f       ./
+    lda l1114,y                                                       ; a07a: b9 14 11    ...
+    sta l1110,y                                                       ; a07d: 99 10 11    ...
+    lda l1115,y                                                       ; a080: b9 15 11    ...
+    sta l1111,y                                                       ; a083: 99 11 11    ...
+    lda l1116,y                                                       ; a086: b9 16 11    ...
+    sta l1112,y                                                       ; a089: 99 12 11    ...
+    jsr sub_ca0b8                                                     ; a08c: 20 b8 a0     ..
+    lda l00b6                                                         ; a08f: a5 b6       ..
+    pha                                                               ; a091: 48          H
+    lda l00b7                                                         ; a092: a5 b7       ..
+    pha                                                               ; a094: 48          H
+    lda l00b8                                                         ; a095: a5 b8       ..
+    pha                                                               ; a097: 48          H
+    lda #0                                                            ; a098: a9 00       ..
+    jsr sub_c9f7c                                                     ; a09a: 20 7c 9f     |.
+    pla                                                               ; a09d: 68          h
+    sta l00b8                                                         ; a09e: 85 b8       ..
+    pla                                                               ; a0a0: 68          h
+    sta l00b7                                                         ; a0a1: 85 b7       ..
+    pla                                                               ; a0a3: 68          h
+    sta l00b6                                                         ; a0a4: 85 b6       ..
+    jmp ca075                                                         ; a0a6: 4c 75 a0    Lu.
+
+; &a0a9 referenced 1 time by &a078
+.ca0a9
+    lda l0000,x                                                       ; a0a9: b5 00       ..
+    sta l1110,y                                                       ; a0ab: 99 10 11    ...
+    lda l0001,x                                                       ; a0ae: b5 01       ..
+    sta l1111,y                                                       ; a0b0: 99 11 11    ...
+    lda l0002,x                                                       ; a0b3: b5 02       ..
+    sta l1112,y                                                       ; a0b5: 99 12 11    ...
+; &a0b8 referenced 1 time by &a08c
+.sub_ca0b8
+    lda #&6f ; 'o'                                                    ; a0b8: a9 6f       .o
+    jsr sub_c9f16                                                     ; a0ba: 20 16 9f     ..
+    lda l110f,y                                                       ; a0bd: b9 0f 11    ...
+    adc l1111,y                                                       ; a0c0: 79 11 11    y..
+    sta l10c4                                                         ; a0c3: 8d c4 10    ...
+    lda l110d,y                                                       ; a0c6: b9 0d 11    ...
+    and #3                                                            ; a0c9: 29 03       ).
+    adc l1112,y                                                       ; a0cb: 79 12 11    y..
+    cmp l111d,y                                                       ; a0ce: d9 1d 11    ...
+    bne ca06b                                                         ; a0d1: d0 98       ..
+    lda l10c4                                                         ; a0d3: ad c4 10    ...
+    cmp l111c,y                                                       ; a0d6: d9 1c 11    ...
+    bne ca06b                                                         ; a0d9: d0 90       ..
+    jmp c9f0d                                                         ; a0db: 4c 0d 9f    L..
+
+; &a0de referenced 5 times by &9e66, &9e9b, &9f9a, &a013, &a055
+.sub_ca0de
+    tax                                                               ; a0de: aa          .
+    lda l1112,y                                                       ; a0df: b9 12 11    ...
+    cmp l1116,x                                                       ; a0e2: dd 16 11    ...
+    bne ca0f5                                                         ; a0e5: d0 0e       ..
+    lda l1111,y                                                       ; a0e7: b9 11 11    ...
+    cmp l1115,x                                                       ; a0ea: dd 15 11    ...
+    bne ca0f5                                                         ; a0ed: d0 06       ..
+    lda l1110,y                                                       ; a0ef: b9 10 11    ...
+    cmp l1114,x                                                       ; a0f2: dd 14 11    ...
+; &a0f5 referenced 2 times by &a0e5, &a0ed
+.ca0f5
+    rts                                                               ; a0f5: 60          `
+
+; &a0f6 referenced 1 time by &a075
+.sub_ca0f6
+    lda l1114,y                                                       ; a0f6: b9 14 11    ...
+    cmp l0000,x                                                       ; a0f9: d5 00       ..
+    lda l1115,y                                                       ; a0fb: b9 15 11    ...
+    sbc l0001,x                                                       ; a0fe: f5 01       ..
+    lda l1116,y                                                       ; a100: b9 16 11    ...
+    sbc l0002,x                                                       ; a103: f5 02       ..
+    rts                                                               ; a105: 60          `
+
+.sub_ca106
+    tya                                                               ; a106: 98          .
+    ldx #&ff                                                          ; a107: a2 ff       ..
+    ldy #&14                                                          ; a109: a0 14       ..
+; &a10b referenced 2 times by &9711, &a13c
+.ca10b
+    pha                                                               ; a10b: 48          H
+    jsr print_inline_l809f_top_bit_clear                              ; a10c: 20 77 80     w.
+    equs &0d, "DFS 2.26", &0d                                         ; a10f: 0d 44 46... .DF
+
+    stx l00bf                                                         ; a119: 86 bf       ..
+    sty l00b7                                                         ; a11b: 84 b7       ..
+; &a11d referenced 1 time by &a12e
+.loop_ca11d
+    lda #0                                                            ; a11d: a9 00       ..
+    sta l00b9                                                         ; a11f: 85 b9       ..
+    ldy #2                                                            ; a121: a0 02       ..
+    jsr sub_ca1c6                                                     ; a123: 20 c6 a1     ..
+    jsr sub_ca168                                                     ; a126: 20 68 a1     h.
+    jsr ca3dc                                                         ; a129: 20 dc a3     ..
+    dec l00b7                                                         ; a12c: c6 b7       ..
+    bne loop_ca11d                                                    ; a12e: d0 ed       ..
+    pla                                                               ; a130: 68          h
+    tay                                                               ; a131: a8          .
+; &a132 referenced 1 time by &a148
+.loop_ca132
+    ldx #&cf                                                          ; a132: a2 cf       ..
+    jmp c8703                                                         ; a134: 4c 03 87    L..
+
+.sub_ca137
+    tya                                                               ; a137: 98          .
+    ldx #&9d                                                          ; a138: a2 9d       ..
+    ldy #6                                                            ; a13a: a0 06       ..
+    bne ca10b                                                         ; a13c: d0 cd       ..
+    jsr clc_jmp_gsinit                                                ; a13e: 20 4c 87     L.
+    beq ca1c0                                                         ; a141: f0 7d       .}
+; &a143 referenced 1 time by &a146
+.loop_ca143
+    jsr sub_c8149                                                     ; a143: 20 49 81     I.
+    bcc loop_ca143                                                    ; a146: 90 fb       ..
+    bcs loop_ca132                                                    ; a148: b0 e8       ..
+; &a14a referenced 13 times by &8257, &8753, &8785, &879a, &87ee, &89b7, &89e9, &8baf, &8bc1, &a324, &a32d, &a469, &a5cb
+.sub_ca14a
+    jsr clc_jmp_gsinit                                                ; a14a: 20 4c 87     L.
+    bne ca1c0                                                         ; a14d: d0 71       .q
+; &a14f referenced 3 times by &8805, &a5e2, &ac25
+.ca14f
+    jsr generate_error                                                ; a14f: 20 48 80     H.
+    equb &dc                                                          ; a152: dc          .
+    equs "Syntax: "                                                   ; a153: 53 79 6e... Syn
+
+    stx l00b9                                                         ; a15b: 86 b9       ..
+    jsr sub_ca168                                                     ; a15d: 20 68 a1     h.
+    lda #0                                                            ; a160: a9 00       ..
+    jsr sub_ca1b4                                                     ; a162: 20 b4 a1     ..
+    jmp l0100                                                         ; a165: 4c 00 01    L..
+
+; &a168 referenced 2 times by &a126, &a15d
+.sub_ca168
+    ldx l00bf                                                         ; a168: a6 bf       ..
+    lda #9                                                            ; a16a: a9 09       ..
+    sta l00b8                                                         ; a16c: 85 b8       ..
+; &a16e referenced 1 time by &a177
+.loop_ca16e
+    inx                                                               ; a16e: e8          .
+    lda command_table,x                                               ; a16f: bd 1c 86    ...
+    bmi ca17a                                                         ; a172: 30 06       0.
+    jsr sub_ca1b4                                                     ; a174: 20 b4 a1     ..
+    jmp loop_ca16e                                                    ; a177: 4c 6e a1    Ln.
+
+; &a17a referenced 1 time by &a172
+.ca17a
+    ldy l00b8                                                         ; a17a: a4 b8       ..
+    cpy #&0c                                                          ; a17c: c0 0c       ..
+    beq ca183                                                         ; a17e: f0 03       ..
+    jsr sub_ca1c6                                                     ; a180: 20 c6 a1     ..
+; &a183 referenced 1 time by &a17e
+.ca183
+    inx                                                               ; a183: e8          .
+    inx                                                               ; a184: e8          .
+    stx l00bf                                                         ; a185: 86 bf       ..
+    lda command_table,x                                               ; a187: bd 1c 86    ...
+    jsr sub_ca190                                                     ; a18a: 20 90 a1     ..
+    jsr sub_c81bf                                                     ; a18d: 20 bf 81     ..
+; &a190 referenced 1 time by &a18a
+.sub_ca190
+    jsr sub_c83e3                                                     ; a190: 20 e3 83     ..
+    and #&0f                                                          ; a193: 29 0f       ).
+    beq ca1c0                                                         ; a195: f0 29       .)
+    tay                                                               ; a197: a8          .
+    lda #&20 ; ' '                                                    ; a198: a9 20       .
+    jsr sub_ca1b4                                                     ; a19a: 20 b4 a1     ..
+    ldx #&ff                                                          ; a19d: a2 ff       ..
+; &a19f referenced 2 times by &a1a3, &a1a6
+.ca19f
+    inx                                                               ; a19f: e8          .
+    lda la1d3,x                                                       ; a1a0: bd d3 a1    ...
+    bpl ca19f                                                         ; a1a3: 10 fa       ..
+    dey                                                               ; a1a5: 88          .
+    bne ca19f                                                         ; a1a6: d0 f7       ..
+    and #&7f                                                          ; a1a8: 29 7f       ).
+; &a1aa referenced 1 time by &a1b1
+.loop_ca1aa
+    jsr sub_ca1b4                                                     ; a1aa: 20 b4 a1     ..
+    inx                                                               ; a1ad: e8          .
+    lda la1d3,x                                                       ; a1ae: bd d3 a1    ...
+    bpl loop_ca1aa                                                    ; a1b1: 10 f7       ..
+    rts                                                               ; a1b3: 60          `
+
+; &a1b4 referenced 5 times by &a162, &a174, &a19a, &a1aa, &a1cc
+.sub_ca1b4
+    jsr sub_c83e3                                                     ; a1b4: 20 e3 83     ..
+    ldx l00b9                                                         ; a1b7: a6 b9       ..
+    beq ca1c1                                                         ; a1b9: f0 06       ..
+    inc l00b9                                                         ; a1bb: e6 b9       ..
+    sta l0100,x                                                       ; a1bd: 9d 00 01    ...
+; &a1c0 referenced 3 times by &a141, &a14d, &a195
+.ca1c0
+    rts                                                               ; a1c0: 60          `
+
+; &a1c1 referenced 1 time by &a1b9
+.ca1c1
+    dec l00b8                                                         ; a1c1: c6 b8       ..
+    jmp c809f                                                         ; a1c3: 4c 9f 80    L..
+
+; &a1c6 referenced 2 times by &a123, &a180
+.sub_ca1c6
+    lda l00b9                                                         ; a1c6: a5 b9       ..
+    bne ca1d2                                                         ; a1c8: d0 08       ..
+    lda #&20 ; ' '                                                    ; a1ca: a9 20       .
+; &a1cc referenced 1 time by &a1d0
+.loop_ca1cc
+    jsr sub_ca1b4                                                     ; a1cc: 20 b4 a1     ..
+    dey                                                               ; a1cf: 88          .
+    bne loop_ca1cc                                                    ; a1d0: d0 fa       ..
+; &a1d2 referenced 1 time by &a1c8
+.ca1d2
+    rts                                                               ; a1d2: 60          `
+
+; &a1d3 referenced 2 times by &a1a0, &a1ae
+.la1d3
+    equb &bc                                                          ; a1d3: bc          .
+    equs "fsp>"                                                       ; a1d4: 66 73 70... fsp
+    equb &bc                                                          ; a1d8: bc          .
+    equs "afsp>"                                                      ; a1d9: 61 66 73... afs
+    equb &a8, &4c, &29, &bc                                           ; a1de: a8 4c 29... .L)
+    equs "source> <dest.>"                                            ; a1e2: 73 6f 75... sou
+    equb &bc                                                          ; a1f1: bc          .
+    equs "old fsp> <new fsp>"                                         ; a1f2: 6f 6c 64... old
+    equb &a8                                                          ; a204: a8          .
+    equs "<dir>)"                                                     ; a205: 3c 64 69... <di
+    equb &a8                                                          ; a20b: a8          .
+    equs "<drive>)"                                                   ; a20c: 3c 64 72... <dr
+    equb &bc                                                          ; a214: bc          .
+    equs "title>"                                                     ; a215: 74 69 74... tit
+    equb &bc                                                          ; a21b: bc          .
+    equs "drive> (40)(80)"                                            ; a21c: 64 72 69... dri
+    equb &b4                                                          ; a22b: b4          .
+    equs "0/80"                                                       ; a22c: 30 2f 38... 0/8
+    equb &a8                                                          ; a230: a8          .
+    equs "<drive>)..."                                                ; a231: 3c 64 72... <dr
+    equb &a8                                                          ; a23c: a8          .
+    equs "<rom>)"                                                     ; a23d: 3c 72 6f... <ro
+    equb &ff                                                          ; a243: ff          .
+
+.sub_ca244
+    jsr sub_c8b86                                                     ; a244: 20 86 8b     ..
+    jsr print_inline_l809f_top_bit_clear                              ; a247: 20 77 80     w.
+    equs "Compacting :"                                               ; a24a: 43 6f 6d... Com
+
+    sta l10d1                                                         ; a256: 8d d1 10    ...
+    sta l10d2                                                         ; a259: 8d d2 10    ...
+    jsr sub_c80c3                                                     ; a25c: 20 c3 80     ..
+    jsr ca3dc                                                         ; a25f: 20 dc a3     ..
+    ldy #0                                                            ; a262: a0 00       ..
+    jsr sub_c9b79                                                     ; a264: 20 79 9b     y.
+    jsr sub_c9a8d                                                     ; a267: 20 8d 9a     ..
+    jsr sub_c8380                                                     ; a26a: 20 80 83     ..
+    ldy l0f05                                                         ; a26d: ac 05 0f    ...
+    sty l00ca                                                         ; a270: 84 ca       ..
+    lda #2                                                            ; a272: a9 02       ..
+    sta l00c8                                                         ; a274: 85 c8       ..
+    lda #0                                                            ; a276: a9 00       ..
+    sta l00c9                                                         ; a278: 85 c9       ..
+; &a27a referenced 1 time by &a312
+.ca27a
+    ldy l00ca                                                         ; a27a: a4 ca       ..
+    jsr sub_c82b2                                                     ; a27c: 20 b2 82     ..
+    cpy #&f8                                                          ; a27f: c0 f8       ..
+    bne ca2ab                                                         ; a281: d0 28       .(
+    lda l0f07                                                         ; a283: ad 07 0f    ...
+    sec                                                               ; a286: 38          8
+    sbc l00c8                                                         ; a287: e5 c8       ..
+    pha                                                               ; a289: 48          H
+    lda l0f06                                                         ; a28a: ad 06 0f    ...
+    and #3                                                            ; a28d: 29 03       ).
+    sbc l00c9                                                         ; a28f: e5 c9       ..
+    jsr sub_c80c3                                                     ; a291: 20 c3 80     ..
+    pla                                                               ; a294: 68          h
+    jsr sub_c80bb                                                     ; a295: 20 bb 80     ..
+    jsr print_inline_l809f_top_bit_clear                              ; a298: 20 77 80     w.
+    equs " free sectors", &0d                                         ; a29b: 20 66 72...  fr
+
+    nop                                                               ; a2a9: ea          .
+    rts                                                               ; a2aa: 60          `
+
+; &a2ab referenced 1 time by &a281
+.ca2ab
+    sty l00ca                                                         ; a2ab: 84 ca       ..
+    jsr sub_c8335                                                     ; a2ad: 20 35 83     5.
+    ldy l00ca                                                         ; a2b0: a4 ca       ..
+    lda l0f0c,y                                                       ; a2b2: b9 0c 0f    ...
+    cmp #1                                                            ; a2b5: c9 01       ..
+    lda #0                                                            ; a2b7: a9 00       ..
+    sta l00bc                                                         ; a2b9: 85 bc       ..
+    sta l00c0                                                         ; a2bb: 85 c0       ..
+    adc l0f0d,y                                                       ; a2bd: 79 0d 0f    y..
+    sta l00c4                                                         ; a2c0: 85 c4       ..
+    lda l0f0e,y                                                       ; a2c2: b9 0e 0f    ...
+    php                                                               ; a2c5: 08          .
+    jsr sub_c81b0                                                     ; a2c6: 20 b0 81     ..
+    plp                                                               ; a2c9: 28          (
+    adc #0                                                            ; a2ca: 69 00       i.
+    sta l00c5                                                         ; a2cc: 85 c5       ..
+    lda l0f0f,y                                                       ; a2ce: b9 0f 0f    ...
+    sta l00c6                                                         ; a2d1: 85 c6       ..
+    lda l0f0e,y                                                       ; a2d3: b9 0e 0f    ...
+    and #3                                                            ; a2d6: 29 03       ).
+    sta l00c7                                                         ; a2d8: 85 c7       ..
+    cmp l00c9                                                         ; a2da: c5 c9       ..
+    bne ca2f2                                                         ; a2dc: d0 14       ..
+    lda l00c6                                                         ; a2de: a5 c6       ..
+    cmp l00c8                                                         ; a2e0: c5 c8       ..
+    bne ca2f2                                                         ; a2e2: d0 0e       ..
+    clc                                                               ; a2e4: 18          .
+    adc l00c4                                                         ; a2e5: 65 c4       e.
+    sta l00c8                                                         ; a2e7: 85 c8       ..
+    lda l00c9                                                         ; a2e9: a5 c9       ..
+    adc l00c5                                                         ; a2eb: 65 c5       e.
+    sta l00c9                                                         ; a2ed: 85 c9       ..
+    jmp ca30d                                                         ; a2ef: 4c 0d a3    L..
+
+; &a2f2 referenced 2 times by &a2dc, &a2e2
+.ca2f2
+    lda l00c8                                                         ; a2f2: a5 c8       ..
+    sta l0f0f,y                                                       ; a2f4: 99 0f 0f    ...
+    lda l0f0e,y                                                       ; a2f7: b9 0e 0f    ...
+    and #&fc                                                          ; a2fa: 29 fc       ).
+    ora l00c9                                                         ; a2fc: 05 c9       ..
+    sta l0f0e,y                                                       ; a2fe: 99 0e 0f    ...
+    lda #0                                                            ; a301: a9 00       ..
+    sta l00a8                                                         ; a303: 85 a8       ..
+    sta l00a9                                                         ; a305: 85 a9       ..
+    jsr sub_ca530                                                     ; a307: 20 30 a5     0.
+    jsr c93e6                                                         ; a30a: 20 e6 93     ..
+; &a30d referenced 1 time by &a2ef
+.ca30d
+    ldy l00ca                                                         ; a30d: a4 ca       ..
+    jsr sub_c833a                                                     ; a30f: 20 3a 83     :.
+    jmp ca27a                                                         ; a312: 4c 7a a2    Lz.
+
+; &a315 referenced 3 times by &8794, &a41a, &a64c
+.sub_ca315
+    bit l10c7                                                         ; a315: 2c c7 10    ,..
+    bpl ca378                                                         ; a318: 10 5e       .^
+    jsr sub_ca3ec                                                     ; a31a: 20 ec a3     ..
+    beq ca321                                                         ; a31d: f0 02       ..
+    pla                                                               ; a31f: 68          h
+    pla                                                               ; a320: 68          h
+; &a321 referenced 1 time by &a31d
+.ca321
+    jmp ca3dc                                                         ; a321: 4c dc a3    L..
+
+; &a324 referenced 2 times by &a417, &a466
+.sub_ca324
+    jsr sub_ca14a                                                     ; a324: 20 4a a1     J.
+    jsr c8b8b                                                         ; a327: 20 8b 8b     ..
+    sta l10d1                                                         ; a32a: 8d d1 10    ...
+    jsr sub_ca14a                                                     ; a32d: 20 4a a1     J.
+    jsr c8b8b                                                         ; a330: 20 8b 8b     ..
+    sta l10d2                                                         ; a333: 8d d2 10    ...
+    tya                                                               ; a336: 98          .
+    pha                                                               ; a337: 48          H
+    lda #0                                                            ; a338: a9 00       ..
+    sta l00a9                                                         ; a33a: 85 a9       ..
+    lda l10d2                                                         ; a33c: ad d2 10    ...
+    cmp l10d1                                                         ; a33f: cd d1 10    ...
+    bne ca34a                                                         ; a342: d0 06       ..
+    lda #&ff                                                          ; a344: a9 ff       ..
+    sta l00a9                                                         ; a346: 85 a9       ..
+    sta l00aa                                                         ; a348: 85 aa       ..
+; &a34a referenced 1 time by &a342
+.ca34a
+    jsr sub_c9a8d                                                     ; a34a: 20 8d 9a     ..
+    jsr print_inline_l809f_top_bit_clear                              ; a34d: 20 77 80     w.
+    equs "Copying from :"                                             ; a350: 43 6f 70... Cop
+
+    lda l10d1                                                         ; a35e: ad d1 10    ...
+    jsr sub_c80c3                                                     ; a361: 20 c3 80     ..
+    jsr print_inline_l809f_top_bit_clear                              ; a364: 20 77 80     w.
+    equs " to :"                                                      ; a367: 20 74 6f...  to
+
+    lda l10d2                                                         ; a36c: ad d2 10    ...
+    jsr sub_c80c3                                                     ; a36f: 20 c3 80     ..
+    jsr ca3dc                                                         ; a372: 20 dc a3     ..
+    pla                                                               ; a375: 68          h
+    tay                                                               ; a376: a8          .
+    clc                                                               ; a377: 18          .
+; &a378 referenced 1 time by &a318
+.ca378
+    rts                                                               ; a378: 60          `
+
+; &a379 referenced 4 times by &a429, &a46f, &a4c8, &a55b
+.sub_ca379
+    jsr sub_c83e3                                                     ; a379: 20 e3 83     ..
+    bit l00a9                                                         ; a37c: 24 a9       $.
+    bpl ca38b                                                         ; a37e: 10 0b       ..
+    lda #0                                                            ; a380: a9 00       ..
+    beq ca38e                                                         ; a382: f0 0a       ..
+; &a384 referenced 3 times by &a440, &a4e4, &a581
+.sub_ca384
+    jsr sub_c83e3                                                     ; a384: 20 e3 83     ..
+    bit l00a9                                                         ; a387: 24 a9       $.
+    bmi ca38c                                                         ; a389: 30 01       0.
+; &a38b referenced 2 times by &a37e, &a390
+.ca38b
+    rts                                                               ; a38b: 60          `
+
+; &a38c referenced 1 time by &a389
+.ca38c
+    lda #&80                                                          ; a38c: a9 80       ..
+; &a38e referenced 1 time by &a382
+.ca38e
+    cmp l00aa                                                         ; a38e: c5 aa       ..
+    beq ca38b                                                         ; a390: f0 f9       ..
+    sta l00aa                                                         ; a392: 85 aa       ..
+    jsr print_inline_l809f_top_bit_clear                              ; a394: 20 77 80     w.
+    equs "Insert "                                                    ; a397: 49 6e 73... Ins
+
+    nop                                                               ; a39e: ea          .
+    bit l00aa                                                         ; a39f: 24 aa       $.
+    bmi ca3ae                                                         ; a3a1: 30 0b       0.
+    jsr print_inline_l809f_top_bit_clear                              ; a3a3: 20 77 80     w.
+    equs "source"                                                     ; a3a6: 73 6f 75... sou
+
+    bcc ca3bd                                                         ; a3ac: 90 0f       ..
+; &a3ae referenced 1 time by &a3a1
+.ca3ae
+    jsr print_inline_l809f_top_bit_clear                              ; a3ae: 20 77 80     w.
+    equs "destination"                                                ; a3b1: 64 65 73... des
+
+    nop                                                               ; a3bc: ea          .
+; &a3bd referenced 1 time by &a3ac
+.ca3bd
+    jsr print_inline_l809f_top_bit_clear                              ; a3bd: 20 77 80     w.
+    equs " disc and hit a key"                                        ; a3c0: 20 64 69...  di
+
+    nop                                                               ; a3d3: ea          .
+    jsr sub_c9ac8                                                     ; a3d4: 20 c8 9a     ..
+    jsr osrdch                                                        ; a3d7: 20 e0 ff     ..
+    bcs ca411                                                         ; a3da: b0 35       .5
+; &a3dc referenced 16 times by &836b, &8522, &854f, &85b2, &85b5, &8779, &87a8, &87b5, &a129, &a25f, &a321, &a372, &a62f, &a6b0, &a73a, &aa95
+.ca3dc
+    pha                                                               ; a3dc: 48          H
+    lda #&0d                                                          ; a3dd: a9 0d       ..
+    jsr c809f                                                         ; a3df: 20 9f 80     ..
+    pla                                                               ; a3e2: 68          h
+    rts                                                               ; a3e3: 60          `
+
+; &a3e4 referenced 1 time by &8761
+.sub_ca3e4
+    jsr print_inline_l809f_top_bit_clear                              ; a3e4: 20 77 80     w.
+    equs " : "                                                        ; a3e7: 20 3a 20     :
+
+    bcc ca3fb                                                         ; a3ea: 90 0f       ..
+; &a3ec referenced 2 times by &87b0, &a31a
+.sub_ca3ec
+    jsr print_inline_l809f_top_bit_clear                              ; a3ec: 20 77 80     w.
+    equs "Go (Y/N) ? "                                                ; a3ef: 47 6f 20... Go
+
+    nop                                                               ; a3fa: ea          .
+; &a3fb referenced 1 time by &a3ea
+.ca3fb
+    jsr sub_c9ac8                                                     ; a3fb: 20 c8 9a     ..
+    jsr osrdch                                                        ; a3fe: 20 e0 ff     ..
+    bcs ca411                                                         ; a401: b0 0e       ..
+    and #&5f ; '_'                                                    ; a403: 29 5f       )_
+    cmp #&59 ; 'Y'                                                    ; a405: c9 59       .Y
+    php                                                               ; a407: 08          .
+    beq ca40c                                                         ; a408: f0 02       ..
+    lda #&4e ; 'N'                                                    ; a40a: a9 4e       .N
+; &a40c referenced 1 time by &a408
+.ca40c
+    jsr c809f                                                         ; a40c: 20 9f 80     ..
+    plp                                                               ; a40f: 28          (
+    rts                                                               ; a410: 60          `
+
+; &a411 referenced 2 times by &a3da, &a401
+.ca411
+    jmp c9436                                                         ; a411: 4c 36 94    L6.
+
+; &a414 referenced 2 times by &a452, &a45b
+.ca414
+    jmp c8a6e                                                         ; a414: 4c 6e 8a    Ln.
+
+.sub_ca417
+    jsr sub_ca324                                                     ; a417: 20 24 a3     $.
+    jsr sub_ca315                                                     ; a41a: 20 15 a3     ..
+    lda #0                                                            ; a41d: a9 00       ..
+    sta l00c7                                                         ; a41f: 85 c7       ..
+    sta l00c9                                                         ; a421: 85 c9       ..
+    sta l00c8                                                         ; a423: 85 c8       ..
+    sta l00c6                                                         ; a425: 85 c6       ..
+    sta l00a8                                                         ; a427: 85 a8       ..
+    jsr sub_ca379                                                     ; a429: 20 79 a3     y.
+    lda l10d1                                                         ; a42c: ad d1 10    ...
+    sta l00cd                                                         ; a42f: 85 cd       ..
+    jsr c940c                                                         ; a431: 20 0c 94     ..
+    lda l0f07                                                         ; a434: ad 07 0f    ...
+    sta l00c4                                                         ; a437: 85 c4       ..
+    lda l0f06                                                         ; a439: ad 06 0f    ...
+    and #3                                                            ; a43c: 29 03       ).
+    sta l00c5                                                         ; a43e: 85 c5       ..
+    jsr sub_ca384                                                     ; a440: 20 84 a3     ..
+    lda l10d2                                                         ; a443: ad d2 10    ...
+    sta l00cd                                                         ; a446: 85 cd       ..
+    jsr c940c                                                         ; a448: 20 0c 94     ..
+    lda l0f06                                                         ; a44b: ad 06 0f    ...
+    and #3                                                            ; a44e: 29 03       ).
+    cmp l00c5                                                         ; a450: c5 c5       ..
+    bcc ca414                                                         ; a452: 90 c0       ..
+    bne ca45d                                                         ; a454: d0 07       ..
+    lda l0f07                                                         ; a456: ad 07 0f    ...
+    cmp l00c4                                                         ; a459: c5 c4       ..
+    bcc ca414                                                         ; a45b: 90 b7       ..
+; &a45d referenced 1 time by &a454
+.ca45d
+    jsr sub_ca530                                                     ; a45d: 20 30 a5     0.
+    jmp c940c                                                         ; a460: 4c 0c 94    L..
+
+.sub_ca463
+    jsr sub_c99ac                                                     ; a463: 20 ac 99     ..
+    jsr sub_ca324                                                     ; a466: 20 24 a3     $.
+    jsr sub_ca14a                                                     ; a469: 20 4a a1     J.
+    jsr sub_c80ed                                                     ; a46c: 20 ed 80     ..
+    jsr sub_ca379                                                     ; a46f: 20 79 a3     y.
+    lda l10d1                                                         ; a472: ad d1 10    ...
+    jsr c8816                                                         ; a475: 20 16 88     ..
+    jsr c8225                                                         ; a478: 20 25 82     %.
+; &a47b referenced 1 time by &a4de
+.ca47b
+    lda l00cc                                                         ; a47b: a5 cc       ..
+    pha                                                               ; a47d: 48          H
+    lda l00b6                                                         ; a47e: a5 b6       ..
+    sta l00ab                                                         ; a480: 85 ab       ..
+    jsr sub_c833a                                                     ; a482: 20 3a 83     :.
+    ldx #0                                                            ; a485: a2 00       ..
+; &a487 referenced 1 time by &a49b
+.loop_ca487
+    lda l0e08,y                                                       ; a487: b9 08 0e    ...
+    sta l00c5,x                                                       ; a48a: 95 c5       ..
+    sta l1050,x                                                       ; a48c: 9d 50 10    .P.
+    lda l0f08,y                                                       ; a48f: b9 08 0f    ...
+    sta l00bb,x                                                       ; a492: 95 bb       ..
+    sta l1047,x                                                       ; a494: 9d 47 10    .G.
+    inx                                                               ; a497: e8          .
+    iny                                                               ; a498: c8          .
+    cpx #8                                                            ; a499: e0 08       ..
+    bne loop_ca487                                                    ; a49b: d0 ea       ..
+    lda l00c1                                                         ; a49d: a5 c1       ..
+    jsr sub_c81b0                                                     ; a49f: 20 b0 81     ..
+    sta l00c3                                                         ; a4a2: 85 c3       ..
+    lda l00bf                                                         ; a4a4: a5 bf       ..
+    clc                                                               ; a4a6: 18          .
+    adc #&ff                                                          ; a4a7: 69 ff       i.
+    lda l00c0                                                         ; a4a9: a5 c0       ..
+    adc #0                                                            ; a4ab: 69 00       i.
+    sta l00c4                                                         ; a4ad: 85 c4       ..
+    lda l00c3                                                         ; a4af: a5 c3       ..
+    adc #0                                                            ; a4b1: 69 00       i.
+    sta l00c5                                                         ; a4b3: 85 c5       ..
+    lda l104e                                                         ; a4b5: ad 4e 10    .N.
+    sta l00c6                                                         ; a4b8: 85 c6       ..
+    lda l104d                                                         ; a4ba: ad 4d 10    .M.
+    and #3                                                            ; a4bd: 29 03       ).
+    sta l00c7                                                         ; a4bf: 85 c7       ..
+    lda #&ff                                                          ; a4c1: a9 ff       ..
+    sta l00a8                                                         ; a4c3: 85 a8       ..
+    jsr sub_ca530                                                     ; a4c5: 20 30 a5     0.
+    jsr sub_ca379                                                     ; a4c8: 20 79 a3     y.
+    lda l10d1                                                         ; a4cb: ad d1 10    ...
+    jsr c8816                                                         ; a4ce: 20 16 88     ..
+    jsr sub_c8380                                                     ; a4d1: 20 80 83     ..
+    lda l00ab                                                         ; a4d4: a5 ab       ..
+    sta l00b6                                                         ; a4d6: 85 b6       ..
+    pla                                                               ; a4d8: 68          h
+    sta l00cc                                                         ; a4d9: 85 cc       ..
+    jsr sub_c8280                                                     ; a4db: 20 80 82     ..
+    bcs ca47b                                                         ; a4de: b0 9b       ..
+    rts                                                               ; a4e0: 60          `
+
+; &a4e1 referenced 1 time by &a56d
+.sub_ca4e1
+    jsr sub_ca51f                                                     ; a4e1: 20 1f a5     ..
+    jsr sub_ca384                                                     ; a4e4: 20 84 a3     ..
+    lda l10d2                                                         ; a4e7: ad d2 10    ...
+    sta l00cd                                                         ; a4ea: 85 cd       ..
+    lda l00cc                                                         ; a4ec: a5 cc       ..
+    pha                                                               ; a4ee: 48          H
+    jsr sub_c8380                                                     ; a4ef: 20 80 83     ..
+    jsr sub_c826d                                                     ; a4f2: 20 6d 82     m.
+    bcc ca4fa                                                         ; a4f5: 90 03       ..
+    jsr sub_c830a                                                     ; a4f7: 20 0a 83     ..
+; &a4fa referenced 1 time by &a4f5
+.ca4fa
+    pla                                                               ; a4fa: 68          h
+    sta l00cc                                                         ; a4fb: 85 cc       ..
+    jsr sub_c8b4d                                                     ; a4fd: 20 4d 8b     M.
+    jsr sub_c8b64                                                     ; a500: 20 64 8b     d.
+    lda l00c2                                                         ; a503: a5 c2       ..
+    jsr sub_c81b0                                                     ; a505: 20 b0 81     ..
+    sta l00c4                                                         ; a508: 85 c4       ..
+    jsr sub_c8ab3                                                     ; a50a: 20 b3 8a     ..
+    lda l00c2                                                         ; a50d: a5 c2       ..
+    and #3                                                            ; a50f: 29 03       ).
+    pha                                                               ; a511: 48          H
+    lda l00c3                                                         ; a512: a5 c3       ..
+    pha                                                               ; a514: 48          H
+    jsr sub_ca51f                                                     ; a515: 20 1f a5     ..
+    pla                                                               ; a518: 68          h
+    sta l00c8                                                         ; a519: 85 c8       ..
+    pla                                                               ; a51b: 68          h
+    sta l00c9                                                         ; a51c: 85 c9       ..
+    rts                                                               ; a51e: 60          `
+
+; &a51f referenced 2 times by &a4e1, &a515
+.sub_ca51f
+    ldx #&11                                                          ; a51f: a2 11       ..
+; &a521 referenced 1 time by &a52d
+.loop_ca521
+    lda l1045,x                                                       ; a521: bd 45 10    .E.
+    ldy l00ba,x                                                       ; a524: b4 ba       ..
+    sta l00ba,x                                                       ; a526: 95 ba       ..
+    tya                                                               ; a528: 98          .
+    sta l1045,x                                                       ; a529: 9d 45 10    .E.
+    dex                                                               ; a52c: ca          .
+    bpl loop_ca521                                                    ; a52d: 10 f2       ..
+    rts                                                               ; a52f: 60          `
+
+; &a530 referenced 3 times by &a307, &a45d, &a4c5
+.sub_ca530
+    lda #0                                                            ; a530: a9 00       ..
+    sta l00bc                                                         ; a532: 85 bc       ..
+    sta l00c0                                                         ; a534: 85 c0       ..
+    beq ca5ab                                                         ; a536: f0 73       .s
+; &a538 referenced 1 time by &a5af
+.ca538
+    lda l00c4                                                         ; a538: a5 c4       ..
+    tay                                                               ; a53a: a8          .
+    cmp l10d0                                                         ; a53b: cd d0 10    ...
+    lda l00c5                                                         ; a53e: a5 c5       ..
+    sbc #0                                                            ; a540: e9 00       ..
+    bcc ca547                                                         ; a542: 90 03       ..
+    ldy l10d0                                                         ; a544: ac d0 10    ...
+; &a547 referenced 1 time by &a542
+.ca547
+    sty l00c1                                                         ; a547: 84 c1       ..
+    lda l00c6                                                         ; a549: a5 c6       ..
+    sta l00c3                                                         ; a54b: 85 c3       ..
+    lda l00c7                                                         ; a54d: a5 c7       ..
+    sta l00c2                                                         ; a54f: 85 c2       ..
+    lda l10cf                                                         ; a551: ad cf 10    ...
+    sta l00bd                                                         ; a554: 85 bd       ..
+    lda l10d1                                                         ; a556: ad d1 10    ...
+    sta l00cd                                                         ; a559: 85 cd       ..
+    jsr sub_ca379                                                     ; a55b: 20 79 a3     y.
+    jsr sub_ca5b2                                                     ; a55e: 20 b2 a5     ..
+    jsr sub_c8855                                                     ; a561: 20 55 88     U.
+    lda l10d2                                                         ; a564: ad d2 10    ...
+    sta l00cd                                                         ; a567: 85 cd       ..
+    bit l00a8                                                         ; a569: 24 a8       $.
+    bpl ca574                                                         ; a56b: 10 07       ..
+    jsr sub_ca4e1                                                     ; a56d: 20 e1 a4     ..
+    lda #0                                                            ; a570: a9 00       ..
+    sta l00a8                                                         ; a572: 85 a8       ..
+; &a574 referenced 1 time by &a56b
+.ca574
+    lda l00c8                                                         ; a574: a5 c8       ..
+    sta l00c3                                                         ; a576: 85 c3       ..
+    lda l00c9                                                         ; a578: a5 c9       ..
+    sta l00c2                                                         ; a57a: 85 c2       ..
+    lda l10cf                                                         ; a57c: ad cf 10    ...
+    sta l00bd                                                         ; a57f: 85 bd       ..
+    jsr sub_ca384                                                     ; a581: 20 84 a3     ..
+    jsr sub_ca5b2                                                     ; a584: 20 b2 a5     ..
+    jsr sub_c8862                                                     ; a587: 20 62 88     b.
+    lda l00c1                                                         ; a58a: a5 c1       ..
+    clc                                                               ; a58c: 18          .
+    adc l00c8                                                         ; a58d: 65 c8       e.
+    sta l00c8                                                         ; a58f: 85 c8       ..
+    bcc ca595                                                         ; a591: 90 02       ..
+    inc l00c9                                                         ; a593: e6 c9       ..
+; &a595 referenced 1 time by &a591
+.ca595
+    lda l00c1                                                         ; a595: a5 c1       ..
+    clc                                                               ; a597: 18          .
+    adc l00c6                                                         ; a598: 65 c6       e.
+    sta l00c6                                                         ; a59a: 85 c6       ..
+    bcc ca5a0                                                         ; a59c: 90 02       ..
+    inc l00c7                                                         ; a59e: e6 c7       ..
+; &a5a0 referenced 1 time by &a59c
+.ca5a0
+    sec                                                               ; a5a0: 38          8
+    lda l00c4                                                         ; a5a1: a5 c4       ..
+    sbc l00c1                                                         ; a5a3: e5 c1       ..
+    sta l00c4                                                         ; a5a5: 85 c4       ..
+    bcs ca5ab                                                         ; a5a7: b0 02       ..
+    dec l00c5                                                         ; a5a9: c6 c5       ..
+; &a5ab referenced 2 times by &a536, &a5a7
+.ca5ab
+    lda l00c4                                                         ; a5ab: a5 c4       ..
+    ora l00c5                                                         ; a5ad: 05 c5       ..
+    bne ca538                                                         ; a5af: d0 87       ..
+    rts                                                               ; a5b1: 60          `
+
+; &a5b2 referenced 2 times by &a55e, &a584
+.sub_ca5b2
+    lda #&ff                                                          ; a5b2: a9 ff       ..
+    sta l1074                                                         ; a5b4: 8d 74 10    .t.
+    sta l1075                                                         ; a5b7: 8d 75 10    .u.
+    rts                                                               ; a5ba: 60          `
+
+.sub_ca5bb
+    lda #0                                                            ; a5bb: a9 00       ..
+    beq ca5c4                                                         ; a5bd: f0 05       ..
+.sub_ca5bf
+    lda #&ff                                                          ; a5bf: a9 ff       ..
+    sta l1082                                                         ; a5c1: 8d 82 10    ...
+; &a5c4 referenced 1 time by &a5bd
+.ca5c4
+    sta l00c9                                                         ; a5c4: 85 c9       ..
+    sta l1090                                                         ; a5c6: 8d 90 10    ...
+    bpl ca5e5                                                         ; a5c9: 10 1a       ..
+    jsr sub_ca14a                                                     ; a5cb: 20 4a a1     J.
+    jsr sub_c8456                                                     ; a5ce: 20 56 84     V.
+    sta l109f                                                         ; a5d1: 8d 9f 10    ...
+    bcs ca5e2                                                         ; a5d4: b0 0c       ..
+    cmp #&23 ; '#'                                                    ; a5d6: c9 23       .#
+    beq ca5e5                                                         ; a5d8: f0 0b       ..
+    cmp #&28 ; '('                                                    ; a5da: c9 28       .(
+    beq ca5e5                                                         ; a5dc: f0 07       ..
+    cmp #&50 ; 'P'                                                    ; a5de: c9 50       .P
+    beq ca5e5                                                         ; a5e0: f0 03       ..
+; &a5e2 referenced 1 time by &a5d4
+.ca5e2
+    jmp ca14f                                                         ; a5e2: 4c 4f a1    LO.
+
+; &a5e5 referenced 4 times by &a5c9, &a5d8, &a5dc, &a5e0
+.ca5e5
+    jsr clc_jmp_gsinit                                                ; a5e5: 20 4c 87     L.
+    sty l00ca                                                         ; a5e8: 84 ca       ..
+    bne ca637                                                         ; a5ea: d0 4b       .K
+    bit l00c9                                                         ; a5ec: 24 c9       $.
+    bmi ca5fb                                                         ; a5ee: 30 0b       0.
+    jsr print_inline_l809f_top_bit_clear                              ; a5f0: 20 77 80     w.
+    equs "Verify"                                                     ; a5f3: 56 65 72... Ver
+
+    bcc ca605                                                         ; a5f9: 90 0a       ..
+; &a5fb referenced 1 time by &a5ee
+.ca5fb
+    jsr print_inline_l809f_top_bit_clear                              ; a5fb: 20 77 80     w.
+    equs "Format"                                                     ; a5fe: 46 6f 72... For
+
+    nop                                                               ; a604: ea          .
+; &a605 referenced 1 time by &a5f9
+.ca605
+    jsr print_inline_l809f_top_bit_clear                              ; a605: 20 77 80     w.
+    equs " which drive ? "                                            ; a608: 20 77 68...  wh
+
+    nop                                                               ; a617: ea          .
+    jsr osrdch                                                        ; a618: 20 e0 ff     ..
+    bcs ca65d                                                         ; a61b: b0 40       .@
+    cmp #&20 ; ' '                                                    ; a61d: c9 20       .
+    bcc ca660                                                         ; a61f: 90 3f       .?
+    jsr c809f                                                         ; a621: 20 9f 80     ..
+    sec                                                               ; a624: 38          8
+    sbc #&30 ; '0'                                                    ; a625: e9 30       .0
+    bcc ca660                                                         ; a627: 90 37       .7
+    cmp #4                                                            ; a629: c9 04       ..
+    bcs ca660                                                         ; a62b: b0 33       .3
+    sta l00cd                                                         ; a62d: 85 cd       ..
+    jsr ca3dc                                                         ; a62f: 20 dc a3     ..
+    ldy l00ca                                                         ; a632: a4 ca       ..
+    jmp ca63a                                                         ; a634: 4c 3a a6    L:.
+
+; &a637 referenced 2 times by &a5ea, &a65a
+.ca637
+    jsr c8b8b                                                         ; a637: 20 8b 8b     ..
+; &a63a referenced 1 time by &a634
+.ca63a
+    sty l00ca                                                         ; a63a: 84 ca       ..
+    bit l00c9                                                         ; a63c: 24 c9       $.
+    bpl ca647                                                         ; a63e: 10 07       ..
+    ldx l00cd                                                         ; a640: a6 cd       ..
+    lda #0                                                            ; a642: a9 00       ..
+    sta l10de,x                                                       ; a644: 9d de 10    ...
+; &a647 referenced 1 time by &a63e
+.ca647
+    bit l1090                                                         ; a647: 2c 90 10    ,..
+    bpl ca652                                                         ; a64a: 10 06       ..
+    jsr sub_ca315                                                     ; a64c: 20 15 a3     ..
+    jsr sub_c9a8d                                                     ; a64f: 20 8d 9a     ..
+; &a652 referenced 1 time by &a64a
+.ca652
+    jsr sub_ca663                                                     ; a652: 20 63 a6     c.
+    ldy l00ca                                                         ; a655: a4 ca       ..
+    jsr clc_jmp_gsinit                                                ; a657: 20 4c 87     L.
+    bne ca637                                                         ; a65a: d0 db       ..
+    rts                                                               ; a65c: 60          `
+
+; &a65d referenced 1 time by &a61b
+.ca65d
+    jmp c9436                                                         ; a65d: 4c 36 94    L6.
+
+; &a660 referenced 3 times by &a61f, &a627, &a62b
+.ca660
+    jmp c8ba2                                                         ; a660: 4c a2 8b    L..
+
+; &a663 referenced 1 time by &a652
+.sub_ca663
+    bit l00c9                                                         ; a663: 24 c9       $.
+    bmi ca675                                                         ; a665: 30 0e       0.
+    jsr print_inline_l809f_top_bit_clear                              ; a667: 20 77 80     w.
+    equs "Verifying"                                                  ; a66a: 56 65 72... Ver
+
+    bcc ca68a                                                         ; a673: 90 15       ..
+; &a675 referenced 1 time by &a665
+.ca675
+    jsr sub_ca76c                                                     ; a675: 20 6c a7     l.
+    jsr print_inline_l809f_top_bit_clear                              ; a678: 20 77 80     w.
+    equs "Formatting"                                                 ; a67b: 46 6f 72... For
+
+    ldx l00cd                                                         ; a685: a6 cd       ..
+    stx l1090                                                         ; a687: 8e 90 10    ...
+; &a68a referenced 1 time by &a673
+.ca68a
+    jsr print_inline_l809f_top_bit_clear                              ; a68a: 20 77 80     w.
+    equs " drive "                                                    ; a68d: 20 64 72...  dr
+
+    lda l00cd                                                         ; a694: a5 cd       ..
+    jsr sub_c80c3                                                     ; a696: 20 c3 80     ..
+    jsr print_inline_l809f_top_bit_clear                              ; a699: 20 77 80     w.
+    equs " track   "                                                  ; a69c: 20 74 72...  tr
+
+    nop                                                               ; a6a5: ea          .
+    bit l00c9                                                         ; a6a6: 24 c9       $.
+    bmi ca6b6                                                         ; a6a8: 30 0c       0.
+    jsr sub_ca7ce                                                     ; a6aa: 20 ce a7     ..
+    txa                                                               ; a6ad: 8a          .
+    bne ca6b3                                                         ; a6ae: d0 03       ..
+    jmp ca3dc                                                         ; a6b0: 4c dc a3    L..
+
+; &a6b3 referenced 1 time by &a6ae
+.ca6b3
+    sta l109f                                                         ; a6b3: 8d 9f 10    ...
+; &a6b6 referenced 1 time by &a6a8
+.ca6b6
+    lda #0                                                            ; a6b6: a9 00       ..
+    sta l1097                                                         ; a6b8: 8d 97 10    ...
+; &a6bb referenced 1 time by &a731
+.ca6bb
+    lda #8                                                            ; a6bb: a9 08       ..
+    jsr c809f                                                         ; a6bd: 20 9f 80     ..
+    jsr c809f                                                         ; a6c0: 20 9f 80     ..
+    lda l1097                                                         ; a6c3: ad 97 10    ...
+    jsr sub_c80bb                                                     ; a6c6: 20 bb 80     ..
+    lda #6                                                            ; a6c9: a9 06       ..
+    sta l109d                                                         ; a6cb: 8d 9d 10    ...
+; &a6ce referenced 1 time by &a708
+.ca6ce
+    jsr sub_ca73d                                                     ; a6ce: 20 3d a7     =.
+    bit l00c9                                                         ; a6d1: 24 c9       $.
+    bpl ca6e2                                                         ; a6d3: 10 0d       ..
+    jsr sub_ca788                                                     ; a6d5: 20 88 a7     ..
+    ldx #&90                                                          ; a6d8: a2 90       ..
+    ldy #&10                                                          ; a6da: a0 10       ..
+    jsr c91af                                                         ; a6dc: 20 af 91     ..
+    tax                                                               ; a6df: aa          .
+    bne ca70a                                                         ; a6e0: d0 28       .(
+; &a6e2 referenced 1 time by &a6d3
+.ca6e2
+    lda #0                                                            ; a6e2: a9 00       ..
+    sta l1098                                                         ; a6e4: 8d 98 10    ...
+    lda l1099                                                         ; a6e7: ad 99 10    ...
+    and #&1f                                                          ; a6ea: 29 1f       ).
+    sta l1099                                                         ; a6ec: 8d 99 10    ...
+    lda #3                                                            ; a6ef: a9 03       ..
+    sta l1095                                                         ; a6f1: 8d 95 10    ...
+    lda #&5f ; '_'                                                    ; a6f4: a9 5f       ._
+    sta l1096                                                         ; a6f6: 8d 96 10    ...
+    jsr sub_c9432                                                     ; a6f9: 20 32 94     2.
+    ldx #&90                                                          ; a6fc: a2 90       ..
+    ldy #&10                                                          ; a6fe: a0 10       ..
+    jsr c91af                                                         ; a700: 20 af 91     ..
+    beq ca712                                                         ; a703: f0 0d       ..
+    dec l109d                                                         ; a705: ce 9d 10    ...
+    bne ca6ce                                                         ; a708: d0 c4       ..
+; &a70a referenced 1 time by &a6e0
+.ca70a
+    jsr print_inline_l809f_top_bit_clear                              ; a70a: 20 77 80     w.
+    equs "?"                                                          ; a70d: 3f          ?
+
+    nop                                                               ; a70e: ea          .
+    jmp c94c2                                                         ; a70f: 4c c2 94    L..
+
+; &a712 referenced 1 time by &a703
+.ca712
+    lda l109d                                                         ; a712: ad 9d 10    ...
+    cmp #6                                                            ; a715: c9 06       ..
+    beq ca721                                                         ; a717: f0 08       ..
+    jsr print_inline_l809f_top_bit_clear                              ; a719: 20 77 80     w.
+    equs "?   "                                                       ; a71c: 3f 20 20... ?
+
+    nop                                                               ; a720: ea          .
+; &a721 referenced 1 time by &a717
+.ca721
+    bit l00c9                                                         ; a721: 24 c9       $.
+    bpl ca728                                                         ; a723: 10 03       ..
+    jsr sub_ca779                                                     ; a725: 20 79 a7     y.
+; &a728 referenced 1 time by &a723
+.ca728
+    inc l1097                                                         ; a728: ee 97 10    ...
+    lda l1097                                                         ; a72b: ad 97 10    ...
+    cmp l109f                                                         ; a72e: cd 9f 10    ...
+    bne ca6bb                                                         ; a731: d0 88       ..
+    bit l00c9                                                         ; a733: 24 c9       $.
+    bpl ca73a                                                         ; a735: 10 03       ..
+    jsr sub_c93f1                                                     ; a737: 20 f1 93     ..
+; &a73a referenced 1 time by &a735
+.ca73a
+    jmp ca3dc                                                         ; a73a: 4c dc a3    L..
+
+; &a73d referenced 1 time by &a6ce
+.sub_ca73d
+    ldx #0                                                            ; a73d: a2 00       ..
+    stx l1091                                                         ; a73f: 8e 91 10    ...
+    stx l109a                                                         ; a742: 8e 9a 10    ...
+    dex                                                               ; a745: ca          .
+    stx l1093                                                         ; a746: 8e 93 10    ...
+    stx l1094                                                         ; a749: 8e 94 10    ...
+    lda l10cf                                                         ; a74c: ad cf 10    ...
+    sta l1092                                                         ; a74f: 8d 92 10    ...
+    lda #5                                                            ; a752: a9 05       ..
+    sta l1095                                                         ; a754: 8d 95 10    ...
+    lda #&63 ; 'c'                                                    ; a757: a9 63       .c
+    sta l1096                                                         ; a759: 8d 96 10    ...
+    lda #&2a ; '*'                                                    ; a75c: a9 2a       .*
+    sta l1099                                                         ; a75e: 8d 99 10    ...
+    ldx #&10                                                          ; a761: a2 10       ..
+    ldy #&13                                                          ; a763: a0 13       ..
+    stx l109b                                                         ; a765: 8e 9b 10    ...
+    sty l1098                                                         ; a768: 8c 98 10    ...
+    rts                                                               ; a76b: 60          `
+
+; &a76c referenced 1 time by &a675
+.sub_ca76c
+    lda #0                                                            ; a76c: a9 00       ..
+    tay                                                               ; a76e: a8          .
+; &a76f referenced 1 time by &a776
+.loop_ca76f
+    sta l0e00,y                                                       ; a76f: 99 00 0e    ...
+    sta l0f00,y                                                       ; a772: 99 00 0f    ...
+    iny                                                               ; a775: c8          .
+    bne loop_ca76f                                                    ; a776: d0 f7       ..
+    rts                                                               ; a778: 60          `
+
+; &a779 referenced 1 time by &a725
+.sub_ca779
+    lda #&0a                                                          ; a779: a9 0a       ..
+    clc                                                               ; a77b: 18          .
+    adc l0f07                                                         ; a77c: 6d 07 0f    m..
+    sta l0f07                                                         ; a77f: 8d 07 0f    ...
+    bcc ca787                                                         ; a782: 90 03       ..
+    inc l0f06                                                         ; a784: ee 06 0f    ...
+; &a787 referenced 1 time by &a782
+.ca787
+    rts                                                               ; a787: 60          `
+
+; &a788 referenced 1 time by &a6d5
+.sub_ca788
+    lda #0                                                            ; a788: a9 00       ..
+    sta l00b0                                                         ; a78a: 85 b0       ..
+    lda l10cf                                                         ; a78c: ad cf 10    ...
+    sta l00b1                                                         ; a78f: 85 b1       ..
+    lda #&0a                                                          ; a791: a9 0a       ..
+    sta l00b2                                                         ; a793: 85 b2       ..
+    lda l1097                                                         ; a795: ad 97 10    ...
+    beq ca7a4                                                         ; a798: f0 0a       ..
+    ldy #2                                                            ; a79a: a0 02       ..
+    lda (l00b0),y                                                     ; a79c: b1 b0       ..
+    clc                                                               ; a79e: 18          .
+    adc #7                                                            ; a79f: 69 07       i.
+    jsr sub_ca7c5                                                     ; a7a1: 20 c5 a7     ..
+; &a7a4 referenced 1 time by &a798
+.ca7a4
+    tax                                                               ; a7a4: aa          .
+    ldy #0                                                            ; a7a5: a0 00       ..
+; &a7a7 referenced 1 time by &a7c1
+.loop_ca7a7
+    lda l1097                                                         ; a7a7: ad 97 10    ...
+    sta (l00b0),y                                                     ; a7aa: 91 b0       ..
+    iny                                                               ; a7ac: c8          .
+    lda #0                                                            ; a7ad: a9 00       ..
+    sta (l00b0),y                                                     ; a7af: 91 b0       ..
+    iny                                                               ; a7b1: c8          .
+    txa                                                               ; a7b2: 8a          .
+    sta (l00b0),y                                                     ; a7b3: 91 b0       ..
+    iny                                                               ; a7b5: c8          .
+    lda #1                                                            ; a7b6: a9 01       ..
+    sta (l00b0),y                                                     ; a7b8: 91 b0       ..
+    iny                                                               ; a7ba: c8          .
+    inx                                                               ; a7bb: e8          .
+    jsr sub_ca7c4                                                     ; a7bc: 20 c4 a7     ..
+    dec l00b2                                                         ; a7bf: c6 b2       ..
+    bne loop_ca7a7                                                    ; a7c1: d0 e4       ..
+    rts                                                               ; a7c3: 60          `
+
+; &a7c4 referenced 1 time by &a7bc
+.sub_ca7c4
+    txa                                                               ; a7c4: 8a          .
+; &a7c5 referenced 1 time by &a7a1
+.sub_ca7c5
+    sec                                                               ; a7c5: 38          8
+; &a7c6 referenced 1 time by &a7c8
+.loop_ca7c6
+    sbc #&0a                                                          ; a7c6: e9 0a       ..
+    bcs loop_ca7c6                                                    ; a7c8: b0 fc       ..
+    adc #&0a                                                          ; a7ca: 69 0a       i.
+    tax                                                               ; a7cc: aa          .
+    rts                                                               ; a7cd: 60          `
+
+; &a7ce referenced 1 time by &a6aa
+.sub_ca7ce
+    jsr sub_c93f5                                                     ; a7ce: 20 f5 93     ..
+    lda l0f06                                                         ; a7d1: ad 06 0f    ...
+    and #3                                                            ; a7d4: 29 03       ).
+    tax                                                               ; a7d6: aa          .
+    lda l0f07                                                         ; a7d7: ad 07 0f    ...
+    ldy #&0a                                                          ; a7da: a0 0a       ..
+    sty l00b0                                                         ; a7dc: 84 b0       ..
+    ldy #&ff                                                          ; a7de: a0 ff       ..
+; &a7e0 referenced 1 time by &a7e7
+.loop_ca7e0
+    sec                                                               ; a7e0: 38          8
+; &a7e1 referenced 1 time by &a7e4
+.loop_ca7e1
+    iny                                                               ; a7e1: c8          .
+    sbc l00b0                                                         ; a7e2: e5 b0       ..
+    bcs loop_ca7e1                                                    ; a7e4: b0 fb       ..
+    dex                                                               ; a7e6: ca          .
+    bpl loop_ca7e0                                                    ; a7e7: 10 f7       ..
+    adc l00b0                                                         ; a7e9: 65 b0       e.
+    pha                                                               ; a7eb: 48          H
+    tya                                                               ; a7ec: 98          .
+    tax                                                               ; a7ed: aa          .
+    pla                                                               ; a7ee: 68          h
+    beq ca7f2                                                         ; a7ef: f0 01       ..
+    inx                                                               ; a7f1: e8          .
+; &a7f2 referenced 1 time by &a7ef
+.ca7f2
+    rts                                                               ; a7f2: 60          `
+
+.sub_ca7f3
+    sec                                                               ; a7f3: 38          8
+    bcs ca7f7                                                         ; a7f4: b0 01       ..
+.sub_ca7f6
+    clc                                                               ; a7f6: 18          .
+; &a7f7 referenced 1 time by &a7f4
+.ca7f7
+    ror l00c6                                                         ; a7f7: 66 c6       f.
+    jsr sub_c8b86                                                     ; a7f9: 20 86 8b     ..
+    jsr sub_c8380                                                     ; a7fc: 20 80 83     ..
+    bit l00c6                                                         ; a7ff: 24 c6       $.
+    bmi ca818                                                         ; a801: 30 15       0.
+    jsr print_inline_osasci_top_bit_clear                             ; a803: 20 9c a9     ..
+    equs "Address :  Length", &0d                                     ; a806: 41 64 64... Add
+
+; &a818 referenced 1 time by &a801
+.ca818
+    lda l0f06                                                         ; a818: ad 06 0f    ...
+    and #3                                                            ; a81b: 29 03       ).
+    sta l00c5                                                         ; a81d: 85 c5       ..
+    sta l00c2                                                         ; a81f: 85 c2       ..
+    lda l0f07                                                         ; a821: ad 07 0f    ...
+    sta l00c4                                                         ; a824: 85 c4       ..
+    sec                                                               ; a826: 38          8
+    sbc #2                                                            ; a827: e9 02       ..
+    sta l00c1                                                         ; a829: 85 c1       ..
+    bcs ca82f                                                         ; a82b: b0 02       ..
+    dec l00c2                                                         ; a82d: c6 c2       ..
+; &a82f referenced 1 time by &a82b
+.ca82f
+    lda #2                                                            ; a82f: a9 02       ..
+    sta l00bb                                                         ; a831: 85 bb       ..
+    lda #0                                                            ; a833: a9 00       ..
+    sta l00bc                                                         ; a835: 85 bc       ..
+    sta l00bf                                                         ; a837: 85 bf       ..
+    sta l00c0                                                         ; a839: 85 c0       ..
+    lda l0f05                                                         ; a83b: ad 05 0f    ...
+    and #&f8                                                          ; a83e: 29 f8       ).
+    tay                                                               ; a840: a8          .
+    beq ca86b                                                         ; a841: f0 28       .(
+    bne ca856                                                         ; a843: d0 11       ..
+; &a845 referenced 2 times by &a869, &a889
+.ca845
+    jsr sub_ca8e2                                                     ; a845: 20 e2 a8     ..
+    jsr sub_c82b2                                                     ; a848: 20 b2 82     ..
+    lda l00c4                                                         ; a84b: a5 c4       ..
+    sec                                                               ; a84d: 38          8
+    sbc l00bb                                                         ; a84e: e5 bb       ..
+    lda l00c5                                                         ; a850: a5 c5       ..
+    sbc l00bc                                                         ; a852: e5 bc       ..
+    bcc ca86b                                                         ; a854: 90 15       ..
+; &a856 referenced 1 time by &a843
+.ca856
+    lda l0f07,y                                                       ; a856: b9 07 0f    ...
+    sec                                                               ; a859: 38          8
+    sbc l00bb                                                         ; a85a: e5 bb       ..
+    sta l00c1                                                         ; a85c: 85 c1       ..
+    php                                                               ; a85e: 08          .
+    lda l0f06,y                                                       ; a85f: b9 06 0f    ...
+    and #3                                                            ; a862: 29 03       ).
+    plp                                                               ; a864: 28          (
+    sbc l00bc                                                         ; a865: e5 bc       ..
+    sta l00c2                                                         ; a867: 85 c2       ..
+    bcc ca845                                                         ; a869: 90 da       ..
+; &a86b referenced 2 times by &a841, &a854
+.ca86b
+    sty l00bd                                                         ; a86b: 84 bd       ..
+    bit l00c6                                                         ; a86d: 24 c6       $.
+    bmi ca87a                                                         ; a86f: 30 09       0.
+    lda l00c1                                                         ; a871: a5 c1       ..
+    ora l00c2                                                         ; a873: 05 c2       ..
+    beq ca87a                                                         ; a875: f0 03       ..
+    jsr sub_ca8be                                                     ; a877: 20 be a8     ..
+; &a87a referenced 2 times by &a86f, &a875
+.ca87a
+    lda l00c1                                                         ; a87a: a5 c1       ..
+    clc                                                               ; a87c: 18          .
+    adc l00bf                                                         ; a87d: 65 bf       e.
+    sta l00bf                                                         ; a87f: 85 bf       ..
+    lda l00c2                                                         ; a881: a5 c2       ..
+    adc l00c0                                                         ; a883: 65 c0       e.
+    sta l00c0                                                         ; a885: 85 c0       ..
+    ldy l00bd                                                         ; a887: a4 bd       ..
+    bne ca845                                                         ; a889: d0 ba       ..
+    bit l00c6                                                         ; a88b: 24 c6       $.
+    bpl ca8bd                                                         ; a88d: 10 2e       ..
+    tay                                                               ; a88f: a8          .
+    ldx l00bf                                                         ; a890: a6 bf       ..
+    lda #&f8                                                          ; a892: a9 f8       ..
+    sec                                                               ; a894: 38          8
+    sbc l0f05                                                         ; a895: ed 05 0f    ...
+    jsr sub_ca90d                                                     ; a898: 20 0d a9     ..
+    jsr print_inline_osasci_top_bit_clear                             ; a89b: 20 9c a9     ..
+    equs "Free", &0d                                                  ; a89e: 46 72 65... Fre
+
+    lda l00c4                                                         ; a8a3: a5 c4       ..
+    sec                                                               ; a8a5: 38          8
+    sbc l00bf                                                         ; a8a6: e5 bf       ..
+    tax                                                               ; a8a8: aa          .
+    lda l00c5                                                         ; a8a9: a5 c5       ..
+    sbc l00c0                                                         ; a8ab: e5 c0       ..
+    tay                                                               ; a8ad: a8          .
+    lda l0f05                                                         ; a8ae: ad 05 0f    ...
+    jsr sub_ca90d                                                     ; a8b1: 20 0d a9     ..
+    jsr print_inline_osasci_top_bit_clear                             ; a8b4: 20 9c a9     ..
+    equs "Used", &0d                                                  ; a8b7: 55 73 65... Use
+
+    nop                                                               ; a8bc: ea          .
+; &a8bd referenced 1 time by &a88d
+.ca8bd
+    rts                                                               ; a8bd: 60          `
+
+; &a8be referenced 1 time by &a877
+.sub_ca8be
+    lda l00bc                                                         ; a8be: a5 bc       ..
+    jsr sub_ca9ca                                                     ; a8c0: 20 ca a9     ..
+    lda l00bb                                                         ; a8c3: a5 bb       ..
+    jsr sub_ca9c2                                                     ; a8c5: 20 c2 a9     ..
+    jsr print_inline_osasci_top_bit_clear                             ; a8c8: 20 9c a9     ..
+    equs "     :  "                                                   ; a8cb: 20 20 20...
+
+    lda l00c2                                                         ; a8d3: a5 c2       ..
+    jsr sub_ca9ca                                                     ; a8d5: 20 ca a9     ..
+    lda l00c1                                                         ; a8d8: a5 c1       ..
+    jsr sub_ca9c2                                                     ; a8da: 20 c2 a9     ..
+    lda #&0d                                                          ; a8dd: a9 0d       ..
+    jsr osasci                                                        ; a8df: 20 e3 ff     ..
+; &a8e2 referenced 1 time by &a845
+.sub_ca8e2
+    lda l0f06,y                                                       ; a8e2: b9 06 0f    ...
+    pha                                                               ; a8e5: 48          H
+    jsr sub_c81b0                                                     ; a8e6: 20 b0 81     ..
+    sta l00bc                                                         ; a8e9: 85 bc       ..
+    pla                                                               ; a8eb: 68          h
+    and #3                                                            ; a8ec: 29 03       ).
+    clc                                                               ; a8ee: 18          .
+    adc l00bc                                                         ; a8ef: 65 bc       e.
+    sta l00bc                                                         ; a8f1: 85 bc       ..
+    lda l0f04,y                                                       ; a8f3: b9 04 0f    ...
+    beq ca8fa                                                         ; a8f6: f0 02       ..
+    lda #1                                                            ; a8f8: a9 01       ..
+; &a8fa referenced 1 time by &a8f6
+.ca8fa
+    clc                                                               ; a8fa: 18          .
+    adc l0f05,y                                                       ; a8fb: 79 05 0f    y..
+    bcc ca902                                                         ; a8fe: 90 02       ..
+    inc l00bc                                                         ; a900: e6 bc       ..
+; &a902 referenced 1 time by &a8fe
+.ca902
+    clc                                                               ; a902: 18          .
+    adc l0f07,y                                                       ; a903: 79 07 0f    y..
+    sta l00bb                                                         ; a906: 85 bb       ..
+    bcc ca90c                                                         ; a908: 90 02       ..
+    inc l00bc                                                         ; a90a: e6 bc       ..
+; &a90c referenced 1 time by &a908
+.ca90c
+    rts                                                               ; a90c: 60          `
+
+; &a90d referenced 2 times by &a898, &a8b1
+.sub_ca90d
+    jsr sub_c81c0                                                     ; a90d: 20 c0 81     ..
+    jsr sub_ca9bf                                                     ; a910: 20 bf a9     ..
+    jsr print_inline_osasci_top_bit_clear                             ; a913: 20 9c a9     ..
+    equs " Files "                                                    ; a916: 20 46 69...  Fi
+
+    stx l00bc                                                         ; a91d: 86 bc       ..
+    sty l00bd                                                         ; a91f: 84 bd       ..
+    tya                                                               ; a921: 98          .
+    jsr sub_ca9ca                                                     ; a922: 20 ca a9     ..
+    txa                                                               ; a925: 8a          .
+    jsr sub_ca9c2                                                     ; a926: 20 c2 a9     ..
+    jsr print_inline_osasci_top_bit_clear                             ; a929: 20 9c a9     ..
+    equs " Sectors "                                                  ; a92c: 20 53 65...  Se
+
+    lda #0                                                            ; a935: a9 00       ..
+    sta l00bb                                                         ; a937: 85 bb       ..
+    sta l00be                                                         ; a939: 85 be       ..
+    ldx #&1f                                                          ; a93b: a2 1f       ..
+    stx l00c1                                                         ; a93d: 86 c1       ..
+    ldx #9                                                            ; a93f: a2 09       ..
+; &a941 referenced 1 time by &a945
+.loop_ca941
+    sta l1000,x                                                       ; a941: 9d 00 10    ...
+    dex                                                               ; a944: ca          .
+    bpl loop_ca941                                                    ; a945: 10 fa       ..
+; &a947 referenced 1 time by &a966
+.loop_ca947
+    asl l00bb                                                         ; a947: 06 bb       ..
+    rol l00bc                                                         ; a949: 26 bc       &.
+    rol l00bd                                                         ; a94b: 26 bd       &.
+    rol l00be                                                         ; a94d: 26 be       &.
+    ldx #0                                                            ; a94f: a2 00       ..
+    ldy #9                                                            ; a951: a0 09       ..
+; &a953 referenced 1 time by &a962
+.loop_ca953
+    lda l1000,x                                                       ; a953: bd 00 10    ...
+    rol a                                                             ; a956: 2a          *
+    cmp #&0a                                                          ; a957: c9 0a       ..
+    bcc ca95d                                                         ; a959: 90 02       ..
+    sbc #&0a                                                          ; a95b: e9 0a       ..
+; &a95d referenced 1 time by &a959
+.ca95d
+    sta l1000,x                                                       ; a95d: 9d 00 10    ...
+    inx                                                               ; a960: e8          .
+    dey                                                               ; a961: 88          .
+    bpl loop_ca953                                                    ; a962: 10 ef       ..
+    dec l00c1                                                         ; a964: c6 c1       ..
+    bpl loop_ca947                                                    ; a966: 10 df       ..
+    ldy #&20 ; ' '                                                    ; a968: a0 20       .
+    ldx #5                                                            ; a96a: a2 05       ..
+; &a96c referenced 1 time by &a98e
+.ca96c
+    bne ca970                                                         ; a96c: d0 02       ..
+    ldy #&2c ; ','                                                    ; a96e: a0 2c       .,
+; &a970 referenced 1 time by &a96c
+.ca970
+    lda l1000,x                                                       ; a970: bd 00 10    ...
+    bne ca97d                                                         ; a973: d0 08       ..
+    cpy #&2c ; ','                                                    ; a975: c0 2c       .,
+    beq ca97d                                                         ; a977: f0 04       ..
+    lda #&20 ; ' '                                                    ; a979: a9 20       .
+    bne ca982                                                         ; a97b: d0 05       ..
+; &a97d referenced 2 times by &a973, &a977
+.ca97d
+    ldy #&2c ; ','                                                    ; a97d: a0 2c       .,
+    clc                                                               ; a97f: 18          .
+    adc #'0'                                                          ; a980: 69 30       i0
+; &a982 referenced 1 time by &a97b
+.ca982
+    jsr osasci                                                        ; a982: 20 e3 ff     ..
+    cpx #3                                                            ; a985: e0 03       ..
+    bne ca98d                                                         ; a987: d0 04       ..
+    tya                                                               ; a989: 98          .
+    jsr osasci                                                        ; a98a: 20 e3 ff     ..
+; &a98d referenced 1 time by &a987
+.ca98d
+    dex                                                               ; a98d: ca          .
+    bpl ca96c                                                         ; a98e: 10 dc       ..
+    jsr print_inline_osasci_top_bit_clear                             ; a990: 20 9c a9     ..
+    equs " Bytes "                                                    ; a993: 20 42 79...  By
+
+    nop                                                               ; a99a: ea          .
+    rts                                                               ; a99b: 60          `
+
+; &a99c referenced 7 times by &a803, &a89b, &a8b4, &a8c8, &a913, &a929, &a990
+.print_inline_osasci_top_bit_clear
+    sta l00b3                                                         ; a99c: 85 b3       ..
+    pla                                                               ; a99e: 68          h
+    sta l00ae                                                         ; a99f: 85 ae       ..
+    pla                                                               ; a9a1: 68          h
+    sta l00af                                                         ; a9a2: 85 af       ..
+    lda l00b3                                                         ; a9a4: a5 b3       ..
+    pha                                                               ; a9a6: 48          H
+    tya                                                               ; a9a7: 98          .
+    pha                                                               ; a9a8: 48          H
+    ldy #0                                                            ; a9a9: a0 00       ..
+; &a9ab referenced 1 time by &a9b5
+.loop_ca9ab
+    jsr inc16_ae                                                      ; a9ab: 20 dc 83     ..
+    lda (l00ae),y                                                     ; a9ae: b1 ae       ..
+    bmi ca9b8                                                         ; a9b0: 30 06       0.
+    jsr osasci                                                        ; a9b2: 20 e3 ff     ..
+    jmp loop_ca9ab                                                    ; a9b5: 4c ab a9    L..
+
+; &a9b8 referenced 1 time by &a9b0
+.ca9b8
+    pla                                                               ; a9b8: 68          h
+    tay                                                               ; a9b9: a8          .
+    pla                                                               ; a9ba: 68          h
+    clc                                                               ; a9bb: 18          .
+    jmp (l00ae)                                                       ; a9bc: 6c ae 00    l..
+
+; &a9bf referenced 1 time by &a910
+.sub_ca9bf
+    jsr sub_c841b                                                     ; a9bf: 20 1b 84     ..
+; &a9c2 referenced 3 times by &a8c5, &a8da, &a926
+.sub_ca9c2
+    pha                                                               ; a9c2: 48          H
+    jsr sub_c81bf                                                     ; a9c3: 20 bf 81     ..
+    jsr sub_ca9ca                                                     ; a9c6: 20 ca a9     ..
+    pla                                                               ; a9c9: 68          h
+; &a9ca referenced 4 times by &a8c0, &a8d5, &a922, &a9c6
+.sub_ca9ca
+    jsr sub_c80c8                                                     ; a9ca: 20 c8 80     ..
+    jmp osasci                                                        ; a9cd: 4c e3 ff    L..
+
+.sub_ca9d0
+    lda #0                                                            ; a9d0: a9 00       ..
+    sta l00a8                                                         ; a9d2: 85 a8       ..
+    jsr sub_caaea                                                     ; a9d4: 20 ea aa     ..
+    lda #&0f                                                          ; a9d7: a9 0f       ..
+    sta l00aa                                                         ; a9d9: 85 aa       ..
+    jsr sub_caadd                                                     ; a9db: 20 dd aa     ..
+    sec                                                               ; a9de: 38          8
+    jsr gsinit                                                        ; a9df: 20 c2 ff     ..
+    sty l00ab                                                         ; a9e2: 84 ab       ..
+    clc                                                               ; a9e4: 18          .
+    beq ca9ff                                                         ; a9e5: f0 18       ..
+; &a9e7 referenced 1 time by &a9fc
+.loop_ca9e7
+    jsr sub_c8456                                                     ; a9e7: 20 56 84     V.
+    bcs ca9ff                                                         ; a9ea: b0 13       ..
+    sty l00ab                                                         ; a9ec: 84 ab       ..
+    and #&0f                                                          ; a9ee: 29 0f       ).
+    sta l00aa                                                         ; a9f0: 85 aa       ..
+    jsr sub_caa53                                                     ; a9f2: 20 53 aa     S.
+    ldy l00ab                                                         ; a9f5: a4 ab       ..
+    jsr clc_jmp_gsinit                                                ; a9f7: 20 4c 87     L.
+    sty l00ab                                                         ; a9fa: 84 ab       ..
+    bne loop_ca9e7                                                    ; a9fc: d0 e9       ..
+    rts                                                               ; a9fe: 60          `
+
+; &a9ff referenced 2 times by &a9e5, &a9ea
+.ca9ff
+    ror l00a8                                                         ; a9ff: 66 a8       f.
+; &aa01 referenced 1 time by &aa0f
+.loop_caa01
+    bit l00a8                                                         ; aa01: 24 a8       $.
+    bpl caa0a                                                         ; aa03: 10 05       ..
+    jsr sub_caa12                                                     ; aa05: 20 12 aa     ..
+    bcc caa0d                                                         ; aa08: 90 03       ..
+; &aa0a referenced 1 time by &aa03
+.caa0a
+    jsr sub_caa53                                                     ; aa0a: 20 53 aa     S.
+; &aa0d referenced 1 time by &aa08
+.caa0d
+    dec l00aa                                                         ; aa0d: c6 aa       ..
+    bpl loop_caa01                                                    ; aa0f: 10 f0       ..
+    rts                                                               ; aa11: 60          `
+
+; &aa12 referenced 1 time by &aa05
+.sub_caa12
+    lda #9                                                            ; aa12: a9 09       ..
+    sta osrdsc_ptr                                                    ; aa14: 85 f6       ..
+    lda #&80                                                          ; aa16: a9 80       ..
+    sta l00f7                                                         ; aa18: 85 f7       ..
+    ldy l00ab                                                         ; aa1a: a4 ab       ..
+; &aa1c referenced 2 times by &aa39, &aa40
+.caa1c
+    lda (os_text_ptr),y                                               ; aa1c: b1 f2       ..
+    cmp #&0d                                                          ; aa1e: c9 0d       ..
+    beq caa44                                                         ; aa20: f0 22       ."
+    cmp #&22 ; '"'                                                    ; aa22: c9 22       ."
+    beq caa44                                                         ; aa24: f0 1e       ..
+    iny                                                               ; aa26: c8          .
+    cmp #&2a ; '*'                                                    ; aa27: c9 2a       .*
+    beq caa51                                                         ; aa29: f0 26       .&
+    jsr sub_c82fe                                                     ; aa2b: 20 fe 82     ..
+    sta l00ae                                                         ; aa2e: 85 ae       ..
+    jsr sub_caacf                                                     ; aa30: 20 cf aa     ..
+    beq caa42                                                         ; aa33: f0 0d       ..
+    ldx l00ae                                                         ; aa35: a6 ae       ..
+    cpx #&23 ; '#'                                                    ; aa37: e0 23       .#
+    beq caa1c                                                         ; aa39: f0 e1       ..
+    jsr sub_c82fe                                                     ; aa3b: 20 fe 82     ..
+    cmp l00ae                                                         ; aa3e: c5 ae       ..
+    beq caa1c                                                         ; aa40: f0 da       ..
+; &aa42 referenced 3 times by &aa33, &aa4f, &aa57
+.caa42
+    clc                                                               ; aa42: 18          .
+    rts                                                               ; aa43: 60          `
+
+; &aa44 referenced 3 times by &aa20, &aa24, &aa4b
+.caa44
+    jsr sub_caacf                                                     ; aa44: 20 cf aa     ..
+    beq caa51                                                         ; aa47: f0 08       ..
+    cmp #&20 ; ' '                                                    ; aa49: c9 20       .
+    beq caa44                                                         ; aa4b: f0 f7       ..
+    cmp #&0d                                                          ; aa4d: c9 0d       ..
+    bne caa42                                                         ; aa4f: d0 f1       ..
+; &aa51 referenced 2 times by &aa29, &aa47
+.caa51
+    sec                                                               ; aa51: 38          8
+    rts                                                               ; aa52: 60          `
+
+; &aa53 referenced 2 times by &a9f2, &aa0a
+.sub_caa53
+    ldy l00aa                                                         ; aa53: a4 aa       ..
+    lda (l00b4),y                                                     ; aa55: b1 b4       ..
+    beq caa42                                                         ; aa57: f0 e9       ..
+    pha                                                               ; aa59: 48          H
+    jsr print_inline_l809f_top_bit_clear                              ; aa5a: 20 77 80     w.
+    equs "Rom "                                                       ; aa5d: 52 6f 6d... Rom
+
+    tya                                                               ; aa61: 98          .
+    jsr sub_c80b8                                                     ; aa62: 20 b8 80     ..
+    jsr print_inline_l809f_top_bit_clear                              ; aa65: 20 77 80     w.
+    equs " : "                                                        ; aa68: 20 3a 20     :
+
+    lda #&28 ; '('                                                    ; aa6b: a9 28       .(
+    jsr c809f                                                         ; aa6d: 20 9f 80     ..
+    pla                                                               ; aa70: 68          h
+    pha                                                               ; aa71: 48          H
+    bmi caa78                                                         ; aa72: 30 04       0.
+    ldy #&20 ; ' '                                                    ; aa74: a0 20       .
+    bne caa7a                                                         ; aa76: d0 02       ..
+; &aa78 referenced 1 time by &aa72
+.caa78
+    ldy #&53 ; 'S'                                                    ; aa78: a0 53       .S
+; &aa7a referenced 1 time by &aa76
+.caa7a
+    tya                                                               ; aa7a: 98          .
+    jsr c809f                                                         ; aa7b: 20 9f 80     ..
+    pla                                                               ; aa7e: 68          h
+    ldy #&20 ; ' '                                                    ; aa7f: a0 20       .
+    asl a                                                             ; aa81: 0a          .
+    bpl caa86                                                         ; aa82: 10 02       ..
+    ldy #&4c ; 'L'                                                    ; aa84: a0 4c       .L
+; &aa86 referenced 1 time by &aa82
+.caa86
+    tya                                                               ; aa86: 98          .
+    jsr c809f                                                         ; aa87: 20 9f 80     ..
+    lda #&29 ; ')'                                                    ; aa8a: a9 29       .)
+    jsr c809f                                                         ; aa8c: 20 9f 80     ..
+    jsr cac0f                                                         ; aa8f: 20 0f ac     ..
+    jsr sub_caa9a                                                     ; aa92: 20 9a aa     ..
+    jsr ca3dc                                                         ; aa95: 20 dc a3     ..
+    sec                                                               ; aa98: 38          8
+    rts                                                               ; aa99: 60          `
+
+; &aa9a referenced 1 time by &aa92
+.sub_caa9a
+    lda #7                                                            ; aa9a: a9 07       ..
+    sta osrdsc_ptr                                                    ; aa9c: 85 f6       ..
+    lda #&80                                                          ; aa9e: a9 80       ..
+    sta l00f7                                                         ; aaa0: 85 f7       ..
+    jsr sub_caacf                                                     ; aaa2: 20 cf aa     ..
+    sta l00ae                                                         ; aaa5: 85 ae       ..
+    inc osrdsc_ptr                                                    ; aaa7: e6 f6       ..
+    ldy #&1e                                                          ; aaa9: a0 1e       ..
+    jsr sub_caac2                                                     ; aaab: 20 c2 aa     ..
+    bcs caab7                                                         ; aaae: b0 07       ..
+    jsr cac0f                                                         ; aab0: 20 0f ac     ..
+    dey                                                               ; aab3: 88          .
+    jsr sub_caac2                                                     ; aab4: 20 c2 aa     ..
+; &aab7 referenced 1 time by &aaae
+.caab7
+    rts                                                               ; aab7: 60          `
+
+; &aab8 referenced 1 time by &aacb
+.loop_caab8
+    cmp #&20 ; ' '                                                    ; aab8: c9 20       .
+    bcs caabe                                                         ; aaba: b0 02       ..
+    lda #&20 ; ' '                                                    ; aabc: a9 20       .
+; &aabe referenced 1 time by &aaba
+.caabe
+    jsr c809f                                                         ; aabe: 20 9f 80     ..
+    dey                                                               ; aac1: 88          .
+; &aac2 referenced 2 times by &aaab, &aab4
+.sub_caac2
+    lda osrdsc_ptr                                                    ; aac2: a5 f6       ..
+    cmp l00ae                                                         ; aac4: c5 ae       ..
+    bcs caace                                                         ; aac6: b0 06       ..
+    jsr sub_caacf                                                     ; aac8: 20 cf aa     ..
+    bne loop_caab8                                                    ; aacb: d0 eb       ..
+    clc                                                               ; aacd: 18          .
+; &aace referenced 1 time by &aac6
+.caace
+    rts                                                               ; aace: 60          `
+
+; &aacf referenced 4 times by &aa30, &aa44, &aaa2, &aac8
+.sub_caacf
+    tya                                                               ; aacf: 98          .
+    pha                                                               ; aad0: 48          H
+    ldy l00aa                                                         ; aad1: a4 aa       ..
+    jsr osrdsc                                                        ; aad3: 20 b9 ff     ..
+    inc osrdsc_ptr                                                    ; aad6: e6 f6       ..
+    tax                                                               ; aad8: aa          .
+    pla                                                               ; aad9: 68          h
+    tay                                                               ; aada: a8          .
+    txa                                                               ; aadb: 8a          .
+    rts                                                               ; aadc: 60          `
+
+; &aadd referenced 1 time by &a9db
+.sub_caadd
+    jsr sub_c840c                                                     ; aadd: 20 0c 84     ..
+    lda #&aa                                                          ; aae0: a9 aa       ..
+    jsr osbyte_read                                                   ; aae2: 20 e5 9a     ..
+    stx l00b4                                                         ; aae5: 86 b4       ..
+    sty l00b5                                                         ; aae7: 84 b5       ..
+    rts                                                               ; aae9: 60          `
+
+; &aaea referenced 1 time by &a9d4
+.sub_caaea
+    tsx                                                               ; aaea: ba          .
+    lda #0                                                            ; aaeb: a9 00       ..
+    sta l0107,x                                                       ; aaed: 9d 07 01    ...
+    rts                                                               ; aaf0: 60          `
+
+; &aaf1 referenced 2 times by &ab51, &abd5
+.sub_caaf1
+    ldx romsel_copy                                                   ; aaf1: a6 f4       ..
+    lda l0df0,x                                                       ; aaf3: bd f0 0d    ...
+    and #&3f ; '?'                                                    ; aaf6: 29 3f       )?
+    sta l00ad                                                         ; aaf8: 85 ad       ..
+    inc l00ad                                                         ; aafa: e6 ad       ..
+    rts                                                               ; aafc: 60          `
+
+.sub_caafd
+    jsr sub_cac18                                                     ; aafd: 20 18 ac     ..
+    lda #0                                                            ; ab00: a9 00       ..
+    beq cab09                                                         ; ab02: f0 05       ..
+.sub_cab04
+    jsr sub_cac18                                                     ; ab04: 20 18 ac     ..
+    lda #&ff                                                          ; ab07: a9 ff       ..
+; &ab09 referenced 1 time by &ab02
+.cab09
+    sta l00ab                                                         ; ab09: 85 ab       ..
+    lda #&40 ; '@'                                                    ; ab0b: a9 40       .@
+    jsr osfind                                                        ; ab0d: 20 ce ff     ..
+    tay                                                               ; ab10: a8          .
+    lda #&0d                                                          ; ab11: a9 0d       ..
+    cpy #0                                                            ; ab13: c0 00       ..
+    bne cab35                                                         ; ab15: d0 1e       ..
+; &ab17 referenced 1 time by &ab4f
+.cab17
+    jmp c822a                                                         ; ab17: 4c 2a 82    L*.
+
+; &ab1a referenced 2 times by &ab21, &ab3a
+.cab1a
+    jsr osbget                                                        ; ab1a: 20 d7 ff     ..
+    bcs cab3d                                                         ; ab1d: b0 1e       ..
+    cmp #&0a                                                          ; ab1f: c9 0a       ..
+    beq cab1a                                                         ; ab21: f0 f7       ..
+    plp                                                               ; ab23: 28          (
+    bne cab2e                                                         ; ab24: d0 08       ..
+    pha                                                               ; ab26: 48          H
+    jsr sub_cac4e                                                     ; ab27: 20 4e ac     N.
+    jsr cac0f                                                         ; ab2a: 20 0f ac     ..
+    pla                                                               ; ab2d: 68          h
+; &ab2e referenced 1 time by &ab24
+.cab2e
+    jsr osasci                                                        ; ab2e: 20 e3 ff     ..
+    bit l00ff                                                         ; ab31: 24 ff       $.
+    bmi cab54                                                         ; ab33: 30 1f       0.
+; &ab35 referenced 1 time by &ab15
+.cab35
+    and l00ab                                                         ; ab35: 25 ab       %.
+    cmp #&0d                                                          ; ab37: c9 0d       ..
+    php                                                               ; ab39: 08          .
+    jmp cab1a                                                         ; ab3a: 4c 1a ab    L..
+
+; &ab3d referenced 1 time by &ab1d
+.cab3d
+    plp                                                               ; ab3d: 28          (
+    jsr osnewl                                                        ; ab3e: 20 e7 ff     ..
+; &ab41 referenced 2 times by &aba5, &abbf
+.cab41
+    lda #0                                                            ; ab41: a9 00       ..
+    jmp osfind                                                        ; ab43: 4c ce ff    L..
+
+.sub_cab46
+    jsr sub_cac18                                                     ; ab46: 20 18 ac     ..
+    lda #&40 ; '@'                                                    ; ab49: a9 40       .@
+    jsr osfind                                                        ; ab4b: 20 ce ff     ..
+    tay                                                               ; ab4e: a8          .
+    beq cab17                                                         ; ab4f: f0 c6       ..
+    jsr sub_caaf1                                                     ; ab51: 20 f1 aa     ..
+; &ab54 referenced 2 times by &ab33, &aba7
+.cab54
+    bit l00ff                                                         ; ab54: 24 ff       $.
+    bmi cabbc                                                         ; ab56: 30 64       0d
+    lda l00a9                                                         ; ab58: a5 a9       ..
+    jsr sub_cac62                                                     ; ab5a: 20 62 ac     b.
+    lda l00a8                                                         ; ab5d: a5 a8       ..
+    jsr sub_cac62                                                     ; ab5f: 20 62 ac     b.
+    jsr cac0f                                                         ; ab62: 20 0f ac     ..
+    lda #8                                                            ; ab65: a9 08       ..
+    sta l00ac                                                         ; ab67: 85 ac       ..
+    ldx #0                                                            ; ab69: a2 00       ..
+; &ab6b referenced 1 time by &ab7a
+.loop_cab6b
+    jsr osbget                                                        ; ab6b: 20 d7 ff     ..
+    bcs cab7d                                                         ; ab6e: b0 0d       ..
+    sta (l00ac,x)                                                     ; ab70: 81 ac       ..
+    jsr sub_cac62                                                     ; ab72: 20 62 ac     b.
+    jsr cac0f                                                         ; ab75: 20 0f ac     ..
+    dec l00ac                                                         ; ab78: c6 ac       ..
+    bne loop_cab6b                                                    ; ab7a: d0 ef       ..
+    clc                                                               ; ab7c: 18          .
+; &ab7d referenced 1 time by &ab6e
+.cab7d
+    php                                                               ; ab7d: 08          .
+    bcc cab93                                                         ; ab7e: 90 13       ..
+; &ab80 referenced 1 time by &ab91
+.loop_cab80
+    lda #&2a ; '*'                                                    ; ab80: a9 2a       .*
+    jsr osasci                                                        ; ab82: 20 e3 ff     ..
+    jsr osasci                                                        ; ab85: 20 e3 ff     ..
+    jsr cac0f                                                         ; ab88: 20 0f ac     ..
+    lda #0                                                            ; ab8b: a9 00       ..
+    sta (l00ac,x)                                                     ; ab8d: 81 ac       ..
+    dec l00ac                                                         ; ab8f: c6 ac       ..
+    bne loop_cab80                                                    ; ab91: d0 ed       ..
+; &ab93 referenced 1 time by &ab7e
+.cab93
+    jsr sub_caba9                                                     ; ab93: 20 a9 ab     ..
+    jsr osnewl                                                        ; ab96: 20 e7 ff     ..
+    lda #8                                                            ; ab99: a9 08       ..
+    clc                                                               ; ab9b: 18          .
+    adc l00a8                                                         ; ab9c: 65 a8       e.
+    sta l00a8                                                         ; ab9e: 85 a8       ..
+    bcc caba4                                                         ; aba0: 90 02       ..
+    inc l00a9                                                         ; aba2: e6 a9       ..
+; &aba4 referenced 1 time by &aba0
+.caba4
+    plp                                                               ; aba4: 28          (
+    bcs cab41                                                         ; aba5: b0 9a       ..
+    bcc cab54                                                         ; aba7: 90 ab       ..
+; &aba9 referenced 1 time by &ab93
+.sub_caba9
+    lda #8                                                            ; aba9: a9 08       ..
+    sta l00ac                                                         ; abab: 85 ac       ..
+; &abad referenced 1 time by &abb9
+.loop_cabad
+    ldx #0                                                            ; abad: a2 00       ..
+    lda (l00ac,x)                                                     ; abaf: a1 ac       ..
+    jsr sub_c842c                                                     ; abb1: 20 2c 84     ,.
+    jsr osasci                                                        ; abb4: 20 e3 ff     ..
+    dec l00ac                                                         ; abb7: c6 ac       ..
+    bne loop_cabad                                                    ; abb9: d0 f2       ..
+    rts                                                               ; abbb: 60          `
+
+; &abbc referenced 2 times by &ab56, &ac02
+.cabbc
+    jsr sub_c9ad8                                                     ; abbc: 20 d8 9a     ..
+    jsr cab41                                                         ; abbf: 20 41 ab     A.
+    jmp c9436                                                         ; abc2: 4c 36 94    L6.
+
+.sub_cabc5
+    jsr sub_cac18                                                     ; abc5: 20 18 ac     ..
+    lda #&80                                                          ; abc8: a9 80       ..
+    jsr osfind                                                        ; abca: 20 ce ff     ..
+    sta l00ab                                                         ; abcd: 85 ab       ..
+; &abcf referenced 1 time by &ac09
+.cabcf
+    jsr sub_cac4e                                                     ; abcf: 20 4e ac     N.
+    jsr cac0f                                                         ; abd2: 20 0f ac     ..
+    jsr sub_caaf1                                                     ; abd5: 20 f1 aa     ..
+    ldx #&ac                                                          ; abd8: a2 ac       ..
+    ldy #&ff                                                          ; abda: a0 ff       ..
+    sty l00ae                                                         ; abdc: 84 ae       ..
+    sty l00b0                                                         ; abde: 84 b0       ..
+    iny                                                               ; abe0: c8          .
+    sty l00ac                                                         ; abe1: 84 ac       ..
+    lda #&20 ; ' '                                                    ; abe3: a9 20       .
+    sta l00af                                                         ; abe5: 85 af       ..
+    tya                                                               ; abe7: 98          .
+    jsr osword                                                        ; abe8: 20 f1 ff     ..
+    php                                                               ; abeb: 08          .
+    sty l00aa                                                         ; abec: 84 aa       ..
+    ldy l00ab                                                         ; abee: a4 ab       ..
+    ldx #0                                                            ; abf0: a2 00       ..
+    beq cabfb                                                         ; abf2: f0 07       ..
+; &abf4 referenced 1 time by &abff
+.loop_cabf4
+    lda (l00ac,x)                                                     ; abf4: a1 ac       ..
+    jsr osbput                                                        ; abf6: 20 d4 ff     ..
+    inc l00ac                                                         ; abf9: e6 ac       ..
+; &abfb referenced 1 time by &abf2
+.cabfb
+    lda l00ac                                                         ; abfb: a5 ac       ..
+    cmp l00aa                                                         ; abfd: c5 aa       ..
+    bne loop_cabf4                                                    ; abff: d0 f3       ..
+    plp                                                               ; ac01: 28          (
+    bcs cabbc                                                         ; ac02: b0 b8       ..
+    lda #&0d                                                          ; ac04: a9 0d       ..
+    jsr osbput                                                        ; ac06: 20 d4 ff     ..
+    jmp cabcf                                                         ; ac09: 4c cf ab    L..
+
+; &ac0c referenced 3 times by &817f, &8198, &85ca
+.sub_cac0c
+    jsr cac0f                                                         ; ac0c: 20 0f ac     ..
+; &ac0f referenced 11 times by &81a7, &834f, &837d, &aa8f, &aab0, &ab2a, &ab62, &ab75, &ab88, &abd2, &ac0c
+.cac0f
+    pha                                                               ; ac0f: 48          H
+    lda #&20 ; ' '                                                    ; ac10: a9 20       .
+    jsr osasci                                                        ; ac12: 20 e3 ff     ..
+    pla                                                               ; ac15: 68          h
+    clc                                                               ; ac16: 18          .
+    rts                                                               ; ac17: 60          `
+
+; &ac18 referenced 4 times by &aafd, &ab04, &ab46, &abc5
+.sub_cac18
+    tsx                                                               ; ac18: ba          .
+    lda #0                                                            ; ac19: a9 00       ..
+    sta l0107,x                                                       ; ac1b: 9d 07 01    ...
+    jsr sub_cac47                                                     ; ac1e: 20 47 ac     G.
+    cmp #&0d                                                          ; ac21: c9 0d       ..
+    bne cac28                                                         ; ac23: d0 03       ..
+    jmp ca14f                                                         ; ac25: 4c 4f a1    LO.
+
+; &ac28 referenced 1 time by &ac23
+.cac28
+    lda #0                                                            ; ac28: a9 00       ..
+    sta l00a8                                                         ; ac2a: 85 a8       ..
+    sta l00a9                                                         ; ac2c: 85 a9       ..
+    pha                                                               ; ac2e: 48          H
+    tya                                                               ; ac2f: 98          .
+    clc                                                               ; ac30: 18          .
+    adc os_text_ptr                                                   ; ac31: 65 f2       e.
+    tax                                                               ; ac33: aa          .
+    lda l00f3                                                         ; ac34: a5 f3       ..
+    adc #0                                                            ; ac36: 69 00       i.
+    tay                                                               ; ac38: a8          .
+    pla                                                               ; ac39: 68          h
+    rts                                                               ; ac3a: 60          `
+
+    tya                                                               ; ac3b: 98          .
+    clc                                                               ; ac3c: 18          .
+    adc os_text_ptr                                                   ; ac3d: 65 f2       e.
+    sta os_text_ptr                                                   ; ac3f: 85 f2       ..
+    bcc cac45                                                         ; ac41: 90 02       ..
+    inc os_text_ptr                                                   ; ac43: e6 f2       ..
+; &ac45 referenced 1 time by &ac41
+.cac45
+    rts                                                               ; ac45: 60          `
+
+; &ac46 referenced 1 time by &ac4b
+.loop_cac46
+    iny                                                               ; ac46: c8          .
+; &ac47 referenced 1 time by &ac1e
+.sub_cac47
+    lda (os_text_ptr),y                                               ; ac47: b1 f2       ..
+    cmp #&20 ; ' '                                                    ; ac49: c9 20       .
+    beq loop_cac46                                                    ; ac4b: f0 f9       ..
+    rts                                                               ; ac4d: 60          `
+
+; &ac4e referenced 2 times by &ab27, &abcf
+.sub_cac4e
+    sed                                                               ; ac4e: f8          .
+    clc                                                               ; ac4f: 18          .
+    lda l00a8                                                         ; ac50: a5 a8       ..
+    adc #1                                                            ; ac52: 69 01       i.
+    sta l00a8                                                         ; ac54: 85 a8       ..
+    lda l00a9                                                         ; ac56: a5 a9       ..
+    adc #0                                                            ; ac58: 69 00       i.
+    sta l00a9                                                         ; ac5a: 85 a9       ..
+    cld                                                               ; ac5c: d8          .
+    jsr sub_cac62                                                     ; ac5d: 20 62 ac     b.
+    lda l00a8                                                         ; ac60: a5 a8       ..
+; &ac62 referenced 4 times by &ab5a, &ab5f, &ab72, &ac5d
+.sub_cac62
+    pha                                                               ; ac62: 48          H
+    jsr sub_c81bf                                                     ; ac63: 20 bf 81     ..
+    jsr sub_cac6a                                                     ; ac66: 20 6a ac     j.
+    pla                                                               ; ac69: 68          h
+; &ac6a referenced 1 time by &ac66
+.sub_cac6a
+    jsr sub_c80c8                                                     ; ac6a: 20 c8 80     ..
+    jsr osasci                                                        ; ac6d: 20 e3 ff     ..
+    sec                                                               ; ac70: 38          8
+    rts                                                               ; ac71: 60          `
+
+; &ac72 referenced 1 time by &96e1
+.sub_cac72
+    jsr sub_c83e3                                                     ; ac72: 20 e3 83     ..
+    lda #&40 ; '@'                                                    ; ac75: a9 40       .@
+    sta l10de                                                         ; ac77: 8d de 10    ...
+    lda #&a8                                                          ; ac7a: a9 a8       ..
+    jsr osbyte_read                                                   ; ac7c: 20 e5 9a     ..
+    stx l00b0                                                         ; ac7f: 86 b0       ..
+    sty l00b1                                                         ; ac81: 84 b1       ..
+    ldy #&0f                                                          ; ac83: a0 0f       ..
+    lda #&4c ; 'L'                                                    ; ac85: a9 4c       .L
+    sta l10e2                                                         ; ac87: 8d e2 10    ...
+    lda bytev                                                         ; ac8a: ad 0a 02    ...
+    sta l10e3                                                         ; ac8d: 8d e3 10    ...
+    lda bytev+1                                                       ; ac90: ad 0b 02    ...
+    sta l10e4                                                         ; ac93: 8d e4 10    ...
+    php                                                               ; ac96: 08          .
+    sei                                                               ; ac97: 78          x
+    lda #&0f                                                          ; ac98: a9 0f       ..
+    sta bytev                                                         ; ac9a: 8d 0a 02    ...
+    lda #&ff                                                          ; ac9d: a9 ff       ..
+    sta bytev+1                                                       ; ac9f: 8d 0b 02    ...
+    lda #&b2                                                          ; aca2: a9 b2       ..
+    sta (l00b0),y                                                     ; aca4: 91 b0       ..
+    iny                                                               ; aca6: c8          .
+    lda #&ac                                                          ; aca7: a9 ac       ..
+    sta (l00b0),y                                                     ; aca9: 91 b0       ..
+    iny                                                               ; acab: c8          .
+    lda romsel_copy                                                   ; acac: a5 f4       ..
+    sta (l00b0),y                                                     ; acae: 91 b0       ..
+    plp                                                               ; acb0: 28          (
+    rts                                                               ; acb1: 60          `
+
+    cmp #0                                                            ; acb2: c9 00       ..
+    beq cacc7                                                         ; acb4: f0 11       ..
+    cmp #&81                                                          ; acb6: c9 81       ..
+    bne cacc4                                                         ; acb8: d0 0a       ..
+    cpy #&ff                                                          ; acba: c0 ff       ..
+    bne cacc4                                                         ; acbc: d0 06       ..
+    cpx #0                                                            ; acbe: e0 00       ..
+    bne cacc4                                                         ; acc0: d0 02       ..
+    dex                                                               ; acc2: ca          .
+    rts                                                               ; acc3: 60          `
+
+; &acc4 referenced 3 times by &acb8, &acbc, &acc0
+.cacc4
+    jmp l10e2                                                         ; acc4: 4c e2 10    L..
+
+; &acc7 referenced 1 time by &acb4
+.cacc7
+    php                                                               ; acc7: 08          .
+    sei                                                               ; acc8: 78          x
+    lda l10e3                                                         ; acc9: ad e3 10    ...
+    sta bytev                                                         ; accc: 8d 0a 02    ...
+    lda l10e4                                                         ; accf: ad e4 10    ...
+    sta bytev+1                                                       ; acd2: 8d 0b 02    ...
+    lda #0                                                            ; acd5: a9 00       ..
+    ldx #1                                                            ; acd7: a2 01       ..
+    plp                                                               ; acd9: 28          (
+    rts                                                               ; acda: 60          `
+
+; &acdb referenced 3 times by &0050, &af19, &af1c
+.tube_host_code2
+; &acdb referenced 3 times by &0050, &af19, &af1c
+
+    org &0500
+; &acdb referenced 3 times by &0050, &af19, &af1c
+.l0500
+    equw          sub_c0537,          sub_c0596,          sub_c05f2   ; acdb: 37 05 96... 7.. :0500[2]
+    equw          sub_c0607,          sub_c0627, tube_host_osword_0   ; ace1: 07 06 27... ..' :0506[2]
+    equw          sub_c055e,          sub_c052d,          sub_c0520   ; ace7: 5e 05 2d... ^.- :050c[2]
+    equw          sub_c0542,          sub_c05a9,          sub_c05d1   ; aced: 42 05 a9... B.. :0512[2]
+; Table of flags used by tube_entry_small_a to set up registers 1/4
+; for the
+; selected operation.
+; &acf3 referenced 1 time by &0453
+.tube_entry_flags
+    equb &86, &88, &96, &98, &18, &18, &82, &18                       ; acf3: 86 88 96... ... :0518[2]
+
+.sub_c0520
+    jsr read_tube_r2_data                                             ; acfb: 20 c5 06     .. :0520[2]
+    tay                                                               ; acfe: a8          .   :0523[2]
+    jsr read_tube_r2_data                                             ; acff: 20 c5 06     .. :0524[2]
+    jsr osbput                                                        ; ad02: 20 d4 ff     .. :0527[2]
+    jmp c059c                                                         ; ad05: 4c 9c 05    L.. :052a[2]
+
+.sub_c052d
+    jsr read_tube_r2_data                                             ; ad08: 20 c5 06     .. :052d[2]
+    tay                                                               ; ad0b: a8          .   :0530[2]
+    jsr osbget                                                        ; ad0c: 20 d7 ff     .. :0531[2]
+    jmp c053a                                                         ; ad0f: 4c 3a 05    L:. :0534[2]
+
+.sub_c0537
+    jsr osrdch                                                        ; ad12: 20 e0 ff     .. :0537[2]
+; &ad15 referenced 2 times by &0534, &05ef
+.c053a
+    ror a                                                             ; ad15: 6a          j   :053a[2]
+    jsr write_tube_r2_data                                            ; ad16: 20 95 06     .. :053b[2]
+    rol a                                                             ; ad19: 2a          *   :053e[2]
+    jmp c059e                                                         ; ad1a: 4c 9e 05    L.. :053f[2]
+
+.sub_c0542
+    jsr read_tube_r2_data                                             ; ad1d: 20 c5 06     .. :0542[2]
+    beq c0552                                                         ; ad20: f0 0b       ..  :0545[2]
+    pha                                                               ; ad22: 48          H   :0547[2]
+    jsr sub_c0582                                                     ; ad23: 20 82 05     .. :0548[2]
+    pla                                                               ; ad26: 68          h   :054b[2]
+    jsr osfind                                                        ; ad27: 20 ce ff     .. :054c[2]
+    jmp c059e                                                         ; ad2a: 4c 9e 05    L.. :054f[2]
+
+; &ad2d referenced 1 time by &0545
+.c0552
+    jsr read_tube_r2_data                                             ; ad2d: 20 c5 06     .. :0552[2]
+    tay                                                               ; ad30: a8          .   :0555[2]
+    lda #0                                                            ; ad31: a9 00       ..  :0556[2]
+    jsr osfind                                                        ; ad33: 20 ce ff     .. :0558[2]
+    jmp c059c                                                         ; ad36: 4c 9c 05    L.. :055b[2]
+
+.sub_c055e
+    jsr read_tube_r2_data                                             ; ad39: 20 c5 06     .. :055e[2]
+    tay                                                               ; ad3c: a8          .   :0561[2]
+    ldx #4                                                            ; ad3d: a2 04       ..  :0562[2]
+; &ad3f referenced 1 time by &056a
+.loop_c0564
+    jsr read_tube_r2_data                                             ; ad3f: 20 c5 06     .. :0564[2]
+    sta l00ff,x                                                       ; ad42: 95 ff       ..  :0567[2]
+    dex                                                               ; ad44: ca          .   :0569[2]
+    bne loop_c0564                                                    ; ad45: d0 f8       ..  :056a[2]
+    jsr read_tube_r2_data                                             ; ad47: 20 c5 06     .. :056c[2]
+    jsr osargs                                                        ; ad4a: 20 da ff     .. :056f[2]
+    jsr write_tube_r2_data                                            ; ad4d: 20 95 06     .. :0572[2]
+    ldx #3                                                            ; ad50: a2 03       ..  :0575[2]
+; &ad52 referenced 1 time by &057d
+.loop_c0577
+    lda l0000,x                                                       ; ad52: b5 00       ..  :0577[2]
+    jsr write_tube_r2_data                                            ; ad54: 20 95 06     .. :0579[2]
+    dex                                                               ; ad57: ca          .   :057c[2]
+    bpl loop_c0577                                                    ; ad58: 10 f8       ..  :057d[2]
+    jmp c0036                                                         ; ad5a: 4c 36 00    L6. :057f[2]
+
+; &ad5d referenced 3 times by &0548, &0596, &05b3
+.sub_c0582
+    ldx #0                                                            ; ad5d: a2 00       ..  :0582[2]
+    ldy #0                                                            ; ad5f: a0 00       ..  :0584[2]
+; &ad61 referenced 1 time by &0591
+.loop_c0586
+    jsr read_tube_r2_data                                             ; ad61: 20 c5 06     .. :0586[2]
+    sta l0700,y                                                       ; ad64: 99 00 07    ... :0589[2]
+    iny                                                               ; ad67: c8          .   :058c[2]
+    beq c0593                                                         ; ad68: f0 04       ..  :058d[2]
+    cmp #&0d                                                          ; ad6a: c9 0d       ..  :058f[2]
+    bne loop_c0586                                                    ; ad6c: d0 f3       ..  :0591[2]
+; &ad6e referenced 1 time by &058d
+.c0593
+    ldy #7                                                            ; ad6e: a0 07       ..  :0593[2]
+    rts                                                               ; ad70: 60          `   :0595[2]
+
+.sub_c0596
+    jsr sub_c0582                                                     ; ad71: 20 82 05     .. :0596[2]
+    jsr oscli                                                         ; ad74: 20 f7 ff     .. :0599[2]
+; &ad77 referenced 3 times by &0489, &052a, &055b
+.c059c
+    lda #&7f                                                          ; ad77: a9 7f       ..  :059c[2]
+; &ad79 referenced 4 times by &053f, &054f, &05a1, &067d
+.c059e
+    bit tube_host_r2_status                                           ; ad79: 2c e2 fe    ,.. :059e[2]
+    bvc c059e                                                         ; ad7c: 50 fb       P.  :05a1[2]
+    sta tube_host_r2_data                                             ; ad7e: 8d e3 fe    ... :05a3[2]
+; &ad81 referenced 1 time by &05cf
+.c05a6
+    jmp c0036                                                         ; ad81: 4c 36 00    L6. :05a6[2]
+
+.sub_c05a9
+    ldx #&10                                                          ; ad84: a2 10       ..  :05a9[2]
+; &ad86 referenced 1 time by &05b1
+.loop_c05ab
+    jsr read_tube_r2_data                                             ; ad86: 20 c5 06     .. :05ab[2]
+    sta l0001,x                                                       ; ad89: 95 01       ..  :05ae[2]
+    dex                                                               ; ad8b: ca          .   :05b0[2]
+    bne loop_c05ab                                                    ; ad8c: d0 f8       ..  :05b1[2]
+    jsr sub_c0582                                                     ; ad8e: 20 82 05     .. :05b3[2]
+    stx l0000                                                         ; ad91: 86 00       ..  :05b6[2]
+    sty l0001                                                         ; ad93: 84 01       ..  :05b8[2]
+    ldy #0                                                            ; ad95: a0 00       ..  :05ba[2]
+    jsr read_tube_r2_data                                             ; ad97: 20 c5 06     .. :05bc[2]
+    jsr osfile                                                        ; ad9a: 20 dd ff     .. :05bf[2]
+    jsr write_tube_r2_data                                            ; ad9d: 20 95 06     .. :05c2[2]
+    ldx #&10                                                          ; ada0: a2 10       ..  :05c5[2]
+; &ada2 referenced 1 time by &05cd
+.loop_c05c7
+    lda l0001,x                                                       ; ada2: b5 01       ..  :05c7[2]
+    jsr write_tube_r2_data                                            ; ada4: 20 95 06     .. :05c9[2]
+    dex                                                               ; ada7: ca          .   :05cc[2]
+    bne loop_c05c7                                                    ; ada8: d0 f8       ..  :05cd[2]
+    beq c05a6                                                         ; adaa: f0 d5       ..  :05cf[2]
+.sub_c05d1
+    ldx #&0d                                                          ; adac: a2 0d       ..  :05d1[2]
+; &adae referenced 1 time by &05d9
+.loop_c05d3
+    jsr read_tube_r2_data                                             ; adae: 20 c5 06     .. :05d3[2]
+    sta l00ff,x                                                       ; adb1: 95 ff       ..  :05d6[2]
+    dex                                                               ; adb3: ca          .   :05d8[2]
+    bne loop_c05d3                                                    ; adb4: d0 f8       ..  :05d9[2]
+    jsr read_tube_r2_data                                             ; adb6: 20 c5 06     .. :05db[2]
+    ldy #0                                                            ; adb9: a0 00       ..  :05de[2]
+    jsr osgbpb                                                        ; adbb: 20 d1 ff     .. :05e0[2]
+    pha                                                               ; adbe: 48          H   :05e3[2]
+    ldx #&0c                                                          ; adbf: a2 0c       ..  :05e4[2]
+; &adc1 referenced 1 time by &05ec
+.loop_c05e6
+    lda l0000,x                                                       ; adc1: b5 00       ..  :05e6[2]
+    jsr write_tube_r2_data                                            ; adc3: 20 95 06     .. :05e8[2]
+    dex                                                               ; adc6: ca          .   :05eb[2]
+    bpl loop_c05e6                                                    ; adc7: 10 f8       ..  :05ec[2]
+    pla                                                               ; adc9: 68          h   :05ee[2]
+    jmp c053a                                                         ; adca: 4c 3a 05    L:. :05ef[2]
+
+.sub_c05f2
+    jsr read_tube_r2_data                                             ; adcd: 20 c5 06     .. :05f2[2]
+    tax                                                               ; add0: aa          .   :05f5[2]
+    jsr read_tube_r2_data                                             ; add1: 20 c5 06     .. :05f6[2]
+    jsr osbyte                                                        ; add4: 20 f4 ff     .. :05f9[2]
+; &add7 referenced 2 times by &05ff, &0625
+.c05fc
+    bit tube_host_r2_status                                           ; add7: 2c e2 fe    ,.. :05fc[2]
+.sub_c05ff
+l0600 = sub_c05ff+1
+    bvc c05fc                                                         ; adda: 50 fb       P.  :05ff[2]
+; &addb referenced 2 times by &af1f, &af22
+    stx tube_host_r2_data                                             ; addc: 8e e3 fe    ... :0601[2]
+; &addf referenced 1 time by &0617
+.loop_c0604
+    jmp c0036                                                         ; addf: 4c 36 00    L6. :0604[2]
+
+.sub_c0607
+    jsr read_tube_r2_data                                             ; ade2: 20 c5 06     .. :0607[2]
+    tax                                                               ; ade5: aa          .   :060a[2]
+    jsr read_tube_r2_data                                             ; ade6: 20 c5 06     .. :060b[2]
+    tay                                                               ; ade9: a8          .   :060e[2]
+    jsr read_tube_r2_data                                             ; adea: 20 c5 06     .. :060f[2]
+    jsr osbyte                                                        ; aded: 20 f4 ff     .. :0612[2]
+    eor #&9d                                                          ; adf0: 49 9d       I.  :0615[2]
+    beq loop_c0604                                                    ; adf2: f0 eb       ..  :0617[2]
+    ror a                                                             ; adf4: 6a          j   :0619[2]
+    jsr write_tube_r2_data                                            ; adf5: 20 95 06     .. :061a[2]
+; &adf8 referenced 1 time by &0620
+.loop_c061d
+    bit tube_host_r2_status                                           ; adf8: 2c e2 fe    ,.. :061d[2]
+    bvc loop_c061d                                                    ; adfb: 50 fb       P.  :0620[2]
+    sty tube_host_r2_data                                             ; adfd: 8c e3 fe    ... :0622[2]
+    bvs c05fc                                                         ; ae00: 70 d5       p.  :0625[2]
+.sub_c0627
+    jsr read_tube_r2_data                                             ; ae02: 20 c5 06     .. :0627[2]
+    tay                                                               ; ae05: a8          .   :062a[2]
+; &ae06 referenced 1 time by &062e
+.loop_c062b
+    bit tube_host_r2_status                                           ; ae06: 2c e2 fe    ,.. :062b[2]
+    bpl loop_c062b                                                    ; ae09: 10 fb       ..  :062e[2]
+    ldx tube_host_r2_data                                             ; ae0b: ae e3 fe    ... :0630[2]
+    dex                                                               ; ae0e: ca          .   :0633[2]
+    bmi c0645                                                         ; ae0f: 30 0f       0.  :0634[2]
+; &ae11 referenced 2 times by &0639, &0642
+.c0636
+    bit tube_host_r2_status                                           ; ae11: 2c e2 fe    ,.. :0636[2]
+    bpl c0636                                                         ; ae14: 10 fb       ..  :0639[2]
+    lda tube_host_r2_data                                             ; ae16: ad e3 fe    ... :063b[2]
+    sta l0128,x                                                       ; ae19: 9d 28 01    .(. :063e[2]
+    dex                                                               ; ae1c: ca          .   :0641[2]
+    bpl c0636                                                         ; ae1d: 10 f2       ..  :0642[2]
+    tya                                                               ; ae1f: 98          .   :0644[2]
+; &ae20 referenced 1 time by &0634
+.c0645
+    ldx #<(l0128)                                                     ; ae20: a2 28       .(  :0645[2]
+    ldy #>(l0128)                                                     ; ae22: a0 01       ..  :0647[2]
+    jsr osword                                                        ; ae24: 20 f1 ff     .. :0649[2]
+; &ae27 referenced 1 time by &064f
+.loop_c064c
+    bit tube_host_r2_status                                           ; ae27: 2c e2 fe    ,.. :064c[2]
+    bpl loop_c064c                                                    ; ae2a: 10 fb       ..  :064f[2]
+    ldx tube_host_r2_data                                             ; ae2c: ae e3 fe    ... :0651[2]
+    dex                                                               ; ae2f: ca          .   :0654[2]
+    bmi c0665                                                         ; ae30: 30 0e       0.  :0655[2]
+; &ae32 referenced 1 time by &0663
+.loop_c0657
+    ldy l0128,x                                                       ; ae32: bc 28 01    .(. :0657[2]
+; &ae35 referenced 1 time by &065d
+.loop_c065a
+    bit tube_host_r2_status                                           ; ae35: 2c e2 fe    ,.. :065a[2]
+    bvc loop_c065a                                                    ; ae38: 50 fb       P.  :065d[2]
+    sty tube_host_r2_data                                             ; ae3a: 8c e3 fe    ... :065f[2]
+    dex                                                               ; ae3d: ca          .   :0662[2]
+    bpl loop_c0657                                                    ; ae3e: 10 f2       ..  :0663[2]
+; &ae40 referenced 1 time by &0655
+.c0665
+    jmp c0036                                                         ; ae40: 4c 36 00    L6. :0665[2]
+
+.tube_host_osword_0
+    ldx #4                                                            ; ae43: a2 04       ..  :0668[2]
+; &ae45 referenced 1 time by &0670
+.tube_host_osword_0_loop
+    jsr read_tube_r2_data                                             ; ae45: 20 c5 06     .. :066a[2]
+    sta l0000,x                                                       ; ae48: 95 00       ..  :066d[2]
+    dex                                                               ; ae4a: ca          .   :066f[2]
+    bpl tube_host_osword_0_loop                                       ; ae4b: 10 f8       ..  :0670[2]
+    inx                                                               ; ae4d: e8          .   :0672[2]
+    ldy #0                                                            ; ae4e: a0 00       ..  :0673[2]
+    txa                                                               ; ae50: 8a          .   :0675[2]
+    jsr osword                                                        ; ae51: 20 f1 ff     .. :0676[2]
+    bcc tube_host_osword_0_no_escape                                  ; ae54: 90 05       ..  :0679[2]
+    lda #&ff                                                          ; ae56: a9 ff       ..  :067b[2]
+    jmp c059e                                                         ; ae58: 4c 9e 05    L.. :067d[2]
+
+; &ae5b referenced 1 time by &0679
+.tube_host_osword_0_no_escape
+    ldx #0                                                            ; ae5b: a2 00       ..  :0680[2]
+    lda #&7f                                                          ; ae5d: a9 7f       ..  :0682[2]
+    jsr write_tube_r2_data                                            ; ae5f: 20 95 06     .. :0684[2]
+; &ae62 referenced 1 time by &0690
+.tube_host_osword_0_no_escape_loop
+    lda l0700,x                                                       ; ae62: bd 00 07    ... :0687[2]
+    jsr write_tube_r2_data                                            ; ae65: 20 95 06     .. :068a[2]
+    inx                                                               ; ae68: e8          .   :068d[2]
+    cmp #&0d                                                          ; ae69: c9 0d       ..  :068e[2]
+    bne tube_host_osword_0_no_escape_loop                             ; ae6b: d0 f5       ..  :0690[2]
+    jmp c0036                                                         ; ae6d: 4c 36 00    L6. :0692[2]
+
+; Wait for register 2 to have space and write A to it.
+; &ae70 referenced 14 times by &0020, &0026, &002c, &0474, &053b, &0572, &0579, &05c2, &05c9, &05e8, &061a, &0684, &068a, &0698
+.write_tube_r2_data
+    bit tube_host_r2_status                                           ; ae70: 2c e2 fe    ,.. :0695[2]
+    bvc write_tube_r2_data                                            ; ae73: 50 fb       P.  :0698[2]
+    sta tube_host_r2_data                                             ; ae75: 8d e3 fe    ... :069a[2]
+    rts                                                               ; ae78: 60          `   :069d[2]
+
+; Wait for register 4 to have space and write A to it.
+; &ae79 referenced 8 times by &0018, &0418, &041d, &043b, &0443, &0448, &0463, &06a1
+.write_tube_r4_data
+    bit tube_host_r4_status                                           ; ae79: 2c e6 fe    ,.. :069e[2]
+    bvc write_tube_r4_data                                            ; ae7c: 50 fb       P.  :06a1[2]
+    sta tube_host_r4_data                                             ; ae7e: 8d e7 fe    ... :06a3[2]
+    rts                                                               ; ae81: 60          `   :06a6[2]
+
+; &ae82 referenced 1 time by &0403
+.c06a7
+    lda l00ff                                                         ; ae82: a5 ff       ..  :06a7[2]
+    sec                                                               ; ae84: 38          8   :06a9[2]
+    ror a                                                             ; ae85: 6a          j   :06aa[2]
+    bmi write_tube_r1_data                                            ; ae86: 30 0f       0.  :06ab[2]
+.tube_evntv_handler
+    pha                                                               ; ae88: 48          H   :06ad[2]
+    lda #0                                                            ; ae89: a9 00       ..  :06ae[2]
+    jsr write_tube_r1_data                                            ; ae8b: 20 bc 06     .. :06b0[2]
+    tya                                                               ; ae8e: 98          .   :06b3[2]
+    jsr write_tube_r1_data                                            ; ae8f: 20 bc 06     .. :06b4[2]
+    txa                                                               ; ae92: 8a          .   :06b7[2]
+    jsr write_tube_r1_data                                            ; ae93: 20 bc 06     .. :06b8[2]
+    pla                                                               ; ae96: 68          h   :06bb[2]
+; Wait for register 1 to have space and write A to it.
+; &ae97 referenced 5 times by &06ab, &06b0, &06b4, &06b8, &06bf
+.write_tube_r1_data
+    bit tube_host_r1_status                                           ; ae97: 2c e0 fe    ,.. :06bc[2]
+    bvc write_tube_r1_data                                            ; ae9a: 50 fb       P.  :06bf[2]
+    sta tube_host_r1_data                                             ; ae9c: 8d e1 fe    ... :06c1[2]
+    rts                                                               ; ae9f: 60          `   :06c4[2]
+
+; Wait for register 2 to have data and read A from it.
+; &aea0 referenced 21 times by &0520, &0524, &052d, &0542, &0552, &055e, &0564, &056c, &0586, &05ab, &05bc, &05d3, &05db, &05f2, &05f6, &0607, &060b, &060f, &0627, &066a, &06c8
+.read_tube_r2_data
+    bit tube_host_r2_status                                           ; aea0: 2c e2 fe    ,.. :06c5[2]
+    bpl read_tube_r2_data                                             ; aea3: 10 fb       ..  :06c8[2]
+    lda tube_host_r2_data                                             ; aea5: ad e3 fe    ... :06ca[2]
+    rts                                                               ; aea8: 60          `   :06cd[2]
+
+; &aea9 referenced 1 time by &965d
+    org tube_host_code2 + (l06ce - l0500)
+    copyblock l0500, l06ce, tube_host_code2
+    clear l0500, l06ce
+
+; &aea9 referenced 1 time by &965d
+.service_handler_help_and_tube
+; &aea9 referenced 1 time by &965d
+    cmp #service_help                                                 ; aea9: c9 09       ..
+    bne caed7                                                         ; aeab: d0 2a       .*
+    tya                                                               ; aead: 98          .
+    pha                                                               ; aeae: 48          H
+    lda (os_text_ptr),y                                               ; aeaf: b1 f2       ..
+    cmp #&0d                                                          ; aeb1: c9 0d       ..
+    bne caed3                                                         ; aeb3: d0 1e       ..
+    lda #&e9                                                          ; aeb5: a9 e9       ..
+    jsr osbyte_read                                                   ; aeb7: 20 e5 9a     ..
+    ldx romsel_copy                                                   ; aeba: a6 f4       ..
+    tya                                                               ; aebc: 98          .
+    beq caed3                                                         ; aebd: f0 14       ..
+    jsr print_inline_l809f_top_bit_clear                              ; aebf: 20 77 80     w.
+    equs &0d, "TUBE HOST 2.30", &0d                                   ; aec2: 0d 54 55... .TU
+
+    nop                                                               ; aed2: ea          .
+; &aed3 referenced 2 times by &aeb3, &aebd
+.caed3
+    pla                                                               ; aed3: 68          h
+    tay                                                               ; aed4: a8          .
+    lda #9                                                            ; aed5: a9 09       ..
+; &aed7 referenced 1 time by &aeab
+.caed7
+    cmp #service_tube_post_init                                       ; aed7: c9 fe       ..
+    bcc just_rts                                                      ; aed9: 90 5c       .\
+    bne service_handler_tube_main_init                                ; aedb: d0 1b       ..
+    cpy #0                                                            ; aedd: c0 00       ..
+    beq just_rts                                                      ; aedf: f0 56       .V
+    ldx #6                                                            ; aee1: a2 06       ..
+    lda #osbyte_explode_chars                                         ; aee3: a9 14       ..
+    jsr osbyte                                                        ; aee5: 20 f4 ff     ..
+; &aee8 referenced 2 times by &aeeb, &aef5
+.tube_banner_loop
+    bit tube_host_r1_status                                           ; aee8: 2c e0 fe    ,..
+    bpl tube_banner_loop                                              ; aeeb: 10 fb       ..
+    lda tube_host_r1_data                                             ; aeed: ad e1 fe    ...
+    beq lda_0_rts                                                     ; aef0: f0 43       .C
+    jsr oswrch                                                        ; aef2: 20 ee ff     ..
+    jmp tube_banner_loop                                              ; aef5: 4c e8 ae    L..
+
+; &aef8 referenced 1 time by &aedb
+.service_handler_tube_main_init
+    lda #<tube_evntv_handler                                          ; aef8: a9 ad       ..
+    sta evntv                                                         ; aefa: 8d 20 02    . .
+    lda #>tube_evntv_handler                                          ; aefd: a9 06       ..
+    sta evntv+1                                                       ; aeff: 8d 21 02    .!.
+    lda #<tube_brkv_handler                                           ; af02: a9 16       ..
+    sta brkv                                                          ; af04: 8d 02 02    ...
+    lda #>tube_brkv_handler                                           ; af07: a9 00       ..
+    sta brkv+1                                                        ; af09: 8d 03 02    ...
+    lda #&8e                                                          ; af0c: a9 8e       ..
+    sta tube_host_r1_status                                           ; af0e: 8d e0 fe    ...
+    ldy #0                                                            ; af11: a0 00       ..
+; &af13 referenced 1 time by &af26
+.loop_caf13
+    lda tube_host_code1,y                                             ; af13: b9 79 af    .y.
+    sta c0400,y                                                       ; af16: 99 00 04    ...
+    lda tube_host_code2,y                                             ; af19: b9 db ac    ...
+    sta l0500,y                                                       ; af1c: 99 00 05    ...
+    lda tube_host_code2+256,y                                         ; af1f: b9 db ad    ...
+    sta l0600,y                                                       ; af22: 99 00 06    ...
+    dey                                                               ; af25: 88          .
+    bne loop_caf13                                                    ; af26: d0 eb       ..
+    jsr sub_c0421                                                     ; af28: 20 21 04     !.
+    ldx #&41 ; 'A'                                                    ; af2b: a2 41       .A
+; &af2d referenced 1 time by &af33
+.loop_caf2d
+    lda tube_host_code3,x                                             ; af2d: bd 38 af    .8.
+    sta tube_brkv_handler_fwd,x                                       ; af30: 95 16       ..
+    dex                                                               ; af32: ca          .
+    bpl loop_caf2d                                                    ; af33: 10 f8       ..
+; &af35 referenced 1 time by &aef0
+.lda_0_rts
+    lda #0                                                            ; af35: a9 00       ..
+; &af37 referenced 2 times by &aed9, &aedf
+.just_rts
+    rts                                                               ; af37: 60          `
+
+; &af38 referenced 2 times by &af2d, &af30
+.tube_host_code3
+; &af38 referenced 2 times by &af2d, &af30
+
+    org &16
+; &af38 referenced 2 times by &af2d, &af30
+.tube_brkv_handler
+    lda #&ff                                                          ; af38: a9 ff       ..  :0016[3]
+    jsr write_tube_r4_data                                            ; af3a: 20 9e 06     .. :0018[3]
+    lda tube_host_r2_data                                             ; af3d: ad e3 fe    ... :001b[3]
+    lda #0                                                            ; af40: a9 00       ..  :001e[3]
+    jsr write_tube_r2_data                                            ; af42: 20 95 06     .. :0020[3]
+    tay                                                               ; af45: a8          .   :0023[3]
+    lda (l00fd),y                                                     ; af46: b1 fd       ..  :0024[3]
+    jsr write_tube_r2_data                                            ; af48: 20 95 06     .. :0026[3]
+; &af4b referenced 1 time by &0030
+.loop_c0029
+    iny                                                               ; af4b: c8          .   :0029[3]
+    lda (l00fd),y                                                     ; af4c: b1 fd       ..  :002a[3]
+    jsr write_tube_r2_data                                            ; af4e: 20 95 06     .. :002c[3]
+    tax                                                               ; af51: aa          .   :002f[3]
+    bne loop_c0029                                                    ; af52: d0 f7       ..  :0030[3]
+; &af54 referenced 1 time by &0477
+.c0032
+    ldx #&ff                                                          ; af54: a2 ff       ..  :0032[3]
+    txs                                                               ; af56: 9a          .   :0034[3]
+    cli                                                               ; af57: 58          X   :0035[3]
+; &af58 referenced 6 times by &0044, &057f, &05a6, &0604, &0665, &0692
+.c0036
+    bit tube_host_r1_status                                           ; af58: 2c e0 fe    ,.. :0036[3]
+    bpl c0041                                                         ; af5b: 10 06       ..  :0039[3]
+; &af5d referenced 1 time by &0049
+.loop_c003b
+    lda tube_host_r1_data                                             ; af5d: ad e1 fe    ... :003b[3]
+    jsr oswrch                                                        ; af60: 20 ee ff     .. :003e[3]
+; &af63 referenced 1 time by &0039
+.c0041
+    bit tube_host_r2_status                                           ; af63: 2c e2 fe    ,.. :0041[3]
+    bpl c0036                                                         ; af66: 10 f0       ..  :0044[3]
+    bit tube_host_r1_status                                           ; af68: 2c e0 fe    ,.. :0046[3]
+    bmi loop_c003b                                                    ; af6b: 30 f0       0.  :0049[3]
+    ldx tube_host_r2_data                                             ; af6d: ae e3 fe    ... :004b[3]
+; Patch the following JMP so we effectively do JMP (&500,X)
+
+; Extra comment after a blank line
+; manually-created comment
+    stx jump_address_low                                              ; af70: 86 51       .Q  :004e[3]
+.sub_c0050
+jump_address_low = sub_c0050+1
+    jmp (l0500)                                                       ; af72: 6c 00 05    l.. :0050[3]
+
+; &af73 referenced 1 time by &004e
+; &af75 referenced 2 times by &04da, &04ea
+.l0053
+    equb 0                                                            ; af75: 00          .   :0053[3]
+; &af76 referenced 3 times by &04b2, &04d0, &04ef
+.l0054
+    equb &80                                                          ; af76: 80          .   :0054[3]
+; &af77 referenced 2 times by &04b6, &04f9
+.l0055
+    equb 0                                                            ; af77: 00          .   :0055[3]
+; &af78 referenced 2 times by &04ba, &04f7
+.l0056
+    equb 0                                                            ; af78: 00          .   :0056[3]
+; &af79 referenced 2 times by &af13, &af16
+    org tube_host_code3 + (l0057 - tube_brkv_handler)
+    copyblock tube_brkv_handler, l0057, tube_host_code3
+    clear tube_brkv_handler, l0057
+
+; &af79 referenced 2 times by &af13, &af16
+.tube_host_code1
+; &af79 referenced 2 times by &af13, &af16
+
+    org &0400
+; &af79 referenced 2 times by &af13, &af16
+.c0400
+    jmp c0484                                                         ; af79: 4c 84 04    L.. :0400[1]
+
+    jmp c06a7                                                         ; af7c: 4c a7 06    L.. :0403[1]
+
+; &af7f referenced 14 times by &0493, &04cb, &892a, &8cae, &8f6e, &8f7d, &9346, &982b, &bd64, &bd91, &be09, &be2c, &be7d, &be85
+.tube_entry
+    cmp #&80                                                          ; af7f: c9 80       ..  :0406[1]
+    bcc tube_entry_small_a                                            ; af81: 90 2b       .+  :0408[1]
+    cmp #&c0                                                          ; af83: c9 c0       ..  :040a[1]
+    bcs tube_entry_claim_tube                                         ; af85: b0 1a       ..  :040c[1]
+; This is a call to release the tube.
+    ora #&40 ; '@'                                                    ; af87: 09 40       .@  :040e[1]
+    cmp l0015                                                         ; af89: c5 15       ..  :0410[1]
+    bne c0434                                                         ; af8b: d0 20       .   :0412[1]
+; &af8d referenced 1 time by &0471
+.sub_c0414
+    php                                                               ; af8d: 08          .   :0414[1]
+    sei                                                               ; af8e: 78          x   :0415[1]
+    lda #5                                                            ; af8f: a9 05       ..  :0416[1]
+    jsr write_tube_r4_data                                            ; af91: 20 9e 06     .. :0418[1]
+    lda l0015                                                         ; af94: a5 15       ..  :041b[1]
+    jsr write_tube_r4_data                                            ; af96: 20 9e 06     .. :041d[1]
+    plp                                                               ; af99: 28          (   :0420[1]
+; &af9a referenced 1 time by &af28
+.sub_c0421
+    lda #&80                                                          ; af9a: a9 80       ..  :0421[1]
+    sta l0015                                                         ; af9c: 85 15       ..  :0423[1]
+    sta l0014                                                         ; af9e: 85 14       ..  :0425[1]
+    rts                                                               ; afa0: 60          `   :0427[1]
+
+; &afa1 referenced 1 time by &040c
+.tube_entry_claim_tube
+    asl l0014                                                         ; afa1: 06 14       ..  :0428[1]
+    bcs c0432                                                         ; afa3: b0 06       ..  :042a[1]
+    cmp l0015                                                         ; afa5: c5 15       ..  :042c[1]
+    beq c0434                                                         ; afa7: f0 04       ..  :042e[1]
+    clc                                                               ; afa9: 18          .   :0430[1]
+    rts                                                               ; afaa: 60          `   :0431[1]
+
+; &afab referenced 1 time by &042a
+.c0432
+    sta l0015                                                         ; afab: 85 15       ..  :0432[1]
+; &afad referenced 2 times by &0412, &042e
+.c0434
+    rts                                                               ; afad: 60          `   :0434[1]
+
+; &afae referenced 1 time by &0408
+.tube_entry_small_a
+    php                                                               ; afae: 08          .   :0435[1]
+    sei                                                               ; afaf: 78          x   :0436[1]
+    sty l0013                                                         ; afb0: 84 13       ..  :0437[1]
+    stx l0012                                                         ; afb2: 86 12       ..  :0439[1]
+    jsr write_tube_r4_data                                            ; afb4: 20 9e 06     .. :043b[1]
+    tax                                                               ; afb7: aa          .   :043e[1]
+    ldy #3                                                            ; afb8: a0 03       ..  :043f[1]
+    lda l0015                                                         ; afba: a5 15       ..  :0441[1]
+    jsr write_tube_r4_data                                            ; afbc: 20 9e 06     .. :0443[1]
+; &afbf referenced 1 time by &044c
+.loop_c0446
+    lda (l0012),y                                                     ; afbf: b1 12       ..  :0446[1]
+    jsr write_tube_r4_data                                            ; afc1: 20 9e 06     .. :0448[1]
+    dey                                                               ; afc4: 88          .   :044b[1]
+    bpl loop_c0446                                                    ; afc5: 10 f8       ..  :044c[1]
+    ldy #&18                                                          ; afc7: a0 18       ..  :044e[1]
+    sty tube_host_r1_status                                           ; afc9: 8c e0 fe    ... :0450[1]
+    lda tube_entry_flags,x                                            ; afcc: bd 18 05    ... :0453[1]
+    sta tube_host_r1_status                                           ; afcf: 8d e0 fe    ... :0456[1]
+    lsr a                                                             ; afd2: 4a          J   :0459[1]
+    lsr a                                                             ; afd3: 4a          J   :045a[1]
+    bcc c0463                                                         ; afd4: 90 06       ..  :045b[1]
+    bit tube_host_r3_data                                             ; afd6: 2c e5 fe    ,.. :045d[1]
+    bit tube_host_r3_data                                             ; afd9: 2c e5 fe    ,.. :0460[1]
+; &afdc referenced 1 time by &045b
+.c0463
+    jsr write_tube_r4_data                                            ; afdc: 20 9e 06     .. :0463[1]
+; &afdf referenced 1 time by &0469
+.loop_c0466
+    bit tube_host_r4_status                                           ; afdf: 2c e6 fe    ,.. :0466[1]
+    bvc loop_c0466                                                    ; afe2: 50 fb       P.  :0469[1]
+    bcs c047a                                                         ; afe4: b0 0d       ..  :046b[1]
+    cpx #4                                                            ; afe6: e0 04       ..  :046d[1]
+    bne c0482                                                         ; afe8: d0 11       ..  :046f[1]
+; &afea referenced 1 time by &048f
+.loop_c0471
+    jsr sub_c0414                                                     ; afea: 20 14 04     .. :0471[1]
+    jsr write_tube_r2_data                                            ; afed: 20 95 06     .. :0474[1]
+    jmp c0032                                                         ; aff0: 4c 32 00    L2. :0477[1]
+
+; &aff3 referenced 1 time by &046b
+.c047a
+    lsr a                                                             ; aff3: 4a          J   :047a[1]
+    bcc c0482                                                         ; aff4: 90 05       ..  :047b[1]
+    ldy #&88                                                          ; aff6: a0 88       ..  :047d[1]
+    sty tube_host_r1_status                                           ; aff8: 8c e0 fe    ... :047f[1]
+; &affb referenced 2 times by &046f, &047b
+.c0482
+    plp                                                               ; affb: 28          (   :0482[1]
+    rts                                                               ; affc: 60          `   :0483[1]
+
+; &affd referenced 1 time by &0400
+.c0484
+    cli                                                               ; affd: 58          X   :0484[1]
+    bcs c0491                                                         ; affe: b0 0a       ..  :0485[1]
+    bne c048c                                                         ; b000: d0 03       ..  :0487[1]
+    jmp c059c                                                         ; b002: 4c 9c 05    L.. :0489[1]
+
+; &b005 referenced 1 time by &0487
+.c048c
+    ldx l028d                                                         ; b005: ae 8d 02    ... :048c[1]
+    beq loop_c0471                                                    ; b008: f0 e0       ..  :048f[1]
+; &b00a referenced 2 times by &0485, &0496
+.c0491
+    lda #&ff                                                          ; b00a: a9 ff       ..  :0491[1]
+    jsr tube_entry                                                    ; b00c: 20 06 04     .. :0493[1]
+    bcc c0491                                                         ; b00f: 90 f9       ..  :0496[1]
+    jsr sub_c04ce                                                     ; b011: 20 ce 04     .. :0498[1]
+; &b014 referenced 1 time by &04c0
+.c049b
+    php                                                               ; b014: 08          .   :049b[1]
+    sei                                                               ; b015: 78          x   :049c[1]
+    lda #7                                                            ; b016: a9 07       ..  :049d[1]
+    jsr sub_c04c7                                                     ; b018: 20 c7 04     .. :049f[1]
+    ldy #0                                                            ; b01b: a0 00       ..  :04a2[1]
+    sty l0000                                                         ; b01d: 84 00       ..  :04a4[1]
+; &b01f referenced 1 time by &04af
+.loop_c04a6
+    lda (l0000),y                                                     ; b01f: b1 00       ..  :04a6[1]
+    sta tube_host_r3_data                                             ; b021: 8d e5 fe    ... :04a8[1]
+    nop                                                               ; b024: ea          .   :04ab[1]
+    nop                                                               ; b025: ea          .   :04ac[1]
+    nop                                                               ; b026: ea          .   :04ad[1]
+    iny                                                               ; b027: c8          .   :04ae[1]
+    bne loop_c04a6                                                    ; b028: d0 f5       ..  :04af[1]
+    plp                                                               ; b02a: 28          (   :04b1[1]
+    inc l0054                                                         ; b02b: e6 54       .T  :04b2[1]
+    bne c04bc                                                         ; b02d: d0 06       ..  :04b4[1]
+    inc l0055                                                         ; b02f: e6 55       .U  :04b6[1]
+    bne c04bc                                                         ; b031: d0 02       ..  :04b8[1]
+    inc l0056                                                         ; b033: e6 56       .V  :04ba[1]
+; &b035 referenced 2 times by &04b4, &04b8
+.c04bc
+    inc l0001                                                         ; b035: e6 01       ..  :04bc[1]
+    bit l0001                                                         ; b037: 24 01       $.  :04be[1]
+    bvc c049b                                                         ; b039: 50 d9       P.  :04c0[1]
+    jsr sub_c04ce                                                     ; b03b: 20 ce 04     .. :04c2[1]
+    lda #4                                                            ; b03e: a9 04       ..  :04c5[1]
+; &b040 referenced 1 time by &049f
+.sub_c04c7
+    ldy #0                                                            ; b040: a0 00       ..  :04c7[1]
+    ldx #&53 ; 'S'                                                    ; b042: a2 53       .S  :04c9[1]
+    jmp tube_entry                                                    ; b044: 4c 06 04    L.. :04cb[1]
+
+; &b047 referenced 2 times by &0498, &04c2
+.sub_c04ce
+    lda #&80                                                          ; b047: a9 80       ..  :04ce[1]
+    sta l0054                                                         ; b049: 85 54       .T  :04d0[1]
+    sta l0001                                                         ; b04b: 85 01       ..  :04d2[1]
+    lda #&20 ; ' '                                                    ; b04d: a9 20       .   :04d4[1]
+    and rom_type                                                      ; b04f: 2d 06 80    -.. :04d6[1]
+    tay                                                               ; b052: a8          .   :04d9[1]
+    sty l0053                                                         ; b053: 84 53       .S  :04da[1]
+    beq c04f7                                                         ; b055: f0 19       ..  :04dc[1]
+    ldx copyright_offset                                              ; b057: ae 07 80    ... :04de[1]
+; &b05a referenced 1 time by &04e5
+.loop_c04e1
+    inx                                                               ; b05a: e8          .   :04e1[1]
+    lda rom_header,x                                                  ; b05b: bd 00 80    ... :04e2[1]
+    bne loop_c04e1                                                    ; b05e: d0 fa       ..  :04e5[1]
+    lda l8001,x                                                       ; b060: bd 01 80    ... :04e7[1]
+    sta l0053                                                         ; b063: 85 53       .S  :04ea[1]
+    lda l8002,x                                                       ; b065: bd 02 80    ... :04ec[1]
+    sta l0054                                                         ; b068: 85 54       .T  :04ef[1]
+    ldy service_entry,x                                               ; b06a: bc 03 80    ... :04f1[1]
+    lda l8004,x                                                       ; b06d: bd 04 80    ... :04f4[1]
+; &b070 referenced 1 time by &04dc
+.c04f7
+    sta l0056                                                         ; b070: 85 56       .V  :04f7[1]
+    sty l0055                                                         ; b072: 84 55       .U  :04f9[1]
+    rts                                                               ; b074: 60          `   :04fb[1]
+
+; &b075 referenced 1 time by &b2b4
+    org tube_host_code1 + (l04fc - c0400)
+    copyblock c0400, l04fc, tube_host_code1
+    clear c0400, l04fc
+
+; &b075 referenced 1 time by &b2b4
+.lb075
+; &b075 referenced 1 time by &b2b4
+    equb &0a                                                          ; b075: 0a          .
+    equs "SRAM 1.05"                                                  ; b076: 53 52 41... SRA
+    equb &0d, &0a                                                     ; b07f: 0d 0a       ..
+    equs "  SRDATA  <id.>"                                            ; b081: 20 20 53...   S
+    equb &0d, &0a                                                     ; b090: 0d 0a       ..
+    equs "  SRLOAD  <filename> <sram address> (<id.>) (Q)"            ; b092: 20 20 53...   S
+    equb &0d, &0a                                                     ; b0c1: 0d 0a       ..
+    equs "  SRREAD  <dest. start> <dest. end> <sram start> (<id.>)"   ; b0c3: 20 20 53...   S
+    equb &0d, &0a                                                     ; b0fb: 0d 0a       ..
+    equs "  SRROM   <id.>"                                            ; b0fd: 20 20 53...   S
+    equb &0d, &0a                                                     ; b10c: 0d 0a       ..
+    equs "  SRSAVE  <filename> <sram start> <sram end> (<id.>) (Q)"   ; b10e: 20 20 53...   S
+    equb &0d, &0a                                                     ; b146: 0d 0a       ..
+    equs "  SRWRITE <source start> <source end> <sram s"              ; b148: 20 20 53...   S
+; &b175 referenced 1 time by &b2bd
+.lb175
+    equs "tart> (<id.>)"                                              ; b175: 74 61 72... tar
+    equb &0d, &0a                                                     ; b182: 0d 0a       ..
+    equs "End addresses may be replaced by +<length>"                 ; b184: 45 6e 64... End
+    equb &0d, &0a,   0                                                ; b1ae: 0d 0a 00    ...
+
+; &b1b1 referenced 1 time by &bedd
+.general_service_handler
+    jsr sub_c965d                                                     ; b1b1: 20 5d 96     ].
+    pha                                                               ; b1b4: 48          H
+    tax                                                               ; b1b5: aa          .
+    lda l00b8                                                         ; b1b6: a5 b8       ..
+    pha                                                               ; b1b8: 48          H
+    lda l00b9                                                         ; b1b9: a5 b9       ..
+    pha                                                               ; b1bb: 48          H
+    tya                                                               ; b1bc: 98          .
+    pha                                                               ; b1bd: 48          H
+    txa                                                               ; b1be: 8a          .
+    ldx romsel_copy                                                   ; b1bf: a6 f4       ..
+    jsr cb82b                                                         ; b1c1: 20 2b b8     +.
+    bit l00b9                                                         ; b1c4: 24 b9       $.
+    bmi cb203                                                         ; b1c6: 30 3b       0;
+    cmp #8                                                            ; b1c8: c9 08       ..
+    bne cb1fc                                                         ; b1ca: d0 30       .0
+    lda l00ef                                                         ; b1cc: a5 ef       ..
+    cmp #&43 ; 'C'                                                    ; b1ce: c9 43       .C
+    bne cb1dd                                                         ; b1d0: d0 0b       ..
+    jsr sub_cb2c8                                                     ; b1d2: 20 c8 b2     ..
+; &b1d5 referenced 3 times by &b1f9, &b231, &b25d
+.cb1d5
+    tsx                                                               ; b1d5: ba          .
+    lda #0                                                            ; b1d6: a9 00       ..
+    sta l0104,x                                                       ; b1d8: 9d 04 01    ...
+    beq cb203                                                         ; b1db: f0 26       .&
+; &b1dd referenced 1 time by &b1d0
+.cb1dd
+    cmp #&42 ; 'B'                                                    ; b1dd: c9 42       .B
+    bne cb203                                                         ; b1df: d0 22       ."
+    ldy #9                                                            ; b1e1: a0 09       ..
+; &b1e3 referenced 1 time by &b1eb
+.loop_cb1e3
+    lda (l00f0),y                                                     ; b1e3: b1 f0       ..
+    sta l00b4,y                                                       ; b1e5: 99 b4 00    ...
+    dey                                                               ; b1e8: 88          .
+    cpy #8                                                            ; b1e9: c0 08       ..
+    bcs loop_cb1e3                                                    ; b1eb: b0 f6       ..
+; &b1ed referenced 1 time by &b1f3
+.loop_cb1ed
+    lda (l00f0),y                                                     ; b1ed: b1 f0       ..
+    sta l00b0,y                                                       ; b1ef: 99 b0 00    ...
+    dey                                                               ; b1f2: 88          .
+    bpl loop_cb1ed                                                    ; b1f3: 10 f8       ..
+    cli                                                               ; b1f5: 58          X
+    jsr cbcb9                                                         ; b1f6: 20 b9 bc     ..
+    jmp cb1d5                                                         ; b1f9: 4c d5 b1    L..
+
+; &b1fc referenced 1 time by &b1ca
+.cb1fc
+    cmp #2                                                            ; b1fc: c9 02       ..
+    bne cb20f                                                         ; b1fe: d0 0f       ..
+    jsr sub_cb882                                                     ; b200: 20 82 b8     ..
+; &b203 referenced 10 times by &b1c6, &b1db, &b1df, &b219, &b21e, &b228, &b22c, &b262, &b26a, &b280
+.cb203
+    pla                                                               ; b203: 68          h
+    tay                                                               ; b204: a8          .
+    pla                                                               ; b205: 68          h
+    sta l00b9                                                         ; b206: 85 b9       ..
+    pla                                                               ; b208: 68          h
+    sta l00b8                                                         ; b209: 85 b8       ..
+    pla                                                               ; b20b: 68          h
+    ldx romsel_copy                                                   ; b20c: a6 f4       ..
+    rts                                                               ; b20e: 60          `
+
+; &b20f referenced 1 time by &b1fe
+.cb20f
+    cmp #6                                                            ; b20f: c9 06       ..
+    bne cb221                                                         ; b211: d0 0e       ..
+    ldy #&ff                                                          ; b213: a0 ff       ..
+    lda (l00b8),y                                                     ; b215: b1 b8       ..
+    cmp #&4e ; 'N'                                                    ; b217: c9 4e       .N
+    bne cb203                                                         ; b219: d0 e8       ..
+    jsr sub_cb5f2                                                     ; b21b: 20 f2 b5     ..
+    jmp cb203                                                         ; b21e: 4c 03 b2    L..
+
+; &b221 referenced 1 time by &b211
+.cb221
+    cmp #4                                                            ; b221: c9 04       ..
+    bne cb23d                                                         ; b223: d0 18       ..
+    jsr sub_cb9f5                                                     ; b225: 20 f5 b9     ..
+    bcs cb203                                                         ; b228: b0 d9       ..
+    cpx #4                                                            ; b22a: e0 04       ..
+    beq cb203                                                         ; b22c: f0 d5       ..
+    jsr sub_cb234                                                     ; b22e: 20 34 b2     4.
+    jmp cb1d5                                                         ; b231: 4c d5 b1    L..
+
+; &b234 referenced 1 time by &b22e
+.sub_cb234
+    lda sram_table,x                                                  ; b234: bd 30 ba    .0.
+    pha                                                               ; b237: 48          H
+    lda sram_table+1,x                                                ; b238: bd 31 ba    .1.
+    pha                                                               ; b23b: 48          H
+    rts                                                               ; b23c: 60          `
+
+; &b23d referenced 1 time by &b223
+.cb23d
+    cmp #7                                                            ; b23d: c9 07       ..
+    bne cb268                                                         ; b23f: d0 27       .'
+    lda l00ef                                                         ; b241: a5 ef       ..
+    cmp #&44 ; 'D'                                                    ; b243: c9 44       .D
+    bne cb260                                                         ; b245: d0 19       ..
+    ldy #&ee                                                          ; b247: a0 ee       ..
+; &b249 referenced 1 time by &b266
+.loop_cb249
+    lda (l00b8),y                                                     ; b249: b1 b8       ..
+    and #&3f ; '?'                                                    ; b24b: 29 3f       )?
+    sta l00b0                                                         ; b24d: 85 b0       ..
+    ldy #&fe                                                          ; b24f: a0 fe       ..
+    lda (l00b8),y                                                     ; b251: b1 b8       ..
+    and #8                                                            ; b253: 29 08       ).
+    asl a                                                             ; b255: 0a          .
+    asl a                                                             ; b256: 0a          .
+    asl a                                                             ; b257: 0a          .
+    asl a                                                             ; b258: 0a          .
+    ora l00b0                                                         ; b259: 05 b0       ..
+    sta l00f0                                                         ; b25b: 85 f0       ..
+    jmp cb1d5                                                         ; b25d: 4c d5 b1    L..
+
+; &b260 referenced 1 time by &b245
+.cb260
+    cmp #&45 ; 'E'                                                    ; b260: c9 45       .E
+    bne cb203                                                         ; b262: d0 9f       ..
+    ldy #&fd                                                          ; b264: a0 fd       ..
+    bne loop_cb249                                                    ; b266: d0 e1       ..
+; &b268 referenced 1 time by &b23f
+.cb268
+    cmp #9                                                            ; b268: c9 09       ..
+    bne cb203                                                         ; b26a: d0 97       ..
+    lda #&0d                                                          ; b26c: a9 0d       ..
+    jsr sub_cbac4                                                     ; b26e: 20 c4 ba     ..
+    bcs cb297                                                         ; b271: b0 24       .$
+    ldx #0                                                            ; b273: a2 00       ..
+; &b275 referenced 1 time by &b27e
+.loop_cb275
+    lda lb283,x                                                       ; b275: bd 83 b2    ...
+    jsr oswrch                                                        ; b278: 20 ee ff     ..
+    inx                                                               ; b27b: e8          .
+    cpx #&14                                                          ; b27c: e0 14       ..
+    bne loop_cb275                                                    ; b27e: d0 f5       ..
+; &b280 referenced 2 times by &b2a6, &b2c0
+.cb280
+    jmp cb203                                                         ; b280: 4c 03 b2    L..
+
+; &b283 referenced 1 time by &b275
+.lb283
+    equb &0a                                                          ; b283: 0a          .
+    equs "SRAM 1.05"                                                  ; b284: 53 52 41... SRA
+    equb &0d, &0a                                                     ; b28d: 0d 0a       ..
+    equs "  SRAM"                                                     ; b28f: 20 20 53...   S
+    equb &0d, &0a                                                     ; b295: 0d 0a       ..
+
+; &b297 referenced 2 times by &b271, &b2b0
+.cb297
+    jsr sub_cb9f5                                                     ; b297: 20 f5 b9     ..
+    cpx #4                                                            ; b29a: e0 04       ..
+    beq cb2b2                                                         ; b29c: f0 14       ..
+    lda #0                                                            ; b29e: a9 00       ..
+; &b2a0 referenced 2 times by &b2aa, &b2ae
+.cb2a0
+    tax                                                               ; b2a0: aa          .
+    iny                                                               ; b2a1: c8          .
+    lda (os_text_ptr),y                                               ; b2a2: b1 f2       ..
+    cmp #&0d                                                          ; b2a4: c9 0d       ..
+    beq cb280                                                         ; b2a6: f0 d8       ..
+    cmp #&20 ; ' '                                                    ; b2a8: c9 20       .
+    beq cb2a0                                                         ; b2aa: f0 f4       ..
+    cpx #&20 ; ' '                                                    ; b2ac: e0 20       .
+    bne cb2a0                                                         ; b2ae: d0 f0       ..
+    beq cb297                                                         ; b2b0: f0 e5       ..
+; &b2b2 referenced 1 time by &b29c
+.cb2b2
+    ldy #0                                                            ; b2b2: a0 00       ..
+; &b2b4 referenced 1 time by &b2bb
+.loop_cb2b4
+    lda lb075,y                                                       ; b2b4: b9 75 b0    .u.
+    jsr oswrch                                                        ; b2b7: 20 ee ff     ..
+    iny                                                               ; b2ba: c8          .
+    bne loop_cb2b4                                                    ; b2bb: d0 f7       ..
+; &b2bd referenced 1 time by &b2c6
+.loop_cb2bd
+    lda lb175,y                                                       ; b2bd: b9 75 b1    .u.
+    beq cb280                                                         ; b2c0: f0 be       ..
+    jsr oswrch                                                        ; b2c2: 20 ee ff     ..
+    iny                                                               ; b2c5: c8          .
+    bne loop_cb2bd                                                    ; b2c6: d0 f5       ..
+; &b2c8 referenced 1 time by &b1d2
+.sub_cb2c8
+    jsr cb82b                                                         ; b2c8: 20 2b b8     +.
+    lda #&ee                                                          ; b2cb: a9 ee       ..
+    sta l00b8                                                         ; b2cd: 85 b8       ..
+    ldy #&0b                                                          ; b2cf: a0 0b       ..
+; &b2d1 referenced 1 time by &b2e4
+.loop_cb2d1
+    lda (l00f0),y                                                     ; b2d1: b1 f0       ..
+    cpy #0                                                            ; b2d3: c0 00       ..
+    bne cb2e1                                                         ; b2d5: d0 0a       ..
+    and #&c0                                                          ; b2d7: 29 c0       ).
+    sta l00bc                                                         ; b2d9: 85 bc       ..
+    lda (l00b8),y                                                     ; b2db: b1 b8       ..
+    and #&3f ; '?'                                                    ; b2dd: 29 3f       )?
+    ora l00bc                                                         ; b2df: 05 bc       ..
+; &b2e1 referenced 1 time by &b2d5
+.cb2e1
+    sta (l00b8),y                                                     ; b2e1: 91 b8       ..
+    dey                                                               ; b2e3: 88          .
+    bpl loop_cb2d1                                                    ; b2e4: 10 eb       ..
+    cli                                                               ; b2e6: 58          X
+; &b2e7 referenced 1 time by &bbcd
+.cb2e7
+    jsr cb82b                                                         ; b2e7: 20 2b b8     +.
+    ldy #&f2                                                          ; b2ea: a0 f2       ..
+    lda (l00b8),y                                                     ; b2ec: b1 b8       ..
+    tax                                                               ; b2ee: aa          .
+    iny                                                               ; b2ef: c8          .
+    lda (l00b8),y                                                     ; b2f0: b1 b8       ..
+    jsr sub_cb85d                                                     ; b2f2: 20 5d b8     ].
+    bvs cb305                                                         ; b2f5: 70 0e       p.
+    ldy #&f1                                                          ; b2f7: a0 f1       ..
+    lda (l00b8),y                                                     ; b2f9: b1 b8       ..
+    tay                                                               ; b2fb: a8          .
+    cpy #&14                                                          ; b2fc: c0 14       ..
+    bcc cb314                                                         ; b2fe: 90 14       ..
+; &b300 referenced 2 times by &b324, &bcd3
+.cb300
+    ldx #0                                                            ; b300: a2 00       ..
+    jmp cb8fb                                                         ; b302: 4c fb b8    L..
+
+; &b305 referenced 1 time by &b2f5
+.cb305
+    jsr sub_cb6b1                                                     ; b305: 20 b1 b6     ..
+    sty l00ba                                                         ; b308: 84 ba       ..
+    ldy #&f3                                                          ; b30a: a0 f3       ..
+    sta (l00b8),y                                                     ; b30c: 91 b8       ..
+    txa                                                               ; b30e: 8a          .
+    dey                                                               ; b30f: 88          .
+    sta (l00b8),y                                                     ; b310: 91 b8       ..
+    ldy l00ba                                                         ; b312: a4 ba       ..
+; &b314 referenced 1 time by &b2fe
+.cb314
+    jsr sub_cb6fe                                                     ; b314: 20 fe b6     ..
+    tax                                                               ; b317: aa          .
+    tya                                                               ; b318: 98          .
+    ldy #&f1                                                          ; b319: a0 f1       ..
+    sta (l00b8),y                                                     ; b31b: 91 b8       ..
+    txa                                                               ; b31d: 8a          .
+    ldy #&ee                                                          ; b31e: a0 ee       ..
+    eor (l00b8),y                                                     ; b320: 51 b8       Q.
+    and #&40 ; '@'                                                    ; b322: 29 40       )@
+    bne cb300                                                         ; b324: d0 da       ..
+    tay                                                               ; b326: a8          .
+    ldx #&ba                                                          ; b327: a2 ba       ..
+    jsr osargs                                                        ; b329: 20 da ff     ..
+    jsr cb82b                                                         ; b32c: 20 2b b8     +.
+    tax                                                               ; b32f: aa          .
+    bne cb337                                                         ; b330: d0 05       ..
+    ldx #2                                                            ; b332: a2 02       ..
+    jmp cb8fb                                                         ; b334: 4c fb b8    L..
+
+; &b337 referenced 1 time by &b330
+.cb337
+    pha                                                               ; b337: 48          H
+    jsr sub_cbe9d                                                     ; b338: 20 9d be     ..
+    pla                                                               ; b33b: 68          h
+    cmp #4                                                            ; b33c: c9 04       ..
+    bcs cb3ba                                                         ; b33e: b0 7a       .z
+    jsr sub_cb85d                                                     ; b340: 20 5d b8     ].
+    bpl cb375                                                         ; b343: 10 30       .0
+    jsr sub_cb5ce                                                     ; b345: 20 ce b5     ..
+    jsr sub_cb607                                                     ; b348: 20 07 b6     ..
+    bne cb371                                                         ; b34b: d0 24       .$
+    beq cb352                                                         ; b34d: f0 03       ..
+; &b34f referenced 1 time by &b36f
+.cb34f
+    jsr sub_cb65f                                                     ; b34f: 20 5f b6     _.
+; &b352 referenced 1 time by &b34d
+.cb352
+    ldy #&fa                                                          ; b352: a0 fa       ..
+    lda (l00b8),y                                                     ; b354: b1 b8       ..
+    tay                                                               ; b356: a8          .
+    jsr osbget                                                        ; b357: 20 d7 ff     ..
+    jsr cb82b                                                         ; b35a: 20 2b b8     +.
+    ldy #&f2                                                          ; b35d: a0 f2       ..
+    jsr sub_cb83f                                                     ; b35f: 20 3f b8     ?.
+    tax                                                               ; b362: aa          .
+    ldy #&f1                                                          ; b363: a0 f1       ..
+    lda (l00b8),y                                                     ; b365: b1 b8       ..
+    tay                                                               ; b367: a8          .
+    txa                                                               ; b368: 8a          .
+    jsr sub_cb745                                                     ; b369: 20 45 b7     E.
+    jsr sub_cb607                                                     ; b36c: 20 07 b6     ..
+    beq cb34f                                                         ; b36f: f0 de       ..
+; &b371 referenced 3 times by &b34b, &b37b, &b3b8
+.cb371
+    jsr sub_cb5f2                                                     ; b371: 20 f2 b5     ..
+    rts                                                               ; b374: 60          `
+
+; &b375 referenced 1 time by &b343
+.cb375
+    jsr sub_cb5ee                                                     ; b375: 20 ee b5     ..
+    jsr sub_cb616                                                     ; b378: 20 16 b6     ..
+    beq cb371                                                         ; b37b: f0 f4       ..
+    bne cb382                                                         ; b37d: d0 03       ..
+; &b37f referenced 1 time by &b3b6
+.cb37f
+    jsr sub_cb65f                                                     ; b37f: 20 5f b6     _.
+; &b382 referenced 1 time by &b37d
+.cb382
+    ldy #&f4                                                          ; b382: a0 f4       ..
+    lda (l00b8),y                                                     ; b384: b1 b8       ..
+    sec                                                               ; b386: 38          8
+    sbc #1                                                            ; b387: e9 01       ..
+    sta (l00b8),y                                                     ; b389: 91 b8       ..
+    cmp #&ff                                                          ; b38b: c9 ff       ..
+    bne cb397                                                         ; b38d: d0 08       ..
+    iny                                                               ; b38f: c8          .
+    lda (l00b8),y                                                     ; b390: b1 b8       ..
+    sec                                                               ; b392: 38          8
+    sbc #1                                                            ; b393: e9 01       ..
+    sta (l00b8),y                                                     ; b395: 91 b8       ..
+; &b397 referenced 1 time by &b38d
+.cb397
+    ldx #&f6                                                          ; b397: a2 f6       ..
+    ldy #&f2                                                          ; b399: a0 f2       ..
+    jsr sub_cb841                                                     ; b39b: 20 41 b8     A.
+    ldy #&f1                                                          ; b39e: a0 f1       ..
+    lda (l00b8),y                                                     ; b3a0: b1 b8       ..
+    tay                                                               ; b3a2: a8          .
+    jsr osrdsc                                                        ; b3a3: 20 b9 ff     ..
+    tax                                                               ; b3a6: aa          .
+    ldy #&fa                                                          ; b3a7: a0 fa       ..
+    lda (l00b8),y                                                     ; b3a9: b1 b8       ..
+    tay                                                               ; b3ab: a8          .
+    txa                                                               ; b3ac: 8a          .
+    jsr osbput                                                        ; b3ad: 20 d4 ff     ..
+    jsr cb82b                                                         ; b3b0: 20 2b b8     +.
+    jsr sub_cb616                                                     ; b3b3: 20 16 b6     ..
+    bne cb37f                                                         ; b3b6: d0 c7       ..
+    beq cb371                                                         ; b3b8: f0 b7       ..
+; &b3ba referenced 1 time by &b33e
+.cb3ba
+    ldy #&f9                                                          ; b3ba: a0 f9       ..
+    lda (l00b8),y                                                     ; b3bc: b1 b8       ..
+    bmi cb3de                                                         ; b3be: 30 1e       0.
+    dey                                                               ; b3c0: 88          .
+    ora (l00b8),y                                                     ; b3c1: 11 b8       ..
+    bne cb406                                                         ; b3c3: d0 41       .A
+    lda #0                                                            ; b3c5: a9 00       ..
+    sta (l00b8),y                                                     ; b3c7: 91 b8       ..
+    lda #1                                                            ; b3c9: a9 01       ..
+    iny                                                               ; b3cb: c8          .
+    sta (l00b8),y                                                     ; b3cc: 91 b8       ..
+    ldy #&f6                                                          ; b3ce: a0 f6       ..
+    lda #0                                                            ; b3d0: a9 00       ..
+    sta (l00b8),y                                                     ; b3d2: 91 b8       ..
+    ldx l00b9                                                         ; b3d4: a6 b9       ..
+    inx                                                               ; b3d6: e8          .
+    txa                                                               ; b3d7: 8a          .
+    iny                                                               ; b3d8: c8          .
+    sta (l00b8),y                                                     ; b3d9: 91 b8       ..
+    jmp cb406                                                         ; b3db: 4c 06 b4    L..
+
+; &b3de referenced 1 time by &b3be
+.cb3de
+    lda #osbyte_read_himem                                            ; b3de: a9 84       ..
+    jsr osbyte                                                        ; b3e0: 20 f4 ff     ..
+    tya                                                               ; b3e3: 98          .
+    pha                                                               ; b3e4: 48          H
+    txa                                                               ; b3e5: 8a          .
+    pha                                                               ; b3e6: 48          H
+    lda #osbyte_read_oshwm                                            ; b3e7: a9 83       ..
+    jsr osbyte                                                        ; b3e9: 20 f4 ff     ..
+    jsr cb82b                                                         ; b3ec: 20 2b b8     +.
+    stx l00ba                                                         ; b3ef: 86 ba       ..
+    sty l00bb                                                         ; b3f1: 84 bb       ..
+    ldy #&f6                                                          ; b3f3: a0 f6       ..
+    jsr sub_cb84e                                                     ; b3f5: 20 4e b8     N.
+    pla                                                               ; b3f8: 68          h
+    sec                                                               ; b3f9: 38          8
+    sbc l00ba                                                         ; b3fa: e5 ba       ..
+    ldy #&f8                                                          ; b3fc: a0 f8       ..
+    sta (l00b8),y                                                     ; b3fe: 91 b8       ..
+    pla                                                               ; b400: 68          h
+    sbc l00bb                                                         ; b401: e5 bb       ..
+    iny                                                               ; b403: c8          .
+    sta (l00b8),y                                                     ; b404: 91 b8       ..
+; &b406 referenced 2 times by &b3c3, &b3db
+.cb406
+    jsr sub_cb85d                                                     ; b406: 20 5d b8     ].
+    bmi cb40e                                                         ; b409: 30 03       0.
+    jmp cb4d8                                                         ; b40b: 4c d8 b4    L..
+
+; &b40e referenced 1 time by &b409
+.cb40e
+    jsr sub_cb5ce                                                     ; b40e: 20 ce b5     ..
+    tsx                                                               ; b411: ba          .
+    txa                                                               ; b412: 8a          .
+    sec                                                               ; b413: 38          8
+    sbc #&10                                                          ; b414: e9 10       ..
+    tax                                                               ; b416: aa          .
+    txs                                                               ; b417: 9a          .
+    ldy #&f0                                                          ; b418: a0 f0       ..
+    lda (l00b8),y                                                     ; b41a: b1 b8       ..
+    pha                                                               ; b41c: 48          H
+    dey                                                               ; b41d: 88          .
+    lda (l00b8),y                                                     ; b41e: b1 b8       ..
+    pha                                                               ; b420: 48          H
+    dex                                                               ; b421: ca          .
+    ldy #1                                                            ; b422: a0 01       ..
+    lda #osfile_read_catalogue_info                                   ; b424: a9 05       ..
+    jsr osfile                                                        ; b426: 20 dd ff     ..
+    jsr cb82b                                                         ; b429: 20 2b b8     +.
+    tsx                                                               ; b42c: ba          .
+    lda l010b,x                                                       ; b42d: bd 0b 01    ...
+    ldy #&f4                                                          ; b430: a0 f4       ..
+    sta (l00b8),y                                                     ; b432: 91 b8       ..
+    sta l00ba                                                         ; b434: 85 ba       ..
+    lda l010c,x                                                       ; b436: bd 0c 01    ...
+    iny                                                               ; b439: c8          .
+    sta (l00b8),y                                                     ; b43a: 91 b8       ..
+    sta l00bb                                                         ; b43c: 85 bb       ..
+    lda l010d,x                                                       ; b43e: bd 0d 01    ...
+    ora l010e,x                                                       ; b441: 1d 0e 01    ...
+    beq cb44b                                                         ; b444: f0 05       ..
+; &b446 referenced 4 times by &b68c, &b6c7, &b715, &bc10
+.cb446
+    ldx #1                                                            ; b446: a2 01       ..
+    jmp cb8fb                                                         ; b448: 4c fb b8    L..
+
+; &b44b referenced 1 time by &b444
+.cb44b
+    ldx #&12                                                          ; b44b: a2 12       ..
+; &b44d referenced 1 time by &b44f
+.loop_cb44d
+    pla                                                               ; b44d: 68          h
+    dex                                                               ; b44e: ca          .
+    bne loop_cb44d                                                    ; b44f: d0 fc       ..
+    bit lb57f                                                         ; b451: 2c 7f b5    ,..
+    lda l00ba                                                         ; b454: a5 ba       ..
+    ora l00bb                                                         ; b456: 05 bb       ..
+    bne cb45e                                                         ; b458: d0 04       ..
+; &b45a referenced 1 time by &b4d2
+.cb45a
+    jsr sub_cb5f2                                                     ; b45a: 20 f2 b5     ..
+    rts                                                               ; b45d: 60          `
+
+; &b45e referenced 2 times by &b458, &b4d5
+.cb45e
+    ldx #&bc                                                          ; b45e: a2 bc       ..
+    ldy #&f8                                                          ; b460: a0 f8       ..
+    jsr sub_cb841                                                     ; b462: 20 41 b8     A.
+    ldy #&ba                                                          ; b465: a0 ba       ..
+    jsr sub_cb58b                                                     ; b467: 20 8b b5     ..
+    bcs cb470                                                         ; b46a: b0 04       ..
+    jsr sub_cb580                                                     ; b46c: 20 80 b5     ..
+    clv                                                               ; b46f: b8          .
+; &b470 referenced 1 time by &b46a
+.cb470
+    ldy #&fb                                                          ; b470: a0 fb       ..
+    jsr sub_cb84e                                                     ; b472: 20 4e b8     N.
+    bvc cb4af                                                         ; b475: 50 38       P8
+    jsr sub_cb5f2                                                     ; b477: 20 f2 b5     ..
+    tsx                                                               ; b47a: ba          .
+    txa                                                               ; b47b: 8a          .
+    sec                                                               ; b47c: 38          8
+    sbc #&0b                                                          ; b47d: e9 0b       ..
+    tax                                                               ; b47f: aa          .
+    txs                                                               ; b480: 9a          .
+    lda #0                                                            ; b481: a9 00       ..
+    pha                                                               ; b483: 48          H
+    lda #&ff                                                          ; b484: a9 ff       ..
+    pha                                                               ; b486: 48          H
+    pha                                                               ; b487: 48          H
+    ldy #&f7                                                          ; b488: a0 f7       ..
+    lda (l00b8),y                                                     ; b48a: b1 b8       ..
+    pha                                                               ; b48c: 48          H
+    dey                                                               ; b48d: 88          .
+    lda (l00b8),y                                                     ; b48e: b1 b8       ..
+    pha                                                               ; b490: 48          H
+    ldy #&f0                                                          ; b491: a0 f0       ..
+    lda (l00b8),y                                                     ; b493: b1 b8       ..
+    pha                                                               ; b495: 48          H
+    dey                                                               ; b496: 88          .
+    lda (l00b8),y                                                     ; b497: b1 b8       ..
+    pha                                                               ; b499: 48          H
+    tsx                                                               ; b49a: ba          .
+    inx                                                               ; b49b: e8          .
+    ldy #1                                                            ; b49c: a0 01       ..
+    lda #osfile_load                                                  ; b49e: a9 ff       ..
+    jsr osfile                                                        ; b4a0: 20 dd ff     ..
+    jsr cb82b                                                         ; b4a3: 20 2b b8     +.
+    ldx #&12                                                          ; b4a6: a2 12       ..
+; &b4a8 referenced 1 time by &b4aa
+.loop_cb4a8
+    pla                                                               ; b4a8: 68          h
+    dex                                                               ; b4a9: ca          .
+    bne loop_cb4a8                                                    ; b4aa: d0 fc       ..
+    jmp cb4b4                                                         ; b4ac: 4c b4 b4    L..
+
+; &b4af referenced 1 time by &b475
+.cb4af
+    lda #4                                                            ; b4af: a9 04       ..
+    jsr sub_cb598                                                     ; b4b1: 20 98 b5     ..
+; &b4b4 referenced 1 time by &b4ac
+.cb4b4
+    ldx #&b1                                                          ; b4b4: a2 b1       ..
+    ldy #&f6                                                          ; b4b6: a0 f6       ..
+    jsr sub_cb841                                                     ; b4b8: 20 41 b8     A.
+    ldx #&b3                                                          ; b4bb: a2 b3       ..
+    ldy #&f2                                                          ; b4bd: a0 f2       ..
+    jsr sub_cb841                                                     ; b4bf: 20 41 b8     A.
+    ldx #&be                                                          ; b4c2: a2 be       ..
+    ldy #&fb                                                          ; b4c4: a0 fb       ..
+    jsr sub_cb841                                                     ; b4c6: 20 41 b8     A.
+    sec                                                               ; b4c9: 38          8
+    jsr cb795                                                         ; b4ca: 20 95 b7     ..
+    ldx #&b3                                                          ; b4cd: a2 b3       ..
+    jsr sub_cb61e                                                     ; b4cf: 20 1e b6     ..
+    beq cb45a                                                         ; b4d2: f0 86       ..
+    clv                                                               ; b4d4: b8          .
+    jmp cb45e                                                         ; b4d5: 4c 5e b4    L^.
+
+; &b4d8 referenced 1 time by &b40b
+.cb4d8
+    jsr sub_cb5ee                                                     ; b4d8: 20 ee b5     ..
+    bit lb57f                                                         ; b4db: 2c 7f b5    ,..
+    php                                                               ; b4de: 08          .
+; &b4df referenced 1 time by &b531
+.cb4df
+    ldy #&f4                                                          ; b4df: a0 f4       ..
+    jsr sub_cb83f                                                     ; b4e1: 20 3f b8     ?.
+    jsr sub_cb616                                                     ; b4e4: 20 16 b6     ..
+    bne cb4ee                                                         ; b4e7: d0 05       ..
+; &b4e9 referenced 1 time by &b57c
+.cb4e9
+    plp                                                               ; b4e9: 28          (
+    jsr sub_cb5f2                                                     ; b4ea: 20 f2 b5     ..
+    rts                                                               ; b4ed: 60          `
+
+; &b4ee referenced 1 time by &b4e7
+.cb4ee
+    ldx #&bc                                                          ; b4ee: a2 bc       ..
+    ldy #&f8                                                          ; b4f0: a0 f8       ..
+    jsr sub_cb841                                                     ; b4f2: 20 41 b8     A.
+    ldy #&ba                                                          ; b4f5: a0 ba       ..
+    jsr sub_cb58b                                                     ; b4f7: 20 8b b5     ..
+    bcs cb502                                                         ; b4fa: b0 06       ..
+    jsr sub_cb580                                                     ; b4fc: 20 80 b5     ..
+    plp                                                               ; b4ff: 28          (
+    clv                                                               ; b500: b8          .
+    php                                                               ; b501: 08          .
+; &b502 referenced 1 time by &b4fa
+.cb502
+    ldy #&fb                                                          ; b502: a0 fb       ..
+    jsr sub_cb84e                                                     ; b504: 20 4e b8     N.
+    ldx #&b1                                                          ; b507: a2 b1       ..
+    ldy #&f2                                                          ; b509: a0 f2       ..
+    jsr sub_cb841                                                     ; b50b: 20 41 b8     A.
+    ldx #&b3                                                          ; b50e: a2 b3       ..
+    ldy #&f6                                                          ; b510: a0 f6       ..
+    jsr sub_cb841                                                     ; b512: 20 41 b8     A.
+    ldx #&be                                                          ; b515: a2 be       ..
+    ldy #&fb                                                          ; b517: a0 fb       ..
+    jsr sub_cb841                                                     ; b519: 20 41 b8     A.
+    clc                                                               ; b51c: 18          .
+    jsr cb795                                                         ; b51d: 20 95 b7     ..
+    ldx #&b1                                                          ; b520: a2 b1       ..
+    jsr sub_cb61e                                                     ; b522: 20 1e b6     ..
+    plp                                                               ; b525: 28          (
+    php                                                               ; b526: 08          .
+    bvs cb534                                                         ; b527: 70 0b       p.
+    lda #2                                                            ; b529: a9 02       ..
+    jsr sub_cb598                                                     ; b52b: 20 98 b5     ..
+    plp                                                               ; b52e: 28          (
+    clv                                                               ; b52f: b8          .
+    php                                                               ; b530: 08          .
+    jmp cb4df                                                         ; b531: 4c df b4    L..
+
+; &b534 referenced 1 time by &b527
+.cb534
+    jsr sub_cb5f2                                                     ; b534: 20 f2 b5     ..
+    lda #&ff                                                          ; b537: a9 ff       ..
+    pha                                                               ; b539: 48          H
+    pha                                                               ; b53a: 48          H
+    ldy #&f6                                                          ; b53b: a0 f6       ..
+    jsr sub_cb83f                                                     ; b53d: 20 3f b8     ?.
+    ldy #&fb                                                          ; b540: a0 fb       ..
+    lda l00ba                                                         ; b542: a5 ba       ..
+    clc                                                               ; b544: 18          .
+    adc (l00b8),y                                                     ; b545: 71 b8       q.
+    tax                                                               ; b547: aa          .
+    lda l00bb                                                         ; b548: a5 bb       ..
+    iny                                                               ; b54a: c8          .
+    adc (l00b8),y                                                     ; b54b: 71 b8       q.
+    pha                                                               ; b54d: 48          H
+    txa                                                               ; b54e: 8a          .
+    pha                                                               ; b54f: 48          H
+    lda #&ff                                                          ; b550: a9 ff       ..
+    pha                                                               ; b552: 48          H
+    pha                                                               ; b553: 48          H
+    lda l00bb                                                         ; b554: a5 bb       ..
+    pha                                                               ; b556: 48          H
+    lda l00ba                                                         ; b557: a5 ba       ..
+    pha                                                               ; b559: 48          H
+    lda #&ff                                                          ; b55a: a9 ff       ..
+    ldx #8                                                            ; b55c: a2 08       ..
+; &b55e referenced 1 time by &b560
+.loop_cb55e
+    pha                                                               ; b55e: 48          H
+    dex                                                               ; b55f: ca          .
+    bne loop_cb55e                                                    ; b560: d0 fc       ..
+    ldy #&f0                                                          ; b562: a0 f0       ..
+    lda (l00b8),y                                                     ; b564: b1 b8       ..
+    pha                                                               ; b566: 48          H
+    dey                                                               ; b567: 88          .
+    tsx                                                               ; b568: ba          .
+    lda (l00b8),y                                                     ; b569: b1 b8       ..
+    pha                                                               ; b56b: 48          H
+    ldy #1                                                            ; b56c: a0 01       ..
+    lda #osfile_save                                                  ; b56e: a9 00       ..
+    jsr osfile                                                        ; b570: 20 dd ff     ..
+    jsr cb82b                                                         ; b573: 20 2b b8     +.
+    ldx #&12                                                          ; b576: a2 12       ..
+; &b578 referenced 1 time by &b57a
+.loop_cb578
+    pla                                                               ; b578: 68          h
+    dex                                                               ; b579: ca          .
+    bne loop_cb578                                                    ; b57a: d0 fc       ..
+    jmp cb4e9                                                         ; b57c: 4c e9 b4    L..
+
+; &b57f referenced 4 times by &b451, &b4db, &bae7, &bbda
+.lb57f
+    equb &40                                                          ; b57f: 40          @
+
+; &b580 referenced 7 times by &b46c, &b4fc, &bcfd, &bd08, &bd12, &bdaa, &bde4
+.sub_cb580
+    lda l0000,x                                                       ; b580: b5 00       ..
+    sta l0000,y                                                       ; b582: 99 00 00    ...
+    lda l0001,x                                                       ; b585: b5 01       ..
+    sta l0001,y                                                       ; b587: 99 01 00    ...
+    rts                                                               ; b58a: 60          `
+
+; &b58b referenced 3 times by &b467, &b4f7, &b800
+.sub_cb58b
+    lda l0001,x                                                       ; b58b: b5 01       ..
+    cmp l0001,y                                                       ; b58d: d9 01 00    ...
+    bne cb597                                                         ; b590: d0 05       ..
+    lda l0000,x                                                       ; b592: b5 00       ..
+    cmp l0000,y                                                       ; b594: d9 00 00    ...
+; &b597 referenced 1 time by &b590
+.cb597
+    rts                                                               ; b597: 60          `
+
+; &b598 referenced 2 times by &b4b1, &b52b
+.sub_cb598
+    pha                                                               ; b598: 48          H
+    pha                                                               ; b599: 48          H
+    pha                                                               ; b59a: 48          H
+    pha                                                               ; b59b: 48          H
+    lda #0                                                            ; b59c: a9 00       ..
+    pha                                                               ; b59e: 48          H
+    pha                                                               ; b59f: 48          H
+    ldy #&fc                                                          ; b5a0: a0 fc       ..
+    lda (l00b8),y                                                     ; b5a2: b1 b8       ..
+    pha                                                               ; b5a4: 48          H
+    dey                                                               ; b5a5: 88          .
+    lda (l00b8),y                                                     ; b5a6: b1 b8       ..
+    pha                                                               ; b5a8: 48          H
+    lda #&ff                                                          ; b5a9: a9 ff       ..
+    pha                                                               ; b5ab: 48          H
+    pha                                                               ; b5ac: 48          H
+    ldy #&f7                                                          ; b5ad: a0 f7       ..
+    lda (l00b8),y                                                     ; b5af: b1 b8       ..
+    pha                                                               ; b5b1: 48          H
+    dey                                                               ; b5b2: 88          .
+    lda (l00b8),y                                                     ; b5b3: b1 b8       ..
+    pha                                                               ; b5b5: 48          H
+    tsx                                                               ; b5b6: ba          .
+    ldy #&fa                                                          ; b5b7: a0 fa       ..
+    lda (l00b8),y                                                     ; b5b9: b1 b8       ..
+    pha                                                               ; b5bb: 48          H
+    lda l0109,x                                                       ; b5bc: bd 09 01    ...
+    ldy #1                                                            ; b5bf: a0 01       ..
+    jsr osgbpb                                                        ; b5c1: 20 d1 ff     ..
+    ldx #&0d                                                          ; b5c4: a2 0d       ..
+; &b5c6 referenced 1 time by &b5c8
+.loop_cb5c6
+    pla                                                               ; b5c6: 68          h
+    dex                                                               ; b5c7: ca          .
+    bne loop_cb5c6                                                    ; b5c8: d0 fc       ..
+    jsr cb82b                                                         ; b5ca: 20 2b b8     +.
+    rts                                                               ; b5cd: 60          `
+
+; &b5ce referenced 2 times by &b345, &b40e
+.sub_cb5ce
+    lda #&40 ; '@'                                                    ; b5ce: a9 40       .@
+; &b5d0 referenced 1 time by &b5f0
+.cb5d0
+    pha                                                               ; b5d0: 48          H
+    ldy #&ef                                                          ; b5d1: a0 ef       ..
+    lda (l00b8),y                                                     ; b5d3: b1 b8       ..
+    tax                                                               ; b5d5: aa          .
+    iny                                                               ; b5d6: c8          .
+    lda (l00b8),y                                                     ; b5d7: b1 b8       ..
+    tay                                                               ; b5d9: a8          .
+    pla                                                               ; b5da: 68          h
+    jsr osfind                                                        ; b5db: 20 ce ff     ..
+    tax                                                               ; b5de: aa          .
+    bne cb5e6                                                         ; b5df: d0 05       ..
+    ldx #4                                                            ; b5e1: a2 04       ..
+    jmp cb8fb                                                         ; b5e3: 4c fb b8    L..
+
+; &b5e6 referenced 1 time by &b5df
+.cb5e6
+    ldy #&fa                                                          ; b5e6: a0 fa       ..
+    jsr cb82b                                                         ; b5e8: 20 2b b8     +.
+    sta (l00b8),y                                                     ; b5eb: 91 b8       ..
+; &b5ed referenced 1 time by &b5f6
+.loop_cb5ed
+    rts                                                               ; b5ed: 60          `
+
+; &b5ee referenced 2 times by &b375, &b4d8
+.sub_cb5ee
+    lda #&80                                                          ; b5ee: a9 80       ..
+    bne cb5d0                                                         ; b5f0: d0 de       ..
+; &b5f2 referenced 6 times by &b21b, &b371, &b45a, &b477, &b4ea, &b534
+.sub_cb5f2
+    ldy #&fa                                                          ; b5f2: a0 fa       ..
+    lda (l00b8),y                                                     ; b5f4: b1 b8       ..
+    beq loop_cb5ed                                                    ; b5f6: f0 f5       ..
+    pha                                                               ; b5f8: 48          H
+    lda #0                                                            ; b5f9: a9 00       ..
+    sta (l00b8),y                                                     ; b5fb: 91 b8       ..
+    pla                                                               ; b5fd: 68          h
+    tay                                                               ; b5fe: a8          .
+    lda #0                                                            ; b5ff: a9 00       ..
+    jsr osfind                                                        ; b601: 20 ce ff     ..
+    jmp cb82b                                                         ; b604: 4c 2b b8    L+.
+
+; &b607 referenced 2 times by &b348, &b36c
+.sub_cb607
+    ldy #&fa                                                          ; b607: a0 fa       ..
+    lda (l00b8),y                                                     ; b609: b1 b8       ..
+    tax                                                               ; b60b: aa          .
+    lda #1                                                            ; b60c: a9 01       ..
+    jsr sub_cb86f                                                     ; b60e: 20 6f b8     o.
+    jsr cb82b                                                         ; b611: 20 2b b8     +.
+    txa                                                               ; b614: 8a          .
+    rts                                                               ; b615: 60          `
+
+; &b616 referenced 4 times by &b378, &b3b3, &b4e4, &be5d
+.sub_cb616
+    ldy #&f4                                                          ; b616: a0 f4       ..
+    lda (l00b8),y                                                     ; b618: b1 b8       ..
+    iny                                                               ; b61a: c8          .
+    ora (l00b8),y                                                     ; b61b: 11 b8       ..
+    rts                                                               ; b61d: 60          `
+
+; &b61e referenced 2 times by &b4cf, &b522
+.sub_cb61e
+    stx l00bc                                                         ; b61e: 86 bc       ..
+    ldy #&fb                                                          ; b620: a0 fb       ..
+    jsr sub_cb83f                                                     ; b622: 20 3f b8     ?.
+    ldy #&f4                                                          ; b625: a0 f4       ..
+    lda (l00b8),y                                                     ; b627: b1 b8       ..
+    sec                                                               ; b629: 38          8
+    sbc l00ba                                                         ; b62a: e5 ba       ..
+    sta (l00b8),y                                                     ; b62c: 91 b8       ..
+    sta l00ba                                                         ; b62e: 85 ba       ..
+    iny                                                               ; b630: c8          .
+    lda (l00b8),y                                                     ; b631: b1 b8       ..
+    sbc l00bb                                                         ; b633: e5 bb       ..
+    sta (l00b8),y                                                     ; b635: 91 b8       ..
+    sta l00bb                                                         ; b637: 85 bb       ..
+    ora l00ba                                                         ; b639: 05 ba       ..
+    beq cb65e                                                         ; b63b: f0 21       .!
+    ldx l00bc                                                         ; b63d: a6 bc       ..
+    jsr sub_cb85d                                                     ; b63f: 20 5d b8     ].
+    bvc cb655                                                         ; b642: 50 11       P.
+    lda l0001,x                                                       ; b644: b5 01       ..
+    cmp #&c0                                                          ; b646: c9 c0       ..
+    bcc cb655                                                         ; b648: 90 0b       ..
+    lda #&10                                                          ; b64a: a9 10       ..
+    sta l0000,x                                                       ; b64c: 95 00       ..
+    lda #&80                                                          ; b64e: a9 80       ..
+    sta l0001,x                                                       ; b650: 95 01       ..
+    jsr sub_cb68f                                                     ; b652: 20 8f b6     ..
+; &b655 referenced 2 times by &b642, &b648
+.cb655
+    ldx l00bc                                                         ; b655: a6 bc       ..
+    ldy #&f2                                                          ; b657: a0 f2       ..
+    jsr sub_cb850                                                     ; b659: 20 50 b8     P.
+    lda #&ff                                                          ; b65c: a9 ff       ..
+; &b65e referenced 1 time by &b63b
+.cb65e
+    rts                                                               ; b65e: 60          `
+
+; &b65f referenced 2 times by &b34f, &b37f
+.sub_cb65f
+    ldx #&bd                                                          ; b65f: a2 bd       ..
+    ldy #&f2                                                          ; b661: a0 f2       ..
+    jsr sub_cb841                                                     ; b663: 20 41 b8     A.
+    inc l00bd                                                         ; b666: e6 bd       ..
+    bne cb684                                                         ; b668: d0 1a       ..
+    inc l00be                                                         ; b66a: e6 be       ..
+    beq cb68c                                                         ; b66c: f0 1e       ..
+    jsr sub_cb85d                                                     ; b66e: 20 5d b8     ].
+    bvc cb684                                                         ; b671: 50 11       P.
+    lda l00be                                                         ; b673: a5 be       ..
+    cmp #&c0                                                          ; b675: c9 c0       ..
+    bne cb684                                                         ; b677: d0 0b       ..
+    jsr sub_cb68f                                                     ; b679: 20 8f b6     ..
+    lda #&10                                                          ; b67c: a9 10       ..
+    sta l00bd                                                         ; b67e: 85 bd       ..
+    lda #&80                                                          ; b680: a9 80       ..
+    sta l00be                                                         ; b682: 85 be       ..
+; &b684 referenced 3 times by &b668, &b671, &b677
+.cb684
+    ldx #&bd                                                          ; b684: a2 bd       ..
+    ldy #&f2                                                          ; b686: a0 f2       ..
+    jsr sub_cb850                                                     ; b688: 20 50 b8     P.
+    rts                                                               ; b68b: 60          `
+
+; &b68c referenced 4 times by &b66c, &b698, &b69c, &b6ae
+.cb68c
+    jmp cb446                                                         ; b68c: 4c 46 b4    LF.
+
+; &b68f referenced 4 times by &b652, &b679, &b81f, &be77
+.sub_cb68f
+    ldy #&f1                                                          ; b68f: a0 f1       ..
+    lda (l00b8),y                                                     ; b691: b1 b8       ..
+    clc                                                               ; b693: 18          .
+    adc #1                                                            ; b694: 69 01       i.
+    cmp #&10                                                          ; b696: c9 10       ..
+    bcs cb68c                                                         ; b698: b0 f2       ..
+    cmp #2                                                            ; b69a: c9 02       ..
+    beq cb68c                                                         ; b69c: f0 ee       ..
+    cmp #&0e                                                          ; b69e: c9 0e       ..
+    bne cb6a6                                                         ; b6a0: d0 04       ..
+    ldy #&fe                                                          ; b6a2: a0 fe       ..
+    and (l00b8),y                                                     ; b6a4: 31 b8       1.
+; &b6a6 referenced 1 time by &b6a0
+.cb6a6
+    ldy #&f1                                                          ; b6a6: a0 f1       ..
+    sta (l00b8),y                                                     ; b6a8: 91 b8       ..
+    tay                                                               ; b6aa: a8          .
+    jsr sub_cb6fe                                                     ; b6ab: 20 fe b6     ..
+    beq cb68c                                                         ; b6ae: f0 dc       ..
+    rts                                                               ; b6b0: 60          `
+
+; &b6b1 referenced 2 times by &b305, &bcda
+.sub_cb6b1
+    ldy #&10                                                          ; b6b1: a0 10       ..
+; &b6b3 referenced 1 time by &b6c5
+.loop_cb6b3
+    cmp cb6ca,y                                                       ; b6b3: d9 ca b6    ...
+    bcc cb6ca                                                         ; b6b6: 90 12       ..
+    bne cb6c2                                                         ; b6b8: d0 08       ..
+    pha                                                               ; b6ba: 48          H
+    txa                                                               ; b6bb: 8a          .
+    cmp lb6c6,y                                                       ; b6bc: d9 c6 b6    ...
+    pla                                                               ; b6bf: 68          h
+    bcc cb6ca                                                         ; b6c0: 90 08       ..
+; &b6c2 referenced 1 time by &b6b8
+.cb6c2
+    iny                                                               ; b6c2: c8          .
+    cpy #&14                                                          ; b6c3: c0 14       ..
+.sub_cb6c5
+lb6c6 = sub_cb6c5+1
+    bcc loop_cb6b3                                                    ; b6c5: 90 ec       ..
+; &b6c6 referenced 1 time by &b6bc
+    jmp cb446                                                         ; b6c7: 4c 46 b4    LF.
+
+; &b6ca referenced 3 times by &b6b3, &b6b6, &b6c0
+.cb6ca
+    pha                                                               ; b6ca: 48          H
+    txa                                                               ; b6cb: 8a          .
+    clc                                                               ; b6cc: 18          .
+.sub_cb6cd
+lb6ce = sub_cb6cd+1
+    adc lb6ce,y                                                       ; b6cd: 79 ce b6    y..
+; &b6ce referenced 1 time by &b6cd
+    tax                                                               ; b6d0: aa          .
+    pla                                                               ; b6d1: 68          h
+; &b6d2 referenced 1 time by &b6d2
+.cb6d2
+    adc cb6d2,y                                                       ; b6d2: 79 d2 b6    y..
+    rts                                                               ; b6d5: 60          `
+
+    equb &f0, &e0, &d0, &c0, &3f, &7f, &bf, &ff, &10                  ; b6d6: f0 e0 d0... ...
+    equs " 0@"                                                        ; b6df: 20 30 40     0@
+    equb &80, &40,   0, &c0                                           ; b6e2: 80 40 00... .@.
+
+; &b6e6 referenced 1 time by &b6fe
+.sub_cb6e6
+    cpy #&10                                                          ; b6e6: c0 10       ..
+    bcs cb6eb                                                         ; b6e8: b0 01       ..
+    rts                                                               ; b6ea: 60          `
+
+; &b6eb referenced 1 time by &b6e8
+.cb6eb
+    tya                                                               ; b6eb: 98          .
+    sec                                                               ; b6ec: 38          8
+    sbc #4                                                            ; b6ed: e9 04       ..
+    tay                                                               ; b6ef: a8          .
+    cpy #&0e                                                          ; b6f0: c0 0e       ..
+    bcs cb6f5                                                         ; b6f2: b0 01       ..
+    rts                                                               ; b6f4: 60          `
+
+; &b6f5 referenced 1 time by &b6f2
+.cb6f5
+    tya                                                               ; b6f5: 98          .
+    and #1                                                            ; b6f6: 29 01       ).
+    ldy #&fe                                                          ; b6f8: a0 fe       ..
+    ora (l00b8),y                                                     ; b6fa: 11 b8       ..
+    tay                                                               ; b6fc: a8          .
+    rts                                                               ; b6fd: 60          `
+
+; &b6fe referenced 5 times by &b314, &b6ab, &bc44, &bc8e, &bce1
+.sub_cb6fe
+    jsr sub_cb6e6                                                     ; b6fe: 20 e6 b6     ..
+    tya                                                               ; b701: 98          .
+    tax                                                               ; b702: aa          .
+    lda lb726,y                                                       ; b703: b9 26 b7    .&.
+    pha                                                               ; b706: 48          H
+    ldy #&ee                                                          ; b707: a0 ee       ..
+    and (l00b8),y                                                     ; b709: 31 b8       1.
+    bne cb718                                                         ; b70b: d0 0b       ..
+    lda (l00b8),y                                                     ; b70d: b1 b8       ..
+    and #&c0                                                          ; b70f: 29 c0       ).
+    cmp #&80                                                          ; b711: c9 80       ..
+    beq cb718                                                         ; b713: f0 03       ..
+    jmp cb446                                                         ; b715: 4c 46 b4    LF.
+
+; &b718 referenced 2 times by &b70b, &b713
+.cb718
+    pla                                                               ; b718: 68          h
+    ldy #&fd                                                          ; b719: a0 fd       ..
+    and (l00b8),y                                                     ; b71b: 31 b8       1.
+    pha                                                               ; b71d: 48          H
+    txa                                                               ; b71e: 8a          .
+    tay                                                               ; b71f: a8          .
+    pla                                                               ; b720: 68          h
+    beq cb725                                                         ; b721: f0 02       ..
+    lda #&ff                                                          ; b723: a9 ff       ..
+; &b725 referenced 1 time by &b721
+.cb725
+    rts                                                               ; b725: 60          `
+
+; &b726 referenced 6 times by &b703, &b898, &b8c8, &b8db, &bc56, &bca1
+.lb726
+    equb   4,   8,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0   ; b726: 04 08 00... ...
+    equb   1,   2, &10, &20                                           ; b732: 01 02 10... ...
+
+; &b736 referenced 1 time by &b75a
+.cb736
+    sty romsel_copy                                                   ; b736: 84 f4       ..
+    sty romsel                                                        ; b738: 8c 30 fe    .0.
+    ldy #0                                                            ; b73b: a0 00       ..
+    sta (l00ba),y                                                     ; b73d: 91 ba       ..
+    stx romsel_copy                                                   ; b73f: 86 f4       ..
+    stx romsel                                                        ; b741: 8e 30 fe    .0.
+    rts                                                               ; b744: 60          `
+
+; &b745 referenced 5 times by &b369, &b8b7, &b8d1, &bc78, &bc9e
+.sub_cb745
+    sta l00bf                                                         ; b745: 85 bf       ..
+    txa                                                               ; b747: 8a          .
+    pha                                                               ; b748: 48          H
+    tya                                                               ; b749: 98          .
+    pha                                                               ; b74a: 48          H
+    ldx romsel_copy                                                   ; b74b: a6 f4       ..
+    lda l0df0,x                                                       ; b74d: bd f0 0d    ...
+    sta l00b1                                                         ; b750: 85 b1       ..
+    inc l00b1                                                         ; b752: e6 b1       ..
+    lda #0                                                            ; b754: a9 00       ..
+    sta l00b0                                                         ; b756: 85 b0       ..
+    ldy #&0e                                                          ; b758: a0 0e       ..
+; &b75a referenced 1 time by &b760
+.loop_cb75a
+    lda cb736,y                                                       ; b75a: b9 36 b7    .6.
+    sta (l00b0),y                                                     ; b75d: 91 b0       ..
+    dey                                                               ; b75f: 88          .
+    bpl loop_cb75a                                                    ; b760: 10 f8       ..
+    pla                                                               ; b762: 68          h
+    pha                                                               ; b763: 48          H
+    tay                                                               ; b764: a8          .
+    lda l00bf                                                         ; b765: a5 bf       ..
+    jsr sub_cb771                                                     ; b767: 20 71 b7     q.
+    pla                                                               ; b76a: 68          h
+    tay                                                               ; b76b: a8          .
+    pla                                                               ; b76c: 68          h
+    tax                                                               ; b76d: aa          .
+    lda l00bf                                                         ; b76e: a5 bf       ..
+    rts                                                               ; b770: 60          `
+
+; &b771 referenced 1 time by &b767
+.sub_cb771
+    jmp (l00b0)                                                       ; b771: 6c b0 00    l..
+
+; &b774 referenced 1 time by &b7be
+.lb774
+    equb &85, &f4, &8d, &30, &fe, &b1, &b1, &91, &b3, &c8, &d0,   5   ; b774: 85 f4 8d... ...
+    equb &e6, &b2, &e6, &b4, &ca, &c4, &b5, &d0, &f0, &8a, &d0, &ed   ; b780: e6 b2 e6... ...
+    equb &68, &85, &f4, &8d, &30, &fe, &4c, &d5, &b7                  ; b78c: 68 85 f4... h..
+
+; &b795 referenced 5 times by &b4ca, &b51d, &bd0b, &bdb0, &bded
+.cb795
+    ldy #&f1                                                          ; b795: a0 f1       ..
+    lda (l00b8),y                                                     ; b797: b1 b8       ..
+    sta l00b0                                                         ; b799: 85 b0       ..
+    ldx l00be                                                         ; b79b: a6 be       ..
+    ldy l00bf                                                         ; b79d: a4 bf       ..
+    lda #0                                                            ; b79f: a9 00       ..
+    rol a                                                             ; b7a1: 2a          *
+    asl a                                                             ; b7a2: 0a          .
+    sta l00b7                                                         ; b7a3: 85 b7       ..
+    inc l00b7                                                         ; b7a5: e6 b7       ..
+    jsr sub_cb85d                                                     ; b7a7: 20 5d b8     ].
+    bvs cb7ed                                                         ; b7aa: 70 41       pA
+    bvc cb7b2                                                         ; b7ac: 50 04       P.
+; &b7ae referenced 1 time by &b803
+.cb7ae
+    ldx l00be                                                         ; b7ae: a6 be       ..
+    ldy l00bf                                                         ; b7b0: a4 bf       ..
+; &b7b2 referenced 1 time by &b7ac
+.cb7b2
+    stx l00b5                                                         ; b7b2: 86 b5       ..
+    sty l00b6                                                         ; b7b4: 84 b6       ..
+; &b7b6 referenced 1 time by &b812
+.sub_cb7b6
+    lda l00b5                                                         ; b7b6: a5 b5       ..
+    ora l00b6                                                         ; b7b8: 05 b6       ..
+    beq cb7ec                                                         ; b7ba: f0 30       .0
+    ldx #&20 ; ' '                                                    ; b7bc: a2 20       .
+; &b7be referenced 1 time by &b7c3
+.loop_cb7be
+    lda lb774,x                                                       ; b7be: bd 74 b7    .t.
+    pha                                                               ; b7c1: 48          H
+    dex                                                               ; b7c2: ca          .
+    bpl loop_cb7be                                                    ; b7c3: 10 f9       ..
+    tsx                                                               ; b7c5: ba          .
+    lda romsel_copy                                                   ; b7c6: a5 f4       ..
+    pha                                                               ; b7c8: 48          H
+    lda #1                                                            ; b7c9: a9 01       ..
+    pha                                                               ; b7cb: 48          H
+    txa                                                               ; b7cc: 8a          .
+    pha                                                               ; b7cd: 48          H
+    lda l00b0                                                         ; b7ce: a5 b0       ..
+    ldx l00b6                                                         ; b7d0: a6 b6       ..
+    ldy #0                                                            ; b7d2: a0 00       ..
+    rts                                                               ; b7d4: 60          `
+
+    ldx #&21 ; '!'                                                    ; b7d5: a2 21       .!
+; &b7d7 referenced 1 time by &b7d9
+.loop_cb7d7
+    pla                                                               ; b7d7: 68          h
+    dex                                                               ; b7d8: ca          .
+    bne loop_cb7d7                                                    ; b7d9: d0 fc       ..
+    ldx #2                                                            ; b7db: a2 02       ..
+; &b7dd referenced 1 time by &b7ea
+.loop_cb7dd
+    lda l00b1,x                                                       ; b7dd: b5 b1       ..
+    clc                                                               ; b7df: 18          .
+    adc l00b5                                                         ; b7e0: 65 b5       e.
+    sta l00b1,x                                                       ; b7e2: 95 b1       ..
+    bcc cb7e8                                                         ; b7e4: 90 02       ..
+    inc l00b2,x                                                       ; b7e6: f6 b2       ..
+; &b7e8 referenced 1 time by &b7e4
+.cb7e8
+    dex                                                               ; b7e8: ca          .
+    dex                                                               ; b7e9: ca          .
+    bpl loop_cb7dd                                                    ; b7ea: 10 f1       ..
+; &b7ec referenced 1 time by &b7ba
+.cb7ec
+    rts                                                               ; b7ec: 60          `
+
+; &b7ed referenced 2 times by &b7aa, &b828
+.cb7ed
+    lda #0                                                            ; b7ed: a9 00       ..
+    sec                                                               ; b7ef: 38          8
+    ldx l00b7                                                         ; b7f0: a6 b7       ..
+    sbc l00b0,x                                                       ; b7f2: f5 b0       ..
+    sta l00b5                                                         ; b7f4: 85 b5       ..
+    lda #&c0                                                          ; b7f6: a9 c0       ..
+    sbc l00b1,x                                                       ; b7f8: f5 b1       ..
+    sta l00b6                                                         ; b7fa: 85 b6       ..
+    ldx #&b5                                                          ; b7fc: a2 b5       ..
+    ldy #&be                                                          ; b7fe: a0 be       ..
+    jsr sub_cb58b                                                     ; b800: 20 8b b5     ..
+    bcs cb7ae                                                         ; b803: b0 a9       ..
+    lda l00be                                                         ; b805: a5 be       ..
+    sec                                                               ; b807: 38          8
+    sbc l00b5                                                         ; b808: e5 b5       ..
+    sta l00be                                                         ; b80a: 85 be       ..
+    lda l00bf                                                         ; b80c: a5 bf       ..
+    sbc l00b6                                                         ; b80e: e5 b6       ..
+    sta l00bf                                                         ; b810: 85 bf       ..
+    jsr sub_cb7b6                                                     ; b812: 20 b6 b7     ..
+    lda #&10                                                          ; b815: a9 10       ..
+    ldx l00b7                                                         ; b817: a6 b7       ..
+    sta l00b0,x                                                       ; b819: 95 b0       ..
+    lda #&80                                                          ; b81b: a9 80       ..
+    sta l00b1,x                                                       ; b81d: 95 b1       ..
+    jsr sub_cb68f                                                     ; b81f: 20 8f b6     ..
+    ldy #&f1                                                          ; b822: a0 f1       ..
+    lda (l00b8),y                                                     ; b824: b1 b8       ..
+    sta l00b0                                                         ; b826: 85 b0       ..
+    jmp cb7ed                                                         ; b828: 4c ed b7    L..
+
+; &b82b referenced 16 times by &b1c1, &b2c8, &b2e7, &b32c, &b35a, &b3b0, &b3ec, &b429, &b4a3, &b573, &b5ca, &b5e8, &b604, &b611, &b86b, &beb5
+.cb82b
+    php                                                               ; b82b: 08          .
+    pha                                                               ; b82c: 48          H
+    txa                                                               ; b82d: 8a          .
+    pha                                                               ; b82e: 48          H
+    lda #0                                                            ; b82f: a9 00       ..
+    sta l00b8                                                         ; b831: 85 b8       ..
+    ldx romsel_copy                                                   ; b833: a6 f4       ..
+    lda l0df0,x                                                       ; b835: bd f0 0d    ...
+    sta l00b9                                                         ; b838: 85 b9       ..
+    pla                                                               ; b83a: 68          h
+    tax                                                               ; b83b: aa          .
+    pla                                                               ; b83c: 68          h
+    plp                                                               ; b83d: 28          (
+    rts                                                               ; b83e: 60          `
+
+; &b83f referenced 4 times by &b35f, &b4e1, &b53d, &b622
+.sub_cb83f
+    ldx #&ba                                                          ; b83f: a2 ba       ..
+; &b841 referenced 12 times by &b39b, &b462, &b4b8, &b4bf, &b4c6, &b4f2, &b50b, &b512, &b519, &b663, &bd4a, &bdc4
+.sub_cb841
+    pha                                                               ; b841: 48          H
+    lda (l00b8),y                                                     ; b842: b1 b8       ..
+    sta l0000,x                                                       ; b844: 95 00       ..
+    iny                                                               ; b846: c8          .
+    lda (l00b8),y                                                     ; b847: b1 b8       ..
+    sta l0001,x                                                       ; b849: 95 01       ..
+    dey                                                               ; b84b: 88          .
+    pla                                                               ; b84c: 68          h
+    rts                                                               ; b84d: 60          `
+
+; &b84e referenced 3 times by &b3f5, &b472, &b504
+.sub_cb84e
+    ldx #&ba                                                          ; b84e: a2 ba       ..
+; &b850 referenced 5 times by &b659, &b688, &bb5c, &bb8d, &bd36
+.sub_cb850
+    pha                                                               ; b850: 48          H
+    lda l0000,x                                                       ; b851: b5 00       ..
+    sta (l00b8),y                                                     ; b853: 91 b8       ..
+    iny                                                               ; b855: c8          .
+    lda l0001,x                                                       ; b856: b5 01       ..
+    sta (l00b8),y                                                     ; b858: 91 b8       ..
+    dey                                                               ; b85a: 88          .
+    pla                                                               ; b85b: 68          h
+    rts                                                               ; b85c: 60          `
+
+; &b85d referenced 8 times by &b2f2, &b340, &b406, &b63f, &b66e, &b7a7, &be64, &be9d
+.sub_cb85d
+    pha                                                               ; b85d: 48          H
+    tya                                                               ; b85e: 98          .
+    pha                                                               ; b85f: 48          H
+    ldy #&ee                                                          ; b860: a0 ee       ..
+    lda (l00b8),y                                                     ; b862: b1 b8       ..
+    sta l00b8                                                         ; b864: 85 b8       ..
+    pla                                                               ; b866: 68          h
+    tay                                                               ; b867: a8          .
+    pla                                                               ; b868: 68          h
+    bit l00b8                                                         ; b869: 24 b8       $.
+    jsr cb82b                                                         ; b86b: 20 2b b8     +.
+    rts                                                               ; b86e: 60          `
+
+; &b86f referenced 1 time by &b60e
+.sub_cb86f
+    jmp (fscv)                                                        ; b86f: 6c 1e 02    l..
+
+; &b872 referenced 2 times by &b9c7, &bc70
+.lb872
+    equb &60,   0,   0, &60,   0,   0,   2, &0c, &ff                  ; b872: 60 00 00... `..
+    equs "RAM"                                                        ; b87b: 52 41 4d    RAM
+; &b87e referenced 1 time by &b9a3
+.lb87e
+    equb 0                                                            ; b87e: 00          .
+    equs "(C)"                                                        ; b87f: 28 43 29    (C)
+
+; &b882 referenced 1 time by &b200
+.sub_cb882
+    lda #0                                                            ; b882: a9 00       ..
+    ldy #&fd                                                          ; b884: a0 fd       ..
+    sta (l00b8),y                                                     ; b886: 91 b8       ..
+    ldy #&ee                                                          ; b888: a0 ee       ..
+    sta (l00b8),y                                                     ; b88a: 91 b8       ..
+    ldy #&fa                                                          ; b88c: a0 fa       ..
+    sta (l00b8),y                                                     ; b88e: 91 b8       ..
+    ldy #&ff                                                          ; b890: a0 ff       ..
+    lda #&4e ; 'N'                                                    ; b892: a9 4e       .N
+    sta (l00b8),y                                                     ; b894: 91 b8       ..
+    ldy #&0f                                                          ; b896: a0 0f       ..
+; &b898 referenced 1 time by &b8e7
+.cb898
+    lda lb726,y                                                       ; b898: b9 26 b7    .&.
+    beq cb8e6                                                         ; b89b: f0 49       .I
+    tya                                                               ; b89d: 98          .
+    pha                                                               ; b89e: 48          H
+    lda #8                                                            ; b89f: a9 08       ..
+    sta osrdsc_ptr                                                    ; b8a1: 85 f6       ..
+    sta l00ba                                                         ; b8a3: 85 ba       ..
+    lda #&80                                                          ; b8a5: a9 80       ..
+    sta l00f7                                                         ; b8a7: 85 f7       ..
+    sta l00bb                                                         ; b8a9: 85 bb       ..
+    jsr osrdsc                                                        ; b8ab: 20 b9 ff     ..
+    sta l00bd                                                         ; b8ae: 85 bd       ..
+    pla                                                               ; b8b0: 68          h
+    pha                                                               ; b8b1: 48          H
+    tay                                                               ; b8b2: a8          .
+    lda l00bd                                                         ; b8b3: a5 bd       ..
+    eor #&ff                                                          ; b8b5: 49 ff       I.
+    jsr sub_cb745                                                     ; b8b7: 20 45 b7     E.
+    jsr osrdsc                                                        ; b8ba: 20 b9 ff     ..
+    cmp l00bd                                                         ; b8bd: c5 bd       ..
+    beq cb8e4                                                         ; b8bf: f0 23       .#
+    pla                                                               ; b8c1: 68          h
+    pha                                                               ; b8c2: 48          H
+    tax                                                               ; b8c3: aa          .
+    ldy #&ee                                                          ; b8c4: a0 ee       ..
+    lda (l00b8),y                                                     ; b8c6: b1 b8       ..
+    ora lb726,x                                                       ; b8c8: 1d 26 b7    .&.
+    sta (l00b8),y                                                     ; b8cb: 91 b8       ..
+    txa                                                               ; b8cd: 8a          .
+    tay                                                               ; b8ce: a8          .
+    lda l00bd                                                         ; b8cf: a5 bd       ..
+    jsr sub_cb745                                                     ; b8d1: 20 45 b7     E.
+    jsr sub_cb986                                                     ; b8d4: 20 86 b9     ..
+    cmp #2                                                            ; b8d7: c9 02       ..
+    bne cb8e4                                                         ; b8d9: d0 09       ..
+    lda lb726,y                                                       ; b8db: b9 26 b7    .&.
+    ldy #&fd                                                          ; b8de: a0 fd       ..
+    ora (l00b8),y                                                     ; b8e0: 11 b8       ..
+    sta (l00b8),y                                                     ; b8e2: 91 b8       ..
+; &b8e4 referenced 2 times by &b8bf, &b8d9
+.cb8e4
+    pla                                                               ; b8e4: 68          h
+    tay                                                               ; b8e5: a8          .
+; &b8e6 referenced 1 time by &b89b
+.cb8e6
+    dey                                                               ; b8e6: 88          .
+    bpl cb898                                                         ; b8e7: 10 af       ..
+    ldy #&ee                                                          ; b8e9: a0 ee       ..
+    lda (l00b8),y                                                     ; b8eb: b1 b8       ..
+    ldx #0                                                            ; b8ed: a2 00       ..
+    and #&0c                                                          ; b8ef: 29 0c       ).
+    bne cb8f5                                                         ; b8f1: d0 02       ..
+    ldx #&0e                                                          ; b8f3: a2 0e       ..
+; &b8f5 referenced 1 time by &b8f1
+.cb8f5
+    txa                                                               ; b8f5: 8a          .
+    ldy #&fe                                                          ; b8f6: a0 fe       ..
+    sta (l00b8),y                                                     ; b8f8: 91 b8       ..
+    rts                                                               ; b8fa: 60          `
+
+; &b8fb referenced 6 times by &b302, &b334, &b448, &b5e3, &bafa, &bc51
+.cb8fb
+    lda #0                                                            ; b8fb: a9 00       ..
+    sta l0100                                                         ; b8fd: 8d 00 01    ...
+    lda lb980,x                                                       ; b900: bd 80 b9    ...
+    sta l0101                                                         ; b903: 8d 01 01    ...
+    lda lb97a,x                                                       ; b906: bd 7a b9    .z.
+    sta l00bf                                                         ; b909: 85 bf       ..
+    ldy lb979,x                                                       ; b90b: bc 79 b9    .y.
+    ldx #0                                                            ; b90e: a2 00       ..
+; &b910 referenced 1 time by &b91a
+.loop_cb910
+    lda lb924,y                                                       ; b910: b9 24 b9    .$.
+    sta l0102,x                                                       ; b913: 9d 02 01    ...
+    inx                                                               ; b916: e8          .
+    iny                                                               ; b917: c8          .
+    cpy l00bf                                                         ; b918: c4 bf       ..
+    bcc loop_cb910                                                    ; b91a: 90 f4       ..
+    lda #0                                                            ; b91c: a9 00       ..
+    sta l0102,x                                                       ; b91e: 9d 02 01    ...
+    jmp l0100                                                         ; b921: 4c 00 01    L..
+
+; &b924 referenced 1 time by &b910
+.lb924
+    equs "Illegal parameterIllegal addressNo filing systemBad comm"   ; b924: 49 6c 6c... Ill
+    equs "andFile not foundRAM occupied"                              ; b95c: 61 6e 64... and
+; &b979 referenced 1 time by &b90b
+.lb979
+    equb 0                                                            ; b979: 00          .
+; &b97a referenced 1 time by &b906
+.lb97a
+    equb &11                                                          ; b97a: 11          .
+    equs " 0;IU"                                                      ; b97b: 20 30 3b...  0;
+; &b980 referenced 1 time by &b900
+.lb980
+    equb &80, &81, &82, &fe, &d6, &83                                 ; b980: 80 81 82... ...
+
+; &b986 referenced 3 times by &b8d4, &bc49, &bcb2
+.sub_cb986
+    txa                                                               ; b986: 8a          .
+    pha                                                               ; b987: 48          H
+    tya                                                               ; b988: 98          .
+    pha                                                               ; b989: 48          H
+    ldx #7                                                            ; b98a: a2 07       ..
+    stx osrdsc_ptr                                                    ; b98c: 86 f6       ..
+    lda #&80                                                          ; b98e: a9 80       ..
+    sta l00f7                                                         ; b990: 85 f7       ..
+    jsr osrdsc                                                        ; b992: 20 b9 ff     ..
+    sta osrdsc_ptr                                                    ; b995: 85 f6       ..
+    ldx #0                                                            ; b997: a2 00       ..
+; &b999 referenced 1 time by &b9b1
+.loop_cb999
+    stx l00bf                                                         ; b999: 86 bf       ..
+    pla                                                               ; b99b: 68          h
+    pha                                                               ; b99c: 48          H
+    tay                                                               ; b99d: a8          .
+    jsr osrdsc                                                        ; b99e: 20 b9 ff     ..
+    ldx l00bf                                                         ; b9a1: a6 bf       ..
+    cmp lb87e,x                                                       ; b9a3: dd 7e b8    .~.
+    bne cb9ee                                                         ; b9a6: d0 46       .F
+    inc osrdsc_ptr                                                    ; b9a8: e6 f6       ..
+    bne cb9ae                                                         ; b9aa: d0 02       ..
+    inc l00f7                                                         ; b9ac: e6 f7       ..
+; &b9ae referenced 1 time by &b9aa
+.cb9ae
+    inx                                                               ; b9ae: e8          .
+    cpx #4                                                            ; b9af: e0 04       ..
+    bcc loop_cb999                                                    ; b9b1: 90 e6       ..
+    lda #2                                                            ; b9b3: a9 02       ..
+    sta l00bf                                                         ; b9b5: 85 bf       ..
+    ldx #&0f                                                          ; b9b7: a2 0f       ..
+    lda #&80                                                          ; b9b9: a9 80       ..
+    sta l00f7                                                         ; b9bb: 85 f7       ..
+; &b9bd referenced 1 time by &b9cf
+.loop_cb9bd
+    stx osrdsc_ptr                                                    ; b9bd: 86 f6       ..
+    pla                                                               ; b9bf: 68          h
+    pha                                                               ; b9c0: 48          H
+    tay                                                               ; b9c1: a8          .
+    jsr osrdsc                                                        ; b9c2: 20 b9 ff     ..
+    ldx osrdsc_ptr                                                    ; b9c5: a6 f6       ..
+    cmp lb872,x                                                       ; b9c7: dd 72 b8    .r.
+    bne cb9d9                                                         ; b9ca: d0 0d       ..
+; &b9cc referenced 1 time by &b9e5
+.loop_cb9cc
+    dex                                                               ; b9cc: ca          .
+    cpx #6                                                            ; b9cd: e0 06       ..
+    bcs loop_cb9bd                                                    ; b9cf: b0 ec       ..
+; &b9d1 referenced 1 time by &b9ec
+.loop_cb9d1
+    clc                                                               ; b9d1: 18          .
+; &b9d2 referenced 1 time by &b9f3
+.cb9d2
+    pla                                                               ; b9d2: 68          h
+    tay                                                               ; b9d3: a8          .
+    pla                                                               ; b9d4: 68          h
+    tax                                                               ; b9d5: aa          .
+    lda l00bf                                                         ; b9d6: a5 bf       ..
+    rts                                                               ; b9d8: 60          `
+
+; &b9d9 referenced 1 time by &b9ca
+.cb9d9
+    cpx #&0a                                                          ; b9d9: e0 0a       ..
+    bne cb9e8                                                         ; b9db: d0 0b       ..
+    cmp #&4f ; 'O'                                                    ; b9dd: c9 4f       .O
+    bne cb9e8                                                         ; b9df: d0 07       ..
+    lda #1                                                            ; b9e1: a9 01       ..
+    sta l00bf                                                         ; b9e3: 85 bf       ..
+    jmp loop_cb9cc                                                    ; b9e5: 4c cc b9    L..
+
+; &b9e8 referenced 2 times by &b9db, &b9df
+.cb9e8
+    lda #0                                                            ; b9e8: a9 00       ..
+    sta l00bf                                                         ; b9ea: 85 bf       ..
+    beq loop_cb9d1                                                    ; b9ec: f0 e3       ..
+; &b9ee referenced 1 time by &b9a6
+.cb9ee
+    lda #&ff                                                          ; b9ee: a9 ff       ..
+    sta l00bf                                                         ; b9f0: 85 bf       ..
+    sec                                                               ; b9f2: 38          8
+    bcs cb9d2                                                         ; b9f3: b0 dd       ..
+; &b9f5 referenced 2 times by &b225, &b297
+.sub_cb9f5
+    ldx #0                                                            ; b9f5: a2 00       ..
+; &b9f7 referenced 1 time by &ba25
+.cb9f7
+    tya                                                               ; b9f7: 98          .
+    pha                                                               ; b9f8: 48          H
+; &b9f9 referenced 1 time by &ba0e
+.loop_cb9f9
+    lda (os_text_ptr),y                                               ; b9f9: b1 f2       ..
+    bmi cba10                                                         ; b9fb: 30 13       0.
+    cmp #&2e ; '.'                                                    ; b9fd: c9 2e       ..
+    beq cba19                                                         ; b9ff: f0 18       ..
+    cmp #&41 ; 'A'                                                    ; ba01: c9 41       .A
+    bcc cba10                                                         ; ba03: 90 0b       ..
+    eor sram_table,x                                                  ; ba05: 5d 30 ba    ]0.
+    and #&df                                                          ; ba08: 29 df       ).
+    bne cba15                                                         ; ba0a: d0 09       ..
+    iny                                                               ; ba0c: c8          .
+    inx                                                               ; ba0d: e8          .
+    bne loop_cb9f9                                                    ; ba0e: d0 e9       ..
+; &ba10 referenced 2 times by &b9fb, &ba03
+.cba10
+    lda sram_table,x                                                  ; ba10: bd 30 ba    .0.
+    bmi cba28                                                         ; ba13: 30 13       0.
+; &ba15 referenced 1 time by &ba0a
+.cba15
+    clc                                                               ; ba15: 18          .
+    pla                                                               ; ba16: 68          h
+    tay                                                               ; ba17: a8          .
+    dey                                                               ; ba18: 88          .
+; &ba19 referenced 1 time by &b9ff
+.cba19
+    iny                                                               ; ba19: c8          .
+; &ba1a referenced 1 time by &ba20
+.loop_cba1a
+    inx                                                               ; ba1a: e8          .
+    lda cba2f,x                                                       ; ba1b: bd 2f ba    ./.
+    beq cba2e                                                         ; ba1e: f0 0e       ..
+    bpl loop_cba1a                                                    ; ba20: 10 f8       ..
+    bcs cba27                                                         ; ba22: b0 03       ..
+    inx                                                               ; ba24: e8          .
+    bcc cb9f7                                                         ; ba25: 90 d0       ..
+; &ba27 referenced 1 time by &ba22
+.cba27
+    dex                                                               ; ba27: ca          .
+; &ba28 referenced 1 time by &ba13
+.cba28
+    pla                                                               ; ba28: 68          h
+    jsr sub_cbab9                                                     ; ba29: 20 b9 ba     ..
+    clc                                                               ; ba2c: 18          .
+    rts                                                               ; ba2d: 60          `
+
+; &ba2e referenced 1 time by &ba1e
+.cba2e
+    sec                                                               ; ba2e: 38          8
+; &ba2f referenced 1 time by &ba1b
+.cba2f
+    rts                                                               ; ba2f: 60          `
+
+; &ba30 referenced 3 times by &b234, &ba05, &ba10
+.sram_table
+    equs "SRAM"                                                       ; ba30: 53 52 41... SRA
+; &ba31 referenced 1 time by &b238
+    equb &ff, &ff                                                     ; ba34: ff ff       ..
+    equs "SRLOAD"                                                     ; ba36: 53 52 4c... SRL
+    equb >(sub_cbb46-1)                                               ; ba3c: bb          .
+    equb <(sub_cbb46-1)                                               ; ba3d: 45          E
+    equs "SRSAVE"                                                     ; ba3e: 53 52 53... SRS
+    equb >(sub_cbb4a-1)                                               ; ba44: bb          .
+    equb <(sub_cbb4a-1)                                               ; ba45: 49          I
+    equs "SRWRITE"                                                    ; ba46: 53 52 57... SRW
+    equb >(sub_cbbd3-1)                                               ; ba4d: bb          .
+    equb <(sub_cbbd3-1)                                               ; ba4e: d2          .
+    equs "SRREAD"                                                     ; ba4f: 53 52 52... SRR
+    equb >(sub_cbbd7-1)                                               ; ba55: bb          .
+    equb <(sub_cbbd7-1)                                               ; ba56: d6          .
+    equs "SRDATA"                                                     ; ba57: 53 52 44... SRD
+    equb >(sub_cbc37-1)                                               ; ba5d: bc          .
+    equb <(sub_cbc37-1)                                               ; ba5e: 36          6
+    equs "SRROM"                                                      ; ba5f: 53 52 52... SRR
+    equb >(sub_cbc81-1)                                               ; ba64: bc          .
+    equb <(sub_cbc81-1)                                               ; ba65: 80          .
+    equb 0                                                            ; ba66: 00          .
+
+; &ba67 referenced 5 times by &bb51, &bb6c, &bbdd, &bbf3, &bc1c
+.sub_cba67
+    txa                                                               ; ba67: 8a          .
+    pha                                                               ; ba68: 48          H
+    jsr sub_cbab9                                                     ; ba69: 20 b9 ba     ..
+    lda #0                                                            ; ba6c: a9 00       ..
+    sta l00bc                                                         ; ba6e: 85 bc       ..
+    sta l00bd                                                         ; ba70: 85 bd       ..
+    sta l00be                                                         ; ba72: 85 be       ..
+    sta l00bf                                                         ; ba74: 85 bf       ..
+    sec                                                               ; ba76: 38          8
+    php                                                               ; ba77: 08          .
+; &ba78 referenced 1 time by &baae
+.cba78
+    lda (os_text_ptr),y                                               ; ba78: b1 f2       ..
+    cmp #&30 ; '0'                                                    ; ba7a: c9 30       .0
+    bcc cbab4                                                         ; ba7c: 90 36       .6
+    cmp #&3a ; ':'                                                    ; ba7e: c9 3a       .:
+    bcc cba8c                                                         ; ba80: 90 0a       ..
+    cmp #&47 ; 'G'                                                    ; ba82: c9 47       .G
+    bcs cbab4                                                         ; ba84: b0 2e       ..
+    cmp #&41 ; 'A'                                                    ; ba86: c9 41       .A
+    bcc cbab4                                                         ; ba88: 90 2a       .*
+    sbc #7                                                            ; ba8a: e9 07       ..
+; &ba8c referenced 1 time by &ba80
+.cba8c
+    sec                                                               ; ba8c: 38          8
+    sbc #&30 ; '0'                                                    ; ba8d: e9 30       .0
+    plp                                                               ; ba8f: 28          (
+    php                                                               ; ba90: 08          .
+    pha                                                               ; ba91: 48          H
+    ldx #4                                                            ; ba92: a2 04       ..
+; &ba94 referenced 1 time by &baa1
+.loop_cba94
+    asl l00bc                                                         ; ba94: 06 bc       ..
+    rol l00bd                                                         ; ba96: 26 bd       &.
+    bvc cba9e                                                         ; ba98: 50 04       P.
+    rol l00be                                                         ; ba9a: 26 be       &.
+    rol l00bf                                                         ; ba9c: 26 bf       &.
+; &ba9e referenced 1 time by &ba98
+.cba9e
+    bcs cbab0                                                         ; ba9e: b0 10       ..
+    dex                                                               ; baa0: ca          .
+    bne loop_cba94                                                    ; baa1: d0 f1       ..
+    pla                                                               ; baa3: 68          h
+    ora l00bc                                                         ; baa4: 05 bc       ..
+    sta l00bc                                                         ; baa6: 85 bc       ..
+    plp                                                               ; baa8: 28          (
+    clc                                                               ; baa9: 18          .
+    php                                                               ; baaa: 08          .
+    iny                                                               ; baab: c8          .
+    beq cbab1                                                         ; baac: f0 03       ..
+    bcc cba78                                                         ; baae: 90 c8       ..
+; &bab0 referenced 1 time by &ba9e
+.cbab0
+    pla                                                               ; bab0: 68          h
+; &bab1 referenced 1 time by &baac
+.cbab1
+    plp                                                               ; bab1: 28          (
+    sec                                                               ; bab2: 38          8
+    php                                                               ; bab3: 08          .
+; &bab4 referenced 3 times by &ba7c, &ba84, &ba88
+.cbab4
+    plp                                                               ; bab4: 28          (
+    pla                                                               ; bab5: 68          h
+    tax                                                               ; bab6: aa          .
+    rts                                                               ; bab7: 60          `
+
+; &bab8 referenced 1 time by &babd
+.loop_cbab8
+    iny                                                               ; bab8: c8          .
+; &bab9 referenced 7 times by &ba29, &ba69, &bac5, &bad2, &bb02, &bb2b, &bbb0
+.sub_cbab9
+    lda (os_text_ptr),y                                               ; bab9: b1 f2       ..
+    cmp #&20 ; ' '                                                    ; babb: c9 20       .
+    beq loop_cbab8                                                    ; babd: f0 f9       ..
+    cmp #&0d                                                          ; babf: c9 0d       ..
+    rts                                                               ; bac1: 60          `
+
+; &bac2 referenced 4 times by &bbbe, &bc2c, &bc3d, &bc87
+.sub_cbac2
+    lda #&0d                                                          ; bac2: a9 0d       ..
+; &bac4 referenced 3 times by &b26e, &bb67, &bbed
+.sub_cbac4
+    pha                                                               ; bac4: 48          H
+    jsr sub_cbab9                                                     ; bac5: 20 b9 ba     ..
+    pla                                                               ; bac8: 68          h
+    cmp (os_text_ptr),y                                               ; bac9: d1 f2       ..
+    bne cbad0                                                         ; bacb: d0 03       ..
+    clc                                                               ; bacd: 18          .
+    iny                                                               ; bace: c8          .
+    rts                                                               ; bacf: 60          `
+
+; &bad0 referenced 1 time by &bacb
+.cbad0
+    sec                                                               ; bad0: 38          8
+    rts                                                               ; bad1: 60          `
+
+; &bad2 referenced 1 time by &bb4d
+.sub_cbad2
+    jsr sub_cbab9                                                     ; bad2: 20 b9 ba     ..
+    tya                                                               ; bad5: 98          .
+    pha                                                               ; bad6: 48          H
+    clc                                                               ; bad7: 18          .
+    adc os_text_ptr                                                   ; bad8: 65 f2       e.
+    ldy #&ef                                                          ; bada: a0 ef       ..
+    sta (l00b8),y                                                     ; badc: 91 b8       ..
+    lda l00f3                                                         ; bade: a5 f3       ..
+    adc #0                                                            ; bae0: 69 00       i.
+    iny                                                               ; bae2: c8          .
+    sta (l00b8),y                                                     ; bae3: 91 b8       ..
+    pla                                                               ; bae5: 68          h
+    tay                                                               ; bae6: a8          .
+    bit lb57f                                                         ; bae7: 2c 7f b5    ,..
+; &baea referenced 1 time by &baf6
+.loop_cbaea
+    lda (os_text_ptr),y                                               ; baea: b1 f2       ..
+    cmp #&20 ; ' '                                                    ; baec: c9 20       .
+    beq cbafd                                                         ; baee: f0 0d       ..
+    cmp #&0d                                                          ; baf0: c9 0d       ..
+    beq cbafd                                                         ; baf2: f0 09       ..
+    clv                                                               ; baf4: b8          .
+    iny                                                               ; baf5: c8          .
+    bne loop_cbaea                                                    ; baf6: d0 f2       ..
+; &baf8 referenced 2 times by &bafd, &bbd0
+.cbaf8
+    ldx #3                                                            ; baf8: a2 03       ..
+    jmp cb8fb                                                         ; bafa: 4c fb b8    L..
+
+; &bafd referenced 2 times by &baee, &baf2
+.cbafd
+    bvs cbaf8                                                         ; bafd: 70 f9       p.
+    rts                                                               ; baff: 60          `
+
+; &bb00 referenced 4 times by &bb92, &bc21, &bc37, &bc81
+.sub_cbb00
+    stx l00bf                                                         ; bb00: 86 bf       ..
+    jsr sub_cbab9                                                     ; bb02: 20 b9 ba     ..
+    ldx #3                                                            ; bb05: a2 03       ..
+; &bb07 referenced 1 time by &bb34
+.cbb07
+    cmp lbb3e,x                                                       ; bb07: dd 3e bb    .>.
+    bcs cbb36                                                         ; bb0a: b0 2a       .*
+    cmp lbb3a,x                                                       ; bb0c: dd 3a bb    .:.
+    bcc cbb33                                                         ; bb0f: 90 22       ."
+    sbc lbb42,x                                                       ; bb11: fd 42 bb    .B.
+    iny                                                               ; bb14: c8          .
+    cmp #1                                                            ; bb15: c9 01       ..
+    bne cbb2a                                                         ; bb17: d0 11       ..
+    lda (os_text_ptr),y                                               ; bb19: b1 f2       ..
+    cmp #&36 ; '6'                                                    ; bb1b: c9 36       .6
+    bcs cbb28                                                         ; bb1d: b0 09       ..
+    cmp #&30 ; '0'                                                    ; bb1f: c9 30       .0
+    bcc cbb28                                                         ; bb21: 90 05       ..
+    sbc #&26 ; '&'                                                    ; bb23: e9 26       .&
+    iny                                                               ; bb25: c8          .
+    bne cbb2a                                                         ; bb26: d0 02       ..
+; &bb28 referenced 2 times by &bb1d, &bb21
+.cbb28
+    lda #1                                                            ; bb28: a9 01       ..
+; &bb2a referenced 2 times by &bb17, &bb26
+.cbb2a
+    pha                                                               ; bb2a: 48          H
+    jsr sub_cbab9                                                     ; bb2b: 20 b9 ba     ..
+    pla                                                               ; bb2e: 68          h
+    ldx l00bf                                                         ; bb2f: a6 bf       ..
+    clc                                                               ; bb31: 18          .
+    rts                                                               ; bb32: 60          `
+
+; &bb33 referenced 1 time by &bb0f
+.cbb33
+    dex                                                               ; bb33: ca          .
+    bpl cbb07                                                         ; bb34: 10 d1       ..
+; &bb36 referenced 1 time by &bb0a
+.cbb36
+    ldx l00bf                                                         ; bb36: a6 bf       ..
+    sec                                                               ; bb38: 38          8
+    rts                                                               ; bb39: 60          `
+
+; &bb3a referenced 1 time by &bb0c
+.lbb3a
+    equs "0AWw"                                                       ; bb3a: 30 41 57... 0AW
+; &bb3e referenced 1 time by &bb07
+.lbb3e
+    equs ":G[{"                                                       ; bb3e: 3a 47 5b... :G[
+; &bb42 referenced 1 time by &bb11
+.lbb42
+    equs "07Gg"                                                       ; bb42: 30 37 47... 07G
+
+.sub_cbb46
+    lda #&c0                                                          ; bb46: a9 c0       ..
+    bne cbb4c                                                         ; bb48: d0 02       ..
+.sub_cbb4a
+    lda #&40 ; '@'                                                    ; bb4a: a9 40       .@
+; &bb4c referenced 1 time by &bb48
+.cbb4c
+    pha                                                               ; bb4c: 48          H
+    jsr sub_cbad2                                                     ; bb4d: 20 d2 ba     ..
+    clv                                                               ; bb50: b8          .
+    jsr sub_cba67                                                     ; bb51: 20 67 ba     g.
+    bcs cbb6f                                                         ; bb54: b0 19       ..
+    sty l00ba                                                         ; bb56: 84 ba       ..
+    ldx #&bc                                                          ; bb58: a2 bc       ..
+    ldy #&f2                                                          ; bb5a: a0 f2       ..
+    jsr sub_cb850                                                     ; bb5c: 20 50 b8     P.
+    ldy l00ba                                                         ; bb5f: a4 ba       ..
+    pla                                                               ; bb61: 68          h
+    pha                                                               ; bb62: 48          H
+    bmi cbb90                                                         ; bb63: 30 2b       0+
+    lda #&2b ; '+'                                                    ; bb65: a9 2b       .+
+    jsr sub_cbac4                                                     ; bb67: 20 c4 ba     ..
+    php                                                               ; bb6a: 08          .
+    clv                                                               ; bb6b: b8          .
+    jsr sub_cba67                                                     ; bb6c: 20 67 ba     g.
+; &bb6f referenced 1 time by &bb54
+.cbb6f
+    bcs cbbd0                                                         ; bb6f: b0 5f       ._
+    sty l00ba                                                         ; bb71: 84 ba       ..
+    plp                                                               ; bb73: 28          (
+    bcc cbb89                                                         ; bb74: 90 13       ..
+    ldy #&f2                                                          ; bb76: a0 f2       ..
+    sec                                                               ; bb78: 38          8
+    lda l00bc                                                         ; bb79: a5 bc       ..
+    sec                                                               ; bb7b: 38          8
+    sbc (l00b8),y                                                     ; bb7c: f1 b8       ..
+    sta l00bc                                                         ; bb7e: 85 bc       ..
+    iny                                                               ; bb80: c8          .
+    lda l00bd                                                         ; bb81: a5 bd       ..
+    sbc (l00b8),y                                                     ; bb83: f1 b8       ..
+    bcc cbbd0                                                         ; bb85: 90 49       .I
+    sta l00bd                                                         ; bb87: 85 bd       ..
+; &bb89 referenced 1 time by &bb74
+.cbb89
+    ldx #&bc                                                          ; bb89: a2 bc       ..
+    ldy #&f4                                                          ; bb8b: a0 f4       ..
+    jsr sub_cb850                                                     ; bb8d: 20 50 b8     P.
+; &bb90 referenced 1 time by &bb63
+.cbb90
+    ldy l00ba                                                         ; bb90: a4 ba       ..
+    jsr sub_cbb00                                                     ; bb92: 20 00 bb     ..
+    sty l00ba                                                         ; bb95: 84 ba       ..
+    bcs cbba1                                                         ; bb97: b0 08       ..
+    ldy #&f1                                                          ; bb99: a0 f1       ..
+    sta (l00b8),y                                                     ; bb9b: 91 b8       ..
+    pla                                                               ; bb9d: 68          h
+    and #&80                                                          ; bb9e: 29 80       ).
+    pha                                                               ; bba0: 48          H
+; &bba1 referenced 1 time by &bb97
+.cbba1
+    pla                                                               ; bba1: 68          h
+    sta l00bb                                                         ; bba2: 85 bb       ..
+    ldy #&ee                                                          ; bba4: a0 ee       ..
+    lda (l00b8),y                                                     ; bba6: b1 b8       ..
+    and #&3f ; '?'                                                    ; bba8: 29 3f       )?
+    ora l00bb                                                         ; bbaa: 05 bb       ..
+    sta (l00b8),y                                                     ; bbac: 91 b8       ..
+    ldy l00ba                                                         ; bbae: a4 ba       ..
+    jsr sub_cbab9                                                     ; bbb0: 20 b9 ba     ..
+    and #&df                                                          ; bbb3: 29 df       ).
+    ldx #0                                                            ; bbb5: a2 00       ..
+    cmp #&51 ; 'Q'                                                    ; bbb7: c9 51       .Q
+    bne cbbbe                                                         ; bbb9: d0 03       ..
+    iny                                                               ; bbbb: c8          .
+    ldx #&ff                                                          ; bbbc: a2 ff       ..
+; &bbbe referenced 1 time by &bbb9
+.cbbbe
+    jsr sub_cbac2                                                     ; bbbe: 20 c2 ba     ..
+    bcs cbbd0                                                         ; bbc1: b0 0d       ..
+    ldy #&f8                                                          ; bbc3: a0 f8       ..
+    lda #0                                                            ; bbc5: a9 00       ..
+    sta (l00b8),y                                                     ; bbc7: 91 b8       ..
+    iny                                                               ; bbc9: c8          .
+    txa                                                               ; bbca: 8a          .
+    sta (l00b8),y                                                     ; bbcb: 91 b8       ..
+    jmp cb2e7                                                         ; bbcd: 4c e7 b2    L..
+
+; &bbd0 referenced 9 times by &bb6f, &bb85, &bbc1, &bbe0, &bbf6, &bc1f, &bc2f, &bc3a, &bc40
+.cbbd0
+    jmp cbaf8                                                         ; bbd0: 4c f8 ba    L..
+
+.sub_cbbd3
+    lda #&c0                                                          ; bbd3: a9 c0       ..
+    bne cbbd9                                                         ; bbd5: d0 02       ..
+.sub_cbbd7
+    lda #&40 ; '@'                                                    ; bbd7: a9 40       .@
+; &bbd9 referenced 1 time by &bbd5
+.cbbd9
+    pha                                                               ; bbd9: 48          H
+    bit lb57f                                                         ; bbda: 2c 7f b5    ,..
+    jsr sub_cba67                                                     ; bbdd: 20 67 ba     g.
+    bcs cbbd0                                                         ; bbe0: b0 ee       ..
+    ldx #3                                                            ; bbe2: a2 03       ..
+; &bbe4 referenced 1 time by &bbe9
+.loop_cbbe4
+    lda l00bc,x                                                       ; bbe4: b5 bc       ..
+    sta l00b1,x                                                       ; bbe6: 95 b1       ..
+    dex                                                               ; bbe8: ca          .
+    bpl loop_cbbe4                                                    ; bbe9: 10 f9       ..
+    lda #&2b ; '+'                                                    ; bbeb: a9 2b       .+
+    jsr sub_cbac4                                                     ; bbed: 20 c4 ba     ..
+    bcs cbbf3                                                         ; bbf0: b0 01       ..
+    clv                                                               ; bbf2: b8          .
+; &bbf3 referenced 1 time by &bbf0
+.cbbf3
+    jsr sub_cba67                                                     ; bbf3: 20 67 ba     g.
+    bcs cbbd0                                                         ; bbf6: b0 d8       ..
+    bvc cbc13                                                         ; bbf8: 50 19       P.
+    sec                                                               ; bbfa: 38          8
+    ldx #0                                                            ; bbfb: a2 00       ..
+    sec                                                               ; bbfd: 38          8
+; &bbfe referenced 1 time by &bc08
+.loop_cbbfe
+    lda l00bc,x                                                       ; bbfe: b5 bc       ..
+    sbc l00b1,x                                                       ; bc00: f5 b1       ..
+    sta l00bc,x                                                       ; bc02: 95 bc       ..
+    inx                                                               ; bc04: e8          .
+    txa                                                               ; bc05: 8a          .
+    and #4                                                            ; bc06: 29 04       ).
+    beq loop_cbbfe                                                    ; bc08: f0 f4       ..
+    lda l00be                                                         ; bc0a: a5 be       ..
+    ora l00bf                                                         ; bc0c: 05 bf       ..
+    beq cbc13                                                         ; bc0e: f0 03       ..
+    jmp cb446                                                         ; bc10: 4c 46 b4    LF.
+
+; &bc13 referenced 2 times by &bbf8, &bc0e
+.cbc13
+    lda l00bc                                                         ; bc13: a5 bc       ..
+    sta l00b5                                                         ; bc15: 85 b5       ..
+    lda l00bd                                                         ; bc17: a5 bd       ..
+    sta l00b6                                                         ; bc19: 85 b6       ..
+    clv                                                               ; bc1b: b8          .
+    jsr sub_cba67                                                     ; bc1c: 20 67 ba     g.
+    bcs cbbd0                                                         ; bc1f: b0 af       ..
+    jsr sub_cbb00                                                     ; bc21: 20 00 bb     ..
+    bcs cbc2c                                                         ; bc24: b0 06       ..
+    sta l00b7                                                         ; bc26: 85 b7       ..
+    pla                                                               ; bc28: 68          h
+    and #&bf                                                          ; bc29: 29 bf       ).
+    pha                                                               ; bc2b: 48          H
+; &bc2c referenced 1 time by &bc24
+.cbc2c
+    jsr sub_cbac2                                                     ; bc2c: 20 c2 ba     ..
+    bcs cbbd0                                                         ; bc2f: b0 9f       ..
+    pla                                                               ; bc31: 68          h
+    sta l00b0                                                         ; bc32: 85 b0       ..
+    jmp cbcb9                                                         ; bc34: 4c b9 bc    L..
+
+.sub_cbc37
+    jsr sub_cbb00                                                     ; bc37: 20 00 bb     ..
+; &bc3a referenced 2 times by &bc84, &bc8a
+.cbc3a
+    bcs cbbd0                                                         ; bc3a: b0 94       ..
+    pha                                                               ; bc3c: 48          H
+    jsr sub_cbac2                                                     ; bc3d: 20 c2 ba     ..
+    bcs cbbd0                                                         ; bc40: b0 8e       ..
+    pla                                                               ; bc42: 68          h
+    tay                                                               ; bc43: a8          .
+    jsr sub_cb6fe                                                     ; bc44: 20 fe b6     ..
+    bne cbc64                                                         ; bc47: d0 1b       ..
+    jsr sub_cb986                                                     ; bc49: 20 86 b9     ..
+    tax                                                               ; bc4c: aa          .
+    bne cbc54                                                         ; bc4d: d0 05       ..
+    ldx #5                                                            ; bc4f: a2 05       ..
+    jmp cb8fb                                                         ; bc51: 4c fb b8    L..
+
+; &bc54 referenced 1 time by &bc4d
+.cbc54
+    sty l00bf                                                         ; bc54: 84 bf       ..
+    lda lb726,y                                                       ; bc56: b9 26 b7    .&.
+    ldy #&fd                                                          ; bc59: a0 fd       ..
+    ora (l00b8),y                                                     ; bc5b: 11 b8       ..
+    sta (l00b8),y                                                     ; bc5d: 91 b8       ..
+    ldy l00bf                                                         ; bc5f: a4 bf       ..
+    jsr sub_cbc68                                                     ; bc61: 20 68 bc     h.
+; &bc64 referenced 1 time by &bc47
+.cbc64
+    jsr sub_cbec2                                                     ; bc64: 20 c2 be     ..
+    rts                                                               ; bc67: 60          `
+
+; &bc68 referenced 2 times by &bc61, &bc95
+.sub_cbc68
+    ldx #&0f                                                          ; bc68: a2 0f       ..
+    stx l00ba                                                         ; bc6a: 86 ba       ..
+    lda #&80                                                          ; bc6c: a9 80       ..
+    sta l00bb                                                         ; bc6e: 85 bb       ..
+; &bc70 referenced 1 time by &bc7e
+.loop_cbc70
+    lda lb872,x                                                       ; bc70: bd 72 b8    .r.
+    cpx #1                                                            ; bc73: e0 01       ..
+    bne cbc78                                                         ; bc75: d0 01       ..
+    tya                                                               ; bc77: 98          .
+; &bc78 referenced 1 time by &bc75
+.cbc78
+    jsr sub_cb745                                                     ; bc78: 20 45 b7     E.
+    dex                                                               ; bc7b: ca          .
+    stx l00ba                                                         ; bc7c: 86 ba       ..
+    bpl loop_cbc70                                                    ; bc7e: 10 f0       ..
+    rts                                                               ; bc80: 60          `
+
+.sub_cbc81
+    jsr sub_cbb00                                                     ; bc81: 20 00 bb     ..
+    bcs cbc3a                                                         ; bc84: b0 b4       ..
+    pha                                                               ; bc86: 48          H
+    jsr sub_cbac2                                                     ; bc87: 20 c2 ba     ..
+    bcs cbc3a                                                         ; bc8a: b0 ae       ..
+    pla                                                               ; bc8c: 68          h
+    tay                                                               ; bc8d: a8          .
+    jsr sub_cb6fe                                                     ; bc8e: 20 fe b6     ..
+    beq cbcb2                                                         ; bc91: f0 1f       ..
+; &bc93 referenced 1 time by &bcb6
+.cbc93
+    sty l00bc                                                         ; bc93: 84 bc       ..
+    jsr sub_cbc68                                                     ; bc95: 20 68 bc     h.
+    lda #&0a                                                          ; bc98: a9 0a       ..
+    sta l00ba                                                         ; bc9a: 85 ba       ..
+    lda #&4f ; 'O'                                                    ; bc9c: a9 4f       .O
+    jsr sub_cb745                                                     ; bc9e: 20 45 b7     E.
+    lda lb726,y                                                       ; bca1: b9 26 b7    .&.
+    eor #&ff                                                          ; bca4: 49 ff       I.
+    ldy #&fd                                                          ; bca6: a0 fd       ..
+    and (l00b8),y                                                     ; bca8: 31 b8       1.
+    sta (l00b8),y                                                     ; bcaa: 91 b8       ..
+    ldy l00bc                                                         ; bcac: a4 bc       ..
+    jsr sub_cbec2                                                     ; bcae: 20 c2 be     ..
+    rts                                                               ; bcb1: 60          `
+
+; &bcb2 referenced 1 time by &bc91
+.cbcb2
+    jsr sub_cb986                                                     ; bcb2: 20 86 b9     ..
+    tax                                                               ; bcb5: aa          .
+    bne cbc93                                                         ; bcb6: d0 db       ..
+    rts                                                               ; bcb8: 60          `
+
+; &bcb9 referenced 2 times by &b1f6, &bc34
+.cbcb9
+    lda l00b0                                                         ; bcb9: a5 b0       ..
+    and #&c0                                                          ; bcbb: 29 c0       ).
+    sta l00be                                                         ; bcbd: 85 be       ..
+    ldy #&ee                                                          ; bcbf: a0 ee       ..
+    lda (l00b8),y                                                     ; bcc1: b1 b8       ..
+    and #&3f ; '?'                                                    ; bcc3: 29 3f       )?
+    ora l00be                                                         ; bcc5: 05 be       ..
+    sta (l00b8),y                                                     ; bcc7: 91 b8       ..
+    bit l00b0                                                         ; bcc9: 24 b0       $.
+    bvs cbcd6                                                         ; bccb: 70 09       p.
+    ldy l00b7                                                         ; bccd: a4 b7       ..
+    cpy #&14                                                          ; bccf: c0 14       ..
+    bcc cbce1                                                         ; bcd1: 90 0e       ..
+; &bcd3 referenced 1 time by &bcef
+.loop_cbcd3
+    jmp cb300                                                         ; bcd3: 4c 00 b3    L..
+
+; &bcd6 referenced 1 time by &bccb
+.cbcd6
+    ldx l00bc                                                         ; bcd6: a6 bc       ..
+    lda l00bd                                                         ; bcd8: a5 bd       ..
+    jsr sub_cb6b1                                                     ; bcda: 20 b1 b6     ..
+    stx l00bc                                                         ; bcdd: 86 bc       ..
+    sta l00bd                                                         ; bcdf: 85 bd       ..
+; &bce1 referenced 1 time by &bcd1
+.cbce1
+    jsr sub_cb6fe                                                     ; bce1: 20 fe b6     ..
+    pha                                                               ; bce4: 48          H
+    tya                                                               ; bce5: 98          .
+    ldy #&f1                                                          ; bce6: a0 f1       ..
+    sta (l00b8),y                                                     ; bce8: 91 b8       ..
+    pla                                                               ; bcea: 68          h
+    eor l00b0                                                         ; bceb: 45 b0       E.
+    and #&40 ; '@'                                                    ; bced: 29 40       )@
+    bne loop_cbcd3                                                    ; bcef: d0 e2       ..
+    jsr sub_cbe9d                                                     ; bcf1: 20 9d be     ..
+    jsr sub_cbe91                                                     ; bcf4: 20 91 be     ..
+    bcs cbd1b                                                         ; bcf7: b0 22       ."
+; &bcf9 referenced 1 time by &bd21
+.cbcf9
+    ldx #&b5                                                          ; bcf9: a2 b5       ..
+    ldy #&be                                                          ; bcfb: a0 be       ..
+    jsr sub_cb580                                                     ; bcfd: 20 80 b5     ..
+    rol l00b0                                                         ; bd00: 26 b0       &.
+    bcc cbd0e                                                         ; bd02: 90 0a       ..
+    ldx #&bc                                                          ; bd04: a2 bc       ..
+    ldy #&b3                                                          ; bd06: a0 b3       ..
+; &bd08 referenced 1 time by &bd19
+.loop_cbd08
+    jsr sub_cb580                                                     ; bd08: 20 80 b5     ..
+    jmp cb795                                                         ; bd0b: 4c 95 b7    L..
+
+; &bd0e referenced 1 time by &bd02
+.cbd0e
+    ldx #&b1                                                          ; bd0e: a2 b1       ..
+    ldy #&b3                                                          ; bd10: a0 b3       ..
+    jsr sub_cb580                                                     ; bd12: 20 80 b5     ..
+    ldx #&bc                                                          ; bd15: a2 bc       ..
+    ldy #&b1                                                          ; bd17: a0 b1       ..
+    bne loop_cbd08                                                    ; bd19: d0 ed       ..
+; &bd1b referenced 1 time by &bcf7
+.cbd1b
+    lda l00b3                                                         ; bd1b: a5 b3       ..
+    and l00b4                                                         ; bd1d: 25 b4       %.
+    cmp #&ff                                                          ; bd1f: c9 ff       ..
+    beq cbcf9                                                         ; bd21: f0 d6       ..
+    lda l00bc                                                         ; bd23: a5 bc       ..
+    pha                                                               ; bd25: 48          H
+    lda l00bd                                                         ; bd26: a5 bd       ..
+    pha                                                               ; bd28: 48          H
+    ldx #3                                                            ; bd29: a2 03       ..
+; &bd2b referenced 1 time by &bd30
+.loop_cbd2b
+    lda l00b1,x                                                       ; bd2b: b5 b1       ..
+    sta l00ba,x                                                       ; bd2d: 95 ba       ..
+    dex                                                               ; bd2f: ca          .
+    bpl loop_cbd2b                                                    ; bd30: 10 f9       ..
+    ldx #&b5                                                          ; bd32: a2 b5       ..
+    ldy #&f4                                                          ; bd34: a0 f4       ..
+    jsr sub_cb850                                                     ; bd36: 20 50 b8     P.
+    bit l00b0                                                         ; bd39: 24 b0       $.
+    bmi cbd40                                                         ; bd3b: 30 03       0.
+    jmp cbdba                                                         ; bd3d: 4c ba bd    L..
+
+; &bd40 referenced 1 time by &bd3b
+.cbd40
+    pla                                                               ; bd40: 68          h
+    sta l00b4                                                         ; bd41: 85 b4       ..
+    pla                                                               ; bd43: 68          h
+    sta l00b3                                                         ; bd44: 85 b3       ..
+; &bd46 referenced 1 time by &bdb6
+.cbd46
+    ldx #&be                                                          ; bd46: a2 be       ..
+    ldy #&f4                                                          ; bd48: a0 f4       ..
+    jsr sub_cb841                                                     ; bd4a: 20 41 b8     A.
+    lda l00bf                                                         ; bd4d: a5 bf       ..
+    bne cbd7e                                                         ; bd4f: d0 2d       .-
+    ldx l00be                                                         ; bd51: a6 be       ..
+    beq cbdb9                                                         ; bd53: f0 64       .d
+    lda #0                                                            ; bd55: a9 00       ..
+    sta (l00b8),y                                                     ; bd57: 91 b8       ..
+    inc l00b9                                                         ; bd59: e6 b9       ..
+    jsr cbe7b                                                         ; bd5b: 20 7b be     {.
+    lda #0                                                            ; bd5e: a9 00       ..
+    ldx #&ba                                                          ; bd60: a2 ba       ..
+    ldy #0                                                            ; bd62: a0 00       ..
+    jsr tube_entry                                                    ; bd64: 20 06 04     ..
+    ldy #7                                                            ; bd67: a0 07       ..
+    jsr cbe89                                                         ; bd69: 20 89 be     ..
+; &bd6c referenced 1 time by &bd7a
+.loop_cbd6c
+    lda tube_host_r3_data                                             ; bd6c: ad e5 fe    ...
+    sta (l00b8),y                                                     ; bd6f: 91 b8       ..
+    ldx #3                                                            ; bd71: a2 03       ..
+    jsr cbe8d                                                         ; bd73: 20 8d be     ..
+    nop                                                               ; bd76: ea          .
+    iny                                                               ; bd77: c8          .
+    cpy l00be                                                         ; bd78: c4 be       ..
+    bne loop_cbd6c                                                    ; bd7a: d0 f0       ..
+    beq cbda3                                                         ; bd7c: f0 25       .%
+; &bd7e referenced 1 time by &bd4f
+.cbd7e
+    lda #0                                                            ; bd7e: a9 00       ..
+    sta l00be                                                         ; bd80: 85 be       ..
+    lda #1                                                            ; bd82: a9 01       ..
+    sta l00bf                                                         ; bd84: 85 bf       ..
+    inc l00b9                                                         ; bd86: e6 b9       ..
+    jsr cbe7b                                                         ; bd88: 20 7b be     {.
+    lda #6                                                            ; bd8b: a9 06       ..
+    ldx #&ba                                                          ; bd8d: a2 ba       ..
+    ldy #0                                                            ; bd8f: a0 00       ..
+    jsr tube_entry                                                    ; bd91: 20 06 04     ..
+    ldy #5                                                            ; bd94: a0 05       ..
+    jsr cbe89                                                         ; bd96: 20 89 be     ..
+; &bd99 referenced 1 time by &bda1
+.loop_cbd99
+    lda tube_host_r3_data                                             ; bd99: ad e5 fe    ...
+    sta (l00b8),y                                                     ; bd9c: 91 b8       ..
+    lda (l00b8),y                                                     ; bd9e: b1 b8       ..
+    iny                                                               ; bda0: c8          .
+    bne loop_cbd99                                                    ; bda1: d0 f6       ..
+; &bda3 referenced 1 time by &bd7c
+.cbda3
+    jsr sub_cbe83                                                     ; bda3: 20 83 be     ..
+    ldx #&b8                                                          ; bda6: a2 b8       ..
+    ldy #&b1                                                          ; bda8: a0 b1       ..
+    jsr sub_cb580                                                     ; bdaa: 20 80 b5     ..
+    dec l00b9                                                         ; bdad: c6 b9       ..
+    sec                                                               ; bdaf: 38          8
+    jsr cb795                                                         ; bdb0: 20 95 b7     ..
+    jsr cbe47                                                         ; bdb3: 20 47 be     G.
+    jmp cbd46                                                         ; bdb6: 4c 46 bd    LF.
+
+; &bdb9 referenced 2 times by &bd53, &bdcd
+.cbdb9
+    rts                                                               ; bdb9: 60          `
+
+; &bdba referenced 1 time by &bd3d
+.cbdba
+    pla                                                               ; bdba: 68          h
+    sta l00b2                                                         ; bdbb: 85 b2       ..
+    pla                                                               ; bdbd: 68          h
+    sta l00b1                                                         ; bdbe: 85 b1       ..
+; &bdc0 referenced 1 time by &be44
+.cbdc0
+    ldx #&be                                                          ; bdc0: a2 be       ..
+    ldy #&f4                                                          ; bdc2: a0 f4       ..
+    jsr sub_cb841                                                     ; bdc4: 20 41 b8     A.
+    lda l00bf                                                         ; bdc7: a5 bf       ..
+    bne cbdd3                                                         ; bdc9: d0 08       ..
+    ldx l00be                                                         ; bdcb: a6 be       ..
+    beq cbdb9                                                         ; bdcd: f0 ea       ..
+    lda #1                                                            ; bdcf: a9 01       ..
+    bne cbddd                                                         ; bdd1: d0 0a       ..
+; &bdd3 referenced 1 time by &bdc9
+.cbdd3
+    lda #0                                                            ; bdd3: a9 00       ..
+    sta l00be                                                         ; bdd5: 85 be       ..
+    lda #1                                                            ; bdd7: a9 01       ..
+    sta l00bf                                                         ; bdd9: 85 bf       ..
+    lda #7                                                            ; bddb: a9 07       ..
+; &bddd referenced 1 time by &bdd1
+.cbddd
+    pha                                                               ; bddd: 48          H
+    inc l00b9                                                         ; bdde: e6 b9       ..
+    ldx #&b8                                                          ; bde0: a2 b8       ..
+    ldy #&b3                                                          ; bde2: a0 b3       ..
+    jsr sub_cb580                                                     ; bde4: 20 80 b5     ..
+    lda l00be                                                         ; bde7: a5 be       ..
+    pha                                                               ; bde9: 48          H
+    dec l00b9                                                         ; bdea: c6 b9       ..
+    clc                                                               ; bdec: 18          .
+    jsr cb795                                                         ; bded: 20 95 b7     ..
+    pla                                                               ; bdf0: 68          h
+    sta l00be                                                         ; bdf1: 85 be       ..
+    pla                                                               ; bdf3: 68          h
+    cmp #1                                                            ; bdf4: c9 01       ..
+    bne cbe21                                                         ; bdf6: d0 29       .)
+    lda #0                                                            ; bdf8: a9 00       ..
+    ldy #&f4                                                          ; bdfa: a0 f4       ..
+    sta (l00b8),y                                                     ; bdfc: 91 b8       ..
+    inc l00b9                                                         ; bdfe: e6 b9       ..
+    jsr cbe7b                                                         ; be00: 20 7b be     {.
+    lda #1                                                            ; be03: a9 01       ..
+    ldx #&ba                                                          ; be05: a2 ba       ..
+    ldy #0                                                            ; be07: a0 00       ..
+    jsr tube_entry                                                    ; be09: 20 06 04     ..
+    ldy #0                                                            ; be0c: a0 00       ..
+; &be0e referenced 1 time by &be1d
+.loop_cbe0e
+    lda (l00b8),y                                                     ; be0e: b1 b8       ..
+    sta tube_host_r3_data                                             ; be10: 8d e5 fe    ...
+    ldx #3                                                            ; be13: a2 03       ..
+    jsr cbe8d                                                         ; be15: 20 8d be     ..
+    iny                                                               ; be18: c8          .
+    cpy l00be                                                         ; be19: c4 be       ..
+    cpy l00be                                                         ; be1b: c4 be       ..
+    bne loop_cbe0e                                                    ; be1d: d0 ef       ..
+    beq cbe3c                                                         ; be1f: f0 1b       ..
+; &be21 referenced 1 time by &bdf6
+.cbe21
+    inc l00b9                                                         ; be21: e6 b9       ..
+    jsr cbe7b                                                         ; be23: 20 7b be     {.
+    lda #7                                                            ; be26: a9 07       ..
+    ldx #&ba                                                          ; be28: a2 ba       ..
+    ldy #0                                                            ; be2a: a0 00       ..
+    jsr tube_entry                                                    ; be2c: 20 06 04     ..
+    ldy #0                                                            ; be2f: a0 00       ..
+; &be31 referenced 1 time by &be3a
+.loop_cbe31
+    lda (l00b8),y                                                     ; be31: b1 b8       ..
+    sta tube_host_r3_data                                             ; be33: 8d e5 fe    ...
+    nop                                                               ; be36: ea          .
+    nop                                                               ; be37: ea          .
+    nop                                                               ; be38: ea          .
+    iny                                                               ; be39: c8          .
+    bne loop_cbe31                                                    ; be3a: d0 f5       ..
+; &be3c referenced 1 time by &be1f
+.cbe3c
+    jsr sub_cbe83                                                     ; be3c: 20 83 be     ..
+    dec l00b9                                                         ; be3f: c6 b9       ..
+    jsr cbe47                                                         ; be41: 20 47 be     G.
+    jmp cbdc0                                                         ; be44: 4c c0 bd    L..
+
+; &be47 referenced 3 times by &bdb3, &be41, &be50
+.cbe47
+    ldx #1                                                            ; be47: a2 01       ..
+    inc l00ba,x                                                       ; be49: f6 ba       ..
+    bne cbe52                                                         ; be4b: d0 05       ..
+    inx                                                               ; be4d: e8          .
+    cpx #4                                                            ; be4e: e0 04       ..
+    bcc cbe47                                                         ; be50: 90 f5       ..
+; &be52 referenced 1 time by &be4b
+.cbe52
+    ldy #&f5                                                          ; be52: a0 f5       ..
+    lda (l00b8),y                                                     ; be54: b1 b8       ..
+    sec                                                               ; be56: 38          8
+    sbc #1                                                            ; be57: e9 01       ..
+    bcc cbe7a                                                         ; be59: 90 1f       ..
+    sta (l00b8),y                                                     ; be5b: 91 b8       ..
+    jsr sub_cb616                                                     ; be5d: 20 16 b6     ..
+    beq cbe7a                                                         ; be60: f0 18       ..
+    ldx l00b7                                                         ; be62: a6 b7       ..
+    jsr sub_cb85d                                                     ; be64: 20 5d b8     ].
+    bvc cbe7a                                                         ; be67: 50 11       P.
+    lda l00b1,x                                                       ; be69: b5 b1       ..
+    cmp #&c0                                                          ; be6b: c9 c0       ..
+    bcc cbe7a                                                         ; be6d: 90 0b       ..
+    lda #&10                                                          ; be6f: a9 10       ..
+    sta l00b0,x                                                       ; be71: 95 b0       ..
+    lda #&80                                                          ; be73: a9 80       ..
+    sta l00b1,x                                                       ; be75: 95 b1       ..
+    jsr sub_cb68f                                                     ; be77: 20 8f b6     ..
+; &be7a referenced 4 times by &be59, &be60, &be67, &be6d
+.cbe7a
+    rts                                                               ; be7a: 60          `
+
+; &be7b referenced 5 times by &bd5b, &bd88, &be00, &be23, &be80
+.cbe7b
+    lda #&c8                                                          ; be7b: a9 c8       ..
+    jsr tube_entry                                                    ; be7d: 20 06 04     ..
+    bcc cbe7b                                                         ; be80: 90 f9       ..
+    rts                                                               ; be82: 60          `
+
+; &be83 referenced 2 times by &bda3, &be3c
+.sub_cbe83
+    lda #&88                                                          ; be83: a9 88       ..
+    jsr tube_entry                                                    ; be85: 20 06 04     ..
+    rts                                                               ; be88: 60          `
+
+; &be89 referenced 3 times by &bd69, &bd96, &be8a
+.cbe89
+    dey                                                               ; be89: 88          .
+    bne cbe89                                                         ; be8a: d0 fd       ..
+    rts                                                               ; be8c: 60          `
+
+; &be8d referenced 3 times by &bd73, &be15, &be8e
+.cbe8d
+    dex                                                               ; be8d: ca          .
+    bne cbe8d                                                         ; be8e: d0 fd       ..
+    rts                                                               ; be90: 60          `
+
+; &be91 referenced 1 time by &bcf4
+.sub_cbe91
+    lda #osbyte_read_tube_presence                                    ; be91: a9 ea       ..
+    ldx #0                                                            ; be93: a2 00       ..
+    ldy #&ff                                                          ; be95: a0 ff       ..
+    jsr osbyte                                                        ; be97: 20 f4 ff     ..
+    cpx #&ff                                                          ; be9a: e0 ff       ..
+    rts                                                               ; be9c: 60          `
+
+; &be9d referenced 2 times by &b338, &bcf1
+.sub_cbe9d
+    jsr sub_cb85d                                                     ; be9d: 20 5d b8     ].
+    bpl cbec1                                                         ; bea0: 10 1f       ..
+    bvs cbec1                                                         ; bea2: 70 1d       p.
+    lda #0                                                            ; bea4: a9 00       ..
+    pha                                                               ; bea6: 48          H
+    ldy #&f1                                                          ; bea7: a0 f1       ..
+    lda (l00b8),y                                                     ; bea9: b1 b8       ..
+; &beab referenced 1 time by &bec6
+.loop_cbeab
+    pha                                                               ; beab: 48          H
+    lda #osbyte_read_rom_info_table_low                               ; beac: a9 aa       ..
+    ldx #0                                                            ; beae: a2 00       ..
+    ldy #&ff                                                          ; beb0: a0 ff       ..
+    jsr osbyte                                                        ; beb2: 20 f4 ff     ..
+    jsr cb82b                                                         ; beb5: 20 2b b8     +.
+    stx l00ba                                                         ; beb8: 86 ba       ..
+    sty l00bb                                                         ; beba: 84 bb       ..
+    pla                                                               ; bebc: 68          h
+    tay                                                               ; bebd: a8          .
+    pla                                                               ; bebe: 68          h
+    sta (l00ba),y                                                     ; bebf: 91 ba       ..
+; &bec1 referenced 2 times by &bea0, &bea2
+.cbec1
+    rts                                                               ; bec1: 60          `
+
+; &bec2 referenced 2 times by &bc64, &bcae
+.sub_cbec2
+    lda #2                                                            ; bec2: a9 02       ..
+    pha                                                               ; bec4: 48          H
+    tya                                                               ; bec5: 98          .
+    bpl loop_cbeab                                                    ; bec6: 10 e3       ..
+; &bec8 referenced 1 time by &8003
+.service_handler
+    cmp #service_claim_absolute_workspace                             ; bec8: c9 01       ..
+    bne cbee0                                                         ; beca: d0 14       ..
+    pha                                                               ; becc: 48          H
+    tya                                                               ; becd: 98          .
+    pha                                                               ; bece: 48          H
+    lda #osbyte_issue_service_request                                 ; becf: a9 8f       ..
+    ldx #service_check_swr_presence                                   ; bed1: a2 2b       .+
+    ldy romsel_copy                                                   ; bed3: a4 f4       ..
+    jsr osbyte                                                        ; bed5: 20 f4 ff     ..
+    pla                                                               ; bed8: 68          h
+    tay                                                               ; bed9: a8          .
+    ldx romsel_copy                                                   ; beda: a6 f4       ..
+    pla                                                               ; bedc: 68          h
+; &bedd referenced 2 times by &bee2, &beec
+.general_service_handler_indirect
+    jmp general_service_handler                                       ; bedd: 4c b1 b1    L..
+
+; &bee0 referenced 1 time by &beca
+.cbee0
+    cmp #service_check_swr_presence                                   ; bee0: c9 2b       .+
+    bne general_service_handler_indirect                              ; bee2: d0 f9       ..
+    cpy romsel_copy                                                   ; bee4: c4 f4       ..
+    beq cbeee                                                         ; bee6: f0 06       ..
+; &bee8 referenced 4 times by &bef8, &beff, &bf08, &bf4c
+.cbee8
+    ldx romsel_copy                                                   ; bee8: a6 f4       ..
+    lda #0                                                            ; beea: a9 00       ..
+    beq general_service_handler_indirect                              ; beec: f0 ef       ..
+; &beee referenced 1 time by &bee6
+.cbeee
+    lda #&72 ; 'r'                                                    ; beee: a9 72       .r
+    ldx #0                                                            ; bef0: a2 00       ..
+    jsr osbyte                                                        ; bef2: 20 f4 ff     ..
+    jsr osbyte                                                        ; bef5: 20 f4 ff     ..
+    bvs cbee8                                                         ; bef8: 70 ee       p.
+    lda #&ea                                                          ; befa: a9 ea       ..
+    jsr sub_cbf82                                                     ; befc: 20 82 bf     ..
+    bne cbee8                                                         ; beff: d0 e7       ..
+    lda #&d7                                                          ; bf01: a9 d7       ..
+    ldy #&7f                                                          ; bf03: a0 7f       ..
+    jsr sub_cbf84                                                     ; bf05: 20 84 bf     ..
+    bpl cbee8                                                         ; bf08: 10 de       ..
+    jsr osnewl                                                        ; bf0a: 20 e7 ff     ..
+    ldx #0                                                            ; bf0d: a2 00       ..
+    jsr sub_cbf7c                                                     ; bf0f: 20 7c bf     |.
+    lda #&fd                                                          ; bf12: a9 fd       ..
+    jsr sub_cbf82                                                     ; bf14: 20 82 bf     ..
+    beq cbf46                                                         ; bf17: f0 2d       .-
+    tsx                                                               ; bf19: ba          .
+    ldy #&30 ; '0'                                                    ; bf1a: a0 30       .0
+; &bf1c referenced 1 time by &bf21
+.loop_cbf1c
+    lda cbf8a,y                                                       ; bf1c: b9 8a bf    ...
+    pha                                                               ; bf1f: 48          H
+    dey                                                               ; bf20: 88          .
+    bne loop_cbf1c                                                    ; bf21: d0 f9       ..
+    txa                                                               ; bf23: 8a          .
+    tay                                                               ; bf24: a8          .
+    lda #1                                                            ; bf25: a9 01       ..
+    pha                                                               ; bf27: 48          H
+    tsx                                                               ; bf28: ba          .
+    inx                                                               ; bf29: e8          .
+    txa                                                               ; bf2a: 8a          .
+    pha                                                               ; bf2b: 48          H
+    ldx #&0f                                                          ; bf2c: a2 0f       ..
+    lda #0                                                            ; bf2e: a9 00       ..
+    sta l00b0                                                         ; bf30: 85 b0       ..
+    rts                                                               ; bf32: 60          `
+
+; &bf33 referenced 1 time by &bfb8
+.cbf33
+    tya                                                               ; bf33: 98          .
+    tax                                                               ; bf34: aa          .
+    txs                                                               ; bf35: 9a          .
+    lda l00b0                                                         ; bf36: a5 b0       ..
+    asl a                                                             ; bf38: 0a          .
+    asl a                                                             ; bf39: 0a          .
+    clc                                                               ; bf3a: 18          .
+    adc #&0d                                                          ; bf3b: 69 0d       i.
+    tax                                                               ; bf3d: aa          .
+    jsr sub_cbf7c                                                     ; bf3e: 20 7c bf     |.
+    ldx #&0a                                                          ; bf41: a2 0a       ..
+    jsr sub_cbf7c                                                     ; bf43: 20 7c bf     |.
+; &bf46 referenced 1 time by &bf17
+.cbf46
+    jsr osnewl                                                        ; bf46: 20 e7 ff     ..
+    jsr osnewl                                                        ; bf49: 20 e7 ff     ..
+    jmp cbee8                                                         ; bf4c: 4c e8 be    L..
+
+; &bf4f referenced 1 time by &bf7c
+.lbf4f
+    equs "Acorn OS "                                                  ; bf4f: 41 63 6f... Aco
+    equb   0, &4b,   7,   0, &36, &34,   0,   0, &38, &30,   0,   0   ; bf58: 00 4b 07... .K.
+    equb &39, &36,   0,   0                                           ; bf64: 39 36 00... 96.
+    equs "112"                                                        ; bf68: 31 31 32    112
+    equb 0                                                            ; bf6b: 00          .
+    equs "128"                                                        ; bf6c: 31 32 38    128
+    equb 0                                                            ; bf6f: 00          .
+    equs "144"                                                        ; bf70: 31 34 34    144
+    equb 0                                                            ; bf73: 00          .
+    equs "160"                                                        ; bf74: 31 36 30    160
+    equb 0                                                            ; bf77: 00          .
+
+; &bf78 referenced 1 time by &bf7f
+.loop_cbf78
+    jsr oswrch                                                        ; bf78: 20 ee ff     ..
+    inx                                                               ; bf7b: e8          .
+; &bf7c referenced 3 times by &bf0f, &bf3e, &bf43
+.sub_cbf7c
+    lda lbf4f,x                                                       ; bf7c: bd 4f bf    .O.
+    bne loop_cbf78                                                    ; bf7f: d0 f7       ..
+    rts                                                               ; bf81: 60          `
+
+; &bf82 referenced 2 times by &befc, &bf14
+.sub_cbf82
+    ldy #&ff                                                          ; bf82: a0 ff       ..
+; &bf84 referenced 1 time by &bf05
+.sub_cbf84
+    ldx #0                                                            ; bf84: a2 00       ..
+    jsr osbyte                                                        ; bf86: 20 f4 ff     ..
+    txa                                                               ; bf89: 8a          .
+; &bf8a referenced 1 time by &bf1c
+.cbf8a
+    rts                                                               ; bf8a: 60          `
+
+    lda romsel_copy                                                   ; bf8b: a5 f4       ..
+    pha                                                               ; bf8d: 48          H
+; &bf8e referenced 2 times by &bfac, &bfb0
+.cbf8e
+    stx romsel_copy                                                   ; bf8e: 86 f4       ..
+    stx romsel                                                        ; bf90: 8e 30 fe    .0.
+    lda lbfff                                                         ; bf93: ad ff bf    ...
+    pha                                                               ; bf96: 48          H
+    eor #&a5                                                          ; bf97: 49 a5       I.
+    sta lbfff                                                         ; bf99: 8d ff bf    ...
+    cmp lbfff                                                         ; bf9c: cd ff bf    ...
+    bne cbfa3                                                         ; bf9f: d0 02       ..
+    inc l00b0                                                         ; bfa1: e6 b0       ..
+; &bfa3 referenced 1 time by &bf9f
+.cbfa3
+    pla                                                               ; bfa3: 68          h
+    sta lbfff                                                         ; bfa4: 8d ff bf    ...
+    dex                                                               ; bfa7: ca          .
+    bmi cbfb2                                                         ; bfa8: 30 08       0.
+    cpx #&0b                                                          ; bfaa: e0 0b       ..
+    bne cbf8e                                                         ; bfac: d0 e0       ..
+    ldx #1                                                            ; bfae: a2 01       ..
+    bne cbf8e                                                         ; bfb0: d0 dc       ..
+; &bfb2 referenced 1 time by &bfa8
+.cbfb2
+    pla                                                               ; bfb2: 68          h
+    sta romsel_copy                                                   ; bfb3: 85 f4       ..
+    sta romsel                                                        ; bfb5: 8d 30 fe    .0.
+    jmp cbf33                                                         ; bfb8: 4c 33 bf    L3.
+
+    equb &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff   ; bfbb: ff ff ff... ...
+    equb &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff   ; bfc7: ff ff ff... ...
+    equb &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff   ; bfd3: ff ff ff... ...
+    equb &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff   ; bfdf: ff ff ff... ...
+    equb &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff   ; bfeb: ff ff ff... ...
+    equb &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff                       ; bff7: ff ff ff... ...
+; &bfff referenced 4 times by &bf93, &bf99, &bf9c, &bfa4
+.lbfff
+    equb &ff                                                          ; bfff: ff          .
+.pydis_end
+
+; Label references by decreasing frequency:
+;     l00b8:                                125
+;     l00b0:                                105
+;     l00ba:                                 44
+;     l00bf:                                 42
+;     l00bc:                                 41
+;     l00b6:                                 35
+;     l00be:                                 31
+;     l00cd:                                 31
+;     print_inline_l809f_top_bit_clear:      31
+;     l00c2:                                 30
+;     l00b1:                                 29
+;     sub_c83e3:                             29
+;     l00b9:                                 28
+;     l00bb:                                 28
+;     l00b5:                                 26
+;     l00bd:                                 26
+;     l00b4:                                 25
+;     l00b3:                                 23
+;     l00c1:                                 23
+;     os_text_ptr:                           23
+;     osbyte:                                22
+;     romsel_copy:                           21
+;     l0f0e:                                 21
+;     caea0:                                 21
+;     l00c4:                                 20
+;     c809f:                                 20
+;     l00b2:                                 19
+;     l10c2:                                 19
+;     l0001:                                 18
+;     l00a8:                                 18
+;     l00aa:                                 18
+;     l00c5:                                 18
+;     l00c9:                                 18
+;     l10de:                                 18
+;     l0000:                                 17
+;     l00b7:                                 17
+;     l0e0f:                                 17
+;     l0f06:                                 17
+;     l1000:                                 17
+;     l00a2:                                 16
+;     l00ab:                                 16
+;     l00ae:                                 16
+;     ca3dc:                                 16
+;     cb82b:                                 16
+;     l00c0:                                 15
+;     l00c3:                                 15
+;     l00c7:                                 15
+;     l0f05:                                 15
+;     l00cc:                                 14
+;     l1117:                                 14
+;     cae70:                                 14
+;     caf7f:                                 14
+;     l00a1:                                 13
+;     l00a5:                                 13
+;     l00c8:                                 13
+;     l0f07:                                 13
+;     sub_ca14a:                             13
+;     tube_host_r3_data:                     13
+;     l00ac:                                 12
+;     clc_jmp_gsinit:                        12
+;     sub_cb841:                             12
+;     osasci:                                12
+;     l00c6:                                 11
+;     osrdsc_ptr:                            11
+;     l0e08:                                 11
+;     generate_error_precheck:               11
+;     sub_c8149:                             11
+;     c996e:                                 11
+;     cac0f:                                 11
+;     lfe84:                                 11
+;     tube_host_r2_data:                     11
+;     l00a9:                                 10
+;     l1111:                                 10
+;     l1112:                                 10
+;     sub_c80c3:                             10
+;     c93e6:                                 10
+;     cb203:                                 10
+;     lfe87:                                 10
+;     tube_host_r2_status:                   10
+;     l00ca:                                  9
+;     l1074:                                  9
+;     l108a:                                  9
+;     l1097:                                  9
+;     l10c0:                                  9
+;     l1110:                                  9
+;     cbbd0:                                  9
+;     l00ce:                                  8
+;     l00ff:                                  8
+;     l0100:                                  8
+;     l0df0:                                  8
+;     l0f04:                                  8
+;     l1060:                                  8
+;     l1082:                                  8
+;     l108b:                                  8
+;     l1090:                                  8
+;     l1096:                                  8
+;     l10ca:                                  8
+;     l10cf:                                  8
+;     l10d1:                                  8
+;     sub_c81b0:                              8
+;     sub_c81bf:                              8
+;     c8816:                                  8
+;     sub_c8b7b:                              8
+;     osbyte_read:                            8
+;     cae79:                                  8
+;     sub_cb85d:                              8
+;     tube_host_r1_status:                    8
+;     osfind:                                 8
+;     l00a7:                                  7
+;     l00cf:                                  7
+;     l0f08:                                  7
+;     l1075:                                  7
+;     l10c9:                                  7
+;     l10d2:                                  7
+;     l1114:                                  7
+;     generate_error2:                        7
+;     sub_c8284:                              7
+;     sub_c8380:                              7
+;     c8b8b:                                  7
+;     print_inline_osasci_top_bit_clear:      7
+;     sub_cb580:                              7
+;     sub_cbab9:                              7
+;     osrdsc:                                 7
+;     l0015:                                  6
+;     l00f3:                                  6
+;     l00f7:                                  6
+;     l0f0f:                                  6
+;     l1100:                                  6
+;     generate_error_precheck_bad:            6
+;     sub_c8280:                              6
+;     sub_c82fe:                              6
+;     command_table:                          6
+;     sub_c87da:                              6
+;     c940c:                                  6
+;     sub_c99ac:                              6
+;     zero_stacked_XXX:                       6
+;     sub_c9e75:                              6
+;     caf58:                                  6
+;     sub_cb5f2:                              6
+;     lb726:                                  6
+;     cb8fb:                                  6
+;     oswrch:                                 6
+;     l00a6:                                  5
+;     l00af:                                  5
+;     l00f0:                                  5
+;     l1087:                                  5
+;     l1088:                                  5
+;     l1099:                                  5
+;     l10c7:                                  5
+;     l10dd:                                  5
+;     l110c:                                  5
+;     l1115:                                  5
+;     l1116:                                  5
+;     sub_c80bb:                              5
+;     sub_c80ed:                              5
+;     sub_c80f3:                              5
+;     c8125:                                  5
+;     sub_c830a:                              5
+;     sub_c8335:                              5
+;     sub_c8386:                              5
+;     sub_c840c:                              5
+;     c8ba2:                                  5
+;     sub_c8f3f:                              5
+;     c9257:                                  5
+;     c99a3:                                  5
+;     sub_c9a6e:                              5
+;     sub_c9ab8:                              5
+;     sub_ca0de:                              5
+;     sub_ca1b4:                              5
+;     cae97:                                  5
+;     sub_cb6fe:                              5
+;     sub_cb745:                              5
+;     cb795:                                  5
+;     sub_cb850:                              5
+;     sub_cba67:                              5
+;     cbe7b:                                  5
+;     osnewl:                                 5
+;     l0002:                                  4
+;     l0e00:                                  4
+;     l0f0c:                                  4
+;     l0f0d:                                  4
+;     l1069:                                  4
+;     l1076:                                  4
+;     l1077:                                  4
+;     l1081:                                  4
+;     l1086:                                  4
+;     l1095:                                  4
+;     l10c4:                                  4
+;     l10cb:                                  4
+;     l10cc:                                  4
+;     l10ce:                                  4
+;     l10d9:                                  4
+;     l10da:                                  4
+;     l110d:                                  4
+;     l1113:                                  4
+;     l111a:                                  4
+;     l111d:                                  4
+;     generate_error_precheck_disc:           4
+;     generate_error:                         4
+;     sub_c80c8:                              4
+;     sub_c8174:                              4
+;     c81a7:                                  4
+;     sub_c821d:                              4
+;     c8225:                                  4
+;     sub_c82b2:                              4
+;     sub_c8327:                              4
+;     inc16_ae:                               4
+;     c8d74:                                  4
+;     c8d91:                                  4
+;     c8e0e:                                  4
+;     c8e12:                                  4
+;     c8e64:                                  4
+;     sub_c8f6b:                              4
+;     c940e:                                  4
+;     c9436:                                  4
+;     c993b:                                  4
+;     sub_c9965:                              4
+;     sub_c9a8d:                              4
+;     c9adf:                                  4
+;     c9ae9:                                  4
+;     sub_ca379:                              4
+;     ca5e5:                                  4
+;     sub_ca9ca:                              4
+;     sub_caacf:                              4
+;     sub_cac18:                              4
+;     sub_cac62:                              4
+;     cad79:                                  4
+;     cb446:                                  4
+;     lb57f:                                  4
+;     sub_cb616:                              4
+;     cb68c:                                  4
+;     sub_cb68f:                              4
+;     sub_cb83f:                              4
+;     sub_cbac2:                              4
+;     sub_cbb00:                              4
+;     cbe7a:                                  4
+;     cbee8:                                  4
+;     lbfff:                                  4
+;     romsel:                                 4
+;     lfe85:                                  4
+;     lfe86:                                  4
+;     osbput:                                 4
+;     osbget:                                 4
+;     osfile:                                 4
+;     osrdch:                                 4
+;     l00ef:                                  3
+;     l0107:                                  3
+;     l0109:                                  3
+;     bytev:                                  3
+;     bytev+1:                                3
+;     l0ef8:                                  3
+;     l1092:                                  3
+;     l1093:                                  3
+;     l1094:                                  3
+;     l1098:                                  3
+;     l109d:                                  3
+;     l109f:                                  3
+;     l10c3:                                  3
+;     l10c5:                                  3
+;     l10c6:                                  3
+;     l10d0:                                  3
+;     l10d3:                                  3
+;     l10d6:                                  3
+;     l10d7:                                  3
+;     l1119:                                  3
+;     l111c:                                  3
+;     c8103:                                  3
+;     sub_c81be:                              3
+;     c8290:                                  3
+;     c82e6:                                  3
+;     sub_c833a:                              3
+;     sub_c836e:                              3
+;     c8454:                                  3
+;     sub_c8456:                              3
+;     c89d7:                                  3
+;     sub_c8b86:                              3
+;     c8d41:                                  3
+;     c8e53:                                  3
+;     c8ecc:                                  3
+;     c8f2a:                                  3
+;     sub_c8f7a:                              3
+;     nmi_handler2_rom_end:                   3
+;     c91af:                                  3
+;     c9214:                                  3
+;     sub_c93fd:                              3
+;     c9444:                                  3
+;     c94bc:                                  3
+;     sub_c9526:                              3
+;     c9738:                                  3
+;     sub_c9940:                              3
+;     c99ed:                                  3
+;     c9a8c:                                  3
+;     sub_c9be5:                              3
+;     generate_error_precheck_open:           3
+;     c9d5d:                                  3
+;     sub_c9e30:                              3
+;     sub_c9f0f:                              3
+;     sub_c9f16:                              3
+;     sub_c9f1e:                              3
+;     ca06b:                                  3
+;     ca14f:                                  3
+;     ca1c0:                                  3
+;     sub_ca315:                              3
+;     sub_ca384:                              3
+;     sub_ca530:                              3
+;     ca660:                                  3
+;     sub_ca9c2:                              3
+;     caa42:                                  3
+;     caa44:                                  3
+;     sub_cac0c:                              3
+;     cacc4:                                  3
+;     tube_host_code2:                        3
+;     sub_cad5d:                              3
+;     cad77:                                  3
+;     laf76:                                  3
+;     cb1d5:                                  3
+;     cb371:                                  3
+;     sub_cb58b:                              3
+;     cb684:                                  3
+;     cb6ca:                                  3
+;     sub_cb84e:                              3
+;     sub_cb986:                              3
+;     sram_table:                             3
+;     cbab4:                                  3
+;     sub_cbac4:                              3
+;     cbe47:                                  3
+;     cbe89:                                  3
+;     cbe8d:                                  3
+;     sub_cbf7c:                              3
+;     lfe80:                                  3
+;     tube_host_r1_data:                      3
+;     osword:                                 3
+;     oscli:                                  3
+;     l0003:                                  2
+;     l0012:                                  2
+;     l0014:                                  2
+;     l00a0:                                  2
+;     l00a3:                                  2
+;     l00a4:                                  2
+;     l00ad:                                  2
+;     l00fd:                                  2
+;     l0101:                                  2
+;     l0102:                                  2
+;     l0105:                                  2
+;     l010b:                                  2
+;     l0128:                                  2
+;     fscv:                                   2
+;     l0700:                                  2
+;     l0e07:                                  2
+;     l0f0a:                                  2
+;     l0f0b:                                  2
+;     l1045:                                  2
+;     l1062:                                  2
+;     l1065:                                  2
+;     l1067:                                  2
+;     l1078:                                  2
+;     l107d:                                  2
+;     l107e:                                  2
+;     l107f:                                  2
+;     l1089:                                  2
+;     l108c:                                  2
+;     l1091:                                  2
+;     l109a:                                  2
+;     l109b:                                  2
+;     l109e:                                  2
+;     l10c1:                                  2
+;     l10cd:                                  2
+;     l10d8:                                  2
+;     l10db:                                  2
+;     l10dc:                                  2
+;     l10e2:                                  2
+;     l10e3:                                  2
+;     l10e4:                                  2
+;     l1109:                                  2
+;     l110b:                                  2
+;     l110e:                                  2
+;     l110f:                                  2
+;     l111b:                                  2
+;     sub_c809a:                              2
+;     sub_c80e3:                              2
+;     c815d:                                  2
+;     sub_c81ae:                              2
+;     sub_c81c5:                              2
+;     c822a:                                  2
+;     c825d:                                  2
+;     sub_c8266:                              2
+;     sub_c826d:                              2
+;     sub_c82bb:                              2
+;     sub_c82e8:                              2
+;     c82fd:                                  2
+;     sub_c841b:                              2
+;     sub_c8439:                              2
+;     c8543:                                  2
+;     sub_c8555:                              2
+;     c8560:                                  2
+;     c85bc:                                  2
+;     c8703:                                  2
+;     c8705:                                  2
+;     c873b:                                  2
+;     sub_c8745:                              2
+;     sub_c87db:                              2
+;     sub_c87e3:                              2
+;     c8808:                                  2
+;     c883f:                                  2
+;     sub_c8855:                              2
+;     sub_c8862:                              2
+;     c88a6:                                  2
+;     c88f4:                                  2
+;     sub_c8951:                              2
+;     c898a:                                  2
+;     c89a5:                                  2
+;     c89b4:                                  2
+;     sub_c89da:                              2
+;     c8a00:                                  2
+;     c8a6e:                                  2
+;     sub_c8a77:                              2
+;     sub_c8ab3:                              2
+;     sub_c8b4d:                              2
+;     sub_c8b64:                              2
+;     c8be3:                                  2
+;     c8c12:                                  2
+;     c8cb2:                                  2
+;     c8d0d:                                  2
+;     c8d13:                                  2
+;     c8e0d:                                  2
+;     c8e32:                                  2
+;     c8e9f:                                  2
+;     c8ea5:                                  2
+;     c8eb7:                                  2
+;     c8eeb:                                  2
+;     c8f3e:                                  2
+;     c90c7:                                  2
+;     c91df:                                  2
+;     sub_c9279:                              2
+;     c9289:                                  2
+;     sub_c928a:                              2
+;     c9367:                                  2
+;     sub_c93c5:                              2
+;     sub_c93d3:                              2
+;     sub_c93f5:                              2
+;     sub_c9432:                              2
+;     sub_c9445:                              2
+;     c94a9:                                  2
+;     c94c6:                                  2
+;     sub_c9516:                              2
+;     sub_c952e:                              2
+;     c95fd:                                  2
+;     c9628:                                  2
+;     c965a:                                  2
+;     c96b7:                                  2
+;     c97b3:                                  2
+;     sub_c992c:                              2
+;     invert_l1065:                           2
+;     sub_c995a:                              2
+;     sub_c99f3:                              2
+;     sub_c9a0f:                              2
+;     sub_c9a50:                              2
+;     sub_c9a60:                              2
+;     sub_c9a63:                              2
+;     sub_c9a78:                              2
+;     sub_c9a82:                              2
+;     sub_c9aa3:                              2
+;     sub_c9ac8:                              2
+;     sub_c9ad8:                              2
+;     c9b6e:                                  2
+;     sub_c9b79:                              2
+;     c9bc5:                                  2
+;     sub_c9bf2:                              2
+;     sub_c9d1e:                              2
+;     c9dcd:                                  2
+;     c9dd5:                                  2
+;     sub_c9df4:                              2
+;     sub_c9e1e:                              2
+;     c9e41:                                  2
+;     sub_c9e54:                              2
+;     sub_c9ef4:                              2
+;     sub_c9f14:                              2
+;     sub_c9f26:                              2
+;     ca01d:                                  2
+;     ca021:                                  2
+;     ca06c:                                  2
+;     ca0f5:                                  2
+;     ca10b:                                  2
+;     sub_ca168:                              2
+;     ca19f:                                  2
+;     sub_ca1c6:                              2
+;     la1d3:                                  2
+;     ca2f2:                                  2
+;     sub_ca324:                              2
+;     ca38b:                                  2
+;     sub_ca3ec:                              2
+;     ca411:                                  2
+;     ca414:                                  2
+;     sub_ca51f:                              2
+;     ca5ab:                                  2
+;     sub_ca5b2:                              2
+;     ca637:                                  2
+;     ca845:                                  2
+;     ca86b:                                  2
+;     ca87a:                                  2
+;     sub_ca90d:                              2
+;     ca97d:                                  2
+;     ca9ff:                                  2
+;     caa1c:                                  2
+;     caa51:                                  2
+;     sub_caa53:                              2
+;     sub_caac2:                              2
+;     sub_caaf1:                              2
+;     cab1a:                                  2
+;     cab41:                                  2
+;     cab54:                                  2
+;     cabbc:                                  2
+;     sub_cac4e:                              2
+;     cad15:                                  2
+;     cadd7:                                  2
+;     tube_host_code2+256:                    2
+;     cae11:                                  2
+;     caed3:                                  2
+;     tube_banner_loop:                       2
+;     just_rts:                               2
+;     tube_host_code3:                        2
+;     laf75:                                  2
+;     laf77:                                  2
+;     laf78:                                  2
+;     tube_host_code1:                        2
+;     cafad:                                  2
+;     caffb:                                  2
+;     cb00a:                                  2
+;     cb035:                                  2
+;     sub_cb047:                              2
+;     cb280:                                  2
+;     cb297:                                  2
+;     cb2a0:                                  2
+;     cb300:                                  2
+;     cb406:                                  2
+;     cb45e:                                  2
+;     sub_cb598:                              2
+;     sub_cb5ce:                              2
+;     sub_cb5ee:                              2
+;     sub_cb607:                              2
+;     sub_cb61e:                              2
+;     cb655:                                  2
+;     sub_cb65f:                              2
+;     sub_cb6b1:                              2
+;     cb718:                                  2
+;     cb7ed:                                  2
+;     lb872:                                  2
+;     cb8e4:                                  2
+;     cb9e8:                                  2
+;     sub_cb9f5:                              2
+;     cba10:                                  2
+;     cbaf8:                                  2
+;     cbafd:                                  2
+;     cbb28:                                  2
+;     cbb2a:                                  2
+;     cbc13:                                  2
+;     cbc3a:                                  2
+;     sub_cbc68:                              2
+;     cbcb9:                                  2
+;     cbdb9:                                  2
+;     sub_cbe83:                              2
+;     sub_cbe9d:                              2
+;     cbec1:                                  2
+;     sub_cbec2:                              2
+;     general_service_handler_indirect:       2
+;     sub_cbf82:                              2
+;     cbf8e:                                  2
+;     tube_host_r4_status:                    2
+;     gsinit:                                 2
+;     gsread:                                 2
+;     osgbpb:                                 2
+;     osargs:                                 2
+;     l0013:                                  1
+;     l00f1:                                  1
+;     l0103:                                  1
+;     l0104:                                  1
+;     l010c:                                  1
+;     l010d:                                  1
+;     l010e:                                  1
+;     brkv:                                   1
+;     brkv+1:                                 1
+;     filev:                                  1
+;     evntv:                                  1
+;     evntv+1:                                1
+;     l028d:                                  1
+;     l0cff:                                  1
+;     l0e0e:                                  1
+;     l0e10:                                  1
+;     l0f00:                                  1
+;     l0f09:                                  1
+;     l0f10:                                  1
+;     l1001:                                  1
+;     l1002:                                  1
+;     l1003:                                  1
+;     l1004:                                  1
+;     l1005:                                  1
+;     l1006:                                  1
+;     l1007:                                  1
+;     l100e:                                  1
+;     l1047:                                  1
+;     l104d:                                  1
+;     l104e:                                  1
+;     l1050:                                  1
+;     l1058:                                  1
+;     l105f:                                  1
+;     l1061:                                  1
+;     l1063:                                  1
+;     l1064:                                  1
+;     l1072:                                  1
+;     l1079:                                  1
+;     l107a:                                  1
+;     l1083:                                  1
+;     l108f:                                  1
+;     rom_header:                             1
+;     l8001:                                  1
+;     l8002:                                  1
+;     service_entry:                          1
+;     l8004:                                  1
+;     rom_type:                               1
+;     copyright_offset:                       1
+;     sub_c8020:                              1
+;     c8040:                                  1
+;     loop_c8064:                             1
+;     loop_c8086:                             1
+;     c8093:                                  1
+;     c8096:                                  1
+;     sub_c809d:                              1
+;     sub_c80b8:                              1
+;     c80d0:                                  1
+;     sub_c80d3:                              1
+;     sub_c80db:                              1
+;     sub_c80e6:                              1
+;     sub_c80f6:                              1
+;     c8111:                                  1
+;     c8115:                                  1
+;     c812e:                                  1
+;     loop_c813a:                             1
+;     c815b:                                  1
+;     c815f:                                  1
+;     loop_c8161:                             1
+;     loop_c816b:                             1
+;     c8184:                                  1
+;     c818a:                                  1
+;     loop_c818c:                             1
+;     c81a2:                                  1
+;     sub_c81b7:                              1
+;     c81bd:                                  1
+;     sub_c81c0:                              1
+;     sub_c81c4:                              1
+;     sub_c81ca:                              1
+;     loop_c820c:                             1
+;     loop_c820d:                             1
+;     loop_c821c:                             1
+;     sub_c8222:                              1
+;     c8243:                                  1
+;     loop_c826f:                             1
+;     c8286:                                  1
+;     c828b:                                  1
+;     c82be:                                  1
+;     loop_c82c7:                             1
+;     loop_c82d1:                             1
+;     c82d9:                                  1
+;     c82e7:                                  1
+;     c82fb:                                  1
+;     c8306:                                  1
+;     loop_c830d:                             1
+;     loop_c8326:                             1
+;     c8332:                                  1
+;     c8333:                                  1
+;     loop_c8370:                             1
+;     loop_c8390:                             1
+;     loop_c8397:                             1
+;     c83ab:                                  1
+;     sub_c83bf:                              1
+;     c83cd:                                  1
+;     sub_c83d1:                              1
+;     sub_c83d4:                              1
+;     c83e2:                                  1
+;     sub_c83ee:                              1
+;     loop_c83f0:                             1
+;     loop_c83fa:                             1
+;     loop_c8406:                             1
+;     loop_c8425:                             1
+;     c842b:                                  1
+;     sub_c842c:                              1
+;     c8436:                                  1
+;     c8438:                                  1
+;     c8453:                                  1
+;     loop_c8463:                             1
+;     c8477:                                  1
+;     c8481:                                  1
+;     c8482:                                  1
+;     loop_c8493:                             1
+;     c849d:                                  1
+;     loop_c84e7:                             1
+;     loop_c8527:                             1
+;     c853e:                                  1
+;     loop_c8552:                             1
+;     c855f:                                  1
+;     loop_c8564:                             1
+;     c8573:                                  1
+;     loop_c857b:                             1
+;     c859b:                                  1
+;     loop_c85b5:                             1
+;     c85c5:                                  1
+;     opt4_table:                             1
+;     sub_c85e3:                              1
+;     sub_c8602:                              1
+;     command_table+1:                        1
+;     loop_c8717:                             1
+;     loop_c8725:                             1
+;     c8734:                                  1
+;     c8759:                                  1
+;     c8779:                                  1
+;     c877c:                                  1
+;     loop_c87a0:                             1
+;     c87ab:                                  1
+;     c87b8:                                  1
+;     loop_c87be:                             1
+;     c87c6:                                  1
+;     c8815:                                  1
+;     sub_c8826:                              1
+;     c8837:                                  1
+;     c8864:                                  1
+;     c8867:                                  1
+;     loop_c88bc:                             1
+;     c892d:                                  1
+;     sub_c8932:                              1
+;     c8945:                                  1
+;     loop_c895f:                             1
+;     c8968:                                  1
+;     c896b:                                  1
+;     sub_c8979:                              1
+;     loop_c8990:                             1
+;     c89ad:                                  1
+;     loop_c89c4:                             1
+;     loop_c89ca:                             1
+;     c89e2:                                  1
+;     c89f6:                                  1
+;     loop_c8a17:                             1
+;     c8a19:                                  1
+;     c8a49:                                  1
+;     c8a50:                                  1
+;     c8a54:                                  1
+;     c8a82:                                  1
+;     loop_c8ac8:                             1
+;     c8ad0:                                  1
+;     loop_c8ad8:                             1
+;     c8aeb:                                  1
+;     loop_c8af0:                             1
+;     loop_c8afb:                             1
+;     c8b18:                                  1
+;     sub_c8b25:                              1
+;     c8b60:                                  1
+;     c8b77:                                  1
+;     loop_c8b80:                             1
+;     loop_c8bea:                             1
+;     sub_c8bf6:                              1
+;     sub_c8bf9:                              1
+;     c8bfb:                                  1
+;     c8c2e:                                  1
+;     c8c3a:                                  1
+;     c8c4e:                                  1
+;     sub_c8c56:                              1
+;     loop_c8c58:                             1
+;     c8c61:                                  1
+;     sub_c8c65:                              1
+;     loop_c8c71:                             1
+;     c8c87:                                  1
+;     c8cae:                                  1
+;     c8cc1:                                  1
+;     c8cd6:                                  1
+;     c8ce7:                                  1
+;     c8cfc:                                  1
+;     c8d03:                                  1
+;     loop_c8d14:                             1
+;     loop_c8d17:                             1
+;     sub_c8d1a:                              1
+;     c8d5d:                                  1
+;     c8d92:                                  1
+;     loop_c8dac:                             1
+;     loop_c8dba:                             1
+;     sub_c8dc6:                              1
+;     c8dd2:                                  1
+;     c8de2:                                  1
+;     loop_c8de9:                             1
+;     loop_c8df0:                             1
+;     c8e03:                                  1
+;     loop_c8e14:                             1
+;     c8e4d:                                  1
+;     c8e6f:                                  1
+;     c8e72:                                  1
+;     loop_c8e85:                             1
+;     c8e9e:                                  1
+;     c8eaf:                                  1
+;     c8ecb:                                  1
+;     c8edf:                                  1
+;     sub_c8eec:                              1
+;     c8ef8:                                  1
+;     sub_c8efa:                              1
+;     sub_c8eff:                              1
+;     c8f12:                                  1
+;     loop_c8f17:                             1
+;     c8f21:                                  1
+;     sub_c8f33:                              1
+;     sub_c8f37:                              1
+;     sub_c8f4f:                              1
+;     sub_c8f5e:                              1
+;     loop_c8f6c:                             1
+;     sub_c8f75:                              1
+;     c8f81:                                  1
+;     sub_c8f82:                              1
+;     sub_c8f94:                              1
+;     loop_c8f96:                             1
+;     loop_c8fac:                             1
+;     c8fb5:                                  1
+;     c8fc7:                                  1
+;     nmi_handler_rom_start:                  1
+;     nmi3_handler_rom_start-1:               1
+;     nmi3_handler_rom_end:                   1
+;     loop_c9047:                             1
+;     c9060:                                  1
+;     nmi_handler2_rom_start-1:               1
+;     c90db:                                  1
+;     c90e7:                                  1
+;     set_c_iff_have_fdc:                     1
+;     loop_c9108:                             1
+;     loop_c9113:                             1
+;     c9115:                                  1
+;     l911d:                                  1
+;     l9121:                                  1
+;     nmi_and_table:                          1
+;     l9139:                                  1
+;     l913f:                                  1
+;     l9145:                                  1
+;     l9146:                                  1
+;     l9191:                                  1
+;     l91a0:                                  1
+;     loop_c91ba:                             1
+;     c91cc:                                  1
+;     loop_c91e7:                             1
+;     c91eb:                                  1
+;     c91f3:                                  1
+;     c91f9:                                  1
+;     c9201:                                  1
+;     c920d:                                  1
+;     c921f:                                  1
+;     c922b:                                  1
+;     c9238:                                  1
+;     c923b:                                  1
+;     c923f:                                  1
+;     c9249:                                  1
+;     c925a:                                  1
+;     c926a:                                  1
+;     c9276:                                  1
+;     c929c:                                  1
+;     sub_c929d:                              1
+;     c92bd:                                  1
+;     c92c4:                                  1
+;     c92c7:                                  1
+;     c92d6:                                  1
+;     c92e3:                                  1
+;     loop_c92ef:                             1
+;     c9302:                                  1
+;     loop_c9355:                             1
+;     loop_c9357:                             1
+;     c936b:                                  1
+;     loop_c936f:                             1
+;     c9379:                                  1
+;     loop_c9382:                             1
+;     c938d:                                  1
+;     c9390:                                  1
+;     c93a8:                                  1
+;     c93b1:                                  1
+;     sub_c93b4:                              1
+;     loop_c93bd:                             1
+;     c93c4:                                  1
+;     sub_c93d8:                              1
+;     loop_c93da:                             1
+;     c93e2:                                  1
+;     c93e5:                                  1
+;     sub_c93f1:                              1
+;     sub_c93f9:                              1
+;     c93ff:                                  1
+;     c9450:                                  1
+;     c945c:                                  1
+;     c948d:                                  1
+;     c94c1:                                  1
+;     c94c2:                                  1
+;     c94d4:                                  1
+;     c9504:                                  1
+;     c9535:                                  1
+;     sub_c9536:                              1
+;     loop_c953a:                             1
+;     c9556:                                  1
+;     c956d:                                  1
+;     c956f:                                  1
+;     loop_c957d:                             1
+;     loop_c9593:                             1
+;     loop_c95b6:                             1
+;     loop_c95d9:                             1
+;     c95e4:                                  1
+;     c95e7:                                  1
+;     loop_c95ec:                             1
+;     loop_c9618:                             1
+;     c9649:                                  1
+;     c964a:                                  1
+;     c9658:                                  1
+;     sub_c965d:                              1
+;     c967a:                                  1
+;     c9682:                                  1
+;     c9683:                                  1
+;     c969e:                                  1
+;     pla_rts:                                1
+;     loop_c96c2:                             1
+;     c96c3:                                  1
+;     c96e4:                                  1
+;     c96e9:                                  1
+;     c96ec:                                  1
+;     loop_c96f2:                             1
+;     c96f5:                                  1
+;     c9700:                                  1
+;     c9714:                                  1
+;     c9736:                                  1
+;     c973c:                                  1
+;     c973d:                                  1
+;     c975b:                                  1
+;     c976c:                                  1
+;     loop_c979d:                             1
+;     loop_c97c8:                             1
+;     c97e6:                                  1
+;     sub_c97e8:                              1
+;     loop_c9803:                             1
+;     c981f:                                  1
+;     c982e:                                  1
+;     sub_c9832:                              1
+;     c9835:                                  1
+;     loop_c9837:                             1
+;     c984c:                                  1
+;     loop_c9851:                             1
+;     c9859:                                  1
+;     loop_c985e:                             1
+;     c986b:                                  1
+;     c9873:                                  1
+;     loop_c9881:                             1
+;     loop_c98a0:                             1
+;     c98b1:                                  1
+;     c98ba:                                  1
+;     loop_c98c1:                             1
+;     c98cd:                                  1
+;     loop_c98e4:                             1
+;     c98ed:                                  1
+;     c98f0:                                  1
+;     loop_c9942:                             1
+;     c994b:                                  1
+;     loop_c994e:                             1
+;     loop_c9964:                             1
+;     c9978:                                  1
+;     sub_c9988:                              1
+;     c9993:                                  1
+;     loop_c99a8:                             1
+;     c99ea:                                  1
+;     c9a2a:                                  1
+;     sub_c9a32:                              1
+;     c9a3f:                                  1
+;     sub_c9a4b:                              1
+;     generate_error_precheck_locked:         1
+;     c9a73:                                  1
+;     c9a77:                                  1
+;     sub_c9ad3:                              1
+;     c9ad4:                                  1
+;     l9aec:                                  1
+;     l9b0f:                                  1
+;     l9b18:                                  1
+;     l9b21:                                  1
+;     l9b29:                                  1
+;     l9b31:                                  1
+;     l9b3a:                                  1
+;     l9b43:                                  1
+;     loop_c9b50:                             1
+;     sub_c9b51:                              1
+;     loop_c9b5e:                             1
+;     sub_c9b61:                              1
+;     loop_c9b63:                             1
+;     c9bc2:                                  1
+;     sub_c9bca:                              1
+;     sub_c9bcd:                              1
+;     loop_c9bcf:                             1
+;     loop_c9be4:                             1
+;     generate_error_precheck_disc_changed:   1
+;     c9c16:                                  1
+;     c9c33:                                  1
+;     loop_c9c38:                             1
+;     c9c51:                                  1
+;     c9c58:                                  1
+;     loop_c9c5d:                             1
+;     c9c6b:                                  1
+;     c9c8b:                                  1
+;     loop_c9c90:                             1
+;     loop_c9ca8:                             1
+;     c9cee:                                  1
+;     loop_c9d03:                             1
+;     c9d12:                                  1
+;     sub_c9d19:                              1
+;     c9d2b:                                  1
+;     loop_c9d43:                             1
+;     c9d57:                                  1
+;     c9d67:                                  1
+;     c9d71:                                  1
+;     c9d72:                                  1
+;     sub_c9d75:                              1
+;     c9d86:                                  1
+;     c9d89:                                  1
+;     c9db4:                                  1
+;     c9dce:                                  1
+;     loop_c9e07:                             1
+;     c9e13:                                  1
+;     c9e16:                                  1
+;     c9e28:                                  1
+;     c9e2a:                                  1
+;     osbyte_write_0:                         1
+;     c9e5c:                                  1
+;     c9e6f:                                  1
+;     c9e71:                                  1
+;     loop_c9e74:                             1
+;     loop_c9e8c:                             1
+;     sub_c9e94:                              1
+;     c9eb3:                                  1
+;     c9ec2:                                  1
+;     c9ef1:                                  1
+;     c9f0d:                                  1
+;     c9f19:                                  1
+;     c9f5e:                                  1
+;     c9f64:                                  1
+;     c9f6a:                                  1
+;     c9f6b:                                  1
+;     loop_c9f6e:                             1
+;     sub_c9f7c:                              1
+;     sub_c9f82:                              1
+;     c9f88:                                  1
+;     c9fd9:                                  1
+;     c9ff4:                                  1
+;     ca005:                                  1
+;     ca054:                                  1
+;     loop_ca061:                             1
+;     ca075:                                  1
+;     ca0a9:                                  1
+;     sub_ca0b8:                              1
+;     sub_ca0f6:                              1
+;     loop_ca11d:                             1
+;     loop_ca132:                             1
+;     loop_ca143:                             1
+;     loop_ca16e:                             1
+;     ca17a:                                  1
+;     ca183:                                  1
+;     sub_ca190:                              1
+;     loop_ca1aa:                             1
+;     ca1c1:                                  1
+;     loop_ca1cc:                             1
+;     ca1d2:                                  1
+;     ca27a:                                  1
+;     ca2ab:                                  1
+;     ca30d:                                  1
+;     ca321:                                  1
+;     ca34a:                                  1
+;     ca378:                                  1
+;     ca38c:                                  1
+;     ca38e:                                  1
+;     ca3ae:                                  1
+;     ca3bd:                                  1
+;     sub_ca3e4:                              1
+;     ca3fb:                                  1
+;     ca40c:                                  1
+;     ca45d:                                  1
+;     ca47b:                                  1
+;     loop_ca487:                             1
+;     sub_ca4e1:                              1
+;     ca4fa:                                  1
+;     loop_ca521:                             1
+;     ca538:                                  1
+;     ca547:                                  1
+;     ca574:                                  1
+;     ca595:                                  1
+;     ca5a0:                                  1
+;     ca5c4:                                  1
+;     ca5e2:                                  1
+;     ca5fb:                                  1
+;     ca605:                                  1
+;     ca63a:                                  1
+;     ca647:                                  1
+;     ca652:                                  1
+;     ca65d:                                  1
+;     sub_ca663:                              1
+;     ca675:                                  1
+;     ca68a:                                  1
+;     ca6b3:                                  1
+;     ca6b6:                                  1
+;     ca6bb:                                  1
+;     ca6ce:                                  1
+;     ca6e2:                                  1
+;     ca70a:                                  1
+;     ca712:                                  1
+;     ca721:                                  1
+;     ca728:                                  1
+;     ca73a:                                  1
+;     sub_ca73d:                              1
+;     sub_ca76c:                              1
+;     loop_ca76f:                             1
+;     sub_ca779:                              1
+;     ca787:                                  1
+;     sub_ca788:                              1
+;     ca7a4:                                  1
+;     loop_ca7a7:                             1
+;     sub_ca7c4:                              1
+;     sub_ca7c5:                              1
+;     loop_ca7c6:                             1
+;     sub_ca7ce:                              1
+;     loop_ca7e0:                             1
+;     loop_ca7e1:                             1
+;     ca7f2:                                  1
+;     ca7f7:                                  1
+;     ca818:                                  1
+;     ca82f:                                  1
+;     ca856:                                  1
+;     ca8bd:                                  1
+;     sub_ca8be:                              1
+;     sub_ca8e2:                              1
+;     ca8fa:                                  1
+;     ca902:                                  1
+;     ca90c:                                  1
+;     loop_ca941:                             1
+;     loop_ca947:                             1
+;     loop_ca953:                             1
+;     ca95d:                                  1
+;     ca96c:                                  1
+;     ca970:                                  1
+;     ca982:                                  1
+;     ca98d:                                  1
+;     loop_ca9ab:                             1
+;     ca9b8:                                  1
+;     sub_ca9bf:                              1
+;     loop_ca9e7:                             1
+;     loop_caa01:                             1
+;     caa0a:                                  1
+;     caa0d:                                  1
+;     sub_caa12:                              1
+;     caa78:                                  1
+;     caa7a:                                  1
+;     caa86:                                  1
+;     sub_caa9a:                              1
+;     caab7:                                  1
+;     loop_caab8:                             1
+;     caabe:                                  1
+;     caace:                                  1
+;     sub_caadd:                              1
+;     sub_caaea:                              1
+;     cab09:                                  1
+;     cab17:                                  1
+;     cab2e:                                  1
+;     cab35:                                  1
+;     cab3d:                                  1
+;     loop_cab6b:                             1
+;     cab7d:                                  1
+;     loop_cab80:                             1
+;     cab93:                                  1
+;     caba4:                                  1
+;     sub_caba9:                              1
+;     loop_cabad:                             1
+;     cabcf:                                  1
+;     loop_cabf4:                             1
+;     cabfb:                                  1
+;     cac28:                                  1
+;     cac45:                                  1
+;     loop_cac46:                             1
+;     sub_cac47:                              1
+;     sub_cac6a:                              1
+;     sub_cac72:                              1
+;     cacc7:                                  1
+;     lacf3:                                  1
+;     cad2d:                                  1
+;     cad3f:                                  1
+;     cad52:                                  1
+;     cad61:                                  1
+;     cad6e:                                  1
+;     cad81:                                  1
+;     cad86:                                  1
+;     cada2:                                  1
+;     cadae:                                  1
+;     cadc1:                                  1
+;     caddf:                                  1
+;     cadf8:                                  1
+;     cae06:                                  1
+;     cae20:                                  1
+;     cae27:                                  1
+;     cae32:                                  1
+;     cae35:                                  1
+;     cae40:                                  1
+;     cae45:                                  1
+;     cae5b:                                  1
+;     cae62:                                  1
+;     cae82:                                  1
+;     service_handler_help_and_tube:          1
+;     caed7:                                  1
+;     service_handler_tube_main_init:         1
+;     loop_caf13:                             1
+;     loop_caf2d:                             1
+;     lda_0_rts:                              1
+;     caf4b:                                  1
+;     caf54:                                  1
+;     caf5d:                                  1
+;     caf63:                                  1
+;     laf73:                                  1
+;     sub_caf8d:                              1
+;     sub_caf9a:                              1
+;     cafa1:                                  1
+;     cafab:                                  1
+;     cafae:                                  1
+;     cafbf:                                  1
+;     cafdc:                                  1
+;     cafdf:                                  1
+;     cafea:                                  1
+;     caff3:                                  1
+;     caffd:                                  1
+;     cb005:                                  1
+;     cb014:                                  1
+;     cb01f:                                  1
+;     sub_cb040:                              1
+;     cb05a:                                  1
+;     cb070:                                  1
+;     lb075:                                  1
+;     lb175:                                  1
+;     general_service_handler:                1
+;     cb1dd:                                  1
+;     loop_cb1e3:                             1
+;     loop_cb1ed:                             1
+;     cb1fc:                                  1
+;     cb20f:                                  1
+;     cb221:                                  1
+;     sub_cb234:                              1
+;     cb23d:                                  1
+;     loop_cb249:                             1
+;     cb260:                                  1
+;     cb268:                                  1
+;     loop_cb275:                             1
+;     lb283:                                  1
+;     cb2b2:                                  1
+;     loop_cb2b4:                             1
+;     loop_cb2bd:                             1
+;     sub_cb2c8:                              1
+;     loop_cb2d1:                             1
+;     cb2e1:                                  1
+;     cb2e7:                                  1
+;     cb305:                                  1
+;     cb314:                                  1
+;     cb337:                                  1
+;     cb34f:                                  1
+;     cb352:                                  1
+;     cb375:                                  1
+;     cb37f:                                  1
+;     cb382:                                  1
+;     cb397:                                  1
+;     cb3ba:                                  1
+;     cb3de:                                  1
+;     cb40e:                                  1
+;     cb44b:                                  1
+;     loop_cb44d:                             1
+;     cb45a:                                  1
+;     cb470:                                  1
+;     loop_cb4a8:                             1
+;     cb4af:                                  1
+;     cb4b4:                                  1
+;     cb4d8:                                  1
+;     cb4df:                                  1
+;     cb4e9:                                  1
+;     cb4ee:                                  1
+;     cb502:                                  1
+;     cb534:                                  1
+;     loop_cb55e:                             1
+;     loop_cb578:                             1
+;     cb597:                                  1
+;     loop_cb5c6:                             1
+;     cb5d0:                                  1
+;     cb5e6:                                  1
+;     loop_cb5ed:                             1
+;     cb65e:                                  1
+;     cb6a6:                                  1
+;     loop_cb6b3:                             1
+;     cb6c2:                                  1
+;     lb6c6:                                  1
+;     lb6ce:                                  1
+;     cb6d2:                                  1
+;     sub_cb6e6:                              1
+;     cb6eb:                                  1
+;     cb6f5:                                  1
+;     cb725:                                  1
+;     cb736:                                  1
+;     loop_cb75a:                             1
+;     sub_cb771:                              1
+;     lb774:                                  1
+;     cb7ae:                                  1
+;     cb7b2:                                  1
+;     sub_cb7b6:                              1
+;     loop_cb7be:                             1
+;     loop_cb7d7:                             1
+;     loop_cb7dd:                             1
+;     cb7e8:                                  1
+;     cb7ec:                                  1
+;     sub_cb86f:                              1
+;     lb87e:                                  1
+;     sub_cb882:                              1
+;     cb898:                                  1
+;     cb8e6:                                  1
+;     cb8f5:                                  1
+;     loop_cb910:                             1
+;     lb924:                                  1
+;     lb979:                                  1
+;     lb97a:                                  1
+;     lb980:                                  1
+;     loop_cb999:                             1
+;     cb9ae:                                  1
+;     loop_cb9bd:                             1
+;     loop_cb9cc:                             1
+;     loop_cb9d1:                             1
+;     cb9d2:                                  1
+;     cb9d9:                                  1
+;     cb9ee:                                  1
+;     cb9f7:                                  1
+;     loop_cb9f9:                             1
+;     cba15:                                  1
+;     cba19:                                  1
+;     loop_cba1a:                             1
+;     cba27:                                  1
+;     cba28:                                  1
+;     cba2e:                                  1
+;     cba2f:                                  1
+;     sram_table+1:                           1
+;     cba78:                                  1
+;     cba8c:                                  1
+;     loop_cba94:                             1
+;     cba9e:                                  1
+;     cbab0:                                  1
+;     cbab1:                                  1
+;     loop_cbab8:                             1
+;     cbad0:                                  1
+;     sub_cbad2:                              1
+;     loop_cbaea:                             1
+;     cbb07:                                  1
+;     cbb33:                                  1
+;     cbb36:                                  1
+;     lbb3a:                                  1
+;     lbb3e:                                  1
+;     lbb42:                                  1
+;     cbb4c:                                  1
+;     cbb6f:                                  1
+;     cbb89:                                  1
+;     cbb90:                                  1
+;     cbba1:                                  1
+;     cbbbe:                                  1
+;     cbbd9:                                  1
+;     loop_cbbe4:                             1
+;     cbbf3:                                  1
+;     loop_cbbfe:                             1
+;     cbc2c:                                  1
+;     cbc54:                                  1
+;     cbc64:                                  1
+;     loop_cbc70:                             1
+;     cbc78:                                  1
+;     cbc93:                                  1
+;     cbcb2:                                  1
+;     loop_cbcd3:                             1
+;     cbcd6:                                  1
+;     cbce1:                                  1
+;     cbcf9:                                  1
+;     loop_cbd08:                             1
+;     cbd0e:                                  1
+;     cbd1b:                                  1
+;     loop_cbd2b:                             1
+;     cbd40:                                  1
+;     cbd46:                                  1
+;     loop_cbd6c:                             1
+;     cbd7e:                                  1
+;     loop_cbd99:                             1
+;     cbda3:                                  1
+;     cbdba:                                  1
+;     cbdc0:                                  1
+;     cbdd3:                                  1
+;     cbddd:                                  1
+;     loop_cbe0e:                             1
+;     cbe21:                                  1
+;     loop_cbe31:                             1
+;     cbe3c:                                  1
+;     cbe52:                                  1
+;     sub_cbe91:                              1
+;     loop_cbeab:                             1
+;     service_handler:                        1
+;     cbee0:                                  1
+;     cbeee:                                  1
+;     loop_cbf1c:                             1
+;     cbf33:                                  1
+;     cbf46:                                  1
+;     lbf4f:                                  1
+;     loop_cbf78:                             1
+;     sub_cbf84:                              1
+;     cbf8a:                                  1
+;     cbfa3:                                  1
+;     cbfb2:                                  1
+;     tube_host_r4_data:                      1
+
+; Automatically generated labels:
+;     c0032
+;     c0036
+;     c0041
+;     c0400
+;     c0432
+;     c0434
+;     c0463
+;     c047a
+;     c0482
+;     c0484
+;     c048c
+;     c0491
+;     c049b
+;     c04bc
+;     c04f7
+;     c053a
+;     c0552
+;     c0593
+;     c059c
+;     c059e
+;     c05a6
+;     c05fc
+;     c0636
+;     c0645
+;     c0665
+;     c06a7
+;     c0d60
+;     c0d74
+;     c0d80
+;     c8040
+;     c8093
+;     c8096
+;     c809f
+;     c80d0
+;     c8103
+;     c8111
+;     c8115
+;     c8125
+;     c812e
+;     c815b
+;     c815d
+;     c815f
+;     c8184
+;     c818a
+;     c81a2
+;     c81a7
+;     c81bd
+;     c8225
+;     c822a
+;     c8243
+;     c825d
+;     c8286
+;     c828b
+;     c8290
+;     c82be
+;     c82d9
+;     c82e6
+;     c82e7
+;     c82fb
+;     c82fd
+;     c8306
+;     c8332
+;     c8333
+;     c83ab
+;     c83cd
+;     c83e2
+;     c842b
+;     c8436
+;     c8438
+;     c8453
+;     c8454
+;     c8477
+;     c8481
+;     c8482
+;     c849d
+;     c853e
+;     c8543
+;     c855f
+;     c8560
+;     c8573
+;     c859b
+;     c85bc
+;     c85c5
+;     c8703
+;     c8705
+;     c8734
+;     c873b
+;     c8759
+;     c8779
+;     c877c
+;     c87ab
+;     c87b8
+;     c87c6
+;     c8808
+;     c8815
+;     c8816
+;     c8837
+;     c883f
+;     c8864
+;     c8867
+;     c88a6
+;     c88f4
+;     c892d
+;     c8945
+;     c8968
+;     c896b
+;     c898a
+;     c89a5
+;     c89ad
+;     c89b4
+;     c89d7
+;     c89e2
+;     c89f6
+;     c8a00
+;     c8a19
+;     c8a49
+;     c8a50
+;     c8a54
+;     c8a6e
+;     c8a82
+;     c8ad0
+;     c8aeb
+;     c8b18
+;     c8b60
+;     c8b77
+;     c8b8b
+;     c8ba2
+;     c8be3
+;     c8bfb
+;     c8c12
+;     c8c2e
+;     c8c3a
+;     c8c4e
+;     c8c61
+;     c8c87
+;     c8cae
+;     c8cb2
+;     c8cc1
+;     c8cd6
+;     c8ce7
+;     c8cfc
+;     c8d03
+;     c8d0d
+;     c8d13
+;     c8d41
+;     c8d5d
+;     c8d74
+;     c8d91
+;     c8d92
+;     c8dd2
+;     c8de2
+;     c8e03
+;     c8e0d
+;     c8e0e
+;     c8e12
+;     c8e32
+;     c8e4d
+;     c8e53
+;     c8e64
+;     c8e6f
+;     c8e72
+;     c8e9e
+;     c8e9f
+;     c8ea5
+;     c8eaf
+;     c8eb7
+;     c8ecb
+;     c8ecc
+;     c8edf
+;     c8eeb
+;     c8ef8
+;     c8f12
+;     c8f21
+;     c8f2a
+;     c8f3e
+;     c8f81
+;     c8fb5
+;     c8fc7
+;     c9060
+;     c90c7
+;     c90db
+;     c90e7
+;     c9115
+;     c91af
+;     c91cc
+;     c91df
+;     c91eb
+;     c91f3
+;     c91f9
+;     c9201
+;     c920d
+;     c9214
+;     c921f
+;     c922b
+;     c9238
+;     c923b
+;     c923f
+;     c9249
+;     c9257
+;     c925a
+;     c926a
+;     c9276
+;     c9289
+;     c929c
+;     c92bd
+;     c92c4
+;     c92c7
+;     c92d6
+;     c92e3
+;     c9302
+;     c9367
+;     c936b
+;     c9379
+;     c938d
+;     c9390
+;     c93a8
+;     c93b1
+;     c93c4
+;     c93e2
+;     c93e5
+;     c93e6
+;     c93ff
+;     c940c
+;     c940e
+;     c9436
+;     c9444
+;     c9450
+;     c945c
+;     c948d
+;     c94a9
+;     c94bc
+;     c94c1
+;     c94c2
+;     c94c6
+;     c94d4
+;     c9504
+;     c9535
+;     c9556
+;     c956d
+;     c956f
+;     c95e4
+;     c95e7
+;     c95fd
+;     c9628
+;     c9649
+;     c964a
+;     c9658
+;     c965a
+;     c967a
+;     c9682
+;     c9683
+;     c969e
+;     c96b7
+;     c96c3
+;     c96e4
+;     c96e9
+;     c96ec
+;     c96f5
+;     c9700
+;     c9714
+;     c9736
+;     c9738
+;     c973c
+;     c973d
+;     c975b
+;     c976c
+;     c97b3
+;     c97e6
+;     c981f
+;     c982e
+;     c9835
+;     c984c
+;     c9859
+;     c986b
+;     c9873
+;     c98b1
+;     c98ba
+;     c98cd
+;     c98ed
+;     c98f0
+;     c993b
+;     c994b
+;     c996e
+;     c9978
+;     c9993
+;     c99a3
+;     c99ea
+;     c99ed
+;     c9a2a
+;     c9a3f
+;     c9a73
+;     c9a77
+;     c9a8c
+;     c9ad4
+;     c9adf
+;     c9ae9
+;     c9b6e
+;     c9bc2
+;     c9bc5
+;     c9c16
+;     c9c33
+;     c9c51
+;     c9c58
+;     c9c6b
+;     c9c8b
+;     c9cee
+;     c9d12
+;     c9d2b
+;     c9d57
+;     c9d5d
+;     c9d67
+;     c9d71
+;     c9d72
+;     c9d86
+;     c9d89
+;     c9db4
+;     c9dcd
+;     c9dce
+;     c9dd5
+;     c9e13
+;     c9e16
+;     c9e28
+;     c9e2a
+;     c9e41
+;     c9e5c
+;     c9e6f
+;     c9e71
+;     c9eb3
+;     c9ec2
+;     c9ef1
+;     c9f0d
+;     c9f19
+;     c9f5e
+;     c9f64
+;     c9f6a
+;     c9f6b
+;     c9f88
+;     c9fd9
+;     c9ff4
+;     ca005
+;     ca01d
+;     ca021
+;     ca054
+;     ca06b
+;     ca06c
+;     ca075
+;     ca0a9
+;     ca0f5
+;     ca10b
+;     ca14f
+;     ca17a
+;     ca183
+;     ca19f
+;     ca1c0
+;     ca1c1
+;     ca1d2
+;     ca27a
+;     ca2ab
+;     ca2f2
+;     ca30d
+;     ca321
+;     ca34a
+;     ca378
+;     ca38b
+;     ca38c
+;     ca38e
+;     ca3ae
+;     ca3bd
+;     ca3dc
+;     ca3fb
+;     ca40c
+;     ca411
+;     ca414
+;     ca45d
+;     ca47b
+;     ca4fa
+;     ca538
+;     ca547
+;     ca574
+;     ca595
+;     ca5a0
+;     ca5ab
+;     ca5c4
+;     ca5e2
+;     ca5e5
+;     ca5fb
+;     ca605
+;     ca637
+;     ca63a
+;     ca647
+;     ca652
+;     ca65d
+;     ca660
+;     ca675
+;     ca68a
+;     ca6b3
+;     ca6b6
+;     ca6bb
+;     ca6ce
+;     ca6e2
+;     ca70a
+;     ca712
+;     ca721
+;     ca728
+;     ca73a
+;     ca787
+;     ca7a4
+;     ca7f2
+;     ca7f7
+;     ca818
+;     ca82f
+;     ca845
+;     ca856
+;     ca86b
+;     ca87a
+;     ca8bd
+;     ca8fa
+;     ca902
+;     ca90c
+;     ca95d
+;     ca96c
+;     ca970
+;     ca97d
+;     ca982
+;     ca98d
+;     ca9b8
+;     ca9ff
+;     caa0a
+;     caa0d
+;     caa1c
+;     caa42
+;     caa44
+;     caa51
+;     caa78
+;     caa7a
+;     caa86
+;     caab7
+;     caabe
+;     caace
+;     cab09
+;     cab17
+;     cab1a
+;     cab2e
+;     cab35
+;     cab3d
+;     cab41
+;     cab54
+;     cab7d
+;     cab93
+;     caba4
+;     cabbc
+;     cabcf
+;     cabfb
+;     cac0f
+;     cac28
+;     cac45
+;     cacc4
+;     cacc7
+;     cad15
+;     cad2d
+;     cad3f
+;     cad52
+;     cad61
+;     cad6e
+;     cad77
+;     cad79
+;     cad81
+;     cad86
+;     cada2
+;     cadae
+;     cadc1
+;     cadd7
+;     caddf
+;     cadf8
+;     cae06
+;     cae11
+;     cae20
+;     cae27
+;     cae32
+;     cae35
+;     cae40
+;     cae45
+;     cae5b
+;     cae62
+;     cae70
+;     cae79
+;     cae82
+;     cae97
+;     caea0
+;     caed3
+;     caed7
+;     caf4b
+;     caf54
+;     caf58
+;     caf5d
+;     caf63
+;     caf7f
+;     cafa1
+;     cafab
+;     cafad
+;     cafae
+;     cafbf
+;     cafdc
+;     cafdf
+;     cafea
+;     caff3
+;     caffb
+;     caffd
+;     cb005
+;     cb00a
+;     cb014
+;     cb01f
+;     cb035
+;     cb05a
+;     cb070
+;     cb1d5
+;     cb1dd
+;     cb1fc
+;     cb203
+;     cb20f
+;     cb221
+;     cb23d
+;     cb260
+;     cb268
+;     cb280
+;     cb297
+;     cb2a0
+;     cb2b2
+;     cb2e1
+;     cb2e7
+;     cb300
+;     cb305
+;     cb314
+;     cb337
+;     cb34f
+;     cb352
+;     cb371
+;     cb375
+;     cb37f
+;     cb382
+;     cb397
+;     cb3ba
+;     cb3de
+;     cb406
+;     cb40e
+;     cb446
+;     cb44b
+;     cb45a
+;     cb45e
+;     cb470
+;     cb4af
+;     cb4b4
+;     cb4d8
+;     cb4df
+;     cb4e9
+;     cb4ee
+;     cb502
+;     cb534
+;     cb597
+;     cb5d0
+;     cb5e6
+;     cb655
+;     cb65e
+;     cb684
+;     cb68c
+;     cb6a6
+;     cb6c2
+;     cb6ca
+;     cb6d2
+;     cb6eb
+;     cb6f5
+;     cb718
+;     cb725
+;     cb736
+;     cb795
+;     cb7ae
+;     cb7b2
+;     cb7e8
+;     cb7ec
+;     cb7ed
+;     cb82b
+;     cb898
+;     cb8e4
+;     cb8e6
+;     cb8f5
+;     cb8fb
+;     cb9ae
+;     cb9d2
+;     cb9d9
+;     cb9e8
+;     cb9ee
+;     cb9f7
+;     cba10
+;     cba15
+;     cba19
+;     cba27
+;     cba28
+;     cba2e
+;     cba2f
+;     cba78
+;     cba8c
+;     cba9e
+;     cbab0
+;     cbab1
+;     cbab4
+;     cbad0
+;     cbaf8
+;     cbafd
+;     cbb07
+;     cbb28
+;     cbb2a
+;     cbb33
+;     cbb36
+;     cbb4c
+;     cbb6f
+;     cbb89
+;     cbb90
+;     cbba1
+;     cbbbe
+;     cbbd0
+;     cbbd9
+;     cbbf3
+;     cbc13
+;     cbc2c
+;     cbc3a
+;     cbc54
+;     cbc64
+;     cbc78
+;     cbc93
+;     cbcb2
+;     cbcb9
+;     cbcd6
+;     cbce1
+;     cbcf9
+;     cbd0e
+;     cbd1b
+;     cbd40
+;     cbd46
+;     cbd7e
+;     cbda3
+;     cbdb9
+;     cbdba
+;     cbdc0
+;     cbdd3
+;     cbddd
+;     cbe21
+;     cbe3c
+;     cbe47
+;     cbe52
+;     cbe7a
+;     cbe7b
+;     cbe89
+;     cbe8d
+;     cbec1
+;     cbee0
+;     cbee8
+;     cbeee
+;     cbf33
+;     cbf46
+;     cbf8a
+;     cbf8e
+;     cbfa3
+;     cbfb2
+;     l0000
+;     l0001
+;     l0002
+;     l0003
+;     l0012
+;     l0013
+;     l0014
+;     l0015
+;     l0053
+;     l0054
+;     l0055
+;     l0056
+;     l0057
+;     l00a0
+;     l00a1
+;     l00a2
+;     l00a3
+;     l00a4
+;     l00a5
+;     l00a6
+;     l00a7
+;     l00a8
+;     l00a9
+;     l00aa
+;     l00ab
+;     l00ac
+;     l00ad
+;     l00ae
+;     l00af
+;     l00b0
+;     l00b1
+;     l00b2
+;     l00b3
+;     l00b4
+;     l00b5
+;     l00b6
+;     l00b7
+;     l00b8
+;     l00b9
+;     l00ba
+;     l00bb
+;     l00bc
+;     l00bd
+;     l00be
+;     l00bf
+;     l00c0
+;     l00c1
+;     l00c2
+;     l00c3
+;     l00c4
+;     l00c5
+;     l00c6
+;     l00c7
+;     l00c8
+;     l00c9
+;     l00ca
+;     l00cc
+;     l00cd
+;     l00ce
+;     l00cf
+;     l00ef
+;     l00f0
+;     l00f1
+;     l00f3
+;     l00f7
+;     l00fd
+;     l00ff
+;     l0100
+;     l0101
+;     l0102
+;     l0103
+;     l0104
+;     l0105
+;     l0107
+;     l0109
+;     l010b
+;     l010c
+;     l010d
+;     l010e
+;     l0128
+;     l028d
+;     l04fc
+;     l0500
+;     l0600
+;     l06ce
+;     l0700
+;     l0cff
+;     l0d00
+;     l0d0f
+;     l0d12
+;     l0d1f
+;     l0d26
+;     l0d2a
+;     l0d30
+;     l0d3d
+;     l0d47
+;     l0d50
+;     l0d94
+;     l0df0
+;     l0e00
+;     l0e07
+;     l0e08
+;     l0e0e
+;     l0e0f
+;     l0e10
+;     l0ef8
+;     l0f00
+;     l0f04
+;     l0f05
+;     l0f06
+;     l0f07
+;     l0f08
+;     l0f09
+;     l0f0a
+;     l0f0b
+;     l0f0c
+;     l0f0d
+;     l0f0e
+;     l0f0f
+;     l0f10
+;     l1000
+;     l1001
+;     l1002
+;     l1003
+;     l1004
+;     l1005
+;     l1006
+;     l1007
+;     l100e
+;     l1045
+;     l1047
+;     l104d
+;     l104e
+;     l1050
+;     l1058
+;     l105f
+;     l1060
+;     l1061
+;     l1062
+;     l1063
+;     l1064
+;     l1065
+;     l1067
+;     l1069
+;     l1072
+;     l1074
+;     l1075
+;     l1076
+;     l1077
+;     l1078
+;     l1079
+;     l107a
+;     l107d
+;     l107e
+;     l107f
+;     l1081
+;     l1082
+;     l1083
+;     l1086
+;     l1087
+;     l1088
+;     l1089
+;     l108a
+;     l108b
+;     l108c
+;     l108f
+;     l1090
+;     l1091
+;     l1092
+;     l1093
+;     l1094
+;     l1095
+;     l1096
+;     l1097
+;     l1098
+;     l1099
+;     l109a
+;     l109b
+;     l109d
+;     l109e
+;     l109f
+;     l10c0
+;     l10c1
+;     l10c2
+;     l10c3
+;     l10c4
+;     l10c5
+;     l10c6
+;     l10c7
+;     l10c9
+;     l10ca
+;     l10cb
+;     l10cc
+;     l10cd
+;     l10ce
+;     l10cf
+;     l10d0
+;     l10d1
+;     l10d2
+;     l10d3
+;     l10d6
+;     l10d7
+;     l10d8
+;     l10d9
+;     l10da
+;     l10db
+;     l10dc
+;     l10dd
+;     l10de
+;     l10e2
+;     l10e3
+;     l10e4
+;     l1100
+;     l1109
+;     l110b
+;     l110c
+;     l110d
+;     l110e
+;     l110f
+;     l1110
+;     l1111
+;     l1112
+;     l1113
+;     l1114
+;     l1115
+;     l1116
+;     l1117
+;     l1119
+;     l111a
+;     l111b
+;     l111c
+;     l111d
+;     l8001
+;     l8002
+;     l8004
+;     l911d
+;     l9121
+;     l9139
+;     l913f
+;     l9145
+;     l9146
+;     l9191
+;     l91a0
+;     l9aec
+;     l9b0f
+;     l9b18
+;     l9b21
+;     l9b29
+;     l9b31
+;     l9b3a
+;     l9b43
+;     la1d3
+;     lacf3
+;     laf73
+;     laf75
+;     laf76
+;     laf77
+;     laf78
+;     lb075
+;     lb175
+;     lb283
+;     lb57f
+;     lb6c6
+;     lb6ce
+;     lb726
+;     lb774
+;     lb872
+;     lb87e
+;     lb924
+;     lb979
+;     lb97a
+;     lb980
+;     lbb3a
+;     lbb3e
+;     lbb42
+;     lbf4f
+;     lbfff
+;     lfe80
+;     lfe84
+;     lfe85
+;     lfe86
+;     lfe87
+;     loop_c0029
+;     loop_c003b
+;     loop_c0446
+;     loop_c0466
+;     loop_c0471
+;     loop_c04a6
+;     loop_c04e1
+;     loop_c0564
+;     loop_c0577
+;     loop_c0586
+;     loop_c05ab
+;     loop_c05c7
+;     loop_c05d3
+;     loop_c05e6
+;     loop_c0604
+;     loop_c061d
+;     loop_c062b
+;     loop_c064c
+;     loop_c0657
+;     loop_c065a
+;     loop_c8064
+;     loop_c8086
+;     loop_c813a
+;     loop_c8161
+;     loop_c816b
+;     loop_c818c
+;     loop_c820c
+;     loop_c820d
+;     loop_c821c
+;     loop_c826f
+;     loop_c82c7
+;     loop_c82d1
+;     loop_c830d
+;     loop_c8326
+;     loop_c8370
+;     loop_c8390
+;     loop_c8397
+;     loop_c83f0
+;     loop_c83fa
+;     loop_c8406
+;     loop_c8425
+;     loop_c8463
+;     loop_c8493
+;     loop_c84e7
+;     loop_c8527
+;     loop_c8552
+;     loop_c8564
+;     loop_c857b
+;     loop_c85b5
+;     loop_c8717
+;     loop_c8725
+;     loop_c87a0
+;     loop_c87be
+;     loop_c88bc
+;     loop_c895f
+;     loop_c8990
+;     loop_c89c4
+;     loop_c89ca
+;     loop_c8a17
+;     loop_c8ac8
+;     loop_c8ad8
+;     loop_c8af0
+;     loop_c8afb
+;     loop_c8b80
+;     loop_c8bea
+;     loop_c8c58
+;     loop_c8c71
+;     loop_c8d14
+;     loop_c8d17
+;     loop_c8dac
+;     loop_c8dba
+;     loop_c8de9
+;     loop_c8df0
+;     loop_c8e14
+;     loop_c8e85
+;     loop_c8f17
+;     loop_c8f6c
+;     loop_c8f96
+;     loop_c8fac
+;     loop_c9047
+;     loop_c9108
+;     loop_c9113
+;     loop_c91ba
+;     loop_c91e7
+;     loop_c92ef
+;     loop_c9355
+;     loop_c9357
+;     loop_c936f
+;     loop_c9382
+;     loop_c93bd
+;     loop_c93da
+;     loop_c953a
+;     loop_c957d
+;     loop_c9593
+;     loop_c95b6
+;     loop_c95d9
+;     loop_c95ec
+;     loop_c9618
+;     loop_c96c2
+;     loop_c96f2
+;     loop_c979d
+;     loop_c97c8
+;     loop_c9803
+;     loop_c9837
+;     loop_c9851
+;     loop_c985e
+;     loop_c9881
+;     loop_c98a0
+;     loop_c98c1
+;     loop_c98e4
+;     loop_c9942
+;     loop_c994e
+;     loop_c9964
+;     loop_c99a8
+;     loop_c9b50
+;     loop_c9b5e
+;     loop_c9b63
+;     loop_c9bcf
+;     loop_c9be4
+;     loop_c9c38
+;     loop_c9c5d
+;     loop_c9c90
+;     loop_c9ca8
+;     loop_c9d03
+;     loop_c9d43
+;     loop_c9e07
+;     loop_c9e74
+;     loop_c9e8c
+;     loop_c9f6e
+;     loop_ca061
+;     loop_ca11d
+;     loop_ca132
+;     loop_ca143
+;     loop_ca16e
+;     loop_ca1aa
+;     loop_ca1cc
+;     loop_ca487
+;     loop_ca521
+;     loop_ca76f
+;     loop_ca7a7
+;     loop_ca7c6
+;     loop_ca7e0
+;     loop_ca7e1
+;     loop_ca941
+;     loop_ca947
+;     loop_ca953
+;     loop_ca9ab
+;     loop_ca9e7
+;     loop_caa01
+;     loop_caab8
+;     loop_cab6b
+;     loop_cab80
+;     loop_cabad
+;     loop_cabf4
+;     loop_cac46
+;     loop_caf13
+;     loop_caf2d
+;     loop_cb1e3
+;     loop_cb1ed
+;     loop_cb249
+;     loop_cb275
+;     loop_cb2b4
+;     loop_cb2bd
+;     loop_cb2d1
+;     loop_cb44d
+;     loop_cb4a8
+;     loop_cb55e
+;     loop_cb578
+;     loop_cb5c6
+;     loop_cb5ed
+;     loop_cb6b3
+;     loop_cb75a
+;     loop_cb7be
+;     loop_cb7d7
+;     loop_cb7dd
+;     loop_cb910
+;     loop_cb999
+;     loop_cb9bd
+;     loop_cb9cc
+;     loop_cb9d1
+;     loop_cb9f9
+;     loop_cba1a
+;     loop_cba94
+;     loop_cbab8
+;     loop_cbaea
+;     loop_cbbe4
+;     loop_cbbfe
+;     loop_cbc70
+;     loop_cbcd3
+;     loop_cbd08
+;     loop_cbd2b
+;     loop_cbd6c
+;     loop_cbd99
+;     loop_cbe0e
+;     loop_cbe31
+;     loop_cbeab
+;     loop_cbf1c
+;     loop_cbf78
+;     sub_c0050
+;     sub_c0414
+;     sub_c0421
+;     sub_c04c7
+;     sub_c04ce
+;     sub_c0520
+;     sub_c052d
+;     sub_c0537
+;     sub_c0542
+;     sub_c055e
+;     sub_c0582
+;     sub_c0596
+;     sub_c05a9
+;     sub_c05d1
+;     sub_c05f2
+;     sub_c05ff
+;     sub_c0607
+;     sub_c0627
+;     sub_c0d5e
+;     sub_c8020
+;     sub_c809a
+;     sub_c809d
+;     sub_c80b8
+;     sub_c80bb
+;     sub_c80c3
+;     sub_c80c8
+;     sub_c80d3
+;     sub_c80db
+;     sub_c80e3
+;     sub_c80e6
+;     sub_c80ed
+;     sub_c80f3
+;     sub_c80f6
+;     sub_c8149
+;     sub_c8174
+;     sub_c81ae
+;     sub_c81b0
+;     sub_c81b7
+;     sub_c81be
+;     sub_c81bf
+;     sub_c81c0
+;     sub_c81c4
+;     sub_c81c5
+;     sub_c81ca
+;     sub_c821d
+;     sub_c8222
+;     sub_c8238
+;     sub_c8254
+;     sub_c8266
+;     sub_c826d
+;     sub_c8280
+;     sub_c8284
+;     sub_c82b2
+;     sub_c82bb
+;     sub_c82e8
+;     sub_c82fe
+;     sub_c830a
+;     sub_c8327
+;     sub_c8335
+;     sub_c833a
+;     sub_c836e
+;     sub_c8380
+;     sub_c8386
+;     sub_c83bf
+;     sub_c83d1
+;     sub_c83d4
+;     sub_c83e3
+;     sub_c83ee
+;     sub_c840c
+;     sub_c841b
+;     sub_c842c
+;     sub_c8439
+;     sub_c8456
+;     sub_c8555
+;     sub_c85e3
+;     sub_c8602
+;     sub_c8745
+;     sub_c8750
+;     sub_c8782
+;     sub_c8794
+;     sub_c87da
+;     sub_c87db
+;     sub_c87e3
+;     sub_c87ee
+;     sub_c8826
+;     sub_c8855
+;     sub_c8862
+;     sub_c8932
+;     sub_c893f
+;     sub_c8943
+;     sub_c8951
+;     sub_c8979
+;     sub_c89b7
+;     sub_c89da
+;     sub_c89e6
+;     sub_c8a77
+;     sub_c8ab3
+;     sub_c8b25
+;     sub_c8b47
+;     sub_c8b4d
+;     sub_c8b64
+;     sub_c8b7b
+;     sub_c8b86
+;     sub_c8bac
+;     sub_c8bf6
+;     sub_c8bf9
+;     sub_c8c56
+;     sub_c8c65
+;     sub_c8d1a
+;     sub_c8dc6
+;     sub_c8eec
+;     sub_c8efa
+;     sub_c8eff
+;     sub_c8f33
+;     sub_c8f37
+;     sub_c8f3f
+;     sub_c8f4f
+;     sub_c8f5e
+;     sub_c8f6b
+;     sub_c8f75
+;     sub_c8f7a
+;     sub_c8f82
+;     sub_c8f94
+;     sub_c9279
+;     sub_c928a
+;     sub_c929d
+;     sub_c93b4
+;     sub_c93c5
+;     sub_c93d3
+;     sub_c93d8
+;     sub_c93f1
+;     sub_c93f5
+;     sub_c93f9
+;     sub_c93fd
+;     sub_c9432
+;     sub_c9445
+;     sub_c9516
+;     sub_c9526
+;     sub_c952e
+;     sub_c9536
+;     sub_c965d
+;     sub_c9785
+;     sub_c97b6
+;     sub_c97c9
+;     sub_c97e8
+;     sub_c9832
+;     sub_c992c
+;     sub_c9940
+;     sub_c995a
+;     sub_c9965
+;     sub_c9988
+;     sub_c99ac
+;     sub_c99f3
+;     sub_c9a0f
+;     sub_c9a32
+;     sub_c9a4b
+;     sub_c9a50
+;     sub_c9a60
+;     sub_c9a63
+;     sub_c9a6e
+;     sub_c9a78
+;     sub_c9a82
+;     sub_c9a8d
+;     sub_c9aa3
+;     sub_c9ab8
+;     sub_c9ac8
+;     sub_c9ad3
+;     sub_c9ad8
+;     sub_c9b51
+;     sub_c9b59
+;     sub_c9b61
+;     sub_c9b79
+;     sub_c9bca
+;     sub_c9bcd
+;     sub_c9be5
+;     sub_c9bf2
+;     sub_c9c0c
+;     sub_c9d19
+;     sub_c9d1e
+;     sub_c9d75
+;     sub_c9d9b
+;     sub_c9df4
+;     sub_c9e1e
+;     sub_c9e30
+;     sub_c9e54
+;     sub_c9e75
+;     sub_c9e94
+;     sub_c9ef4
+;     sub_c9f0f
+;     sub_c9f14
+;     sub_c9f16
+;     sub_c9f1e
+;     sub_c9f26
+;     sub_c9f7c
+;     sub_c9f82
+;     sub_ca0b8
+;     sub_ca0de
+;     sub_ca0f6
+;     sub_ca106
+;     sub_ca137
+;     sub_ca14a
+;     sub_ca168
+;     sub_ca190
+;     sub_ca1b4
+;     sub_ca1c6
+;     sub_ca244
+;     sub_ca315
+;     sub_ca324
+;     sub_ca379
+;     sub_ca384
+;     sub_ca3e4
+;     sub_ca3ec
+;     sub_ca417
+;     sub_ca463
+;     sub_ca4e1
+;     sub_ca51f
+;     sub_ca530
+;     sub_ca5b2
+;     sub_ca5bb
+;     sub_ca5bf
+;     sub_ca663
+;     sub_ca73d
+;     sub_ca76c
+;     sub_ca779
+;     sub_ca788
+;     sub_ca7c4
+;     sub_ca7c5
+;     sub_ca7ce
+;     sub_ca7f3
+;     sub_ca7f6
+;     sub_ca8be
+;     sub_ca8e2
+;     sub_ca90d
+;     sub_ca9bf
+;     sub_ca9c2
+;     sub_ca9ca
+;     sub_ca9d0
+;     sub_caa12
+;     sub_caa53
+;     sub_caa9a
+;     sub_caac2
+;     sub_caacf
+;     sub_caadd
+;     sub_caaea
+;     sub_caaf1
+;     sub_caafd
+;     sub_cab04
+;     sub_cab46
+;     sub_caba9
+;     sub_cabc5
+;     sub_cac0c
+;     sub_cac18
+;     sub_cac47
+;     sub_cac4e
+;     sub_cac62
+;     sub_cac6a
+;     sub_cac72
+;     sub_cad5d
+;     sub_caf8d
+;     sub_caf9a
+;     sub_cb040
+;     sub_cb047
+;     sub_cb234
+;     sub_cb2c8
+;     sub_cb580
+;     sub_cb58b
+;     sub_cb598
+;     sub_cb5ce
+;     sub_cb5ee
+;     sub_cb5f2
+;     sub_cb607
+;     sub_cb616
+;     sub_cb61e
+;     sub_cb65f
+;     sub_cb68f
+;     sub_cb6b1
+;     sub_cb6c5
+;     sub_cb6cd
+;     sub_cb6e6
+;     sub_cb6fe
+;     sub_cb745
+;     sub_cb771
+;     sub_cb7b6
+;     sub_cb83f
+;     sub_cb841
+;     sub_cb84e
+;     sub_cb850
+;     sub_cb85d
+;     sub_cb86f
+;     sub_cb882
+;     sub_cb986
+;     sub_cb9f5
+;     sub_cba67
+;     sub_cbab9
+;     sub_cbac2
+;     sub_cbac4
+;     sub_cbad2
+;     sub_cbb00
+;     sub_cbb46
+;     sub_cbb4a
+;     sub_cbbd3
+;     sub_cbbd7
+;     sub_cbc37
+;     sub_cbc68
+;     sub_cbc81
+;     sub_cbe83
+;     sub_cbe91
+;     sub_cbe9d
+;     sub_cbec2
+;     sub_cbf7c
+;     sub_cbf82
+;     sub_cbf84
+    assert <(c956d-1) == &6c
+    assert <(c956d-1) == &6c
+    assert <(l0128) == &28
+    assert <(l1000) == &00
+    assert <(sub_c8238-1) == &37
+    assert <(sub_c8254-1) == &53
+    assert <(sub_c8750-1) == &4f
+    assert <(sub_c8782-1) == &81
+    assert <(sub_c8794-1) == &93
+    assert <(sub_c87ee-1) == &ed
+    assert <(sub_c893f-1) == &3e
+    assert <(sub_c8943-1) == &42
+    assert <(sub_c89b7-1) == &b6
+    assert <(sub_c89e6-1) == &e5
+    assert <(sub_c8b47-1) == &46
+    assert <(sub_c8bac-1) == &ab
+    assert <(sub_c9b59-1) == &58
+    assert <(sub_ca106-1) == &05
+    assert <(sub_ca137-1) == &36
+    assert <(sub_ca244-1) == &43
+    assert <(sub_ca417-1) == &16
+    assert <(sub_ca463-1) == &62
+    assert <(sub_ca5bb-1) == &ba
+    assert <(sub_ca5bf-1) == &be
+    assert <(sub_ca7f3-1) == &f2
+    assert <(sub_ca7f6-1) == &f5
+    assert <(sub_ca9d0-1) == &cf
+    assert <(sub_caafd-1) == &fc
+    assert <(sub_cab04-1) == &03
+    assert <(sub_cab46-1) == &45
+    assert <(sub_cabc5-1) == &c4
+    assert <(sub_cbb46-1) == &45
+    assert <(sub_cbb4a-1) == &49
+    assert <(sub_cbbd3-1) == &d2
+    assert <(sub_cbbd7-1) == &d6
+    assert <(sub_cbc37-1) == &36
+    assert <(sub_cbc81-1) == &80
+    assert <tube_brkv_handler == &16
+    assert <tube_evntv_handler == &ad
+    assert >(c956d-1) == &95
+    assert >(c956d-1) == &95
+    assert >(l0128) == &01
+    assert >(l1000) == &10
+    assert >(sub_c8238-1) == &82
+    assert >(sub_c8254-1) == &82
+    assert >(sub_c8750-1) == &87
+    assert >(sub_c8782-1) == &87
+    assert >(sub_c8794-1) == &87
+    assert >(sub_c87ee-1) == &87
+    assert >(sub_c893f-1) == &89
+    assert >(sub_c8943-1) == &89
+    assert >(sub_c89b7-1) == &89
+    assert >(sub_c89e6-1) == &89
+    assert >(sub_c8b47-1) == &8b
+    assert >(sub_c8bac-1) == &8b
+    assert >(sub_c9b59-1) == &9b
+    assert >(sub_ca106-1) == &a1
+    assert >(sub_ca137-1) == &a1
+    assert >(sub_ca244-1) == &a2
+    assert >(sub_ca417-1) == &a4
+    assert >(sub_ca463-1) == &a4
+    assert >(sub_ca5bb-1) == &a5
+    assert >(sub_ca5bf-1) == &a5
+    assert >(sub_ca7f3-1) == &a7
+    assert >(sub_ca7f6-1) == &a7
+    assert >(sub_ca9d0-1) == &a9
+    assert >(sub_caafd-1) == &aa
+    assert >(sub_cab04-1) == &ab
+    assert >(sub_cab46-1) == &ab
+    assert >(sub_cabc5-1) == &ab
+    assert >(sub_cbb46-1) == &bb
+    assert >(sub_cbb4a-1) == &bb
+    assert >(sub_cbbd3-1) == &bb
+    assert >(sub_cbbd7-1) == &bb
+    assert >(sub_cbc37-1) == &bc
+    assert >(sub_cbc81-1) == &bc
+    assert >tube_brkv_handler == &00
+    assert >tube_evntv_handler == &06
+    assert copyright - rom_header == &11
+    assert jump_address_low == &51
+    assert nmi3_handler_rom_end-nmi3_handler_rom_start == &0e
+    assert nmi_XXX1-(nmi_beq+2) == &48
+    assert nmi_XXX10-(nmi_bcs+2) == &32
+    assert nmi_XXX11-(nmi_bcs+2) == &3b
+    assert nmi_XXX12-(nmi_bcs+2) == &3f
+    assert nmi_XXX13-(nmi_bcs+2) == &49
+    assert nmi_XXX14-(nmi_bcs+2) == &4d
+    assert nmi_XXX15-(nmi_bcs+2) == &55
+    assert nmi_XXX16-(nmi_bcs+2) == &5d
+    assert nmi_XXX17-(nmi_bcs+2) == &06
+    assert nmi_XXX18-(nmi_bcs+2) == &11
+    assert nmi_XXX19-(nmi_bcs+2) == &7b
+    assert nmi_XXX2-(nmi_beq+2) == &2f
+    assert nmi_XXX2-1 == &0d38
+    assert nmi_XXX20-(nmi_bcs+2) == &7f
+    assert nmi_XXX21-(nmi_bcs+2) == &26
+    assert nmi_XXX22-(nmi_bcs+2) == &77
+    assert nmi_XXX23-(nmi_bcs+2) == &24
+    assert nmi_XXX5-(nmi_cmp_imm_or_bcs+2) == &06
+    assert nmi_XXX7-(nmi_XXX6+2) == &06
+    assert nmi_XXX8-(nmi_beq+2) == &4d
+    assert nmi_handler2_rom_end-nmi_handler2_rom_start == &94
+    assert nmi_handler_rom_end-nmi_handler_rom_start-1 == &5d
+    assert opcode_bcs == &b0
+    assert opcode_rti == &40
+    assert osbyte_close_spool_exec == &77
+    assert osbyte_explode_chars == &14
+    assert osbyte_issue_service_request == &8f
+    assert osbyte_read_himem == &84
+    assert osbyte_read_oshwm == &83
+    assert osbyte_read_rom_info_table_low == &aa
+    assert osbyte_read_tube_presence == &ea
+    assert osbyte_read_write_spool_file_handle == &c7
+    assert osbyte_read_write_startup_options == &ff
+    assert osbyte_rw_exec_handle == &c6
+    assert osbyte_scan_keyboard_from_16 == &7a
+    assert osbyte_write_keys_pressed == &78
+    assert osfile_load == &ff
+    assert osfile_read_catalogue_info == &05
+    assert osfile_save == &00
+    assert service_absolute_workspace_claimed == &0a
+    assert service_boot == &03
+    assert service_check_swr_presence == &2b
+    assert service_claim_absolute_workspace == &01
+    assert service_claim_private_workspace == &02
+    assert service_help == &09
+    assert service_select_filing_system == &12
+    assert service_tube_post_init == &fe
+    assert service_unrecognised_command == &04
+    assert service_unrecognised_osword == &08
+    assert sub_c0520 == &0520
+    assert sub_c052d == &052d
+    assert sub_c0537 == &0537
+    assert sub_c0542 == &0542
+    assert sub_c055e == &055e
+    assert sub_c0596 == &0596
+    assert sub_c05a9 == &05a9
+    assert sub_c05d1 == &05d1
+    assert sub_c05f2 == &05f2
+    assert sub_c0607 == &0607
+    assert sub_c0627 == &0627
+    assert sub_c9785 == &9785
+    assert sub_c97b6 == &97b6
+    assert sub_c97c9 == &97c9
+    assert sub_c9c0c == &9c0c
+    assert sub_c9d9b == &9d9b
+    assert sub_c9e94 == &9e94
+    assert sub_c9f82 == &9f82
+    assert tube_brkv_handler_fwd == &16
+    assert tube_host_osword_0 == &0668
+
+save pydis_start, pydis_end

--- a/examples/known_good/dfs226_xa.asm
+++ b/examples/known_good/dfs226_xa.asm
@@ -1,0 +1,13532 @@
+// Constants
+opcode_bcs                            = 176
+opcode_rti                            = 64
+osbyte_close_spool_exec               = 119
+osbyte_explode_chars                  = 20
+osbyte_issue_service_request          = 143
+osbyte_read_himem                     = 132
+osbyte_read_oshwm                     = 131
+osbyte_read_rom_info_table_low        = 170
+osbyte_read_tube_presence             = 234
+osbyte_read_write_spool_file_handle   = 199
+osbyte_read_write_startup_options     = 255
+osbyte_rw_exec_handle                 = 198
+osbyte_scan_keyboard_from_16          = 122
+osbyte_write_keys_pressed             = 120
+osfile_load                           = 255
+osfile_read_catalogue_info            = 5
+osfile_save                           = 0
+service_absolute_workspace_claimed    = 10
+service_boot                          = 3
+service_check_swr_presence            = 43
+service_claim_absolute_workspace      = 1
+service_claim_private_workspace       = 2
+service_help                          = 9
+service_select_filing_system          = 18
+service_tube_post_init                = 254
+service_unrecognised_command          = 4
+service_unrecognised_osword           = 8
+tube_brkv_handler_fwd                 = 22
+
+// Memory locations
+l0000               = $0000
+l0001               = $0001
+l0002               = $0002
+l0003               = $0003
+l0012               = $0012
+l0013               = $0013
+l0014               = $0014
+l0015               = $0015
+l00a0               = $00a0
+l00a1               = $00a1
+l00a2               = $00a2
+l00a3               = $00a3
+l00a4               = $00a4
+l00a5               = $00a5
+l00a6               = $00a6
+l00a7               = $00a7
+l00a8               = $00a8
+l00a9               = $00a9
+l00aa               = $00aa
+l00ab               = $00ab
+l00ac               = $00ac
+l00ad               = $00ad
+l00ae               = $00ae
+l00af               = $00af
+l00b0               = $00b0
+l00b1               = $00b1
+l00b2               = $00b2
+l00b3               = $00b3
+l00b4               = $00b4
+l00b5               = $00b5
+l00b6               = $00b6
+l00b7               = $00b7
+l00b8               = $00b8
+l00b9               = $00b9
+l00ba               = $00ba
+l00bb               = $00bb
+l00bc               = $00bc
+l00bd               = $00bd
+l00be               = $00be
+l00bf               = $00bf
+l00c0               = $00c0
+l00c1               = $00c1
+l00c2               = $00c2
+l00c3               = $00c3
+l00c4               = $00c4
+l00c5               = $00c5
+l00c6               = $00c6
+l00c7               = $00c7
+l00c8               = $00c8
+l00c9               = $00c9
+l00ca               = $00ca
+l00cc               = $00cc
+l00cd               = $00cd
+l00ce               = $00ce
+l00cf               = $00cf
+l00ef               = $00ef
+l00f0               = $00f0
+l00f1               = $00f1
+os_text_ptr         = $00f2
+l00f3               = $00f3
+romsel_copy         = $00f4
+osrdsc_ptr          = $00f6
+l00f7               = $00f7
+l00fd               = $00fd
+l00ff               = $00ff
+l0100               = $0100
+l0101               = $0101
+l0102               = $0102
+l0103               = $0103
+l0104               = $0104
+l0105               = $0105
+l0107               = $0107
+l0109               = $0109
+l010b               = $010b
+l010c               = $010c
+l010d               = $010d
+l010e               = $010e
+l0128               = $0128
+brkv                = $0202
+bytev               = $020a
+filev               = $0212
+fscv                = $021e
+evntv               = $0220
+l028d               = $028d
+l0700               = $0700
+l0cff               = $0cff
+l0df0               = $0df0
+l0e00               = $0e00
+l0e07               = $0e07
+l0e08               = $0e08
+l0e0e               = $0e0e
+l0e0f               = $0e0f
+l0e10               = $0e10
+l0ef8               = $0ef8
+l0f00               = $0f00
+l0f04               = $0f04
+l0f05               = $0f05
+l0f06               = $0f06
+l0f07               = $0f07
+l0f08               = $0f08
+l0f09               = $0f09
+l0f0a               = $0f0a
+l0f0b               = $0f0b
+l0f0c               = $0f0c
+l0f0d               = $0f0d
+l0f0e               = $0f0e
+l0f0f               = $0f0f
+l0f10               = $0f10
+l1000               = $1000
+l1001               = $1001
+l1002               = $1002
+l1003               = $1003
+l1004               = $1004
+l1005               = $1005
+l1006               = $1006
+l1007               = $1007
+l100e               = $100e
+l1045               = $1045
+l1047               = $1047
+l104d               = $104d
+l104e               = $104e
+l1050               = $1050
+l1058               = $1058
+l105f               = $105f
+l1060               = $1060
+l1061               = $1061
+l1062               = $1062
+l1063               = $1063
+l1064               = $1064
+l1065               = $1065
+l1067               = $1067
+l1069               = $1069
+l1072               = $1072
+l1074               = $1074
+l1075               = $1075
+l1076               = $1076
+l1077               = $1077
+l1078               = $1078
+l1079               = $1079
+l107a               = $107a
+l107d               = $107d
+l107e               = $107e
+l107f               = $107f
+l1081               = $1081
+l1082               = $1082
+l1083               = $1083
+l1086               = $1086
+l1087               = $1087
+l1088               = $1088
+l1089               = $1089
+l108a               = $108a
+l108b               = $108b
+l108c               = $108c
+l108f               = $108f
+l1090               = $1090
+l1091               = $1091
+l1092               = $1092
+l1093               = $1093
+l1094               = $1094
+l1095               = $1095
+l1096               = $1096
+l1097               = $1097
+l1098               = $1098
+l1099               = $1099
+l109a               = $109a
+l109b               = $109b
+l109d               = $109d
+l109e               = $109e
+l109f               = $109f
+l10c0               = $10c0
+l10c1               = $10c1
+l10c2               = $10c2
+l10c3               = $10c3
+l10c4               = $10c4
+l10c5               = $10c5
+l10c6               = $10c6
+l10c7               = $10c7
+l10c9               = $10c9
+l10ca               = $10ca
+l10cb               = $10cb
+l10cc               = $10cc
+l10cd               = $10cd
+l10ce               = $10ce
+l10cf               = $10cf
+l10d0               = $10d0
+l10d1               = $10d1
+l10d2               = $10d2
+l10d3               = $10d3
+l10d6               = $10d6
+l10d7               = $10d7
+l10d8               = $10d8
+l10d9               = $10d9
+l10da               = $10da
+l10db               = $10db
+l10dc               = $10dc
+l10dd               = $10dd
+l10de               = $10de
+l10e2               = $10e2
+l10e3               = $10e3
+l10e4               = $10e4
+l1100               = $1100
+l1109               = $1109
+l110b               = $110b
+l110c               = $110c
+l110d               = $110d
+l110e               = $110e
+l110f               = $110f
+l1110               = $1110
+l1111               = $1111
+l1112               = $1112
+l1113               = $1113
+l1114               = $1114
+l1115               = $1115
+l1116               = $1116
+l1117               = $1117
+l1119               = $1119
+l111a               = $111a
+l111b               = $111b
+l111c               = $111c
+l111d               = $111d
+romsel              = $fe30
+lfe80               = $fe80
+lfe84               = $fe84
+lfe85               = $fe85
+lfe86               = $fe86
+lfe87               = $fe87
+tube_host_r1_status = $fee0
+tube_host_r1_data   = $fee1
+tube_host_r2_status = $fee2
+tube_host_r2_data   = $fee3
+tube_host_r3_data   = $fee5
+tube_host_r4_status = $fee6
+tube_host_r4_data   = $fee7
+osrdsc              = $ffb9
+gsinit              = $ffc2
+gsread              = $ffc5
+osfind              = $ffce
+osgbpb              = $ffd1
+osbput              = $ffd4
+osbget              = $ffd7
+osargs              = $ffda
+osfile              = $ffdd
+osrdch              = $ffe0
+osasci              = $ffe3
+osnewl              = $ffe7
+oswrch              = $ffee
+osword              = $fff1
+osbyte              = $fff4
+oscli               = $fff7
+
+    * = $8000
+
+// Sideways ROM header
+// $8000 referenced 1 time by $04e2
+rom_header
+language_entry
+pydis_start
+l8001 = rom_header+1
+l8002 = rom_header+2
+    .byt 0, 0, 0                                                      // 8000: 00 00 00    ...
+// $8001 referenced 1 time by $04e7
+// $8002 referenced 1 time by $04ec
+
+// $8003 referenced 1 time by $04f1
+service_entry
+l8004 = service_entry+1
+    jmp service_handler                                               // 8003: 4c c8 be    L..
+
+// $8004 referenced 1 time by $04f4
+// $8006 referenced 1 time by $04d6
+rom_type
+    .byt $82                                                          // 8006: 82          .
+// $8007 referenced 1 time by $04de
+copyright_offset
+    .byt copyright - rom_header                                       // 8007: 11          .
+binary_version
+    .byt $7b                                                          // 8008: 7b          {
+title
+    .asc "DFS"                                                        // 8009: 44 46 53    DFS
+version
+    .byt 0                                                            // 800c: 00          .
+    .asc "2.26"                                                       // 800d: 32 2e 32... 2.2
+copyright
+    .byt 0                                                            // 8011: 00          .
+    .asc "(C)1985 Acorn", 0                                           // 8012: 28 43 29... (C)
+
+// $8020 referenced 1 time by $9575
+sub_c8020
+    jmp (fscv)                                                        // 8020: 6c 1e 02    l..
+
+// $8023 referenced 4 times by $8a6e, $94c6, $94d5, $9c00
+generate_error_precheck_disc
+    jsr generate_error_precheck                                       // 8023: 20 38 80     8.
+    .byt 0                                                            // 8026: 00          .
+    .asc "Disc "                                                      // 8027: 44 69 73... Dis
+
+    bcc generate_error2                                               // 802c: 90 21       .!
+// $802e referenced 6 times by $8125, $889a, $89a5, $8a24, $8a3e, $8ba2
+generate_error_precheck_bad
+    jsr generate_error_precheck                                       // 802e: 20 38 80     8.
+    .byt 0                                                            // 8031: 00          .
+    .asc "Bad "                                                       // 8032: 42 61 64... Bad
+
+    bcc generate_error2                                               // 8036: 90 17       ..
+// $8038 referenced 11 times by $8023, $802e, $8b18, $8bd8, $9a55, $9c70, $9c82, $9e80, $9e8c, $9f6e, $9fc8
+generate_error_precheck
+    lda l10dd                                                         // 8038: ad dd 10    ...
+    bne c8040                                                         // 803b: d0 03       ..
+    jsr sub_c9e30                                                     // 803d: 20 30 9e     0.
+// $8040 referenced 1 time by $803b
+c8040
+    lda #%11111111                                                    // 8040: a9 ff       ..
+    sta l1082                                                         // 8042: 8d 82 10    ...
+    sta l10dd                                                         // 8045: 8d dd 10    ...
+// Generate an OS error using inline data. Called as either:
+//     jsr XXX:equb errnum, "error message", 0
+// to actually generate an error now, or as:
+//     jsr XXX:equb errnum, "partial error message", instruction...
+// to partially construct an error (on the stack) and continue executing
+// 'instruction' afterwards; its opcode must have its top bit set. Carry is
+// always clear on exit.
+// $8048 referenced 4 times by $822a, $9439, $947c, $a14f
+generate_error
+    ldx #2                                                            // 8048: a2 02       ..
+    lda #0                                                            // 804a: a9 00       ..
+    sta l0100                                                         // 804c: 8d 00 01    ...
+// $804f referenced 7 times by $802c, $8036, $94da, $94e9, $94f7, $9507, $9511
+generate_error2
+    sta l00b3                                                         // 804f: 85 b3       ..
+    pla                                                               // 8051: 68          h
+    sta l00ae                                                         // 8052: 85 ae       ..
+    pla                                                               // 8054: 68          h
+    sta l00af                                                         // 8055: 85 af       ..
+// XXX: Redundant lda l00b3? Is sta l00b3 above redundant too?
+    lda l00b3                                                         // 8057: a5 b3       ..
+    ldy #0                                                            // 8059: a0 00       ..
+    jsr inc16_ae                                                      // 805b: 20 dc 83     ..
+    lda (l00ae),y                                                     // 805e: b1 ae       ..
+    sta l0101                                                         // 8060: 8d 01 01    ...
+    dex                                                               // 8063: ca          .
+// $8064 referenced 1 time by $806f
+loop_c8064
+    jsr inc16_ae                                                      // 8064: 20 dc 83     ..
+    inx                                                               // 8067: e8          .
+    lda (l00ae),y                                                     // 8068: b1 ae       ..
+    sta l0100,x                                                       // 806a: 9d 00 01    ...
+    bmi c8096                                                         // 806d: 30 27       0'
+    bne loop_c8064                                                    // 806f: d0 f3       ..
+    jsr sub_c8f75                                                     // 8071: 20 75 8f     u.
+    jmp l0100                                                         // 8074: 4c 00 01    L..
+
+// Print (XXX: using l809f, which seems to be quite fancy) an inline
+// string terminated by a top-bit set instruction to execute after
+// printing the string. Carry is always clear on exit.
+// $8077 referenced 31 times by $84a5, $84b0, $84c8, $84dc, $84f1, $850d, $87ce, $9558, $a10c, $a247, $a298, $a34d, $a364, $a394, $a3a3, $a3ae, $a3bd, $a3e4, $a3ec, $a5f0, $a5fb, $a605, $a667, $a678, $a68a, $a699, $a70a, $a719, $aa5a, $aa65, $aebf
+print_inline_l809f_top_bit_clear
+    sta l00b3                                                         // 8077: 85 b3       ..
+    pla                                                               // 8079: 68          h
+    sta l00ae                                                         // 807a: 85 ae       ..
+    pla                                                               // 807c: 68          h
+    sta l00af                                                         // 807d: 85 af       ..
+    lda l00b3                                                         // 807f: a5 b3       ..
+    pha                                                               // 8081: 48          H
+    tya                                                               // 8082: 98          .
+    pha                                                               // 8083: 48          H
+    ldy #0                                                            // 8084: a0 00       ..
+// $8086 referenced 1 time by $8090
+loop_c8086
+    jsr inc16_ae                                                      // 8086: 20 dc 83     ..
+    lda (l00ae),y                                                     // 8089: b1 ae       ..
+    bmi c8093                                                         // 808b: 30 06       0.
+    jsr c809f                                                         // 808d: 20 9f 80     ..
+    jmp loop_c8086                                                    // 8090: 4c 86 80    L..
+
+// $8093 referenced 1 time by $808b
+c8093
+    pla                                                               // 8093: 68          h
+    tay                                                               // 8094: a8          .
+    pla                                                               // 8095: 68          h
+// $8096 referenced 1 time by $806d
+c8096
+    clc                                                               // 8096: 18          .
+    jmp (l00ae)                                                       // 8097: 6c ae 00    l..
+
+// $809a referenced 2 times by $84ff, $8519
+sub_c809a
+    jsr sub_c80c3                                                     // 809a: 20 c3 80     ..
+// $809d referenced 1 time by $8187
+sub_c809d
+    lda #$2e // '.'                                                   // 809d: a9 2e       ..
+// $809f referenced 20 times by $808d, $80c6, $8184, $8191, $81a2, $849d, $84ea, $8505, $851f, $a1c3, $a3df, $a40c, $a621, $a6bd, $a6c0, $aa6d, $aa7b, $aa87, $aa8c, $aabe
+c809f
+    jsr sub_c83e3                                                     // 809f: 20 e3 83     ..
+    pha                                                               // 80a2: 48          H
+    lda #$ec                                                          // 80a3: a9 ec       ..
+    jsr osbyte_read                                                   // 80a5: 20 e5 9a     ..
+    txa                                                               // 80a8: 8a          .
+    pha                                                               // 80a9: 48          H
+    ora #$10                                                          // 80aa: 09 10       ..
+    jsr sub_c9ad3                                                     // 80ac: 20 d3 9a     ..
+    pla                                                               // 80af: 68          h
+    tax                                                               // 80b0: aa          .
+    pla                                                               // 80b1: 68          h
+    jsr osasci                                                        // 80b2: 20 e3 ff     ..
+    jmp c9ad4                                                         // 80b5: 4c d4 9a    L..
+
+// $80b8 referenced 1 time by $aa62
+sub_c80b8
+    jsr sub_c841b                                                     // 80b8: 20 1b 84     ..
+// $80bb referenced 5 times by $8368, $8373, $84ad, $a295, $a6c6
+sub_c80bb
+    pha                                                               // 80bb: 48          H
+    jsr sub_c81bf                                                     // 80bc: 20 bf 81     ..
+    jsr sub_c80c3                                                     // 80bf: 20 c3 80     ..
+    pla                                                               // 80c2: 68          h
+// $80c3 referenced 10 times by $809a, $80bf, $8362, $84c0, $84d9, $a25c, $a291, $a361, $a36f, $a696
+sub_c80c3
+    jsr sub_c80c8                                                     // 80c3: 20 c8 80     ..
+    bne c809f                                                         // 80c6: d0 d7       ..
+// $80c8 referenced 4 times by $80c3, $952e, $a9ca, $ac6a
+sub_c80c8
+    and #$0f                                                          // 80c8: 29 0f       ).
+    cmp #$0a                                                          // 80ca: c9 0a       ..
+    bcc c80d0                                                         // 80cc: 90 02       ..
+    adc #6                                                            // 80ce: 69 06       i.
+// $80d0 referenced 1 time by $80cc
+c80d0
+    adc #'0'                                                          // 80d0: 69 30       i0
+    rts                                                               // 80d2: 60          `
+
+// $80d3 referenced 1 time by $979d
+sub_c80d3
+    jsr sub_c80e3                                                     // 80d3: 20 e3 80     ..
+    dex                                                               // 80d6: ca          .
+    dex                                                               // 80d7: ca          .
+    jsr sub_c80db                                                     // 80d8: 20 db 80     ..
+// $80db referenced 1 time by $80d8
+sub_c80db
+    lda (l00b0),y                                                     // 80db: b1 b0       ..
+    sta l1072,x                                                       // 80dd: 9d 72 10    .r.
+    inx                                                               // 80e0: e8          .
+    iny                                                               // 80e1: c8          .
+    rts                                                               // 80e2: 60          `
+
+// $80e3 referenced 2 times by $80d3, $979a
+sub_c80e3
+    jsr sub_c80e6                                                     // 80e3: 20 e6 80     ..
+// $80e6 referenced 1 time by $80e3
+sub_c80e6
+    lda (l00b0),y                                                     // 80e6: b1 b0       ..
+    sta l00ba,x                                                       // 80e8: 95 ba       ..
+    inx                                                               // 80ea: e8          .
+    iny                                                               // 80eb: c8          .
+    rts                                                               // 80ec: 60          `
+
+// $80ed referenced 5 times by $821d, $89ec, $8bb2, $8bc7, $a46c
+sub_c80ed
+    jsr sub_c8b7b                                                     // 80ed: 20 7b 8b     {.
+    jmp c8103                                                         // 80f0: 4c 03 81    L..
+
+// $80f3 referenced 5 times by $8222, $8879, $8a77, $9a78, $9c22
+sub_c80f3
+    jsr sub_c8b7b                                                     // 80f3: 20 7b 8b     {.
+// $80f6 referenced 1 time by $8892
+sub_c80f6
+    lda l00ba                                                         // 80f6: a5 ba       ..
+    sta os_text_ptr                                                   // 80f8: 85 f2       ..
+    lda l00bb                                                         // 80fa: a5 bb       ..
+    sta l00f3                                                         // 80fc: 85 f3       ..
+    ldy #0                                                            // 80fe: a0 00       ..
+    jsr clc_jmp_gsinit                                                // 8100: 20 4c 87     L.
+// $8103 referenced 3 times by $80f0, $8113, $8123
+c8103
+    ldx #$20                                                          // 8103: a2 20       .
+    jsr sub_c8149                                                     // 8105: 20 49 81     I.
+    bcs c8125                                                         // 8108: b0 1b       ..
+    sta l1000                                                         // 810a: 8d 00 10    ...
+    cmp #'.'                                                          // 810d: c9 2e       ..
+    bne c8115                                                         // 810f: d0 04       ..
+// $8111 referenced 1 time by $8136
+c8111
+    stx l00cc                                                         // 8111: 86 cc       ..
+    beq c8103                                                         // 8113: f0 ee       ..
+// $8115 referenced 1 time by $810f
+c8115
+    cmp #$3a // ':'                                                   // 8115: c9 3a       .:
+    bne c812e                                                         // 8117: d0 15       ..
+    jsr c8b8b                                                         // 8119: 20 8b 8b     ..
+    jsr sub_c8149                                                     // 811c: 20 49 81     I.
+    bcs c8125                                                         // 811f: b0 04       ..
+    cmp #$2e // '.'                                                   // 8121: c9 2e       ..
+    beq c8103                                                         // 8123: f0 de       ..
+// $8125 referenced 5 times by $8108, $811f, $8147, $8155, $8159
+c8125
+    jsr generate_error_precheck_bad                                   // 8125: 20 2e 80     ..
+    .byt $cc                                                          // 8128: cc          .
+    .asc "name"                                                       // 8129: 6e 61 6d... nam
+    .byt 0                                                            // 812d: 00          .
+
+// $812e referenced 1 time by $8117
+c812e
+    tax                                                               // 812e: aa          .
+    jsr sub_c8149                                                     // 812f: 20 49 81     I.
+    bcs c815d                                                         // 8132: b0 29       .)
+    cmp #$2e // '.'                                                   // 8134: c9 2e       ..
+    beq c8111                                                         // 8136: f0 d9       ..
+    ldx #1                                                            // 8138: a2 01       ..
+// $813a referenced 1 time by $8145
+loop_c813a
+    sta l1000,x                                                       // 813a: 9d 00 10    ...
+    inx                                                               // 813d: e8          .
+    jsr sub_c8149                                                     // 813e: 20 49 81     I.
+    bcs c815f                                                         // 8141: b0 1c       ..
+    cpx #7                                                            // 8143: e0 07       ..
+    bne loop_c813a                                                    // 8145: d0 f3       ..
+    beq c8125                                                         // 8147: f0 dc       ..
+// $8149 referenced 11 times by $8105, $811c, $812f, $813e, $8990, $899c, $89af, $89cb, $8a19, $8b8b, $a143
+sub_c8149
+    jsr gsread                                                        // 8149: 20 c5 ff     ..
+    php                                                               // 814c: 08          .
+    and #$7f                                                          // 814d: 29 7f       ).
+    cmp #13                                                           // 814f: c9 0d       ..
+    beq c815b                                                         // 8151: f0 08       ..
+    cmp #$20 // ' '                                                   // 8153: c9 20       .
+    bcc c8125                                                         // 8155: 90 ce       ..
+    cmp #$7f                                                          // 8157: c9 7f       ..
+    beq c8125                                                         // 8159: f0 ca       ..
+// $815b referenced 1 time by $8151
+c815b
+    plp                                                               // 815b: 28          (
+    rts                                                               // 815c: 60          `
+
+// $815d referenced 2 times by $8132, $8248
+c815d
+    ldx #1                                                            // 815d: a2 01       ..
+// $815f referenced 1 time by $8141
+c815f
+    lda #$20 // ' '                                                   // 815f: a9 20       .
+// $8161 referenced 1 time by $8167
+loop_c8161
+    sta l1000,x                                                       // 8161: 9d 00 10    ...
+    inx                                                               // 8164: e8          .
+    cpx #$40 // '@'                                                   // 8165: e0 40       .@
+    bne loop_c8161                                                    // 8167: d0 f8       ..
+    ldx #6                                                            // 8169: a2 06       ..
+// $816b referenced 1 time by $8171
+loop_c816b
+    lda l1000,x                                                       // 816b: bd 00 10    ...
+    sta l00c5,x                                                       // 816e: 95 c5       ..
+    dex                                                               // 8170: ca          .
+    bpl loop_c816b                                                    // 8171: 10 f8       ..
+    rts                                                               // 8173: 60          `
+
+// $8174 referenced 4 times by $833d, $85cd, $875e, $87a5
+sub_c8174
+    jsr sub_c83e3                                                     // 8174: 20 e3 83     ..
+    lda l0e0f,y                                                       // 8177: b9 0f 0e    ...
+    php                                                               // 817a: 08          .
+    and #$7f                                                          // 817b: 29 7f       ).
+    bne c8184                                                         // 817d: d0 05       ..
+    jsr sub_cac0c                                                     // 817f: 20 0c ac     ..
+    beq c818a                                                         // 8182: f0 06       ..
+// $8184 referenced 1 time by $817d
+c8184
+    jsr c809f                                                         // 8184: 20 9f 80     ..
+    jsr sub_c809d                                                     // 8187: 20 9d 80     ..
+// $818a referenced 1 time by $8182
+c818a
+    ldx #6                                                            // 818a: a2 06       ..
+// $818c referenced 1 time by $8196
+loop_c818c
+    lda l0e08,y                                                       // 818c: b9 08 0e    ...
+    and #$7f                                                          // 818f: 29 7f       ).
+    jsr c809f                                                         // 8191: 20 9f 80     ..
+    iny                                                               // 8194: c8          .
+    dex                                                               // 8195: ca          .
+    bpl loop_c818c                                                    // 8196: 10 f4       ..
+    jsr sub_cac0c                                                     // 8198: 20 0c ac     ..
+    lda #$20 // ' '                                                   // 819b: a9 20       .
+    plp                                                               // 819d: 28          (
+    bpl c81a2                                                         // 819e: 10 02       ..
+    lda #$4c // 'L'                                                   // 81a0: a9 4c       .L
+// $81a2 referenced 1 time by $819e
+c81a2
+    jsr c809f                                                         // 81a2: 20 9f 80     ..
+    ldy #1                                                            // 81a5: a0 01       ..
+// $81a7 referenced 4 times by $81ab, $84c5, $850a, $85c2
+c81a7
+    jsr cac0f                                                         // 81a7: 20 0f ac     ..
+    dey                                                               // 81aa: 88          .
+    bne c81a7                                                         // 81ab: d0 fa       ..
+    rts                                                               // 81ad: 60          `
+
+// $81ae referenced 2 times by $88a9, $8b6b
+sub_c81ae
+    lsr                                                               // 81ae: 4a          J
+    lsr                                                               // 81af: 4a          J
+// $81b0 referenced 8 times by $81f5, $85e6, $9cdb, $9cfd, $a2c6, $a49f, $a505, $a8e6
+sub_c81b0
+    lsr                                                               // 81b0: 4a          J
+    lsr                                                               // 81b1: 4a          J
+    lsr                                                               // 81b2: 4a          J
+    lsr                                                               // 81b3: 4a          J
+    and #3                                                            // 81b4: 29 03       ).
+    rts                                                               // 81b6: 60          `
+
+// $81b7 referenced 1 time by $8b54
+sub_c81b7
+    and #8                                                            // 81b7: 29 08       ).
+    beq c81bd                                                         // 81b9: f0 02       ..
+    lda #3                                                            // 81bb: a9 03       ..
+// $81bd referenced 1 time by $81b9
+c81bd
+    rts                                                               // 81bd: 60          `
+
+// $81be referenced 3 times by $9cb3, $9d0c, $9e00
+sub_c81be
+    lsr                                                               // 81be: 4a          J
+// $81bf referenced 8 times by $80bc, $84d5, $9527, $9644, $98fb, $a18d, $a9c3, $ac63
+sub_c81bf
+    lsr                                                               // 81bf: 4a          J
+// $81c0 referenced 1 time by $a90d
+sub_c81c0
+    lsr                                                               // 81c0: 4a          J
+    lsr                                                               // 81c1: 4a          J
+    lsr                                                               // 81c2: 4a          J
+    rts                                                               // 81c3: 60          `
+
+// $81c4 referenced 1 time by $9e2a
+sub_c81c4
+    asl                                                               // 81c4: 0a          .
+// $81c5 referenced 2 times by $8a5d, $9bae
+sub_c81c5
+    asl                                                               // 81c5: 0a          .
+    asl                                                               // 81c6: 0a          .
+    asl                                                               // 81c7: 0a          .
+    asl                                                               // 81c8: 0a          .
+    rts                                                               // 81c9: 60          `
+
+// $81ca referenced 1 time by $8867
+sub_c81ca
+    lda #5                                                            // 81ca: a9 05       ..
+    sta l1095                                                         // 81cc: 8d 95 10    ...
+    lda l00cd                                                         // 81cf: a5 cd       ..
+    sta l1090                                                         // 81d1: 8d 90 10    ...
+    lda #$0a                                                          // 81d4: a9 0a       ..
+    sta l00b0                                                         // 81d6: 85 b0       ..
+    lda l00bc                                                         // 81d8: a5 bc       ..
+    sta l1091                                                         // 81da: 8d 91 10    ...
+    lda l00bd                                                         // 81dd: a5 bd       ..
+    sta l1092                                                         // 81df: 8d 92 10    ...
+    lda l1074                                                         // 81e2: ad 74 10    .t.
+    sta l1093                                                         // 81e5: 8d 93 10    ...
+    lda l1075                                                         // 81e8: ad 75 10    .u.
+    sta l1094                                                         // 81eb: 8d 94 10    ...
+    lda #$ff                                                          // 81ee: a9 ff       ..
+    sta l1097                                                         // 81f0: 8d 97 10    ...
+    lda l00c2                                                         // 81f3: a5 c2       ..
+    jsr sub_c81b0                                                     // 81f5: 20 b0 81     ..
+    sta l109a                                                         // 81f8: 8d 9a 10    ...
+    lda l00c0                                                         // 81fb: a5 c0       ..
+    sta l109b                                                         // 81fd: 8d 9b 10    ...
+    lda l00c1                                                         // 8200: a5 c1       ..
+    sta l1099                                                         // 8202: 8d 99 10    ...
+    lda l00c2                                                         // 8205: a5 c2       ..
+    and #$03                                                          // 8207: 29 03       ).
+    tax                                                               // 8209: aa          .
+    lda l00c3                                                         // 820a: a5 c3       ..
+// $820c referenced 1 time by $8215
+loop_c820c
+    sec                                                               // 820c: 38          8
+// $820d referenced 1 time by $8212
+loop_c820d
+    inc l1097                                                         // 820d: ee 97 10    ...
+    sbc l00b0                                                         // 8210: e5 b0       ..
+    bcs loop_c820d                                                    // 8212: b0 f9       ..
+    dex                                                               // 8214: ca          .
+    bpl loop_c820c                                                    // 8215: 10 f5       ..
+    adc l00b0                                                         // 8217: 65 b0       e.
+    sta l1098                                                         // 8219: 8d 98 10    ...
+// $821c referenced 1 time by $8228
+loop_c821c
+    rts                                                               // 821c: 60          `
+
+// $821d referenced 4 times by $825a, $8756, $8788, $879d
+sub_c821d
+    jsr sub_c80ed                                                     // 821d: 20 ed 80     ..
+    bmi c8225                                                         // 8220: 30 03       0.
+// $8222 referenced 1 time by $881b
+sub_c8222
+    jsr sub_c80f3                                                     // 8222: 20 f3 80     ..
+// $8225 referenced 4 times by $8220, $824e, $8bb7, $a478
+c8225
+    jsr sub_c8284                                                     // 8225: 20 84 82     ..
+    bcs loop_c821c                                                    // 8228: b0 f2       ..
+// $822a referenced 2 times by $89fd, $ab17
+c822a
+    jsr generate_error                                                // 822a: 20 48 80     H.
+    .byt $d6                                                          // 822d: d6          .
+    .asc "Not found"                                                  // 822e: 4e 6f 74... Not
+    .byt 0                                                            // 8237: 00          .
+
+sub_c8238
+    jsr sub_c8b7b                                                     // 8238: 20 7b 8b     {.
+    jsr clc_jmp_gsinit                                                // 823b: 20 4c 87     L.
+    beq c8243                                                         // 823e: f0 03       ..
+    jsr c898a                                                         // 8240: 20 8a 89     ..
+// $8243 referenced 1 time by $823e
+c8243
+    lda #$2a // '*'                                                   // 8243: a9 2a       .*
+    sta l1000                                                         // 8245: 8d 00 10    ...
+    jsr c815d                                                         // 8248: 20 5d 81     ].
+    jsr sub_c99ac                                                     // 824b: 20 ac 99     ..
+    jsr c8225                                                         // 824e: 20 25 82     %.
+    jmp c825d                                                         // 8251: 4c 5d 82    L].
+
+sub_c8254
+    jsr sub_c99ac                                                     // 8254: 20 ac 99     ..
+    jsr sub_ca14a                                                     // 8257: 20 4a a1     J.
+    jsr sub_c821d                                                     // 825a: 20 1d 82     ..
+// $825d referenced 2 times by $8251, $8263
+c825d
+    jsr sub_c833a                                                     // 825d: 20 3a 83     :.
+    jsr sub_c8280                                                     // 8260: 20 80 82     ..
+    bcs c825d                                                         // 8263: b0 f8       ..
+    rts                                                               // 8265: 60          `
+
+// $8266 referenced 2 times by $887f, $8895
+sub_c8266
+    jsr sub_c93f9                                                     // 8266: 20 f9 93     ..
+    lda #0                                                            // 8269: a9 00       ..
+    beq c828b                                                         // 826b: f0 1e       ..
+// $826d referenced 2 times by $9bd9, $a4f2
+sub_c826d
+    ldx #6                                                            // 826d: a2 06       ..
+// $826f referenced 1 time by $8275
+loop_c826f
+    lda l00c5,x                                                       // 826f: b5 c5       ..
+    sta l1058,x                                                       // 8271: 9d 58 10    .X.
+    dex                                                               // 8274: ca          .
+    bpl loop_c826f                                                    // 8275: 10 f8       ..
+    lda #$20 // ' '                                                   // 8277: a9 20       .
+    sta l105f                                                         // 8279: 8d 5f 10    ._.
+    lda #$58 // 'X'                                                   // 827c: a9 58       .X
+    bne c8286                                                         // 827e: d0 06       ..
+// $8280 referenced 6 times by $8260, $877c, $87ab, $87c6, $8a10, $a4db
+sub_c8280
+    ldx #0                                                            // 8280: a2 00       ..
+    beq c8290                                                         // 8282: f0 0c       ..
+// $8284 referenced 7 times by $8225, $87bb, $89f8, $8a7a, $8bcf, $9a7b, $9c28
+sub_c8284
+    lda #0                                                            // 8284: a9 00       ..
+// $8286 referenced 1 time by $827e
+c8286
+    pha                                                               // 8286: 48          H
+    jsr sub_c93fd                                                     // 8287: 20 fd 93     ..
+    pla                                                               // 828a: 68          h
+// $828b referenced 1 time by $826b
+c828b
+    tax                                                               // 828b: aa          .
+    lda #0                                                            // 828c: a9 00       ..
+    sta l00b6                                                         // 828e: 85 b6       ..
+// $8290 referenced 3 times by $8282, $82a4, $82ad
+c8290
+    ldy #0                                                            // 8290: a0 00       ..
+    lda #$0e                                                          // 8292: a9 0e       ..
+    sta l00b7                                                         // 8294: 85 b7       ..
+    lda l00b6                                                         // 8296: a5 b6       ..
+    cmp l0f05                                                         // 8298: cd 05 0f    ...
+    bcs c82e6                                                         // 829b: b0 49       .I
+    adc #8                                                            // 829d: 69 08       i.
+    sta l00b6                                                         // 829f: 85 b6       ..
+    jsr sub_c82bb                                                     // 82a1: 20 bb 82     ..
+    bcc c8290                                                         // 82a4: 90 ea       ..
+    lda l00cc                                                         // 82a6: a5 cc       ..
+    ldy #7                                                            // 82a8: a0 07       ..
+    jsr sub_c82e8                                                     // 82aa: 20 e8 82     ..
+    bne c8290                                                         // 82ad: d0 e1       ..
+    ldy l00b6                                                         // 82af: a4 b6       ..
+    sec                                                               // 82b1: 38          8
+// $82b2 referenced 4 times by $87e8, $8aca, $a27c, $a848
+sub_c82b2
+    dey                                                               // 82b2: 88          .
+    dey                                                               // 82b3: 88          .
+    dey                                                               // 82b4: 88          .
+    dey                                                               // 82b5: 88          .
+    dey                                                               // 82b6: 88          .
+    dey                                                               // 82b7: 88          .
+    dey                                                               // 82b8: 88          .
+    dey                                                               // 82b9: 88          .
+    rts                                                               // 82ba: 60          `
+
+// $82bb referenced 2 times by $82a1, $82c7
+sub_c82bb
+    jsr sub_c83e3                                                     // 82bb: 20 e3 83     ..
+// $82be referenced 1 time by $82e4
+c82be
+    lda l1000,x                                                       // 82be: bd 00 10    ...
+    cmp l10ce                                                         // 82c1: cd ce 10    ...
+    bne c82d9                                                         // 82c4: d0 13       ..
+    inx                                                               // 82c6: e8          .
+// $82c7 referenced 1 time by $82cf
+loop_c82c7
+    jsr sub_c82bb                                                     // 82c7: 20 bb 82     ..
+    bcs c82e7                                                         // 82ca: b0 1b       ..
+    iny                                                               // 82cc: c8          .
+    cpy #7                                                            // 82cd: c0 07       ..
+    bcc loop_c82c7                                                    // 82cf: 90 f6       ..
+// $82d1 referenced 1 time by $82db
+loop_c82d1
+    lda l1000,x                                                       // 82d1: bd 00 10    ...
+    cmp #$20 // ' '                                                   // 82d4: c9 20       .
+    bne c82e6                                                         // 82d6: d0 0e       ..
+    rts                                                               // 82d8: 60          `
+
+// $82d9 referenced 1 time by $82c4
+c82d9
+    cpy #7                                                            // 82d9: c0 07       ..
+    bcs loop_c82d1                                                    // 82db: b0 f4       ..
+    jsr sub_c82e8                                                     // 82dd: 20 e8 82     ..
+    bne c82e6                                                         // 82e0: d0 04       ..
+    inx                                                               // 82e2: e8          .
+    iny                                                               // 82e3: c8          .
+    bne c82be                                                         // 82e4: d0 d8       ..
+// $82e6 referenced 3 times by $829b, $82d6, $82e0
+c82e6
+    clc                                                               // 82e6: 18          .
+// $82e7 referenced 1 time by $82ca
+c82e7
+    rts                                                               // 82e7: 60          `
+
+// $82e8 referenced 2 times by $82aa, $82dd
+sub_c82e8
+    cmp l10ce                                                         // 82e8: cd ce 10    ...
+    beq c82fd                                                         // 82eb: f0 10       ..
+    cmp l10cd                                                         // 82ed: cd cd 10    ...
+    beq c82fd                                                         // 82f0: f0 0b       ..
+    jsr sub_c8327                                                     // 82f2: 20 27 83     '.
+    eor (l00b6),y                                                     // 82f5: 51 b6       Q.
+    bcs c82fb                                                         // 82f7: b0 02       ..
+    and #%01011111                                                    // 82f9: 29 5f       )_
+// $82fb referenced 1 time by $82f7
+c82fb
+    and #$7f                                                          // 82fb: 29 7f       ).
+// $82fd referenced 2 times by $82eb, $82f0
+c82fd
+    rts                                                               // 82fd: 60          `
+
+// $82fe referenced 6 times by $8441, $8567, $857e, $858e, $aa2b, $aa3b
+sub_c82fe
+    php                                                               // 82fe: 08          .
+    jsr sub_c8327                                                     // 82ff: 20 27 83     '.
+    bcs c8306                                                         // 8302: b0 02       ..
+    and #$5f // '_'                                                   // 8304: 29 5f       )_
+// $8306 referenced 1 time by $8302
+c8306
+    and #$7f                                                          // 8306: 29 7f       ).
+    plp                                                               // 8308: 28          (
+    rts                                                               // 8309: 60          `
+
+// $830a referenced 5 times by $878e, $87e3, $8a7f, $99c4, $a4f7
+sub_c830a
+    jsr sub_c9a60                                                     // 830a: 20 60 9a     `.
+// $830d referenced 1 time by $831d
+loop_c830d
+    lda l0e10,y                                                       // 830d: b9 10 0e    ...
+    sta l0e08,y                                                       // 8310: 99 08 0e    ...
+    lda l0f10,y                                                       // 8313: b9 10 0f    ...
+    sta l0f08,y                                                       // 8316: 99 08 0f    ...
+    iny                                                               // 8319: c8          .
+    cpy l0f05                                                         // 831a: cc 05 0f    ...
+    bcc loop_c830d                                                    // 831d: 90 ee       ..
+    tya                                                               // 831f: 98          .
+    sbc #8                                                            // 8320: e9 08       ..
+    sta l0f05                                                         // 8322: 8d 05 0f    ...
+    clc                                                               // 8325: 18          .
+// $8326 referenced 1 time by $8338
+loop_c8326
+    rts                                                               // 8326: 60          `
+
+// $8327 referenced 4 times by $82f2, $82ff, $8736, $98a8
+sub_c8327
+    pha                                                               // 8327: 48          H
+    and #$5f // '_'                                                   // 8328: 29 5f       )_
+    cmp #$41 // 'A'                                                   // 832a: c9 41       .A
+    bcc c8332                                                         // 832c: 90 04       ..
+    cmp #$5b // '['                                                   // 832e: c9 5b       .[
+    bcc c8333                                                         // 8330: 90 01       ..
+// $8332 referenced 1 time by $832c
+c8332
+    sec                                                               // 8332: 38          8
+// $8333 referenced 1 time by $8330
+c8333
+    pla                                                               // 8333: 68          h
+    rts                                                               // 8334: 60          `
+
+// $8335 referenced 5 times by $878b, $884f, $8a0d, $8b04, $a2ad
+sub_c8335
+    bit l10c6                                                         // 8335: 2c c6 10    ,..
+    bmi loop_c8326                                                    // 8338: 30 ec       0.
+// $833a referenced 3 times by $825d, $a30f, $a482
+sub_c833a
+    jsr sub_c83e3                                                     // 833a: 20 e3 83     ..
+    jsr sub_c8174                                                     // 833d: 20 74 81     t.
+    tya                                                               // 8340: 98          .
+    pha                                                               // 8341: 48          H
+    lda #$60 // '`'                                                   // 8342: a9 60       .`
+    sta l00b0                                                         // 8344: 85 b0       ..
+    lda #$10                                                          // 8346: a9 10       ..
+    sta l00b1                                                         // 8348: 85 b1       ..
+    jsr sub_c8386                                                     // 834a: 20 86 83     ..
+    ldy #2                                                            // 834d: a0 02       ..
+    jsr cac0f                                                         // 834f: 20 0f ac     ..
+    jsr sub_c836e                                                     // 8352: 20 6e 83     n.
+    jsr sub_c836e                                                     // 8355: 20 6e 83     n.
+    jsr sub_c836e                                                     // 8358: 20 6e 83     n.
+    pla                                                               // 835b: 68          h
+    tay                                                               // 835c: a8          .
+    lda l0f0e,y                                                       // 835d: b9 0e 0f    ...
+    and #3                                                            // 8360: 29 03       ).
+    jsr sub_c80c3                                                     // 8362: 20 c3 80     ..
+    lda l0f0f,y                                                       // 8365: b9 0f 0f    ...
+    jsr sub_c80bb                                                     // 8368: 20 bb 80     ..
+    jmp ca3dc                                                         // 836b: 4c dc a3    L..
+
+// $836e referenced 3 times by $8352, $8355, $8358
+sub_c836e
+    ldx #3                                                            // 836e: a2 03       ..
+// $8370 referenced 1 time by $8378
+loop_c8370
+    lda l1062,y                                                       // 8370: b9 62 10    .b.
+    jsr sub_c80bb                                                     // 8373: 20 bb 80     ..
+    dey                                                               // 8376: 88          .
+    dex                                                               // 8377: ca          .
+    bne loop_c8370                                                    // 8378: d0 f6       ..
+    jsr sub_c87db                                                     // 837a: 20 db 87     ..
+    jmp cac0f                                                         // 837d: 4c 0f ac    L..
+
+// $8380 referenced 7 times by $89bd, $975e, $9bf8, $a26a, $a4d1, $a4ef, $a7fc
+sub_c8380
+    jsr sub_c83e3                                                     // 8380: 20 e3 83     ..
+    jmp c940c                                                         // 8383: 4c 0c 94    L..
+
+// $8386 referenced 5 times by $834a, $8821, $885f, $99b8, $99c1
+sub_c8386
+    jsr sub_c83e3                                                     // 8386: 20 e3 83     ..
+    tya                                                               // 8389: 98          .
+    pha                                                               // 838a: 48          H
+    tax                                                               // 838b: aa          .
+    ldy #$12                                                          // 838c: a0 12       ..
+    lda #0                                                            // 838e: a9 00       ..
+// $8390 referenced 1 time by $8395
+loop_c8390
+    dey                                                               // 8390: 88          .
+    sta (l00b0),y                                                     // 8391: 91 b0       ..
+    cpy #2                                                            // 8393: c0 02       ..
+    bne loop_c8390                                                    // 8395: d0 f9       ..
+// $8397 referenced 1 time by $839e
+loop_c8397
+    jsr sub_c83d1                                                     // 8397: 20 d1 83     ..
+    iny                                                               // 839a: c8          .
+    iny                                                               // 839b: c8          .
+    cpy #$0e                                                          // 839c: c0 0e       ..
+    bne loop_c8397                                                    // 839e: d0 f7       ..
+    pla                                                               // 83a0: 68          h
+    tax                                                               // 83a1: aa          .
+    lda l0e0f,x                                                       // 83a2: bd 0f 0e    ...
+    bpl c83ab                                                         // 83a5: 10 04       ..
+    lda #8                                                            // 83a7: a9 08       ..
+    sta (l00b0),y                                                     // 83a9: 91 b0       ..
+// $83ab referenced 1 time by $83a5
+c83ab
+    lda l0f0e,x                                                       // 83ab: bd 0e 0f    ...
+    ldy #4                                                            // 83ae: a0 04       ..
+    jsr sub_c83bf                                                     // 83b0: 20 bf 83     ..
+    ldy #$0c                                                          // 83b3: a0 0c       ..
+    lsr                                                               // 83b5: 4a          J
+    lsr                                                               // 83b6: 4a          J
+    pha                                                               // 83b7: 48          H
+    and #3                                                            // 83b8: 29 03       ).
+    sta (l00b0),y                                                     // 83ba: 91 b0       ..
+    pla                                                               // 83bc: 68          h
+    ldy #8                                                            // 83bd: a0 08       ..
+// $83bf referenced 1 time by $83b0
+sub_c83bf
+    lsr                                                               // 83bf: 4a          J
+    lsr                                                               // 83c0: 4a          J
+    pha                                                               // 83c1: 48          H
+    and #3                                                            // 83c2: 29 03       ).
+    cmp #3                                                            // 83c4: c9 03       ..
+    bne c83cd                                                         // 83c6: d0 05       ..
+    lda #$ff                                                          // 83c8: a9 ff       ..
+    sta (l00b0),y                                                     // 83ca: 91 b0       ..
+    iny                                                               // 83cc: c8          .
+// $83cd referenced 1 time by $83c6
+c83cd
+    sta (l00b0),y                                                     // 83cd: 91 b0       ..
+    pla                                                               // 83cf: 68          h
+    rts                                                               // 83d0: 60          `
+
+// $83d1 referenced 1 time by $8397
+sub_c83d1
+    jsr sub_c83d4                                                     // 83d1: 20 d4 83     ..
+// $83d4 referenced 1 time by $83d1
+sub_c83d4
+    lda l0f08,x                                                       // 83d4: bd 08 0f    ...
+    sta (l00b0),y                                                     // 83d7: 91 b0       ..
+    inx                                                               // 83d9: e8          .
+    iny                                                               // 83da: c8          .
+    rts                                                               // 83db: 60          `
+
+// $83dc referenced 4 times by $805b, $8064, $8086, $a9ab
+inc16_ae
+    inc l00ae                                                         // 83dc: e6 ae       ..
+    bne c83e2                                                         // 83de: d0 02       ..
+    inc l00af                                                         // 83e0: e6 af       ..
+// $83e2 referenced 1 time by $83de
+c83e2
+    rts                                                               // 83e2: 60          `
+
+// $83e3 referenced 29 times by $809f, $8174, $82bb, $833a, $8380, $8386, $8951, $8a32, $96c3, $97cd, $993b, $99f3, $9a0f, $9a32, $9a63, $9ac8, $9ad8, $9b51, $9bf2, $9c10, $9d9b, $9f7c, $9f82, $a06c, $a190, $a1b4, $a379, $a384, $ac72
+sub_c83e3
+    pha                                                               // 83e3: 48          H
+    txa                                                               // 83e4: 8a          .
+    pha                                                               // 83e5: 48          H
+    tya                                                               // 83e6: 98          .
+    pha                                                               // 83e7: 48          H
+    lda #$84                                                          // 83e8: a9 84       ..
+    pha                                                               // 83ea: 48          H
+    lda #5                                                            // 83eb: a9 05       ..
+    pha                                                               // 83ed: 48          H
+// $83ee referenced 1 time by $8411
+sub_c83ee
+    ldy #5                                                            // 83ee: a0 05       ..
+// $83f0 referenced 1 time by $83f6
+loop_c83f0
+    tsx                                                               // 83f0: ba          .
+    lda l0107,x                                                       // 83f1: bd 07 01    ...
+    pha                                                               // 83f4: 48          H
+    dey                                                               // 83f5: 88          .
+    bne loop_c83f0                                                    // 83f6: d0 f8       ..
+    ldy #$0a                                                          // 83f8: a0 0a       ..
+// $83fa referenced 1 time by $8402
+loop_c83fa
+    lda l0109,x                                                       // 83fa: bd 09 01    ...
+    sta l010b,x                                                       // 83fd: 9d 0b 01    ...
+    dex                                                               // 8400: ca          .
+    dey                                                               // 8401: 88          .
+    bne loop_c83fa                                                    // 8402: d0 f6       ..
+    pla                                                               // 8404: 68          h
+    pla                                                               // 8405: 68          h
+// $8406 referenced 1 time by $8418
+loop_c8406
+    pla                                                               // 8406: 68          h
+    tay                                                               // 8407: a8          .
+    pla                                                               // 8408: 68          h
+    tax                                                               // 8409: aa          .
+    pla                                                               // 840a: 68          h
+    rts                                                               // 840b: 60          `
+
+// $840c referenced 5 times by $841b, $9785, $9c16, $9e94, $aadd
+sub_c840c
+    pha                                                               // 840c: 48          H
+    txa                                                               // 840d: 8a          .
+    pha                                                               // 840e: 48          H
+    tya                                                               // 840f: 98          .
+    pha                                                               // 8410: 48          H
+    jsr sub_c83ee                                                     // 8411: 20 ee 83     ..
+    tsx                                                               // 8414: ba          .
+    sta l0103,x                                                       // 8415: 9d 03 01    ...
+    jmp loop_c8406                                                    // 8418: 4c 06 84    L..
+
+// $841b referenced 2 times by $80b8, $a9bf
+sub_c841b
+    jsr sub_c840c                                                     // 841b: 20 0c 84     ..
+    tay                                                               // 841e: a8          .
+    beq c842b                                                         // 841f: f0 0a       ..
+    clc                                                               // 8421: 18          .
+    sed                                                               // 8422: f8          .
+    lda #0                                                            // 8423: a9 00       ..
+// $8425 referenced 1 time by $8428
+loop_c8425
+    adc #1                                                            // 8425: 69 01       i.
+    dey                                                               // 8427: 88          .
+    bne loop_c8425                                                    // 8428: d0 fb       ..
+    cld                                                               // 842a: d8          .
+// $842b referenced 1 time by $841f
+c842b
+    rts                                                               // 842b: 60          `
+
+// $842c referenced 1 time by $abb1
+sub_c842c
+    and #$7f                                                          // 842c: 29 7f       ).
+    cmp #$7f                                                          // 842e: c9 7f       ..
+    beq c8436                                                         // 8430: f0 04       ..
+    cmp #$20 // ' '                                                   // 8432: c9 20       .
+    bcs c8438                                                         // 8434: b0 02       ..
+// $8436 referenced 1 time by $8430
+c8436
+    lda #$2e // '.'                                                   // 8436: a9 2e       ..
+// $8438 referenced 1 time by $8434
+c8438
+    rts                                                               // 8438: 60          `
+
+// $8439 referenced 2 times by $8444, $8463
+sub_c8439
+    sec                                                               // 8439: 38          8
+    sbc #$30 // '0'                                                   // 843a: e9 30       .0
+    bcc c8454                                                         // 843c: 90 16       ..
+    cmp #$0a                                                          // 843e: c9 0a       ..
+    rts                                                               // 8440: 60          `
+
+    jsr sub_c82fe                                                     // 8441: 20 fe 82     ..
+    jsr sub_c8439                                                     // 8444: 20 39 84     9.
+    bcc c8453                                                         // 8447: 90 0a       ..
+    sbc #7                                                            // 8449: e9 07       ..
+    bcc c8454                                                         // 844b: 90 07       ..
+    cmp #$0a                                                          // 844d: c9 0a       ..
+    bcc c8454                                                         // 844f: 90 03       ..
+    cmp #$10                                                          // 8451: c9 10       ..
+// $8453 referenced 1 time by $8447
+c8453
+    rts                                                               // 8453: 60          `
+
+// $8454 referenced 3 times by $843c, $844b, $844f
+c8454
+    sec                                                               // 8454: 38          8
+    rts                                                               // 8455: 60          `
+
+// $8456 referenced 3 times by $87f7, $a5ce, $a9e7
+sub_c8456
+    jsr clc_jmp_gsinit                                                // 8456: 20 4c 87     L.
+    sec                                                               // 8459: 38          8
+    beq c8482                                                         // 845a: f0 26       .&
+    php                                                               // 845c: 08          .
+    lda #0                                                            // 845d: a9 00       ..
+    sta l00b9                                                         // 845f: 85 b9       ..
+    beq c8477                                                         // 8461: f0 14       ..
+// $8463 referenced 1 time by $847a
+loop_c8463
+    jsr sub_c8439                                                     // 8463: 20 39 84     9.
+    bcs c8481                                                         // 8466: b0 19       ..
+    sta l00b8                                                         // 8468: 85 b8       ..
+    lda l00b9                                                         // 846a: a5 b9       ..
+    asl                                                               // 846c: 0a          .
+    sta l00b9                                                         // 846d: 85 b9       ..
+    asl                                                               // 846f: 0a          .
+    asl                                                               // 8470: 0a          .
+    adc l00b9                                                         // 8471: 65 b9       e.
+    adc l00b8                                                         // 8473: 65 b8       e.
+    sta l00b9                                                         // 8475: 85 b9       ..
+// $8477 referenced 1 time by $8461
+c8477
+    jsr gsread                                                        // 8477: 20 c5 ff     ..
+    bcc loop_c8463                                                    // 847a: 90 e7       ..
+    lda l00b9                                                         // 847c: a5 b9       ..
+    plp                                                               // 847e: 28          (
+    clc                                                               // 847f: 18          .
+    rts                                                               // 8480: 60          `
+
+// $8481 referenced 1 time by $8466
+c8481
+    plp                                                               // 8481: 28          (
+// $8482 referenced 1 time by $845a
+c8482
+    rts                                                               // 8482: 60          `
+
+    jsr sub_c8745                                                     // 8483: 20 45 87     E.
+    jsr sub_c8b86                                                     // 8486: 20 86 8b     ..
+    jsr c940c                                                         // 8489: 20 0c 94     ..
+    ldy #$ff                                                          // 848c: a0 ff       ..
+    sty l00a8                                                         // 848e: 84 a8       ..
+    iny                                                               // 8490: c8          .
+    sty l00aa                                                         // 8491: 84 aa       ..
+// $8493 referenced 1 time by $84a3
+loop_c8493
+    lda l0e00,y                                                       // 8493: b9 00 0e    ...
+    cpy #8                                                            // 8496: c0 08       ..
+    bcc c849d                                                         // 8498: 90 03       ..
+    lda l0ef8,y                                                       // 849a: b9 f8 0e    ...
+// $849d referenced 1 time by $8498
+c849d
+    jsr c809f                                                         // 849d: 20 9f 80     ..
+    iny                                                               // 84a0: c8          .
+    cpy #$0c                                                          // 84a1: c0 0c       ..
+    bne loop_c8493                                                    // 84a3: d0 ee       ..
+    jsr print_inline_l809f_top_bit_clear                              // 84a5: 20 77 80     w.
+    .asc " ("                                                         // 84a8: 20 28        (
+
+    lda l0f04                                                         // 84aa: ad 04 0f    ...
+    jsr sub_c80bb                                                     // 84ad: 20 bb 80     ..
+    jsr print_inline_l809f_top_bit_clear                              // 84b0: 20 77 80     w.
+    .asc ") FM", $0d, "Drive "                                        // 84b3: 29 20 46... ) F
+
+    lda l00cd                                                         // 84be: a5 cd       ..
+    jsr sub_c80c3                                                     // 84c0: 20 c3 80     ..
+    ldy #$0d                                                          // 84c3: a0 0d       ..
+    jsr c81a7                                                         // 84c5: 20 a7 81     ..
+    jsr print_inline_l809f_top_bit_clear                              // 84c8: 20 77 80     w.
+    .asc "Option "                                                    // 84cb: 4f 70 74... Opt
+
+    lda l0f06                                                         // 84d2: ad 06 0f    ...
+    jsr sub_c81bf                                                     // 84d5: 20 bf 81     ..
+    pha                                                               // 84d8: 48          H
+    jsr sub_c80c3                                                     // 84d9: 20 c3 80     ..
+    jsr print_inline_l809f_top_bit_clear                              // 84dc: 20 77 80     w.
+    .asc " ("                                                         // 84df: 20 28        (
+
+    ldy #3                                                            // 84e1: a0 03       ..
+    pla                                                               // 84e3: 68          h
+    asl                                                               // 84e4: 0a          .
+    asl                                                               // 84e5: 0a          .
+    tax                                                               // 84e6: aa          .
+// $84e7 referenced 1 time by $84ef
+loop_c84e7
+    lda opt4_table,x                                                  // 84e7: bd d3 85    ...
+    jsr c809f                                                         // 84ea: 20 9f 80     ..
+    inx                                                               // 84ed: e8          .
+    dey                                                               // 84ee: 88          .
+    bpl loop_c84e7                                                    // 84ef: 10 f6       ..
+    jsr print_inline_l809f_top_bit_clear                              // 84f1: 20 77 80     w.
+    .asc ")", $0d, "Dir. :"                                           // 84f4: 29 0d 44... ).D
+
+    lda l10ca                                                         // 84fc: ad ca 10    ...
+    jsr sub_c809a                                                     // 84ff: 20 9a 80     ..
+    lda l10c9                                                         // 8502: ad c9 10    ...
+    jsr c809f                                                         // 8505: 20 9f 80     ..
+    ldy #$0b                                                          // 8508: a0 0b       ..
+    jsr c81a7                                                         // 850a: 20 a7 81     ..
+    jsr print_inline_l809f_top_bit_clear                              // 850d: 20 77 80     w.
+    .asc "Lib. :"                                                     // 8510: 4c 69 62... Lib
+
+    lda l10cc                                                         // 8516: ad cc 10    ...
+    jsr sub_c809a                                                     // 8519: 20 9a 80     ..
+    lda l10cb                                                         // 851c: ad cb 10    ...
+    jsr c809f                                                         // 851f: 20 9f 80     ..
+    jsr ca3dc                                                         // 8522: 20 dc a3     ..
+    ldy #0                                                            // 8525: a0 00       ..
+// $8527 referenced 1 time by $8541
+loop_c8527
+    cpy l0f05                                                         // 8527: cc 05 0f    ...
+    bcs c8543                                                         // 852a: b0 17       ..
+    lda l0e0f,y                                                       // 852c: b9 0f 0e    ...
+    eor l10c9                                                         // 852f: 4d c9 10    M..
+    and #$5f // '_'                                                   // 8532: 29 5f       )_
+    bne c853e                                                         // 8534: d0 08       ..
+    lda l0e0f,y                                                       // 8536: b9 0f 0e    ...
+    and #$80                                                          // 8539: 29 80       ).
+    sta l0e0f,y                                                       // 853b: 99 0f 0e    ...
+// $853e referenced 1 time by $8534
+c853e
+    jsr sub_c87da                                                     // 853e: 20 da 87     ..
+    bcc loop_c8527                                                    // 8541: 90 e4       ..
+// $8543 referenced 2 times by $852a, $85d0
+c8543
+    ldy #0                                                            // 8543: a0 00       ..
+    jsr sub_c8555                                                     // 8545: 20 55 85     U.
+    bcc c8560                                                         // 8548: 90 16       ..
+    lda #$ff                                                          // 854a: a9 ff       ..
+    sta l1082                                                         // 854c: 8d 82 10    ...
+    jmp ca3dc                                                         // 854f: 4c dc a3    L..
+
+// $8552 referenced 1 time by $855d
+loop_c8552
+    jsr sub_c87da                                                     // 8552: 20 da 87     ..
+// $8555 referenced 2 times by $8545, $8573
+sub_c8555
+    cpy l0f05                                                         // 8555: cc 05 0f    ...
+    bcs c855f                                                         // 8558: b0 05       ..
+    lda l0e08,y                                                       // 855a: b9 08 0e    ...
+    bmi loop_c8552                                                    // 855d: 30 f3       0.
+// $855f referenced 1 time by $8558
+c855f
+    rts                                                               // 855f: 60          `
+
+// $8560 referenced 2 times by $8548, $8594
+c8560
+    sty l00ab                                                         // 8560: 84 ab       ..
+    ldx #0                                                            // 8562: a2 00       ..
+// $8564 referenced 1 time by $8571
+loop_c8564
+    lda l0e08,y                                                       // 8564: b9 08 0e    ...
+    jsr sub_c82fe                                                     // 8567: 20 fe 82     ..
+    sta l1060,x                                                       // 856a: 9d 60 10    .`.
+    iny                                                               // 856d: c8          .
+    inx                                                               // 856e: e8          .
+    cpx #8                                                            // 856f: e0 08       ..
+    bne loop_c8564                                                    // 8571: d0 f1       ..
+// $8573 referenced 1 time by $8599
+c8573
+    jsr sub_c8555                                                     // 8573: 20 55 85     U.
+    bcs c859b                                                         // 8576: b0 23       .#
+    sec                                                               // 8578: 38          8
+    ldx #6                                                            // 8579: a2 06       ..
+// $857b referenced 1 time by $8586
+loop_c857b
+    lda l0e0e,y                                                       // 857b: b9 0e 0e    ...
+    jsr sub_c82fe                                                     // 857e: 20 fe 82     ..
+    sbc l1060,x                                                       // 8581: fd 60 10    .`.
+    dey                                                               // 8584: 88          .
+    dex                                                               // 8585: ca          .
+    bpl loop_c857b                                                    // 8586: 10 f3       ..
+    jsr sub_c87db                                                     // 8588: 20 db 87     ..
+    lda l0e0f,y                                                       // 858b: b9 0f 0e    ...
+    jsr sub_c82fe                                                     // 858e: 20 fe 82     ..
+    sbc l1067                                                         // 8591: ed 67 10    .g.
+    bcc c8560                                                         // 8594: 90 ca       ..
+    jsr sub_c87da                                                     // 8596: 20 da 87     ..
+    bcs c8573                                                         // 8599: b0 d8       ..
+// $859b referenced 1 time by $8576
+c859b
+    ldy l00ab                                                         // 859b: a4 ab       ..
+    lda l0e08,y                                                       // 859d: b9 08 0e    ...
+    ora #$80                                                          // 85a0: 09 80       ..
+    sta l0e08,y                                                       // 85a2: 99 08 0e    ...
+    lda l1067                                                         // 85a5: ad 67 10    .g.
+    cmp l00aa                                                         // 85a8: c5 aa       ..
+    beq c85bc                                                         // 85aa: f0 10       ..
+    ldx l00aa                                                         // 85ac: a6 aa       ..
+    sta l00aa                                                         // 85ae: 85 aa       ..
+    bne c85bc                                                         // 85b0: d0 0a       ..
+    jsr ca3dc                                                         // 85b2: 20 dc a3     ..
+// $85b5 referenced 1 time by $85be
+loop_c85b5
+    jsr ca3dc                                                         // 85b5: 20 dc a3     ..
+    ldy #$ff                                                          // 85b8: a0 ff       ..
+    bne c85c5                                                         // 85ba: d0 09       ..
+// $85bc referenced 2 times by $85aa, $85b0
+c85bc
+    ldy l00a8                                                         // 85bc: a4 a8       ..
+    bne loop_c85b5                                                    // 85be: d0 f5       ..
+    ldy #5                                                            // 85c0: a0 05       ..
+    jsr c81a7                                                         // 85c2: 20 a7 81     ..
+// $85c5 referenced 1 time by $85ba
+c85c5
+    iny                                                               // 85c5: c8          .
+    sty l00a8                                                         // 85c6: 84 a8       ..
+    ldy l00ab                                                         // 85c8: a4 ab       ..
+    jsr sub_cac0c                                                     // 85ca: 20 0c ac     ..
+    jsr sub_c8174                                                     // 85cd: 20 74 81     t.
+    jmp c8543                                                         // 85d0: 4c 43 85    LC.
+
+// $85d3 referenced 1 time by $84e7
+opt4_table
+    .asc "off", 0                                                     // 85d3: 6f 66 66... off
+    .asc "LOAD"                                                       // 85d7: 4c 4f 41... LOA
+    .asc "RUN", 0                                                     // 85db: 52 55 4e... RUN
+    .asc "EXEC"                                                       // 85df: 45 58 45... EXE
+
+// $85e3 referenced 1 time by $8acd
+sub_c85e3
+    lda l0f0e,y                                                       // 85e3: b9 0e 0f    ...
+    jsr sub_c81b0                                                     // 85e6: 20 b0 81     ..
+    sta l00c2                                                         // 85e9: 85 c2       ..
+    clc                                                               // 85eb: 18          .
+    lda #$ff                                                          // 85ec: a9 ff       ..
+    adc l0f0c,y                                                       // 85ee: 79 0c 0f    y..
+    lda l0f0f,y                                                       // 85f1: b9 0f 0f    ...
+    adc l0f0d,y                                                       // 85f4: 79 0d 0f    y..
+    sta l00c3                                                         // 85f7: 85 c3       ..
+    lda l0f0e,y                                                       // 85f9: b9 0e 0f    ...
+    and #3                                                            // 85fc: 29 03       ).
+    adc l00c2                                                         // 85fe: 65 c2       e.
+    sta l00c2                                                         // 8600: 85 c2       ..
+// $8602 referenced 1 time by $8ac2
+sub_c8602
+    sec                                                               // 8602: 38          8
+    lda l0f07,y                                                       // 8603: b9 07 0f    ...
+    sbc l00c3                                                         // 8606: e5 c3       ..
+    pha                                                               // 8608: 48          H
+    lda l0f06,y                                                       // 8609: b9 06 0f    ...
+    and #3                                                            // 860c: 29 03       ).
+    sbc l00c2                                                         // 860e: e5 c2       ..
+    tax                                                               // 8610: aa          .
+    lda #0                                                            // 8611: a9 00       ..
+    cmp l00c0                                                         // 8613: c5 c0       ..
+    pla                                                               // 8615: 68          h
+    sbc l00c1                                                         // 8616: e5 c1       ..
+    txa                                                               // 8618: 8a          .
+    sbc l00c4                                                         // 8619: e5 c4       ..
+    rts                                                               // 861b: 60          `
+
+// $861c referenced 6 times by $870e, $8719, $8726, $873c, $a16f, $a187
+command_table
+    .asc "ACCESS"                                                     // 861c: 41 43 43... ACC
+// $861d referenced 1 time by $8740
+    .byt >(sub_c89e6-1)                                               // 8622: 89          .
+    .byt <(sub_c89e6-1)                                               // 8623: e5          .
+    .byt $32                                                          // 8624: 32          2
+    .asc "BACKUP"                                                     // 8625: 42 41 43... BAC
+    .byt >(sub_ca417-1)                                               // 862b: a4          .
+    .byt <(sub_ca417-1)                                               // 862c: 16          .
+    .byt 4                                                            // 862d: 04          .
+    .asc "CLOSE"                                                      // 862e: 43 4c 4f... CLO
+    .byt >(sub_c9b59-1)                                               // 8633: 9b          .
+    .byt <(sub_c9b59-1)                                               // 8634: 58          X
+    .byt 0                                                            // 8635: 00          .
+    .asc "COMPACT"                                                    // 8636: 43 4f 4d... COM
+    .byt >(sub_ca244-1)                                               // 863d: a2          .
+    .byt <(sub_ca244-1)                                               // 863e: 43          C
+    .byt 7                                                            // 863f: 07          .
+    .asc "COPY"                                                       // 8640: 43 4f 50... COP
+    .byt >(sub_ca463-1)                                               // 8644: a4          .
+    .byt <(sub_ca463-1)                                               // 8645: 62          b
+    .byt $24                                                          // 8646: 24          $
+    .asc "DELETE"                                                     // 8647: 44 45 4c... DEL
+    .byt >(sub_c8782-1)                                               // 864d: 87          .
+    .byt <(sub_c8782-1)                                               // 864e: 81          .
+    .byt 1                                                            // 864f: 01          .
+    .asc "DESTROY"                                                    // 8650: 44 45 53... DES
+    .byt >(sub_c8794-1)                                               // 8657: 87          .
+    .byt <(sub_c8794-1)                                               // 8658: 93          .
+    .byt 2                                                            // 8659: 02          .
+    .asc "DIR"                                                        // 865a: 44 49 52    DIR
+    .byt >(sub_c893f-1)                                               // 865d: 89          .
+    .byt <(sub_c893f-1)                                               // 865e: 3e          >
+    .byt 6                                                            // 865f: 06          .
+    .asc "DRIVE"                                                      // 8660: 44 52 49... DRI
+    .byt >(sub_c87ee-1)                                               // 8665: 87          .
+    .byt <(sub_c87ee-1)                                               // 8666: ed          .
+    .byt 9                                                            // 8667: 09          .
+    .asc "ENABLE"                                                     // 8668: 45 4e 41... ENA
+    .byt >(sub_c8b47-1)                                               // 866e: 8b          .
+    .byt <(sub_c8b47-1)                                               // 866f: 46          F
+    .byt 0                                                            // 8670: 00          .
+    .asc "EX"                                                         // 8671: 45 58       EX
+    .byt >(sub_c8238-1)                                               // 8673: 82          .
+    .byt <(sub_c8238-1)                                               // 8674: 37          7
+    .byt 6                                                            // 8675: 06          .
+    .asc "FORM"                                                       // 8676: 46 4f 52... FOR
+    .byt >(sub_ca5bf-1)                                               // 867a: a5          .
+    .byt <(sub_ca5bf-1)                                               // 867b: be          .
+    .byt $ba                                                          // 867c: ba          .
+    .asc "FREE"                                                       // 867d: 46 52 45... FRE
+    .byt >(sub_ca7f3-1)                                               // 8681: a7          .
+    .byt <(sub_ca7f3-1)                                               // 8682: f2          .
+    .byt 7                                                            // 8683: 07          .
+    .asc "INFO"                                                       // 8684: 49 4e 46... INF
+    .byt >(sub_c8254-1)                                               // 8688: 82          .
+    .byt <(sub_c8254-1)                                               // 8689: 53          S
+    .byt 2                                                            // 868a: 02          .
+    .asc "LIB"                                                        // 868b: 4c 49 42    LIB
+    .byt >(sub_c8943-1)                                               // 868e: 89          .
+    .byt <(sub_c8943-1)                                               // 868f: 42          B
+    .byt 6                                                            // 8690: 06          .
+    .asc "MAP"                                                        // 8691: 4d 41 50    MAP
+    .byt >(sub_ca7f6-1)                                               // 8694: a7          .
+    .byt <(sub_ca7f6-1)                                               // 8695: f5          .
+    .byt 7                                                            // 8696: 07          .
+    .asc "RENAME"                                                     // 8697: 52 45 4e... REN
+    .byt >(sub_c8bac-1)                                               // 869d: 8b          .
+    .byt <(sub_c8bac-1)                                               // 869e: ab          .
+    .byt 5                                                            // 869f: 05          .
+    .asc "TITLE"                                                      // 86a0: 54 49 54... TIT
+    .byt >(sub_c89b7-1)                                               // 86a5: 89          .
+    .byt <(sub_c89b7-1)                                               // 86a6: b6          .
+    .byt 8                                                            // 86a7: 08          .
+    .asc "VERIFY"                                                     // 86a8: 56 45 52... VER
+    .byt >(sub_ca5bb-1)                                               // 86ae: a5          .
+    .byt <(sub_ca5bb-1)                                               // 86af: ba          .
+    .byt $0b                                                          // 86b0: 0b          .
+    .asc "WIPE"                                                       // 86b1: 57 49 50... WIP
+    .byt >(sub_c8750-1)                                               // 86b5: 87          .
+    .byt <(sub_c8750-1)                                               // 86b6: 4f          O
+    .byt   2, $88, $72                                                // 86b7: 02 88 72    ..r
+    .asc "BUILD"                                                      // 86ba: 42 55 49... BUI
+    .byt >(sub_cabc5-1)                                               // 86bf: ab          .
+    .byt <(sub_cabc5-1)                                               // 86c0: c4          .
+    .byt 1                                                            // 86c1: 01          .
+    .asc "DISC"                                                       // 86c2: 44 49 53... DIS
+    .byt >(c956d-1)                                                   // 86c6: 95          .
+    .byt <(c956d-1)                                                   // 86c7: 6c          l
+    .byt 0                                                            // 86c8: 00          .
+    .asc "DUMP"                                                       // 86c9: 44 55 4d... DUM
+    .byt >(sub_cab46-1)                                               // 86cd: ab          .
+    .byt <(sub_cab46-1)                                               // 86ce: 45          E
+    .byt 1                                                            // 86cf: 01          .
+    .asc "LIST"                                                       // 86d0: 4c 49 53... LIS
+    .byt >(sub_cab04-1)                                               // 86d4: ab          .
+    .byt <(sub_cab04-1)                                               // 86d5: 03          .
+    .byt 1                                                            // 86d6: 01          .
+    .asc "ROMS"                                                       // 86d7: 52 4f 4d... ROM
+    .byt >(sub_ca9d0-1)                                               // 86db: a9          .
+    .byt <(sub_ca9d0-1)                                               // 86dc: cf          .
+    .byt $0c                                                          // 86dd: 0c          .
+    .asc "TYPE"                                                       // 86de: 54 59 50... TYP
+    .byt >(sub_caafd-1)                                               // 86e2: aa          .
+    .byt <(sub_caafd-1)                                               // 86e3: fc          .
+    .byt 1                                                            // 86e4: 01          .
+    .asc "DISK"                                                       // 86e5: 44 49 53... DIS
+    .byt >(c956d-1)                                                   // 86e9: 95          .
+    .byt <(c956d-1)                                                   // 86ea: 6c          l
+    .byt   0, $86, $1a                                                // 86eb: 00 86 1a    ...
+    .asc "DFS"                                                        // 86ee: 44 46 53    DFS
+    .byt >(sub_ca106-1)                                               // 86f1: a1          .
+    .byt <(sub_ca106-1)                                               // 86f2: 05          .
+    .byt 0                                                            // 86f3: 00          .
+    .asc "UTILS"                                                      // 86f4: 55 54 49... UTI
+    .byt >(sub_ca137-1)                                               // 86f9: a1          .
+    .byt <(sub_ca137-1)                                               // 86fa: 36          6
+    .byt   0, $a1                                                     // 86fb: 00 a1       ..
+    .asc "= E"                                                        // 86fd: 3d 20 45    = E
+    .byt $87, $a2, $fd                                                // 8700: 87 a2 fd    ...
+
+// $8703 referenced 2 times by $96f2, $a134
+c8703
+    tya                                                               // 8703: 98          .
+    pha                                                               // 8704: 48          H
+// $8705 referenced 2 times by $872f, $8739
+c8705
+    inx                                                               // 8705: e8          .
+    inx                                                               // 8706: e8          .
+    pla                                                               // 8707: 68          h
+    pha                                                               // 8708: 48          H
+    tay                                                               // 8709: a8          .
+    jsr clc_jmp_gsinit                                                // 870a: 20 4c 87     L.
+    inx                                                               // 870d: e8          .
+    lda command_table,x                                               // 870e: bd 1c 86    ...
+    bmi c873b                                                         // 8711: 30 28       0(
+    dex                                                               // 8713: ca          .
+    dey                                                               // 8714: 88          .
+    stx l00bf                                                         // 8715: 86 bf       ..
+// $8717 referenced 1 time by $8722
+loop_c8717
+    inx                                                               // 8717: e8          .
+    iny                                                               // 8718: c8          .
+    lda command_table,x                                               // 8719: bd 1c 86    ...
+    bmi c8734                                                         // 871c: 30 16       0.
+    eor (os_text_ptr),y                                               // 871e: 51 f2       Q.
+    and #$5f // '_'                                                   // 8720: 29 5f       )_
+    beq loop_c8717                                                    // 8722: f0 f3       ..
+    dex                                                               // 8724: ca          .
+// $8725 referenced 1 time by $8729
+loop_c8725
+    inx                                                               // 8725: e8          .
+    lda command_table,x                                               // 8726: bd 1c 86    ...
+    bpl loop_c8725                                                    // 8729: 10 fa       ..
+    lda (os_text_ptr),y                                               // 872b: b1 f2       ..
+    cmp #$2e // '.'                                                   // 872d: c9 2e       ..
+    bne c8705                                                         // 872f: d0 d4       ..
+    iny                                                               // 8731: c8          .
+    bcs c873b                                                         // 8732: b0 07       ..
+// $8734 referenced 1 time by $871c
+c8734
+    lda (os_text_ptr),y                                               // 8734: b1 f2       ..
+    jsr sub_c8327                                                     // 8736: 20 27 83     '.
+    bcc c8705                                                         // 8739: 90 ca       ..
+// $873b referenced 2 times by $8711, $8732
+c873b
+    pla                                                               // 873b: 68          h
+    lda command_table,x                                               // 873c: bd 1c 86    ...
+    pha                                                               // 873f: 48          H
+    lda command_table+1,x                                             // 8740: bd 1d 86    ...
+    pha                                                               // 8743: 48          H
+    rts                                                               // 8744: 60          `
+
+// $8745 referenced 2 times by $8483, $8870
+sub_c8745
+    stx os_text_ptr                                                   // 8745: 86 f2       ..
+    sty l00f3                                                         // 8747: 84 f3       ..
+    ldy #0                                                            // 8749: a0 00       ..
+    rts                                                               // 874b: 60          `
+
+// $874c referenced 12 times by $8100, $823b, $8456, $870a, $897e, $89f1, $8b86, $a13e, $a14a, $a5e5, $a657, $a9f7
+clc_jmp_gsinit
+    clc                                                               // 874c: 18          .
+    jmp gsinit                                                        // 874d: 4c c2 ff    L..
+
+sub_c8750
+    jsr sub_c99ac                                                     // 8750: 20 ac 99     ..
+    jsr sub_ca14a                                                     // 8753: 20 4a a1     J.
+    jsr sub_c821d                                                     // 8756: 20 1d 82     ..
+// $8759 referenced 1 time by $877f
+c8759
+    lda l0e0f,y                                                       // 8759: b9 0f 0e    ...
+    bmi c877c                                                         // 875c: 30 1e       0.
+    jsr sub_c8174                                                     // 875e: 20 74 81     t.
+    jsr sub_ca3e4                                                     // 8761: 20 e4 a3     ..
+    bne c8779                                                         // 8764: d0 13       ..
+    ldx l00b6                                                         // 8766: a6 b6       ..
+    jsr sub_c9bf2                                                     // 8768: 20 f2 9b     ..
+    stx l00b6                                                         // 876b: 86 b6       ..
+    jsr sub_c87e3                                                     // 876d: 20 e3 87     ..
+    sty l00ab                                                         // 8770: 84 ab       ..
+    jsr c93e6                                                         // 8772: 20 e6 93     ..
+    lda l00ab                                                         // 8775: a5 ab       ..
+    sta l00b6                                                         // 8777: 85 b6       ..
+// $8779 referenced 1 time by $8764
+c8779
+    jsr ca3dc                                                         // 8779: 20 dc a3     ..
+// $877c referenced 1 time by $875c
+c877c
+    jsr sub_c8280                                                     // 877c: 20 80 82     ..
+    bcs c8759                                                         // 877f: b0 d8       ..
+    rts                                                               // 8781: 60          `
+
+sub_c8782
+    jsr c99a3                                                         // 8782: 20 a3 99     ..
+    jsr sub_ca14a                                                     // 8785: 20 4a a1     J.
+    jsr sub_c821d                                                     // 8788: 20 1d 82     ..
+    jsr sub_c8335                                                     // 878b: 20 35 83     5.
+    jsr sub_c830a                                                     // 878e: 20 0a 83     ..
+    jmp c93e6                                                         // 8791: 4c e6 93    L..
+
+sub_c8794
+    jsr sub_ca315                                                     // 8794: 20 15 a3     ..
+    jsr sub_c99ac                                                     // 8797: 20 ac 99     ..
+    jsr sub_ca14a                                                     // 879a: 20 4a a1     J.
+    jsr sub_c821d                                                     // 879d: 20 1d 82     ..
+// $87a0 referenced 1 time by $87ae
+loop_c87a0
+    lda l0e0f,y                                                       // 87a0: b9 0f 0e    ...
+    bmi c87ab                                                         // 87a3: 30 06       0.
+    jsr sub_c8174                                                     // 87a5: 20 74 81     t.
+    jsr ca3dc                                                         // 87a8: 20 dc a3     ..
+// $87ab referenced 1 time by $87a3
+c87ab
+    jsr sub_c8280                                                     // 87ab: 20 80 82     ..
+    bcs loop_c87a0                                                    // 87ae: b0 f0       ..
+    jsr sub_ca3ec                                                     // 87b0: 20 ec a3     ..
+    beq c87b8                                                         // 87b3: f0 03       ..
+    jmp ca3dc                                                         // 87b5: 4c dc a3    L..
+
+// $87b8 referenced 1 time by $87b3
+c87b8
+    jsr sub_c9bf2                                                     // 87b8: 20 f2 9b     ..
+    jsr sub_c8284                                                     // 87bb: 20 84 82     ..
+// $87be referenced 1 time by $87c9
+loop_c87be
+    lda l0e0f,y                                                       // 87be: b9 0f 0e    ...
+    bmi c87c6                                                         // 87c1: 30 03       0.
+    jsr sub_c87e3                                                     // 87c3: 20 e3 87     ..
+// $87c6 referenced 1 time by $87c1
+c87c6
+    jsr sub_c8280                                                     // 87c6: 20 80 82     ..
+    bcs loop_c87be                                                    // 87c9: b0 f3       ..
+    jsr c93e6                                                         // 87cb: 20 e6 93     ..
+    jsr print_inline_l809f_top_bit_clear                              // 87ce: 20 77 80     w.
+    .asc $0d, "Deleted", $0d                                          // 87d1: 0d 44 65... .De
+
+// $87da referenced 6 times by $853e, $8552, $8596, $8b0c, $8be5, $98b5
+sub_c87da
+    iny                                                               // 87da: c8          .
+// $87db referenced 2 times by $837a, $8588
+sub_c87db
+    iny                                                               // 87db: c8          .
+    iny                                                               // 87dc: c8          .
+    iny                                                               // 87dd: c8          .
+    iny                                                               // 87de: c8          .
+    iny                                                               // 87df: c8          .
+    iny                                                               // 87e0: c8          .
+    iny                                                               // 87e1: c8          .
+    rts                                                               // 87e2: 60          `
+
+// $87e3 referenced 2 times by $876d, $87c3
+sub_c87e3
+    jsr sub_c830a                                                     // 87e3: 20 0a 83     ..
+    ldy l00b6                                                         // 87e6: a4 b6       ..
+    jsr sub_c82b2                                                     // 87e8: 20 b2 82     ..
+    sty l00b6                                                         // 87eb: 84 b6       ..
+    rts                                                               // 87ed: 60          `
+
+sub_c87ee
+    jsr sub_ca14a                                                     // 87ee: 20 4a a1     J.
+    jsr c8b8b                                                         // 87f1: 20 8b 8b     ..
+    sta l10ca                                                         // 87f4: 8d ca 10    ...
+    jsr sub_c8456                                                     // 87f7: 20 56 84     V.
+    beq c8815                                                         // 87fa: f0 19       ..
+    cmp #$28 // '('                                                   // 87fc: c9 28       .(
+    beq c8808                                                         // 87fe: f0 08       ..
+    cmp #$50 // 'P'                                                   // 8800: c9 50       .P
+    clc                                                               // 8802: 18          .
+    beq c8808                                                         // 8803: f0 03       ..
+    jmp ca14f                                                         // 8805: 4c 4f a1    LO.
+
+// $8808 referenced 2 times by $87fe, $8803
+c8808
+    php                                                               // 8808: 08          .
+    ldx l10ca                                                         // 8809: ae ca 10    ...
+    lda l10de,x                                                       // 880c: bd de 10    ...
+    rol                                                               // 880f: 2a          *
+    plp                                                               // 8810: 28          (
+    ror                                                               // 8811: 6a          j
+    sta l10de,x                                                       // 8812: 9d de 10    ...
+// $8815 referenced 1 time by $87fa
+c8815
+    rts                                                               // 8815: 60          `
+
+// $8816 referenced 8 times by $888f, $8985, $898d, $8b83, $8b9d, $9bef, $a475, $a4ce
+c8816
+    and #3                                                            // 8816: 29 03       ).
+    sta l00cd                                                         // 8818: 85 cd       ..
+    rts                                                               // 881a: 60          `
+
+    jsr sub_c8222                                                     // 881b: 20 22 82     ".
+    jsr sub_c9a82                                                     // 881e: 20 82 9a     ..
+    jsr sub_c8386                                                     // 8821: 20 86 83     ..
+    lda #$80                                                          // 8824: a9 80       ..
+// $8826 referenced 1 time by $88f6
+sub_c8826
+    sta l1096                                                         // 8826: 8d 96 10    ...
+    sty l00ba                                                         // 8829: 84 ba       ..
+    ldx #0                                                            // 882b: a2 00       ..
+    lda l00be                                                         // 882d: a5 be       ..
+    bne c8837                                                         // 882f: d0 06       ..
+    iny                                                               // 8831: c8          .
+    iny                                                               // 8832: c8          .
+    ldx #2                                                            // 8833: a2 02       ..
+    bne c883f                                                         // 8835: d0 08       ..
+// $8837 referenced 1 time by $882f
+c8837
+    lda l0f0e,y                                                       // 8837: b9 0e 0f    ...
+    sta l00c2                                                         // 883a: 85 c2       ..
+    jsr sub_c8b4d                                                     // 883c: 20 4d 8b     M.
+// $883f referenced 2 times by $8835, $8848
+c883f
+    lda l0f08,y                                                       // 883f: b9 08 0f    ...
+    sta l00bc,x                                                       // 8842: 95 bc       ..
+    iny                                                               // 8844: c8          .
+    inx                                                               // 8845: e8          .
+    cpx #8                                                            // 8846: e0 08       ..
+    bne c883f                                                         // 8848: d0 f5       ..
+    jsr sub_c8b64                                                     // 884a: 20 64 8b     d.
+    ldy l00ba                                                         // 884d: a4 ba       ..
+    jsr sub_c8335                                                     // 884f: 20 35 83     5.
+    jmp c8867                                                         // 8852: 4c 67 88    Lg.
+
+// $8855 referenced 2 times by $9f61, $a561
+sub_c8855
+    lda #$80                                                          // 8855: a9 80       ..
+    bne c8864                                                         // 8857: d0 0b       ..
+    jsr sub_c8a77                                                     // 8859: 20 77 8a     w.
+    jsr sub_c9a82                                                     // 885c: 20 82 9a     ..
+    jsr sub_c8386                                                     // 885f: 20 86 83     ..
+// $8862 referenced 2 times by $9f51, $a587
+sub_c8862
+    lda #$a0                                                          // 8862: a9 a0       ..
+// $8864 referenced 1 time by $8857
+c8864
+    sta l1096                                                         // 8864: 8d 96 10    ...
+// $8867 referenced 1 time by $8852
+c8867
+    jsr sub_c81ca                                                     // 8867: 20 ca 81     ..
+    jsr sub_c9445                                                     // 886a: 20 45 94     E.
+    lda #1                                                            // 886d: a9 01       ..
+    rts                                                               // 886f: 60          `
+
+    jsr sub_c8745                                                     // 8870: 20 45 87     E.
+    jsr sub_c8932                                                     // 8873: 20 32 89     2.
+    sty l10da                                                         // 8876: 8c da 10    ...
+    jsr sub_c80f3                                                     // 8879: 20 f3 80     ..
+    sty l10d9                                                         // 887c: 8c d9 10    ...
+    jsr sub_c8266                                                     // 887f: 20 66 82     f.
+    bcs c88a6                                                         // 8882: b0 22       ."
+    ldy l10da                                                         // 8884: ac da 10    ...
+    lda l10cb                                                         // 8887: ad cb 10    ...
+    sta l00cc                                                         // 888a: 85 cc       ..
+    lda l10cc                                                         // 888c: ad cc 10    ...
+    jsr c8816                                                         // 888f: 20 16 88     ..
+    jsr sub_c80f6                                                     // 8892: 20 f6 80     ..
+    jsr sub_c8266                                                     // 8895: 20 66 82     f.
+    bcs c88a6                                                         // 8898: b0 0c       ..
+    jsr generate_error_precheck_bad                                   // 889a: 20 2e 80     ..
+    .byt $fe                                                          // 889d: fe          .
+    .asc "command"                                                    // 889e: 63 6f 6d... com
+    .byt 0                                                            // 88a5: 00          .
+
+// $88a6 referenced 2 times by $8882, $8898
+c88a6
+    lda l0f0e,y                                                       // 88a6: b9 0e 0f    ...
+    jsr sub_c81ae                                                     // 88a9: 20 ae 81     ..
+    cmp #3                                                            // 88ac: c9 03       ..
+    bne c88f4                                                         // 88ae: d0 44       .D
+    lda l0f0a,y                                                       // 88b0: b9 0a 0f    ...
+    and l0f0b,y                                                       // 88b3: 39 0b 0f    9..
+    cmp #$ff                                                          // 88b6: c9 ff       ..
+    bne c88f4                                                         // 88b8: d0 3a       .:
+    ldx #6                                                            // 88ba: a2 06       ..
+// $88bc referenced 1 time by $88c3
+loop_c88bc
+    lda l1000,x                                                       // 88bc: bd 00 10    ...
+    sta l1007,x                                                       // 88bf: 9d 07 10    ...
+    dex                                                               // 88c2: ca          .
+    bpl loop_c88bc                                                    // 88c3: 10 f7       ..
+    lda #$0d                                                          // 88c5: a9 0d       ..
+    sta l100e                                                         // 88c7: 8d 0e 10    ...
+    lda #$45 // 'E'                                                   // 88ca: a9 45       .E
+    sta l1000                                                         // 88cc: 8d 00 10    ...
+    lda #$2e // '.'                                                   // 88cf: a9 2e       ..
+    sta l1001                                                         // 88d1: 8d 01 10    ...
+    lda #$3a // ':'                                                   // 88d4: a9 3a       .:
+    sta l1002                                                         // 88d6: 8d 02 10    ...
+    lda l00cd                                                         // 88d9: a5 cd       ..
+    ora #$30 // '0'                                                   // 88db: 09 30       .0
+    sta l1003                                                         // 88dd: 8d 03 10    ...
+    lda #$2e // '.'                                                   // 88e0: a9 2e       ..
+    sta l1004                                                         // 88e2: 8d 04 10    ...
+    sta l1006                                                         // 88e5: 8d 06 10    ...
+    lda l00cc                                                         // 88e8: a5 cc       ..
+    sta l1005                                                         // 88ea: 8d 05 10    ...
+    ldx #<(l1000)                                                     // 88ed: a2 00       ..
+    ldy #>(l1000)                                                     // 88ef: a0 10       ..
+    jmp oscli                                                         // 88f1: 4c f7 ff    L..
+
+// $88f4 referenced 2 times by $88ae, $88b8
+c88f4
+    lda #$81                                                          // 88f4: a9 81       ..
+    jsr sub_c8826                                                     // 88f6: 20 26 88     &.
+    clc                                                               // 88f9: 18          .
+    lda l10d9                                                         // 88fa: ad d9 10    ...
+    tay                                                               // 88fd: a8          .
+    adc os_text_ptr                                                   // 88fe: 65 f2       e.
+    sta l10d9                                                         // 8900: 8d d9 10    ...
+    lda l00f3                                                         // 8903: a5 f3       ..
+    adc #0                                                            // 8905: 69 00       i.
+    sta l10da                                                         // 8907: 8d da 10    ...
+    lda l1076                                                         // 890a: ad 76 10    .v.
+    and l1077                                                         // 890d: 2d 77 10    -w.
+    ora l10d6                                                         // 8910: 0d d6 10    ...
+    cmp #$ff                                                          // 8913: c9 ff       ..
+    beq c892d                                                         // 8915: f0 16       ..
+    lda l00be                                                         // 8917: a5 be       ..
+    sta l1074                                                         // 8919: 8d 74 10    .t.
+    lda l00bf                                                         // 891c: a5 bf       ..
+    sta l1075                                                         // 891e: 8d 75 10    .u.
+    jsr sub_c8f6b                                                     // 8921: 20 6b 8f     k.
+    ldx #$74 // 't'                                                   // 8924: a2 74       .t
+    ldy #$10                                                          // 8926: a0 10       ..
+    lda #4                                                            // 8928: a9 04       ..
+    jmp tube_entry                                                    // 892a: 4c 06 04    L..
+
+// $892d referenced 1 time by $8915
+c892d
+    lda #1                                                            // 892d: a9 01       ..
+    jmp (l00be)                                                       // 892f: 6c be 00    l..
+
+// $8932 referenced 1 time by $8873
+sub_c8932
+    lda #$ff                                                          // 8932: a9 ff       ..
+    sta l00be                                                         // 8934: 85 be       ..
+    lda os_text_ptr                                                   // 8936: a5 f2       ..
+    sta l00ba                                                         // 8938: 85 ba       ..
+    lda l00f3                                                         // 893a: a5 f3       ..
+    sta l00bb                                                         // 893c: 85 bb       ..
+    rts                                                               // 893e: 60          `
+
+sub_c893f
+    ldx #0                                                            // 893f: a2 00       ..
+    beq c8945                                                         // 8941: f0 02       ..
+sub_c8943
+    ldx #2                                                            // 8943: a2 02       ..
+// $8945 referenced 1 time by $8941
+c8945
+    jsr sub_c8979                                                     // 8945: 20 79 89     y.
+    sta l10ca,x                                                       // 8948: 9d ca 10    ...
+    lda l00cc                                                         // 894b: a5 cc       ..
+    sta l10c9,x                                                       // 894d: 9d c9 10    ...
+    rts                                                               // 8950: 60          `
+
+// $8951 referenced 2 times by $96b4, $9729
+sub_c8951
+    jsr sub_c83e3                                                     // 8951: 20 e3 83     ..
+    lda l00b0                                                         // 8954: a5 b0       ..
+    pha                                                               // 8956: 48          H
+    lda l00b1                                                         // 8957: a5 b1       ..
+    pha                                                               // 8959: 48          H
+    jsr sub_c9ab8                                                     // 895a: 20 b8 9a     ..
+    ldy #0                                                            // 895d: a0 00       ..
+// $895f referenced 1 time by $8970
+loop_c895f
+    cpy #$c0                                                          // 895f: c0 c0       ..
+    bcc c8968                                                         // 8961: 90 05       ..
+    lda l1000,y                                                       // 8963: b9 00 10    ...
+    bcs c896b                                                         // 8966: b0 03       ..
+// $8968 referenced 1 time by $8961
+c8968
+    lda l1100,y                                                       // 8968: b9 00 11    ...
+// $896b referenced 1 time by $8966
+c896b
+    sta (l00b0),y                                                     // 896b: 91 b0       ..
+    iny                                                               // 896d: c8          .
+    cpy #$ee                                                          // 896e: c0 ee       ..
+    bne loop_c895f                                                    // 8970: d0 ed       ..
+    pla                                                               // 8972: 68          h
+    sta l00b1                                                         // 8973: 85 b1       ..
+    pla                                                               // 8975: 68          h
+    sta l00b0                                                         // 8976: 85 b0       ..
+    rts                                                               // 8978: 60          `
+
+// $8979 referenced 1 time by $8945
+sub_c8979
+    lda l10c9                                                         // 8979: ad c9 10    ...
+    sta l00cc                                                         // 897c: 85 cc       ..
+    jsr clc_jmp_gsinit                                                // 897e: 20 4c 87     L.
+    bne c898a                                                         // 8981: d0 07       ..
+    lda #0                                                            // 8983: a9 00       ..
+    jsr c8816                                                         // 8985: 20 16 88     ..
+    beq c89b4                                                         // 8988: f0 2a       .*
+// $898a referenced 2 times by $8240, $8981
+c898a
+    lda l10ca                                                         // 898a: ad ca 10    ...
+    jsr c8816                                                         // 898d: 20 16 88     ..
+// $8990 referenced 1 time by $89a3
+loop_c8990
+    jsr sub_c8149                                                     // 8990: 20 49 81     I.
+    bcs c89a5                                                         // 8993: b0 10       ..
+    cmp #$3a // ':'                                                   // 8995: c9 3a       .:
+    bne c89ad                                                         // 8997: d0 14       ..
+    jsr c8b8b                                                         // 8999: 20 8b 8b     ..
+    jsr sub_c8149                                                     // 899c: 20 49 81     I.
+    bcs c89b4                                                         // 899f: b0 13       ..
+    cmp #$2e // '.'                                                   // 89a1: c9 2e       ..
+    beq loop_c8990                                                    // 89a3: f0 eb       ..
+// $89a5 referenced 2 times by $8993, $89b2
+c89a5
+    jsr generate_error_precheck_bad                                   // 89a5: 20 2e 80     ..
+    .byt $ce                                                          // 89a8: ce          .
+    .asc "dir"                                                        // 89a9: 64 69 72    dir
+    .byt 0                                                            // 89ac: 00          .
+
+// $89ad referenced 1 time by $8997
+c89ad
+    sta l00cc                                                         // 89ad: 85 cc       ..
+    jsr sub_c8149                                                     // 89af: 20 49 81     I.
+    bcc c89a5                                                         // 89b2: 90 f1       ..
+// $89b4 referenced 2 times by $8988, $899f
+c89b4
+    lda l00cd                                                         // 89b4: a5 cd       ..
+    rts                                                               // 89b6: 60          `
+
+sub_c89b7
+    jsr sub_ca14a                                                     // 89b7: 20 4a a1     J.
+    jsr sub_c8b7b                                                     // 89ba: 20 7b 8b     {.
+    jsr sub_c8380                                                     // 89bd: 20 80 83     ..
+    ldx #$0b                                                          // 89c0: a2 0b       ..
+    lda #0                                                            // 89c2: a9 00       ..
+// $89c4 referenced 1 time by $89c8
+loop_c89c4
+    jsr sub_c89da                                                     // 89c4: 20 da 89     ..
+    dex                                                               // 89c7: ca          .
+    bpl loop_c89c4                                                    // 89c8: 10 fa       ..
+// $89ca referenced 1 time by $89d5
+loop_c89ca
+    inx                                                               // 89ca: e8          .
+    jsr sub_c8149                                                     // 89cb: 20 49 81     I.
+    bcs c89d7                                                         // 89ce: b0 07       ..
+    jsr sub_c89da                                                     // 89d0: 20 da 89     ..
+    cpx #$0b                                                          // 89d3: e0 0b       ..
+    bcc loop_c89ca                                                    // 89d5: 90 f3       ..
+// $89d7 referenced 3 times by $89ce, $8a15, $99ed
+c89d7
+    jmp c93e6                                                         // 89d7: 4c e6 93    L..
+
+// $89da referenced 2 times by $89c4, $89d0
+sub_c89da
+    cpx #8                                                            // 89da: e0 08       ..
+    bcc c89e2                                                         // 89dc: 90 04       ..
+    sta l0ef8,x                                                       // 89de: 9d f8 0e    ...
+    rts                                                               // 89e1: 60          `
+
+// $89e2 referenced 1 time by $89dc
+c89e2
+    sta l0e00,x                                                       // 89e2: 9d 00 0e    ...
+    rts                                                               // 89e5: 60          `
+
+sub_c89e6
+    jsr sub_c99ac                                                     // 89e6: 20 ac 99     ..
+    jsr sub_ca14a                                                     // 89e9: 20 4a a1     J.
+    jsr sub_c80ed                                                     // 89ec: 20 ed 80     ..
+    ldx #0                                                            // 89ef: a2 00       ..
+    jsr clc_jmp_gsinit                                                // 89f1: 20 4c 87     L.
+    bne c8a19                                                         // 89f4: d0 23       .#
+// $89f6 referenced 1 time by $8a1c
+c89f6
+    stx l00aa                                                         // 89f6: 86 aa       ..
+    jsr sub_c8284                                                     // 89f8: 20 84 82     ..
+    bcs c8a00                                                         // 89fb: b0 03       ..
+    jmp c822a                                                         // 89fd: 4c 2a 82    L*.
+
+// $8a00 referenced 2 times by $89fb, $8a13
+c8a00
+    jsr sub_c9a63                                                     // 8a00: 20 63 9a     c.
+    lda l0e0f,y                                                       // 8a03: b9 0f 0e    ...
+    and #$7f                                                          // 8a06: 29 7f       ).
+    ora l00aa                                                         // 8a08: 05 aa       ..
+    sta l0e0f,y                                                       // 8a0a: 99 0f 0e    ...
+    jsr sub_c8335                                                     // 8a0d: 20 35 83     5.
+    jsr sub_c8280                                                     // 8a10: 20 80 82     ..
+    bcs c8a00                                                         // 8a13: b0 eb       ..
+    bcc c89d7                                                         // 8a15: 90 c0       ..
+// $8a17 referenced 1 time by $8a22
+loop_c8a17
+    ldx #$80                                                          // 8a17: a2 80       ..
+// $8a19 referenced 1 time by $89f4
+c8a19
+    jsr sub_c8149                                                     // 8a19: 20 49 81     I.
+    bcs c89f6                                                         // 8a1c: b0 d8       ..
+    and #$5f // '_'                                                   // 8a1e: 29 5f       )_
+    cmp #$4c // 'L'                                                   // 8a20: c9 4c       .L
+    beq loop_c8a17                                                    // 8a22: f0 f3       ..
+    jsr generate_error_precheck_bad                                   // 8a24: 20 2e 80     ..
+    .byt $cf                                                          // 8a27: cf          .
+    .asc "attribute"                                                  // 8a28: 61 74 74... att
+    .byt 0                                                            // 8a31: 00          .
+
+    jsr sub_c83e3                                                     // 8a32: 20 e3 83     ..
+    txa                                                               // 8a35: 8a          .
+    cmp #4                                                            // 8a36: c9 04       ..
+    beq c8a54                                                         // 8a38: f0 1a       ..
+    cmp #2                                                            // 8a3a: c9 02       ..
+    bcc c8a49                                                         // 8a3c: 90 0b       ..
+    jsr generate_error_precheck_bad                                   // 8a3e: 20 2e 80     ..
+    .byt $cb                                                          // 8a41: cb          .
+    .asc "option"                                                     // 8a42: 6f 70 74... opt
+    .byt 0                                                            // 8a48: 00          .
+
+// $8a49 referenced 1 time by $8a3c
+c8a49
+    ldx #$ff                                                          // 8a49: a2 ff       ..
+    tya                                                               // 8a4b: 98          .
+    beq c8a50                                                         // 8a4c: f0 02       ..
+    ldx #0                                                            // 8a4e: a2 00       ..
+// $8a50 referenced 1 time by $8a4c
+c8a50
+    stx l10c6                                                         // 8a50: 8e c6 10    ...
+    rts                                                               // 8a53: 60          `
+
+// $8a54 referenced 1 time by $8a38
+c8a54
+    tya                                                               // 8a54: 98          .
+    pha                                                               // 8a55: 48          H
+    jsr sub_c8b7b                                                     // 8a56: 20 7b 8b     {.
+    jsr c940c                                                         // 8a59: 20 0c 94     ..
+    pla                                                               // 8a5c: 68          h
+    jsr sub_c81c5                                                     // 8a5d: 20 c5 81     ..
+    eor l0f06                                                         // 8a60: 4d 06 0f    M..
+    and #$30 // '0'                                                   // 8a63: 29 30       )0
+    eor l0f06                                                         // 8a65: 4d 06 0f    M..
+    sta l0f06                                                         // 8a68: 8d 06 0f    ...
+    jmp c93e6                                                         // 8a6b: 4c e6 93    L..
+
+// $8a6e referenced 2 times by $8ac8, $a414
+c8a6e
+    jsr generate_error_precheck_disc                                  // 8a6e: 20 23 80     #.
+    .byt $c6                                                          // 8a71: c6          .
+    .asc "full"                                                       // 8a72: 66 75 6c... ful
+    .byt 0                                                            // 8a76: 00          .
+
+// $8a77 referenced 2 times by $8859, $9c4e
+sub_c8a77
+    jsr sub_c80f3                                                     // 8a77: 20 f3 80     ..
+    jsr sub_c8284                                                     // 8a7a: 20 84 82     ..
+    bcc c8a82                                                         // 8a7d: 90 03       ..
+    jsr sub_c830a                                                     // 8a7f: 20 0a 83     ..
+// $8a82 referenced 1 time by $8a7d
+c8a82
+    lda l00c0                                                         // 8a82: a5 c0       ..
+    pha                                                               // 8a84: 48          H
+    lda l00c1                                                         // 8a85: a5 c1       ..
+    pha                                                               // 8a87: 48          H
+    sec                                                               // 8a88: 38          8
+    lda l00c2                                                         // 8a89: a5 c2       ..
+    sbc l00c0                                                         // 8a8b: e5 c0       ..
+    sta l00c0                                                         // 8a8d: 85 c0       ..
+    lda l00c3                                                         // 8a8f: a5 c3       ..
+    sbc l00c1                                                         // 8a91: e5 c1       ..
+    sta l00c1                                                         // 8a93: 85 c1       ..
+    lda l107a                                                         // 8a95: ad 7a 10    .z.
+    sbc l1078                                                         // 8a98: ed 78 10    .x.
+    sta l00c4                                                         // 8a9b: 85 c4       ..
+    jsr sub_c8ab3                                                     // 8a9d: 20 b3 8a     ..
+    lda l1079                                                         // 8aa0: ad 79 10    .y.
+    sta l1075                                                         // 8aa3: 8d 75 10    .u.
+    lda l1078                                                         // 8aa6: ad 78 10    .x.
+    sta l1074                                                         // 8aa9: 8d 74 10    .t.
+    pla                                                               // 8aac: 68          h
+    sta l00bd                                                         // 8aad: 85 bd       ..
+    pla                                                               // 8aaf: 68          h
+    sta l00bc                                                         // 8ab0: 85 bc       ..
+    rts                                                               // 8ab2: 60          `
+
+// $8ab3 referenced 2 times by $8a9d, $a50a
+sub_c8ab3
+    lda #0                                                            // 8ab3: a9 00       ..
+    sta l00c2                                                         // 8ab5: 85 c2       ..
+    lda #2                                                            // 8ab7: a9 02       ..
+    sta l00c3                                                         // 8ab9: 85 c3       ..
+    ldy l0f05                                                         // 8abb: ac 05 0f    ...
+    cpy #$f8                                                          // 8abe: c0 f8       ..
+    bcs c8b18                                                         // 8ac0: b0 56       .V
+    jsr sub_c8602                                                     // 8ac2: 20 02 86     ..
+    jmp c8ad0                                                         // 8ac5: 4c d0 8a    L..
+
+// $8ac8 referenced 1 time by $8ad1
+loop_c8ac8
+    beq c8a6e                                                         // 8ac8: f0 a4       ..
+    jsr sub_c82b2                                                     // 8aca: 20 b2 82     ..
+    jsr sub_c85e3                                                     // 8acd: 20 e3 85     ..
+// $8ad0 referenced 1 time by $8ac5
+c8ad0
+    tya                                                               // 8ad0: 98          .
+    bcc loop_c8ac8                                                    // 8ad1: 90 f5       ..
+    sty l00b0                                                         // 8ad3: 84 b0       ..
+    ldy l0f05                                                         // 8ad5: ac 05 0f    ...
+// $8ad8 referenced 1 time by $8ae9
+loop_c8ad8
+    cpy l00b0                                                         // 8ad8: c4 b0       ..
+    beq c8aeb                                                         // 8ada: f0 0f       ..
+    lda l0e07,y                                                       // 8adc: b9 07 0e    ...
+    sta l0e0f,y                                                       // 8adf: 99 0f 0e    ...
+    lda l0f07,y                                                       // 8ae2: b9 07 0f    ...
+    sta l0f0f,y                                                       // 8ae5: 99 0f 0f    ...
+    dey                                                               // 8ae8: 88          .
+    bcs loop_c8ad8                                                    // 8ae9: b0 ed       ..
+// $8aeb referenced 1 time by $8ada
+c8aeb
+    ldx #0                                                            // 8aeb: a2 00       ..
+    jsr sub_c8b25                                                     // 8aed: 20 25 8b     %.
+// $8af0 referenced 1 time by $8af9
+loop_c8af0
+    lda l00c5,x                                                       // 8af0: b5 c5       ..
+    sta l0e08,y                                                       // 8af2: 99 08 0e    ...
+    iny                                                               // 8af5: c8          .
+    inx                                                               // 8af6: e8          .
+    cpx #8                                                            // 8af7: e0 08       ..
+    bne loop_c8af0                                                    // 8af9: d0 f5       ..
+// $8afb referenced 1 time by $8b02
+loop_c8afb
+    lda l00bb,x                                                       // 8afb: b5 bb       ..
+    dey                                                               // 8afd: 88          .
+    sta l0f08,y                                                       // 8afe: 99 08 0f    ...
+    dex                                                               // 8b01: ca          .
+    bne loop_c8afb                                                    // 8b02: d0 f7       ..
+    jsr sub_c8335                                                     // 8b04: 20 35 83     5.
+    tya                                                               // 8b07: 98          .
+    pha                                                               // 8b08: 48          H
+    ldy l0f05                                                         // 8b09: ac 05 0f    ...
+    jsr sub_c87da                                                     // 8b0c: 20 da 87     ..
+    sty l0f05                                                         // 8b0f: 8c 05 0f    ...
+    jsr c93e6                                                         // 8b12: 20 e6 93     ..
+    pla                                                               // 8b15: 68          h
+    tay                                                               // 8b16: a8          .
+    rts                                                               // 8b17: 60          `
+
+// $8b18 referenced 1 time by $8ac0
+c8b18
+    jsr generate_error_precheck                                       // 8b18: 20 38 80     8.
+    .byt $be                                                          // 8b1b: be          .
+    .asc "Cat full"                                                   // 8b1c: 43 61 74... Cat
+    .byt 0                                                            // 8b24: 00          .
+
+// $8b25 referenced 1 time by $8aed
+sub_c8b25
+    lda l1076                                                         // 8b25: ad 76 10    .v.
+    and #3                                                            // 8b28: 29 03       ).
+    asl                                                               // 8b2a: 0a          .
+    asl                                                               // 8b2b: 0a          .
+    eor l00c4                                                         // 8b2c: 45 c4       E.
+    and #$fc                                                          // 8b2e: 29 fc       ).
+    eor l00c4                                                         // 8b30: 45 c4       E.
+    asl                                                               // 8b32: 0a          .
+    asl                                                               // 8b33: 0a          .
+    eor l1074                                                         // 8b34: 4d 74 10    Mt.
+    and #$fc                                                          // 8b37: 29 fc       ).
+    eor l1074                                                         // 8b39: 4d 74 10    Mt.
+    asl                                                               // 8b3c: 0a          .
+    asl                                                               // 8b3d: 0a          .
+    eor l00c2                                                         // 8b3e: 45 c2       E.
+    and #$fc                                                          // 8b40: 29 fc       ).
+    eor l00c2                                                         // 8b42: 45 c2       E.
+    sta l00c2                                                         // 8b44: 85 c2       ..
+    rts                                                               // 8b46: 60          `
+
+sub_c8b47
+    lda #1                                                            // 8b47: a9 01       ..
+    sta l10c7                                                         // 8b49: 8d c7 10    ...
+    rts                                                               // 8b4c: 60          `
+
+// $8b4d referenced 2 times by $883c, $a4fd
+sub_c8b4d
+    lda #0                                                            // 8b4d: a9 00       ..
+    sta l1075                                                         // 8b4f: 8d 75 10    .u.
+    lda l00c2                                                         // 8b52: a5 c2       ..
+    jsr sub_c81b7                                                     // 8b54: 20 b7 81     ..
+    cmp #3                                                            // 8b57: c9 03       ..
+    bne c8b60                                                         // 8b59: d0 05       ..
+    lda #$ff                                                          // 8b5b: a9 ff       ..
+    sta l1075                                                         // 8b5d: 8d 75 10    .u.
+// $8b60 referenced 1 time by $8b59
+c8b60
+    sta l1074                                                         // 8b60: 8d 74 10    .t.
+    rts                                                               // 8b63: 60          `
+
+// $8b64 referenced 2 times by $884a, $a500
+sub_c8b64
+    lda #0                                                            // 8b64: a9 00       ..
+    sta l1077                                                         // 8b66: 8d 77 10    .w.
+    lda l00c2                                                         // 8b69: a5 c2       ..
+    jsr sub_c81ae                                                     // 8b6b: 20 ae 81     ..
+    cmp #3                                                            // 8b6e: c9 03       ..
+    bne c8b77                                                         // 8b70: d0 05       ..
+    lda #$ff                                                          // 8b72: a9 ff       ..
+    sta l1077                                                         // 8b74: 8d 77 10    .w.
+// $8b77 referenced 1 time by $8b70
+c8b77
+    sta l1076                                                         // 8b77: 8d 76 10    .v.
+    rts                                                               // 8b7a: 60          `
+
+// $8b7b referenced 8 times by $80ed, $80f3, $8238, $89ba, $8a56, $975b, $988b, $98d7
+sub_c8b7b
+    lda l10c9                                                         // 8b7b: ad c9 10    ...
+    sta l00cc                                                         // 8b7e: 85 cc       ..
+// $8b80 referenced 1 time by $8b89
+loop_c8b80
+    lda l10ca                                                         // 8b80: ad ca 10    ...
+    jmp c8816                                                         // 8b83: 4c 16 88    L..
+
+// $8b86 referenced 3 times by $8486, $a244, $a7f9
+sub_c8b86
+    jsr clc_jmp_gsinit                                                // 8b86: 20 4c 87     L.
+    beq loop_c8b80                                                    // 8b89: f0 f5       ..
+// $8b8b referenced 7 times by $8119, $87f1, $8999, $8b92, $a327, $a330, $a637
+c8b8b
+    jsr sub_c8149                                                     // 8b8b: 20 49 81     I.
+    bcs c8ba2                                                         // 8b8e: b0 12       ..
+    cmp #$3a // ':'                                                   // 8b90: c9 3a       .:
+    beq c8b8b                                                         // 8b92: f0 f7       ..
+    sec                                                               // 8b94: 38          8
+    sbc #$30 // '0'                                                   // 8b95: e9 30       .0
+    bcc c8ba2                                                         // 8b97: 90 09       ..
+    cmp #4                                                            // 8b99: c9 04       ..
+    bcs c8ba2                                                         // 8b9b: b0 05       ..
+    jsr c8816                                                         // 8b9d: 20 16 88     ..
+    clc                                                               // 8ba0: 18          .
+    rts                                                               // 8ba1: 60          `
+
+// $8ba2 referenced 5 times by $8b8e, $8b97, $8b9b, $8bcd, $a660
+c8ba2
+    jsr generate_error_precheck_bad                                   // 8ba2: 20 2e 80     ..
+    .byt $cd                                                          // 8ba5: cd          .
+    .asc "drive"                                                      // 8ba6: 64 72 69... dri
+    .byt 0                                                            // 8bab: 00          .
+
+sub_c8bac
+    jsr c99a3                                                         // 8bac: 20 a3 99     ..
+    jsr sub_ca14a                                                     // 8baf: 20 4a a1     J.
+    jsr sub_c80ed                                                     // 8bb2: 20 ed 80     ..
+    tya                                                               // 8bb5: 98          .
+    pha                                                               // 8bb6: 48          H
+    jsr c8225                                                         // 8bb7: 20 25 82     %.
+    jsr sub_c9a60                                                     // 8bba: 20 60 9a     `.
+    sty l00c4                                                         // 8bbd: 84 c4       ..
+    pla                                                               // 8bbf: 68          h
+    tay                                                               // 8bc0: a8          .
+    jsr sub_ca14a                                                     // 8bc1: 20 4a a1     J.
+    lda l00cd                                                         // 8bc4: a5 cd       ..
+    pha                                                               // 8bc6: 48          H
+    jsr sub_c80ed                                                     // 8bc7: 20 ed 80     ..
+    pla                                                               // 8bca: 68          h
+    cmp l00cd                                                         // 8bcb: c5 cd       ..
+    bne c8ba2                                                         // 8bcd: d0 d3       ..
+    jsr sub_c8284                                                     // 8bcf: 20 84 82     ..
+    bcc c8be3                                                         // 8bd2: 90 0f       ..
+    cpy l00c4                                                         // 8bd4: c4 c4       ..
+    beq c8be3                                                         // 8bd6: f0 0b       ..
+    jsr generate_error_precheck                                       // 8bd8: 20 38 80     8.
+    .byt $c4                                                          // 8bdb: c4          .
+    .asc "Exists"                                                     // 8bdc: 45 78 69... Exi
+    .byt 0                                                            // 8be2: 00          .
+
+// $8be3 referenced 2 times by $8bd2, $8bd6
+c8be3
+    ldy l00c4                                                         // 8be3: a4 c4       ..
+    jsr sub_c87da                                                     // 8be5: 20 da 87     ..
+    ldx #7                                                            // 8be8: a2 07       ..
+// $8bea referenced 1 time by $8bf1
+loop_c8bea
+    lda l00c5,x                                                       // 8bea: b5 c5       ..
+    sta l0e07,y                                                       // 8bec: 99 07 0e    ...
+    dey                                                               // 8bef: 88          .
+    dex                                                               // 8bf0: ca          .
+    bpl loop_c8bea                                                    // 8bf1: 10 f7       ..
+    jmp c93e6                                                         // 8bf3: 4c e6 93    L..
+
+// $8bf6 referenced 1 time by $9466
+sub_c8bf6
+    clc                                                               // 8bf6: 18          .
+    bcc c8bfb                                                         // 8bf7: 90 02       ..
+// $8bf9 referenced 1 time by $9211
+sub_c8bf9
+    cli                                                               // 8bf9: 58          X
+    sec                                                               // 8bfa: 38          8
+// $8bfb referenced 1 time by $8bf7
+c8bfb
+    ror l00b2                                                         // 8bfb: 66 b2       f.
+    stx l00b0                                                         // 8bfd: 86 b0       ..
+    sty l00b1                                                         // 8bff: 84 b1       ..
+    cld                                                               // 8c01: d8          .
+    jsr sub_c8c65                                                     // 8c02: 20 65 8c     e.
+    lda l00a2                                                         // 8c05: a5 a2       ..
+    bne c8c12                                                         // 8c07: d0 09       ..
+    ldy #5                                                            // 8c09: a0 05       ..
+    lda (l00b0),y                                                     // 8c0b: b1 b0       ..
+    beq c8c12                                                         // 8c0d: f0 03       ..
+    jsr sub_c8d1a                                                     // 8c0f: 20 1a 8d     ..
+// $8c12 referenced 2 times by $8c07, $8c0d
+c8c12
+    ldy #5                                                            // 8c12: a0 05       ..
+    lda (l00b0),y                                                     // 8c14: b1 b0       ..
+    clc                                                               // 8c16: 18          .
+    adc #7                                                            // 8c17: 69 07       i.
+    tay                                                               // 8c19: a8          .
+    lda l00a2                                                         // 8c1a: a5 a2       ..
+    jsr sub_c8c56                                                     // 8c1c: 20 56 8c     V.
+    sta (l00b0),y                                                     // 8c1f: 91 b0       ..
+    ldx l00a7                                                         // 8c21: a6 a7       ..
+    cpx #$80                                                          // 8c23: e0 80       ..
+    bne c8c2e                                                         // 8c25: d0 07       ..
+    lda lfe84                                                         // 8c27: ad 84 fe    ...
+    and #$20 // ' '                                                   // 8c2a: 29 20       )
+    ora (l00b0),y                                                     // 8c2c: 11 b0       ..
+// $8c2e referenced 1 time by $8c25
+c8c2e
+    pha                                                               // 8c2e: 48          H
+    and #$df                                                          // 8c2f: 29 df       ).
+    cmp #$18                                                          // 8c31: c9 18       ..
+    bne c8c3a                                                         // 8c33: d0 05       ..
+    lda #$ff                                                          // 8c35: a9 ff       ..
+    sta l1087                                                         // 8c37: 8d 87 10    ...
+// $8c3a referenced 1 time by $8c33
+c8c3a
+    lda l00cd                                                         // 8c3a: a5 cd       ..
+    and #1                                                            // 8c3c: 29 01       ).
+    tay                                                               // 8c3e: a8          .
+    lda l00ce                                                         // 8c3f: a5 ce       ..
+    sta l1088,y                                                       // 8c41: 99 88 10    ...
+    jsr c8f2a                                                         // 8c44: 20 2a 8f     *.
+    bit l00a1                                                         // 8c47: 24 a1       $.
+    bpl c8c4e                                                         // 8c49: 10 03       ..
+    jsr sub_c8f7a                                                     // 8c4b: 20 7a 8f     z.
+// $8c4e referenced 1 time by $8c49
+c8c4e
+    jsr sub_c8f5e                                                     // 8c4e: 20 5e 8f     ^.
+    lda lfe87                                                         // 8c51: ad 87 fe    ...
+    pla                                                               // 8c54: 68          h
+    rts                                                               // 8c55: 60          `
+
+// $8c56 referenced 1 time by $8c1c
+sub_c8c56
+    ldx #5                                                            // 8c56: a2 05       ..
+// $8c58 referenced 1 time by $8c5e
+loop_c8c58
+    cmp l9139,x                                                       // 8c58: dd 39 91    .9.
+    beq c8c61                                                         // 8c5b: f0 04       ..
+    dex                                                               // 8c5d: ca          .
+    bpl loop_c8c58                                                    // 8c5e: 10 f8       ..
+    rts                                                               // 8c60: 60          `
+
+// $8c61 referenced 1 time by $8c5b
+c8c61
+    lda l913f,x                                                       // 8c61: bd 3f 91    .?.
+    rts                                                               // 8c64: 60          `
+
+// $8c65 referenced 1 time by $8c02
+sub_c8c65
+    jsr sub_c8f4f                                                     // 8c65: 20 4f 8f     O.
+    jsr sub_c8f82                                                     // 8c68: 20 82 8f     ..
+    lda #0                                                            // 8c6b: a9 00       ..
+    sta l00a1                                                         // 8c6d: 85 a1       ..
+    ldy #9                                                            // 8c6f: a0 09       ..
+// $8c71 referenced 1 time by $8c79
+loop_c8c71
+    lda (l00b0),y                                                     // 8c71: b1 b0       ..
+    sta l00aa,y                                                       // 8c73: 99 aa 00    ...
+    iny                                                               // 8c76: c8          .
+    cpy #$0c                                                          // 8c77: c0 0c       ..
+    bne loop_c8c71                                                    // 8c79: d0 f6       ..
+    ldy #6                                                            // 8c7b: a0 06       ..
+    lda (l00b0),y                                                     // 8c7d: b1 b0       ..
+    and #$f0                                                          // 8c7f: 29 f0       ).
+    cmp #$a0                                                          // 8c81: c9 a0       ..
+    beq c8c87                                                         // 8c83: f0 02       ..
+    cmp #$f0                                                          // 8c85: c9 f0       ..
+// $8c87 referenced 1 time by $8c83
+c8c87
+    ror l00a1                                                         // 8c87: 66 a1       f.
+    ldy #3                                                            // 8c89: a0 03       ..
+    lda (l00b0),y                                                     // 8c8b: b1 b0       ..
+    iny                                                               // 8c8d: c8          .
+    and (l00b0),y                                                     // 8c8e: 31 b0       1.
+    cmp #$ff                                                          // 8c90: c9 ff       ..
+    clc                                                               // 8c92: 18          .
+    beq c8cb2                                                         // 8c93: f0 1d       ..
+    jsr sub_c8f3f                                                     // 8c95: 20 3f 8f     ?.
+    clc                                                               // 8c98: 18          .
+    bmi c8cb2                                                         // 8c99: 30 17       0.
+    jsr sub_c8f6b                                                     // 8c9b: 20 6b 8f     k.
+    lda l00a1                                                         // 8c9e: a5 a1       ..
+    rol                                                               // 8ca0: 2a          *
+    rol                                                               // 8ca1: 2a          *
+    and #1                                                            // 8ca2: 29 01       ).
+    eor #1                                                            // 8ca4: 49 01       I.
+    ldx l00b0                                                         // 8ca6: a6 b0       ..
+    ldy l00b1                                                         // 8ca8: a4 b1       ..
+    inx                                                               // 8caa: e8          .
+    bne c8cae                                                         // 8cab: d0 01       ..
+    iny                                                               // 8cad: c8          .
+// $8cae referenced 1 time by $8cab
+c8cae
+    jsr tube_entry                                                    // 8cae: 20 06 04     ..
+    sec                                                               // 8cb1: 38          8
+// $8cb2 referenced 2 times by $8c93, $8c99
+c8cb2
+    ror l00a1                                                         // 8cb2: 66 a1       f.
+    jsr sub_c8f94                                                     // 8cb4: 20 94 8f     ..
+    ldy #0                                                            // 8cb7: a0 00       ..
+    lda (l00b0),y                                                     // 8cb9: b1 b0       ..
+    bmi c8cc1                                                         // 8cbb: 30 04       0.
+    and #$0f                                                          // 8cbd: 29 0f       ).
+    sta l00cd                                                         // 8cbf: 85 cd       ..
+// $8cc1 referenced 1 time by $8cbb
+c8cc1
+    lda l00cd                                                         // 8cc1: a5 cd       ..
+    and #3                                                            // 8cc3: 29 03       ).
+    tax                                                               // 8cc5: aa          .
+    lda l10de,x                                                       // 8cc6: bd de 10    ...
+    sta l108a                                                         // 8cc9: 8d 8a 10    ...
+    lda l00cd                                                         // 8ccc: a5 cd       ..
+    ldy #$0a                                                          // 8cce: a0 0a       ..
+    and #8                                                            // 8cd0: 29 08       ).
+    beq c8cd6                                                         // 8cd2: f0 02       ..
+    ldy #$10                                                          // 8cd4: a0 10       ..
+// $8cd6 referenced 1 time by $8cd2
+c8cd6
+    sty l00a3                                                         // 8cd6: 84 a3       ..
+    eor l911d,x                                                       // 8cd8: 5d 1d 91    ]..
+    sta lfe80                                                         // 8cdb: 8d 80 fe    ...
+    lsr                                                               // 8cde: 4a          J
+    ldx l1088                                                         // 8cdf: ae 88 10    ...
+    bcs c8ce7                                                         // 8ce2: b0 03       ..
+    ldx l1089                                                         // 8ce4: ae 89 10    ...
+// $8ce7 referenced 1 time by $8ce2
+c8ce7
+    ldy #0                                                            // 8ce7: a0 00       ..
+    sty l00a2                                                         // 8ce9: 84 a2       ..
+    lda l1087                                                         // 8ceb: ad 87 10    ...
+    bit l1087                                                         // 8cee: 2c 87 10    ,..
+    bcc c8cfc                                                         // 8cf1: 90 09       ..
+    bpl c8d0d                                                         // 8cf3: 10 18       ..
+    sty l1088                                                         // 8cf5: 8c 88 10    ...
+    and #$7f                                                          // 8cf8: 29 7f       ).
+    bpl c8d03                                                         // 8cfa: 10 07       ..
+// $8cfc referenced 1 time by $8cf1
+c8cfc
+    bvc c8d0d                                                         // 8cfc: 50 0f       P.
+    sty l1089                                                         // 8cfe: 8c 89 10    ...
+    and #$bf                                                          // 8d01: 29 bf       ).
+// $8d03 referenced 1 time by $8cfa
+c8d03
+    sta l1087                                                         // 8d03: 8d 87 10    ...
+    lda #0                                                            // 8d06: a9 00       ..
+    jsr c8e12                                                         // 8d08: 20 12 8e     ..
+    ldx #0                                                            // 8d0b: a2 00       ..
+// $8d0d referenced 2 times by $8cf3, $8cfc
+c8d0d
+    txa                                                               // 8d0d: 8a          .
+    sta l00ce                                                         // 8d0e: 85 ce       ..
+    jsr c8f2a                                                         // 8d10: 20 2a 8f     *.
+// $8d13 referenced 2 times by $8d1d, $8d25
+c8d13
+    rts                                                               // 8d13: 60          `
+
+// $8d14 referenced 1 time by $8d29
+loop_c8d14
+    jmp c8eaf                                                         // 8d14: 4c af 8e    L..
+
+// $8d17 referenced 1 time by $8d2d
+loop_c8d17
+    jmp c8e12                                                         // 8d17: 4c 12 8e    L..
+
+// $8d1a referenced 1 time by $8c0f
+sub_c8d1a
+    jsr sub_c8eff                                                     // 8d1a: 20 ff 8e     ..
+    bne c8d13                                                         // 8d1d: d0 f4       ..
+    ldy #6                                                            // 8d1f: a0 06       ..
+    lda (l00b0),y                                                     // 8d21: b1 b0       ..
+    cmp #$10                                                          // 8d23: c9 10       ..
+    beq c8d13                                                         // 8d25: f0 ec       ..
+    cmp #$c0                                                          // 8d27: c9 c0       ..
+    beq loop_c8d14                                                    // 8d29: f0 e9       ..
+    cmp #$e0                                                          // 8d2b: c9 e0       ..
+    bcs loop_c8d17                                                    // 8d2d: b0 e8       ..
+    ldy #8                                                            // 8d2f: a0 08       ..
+    lda (l00b0),y                                                     // 8d31: b1 b0       ..
+    bit l00b2                                                         // 8d33: 24 b2       $.
+    bmi c8d92                                                         // 8d35: 30 5b       0[
+    ldx l00b5                                                         // 8d37: a6 b5       ..
+    beq c8d41                                                         // 8d39: f0 06       ..
+    inc l00b3                                                         // 8d3b: e6 b3       ..
+    bne c8d41                                                         // 8d3d: d0 02       ..
+    inc l00b4                                                         // 8d3f: e6 b4       ..
+// $8d41 referenced 3 times by $8d39, $8d3d, $8d8f
+c8d41
+    jsr nmi_handler2_rom_end                                          // 8d41: 20 fb 90     ..
+    sta l00cf                                                         // 8d44: 85 cf       ..
+    sbc l00a3                                                         // 8d46: e5 a3       ..
+    eor #$ff                                                          // 8d48: 49 ff       I.
+    clc                                                               // 8d4a: 18          .
+    adc #1                                                            // 8d4b: 69 01       i.
+    sta l00a5                                                         // 8d4d: 85 a5       ..
+    lda l00b4                                                         // 8d4f: a5 b4       ..
+    bne c8d74                                                         // 8d51: d0 21       .!
+    lda l00b3                                                         // 8d53: a5 b3       ..
+    beq c8d91                                                         // 8d55: f0 3a       .:
+    cmp l00a5                                                         // 8d57: c5 a5       ..
+    beq c8d5d                                                         // 8d59: f0 02       ..
+    bcs c8d74                                                         // 8d5b: b0 17       ..
+// $8d5d referenced 1 time by $8d59
+c8d5d
+    sta l00a5                                                         // 8d5d: 85 a5       ..
+    ldx l00b5                                                         // 8d5f: a6 b5       ..
+    beq c8d74                                                         // 8d61: f0 11       ..
+    stx l00a6                                                         // 8d63: 86 a6       ..
+    ror l00a1                                                         // 8d65: 66 a1       f.
+    sec                                                               // 8d67: 38          8
+    rol l00a1                                                         // 8d68: 26 a1       &.
+    cmp #1                                                            // 8d6a: c9 01       ..
+    bne c8d74                                                         // 8d6c: d0 06       ..
+    lda nmi_lda_immXXX4+1                                             // 8d6e: ad 22 0d    .".
+    sta nmi_lda_immXXX3+1                                             // 8d71: 8d 4c 0d    .L.
+// $8d74 referenced 4 times by $8d51, $8d5b, $8d61, $8d6c
+c8d74
+    lda l00b3                                                         // 8d74: a5 b3       ..
+    sec                                                               // 8d76: 38          8
+    sbc l00a5                                                         // 8d77: e5 a5       ..
+    sta l00b3                                                         // 8d79: 85 b3       ..
+    lda l00b4                                                         // 8d7b: a5 b4       ..
+    sbc #0                                                            // 8d7d: e9 00       ..
+    sta l00b4                                                         // 8d7f: 85 b4       ..
+    jsr c8e0e                                                         // 8d81: 20 0e 8e     ..
+    bne c8d91                                                         // 8d84: d0 0b       ..
+    lda l00b3                                                         // 8d86: a5 b3       ..
+    ora l00b4                                                         // 8d88: 05 b4       ..
+    beq c8d91                                                         // 8d8a: f0 05       ..
+    jsr c8ecc                                                         // 8d8c: 20 cc 8e     ..
+    beq c8d41                                                         // 8d8f: f0 b0       ..
+// $8d91 referenced 4 times by $8d55, $8d84, $8d8a, $8d9d
+c8d91
+    rts                                                               // 8d91: 60          `
+
+// $8d92 referenced 1 time by $8d35
+c8d92
+    jsr nmi_handler2_rom_end                                          // 8d92: 20 fb 90     ..
+    sta l00cf                                                         // 8d95: 85 cf       ..
+    ldy #9                                                            // 8d97: a0 09       ..
+    lda (l00b0),y                                                     // 8d99: b1 b0       ..
+    and #$1f                                                          // 8d9b: 29 1f       ).
+    beq c8d91                                                         // 8d9d: f0 f2       ..
+    sta l00a5                                                         // 8d9f: 85 a5       ..
+    bit l00a1                                                         // 8da1: 24 a1       $.
+    bvs c8e0e                                                         // 8da3: 70 69       pi
+    bit l108a                                                         // 8da5: 2c 8a 10    ,..
+    bvc c8e0e                                                         // 8da8: 50 64       Pd
+    ldx #$33 // '3'                                                   // 8daa: a2 33       .3
+// $8dac referenced 1 time by $8db3
+loop_c8dac
+    lda c0d60,x                                                       // 8dac: bd 60 0d    .`.
+    sta l1000,x                                                       // 8daf: 9d 00 10    ...
+    dex                                                               // 8db2: ca          .
+    bpl loop_c8dac                                                    // 8db3: 10 f7       ..
+    jsr sub_c8dc6                                                     // 8db5: 20 c6 8d     ..
+    ldx #$33 // '3'                                                   // 8db8: a2 33       .3
+// $8dba referenced 1 time by $8dc1
+loop_c8dba
+    lda l1000,x                                                       // 8dba: bd 00 10    ...
+    sta c0d60,x                                                       // 8dbd: 9d 60 0d    .`.
+    dex                                                               // 8dc0: ca          .
+    bpl loop_c8dba                                                    // 8dc1: 10 f7       ..
+    lda l00a2                                                         // 8dc3: a5 a2       ..
+    rts                                                               // 8dc5: 60          `
+
+// $8dc6 referenced 1 time by $8db5
+sub_c8dc6
+    lda #0                                                            // 8dc6: a9 00       ..
+    sta l00b4                                                         // 8dc8: 85 b4       ..
+    lda (l00b0),y                                                     // 8dca: b1 b0       ..
+    and #$e0                                                          // 8dcc: 29 e0       ).
+    bne c8dd2                                                         // 8dce: d0 02       ..
+    lda #$10                                                          // 8dd0: a9 10       ..
+// $8dd2 referenced 1 time by $8dce
+c8dd2
+    asl                                                               // 8dd2: 0a          .
+    rol l00b4                                                         // 8dd3: 26 b4       &.
+    asl                                                               // 8dd5: 0a          .
+    rol l00b4                                                         // 8dd6: 26 b4       &.
+    asl                                                               // 8dd8: 0a          .
+    rol l00b4                                                         // 8dd9: 26 b4       &.
+    sta l00b3                                                         // 8ddb: 85 b3       ..
+    tax                                                               // 8ddd: aa          .
+    beq c8de2                                                         // 8dde: f0 02       ..
+    inc l00b4                                                         // 8de0: e6 b4       ..
+// $8de2 referenced 1 time by $8dde
+c8de2
+    jsr nmi3_handler_rom_end                                          // 8de2: 20 3e 90     >.
+    lda #$14                                                          // 8de5: a9 14       ..
+    sta l00b7                                                         // 8de7: 85 b7       ..
+// $8de9 referenced 1 time by $8dfc
+loop_c8de9
+    lda #$e0                                                          // 8de9: a9 e0       ..
+    sta l00a2                                                         // 8deb: 85 a2       ..
+    sta lfe84                                                         // 8ded: 8d 84 fe    ...
+// $8df0 referenced 1 time by $8df2
+loop_c8df0
+    lda l00a2                                                         // 8df0: a5 a2       ..
+    bmi loop_c8df0                                                    // 8df2: 30 fc       0.
+    bne c8e0d                                                         // 8df4: d0 17       ..
+    lda l00a5                                                         // 8df6: a5 a5       ..
+    beq c8e03                                                         // 8df8: f0 09       ..
+    dec l00b7                                                         // 8dfa: c6 b7       ..
+    bne loop_c8de9                                                    // 8dfc: d0 eb       ..
+    lda #$10                                                          // 8dfe: a9 10       ..
+    sta l00a2                                                         // 8e00: 85 a2       ..
+    rts                                                               // 8e02: 60          `
+
+// $8e03 referenced 1 time by $8df8
+c8e03
+    lda l00b6                                                         // 8e03: a5 b6       ..
+    eor #$fb                                                          // 8e05: 49 fb       I.
+    beq c8e0d                                                         // 8e07: f0 04       ..
+    lda #$20 // ' '                                                   // 8e09: a9 20       .
+    sta l00a2                                                         // 8e0b: 85 a2       ..
+// $8e0d referenced 2 times by $8df4, $8e07
+c8e0d
+    rts                                                               // 8e0d: 60          `
+
+// $8e0e referenced 4 times by $8d81, $8da3, $8da8, $8ec2
+c8e0e
+    ldy #6                                                            // 8e0e: a0 06       ..
+    lda (l00b0),y                                                     // 8e10: b1 b0       ..
+// $8e12 referenced 4 times by $8d08, $8d17, $8efc, $8f21
+c8e12
+    ldy #$ff                                                          // 8e12: a0 ff       ..
+// $8e14 referenced 1 time by $8e18
+loop_c8e14
+    iny                                                               // 8e14: c8          .
+    cmp l9121,y                                                       // 8e15: d9 21 91    .!.
+    bne loop_c8e14                                                    // 8e18: d0 fa       ..
+    pha                                                               // 8e1a: 48          H
+    lda nmi_and_table,y                                               // 8e1b: b9 2d 91    .-.
+    sta nmi_and_imm+1                                                 // 8e1e: 8d 05 0d    ...
+    ror l00a2                                                         // 8e21: 66 a2       f.
+    pla                                                               // 8e23: 68          h
+    bpl c8e72                                                         // 8e24: 10 4c       .L
+    bit l00a1                                                         // 8e26: 24 a1       $.
+    bvc c8e32                                                         // 8e28: 50 08       P.
+    ldy l00ce                                                         // 8e2a: a4 ce       ..
+    cpy #$14                                                          // 8e2c: c0 14       ..
+    bcc c8e32                                                         // 8e2e: 90 02       ..
+    ora #2                                                            // 8e30: 09 02       ..
+// $8e32 referenced 2 times by $8e28, $8e2e
+c8e32
+    sta l00a7                                                         // 8e32: 85 a7       ..
+    ldy #1                                                            // 8e34: a0 01       ..
+    cmp #$c0                                                          // 8e36: c9 c0       ..
+    beq c8e53                                                         // 8e38: f0 19       ..
+    ora #4                                                            // 8e3a: 09 04       ..
+    bcs c8e53                                                         // 8e3c: b0 15       ..
+    ldy l00a5                                                         // 8e3e: a4 a5       ..
+    cmp #$85                                                          // 8e40: c9 85       ..
+    beq c8e4d                                                         // 8e42: f0 09       ..
+    cmp #$87                                                          // 8e44: c9 87       ..
+    bne c8e53                                                         // 8e46: d0 0b       ..
+    lda #nmi_XXX1-(nmi_beq+2)                                         // 8e48: a9 48       .H
+    sta nmi_beq+1                                                     // 8e4a: 8d 09 0d    ...
+// $8e4d referenced 1 time by $8e42
+c8e4d
+    lda #$80                                                          // 8e4d: a9 80       ..
+    sta l00a7                                                         // 8e4f: 85 a7       ..
+    lda #$84                                                          // 8e51: a9 84       ..
+// $8e53 referenced 3 times by $8e38, $8e3c, $8e46
+c8e53
+    sty l00a5                                                         // 8e53: 84 a5       ..
+    sta lfe84                                                         // 8e55: 8d 84 fe    ...
+    cmp #$f0                                                          // 8e58: c9 f0       ..
+    bcc c8e64                                                         // 8e5a: 90 08       ..
+    jsr c8e9f                                                         // 8e5c: 20 9f 8e     ..
+    and #$5c // '\'                                                   // 8e5f: 29 5c       )\ 
+    sta l00a2                                                         // 8e61: 85 a2       ..
+    rts                                                               // 8e63: 60          `
+
+// $8e64 referenced 4 times by $8e5a, $8e66, $8e7f, $8e83
+c8e64
+    lda l00a2                                                         // 8e64: a5 a2       ..
+    bmi c8e64                                                         // 8e66: 30 fc       0.
+    cmp #$20 // ' '                                                   // 8e68: c9 20       .
+    bne c8e6f                                                         // 8e6a: d0 03       ..
+    jsr c8ea5                                                         // 8e6c: 20 a5 8e     ..
+// $8e6f referenced 1 time by $8e6a
+c8e6f
+    lda l00a2                                                         // 8e6f: a5 a2       ..
+    rts                                                               // 8e71: 60          `
+
+// $8e72 referenced 1 time by $8e24
+c8e72
+    ldy #1                                                            // 8e72: a0 01       ..
+    sty l00a5                                                         // 8e74: 84 a5       ..
+    ora l00a4                                                         // 8e76: 05 a4       ..
+    sta l00a7                                                         // 8e78: 85 a7       ..
+    sta lfe84                                                         // 8e7a: 8d 84 fe    ...
+    bit l00b2                                                         // 8e7d: 24 b2       $.
+    bmi c8e64                                                         // 8e7f: 30 e3       0.
+    cmp #$20 // ' '                                                   // 8e81: c9 20       .
+    bcs c8e64                                                         // 8e83: b0 df       ..
+// $8e85 referenced 1 time by $8e8b
+loop_c8e85
+    lda l00a2                                                         // 8e85: a5 a2       ..
+    bpl c8e9e                                                         // 8e87: 10 15       ..
+    lda l00ff                                                         // 8e89: a5 ff       ..
+    bpl loop_c8e85                                                    // 8e8b: 10 f8       ..
+    lda #opcode_rti                                                   // 8e8d: a9 40       .@
+    sta nmi_handler_ram                                               // 8e8f: 8d 00 0d    ...
+    lda #0                                                            // 8e92: a9 00       ..
+    sta lfe80                                                         // 8e94: 8d 80 fe    ...
+    lda l00ff                                                         // 8e97: a5 ff       ..
+    sta l1082                                                         // 8e99: 8d 82 10    ...
+    sta l00a2                                                         // 8e9c: 85 a2       ..
+// $8e9e referenced 1 time by $8e87
+c8e9e
+    rts                                                               // 8e9e: 60          `
+
+// $8e9f referenced 2 times by $8e5c, $8ea3
+c8e9f
+    lda lfe84                                                         // 8e9f: ad 84 fe    ...
+    ror                                                               // 8ea2: 6a          j
+    bcc c8e9f                                                         // 8ea3: 90 fa       ..
+// $8ea5 referenced 2 times by $8e6c, $8ea9
+c8ea5
+    lda lfe84                                                         // 8ea5: ad 84 fe    ...
+    ror                                                               // 8ea8: 6a          j
+    bcs c8ea5                                                         // 8ea9: b0 fa       ..
+    lda lfe84                                                         // 8eab: ad 84 fe    ...
+    rts                                                               // 8eae: 60          `
+
+// $8eaf referenced 1 time by $8d14
+c8eaf
+    lda #nmi_XXX1-(nmi_beq+2)                                         // 8eaf: a9 48       .H
+    sta nmi_lda_immXXX3+1                                             // 8eb1: 8d 4c 0d    .L.
+    ldx nmi_beq+1                                                     // 8eb4: ae 09 0d    ...
+// $8eb7 referenced 2 times by $8eb9, $8ec9
+c8eb7
+    sbc #1                                                            // 8eb7: e9 01       ..
+    bne c8eb7                                                         // 8eb9: d0 fc       ..
+    stx nmi_beq+1                                                     // 8ebb: 8e 09 0d    ...
+    lda #4                                                            // 8ebe: a9 04       ..
+    sta l00a6                                                         // 8ec0: 85 a6       ..
+    jsr c8e0e                                                         // 8ec2: 20 0e 8e     ..
+    bne c8ecb                                                         // 8ec5: d0 04       ..
+    dec l00b3                                                         // 8ec7: c6 b3       ..
+    bne c8eb7                                                         // 8ec9: d0 ec       ..
+// $8ecb referenced 1 time by $8ec5
+c8ecb
+    rts                                                               // 8ecb: 60          `
+
+// $8ecc referenced 3 times by $8d8c, $8ee2, $8ee7
+c8ecc
+    jsr sub_c8eec                                                     // 8ecc: 20 ec 8e     ..
+    bne c8eeb                                                         // 8ecf: d0 1a       ..
+    lda l00cd                                                         // 8ed1: a5 cd       ..
+    and #1                                                            // 8ed3: 29 01       ).
+    asl                                                               // 8ed5: 0a          .
+    tay                                                               // 8ed6: a8          .
+    lda l00ce                                                         // 8ed7: a5 ce       ..
+    bit l108a                                                         // 8ed9: 2c 8a 10    ,..
+    bpl c8edf                                                         // 8edc: 10 01       ..
+    lsr                                                               // 8ede: 4a          J
+// $8edf referenced 1 time by $8edc
+c8edf
+    cmp l108b,y                                                       // 8edf: d9 8b 10    ...
+    beq c8ecc                                                         // 8ee2: f0 e8       ..
+    cmp l108c,y                                                       // 8ee4: d9 8c 10    ...
+    beq c8ecc                                                         // 8ee7: f0 e3       ..
+    lda #0                                                            // 8ee9: a9 00       ..
+// $8eeb referenced 2 times by $8ecf, $8ef6
+c8eeb
+    rts                                                               // 8eeb: 60          `
+
+// $8eec referenced 1 time by $8ecc
+sub_c8eec
+    bit l108a                                                         // 8eec: 2c 8a 10    ,..
+    bpl c8ef8                                                         // 8eef: 10 07       ..
+    lda #$40 // '@'                                                   // 8ef1: a9 40       .@
+    jsr sub_c8efa                                                     // 8ef3: 20 fa 8e     ..
+    bne c8eeb                                                         // 8ef6: d0 f3       ..
+// $8ef8 referenced 1 time by $8eef
+c8ef8
+    lda #$50 // 'P'                                                   // 8ef8: a9 50       .P
+// $8efa referenced 1 time by $8ef3
+sub_c8efa
+    inc l00ce                                                         // 8efa: e6 ce       ..
+    jmp c8e12                                                         // 8efc: 4c 12 8e    L..
+
+// $8eff referenced 1 time by $8d1a
+sub_c8eff
+    lda l00cd                                                         // 8eff: a5 cd       ..
+    and #1                                                            // 8f01: 29 01       ).
+    asl                                                               // 8f03: 0a          .
+    tax                                                               // 8f04: aa          .
+    ldy #7                                                            // 8f05: a0 07       ..
+    lda (l00b0),y                                                     // 8f07: b1 b0       ..
+    jsr sub_c8f33                                                     // 8f09: 20 33 8f     3.
+    bit l108a                                                         // 8f0c: 2c 8a 10    ,..
+    bpl c8f12                                                         // 8f0f: 10 01       ..
+    asl                                                               // 8f11: 0a          .
+// $8f12 referenced 1 time by $8f0f
+c8f12
+    sta l00ce                                                         // 8f12: 85 ce       ..
+    tay                                                               // 8f14: a8          .
+    beq c8f21                                                         // 8f15: f0 0a       ..
+// $8f17 referenced 1 time by $8f1d
+loop_c8f17
+    sta lfe87                                                         // 8f17: 8d 87 fe    ...
+    cmp lfe87                                                         // 8f1a: cd 87 fe    ...
+    bne loop_c8f17                                                    // 8f1d: d0 f8       ..
+    lda #$10                                                          // 8f1f: a9 10       ..
+// $8f21 referenced 1 time by $8f15
+c8f21
+    jsr c8e12                                                         // 8f21: 20 12 8e     ..
+    bne c8f3e                                                         // 8f24: d0 18       ..
+    ldy #7                                                            // 8f26: a0 07       ..
+    lda (l00b0),y                                                     // 8f28: b1 b0       ..
+// $8f2a referenced 3 times by $8c44, $8d10, $8f30
+c8f2a
+    sta lfe85                                                         // 8f2a: 8d 85 fe    ...
+    cmp lfe85                                                         // 8f2d: cd 85 fe    ...
+    bne c8f2a                                                         // 8f30: d0 f8       ..
+    rts                                                               // 8f32: 60          `
+
+// $8f33 referenced 1 time by $8f09
+sub_c8f33
+    jsr sub_c8f37                                                     // 8f33: 20 37 8f     7.
+    inx                                                               // 8f36: e8          .
+// $8f37 referenced 1 time by $8f33
+sub_c8f37
+    cmp l108b,x                                                       // 8f37: dd 8b 10    ...
+    bcc c8f3e                                                         // 8f3a: 90 02       ..
+    adc #0                                                            // 8f3c: 69 00       i.
+// $8f3e referenced 2 times by $8f24, $8f3a
+c8f3e
+    rts                                                               // 8f3e: 60          `
+
+// $8f3f referenced 5 times by $8c95, $8f75, $92b0, $932b, $9628
+sub_c8f3f
+    lda #osbyte_read_tube_presence                                    // 8f3f: a9 ea       ..
+    ldx #0                                                            // 8f41: a2 00       ..
+    ldy #$ff                                                          // 8f43: a0 ff       ..
+    jsr osbyte                                                        // 8f45: 20 f4 ff     ..
+    txa                                                               // 8f48: 8a          .
+    eor #$ff                                                          // 8f49: 49 ff       I.
+    sta l10d6                                                         // 8f4b: 8d d6 10    ...
+    rts                                                               // 8f4e: 60          `
+
+// $8f4f referenced 1 time by $8c65
+sub_c8f4f
+    lda #osbyte_issue_service_request                                 // 8f4f: a9 8f       ..
+    ldx #$0c                                                          // 8f51: a2 0c       ..
+    ldy #$ff                                                          // 8f53: a0 ff       ..
+    jsr osbyte                                                        // 8f55: 20 f4 ff     ..
+    sty l00a0                                                         // 8f58: 84 a0       ..
+    inc l10d3                                                         // 8f5a: ee d3 10    ...
+    rts                                                               // 8f5d: 60          `
+
+// $8f5e referenced 1 time by $8c4e
+sub_c8f5e
+    ldy l00a0                                                         // 8f5e: a4 a0       ..
+    lda #osbyte_issue_service_request                                 // 8f60: a9 8f       ..
+    ldx #$0b                                                          // 8f62: a2 0b       ..
+    jsr osbyte                                                        // 8f64: 20 f4 ff     ..
+    dec l10d3                                                         // 8f67: ce d3 10    ...
+    rts                                                               // 8f6a: 60          `
+
+// $8f6b referenced 4 times by $8921, $8c9b, $933e, $9819
+sub_c8f6b
+    pha                                                               // 8f6b: 48          H
+// $8f6c referenced 1 time by $8f71
+loop_c8f6c
+    lda #$c1                                                          // 8f6c: a9 c1       ..
+    jsr tube_entry                                                    // 8f6e: 20 06 04     ..
+    bcc loop_c8f6c                                                    // 8f71: 90 f9       ..
+    pla                                                               // 8f73: 68          h
+    rts                                                               // 8f74: 60          `
+
+// $8f75 referenced 1 time by $8071
+sub_c8f75
+    jsr sub_c8f3f                                                     // 8f75: 20 3f 8f     ?.
+    bmi c8f81                                                         // 8f78: 30 07       0.
+// $8f7a referenced 3 times by $8c4b, $9364, $97e3
+sub_c8f7a
+    pha                                                               // 8f7a: 48          H
+    lda #$81                                                          // 8f7b: a9 81       ..
+    jsr tube_entry                                                    // 8f7d: 20 06 04     ..
+    pla                                                               // 8f80: 68          h
+// $8f81 referenced 1 time by $8f78
+c8f81
+    rts                                                               // 8f81: 60          `
+
+// $8f82 referenced 1 time by $8c68
+sub_c8f82
+    lda #osbyte_read_write_startup_options                            // 8f82: a9 ff       ..
+    ldx #0                                                            // 8f84: a2 00       ..
+    tay                                                               // 8f86: a8          .
+    jsr osbyte                                                        // 8f87: 20 f4 ff     ..
+    txa                                                               // 8f8a: 8a          .
+    lsr                                                               // 8f8b: 4a          J
+    lsr                                                               // 8f8c: 4a          J
+    lsr                                                               // 8f8d: 4a          J
+    lsr                                                               // 8f8e: 4a          J
+    and #3                                                            // 8f8f: 29 03       ).
+    sta l00a4                                                         // 8f91: 85 a4       ..
+    rts                                                               // 8f93: 60          `
+
+// $8f94 referenced 1 time by $8cb4
+sub_c8f94
+    ldx #nmi_handler_rom_end-nmi_handler_rom_start-1                  // 8f94: a2 5d       .]
+// $8f96 referenced 1 time by $8f9d
+loop_c8f96
+    lda nmi_handler_rom_start,x                                       // 8f96: bd d2 8f    ...
+    sta nmi_handler_ram,x                                             // 8f99: 9d 00 0d    ...
+    dex                                                               // 8f9c: ca          .
+    bpl loop_c8f96                                                    // 8f9d: 10 f7       ..
+    ldx #3                                                            // 8f9f: a2 03       ..
+    bit l00a1                                                         // 8fa1: 24 a1       $.
+    bvc c8fb5                                                         // 8fa3: 50 10       P.
+    lda #nmi_XXX8-(nmi_beq+2)                                         // 8fa5: a9 4d       .M
+    sta nmi_lda_immXXX4+1                                             // 8fa7: 8d 22 0d    .".
+    ldx #nmi3_handler_rom_end-nmi3_handler_rom_start                  // 8faa: a2 0e       ..
+// $8fac referenced 1 time by $8fb3
+loop_c8fac
+    lda nmi3_handler_rom_start-1,x                                    // 8fac: bd 2f 90    ./.
+    sta nmi_XXX2-1,x                                                  // 8faf: 9d 38 0d    .8.
+    dex                                                               // 8fb2: ca          .
+    bne loop_c8fac                                                    // 8fb3: d0 f7       ..
+// $8fb5 referenced 1 time by $8fa3
+c8fb5
+    bit l00a1                                                         // 8fb5: 24 a1       $.
+    bmi c8fc7                                                         // 8fb7: 30 0e       0.
+    ldy #1                                                            // 8fb9: a0 01       ..
+    lda (l00b0),y                                                     // 8fbb: b1 b0       ..
+    sta nmi_lda_abs+1,x                                               // 8fbd: 9d 3a 0d    .:.
+    iny                                                               // 8fc0: c8          .
+    lda (l00b0),y                                                     // 8fc1: b1 b0       ..
+    sta nmi_lda_abs+2,x                                               // 8fc3: 9d 3b 0d    .;.
+    rts                                                               // 8fc6: 60          `
+
+// $8fc7 referenced 1 time by $8fb7
+c8fc7
+    lda #opcode_bcs                                                   // 8fc7: a9 b0       ..
+    sta nmi_XXX6                                                      // 8fc9: 8d 3f 0d    .?.
+    lda #nmi_XXX7-(nmi_XXX6+2)                                        // 8fcc: a9 06       ..
+    sta nmi_XXX6+1                                                    // 8fce: 8d 40 0d    .@.
+    rts                                                               // 8fd1: 60          `
+
+// $8fd2 referenced 1 time by $8f96
+nmi_handler_rom_start
+// $8fd2 referenced 1 time by $8f96
+* = $0d00
+// $8fd2 referenced 1 time by $8f96
+nmi_handler_ram
+    pha                                                               // 8fd2: 48          H   :0d00[4]
+    lda lfe84                                                         // 8fd3: ad 84 fe    ... :0d01[4]
+// The operand of this and is modified at runtime.
+nmi_and_imm
+    and #$18                                                          // 8fd6: 29 18       ).  :0d04[4]
+    cmp #3                                                            // 8fd8: c9 03       ..  :0d06[4]
+// The operand of this "beq" is modified at runtime.
+nmi_beq
+    beq nmi_XXX2                                                      // 8fda: f0 2f       ./  :0d08[4]
+    and #$fc                                                          // 8fdc: 29 fc       ).  :0d0a[4]
+    bne l0d12                                                         // 8fde: d0 04       ..  :0d0c[4]
+    dec l00a5                                                         // 8fe0: c6 a5       ..  :0d0e[4]
+    bne nmi_lda_zp                                                    // 8fe2: d0 04       ..  :0d10[4]
+l0d12
+    sta l00a2                                                         // 8fe4: 85 a2       ..  :0d12[4]
+    pla                                                               // 8fe6: 68          h   :0d14[4]
+    rti                                                               // 8fe7: 40          @   :0d15[4]
+
+// The operand of this lda is modified at runtime.
+nmi_lda_zp
+    lda l00a5                                                         // 8fe8: a5 a5       ..  :0d16[4]
+// This instruction is patched at runtime to toggle between cmp #/bcs.
+nmi_cmp_imm_or_bcs
+    cmp #1                                                            // 8fea: c9 01       ..  :0d18[4]
+    bne l0d26                                                         // 8fec: d0 0a       ..  :0d1a[4]
+    lda l00a1                                                         // 8fee: a5 a1       ..  :0d1c[4]
+    ror                                                               // 8ff0: 6a          j   :0d1e[4]
+l0d1f
+nmi_XXX5 = l0d1f+1
+    bcc l0d26                                                         // 8ff1: 90 05       ..  :0d1f[4]
+// One patched variant of the code transfers control to nmi_XXX5,
+// which is the
+// second byte of the following bcc instruction. That is always &05,
+// which is
+// ORA #. XXX: correct?
+// The operand of this lda is modified at runtime.
+nmi_lda_immXXX4
+    lda #nmi_XXX1-(nmi_beq+2)                                         // 8ff3: a9 48       .H  :0d21[4]
+    sta nmi_lda_immXXX3+1                                             // 8ff5: 8d 4c 0d    .L. :0d23[4]
+l0d26
+    inc l00cf                                                         // 8ff8: e6 cf       ..  :0d26[4]
+    lda l00cf                                                         // 8ffa: a5 cf       ..  :0d28[4]
+l0d2a
+    sta lfe86                                                         // 8ffc: 8d 86 fe    ... :0d2a[4]
+    cmp lfe86                                                         // 8fff: cd 86 fe    ... :0d2d[4]
+    bne l0d2a                                                         // 9002: d0 f8       ..  :0d30[4]
+    lda l00a7                                                         // 9004: a5 a7       ..  :0d32[4]
+    sta lfe84                                                         // 9006: 8d 84 fe    ... :0d34[4]
+    pla                                                               // 9009: 68          h   :0d37[4]
+    rti                                                               // 900a: 40          @   :0d38[4]
+
+nmi_XXX2
+    lda lfe87                                                         // 900b: ad 87 fe    ... :0d39[4]
+// The operand of this sta is modified at runtime.
+nmi_sta_abs
+    sta tube_host_r3_data                                             // 900e: 8d e5 fe    ... :0d3c[4]
+// The first two bytes of the following instruction may be patched at
+// runtime.
+nmi_XXX6
+    inc nmi_sta_abs+1                                                 // 9011: ee 3d 0d    .=. :0d3f[4]
+    bne nmi_XXX7                                                      // 9014: d0 03       ..  :0d42[4]
+    inc nmi_sta_abs+2                                                 // 9016: ee 3e 0d    .>. :0d44[4]
+nmi_XXX7
+    dec l00a6                                                         // 9019: c6 a6       ..  :0d47[4]
+    bne l0d50                                                         // 901b: d0 05       ..  :0d49[4]
+// The operand of this lda is modified at runtime.
+nmi_lda_immXXX3
+    lda #nmi_XXX2-(nmi_beq+2)                                         // 901d: a9 2f       ./  :0d4b[4]
+    sta nmi_beq+1                                                     // 901f: 8d 09 0d    ... :0d4d[4]
+l0d50
+    pla                                                               // 9022: 68          h   :0d50[4]
+    rti                                                               // 9023: 40          @   :0d51[4]
+
+nmi_XXX1
+    lda lfe87                                                         // 9024: ad 87 fe    ... :0d52[4]
+    pla                                                               // 9027: 68          h   :0d55[4]
+    rti                                                               // 9028: 40          @   :0d56[4]
+
+nmi_XXX8
+    lda #0                                                            // 9029: a9 00       ..  :0d57[4]
+    sta lfe87                                                         // 902b: 8d 87 fe    ... :0d59[4]
+    pla                                                               // 902e: 68          h   :0d5c[4]
+// $902f referenced 1 time by $8fac
+    rti                                                               // 902f: 40          @   :0d5d[4]
+
+// The operand of this lda is modified at runtime.
+* = $9030
+// The operand of this lda is modified at runtime.
+nmi_handler_rom_end
+nmi3_handler_rom_start
+// The operand of this lda is modified at runtime.
+* = $0d39
+// The operand of this lda is modified at runtime.
+nmi_lda_abs
+    lda tube_host_r3_data                                             // 9030: ad e5 fe    ... :0d39[5]
+    sta lfe87                                                         // 9033: 8d 87 fe    ... :0d3c[5]
+    inc nmi_lda_abs+1                                                 // 9036: ee 3a 0d    .:. :0d3f[5]
+    bne nmi_XXX7                                                      // 9039: d0 03       ..  :0d42[5]
+    inc nmi_lda_abs+2                                                 // 903b: ee 3b 0d    .;. :0d44[5]
+// $903e referenced 1 time by $8de2
+* = $903e
+// $903e referenced 1 time by $8de2
+nmi3_handler_rom_end
+// $903e referenced 1 time by $8de2
+    ldx nmi_sta_abs+1                                                 // 903e: ae 3d 0d    .=.
+    lda nmi_sta_abs+2                                                 // 9041: ad 3e 0d    .>.
+    pha                                                               // 9044: 48          H
+    ldy #nmi_handler2_rom_end-nmi_handler2_rom_start                  // 9045: a0 94       ..
+// $9047 referenced 1 time by $904e
+loop_c9047
+    lda nmi_handler2_rom_start-1,y                                    // 9047: b9 66 90    .f.
+    sta l0cff,y                                                       // 904a: 99 ff 0c    ...
+    dey                                                               // 904d: 88          .
+    bne loop_c9047                                                    // 904e: d0 f7       ..
+    pla                                                               // 9050: 68          h
+    bit l00a1                                                         // 9051: 24 a1       $.
+    bpl c9060                                                         // 9053: 10 0b       ..
+    lda #opcode_bcs                                                   // 9055: a9 b0       ..
+    sta nmi_cmp_imm_or_bcs                                            // 9057: 8d 18 0d    ...
+    lda #nmi_XXX5-(nmi_cmp_imm_or_bcs+2)                              // 905a: a9 06       ..
+    sta nmi_cmp_imm_or_bcs+1                                          // 905c: 8d 19 0d    ...
+    rts                                                               // 905f: 60          `
+
+// $9060 referenced 1 time by $9053
+c9060
+    stx nmi_lda_zp                                                    // 9060: 8e 16 0d    ...
+    sta nmi_lda_zp+1                                                  // 9063: 8d 17 0d    ...
+// $9066 referenced 1 time by $9047
+    rts                                                               // 9066: 60          `
+
+nmi_handler2_rom_start
+* = $0d00
+    pha                                                               // 9067: 48          H   :0d00[6]
+    lda lfe84                                                         // 9068: ad 84 fe    ... :0d01[6]
+    and #$1b                                                          // 906b: 29 1b       ).  :0d04[6]
+    cmp #3                                                            // 906d: c9 03       ..  :0d06[6]
+    bne l0d0f                                                         // 906f: d0 05       ..  :0d08[6]
+    lda lfe87                                                         // 9071: ad 87 fe    ... :0d0a[6]
+// The operand of this bcs is modified at runtime
+nmi_bcs
+    bcs nmi_XXX21                                                     // 9074: b0 26       .&  :0d0d[6]
+l0d0f
+    and #$fc                                                          // 9076: 29 fc       ).  :0d0f[6]
+    sta l00a2                                                         // 9078: 85 a2       ..  :0d11[6]
+    pla                                                               // 907a: 68          h   :0d13[6]
+    rti                                                               // 907b: 40          @   :0d14[6]
+
+// The operand of this sta is modified at runtime.
+nmi_XXX17
+nmi_sta_abs2
+    sta tube_host_r3_data                                             // 907c: 8d e5 fe    ... :0d15[6]
+    inc nmi_sta_abs2+1                                                // 907f: ee 16 0d    ... :0d18[6]
+    bne nmi_XXX18                                                     // 9082: d0 03       ..  :0d1b[6]
+    inc nmi_sta_abs2+2                                                // 9084: ee 17 0d    ... :0d1d[6]
+nmi_XXX18
+    dec l00a6                                                         // 9087: c6 a6       ..  :0d20[6]
+    bne nmi_XXX23                                                     // 9089: d0 0f       ..  :0d22[6]
+    dec l00a7                                                         // 908b: c6 a7       ..  :0d24[6]
+    bne nmi_XXX23                                                     // 908d: d0 0b       ..  :0d26[6]
+    lda #nmi_XXX22-(nmi_bcs+2)                                        // 908f: a9 77       .w  :0d28[6]
+    dec l00a5                                                         // 9091: c6 a5       ..  :0d2a[6]
+    bne l0d30                                                         // 9093: d0 02       ..  :0d2c[6]
+    lda #nmi_XXX23-(nmi_bcs+2)                                        // 9095: a9 24       .$  :0d2e[6]
+l0d30
+    sta nmi_bcs+1                                                     // 9097: 8d 0e 0d    ... :0d30[6]
+nmi_XXX23
+    pla                                                               // 909a: 68          h   :0d33[6]
+    rti                                                               // 909b: 40          @   :0d34[6]
+
+nmi_XXX21
+    cmp #$fe                                                          // 909c: c9 fe       ..  :0d35[6]
+    beq l0d3d                                                         // 909e: f0 04       ..  :0d37[6]
+    cmp #$ce                                                          // 90a0: c9 ce       ..  :0d39[6]
+    bne nmi_XXX23                                                     // 90a2: d0 f6       ..  :0d3b[6]
+l0d3d
+    lda #nmi_XXX10-(nmi_bcs+2)                                        // 90a4: a9 32       .2  :0d3d[6]
+    bne l0d30                                                         // 90a6: d0 ef       ..  :0d3f[6]
+nmi_XXX10
+    sbc lfe87                                                         // 90a8: ed 87 fe    ... :0d41[6]
+    sta l00b5                                                         // 90ab: 85 b5       ..  :0d44[6]
+    lda #nmi_XXX11-(nmi_bcs+2)                                        // 90ad: a9 3b       .;  :0d46[6]
+    bne l0d30                                                         // 90af: d0 e6       ..  :0d48[6]
+nmi_XXX11
+    lda #nmi_XXX12-(nmi_bcs+2)                                        // 90b1: a9 3f       .?  :0d4a[6]
+    bne l0d30                                                         // 90b3: d0 e2       ..  :0d4c[6]
+nmi_XXX12
+    sbc l00cf                                                         // 90b5: e5 cf       ..  :0d4e[6]
+    ora l00b5                                                         // 90b7: 05 b5       ..  :0d50[6]
+    sta l00b5                                                         // 90b9: 85 b5       ..  :0d52[6]
+    lda #nmi_XXX13-(nmi_bcs+2)                                        // 90bb: a9 49       .I  :0d54[6]
+    bne l0d30                                                         // 90bd: d0 d8       ..  :0d56[6]
+nmi_XXX13
+    lda #nmi_XXX14-(nmi_bcs+2)                                        // 90bf: a9 4d       .M  :0d58[6]
+    bne l0d30                                                         // 90c1: d0 d4       ..  :0d5a[6]
+nmi_XXX14
+    lda l00b3                                                         // 90c3: a5 b3       ..  :0d5c[6]
+    sta l00a6                                                         // 90c5: 85 a6       ..  :0d5e[6]
+// $90c7 referenced 2 times by $8dac, $8dbd
+c0d60
+    lda #nmi_XXX15-(nmi_bcs+2)                                        // 90c7: a9 55       .U  :0d60[6]
+    bne l0d30                                                         // 90c9: d0 cc       ..  :0d62[6]
+nmi_XXX15
+    lda l00b4                                                         // 90cb: a5 b4       ..  :0d64[6]
+    sta l00a7                                                         // 90cd: 85 a7       ..  :0d66[6]
+    lda #nmi_XXX16-(nmi_bcs+2)                                        // 90cf: a9 5d       .]  :0d68[6]
+    bne l0d30                                                         // 90d1: d0 c4       ..  :0d6a[6]
+nmi_XXX16
+    cmp #$fb                                                          // 90d3: c9 fb       ..  :0d6c[6]
+    beq c0d74                                                         // 90d5: f0 04       ..  :0d6e[6]
+    cmp #$f8                                                          // 90d7: c9 f8       ..  :0d70[6]
+    bne nmi_XXX23                                                     // 90d9: d0 bf       ..  :0d72[6]
+// $90db referenced 1 time by $0d6e
+c0d74
+    sta l00b6                                                         // 90db: 85 b6       ..  :0d74[6]
+    lda l00b5                                                         // 90dd: a5 b5       ..  :0d76[6]
+    bne c0d80                                                         // 90df: d0 06       ..  :0d78[6]
+    inc l00cf                                                         // 90e1: e6 cf       ..  :0d7a[6]
+    lda #nmi_XXX17-(nmi_bcs+2)                                        // 90e3: a9 06       ..  :0d7c[6]
+    bne l0d30                                                         // 90e5: d0 b0       ..  :0d7e[6]
+// $90e7 referenced 1 time by $0d78
+c0d80
+    inc l00a5                                                         // 90e7: e6 a5       ..  :0d80[6]
+    lda #nmi_XXX18-(nmi_bcs+2)                                        // 90e9: a9 11       ..  :0d82[6]
+    bne l0d30                                                         // 90eb: d0 aa       ..  :0d84[6]
+nmi_XXX22
+    lda #nmi_XXX19-(nmi_bcs+2)                                        // 90ed: a9 7b       .{  :0d86[6]
+    bne l0d30                                                         // 90ef: d0 a6       ..  :0d88[6]
+nmi_XXX19
+    lda #nmi_XXX20-(nmi_bcs+2)                                        // 90f1: a9 7f       ..  :0d8a[6]
+    bne l0d30                                                         // 90f3: d0 a2       ..  :0d8c[6]
+nmi_XXX20
+    bne nmi_XXX23                                                     // 90f5: d0 a3       ..  :0d8e[6]
+    lda #nmi_XXX21-(nmi_bcs+2)                                        // 90f7: a9 26       .&  :0d90[6]
+    bne l0d30                                                         // 90f9: d0 9c       ..  :0d92[6]
+// $90fb referenced 3 times by $8d41, $8d92, $9101
+* = $90fb
+// $90fb referenced 3 times by $8d41, $8d92, $9101
+nmi_handler2_rom_end
+// $90fb referenced 3 times by $8d41, $8d92, $9101
+    sta lfe86                                                         // 90fb: 8d 86 fe    ...
+    cmp lfe86                                                         // 90fe: cd 86 fe    ...
+    bne nmi_handler2_rom_end                                          // 9101: d0 f8       ..
+    rts                                                               // 9103: 60          `
+
+// $9104 referenced 1 time by $966b
+set_c_iff_have_fdc
+    ldx #0                                                            // 9104: a2 00       ..
+    lda #$5a // 'Z'                                                   // 9106: a9 5a       .Z
+// $9108 referenced 1 time by $9111
+loop_c9108
+    sta lfe85                                                         // 9108: 8d 85 fe    ...
+    cmp lfe85                                                         // 910b: cd 85 fe    ...
+    beq c9115                                                         // 910e: f0 05       ..
+    dex                                                               // 9110: ca          .
+    bne loop_c9108                                                    // 9111: d0 f5       ..
+// $9113 referenced 1 time by $911a
+loop_c9113
+    clc                                                               // 9113: 18          .
+    rts                                                               // 9114: 60          `
+
+// $9115 referenced 1 time by $910e
+c9115
+    lda lfe80                                                         // 9115: ad 80 fe    ...
+    and #3                                                            // 9118: 29 03       ).
+    beq loop_c9113                                                    // 911a: f0 f7       ..
+    rts                                                               // 911c: 60          `
+
+// $911d referenced 1 time by $8cd8
+l911d
+    .asc ")*-."                                                       // 911d: 29 2a 2d... )*-
+// $9121 referenced 1 time by $8e15
+l9121
+    .byt   0, $10, $40, $50, $80, $81, $83, $a0, $a1, $c0, $e0, $f0   // 9121: 00 10 40... ..@
+// $912d referenced 1 time by $8e1b
+nmi_and_table
+    .byt $18, $18, $18, $18, $3f, $1f, $1f, $5f, $5f, $17, $1b, $5f   // 912d: 18 18 18... ...
+// $9139 referenced 1 time by $8c58
+l9139
+    .byt   8, $10, $18, $20, $40,   0                                 // 9139: 08 10 18... ...
+// $913f referenced 1 time by $8c61
+l913f
+    .byt $0e, $18, $0c, $20, $12,   0                                 // 913f: 0e 18 0c... ...
+// $9145 referenced 1 time by $92e3
+l9145
+    .byt $6d                                                          // 9145: 6d          m
+// $9146 referenced 1 time by $92e8
+l9146
+    .byt $91, $49, $91                                                // 9146: 91 49 91    .I.
+    .byt $3c, $0c,   3                                                // 9149: 3c 0c 03    <..
+    .byt   1,   1,   1                                                // 914c: 01 01 01    ...
+    .byt   1,   1,   1                                                // 914f: 01 01 01    ...
+    .byt $16, $0c,   3                                                // 9152: 16 0c 03    ...
+    .byt   1, $ff,   1                                                // 9155: 01 ff 01    ...
+    .byt   1, $18,   4                                                // 9158: 01 18 04    ...
+    .byt $4e,   0, $f5                                                // 915b: 4e 00 f5    N..
+    .byt $fe,   0,   0                                                // 915e: fe 00 00    ...
+    .byt   0,   0, $f7                                                // 9161: 00 00 f7    ...
+    .byt $4e,   0                                                     // 9164: 4e 00       N.
+    .byt $f5, $fb, $5a, $5a, $f7, $4e, $4e, $10,   6,   0,   1,   1   // 9166: f5 fb 5a... ..Z
+    .byt   1,   1,   1,   1, $0b,   6,   0,   1, $ff,   1,   1, $13   // 9172: 01 01 01... ...
+    .byt   3, $ff,   0,   0, $fe,   0,   0,   0,   0, $f7, $ff,   0   // 917e: 03 ff 00... ...
+    .byt   0, $fb, $e5, $e5, $f7, $ff, $ff                            // 918a: 00 fb e5... ...
+// $9191 referenced 1 time by $91df
+l9191
+    .byt $0a, $0b, $0e, $0f, $12, $13, $16, $17, $1b, $1e, $1f        // 9191: 0a 0b 0e... ...
+    .asc "#) 0"                                                       // 919c: 23 29 20... #)
+// $91a0 referenced 1 time by $9201
+l91a0
+    .byt $a0, $a0, $a1, $a1, $80, $80, $81, $81, $c0, $83, $83, $f0   // 91a0: a0 a0 a1... ...
+    .byt $10, $e0, $f0                                                // 91ac: 10 e0 f0    ...
+
+// $91af referenced 3 times by $9758, $a6dc, $a700
+c91af
+    lda #$ff                                                          // 91af: a9 ff       ..
+    sta l1082                                                         // 91b1: 8d 82 10    ...
+    stx l00c7                                                         // 91b4: 86 c7       ..
+    sty l00c8                                                         // 91b6: 84 c8       ..
+    ldy #$0c                                                          // 91b8: a0 0c       ..
+// $91ba referenced 1 time by $91c0
+loop_c91ba
+    lda (l00c7),y                                                     // 91ba: b1 c7       ..
+    sta l00ba,y                                                       // 91bc: 99 ba 00    ...
+    dey                                                               // 91bf: 88          .
+    bpl loop_c91ba                                                    // 91c0: 10 f8       ..
+    ldx #$0c                                                          // 91c2: a2 0c       ..
+    lda l00bf                                                         // 91c4: a5 bf       ..
+    cmp #$0a                                                          // 91c6: c9 0a       ..
+    bne c91cc                                                         // 91c8: d0 02       ..
+    ldx #$0e                                                          // 91ca: a2 0e       ..
+// $91cc referenced 1 time by $91c8
+c91cc
+    lda l00c0                                                         // 91cc: a5 c0       ..
+    and #$3f // '?'                                                   // 91ce: 29 3f       )?
+    cmp #$3a // ':'                                                   // 91d0: c9 3a       .:
+    beq c921f                                                         // 91d2: f0 4b       .K
+    cmp #$3d // '='                                                   // 91d4: c9 3d       .=
+    beq c923f                                                         // 91d6: f0 67       .g
+    cmp #$35 // '5'                                                   // 91d8: c9 35       .5
+    bne c91df                                                         // 91da: d0 03       ..
+    jmp c925a                                                         // 91dc: 4c 5a 92    LZ.
+
+// $91df referenced 2 times by $91da, $91e5
+c91df
+    cmp l9191,x                                                       // 91df: dd 91 91    ...
+    beq c91eb                                                         // 91e2: f0 07       ..
+    dex                                                               // 91e4: ca          .
+    bpl c91df                                                         // 91e5: 10 f8       ..
+// $91e7 referenced 1 time by $91ff
+loop_c91e7
+    lda #$fe                                                          // 91e7: a9 fe       ..
+    bmi c9214                                                         // 91e9: 30 29       0)
+// $91eb referenced 1 time by $91e2
+c91eb
+    cmp #$23 // '#'                                                   // 91eb: c9 23       .#
+    beq c91f3                                                         // 91ed: f0 04       ..
+    cpx #4                                                            // 91ef: e0 04       ..
+    bcs c9201                                                         // 91f1: b0 0e       ..
+// $91f3 referenced 1 time by $91ed
+c91f3
+    lda l00ba                                                         // 91f3: a5 ba       ..
+    bpl c91f9                                                         // 91f5: 10 02       ..
+    lda l00cd                                                         // 91f7: a5 cd       ..
+// $91f9 referenced 1 time by $91f5
+c91f9
+    and #3                                                            // 91f9: 29 03       ).
+    tay                                                               // 91fb: a8          .
+    lda l10de,y                                                       // 91fc: b9 de 10    ...
+    bmi loop_c91e7                                                    // 91ff: 30 e6       0.
+// $9201 referenced 1 time by $91f1
+c9201
+    ldy l91a0,x                                                       // 9201: bc a0 91    ...
+    sty l00c0                                                         // 9204: 84 c0       ..
+    cpy #$f0                                                          // 9206: c0 f0       ..
+    bne c920d                                                         // 9208: d0 03       ..
+    jsr sub_c929d                                                     // 920a: 20 9d 92     ..
+// $920d referenced 1 time by $9208
+c920d
+    ldx #$ba                                                          // 920d: a2 ba       ..
+    ldy #0                                                            // 920f: a0 00       ..
+    jsr sub_c8bf9                                                     // 9211: 20 f9 8b     ..
+// $9214 referenced 3 times by $91e9, $9257, $9276
+c9214
+    pha                                                               // 9214: 48          H
+    lda l00bf                                                         // 9215: a5 bf       ..
+    clc                                                               // 9217: 18          .
+    adc #7                                                            // 9218: 69 07       i.
+    tay                                                               // 921a: a8          .
+    pla                                                               // 921b: 68          h
+    sta (l00c7),y                                                     // 921c: 91 c7       ..
+    rts                                                               // 921e: 60          `
+
+// $921f referenced 1 time by $91d2
+c921f
+    jsr sub_c928a                                                     // 921f: 20 8a 92     ..
+    bcs c922b                                                         // 9222: b0 07       ..
+    lda l00c2                                                         // 9224: a5 c2       ..
+    sta l108b,x                                                       // 9226: 9d 8b 10    ...
+    bcc c923b                                                         // 9229: 90 10       ..
+// $922b referenced 1 time by $9222
+c922b
+    jsr sub_c9279                                                     // 922b: 20 79 92     y.
+    bcc c9257                                                         // 922e: 90 27       .'
+    lda l00c2                                                         // 9230: a5 c2       ..
+    ldy l10de,x                                                       // 9232: bc de 10    ...
+    bpl c9238                                                         // 9235: 10 01       ..
+    asl                                                               // 9237: 0a          .
+// $9238 referenced 1 time by $9235
+c9238
+    sta l1088,x                                                       // 9238: 9d 88 10    ...
+// $923b referenced 1 time by $9229
+c923b
+    lda #0                                                            // 923b: a9 00       ..
+    beq c9257                                                         // 923d: f0 18       ..
+// $923f referenced 1 time by $91d6
+c923f
+    jsr sub_c928a                                                     // 923f: 20 8a 92     ..
+    bcs c9249                                                         // 9242: b0 05       ..
+    lda l108b,x                                                       // 9244: bd 8b 10    ...
+    bcc c9257                                                         // 9247: 90 0e       ..
+// $9249 referenced 1 time by $9242
+c9249
+    jsr sub_c9279                                                     // 9249: 20 79 92     y.
+    bcc c9257                                                         // 924c: 90 09       ..
+    lda l1088,x                                                       // 924e: bd 88 10    ...
+    ldy l10de,x                                                       // 9251: bc de 10    ...
+    bpl c9257                                                         // 9254: 10 01       ..
+    lsr                                                               // 9256: 4a          J
+// $9257 referenced 5 times by $922e, $923d, $9247, $924c, $9254
+c9257
+    jmp c9214                                                         // 9257: 4c 14 92    L..
+
+// $925a referenced 1 time by $91dc
+c925a
+    lda #$ff                                                          // 925a: a9 ff       ..
+    ldx #0                                                            // 925c: a2 00       ..
+    ldy l00c1                                                         // 925e: a4 c1       ..
+    cpy #$10                                                          // 9260: c0 10       ..
+    beq c926a                                                         // 9262: f0 06       ..
+    cpy #$18                                                          // 9264: c0 18       ..
+    bne c9276                                                         // 9266: d0 0e       ..
+    inx                                                               // 9268: e8          .
+    inx                                                               // 9269: e8          .
+// $926a referenced 1 time by $9262
+c926a
+    lda l00c2                                                         // 926a: a5 c2       ..
+    sta l108b,x                                                       // 926c: 9d 8b 10    ...
+    lda l00c3                                                         // 926f: a5 c3       ..
+    sta l108c,x                                                       // 9271: 9d 8c 10    ...
+    lda #0                                                            // 9274: a9 00       ..
+// $9276 referenced 1 time by $9266
+c9276
+    jmp c9214                                                         // 9276: 4c 14 92    L..
+
+// $9279 referenced 2 times by $922b, $9249
+sub_c9279
+    ldx #0                                                            // 9279: a2 00       ..
+    lda l00c1                                                         // 927b: a5 c1       ..
+    cmp #$12                                                          // 927d: c9 12       ..
+    beq c9289                                                         // 927f: f0 08       ..
+    inx                                                               // 9281: e8          .
+    cmp #$1a                                                          // 9282: c9 1a       ..
+    beq c9289                                                         // 9284: f0 03       ..
+    lda #$fe                                                          // 9286: a9 fe       ..
+    clc                                                               // 9288: 18          .
+// $9289 referenced 2 times by $927f, $9284
+c9289
+    rts                                                               // 9289: 60          `
+
+// $928a referenced 2 times by $921f, $923f
+sub_c928a
+    lda l00c1                                                         // 928a: a5 c1       ..
+    and #$f6                                                          // 928c: 29 f6       ).
+    cmp #$10                                                          // 928e: c9 10       ..
+    sec                                                               // 9290: 38          8
+    bne c929c                                                         // 9291: d0 09       ..
+    lda l00c1                                                         // 9293: a5 c1       ..
+    lsr                                                               // 9295: 4a          J
+    lsr                                                               // 9296: 4a          J
+    ora l00c1                                                         // 9297: 05 c1       ..
+    and #3                                                            // 9299: 29 03       ).
+    tax                                                               // 929b: aa          .
+// $929c referenced 1 time by $9291
+c929c
+    rts                                                               // 929c: 60          `
+
+// $929d referenced 1 time by $920a
+sub_c929d
+    jsr sub_c9a8d                                                     // 929d: 20 8d 9a     ..
+    lda l00bb                                                         // 92a0: a5 bb       ..
+    sta l00b0                                                         // 92a2: 85 b0       ..
+    sta l00b4                                                         // 92a4: 85 b4       ..
+    clc                                                               // 92a6: 18          .
+    adc #$80                                                          // 92a7: 69 80       i.
+    sta l00b2                                                         // 92a9: 85 b2       ..
+    lda l00bc                                                         // 92ab: a5 bc       ..
+    sta l00b1                                                         // 92ad: 85 b1       ..
+    php                                                               // 92af: 08          .
+    jsr sub_c8f3f                                                     // 92b0: 20 3f 8f     ?.
+    bmi c92bd                                                         // 92b3: 30 08       0.
+    lda l00bd                                                         // 92b5: a5 bd       ..
+    ora l00be                                                         // 92b7: 05 be       ..
+    cmp #$ff                                                          // 92b9: c9 ff       ..
+    bne c92c4                                                         // 92bb: d0 07       ..
+// $92bd referenced 1 time by $92b3
+c92bd
+    lda l00b1                                                         // 92bd: a5 b1       ..
+    cmp l10cf                                                         // 92bf: cd cf 10    ...
+    bcs c92c7                                                         // 92c2: b0 03       ..
+// $92c4 referenced 1 time by $92bb
+c92c4
+    lda l10cf                                                         // 92c4: ad cf 10    ...
+// $92c7 referenced 1 time by $92c2
+c92c7
+    plp                                                               // 92c7: 28          (
+    sta l00b5                                                         // 92c8: 85 b5       ..
+    adc #0                                                            // 92ca: 69 00       i.
+    sta l00b3                                                         // 92cc: 85 b3       ..
+    inc l00b5                                                         // 92ce: e6 b5       ..
+    lda l00ba                                                         // 92d0: a5 ba       ..
+    bpl c92d6                                                         // 92d2: 10 02       ..
+    lda #0                                                            // 92d4: a9 00       ..
+// $92d6 referenced 1 time by $92d2
+c92d6
+    rol                                                               // 92d6: 2a          *
+    rol                                                               // 92d7: 2a          *
+    rol                                                               // 92d8: 2a          *
+    sta l108a                                                         // 92d9: 8d 8a 10    ...
+    ldx #2                                                            // 92dc: a2 02       ..
+    rol                                                               // 92de: 2a          *
+    bmi c92e3                                                         // 92df: 30 02       0.
+    ldx #0                                                            // 92e1: a2 00       ..
+// $92e3 referenced 1 time by $92df
+c92e3
+    lda l9145,x                                                       // 92e3: bd 45 91    .E.
+    sta l00b6                                                         // 92e6: 85 b6       ..
+    lda l9146,x                                                       // 92e8: bd 46 91    .F.
+    sta l00b7                                                         // 92eb: 85 b7       ..
+    ldy #$23 // '#'                                                   // 92ed: a0 23       .#
+// $92ef referenced 1 time by $92f4
+loop_c92ef
+    lda (l00b6),y                                                     // 92ef: b1 b6       ..
+    sta (l00b2),y                                                     // 92f1: 91 b2       ..
+    dey                                                               // 92f3: 88          .
+    bpl loop_c92ef                                                    // 92f4: 10 f9       ..
+    iny                                                               // 92f6: c8          .
+    sty l00b6                                                         // 92f7: 84 b6       ..
+    lda l00c3                                                         // 92f9: a5 c3       ..
+    pha                                                               // 92fb: 48          H
+    and #$e0                                                          // 92fc: 29 e0       ).
+    bne c9302                                                         // 92fe: d0 02       ..
+    lda #$10                                                          // 9300: a9 10       ..
+// $9302 referenced 1 time by $92fe
+c9302
+    asl                                                               // 9302: 0a          .
+    rol l00b6                                                         // 9303: 26 b6       &.
+    asl                                                               // 9305: 0a          .
+    rol l00b6                                                         // 9306: 26 b6       &.
+    asl                                                               // 9308: 0a          .
+    rol l00b6                                                         // 9309: 26 b6       &.
+    ldy #$0d                                                          // 930b: a0 0d       ..
+    sta (l00b2),y                                                     // 930d: 91 b2       ..
+    lda l00b6                                                         // 930f: a5 b6       ..
+    iny                                                               // 9311: c8          .
+    sta (l00b2),y                                                     // 9312: 91 b2       ..
+    pla                                                               // 9314: 68          h
+    and #$1f                                                          // 9315: 29 1f       ).
+    sta l00b9                                                         // 9317: 85 b9       ..
+    lda l00c2                                                         // 9319: a5 c2       ..
+    ldy #$10                                                          // 931b: a0 10       ..
+    sta (l00b2),y                                                     // 931d: 91 b2       ..
+    lda l00c5                                                         // 931f: a5 c5       ..
+    ldy #0                                                            // 9321: a0 00       ..
+    sta (l00b2),y                                                     // 9323: 91 b2       ..
+    tya                                                               // 9325: 98          .
+    sta l00b8                                                         // 9326: 85 b8       ..
+    jsr sub_c93d3                                                     // 9328: 20 d3 93     ..
+    jsr sub_c8f3f                                                     // 932b: 20 3f 8f     ?.
+    bmi c9367                                                         // 932e: 30 37       07
+    lda l00bd                                                         // 9330: a5 bd       ..
+    and l00be                                                         // 9332: 25 be       %.
+    cmp #$ff                                                          // 9334: c9 ff       ..
+    beq c9367                                                         // 9336: f0 2f       ./
+    lda #$ff                                                          // 9338: a9 ff       ..
+    sta l00bd                                                         // 933a: 85 bd       ..
+    sta l00be                                                         // 933c: 85 be       ..
+    jsr sub_c8f6b                                                     // 933e: 20 6b 8f     k.
+    ldx #$bb                                                          // 9341: a2 bb       ..
+    ldy #0                                                            // 9343: a0 00       ..
+    tya                                                               // 9345: 98          .
+    jsr tube_entry                                                    // 9346: 20 06 04     ..
+    ldx l00b5                                                         // 9349: a6 b5       ..
+    dex                                                               // 934b: ca          .
+    stx l00b1                                                         // 934c: 86 b1       ..
+    lda l00b9                                                         // 934e: a5 b9       ..
+    asl                                                               // 9350: 0a          .
+    asl                                                               // 9351: 0a          .
+    tax                                                               // 9352: aa          .
+    ldy #0                                                            // 9353: a0 00       ..
+// $9355 referenced 1 time by $9362
+loop_c9355
+    lda #7                                                            // 9355: a9 07       ..
+// $9357 referenced 1 time by $9359
+loop_c9357
+    sbc #1                                                            // 9357: e9 01       ..
+    bne loop_c9357                                                    // 9359: d0 fc       ..
+    lda tube_host_r3_data                                             // 935b: ad e5 fe    ...
+    sta (l00b0),y                                                     // 935e: 91 b0       ..
+    iny                                                               // 9360: c8          .
+    dex                                                               // 9361: ca          .
+    bpl loop_c9355                                                    // 9362: 10 f1       ..
+    jsr sub_c8f7a                                                     // 9364: 20 7a 8f     z.
+// $9367 referenced 2 times by $932e, $9336
+c9367
+    lda l00b5                                                         // 9367: a5 b5       ..
+    sta l00bc                                                         // 9369: 85 bc       ..
+// $936b referenced 1 time by $939c
+c936b
+    ldy #$16                                                          // 936b: a0 16       ..
+    ldx #0                                                            // 936d: a2 00       ..
+// $936f referenced 1 time by $937c
+loop_c936f
+    lda (l00b0,x)                                                     // 936f: a1 b0       ..
+    sta (l00b2),y                                                     // 9371: 91 b2       ..
+    inc l00b0                                                         // 9373: e6 b0       ..
+    bne c9379                                                         // 9375: d0 02       ..
+    inc l00b1                                                         // 9377: e6 b1       ..
+// $9379 referenced 1 time by $9375
+c9379
+    iny                                                               // 9379: c8          .
+    cpy #$1a                                                          // 937a: c0 1a       ..
+    bne loop_c936f                                                    // 937c: d0 f1       ..
+    lda #1                                                            // 937e: a9 01       ..
+    sta l00b6                                                         // 9380: 85 b6       ..
+// $9382 referenced 1 time by $9396
+loop_c9382
+    lda l00b6                                                         // 9382: a5 b6       ..
+    cmp #$0e                                                          // 9384: c9 0e       ..
+    bne c938d                                                         // 9386: d0 05       ..
+    jsr sub_c93b4                                                     // 9388: 20 b4 93     ..
+    beq c9390                                                         // 938b: f0 03       ..
+// $938d referenced 1 time by $9386
+c938d
+    jsr sub_c93d3                                                     // 938d: 20 d3 93     ..
+// $9390 referenced 1 time by $938b
+c9390
+    inc l00b6                                                         // 9390: e6 b6       ..
+    lda l00b6                                                         // 9392: a5 b6       ..
+    cmp #$11                                                          // 9394: c9 11       ..
+    bne loop_c9382                                                    // 9396: d0 ea       ..
+    inc l00b8                                                         // 9398: e6 b8       ..
+    dec l00b9                                                         // 939a: c6 b9       ..
+    bne c936b                                                         // 939c: d0 cd       ..
+    tay                                                               // 939e: a8          .
+    lda #$0e                                                          // 939f: a9 0e       ..
+    bit l108a                                                         // 93a1: 2c 8a 10    ,..
+    bvc c93a8                                                         // 93a4: 50 02       P.
+    lda #$1a                                                          // 93a6: a9 1a       ..
+// $93a8 referenced 1 time by $93a4
+c93a8
+    clc                                                               // 93a8: 18          .
+    adc l00bc                                                         // 93a9: 65 bc       e.
+    sbc l00b5                                                         // 93ab: e5 b5       ..
+    bcs c93b1                                                         // 93ad: b0 02       ..
+    lda #1                                                            // 93af: a9 01       ..
+// $93b1 referenced 1 time by $93ad
+c93b1
+    sta (l00b2),y                                                     // 93b1: 91 b2       ..
+    tya                                                               // 93b3: 98          .
+// $93b4 referenced 1 time by $9388
+sub_c93b4
+    jsr sub_c93c5                                                     // 93b4: 20 c5 93     ..
+    beq c93c4                                                         // 93b7: f0 0b       ..
+    stx l00b7                                                         // 93b9: 86 b7       ..
+    ldx #0                                                            // 93bb: a2 00       ..
+// $93bd referenced 1 time by $93c2
+loop_c93bd
+    jsr sub_c93d8                                                     // 93bd: 20 d8 93     ..
+    dec l00b7                                                         // 93c0: c6 b7       ..
+    bne loop_c93bd                                                    // 93c2: d0 f9       ..
+// $93c4 referenced 1 time by $93b7
+c93c4
+    rts                                                               // 93c4: 60          `
+
+// $93c5 referenced 2 times by $93b4, $93d3
+sub_c93c5
+    tay                                                               // 93c5: a8          .
+    lda (l00b2),y                                                     // 93c6: b1 b2       ..
+    tax                                                               // 93c8: aa          .
+    tya                                                               // 93c9: 98          .
+    clc                                                               // 93ca: 18          .
+    adc #$12                                                          // 93cb: 69 12       i.
+    tay                                                               // 93cd: a8          .
+    lda (l00b2),y                                                     // 93ce: b1 b2       ..
+    cpx #0                                                            // 93d0: e0 00       ..
+    rts                                                               // 93d2: 60          `
+
+// $93d3 referenced 2 times by $9328, $938d
+sub_c93d3
+    jsr sub_c93c5                                                     // 93d3: 20 c5 93     ..
+    beq c93e5                                                         // 93d6: f0 0d       ..
+// $93d8 referenced 1 time by $93bd
+sub_c93d8
+    ldy #0                                                            // 93d8: a0 00       ..
+// $93da referenced 1 time by $93e3
+loop_c93da
+    sta (l00b4),y                                                     // 93da: 91 b4       ..
+    inc l00b4                                                         // 93dc: e6 b4       ..
+    bne c93e2                                                         // 93de: d0 02       ..
+    inc l00b5                                                         // 93e0: e6 b5       ..
+// $93e2 referenced 1 time by $93de
+c93e2
+    dex                                                               // 93e2: ca          .
+    bne loop_c93da                                                    // 93e3: d0 f5       ..
+// $93e5 referenced 1 time by $93d6
+c93e5
+    rts                                                               // 93e5: 60          `
+
+// $93e6 referenced 10 times by $8772, $8791, $87cb, $89d7, $8a6b, $8b12, $8bf3, $9bbc, $9fff, $a30a
+c93e6
+    lda l0f04                                                         // 93e6: ad 04 0f    ...
+    clc                                                               // 93e9: 18          .
+    sed                                                               // 93ea: f8          .
+    adc #1                                                            // 93eb: 69 01       i.
+    sta l0f04                                                         // 93ed: 8d 04 0f    ...
+    cld                                                               // 93f0: d8          .
+// $93f1 referenced 1 time by $a737
+sub_c93f1
+    ldy #$a0                                                          // 93f1: a0 a0       ..
+    bne c940e                                                         // 93f3: d0 19       ..
+// $93f5 referenced 2 times by $9636, $a7ce
+sub_c93f5
+    ldy #$81                                                          // 93f5: a0 81       ..
+    bne c940e                                                         // 93f7: d0 15       ..
+// $93f9 referenced 1 time by $8266
+sub_c93f9
+    ldy #$81                                                          // 93f9: a0 81       ..
+    bne c93ff                                                         // 93fb: d0 02       ..
+// $93fd referenced 3 times by $8287, $988e, $98da
+sub_c93fd
+    ldy #$80                                                          // 93fd: a0 80       ..
+// $93ff referenced 1 time by $93fb
+c93ff
+    bit lfe84                                                         // 93ff: 2c 84 fe    ,..
+    bpl c940e                                                         // 9402: 10 0a       ..
+    lda l1082                                                         // 9404: ad 82 10    ...
+    cmp l00cd                                                         // 9407: c5 cd       ..
+    bne c940e                                                         // 9409: d0 03       ..
+    rts                                                               // 940b: 60          `
+
+// $940c referenced 6 times by $8383, $8489, $8a59, $a431, $a448, $a460
+c940c
+    ldy #$80                                                          // 940c: a0 80       ..
+// $940e referenced 4 times by $93f3, $93f7, $9402, $9409
+c940e
+    jsr sub_c9536                                                     // 940e: 20 36 95     6.
+    sty l1096                                                         // 9411: 8c 96 10    ...
+    lda l00cd                                                         // 9414: a5 cd       ..
+    sta l1090                                                         // 9416: 8d 90 10    ...
+    lda #2                                                            // 9419: a9 02       ..
+    sta l1099                                                         // 941b: 8d 99 10    ...
+    lda #$0e                                                          // 941e: a9 0e       ..
+    sta l1092                                                         // 9420: 8d 92 10    ...
+    dec l1093                                                         // 9423: ce 93 10    ...
+    dec l1094                                                         // 9426: ce 94 10    ...
+    jsr sub_c9445                                                     // 9429: 20 45 94     E.
+    lda l00cd                                                         // 942c: a5 cd       ..
+    sta l1082                                                         // 942e: 8d 82 10    ...
+    rts                                                               // 9431: 60          `
+
+// $9432 referenced 2 times by $944d, $a6f9
+sub_c9432
+    bit l00ff                                                         // 9432: 24 ff       $.
+    bpl c9444                                                         // 9434: 10 0e       ..
+// $9436 referenced 4 times by $946c, $a411, $a65d, $abc2
+c9436
+    jsr sub_c9ad8                                                     // 9436: 20 d8 9a     ..
+    jsr generate_error                                                // 9439: 20 48 80     H.
+    .byt $11                                                          // 943c: 11          .
+    .asc "Escape"                                                     // 943d: 45 73 63... Esc
+    .byt 0                                                            // 9443: 00          .
+
+// $9444 referenced 3 times by $9434, $946a, $947a
+c9444
+    rts                                                               // 9444: 60          `
+
+// $9445 referenced 2 times by $886a, $9429
+sub_c9445
+    jsr sub_c9516                                                     // 9445: 20 16 95     ..
+    lda #6                                                            // 9448: a9 06       ..
+    sta l109e                                                         // 944a: 8d 9e 10    ...
+    jsr sub_c9432                                                     // 944d: 20 32 94     2.
+// $9450 referenced 1 time by $94bf
+c9450
+    lda l1097                                                         // 9450: ad 97 10    ...
+    ldx l1090                                                         // 9453: ae 90 10    ...
+    ldy l10de,x                                                       // 9456: bc de 10    ...
+    bpl c945c                                                         // 9459: 10 01       ..
+    asl                                                               // 945b: 0a          .
+// $945c referenced 1 time by $9459
+c945c
+    ldy #$18                                                          // 945c: a0 18       ..
+    cmp #$50 // 'P'                                                   // 945e: c9 50       .P
+    bcs c94c1                                                         // 9460: b0 5f       ._
+    ldx #$90                                                          // 9462: a2 90       ..
+    ldy #$10                                                          // 9464: a0 10       ..
+    jsr sub_c8bf6                                                     // 9466: 20 f6 8b     ..
+    tay                                                               // 9469: a8          .
+    beq c9444                                                         // 946a: f0 d8       ..
+    bmi c9436                                                         // 946c: 30 c8       0.
+    cmp #$12                                                          // 946e: c9 12       ..
+    beq c94c6                                                         // 9470: f0 54       .T
+    cmp #$20 // ' '                                                   // 9472: c9 20       .
+    bne c948d                                                         // 9474: d0 17       ..
+    lda l1096                                                         // 9476: ad 96 10    ...
+    ror                                                               // 9479: 6a          j
+    bcs c9444                                                         // 947a: b0 c8       ..
+    jsr generate_error                                                // 947c: 20 48 80     H.
+    .byt $bc                                                          // 947f: bc          .
+    .asc "Execute only"                                               // 9480: 45 78 65... Exe
+    .byt 0                                                            // 948c: 00          .
+
+// $948d referenced 1 time by $9474
+c948d
+    cmp #$18                                                          // 948d: c9 18       ..
+    bne c94bc                                                         // 948f: d0 2b       .+
+    lda l108a                                                         // 9491: ad 8a 10    ...
+    cmp #4                                                            // 9494: c9 04       ..
+    bne c94a9                                                         // 9496: d0 11       ..
+    ldx l1096                                                         // 9498: ae 96 10    ...
+    cpx #$81                                                          // 949b: e0 81       ..
+    bne c94a9                                                         // 949d: d0 0a       ..
+    lda #$ff                                                          // 949f: a9 ff       ..
+    eor l108b                                                         // 94a1: 4d 8b 10    M..
+    sta l108b                                                         // 94a4: 8d 8b 10    ...
+    bcs c94bc                                                         // 94a7: b0 13       ..
+// $94a9 referenced 2 times by $9496, $949d
+c94a9
+    ldx l00ce                                                         // 94a9: a6 ce       ..
+    beq c94bc                                                         // 94ab: f0 0f       ..
+    rol                                                               // 94ad: 2a          *
+    and #$80                                                          // 94ae: 29 80       ).
+    ldx l1090                                                         // 94b0: ae 90 10    ...
+    eor l10de,x                                                       // 94b3: 5d de 10    ]..
+    sta l10de,x                                                       // 94b6: 9d de 10    ...
+    jsr sub_c9516                                                     // 94b9: 20 16 95     ..
+// $94bc referenced 3 times by $948f, $94a7, $94ab
+c94bc
+    dec l109e                                                         // 94bc: ce 9e 10    ...
+    bne c9450                                                         // 94bf: d0 8f       ..
+// $94c1 referenced 1 time by $9460
+c94c1
+    tya                                                               // 94c1: 98          .
+// $94c2 referenced 1 time by $a70f
+c94c2
+    cmp #$12                                                          // 94c2: c9 12       ..
+    bne c94d4                                                         // 94c4: d0 0e       ..
+// $94c6 referenced 2 times by $9470, $9523
+c94c6
+    jsr generate_error_precheck_disc                                  // 94c6: 20 23 80     #.
+    .byt $c9                                                          // 94c9: c9          .
+    .asc "read only"                                                  // 94ca: 72 65 61... rea
+    .byt 0                                                            // 94d3: 00          .
+
+// $94d4 referenced 1 time by $94c4
+c94d4
+    pha                                                               // 94d4: 48          H
+    jsr generate_error_precheck_disc                                  // 94d5: 20 23 80     #.
+    .byt 0                                                            // 94d8: 00          .
+
+    nop                                                               // 94d9: ea          .
+    jsr generate_error2                                               // 94da: 20 4f 80     O.
+    .byt $c7                                                          // 94dd: c7          .
+    .asc "fault "                                                     // 94de: 66 61 75... fau
+
+    nop                                                               // 94e4: ea          .
+    pla                                                               // 94e5: 68          h
+    jsr sub_c9526                                                     // 94e6: 20 26 95     &.
+    jsr generate_error2                                               // 94e9: 20 4f 80     O.
+    .byt 0                                                            // 94ec: 00          .
+    .asc " at :"                                                      // 94ed: 20 61 74...  at
+
+    lda l00cd                                                         // 94f2: a5 cd       ..
+    jsr sub_c952e                                                     // 94f4: 20 2e 95     ..
+    jsr generate_error2                                               // 94f7: 20 4f 80     O.
+    .byt 0                                                            // 94fa: 00          .
+    .asc " "                                                          // 94fb: 20
+
+    lda l00ce                                                         // 94fc: a5 ce       ..
+    bit l108a                                                         // 94fe: 2c 8a 10    ,..
+    bpl c9504                                                         // 9501: 10 01       ..
+    lsr                                                               // 9503: 4a          J
+// $9504 referenced 1 time by $9501
+c9504
+    jsr sub_c9526                                                     // 9504: 20 26 95     &.
+    jsr generate_error2                                               // 9507: 20 4f 80     O.
+    .byt 0                                                            // 950a: 00          .
+    .asc $2f                                                          // 950b: 2f          /
+
+    lda l00cf                                                         // 950c: a5 cf       ..
+    jsr sub_c9526                                                     // 950e: 20 26 95     &.
+    jsr generate_error2                                               // 9511: 20 4f 80     O.
+    .byt $c7,   0                                                     // 9514: c7 00       ..
+
+// $9516 referenced 2 times by $9445, $94b9
+sub_c9516
+    lda l1096                                                         // 9516: ad 96 10    ...
+    cmp #$a0                                                          // 9519: c9 a0       ..
+    bcc c9535                                                         // 951b: 90 18       ..
+    ldx l1090                                                         // 951d: ae 90 10    ...
+    lda l10de,x                                                       // 9520: bd de 10    ...
+    bmi c94c6                                                         // 9523: 30 a1       0.
+    rts                                                               // 9525: 60          `
+
+// $9526 referenced 3 times by $94e6, $9504, $950e
+sub_c9526
+    pha                                                               // 9526: 48          H
+    jsr sub_c81bf                                                     // 9527: 20 bf 81     ..
+    jsr sub_c952e                                                     // 952a: 20 2e 95     ..
+    pla                                                               // 952d: 68          h
+// $952e referenced 2 times by $94f4, $952a
+sub_c952e
+    jsr sub_c80c8                                                     // 952e: 20 c8 80     ..
+    sta l0100,x                                                       // 9531: 9d 00 01    ...
+    inx                                                               // 9534: e8          .
+// $9535 referenced 1 time by $951b
+c9535
+    rts                                                               // 9535: 60          `
+
+// $9536 referenced 1 time by $940e
+sub_c9536
+    ldx #$0d                                                          // 9536: a2 0d       ..
+    lda #0                                                            // 9538: a9 00       ..
+// $953a referenced 1 time by $953e
+loop_c953a
+    sta l108f,x                                                       // 953a: 9d 8f 10    ...
+    dex                                                               // 953d: ca          .
+    bne loop_c953a                                                    // 953e: d0 fa       ..
+    lda #5                                                            // 9540: a9 05       ..
+    sta l1095                                                         // 9542: 8d 95 10    ...
+    rts                                                               // 9545: 60          `
+
+    .asc "L.!BOOT", $0d                                               // 9546: 4c 2e 21... L.!
+    .asc "E.!BOOT", $0d                                               // 954e: 45 2e 21... E.!
+
+// $9556 referenced 1 time by $96e9
+c9556
+    lda l00b3                                                         // 9556: a5 b3       ..
+    jsr print_inline_l809f_top_bit_clear                              // 9558: 20 77 80     w.
+    .asc "Acorn 1770 DFS", $0d, $0d                                   // 955b: 41 63 6f... Aco
+
+    bcc c956f                                                         // 956b: 90 02       ..
+// $956d referenced 1 time by $96fd
+c956d
+    lda #$ff                                                          // 956d: a9 ff       ..
+// $956f referenced 1 time by $956b
+c956f
+    jsr zero_stacked_XXX                                              // 956f: 20 8e 9d     ..
+    pha                                                               // 9572: 48          H
+    lda #6                                                            // 9573: a9 06       ..
+    jsr sub_c8020                                                     // 9575: 20 20 80      .
+    lda lfe87                                                         // 9578: ad 87 fe    ...
+    ldx #$0d                                                          // 957b: a2 0d       ..
+// $957d referenced 1 time by $9584
+loop_c957d
+    lda l9aec,x                                                       // 957d: bd ec 9a    ...
+    sta filev,x                                                       // 9580: 9d 12 02    ...
+    dex                                                               // 9583: ca          .
+    bpl loop_c957d                                                    // 9584: 10 f7       ..
+    lda #$a8                                                          // 9586: a9 a8       ..
+    jsr osbyte_read                                                   // 9588: 20 e5 9a     ..
+    sty l00b1                                                         // 958b: 84 b1       ..
+    stx l00b0                                                         // 958d: 86 b0       ..
+    ldx #7                                                            // 958f: a2 07       ..
+    ldy #$1b                                                          // 9591: a0 1b       ..
+// $9593 referenced 1 time by $95a5
+loop_c9593
+    lda c9adf,y                                                       // 9593: b9 df 9a    ...
+    sta (l00b0),y                                                     // 9596: 91 b0       ..
+    iny                                                               // 9598: c8          .
+    lda c9adf,y                                                       // 9599: b9 df 9a    ...
+    sta (l00b0),y                                                     // 959c: 91 b0       ..
+    iny                                                               // 959e: c8          .
+    lda romsel_copy                                                   // 959f: a5 f4       ..
+    sta (l00b0),y                                                     // 95a1: 91 b0       ..
+    iny                                                               // 95a3: c8          .
+    dex                                                               // 95a4: ca          .
+    bne loop_c9593                                                    // 95a5: d0 ec       ..
+    sty l1082                                                         // 95a7: 8c 82 10    ...
+    sty l1083                                                         // 95aa: 8c 83 10    ...
+    stx l00cd                                                         // 95ad: 86 cd       ..
+    lda #$ff                                                          // 95af: a9 ff       ..
+    sta l1087                                                         // 95b1: 8d 87 10    ...
+    ldy #3                                                            // 95b4: a0 03       ..
+// $95b6 referenced 1 time by $95ba
+loop_c95b6
+    sta l108b,y                                                       // 95b6: 99 8b 10    ...
+    dey                                                               // 95b9: 88          .
+    bpl loop_c95b6                                                    // 95ba: 10 fa       ..
+    ldx #$0f                                                          // 95bc: a2 0f       ..
+    jsr c9adf                                                         // 95be: 20 df 9a     ..
+    jsr sub_c9ab8                                                     // 95c1: 20 b8 9a     ..
+    ldy #$d3                                                          // 95c4: a0 d3       ..
+    lda (l00b0),y                                                     // 95c6: b1 b0       ..
+    bpl c95fd                                                         // 95c8: 10 33       .3
+    pla                                                               // 95ca: 68          h
+    pha                                                               // 95cb: 48          H
+    beq c95fd                                                         // 95cc: f0 2f       ./
+    ldy #$d4                                                          // 95ce: a0 d4       ..
+    lda (l00b0),y                                                     // 95d0: b1 b0       ..
+    bmi c9628                                                         // 95d2: 30 54       0T
+    jsr sub_c9aa3                                                     // 95d4: 20 a3 9a     ..
+    ldy #0                                                            // 95d7: a0 00       ..
+// $95d9 referenced 1 time by $95e8
+loop_c95d9
+    lda (l00b0),y                                                     // 95d9: b1 b0       ..
+    cpy #$c0                                                          // 95db: c0 c0       ..
+    bcc c95e4                                                         // 95dd: 90 05       ..
+    sta l1000,y                                                       // 95df: 99 00 10    ...
+    bcs c95e7                                                         // 95e2: b0 03       ..
+// $95e4 referenced 1 time by $95dd
+c95e4
+    sta l1100,y                                                       // 95e4: 99 00 11    ...
+// $95e7 referenced 1 time by $95e2
+c95e7
+    dey                                                               // 95e7: 88          .
+    bne loop_c95d9                                                    // 95e8: d0 ef       ..
+    lda #$a0                                                          // 95ea: a9 a0       ..
+// $95ec referenced 1 time by $95f9
+loop_c95ec
+    tay                                                               // 95ec: a8          .
+    pha                                                               // 95ed: 48          H
+    lda #$3f // '?'                                                   // 95ee: a9 3f       .?
+    jsr sub_c9f16                                                     // 95f0: 20 16 9f     ..
+    pla                                                               // 95f3: 68          h
+    sta l111d,y                                                       // 95f4: 99 1d 11    ...
+    sbc #$1f                                                          // 95f7: e9 1f       ..
+    bne loop_c95ec                                                    // 95f9: d0 f1       ..
+    beq c9628                                                         // 95fb: f0 2b       .+
+// $95fd referenced 2 times by $95c8, $95cc
+c95fd
+    jsr sub_c9aa3                                                     // 95fd: 20 a3 9a     ..
+    lda #$24 // '$'                                                   // 9600: a9 24       .$
+    sta l10c9                                                         // 9602: 8d c9 10    ...
+    sta l10cb                                                         // 9605: 8d cb 10    ...
+    ldy #0                                                            // 9608: a0 00       ..
+    sty l10ca                                                         // 960a: 8c ca 10    ...
+    sty l10cc                                                         // 960d: 8c cc 10    ...
+    ldy #0                                                            // 9610: a0 00       ..
+    sty l10c0                                                         // 9612: 8c c0 10    ...
+    ldx #3                                                            // 9615: a2 03       ..
+    tya                                                               // 9617: 98          .
+// $9618 referenced 1 time by $961c
+loop_c9618
+    sta l10de,x                                                       // 9618: 9d de 10    ...
+    dex                                                               // 961b: ca          .
+    bne loop_c9618                                                    // 961c: d0 fa       ..
+    dey                                                               // 961e: 88          .
+    sty l10c7                                                         // 961f: 8c c7 10    ...
+    sty l10c6                                                         // 9622: 8c c6 10    ...
+    sty l10dd                                                         // 9625: 8c dd 10    ...
+// $9628 referenced 2 times by $95d2, $95fb
+c9628
+    jsr sub_c8f3f                                                     // 9628: 20 3f 8f     ?.
+    pla                                                               // 962b: 68          h
+    bne c9649                                                         // 962c: d0 1b       ..
+    lda #4                                                            // 962e: a9 04       ..
+    ora l10de                                                         // 9630: 0d de 10    ...
+    sta l10de                                                         // 9633: 8d de 10    ...
+    jsr sub_c93f5                                                     // 9636: 20 f5 93     ..
+    lda #$fb                                                          // 9639: a9 fb       ..
+    and l10de                                                         // 963b: 2d de 10    -..
+    sta l10de                                                         // 963e: 8d de 10    ...
+    lda l0f06                                                         // 9641: ad 06 0f    ...
+    jsr sub_c81bf                                                     // 9644: 20 bf 81     ..
+    bne c964a                                                         // 9647: d0 01       ..
+// $9649 referenced 1 time by $962c
+c9649
+    rts                                                               // 9649: 60          `
+
+// $964a referenced 1 time by $9647
+c964a
+    ldy #$95                                                          // 964a: a0 95       ..
+    ldx #$46 // 'F'                                                   // 964c: a2 46       .F
+    cmp #2                                                            // 964e: c9 02       ..
+    bcc c965a                                                         // 9650: 90 08       ..
+    beq c9658                                                         // 9652: f0 04       ..
+    ldx #$4e // 'N'                                                   // 9654: a2 4e       .N
+    bne c965a                                                         // 9656: d0 02       ..
+// $9658 referenced 1 time by $9652
+c9658
+    ldx #$50 // 'P'                                                   // 9658: a2 50       .P
+// $965a referenced 2 times by $9650, $9656
+c965a
+    jmp oscli                                                         // 965a: 4c f7 ff    L..
+
+// $965d referenced 1 time by $b1b1
+sub_c965d
+    jsr service_handler_help_and_tube                                 // 965d: 20 a9 ae     ..
+    pha                                                               // 9660: 48          H
+    lda l0df0,x                                                       // 9661: bd f0 0d    ...
+    bmi pla_rts                                                       // 9664: 30 5b       0[
+    pla                                                               // 9666: 68          h
+    cmp #service_claim_absolute_workspace                             // 9667: c9 01       ..
+    bne c9683                                                         // 9669: d0 18       ..
+    jsr set_c_iff_have_fdc                                            // 966b: 20 04 91     ..
+    ldx romsel_copy                                                   // 966e: a6 f4       ..
+    bcs c967a                                                         // 9670: b0 08       ..
+    lda #$80                                                          // 9672: a9 80       ..
+    sta l0df0,x                                                       // 9674: 9d f0 0d    ...
+    lda #1                                                            // 9677: a9 01       ..
+    rts                                                               // 9679: 60          `
+
+// $967a referenced 1 time by $9670
+c967a
+    lda #service_claim_absolute_workspace                             // 967a: a9 01       ..
+    cpy #$17                                                          // 967c: c0 17       ..
+    bcs c9682                                                         // 967e: b0 02       ..
+    ldy #$17                                                          // 9680: a0 17       ..
+// $9682 referenced 1 time by $967e
+c9682
+    rts                                                               // 9682: 60          `
+
+// $9683 referenced 1 time by $9669
+c9683
+    cmp #service_claim_private_workspace                              // 9683: c9 02       ..
+    bne c96c3                                                         // 9685: d0 3c       .<
+    pha                                                               // 9687: 48          H
+    tya                                                               // 9688: 98          .
+    pha                                                               // 9689: 48          H
+    sta l00b1                                                         // 968a: 85 b1       ..
+    ldy l0df0,x                                                       // 968c: bc f0 0d    ...
+    sta l0df0,x                                                       // 968f: 9d f0 0d    ...
+    lda #0                                                            // 9692: a9 00       ..
+    sta l00b0                                                         // 9694: 85 b0       ..
+    cpy l00b1                                                         // 9696: c4 b1       ..
+    beq c969e                                                         // 9698: f0 04       ..
+    ldy #$d3                                                          // 969a: a0 d3       ..
+    sta (l00b0),y                                                     // 969c: 91 b0       ..
+// $969e referenced 1 time by $9698
+c969e
+    lda #$fd                                                          // 969e: a9 fd       ..
+    jsr osbyte_read                                                   // 96a0: 20 e5 9a     ..
+    dex                                                               // 96a3: ca          .
+    txa                                                               // 96a4: 8a          .
+    ldy #$d3                                                          // 96a5: a0 d3       ..
+    and (l00b0),y                                                     // 96a7: 31 b0       1.
+    sta (l00b0),y                                                     // 96a9: 91 b0       ..
+    php                                                               // 96ab: 08          .
+    iny                                                               // 96ac: c8          .
+    plp                                                               // 96ad: 28          (
+    bpl c96b7                                                         // 96ae: 10 07       ..
+    lda (l00b0),y                                                     // 96b0: b1 b0       ..
+    bpl c96b7                                                         // 96b2: 10 03       ..
+    jsr sub_c8951                                                     // 96b4: 20 51 89     Q.
+// $96b7 referenced 2 times by $96ae, $96b2
+c96b7
+    lda #0                                                            // 96b7: a9 00       ..
+    sta (l00b0),y                                                     // 96b9: 91 b0       ..
+    ldx romsel_copy                                                   // 96bb: a6 f4       ..
+    pla                                                               // 96bd: 68          h
+    tay                                                               // 96be: a8          .
+    iny                                                               // 96bf: c8          .
+    iny                                                               // 96c0: c8          .
+// $96c1 referenced 1 time by $9664
+pla_rts
+    pla                                                               // 96c1: 68          h
+// $96c2 referenced 1 time by $96df
+loop_c96c2
+    rts                                                               // 96c2: 60          `
+
+// $96c3 referenced 1 time by $9685
+c96c3
+    jsr sub_c83e3                                                     // 96c3: 20 e3 83     ..
+    cmp #service_boot                                                 // 96c6: c9 03       ..
+    bne c96ec                                                         // 96c8: d0 22       ."
+    sty l00b3                                                         // 96ca: 84 b3       ..
+    lda #0                                                            // 96cc: a9 00       ..
+    sta l10de                                                         // 96ce: 8d de 10    ...
+    lda #osbyte_scan_keyboard_from_16                                 // 96d1: a9 7a       .z
+    jsr osbyte                                                        // 96d3: 20 f4 ff     ..
+    txa                                                               // 96d6: 8a          .
+    bmi c96e9                                                         // 96d7: 30 10       0.
+    cmp #$32 // '2'                                                   // 96d9: c9 32       .2
+    beq c96e4                                                         // 96db: f0 07       ..
+    cmp #$61 // 'a'                                                   // 96dd: c9 61       .a
+    bne loop_c96c2                                                    // 96df: d0 e1       ..
+    jsr sub_cac72                                                     // 96e1: 20 72 ac     r.
+// $96e4 referenced 1 time by $96db
+c96e4
+    lda #osbyte_write_keys_pressed                                    // 96e4: a9 78       .x
+    jsr osbyte                                                        // 96e6: 20 f4 ff     ..
+// $96e9 referenced 1 time by $96d7
+c96e9
+    jmp c9556                                                         // 96e9: 4c 56 95    LV.
+
+// $96ec referenced 1 time by $96c8
+c96ec
+    cmp #service_unrecognised_command                                 // 96ec: c9 04       ..
+    bne c96f5                                                         // 96ee: d0 05       ..
+    ldx #$9b                                                          // 96f0: a2 9b       ..
+// $96f2 referenced 1 time by $970a
+loop_c96f2
+    jmp c8703                                                         // 96f2: 4c 03 87    L..
+
+// $96f5 referenced 1 time by $96ee
+c96f5
+    cmp #service_select_filing_system                                 // 96f5: c9 12       ..
+    bne c9700                                                         // 96f7: d0 07       ..
+    cpy #4                                                            // 96f9: c0 04       ..
+    bne c973c                                                         // 96fb: d0 3f       .?
+    jmp c956d                                                         // 96fd: 4c 6d 95    Lm.
+
+// $9700 referenced 1 time by $96f7
+c9700
+    cmp #service_help                                                 // 9700: c9 09       ..
+    bne c9714                                                         // 9702: d0 10       ..
+    lda (os_text_ptr),y                                               // 9704: b1 f2       ..
+    ldx #$cf                                                          // 9706: a2 cf       ..
+    cmp #$0d                                                          // 9708: c9 0d       ..
+    bne loop_c96f2                                                    // 970a: d0 e6       ..
+    tya                                                               // 970c: 98          .
+    inx                                                               // 970d: e8          .
+    inx                                                               // 970e: e8          .
+    ldy #2                                                            // 970f: a0 02       ..
+    jmp ca10b                                                         // 9711: 4c 0b a1    L..
+
+// $9714 referenced 1 time by $9702
+c9714
+    jsr zero_stacked_XXX                                              // 9714: 20 8e 9d     ..
+    cmp #service_absolute_workspace_claimed                           // 9717: c9 0a       ..
+    bne c973d                                                         // 9719: d0 22       ."
+    jsr sub_c9ab8                                                     // 971b: 20 b8 9a     ..
+    ldy #$d4                                                          // 971e: a0 d4       ..
+    lda (l00b0),y                                                     // 9720: b1 b0       ..
+    bpl c9736                                                         // 9722: 10 12       ..
+    ldy #0                                                            // 9724: a0 00       ..
+    jsr sub_c9d75                                                     // 9726: 20 75 9d     u.
+    jsr sub_c8951                                                     // 9729: 20 51 89     Q.
+    jsr sub_c9ab8                                                     // 972c: 20 b8 9a     ..
+    ldy #$d4                                                          // 972f: a0 d4       ..
+    lda #0                                                            // 9731: a9 00       ..
+    sta (l00b0),y                                                     // 9733: 91 b0       ..
+    rts                                                               // 9735: 60          `
+
+// $9736 referenced 1 time by $9722
+c9736
+    lda #$0a                                                          // 9736: a9 0a       ..
+// $9738 referenced 3 times by $973f, $9743, $9747
+c9738
+    tsx                                                               // 9738: ba          .
+    sta l0105,x                                                       // 9739: 9d 05 01    ...
+// $973c referenced 1 time by $96fb
+c973c
+    rts                                                               // 973c: 60          `
+
+// $973d referenced 1 time by $9719
+c973d
+    cmp #service_unrecognised_osword                                  // 973d: c9 08       ..
+    bne c9738                                                         // 973f: d0 f7       ..
+    ldy l00ef                                                         // 9741: a4 ef       ..
+    bmi c9738                                                         // 9743: 30 f3       0.
+    cpy #$7d // '}'                                                   // 9745: c0 7d       .}
+    bcc c9738                                                         // 9747: 90 ef       ..
+    ldx l00f0                                                         // 9749: a6 f0       ..
+    stx l00c7                                                         // 974b: 86 c7       ..
+    ldx l00f1                                                         // 974d: a6 f1       ..
+    stx l00c8                                                         // 974f: 86 c8       ..
+    iny                                                               // 9751: c8          .
+    bpl c975b                                                         // 9752: 10 07       ..
+    ldx l00c7                                                         // 9754: a6 c7       ..
+    ldy l00c8                                                         // 9756: a4 c8       ..
+    jmp c91af                                                         // 9758: 4c af 91    L..
+
+// $975b referenced 1 time by $9752
+c975b
+    jsr sub_c8b7b                                                     // 975b: 20 7b 8b     {.
+    jsr sub_c8380                                                     // 975e: 20 80 83     ..
+    iny                                                               // 9761: c8          .
+    bmi c976c                                                         // 9762: 30 08       0.
+    ldy #0                                                            // 9764: a0 00       ..
+    lda l0f04                                                         // 9766: ad 04 0f    ...
+    sta (l00c7),y                                                     // 9769: 91 c7       ..
+    rts                                                               // 976b: 60          `
+
+// $976c referenced 1 time by $9762
+c976c
+    lda #0                                                            // 976c: a9 00       ..
+    tay                                                               // 976e: a8          .
+    sta (l00c7),y                                                     // 976f: 91 c7       ..
+    iny                                                               // 9771: c8          .
+    lda l0f07                                                         // 9772: ad 07 0f    ...
+    sta (l00c7),y                                                     // 9775: 91 c7       ..
+    iny                                                               // 9777: c8          .
+    lda l0f06                                                         // 9778: ad 06 0f    ...
+    and #3                                                            // 977b: 29 03       ).
+    sta (l00c7),y                                                     // 977d: 91 c7       ..
+    iny                                                               // 977f: c8          .
+    lda #0                                                            // 9780: a9 00       ..
+    sta (l00c7),y                                                     // 9782: 91 c7       ..
+    rts                                                               // 9784: 60          `
+
+sub_c9785
+    jsr sub_c840c                                                     // 9785: 20 0c 84     ..
+    pha                                                               // 9788: 48          H
+    jsr c99a3                                                         // 9789: 20 a3 99     ..
+    stx l00b0                                                         // 978c: 86 b0       ..
+    stx l10db                                                         // 978e: 8e db 10    ...
+    sty l00b1                                                         // 9791: 84 b1       ..
+    sty l10dc                                                         // 9793: 8c dc 10    ...
+    ldx #0                                                            // 9796: a2 00       ..
+    ldy #0                                                            // 9798: a0 00       ..
+    jsr sub_c80e3                                                     // 979a: 20 e3 80     ..
+// $979d referenced 1 time by $97a2
+loop_c979d
+    jsr sub_c80d3                                                     // 979d: 20 d3 80     ..
+    cpy #$12                                                          // 97a0: c0 12       ..
+    bne loop_c979d                                                    // 97a2: d0 f9       ..
+    pla                                                               // 97a4: 68          h
+    tax                                                               // 97a5: aa          .
+    inx                                                               // 97a6: e8          .
+    cpx #8                                                            // 97a7: e0 08       ..
+    bcs c97b3                                                         // 97a9: b0 08       ..
+    lda l9b29,x                                                       // 97ab: bd 29 9b    .).
+    pha                                                               // 97ae: 48          H
+    lda l9b21,x                                                       // 97af: bd 21 9b    .!.
+    pha                                                               // 97b2: 48          H
+// $97b3 referenced 2 times by $97a9, $97b8
+c97b3
+    lda #0                                                            // 97b3: a9 00       ..
+    rts                                                               // 97b5: 60          `
+
+sub_c97b6
+    cmp #9                                                            // 97b6: c9 09       ..
+    bcs c97b3                                                         // 97b8: b0 f9       ..
+    stx l00b5                                                         // 97ba: 86 b5       ..
+    tax                                                               // 97bc: aa          .
+    lda l9b18,x                                                       // 97bd: bd 18 9b    ...
+    pha                                                               // 97c0: 48          H
+    lda l9b0f,x                                                       // 97c1: bd 0f 9b    ...
+    pha                                                               // 97c4: 48          H
+    txa                                                               // 97c5: 8a          .
+    ldx l00b5                                                         // 97c6: a6 b5       ..
+// $97c8 referenced 1 time by $97cb
+loop_c97c8
+    rts                                                               // 97c8: 60          `
+
+sub_c97c9
+    cmp #9                                                            // 97c9: c9 09       ..
+    bcs loop_c97c8                                                    // 97cb: b0 fb       ..
+    jsr sub_c83e3                                                     // 97cd: 20 e3 83     ..
+    jsr zero_stacked_XXX                                              // 97d0: 20 8e 9d     ..
+    stx l107d                                                         // 97d3: 8e 7d 10    .}.
+    sty l107e                                                         // 97d6: 8c 7e 10    .~.
+    tay                                                               // 97d9: a8          .
+    jsr sub_c97e8                                                     // 97da: 20 e8 97     ..
+    php                                                               // 97dd: 08          .
+    bit l1081                                                         // 97de: 2c 81 10    ,..
+    bpl c97e6                                                         // 97e1: 10 03       ..
+    jsr sub_c8f7a                                                     // 97e3: 20 7a 8f     z.
+// $97e6 referenced 1 time by $97e1
+c97e6
+    plp                                                               // 97e6: 28          (
+    rts                                                               // 97e7: 60          `
+
+// $97e8 referenced 1 time by $97da
+sub_c97e8
+    lda l9b31,y                                                       // 97e8: b9 31 9b    .1.
+    sta l10d7                                                         // 97eb: 8d d7 10    ...
+    lda l9b3a,y                                                       // 97ee: b9 3a 9b    .:.
+    sta l10d8                                                         // 97f1: 8d d8 10    ...
+    lda l9b43,y                                                       // 97f4: b9 43 9b    .C.
+    lsr                                                               // 97f7: 4a          J
+    php                                                               // 97f8: 08          .
+    lsr                                                               // 97f9: 4a          J
+    php                                                               // 97fa: 08          .
+    sta l107f                                                         // 97fb: 8d 7f 10    ...
+    jsr sub_c995a                                                     // 97fe: 20 5a 99     Z.
+    ldy #$0c                                                          // 9801: a0 0c       ..
+// $9803 referenced 1 time by $9809
+loop_c9803
+    lda (l00b4),y                                                     // 9803: b1 b4       ..
+    sta l1060,y                                                       // 9805: 99 60 10    .`.
+    dey                                                               // 9808: 88          .
+    bpl loop_c9803                                                    // 9809: 10 f8       ..
+    lda l1063                                                         // 980b: ad 63 10    .c.
+    and l1064                                                         // 980e: 2d 64 10    -d.
+    ora l10d6                                                         // 9811: 0d d6 10    ...
+    clc                                                               // 9814: 18          .
+    adc #1                                                            // 9815: 69 01       i.
+    beq c981f                                                         // 9817: f0 06       ..
+    jsr sub_c8f6b                                                     // 9819: 20 6b 8f     k.
+    clc                                                               // 981c: 18          .
+    lda #$ff                                                          // 981d: a9 ff       ..
+// $981f referenced 1 time by $9817
+c981f
+    sta l1081                                                         // 981f: 8d 81 10    ...
+    lda l107f                                                         // 9822: ad 7f 10    ...
+    bcs c982e                                                         // 9825: b0 07       ..
+    ldx #$61 // 'a'                                                   // 9827: a2 61       .a
+    ldy #$10                                                          // 9829: a0 10       ..
+    jsr tube_entry                                                    // 982b: 20 06 04     ..
+// $982e referenced 1 time by $9825
+c982e
+    plp                                                               // 982e: 28          (
+    bcs c9835                                                         // 982f: b0 04       ..
+    plp                                                               // 9831: 28          (
+// $9832 referenced 1 time by $9861
+sub_c9832
+    jmp (l10d7)                                                       // 9832: 6c d7 10    l..
+
+// $9835 referenced 1 time by $982f
+c9835
+    ldx #3                                                            // 9835: a2 03       ..
+// $9837 referenced 1 time by $983d
+loop_c9837
+    lda l1069,x                                                       // 9837: bd 69 10    .i.
+    sta l00b6,x                                                       // 983a: 95 b6       ..
+    dex                                                               // 983c: ca          .
+    bpl loop_c9837                                                    // 983d: 10 f8       ..
+    ldx #$b6                                                          // 983f: a2 b6       ..
+    ldy l1060                                                         // 9841: ac 60 10    .`.
+    lda #0                                                            // 9844: a9 00       ..
+    plp                                                               // 9846: 28          (
+    bcs c984c                                                         // 9847: b0 03       ..
+    jsr ca06c                                                         // 9849: 20 6c a0     l.
+// $984c referenced 1 time by $9847
+c984c
+    jsr c9dd5                                                         // 984c: 20 d5 9d     ..
+    ldx #3                                                            // 984f: a2 03       ..
+// $9851 referenced 1 time by $9857
+loop_c9851
+    lda l00b6,x                                                       // 9851: b5 b6       ..
+    sta l1069,x                                                       // 9853: 9d 69 10    .i.
+    dex                                                               // 9856: ca          .
+    bpl loop_c9851                                                    // 9857: 10 f8       ..
+// $9859 referenced 1 time by $989b
+c9859
+    jsr invert_l1065                                                  // 9859: 20 4c 99     L.
+    bmi c986b                                                         // 985c: 30 0d       0.
+// $985e referenced 1 time by $9870
+loop_c985e
+    ldy l1060                                                         // 985e: ac 60 10    .`.
+    jsr sub_c9832                                                     // 9861: 20 32 98     2.
+    bcs c9873                                                         // 9864: b0 0d       ..
+    ldx #9                                                            // 9866: a2 09       ..
+    jsr sub_c9940                                                     // 9868: 20 40 99     @.
+// $986b referenced 1 time by $985c
+c986b
+    ldx #5                                                            // 986b: a2 05       ..
+    jsr sub_c9940                                                     // 986d: 20 40 99     @.
+    bne loop_c985e                                                    // 9870: d0 ec       ..
+    clc                                                               // 9872: 18          .
+// $9873 referenced 1 time by $9864
+c9873
+    php                                                               // 9873: 08          .
+    jsr invert_l1065                                                  // 9874: 20 4c 99     L.
+    ldx #5                                                            // 9877: a2 05       ..
+    jsr sub_c9940                                                     // 9879: 20 40 99     @.
+    ldy #$0c                                                          // 987c: a0 0c       ..
+    jsr sub_c995a                                                     // 987e: 20 5a 99     Z.
+// $9881 referenced 1 time by $9887
+loop_c9881
+    lda l1060,y                                                       // 9881: b9 60 10    .`.
+    sta (l00b4),y                                                     // 9884: 91 b4       ..
+    dey                                                               // 9886: 88          .
+    bpl loop_c9881                                                    // 9887: 10 f8       ..
+    plp                                                               // 9889: 28          (
+    rts                                                               // 988a: 60          `
+
+    jsr sub_c8b7b                                                     // 988b: 20 7b 8b     {.
+    jsr sub_c93fd                                                     // 988e: 20 fd 93     ..
+    lda #$9d                                                          // 9891: a9 9d       ..
+    sta l10d7                                                         // 9893: 8d d7 10    ...
+    lda #$98                                                          // 9896: a9 98       ..
+    sta l10d8                                                         // 9898: 8d d8 10    ...
+    bne c9859                                                         // 989b: d0 bc       ..
+    ldy l1069                                                         // 989d: ac 69 10    .i.
+// $98a0 referenced 1 time by $98b8
+loop_c98a0
+    cpy l0f05                                                         // 98a0: cc 05 0f    ...
+    bcs c98cd                                                         // 98a3: b0 28       .(
+    lda l0e0f,y                                                       // 98a5: b9 0f 0e    ...
+    jsr sub_c8327                                                     // 98a8: 20 27 83     '.
+    eor l00cc                                                         // 98ab: 45 cc       E.
+    bcs c98b1                                                         // 98ad: b0 02       ..
+    and #$df                                                          // 98af: 29 df       ).
+// $98b1 referenced 1 time by $98ad
+c98b1
+    and #$7f                                                          // 98b1: 29 7f       ).
+    beq c98ba                                                         // 98b3: f0 05       ..
+    jsr sub_c87da                                                     // 98b5: 20 da 87     ..
+    bne loop_c98a0                                                    // 98b8: d0 e6       ..
+// $98ba referenced 1 time by $98b3
+c98ba
+    lda #7                                                            // 98ba: a9 07       ..
+    jsr c996e                                                         // 98bc: 20 6e 99     n.
+    sta l00b0                                                         // 98bf: 85 b0       ..
+// $98c1 referenced 1 time by $98ca
+loop_c98c1
+    lda l0e08,y                                                       // 98c1: b9 08 0e    ...
+    jsr c996e                                                         // 98c4: 20 6e 99     n.
+    iny                                                               // 98c7: c8          .
+    dec l00b0                                                         // 98c8: c6 b0       ..
+    bne loop_c98c1                                                    // 98ca: d0 f5       ..
+    clc                                                               // 98cc: 18          .
+// $98cd referenced 1 time by $98a3
+c98cd
+    sty l1069                                                         // 98cd: 8c 69 10    .i.
+    lda l0f04                                                         // 98d0: ad 04 0f    ...
+    sta l1060                                                         // 98d3: 8d 60 10    .`.
+    rts                                                               // 98d6: 60          `
+
+    jsr sub_c8b7b                                                     // 98d7: 20 7b 8b     {.
+    jsr sub_c93fd                                                     // 98da: 20 fd 93     ..
+    lda #$0c                                                          // 98dd: a9 0c       ..
+    jsr c996e                                                         // 98df: 20 6e 99     n.
+    ldy #0                                                            // 98e2: a0 00       ..
+// $98e4 referenced 1 time by $98f6
+loop_c98e4
+    cpy #8                                                            // 98e4: c0 08       ..
+    bcs c98ed                                                         // 98e6: b0 05       ..
+    lda l0e00,y                                                       // 98e8: b9 00 0e    ...
+    bcc c98f0                                                         // 98eb: 90 03       ..
+// $98ed referenced 1 time by $98e6
+c98ed
+    lda l0ef8,y                                                       // 98ed: b9 f8 0e    ...
+// $98f0 referenced 1 time by $98eb
+c98f0
+    jsr c996e                                                         // 98f0: 20 6e 99     n.
+    iny                                                               // 98f3: c8          .
+    cpy #$0c                                                          // 98f4: c0 0c       ..
+    bne loop_c98e4                                                    // 98f6: d0 ec       ..
+    lda l0f06                                                         // 98f8: ad 06 0f    ...
+    jsr sub_c81bf                                                     // 98fb: 20 bf 81     ..
+    jsr c996e                                                         // 98fe: 20 6e 99     n.
+    lda l00cd                                                         // 9901: a5 cd       ..
+    jmp c996e                                                         // 9903: 4c 6e 99    Ln.
+
+    jsr sub_c9965                                                     // 9906: 20 65 99     e.
+    lda l10ca                                                         // 9909: ad ca 10    ...
+    ora #$30 // '0'                                                   // 990c: 09 30       .0
+    jsr c996e                                                         // 990e: 20 6e 99     n.
+    jsr sub_c9965                                                     // 9911: 20 65 99     e.
+    lda l10c9                                                         // 9914: ad c9 10    ...
+    bne c996e                                                         // 9917: d0 55       .U
+    jsr sub_c9965                                                     // 9919: 20 65 99     e.
+    lda l10cc                                                         // 991c: ad cc 10    ...
+    ora #$30 // '0'                                                   // 991f: 09 30       .0
+    jsr c996e                                                         // 9921: 20 6e 99     n.
+    jsr sub_c9965                                                     // 9924: 20 65 99     e.
+    lda l10cb                                                         // 9927: ad cb 10    ...
+    bne c996e                                                         // 992a: d0 42       .B
+// $992c referenced 2 times by $9978, $9993
+sub_c992c
+    pha                                                               // 992c: 48          H
+    lda l1061                                                         // 992d: ad 61 10    .a.
+    sta l00b8                                                         // 9930: 85 b8       ..
+    lda l1062                                                         // 9932: ad 62 10    .b.
+    sta l00b9                                                         // 9935: 85 b9       ..
+    ldx #0                                                            // 9937: a2 00       ..
+    pla                                                               // 9939: 68          h
+    rts                                                               // 993a: 60          `
+
+// $993b referenced 4 times by $9976, $997d, $9990, $9998
+c993b
+    jsr sub_c83e3                                                     // 993b: 20 e3 83     ..
+    ldx #1                                                            // 993e: a2 01       ..
+// $9940 referenced 3 times by $9868, $986d, $9879
+sub_c9940
+    ldy #4                                                            // 9940: a0 04       ..
+// $9942 referenced 1 time by $9949
+loop_c9942
+    inc l1060,x                                                       // 9942: fe 60 10    .`.
+    bne c994b                                                         // 9945: d0 04       ..
+    inx                                                               // 9947: e8          .
+    dey                                                               // 9948: 88          .
+    bne loop_c9942                                                    // 9949: d0 f7       ..
+// $994b referenced 1 time by $9945
+c994b
+    rts                                                               // 994b: 60          `
+
+// Invert the 32-bit value at l1065
+// $994c referenced 2 times by $9859, $9874
+invert_l1065
+    ldx #3                                                            // 994c: a2 03       ..
+// $994e referenced 1 time by $9957
+loop_c994e
+    lda #$ff                                                          // 994e: a9 ff       ..
+    eor l1065,x                                                       // 9950: 5d 65 10    ]e.
+    sta l1065,x                                                       // 9953: 9d 65 10    .e.
+    dex                                                               // 9956: ca          .
+    bpl loop_c994e                                                    // 9957: 10 f5       ..
+    rts                                                               // 9959: 60          `
+
+// $995a referenced 2 times by $97fe, $987e
+sub_c995a
+    lda l107d                                                         // 995a: ad 7d 10    .}.
+    sta l00b4                                                         // 995d: 85 b4       ..
+    lda l107e                                                         // 995f: ad 7e 10    .~.
+    sta l00b5                                                         // 9962: 85 b5       ..
+// $9964 referenced 1 time by $996c
+loop_c9964
+    rts                                                               // 9964: 60          `
+
+// $9965 referenced 4 times by $9906, $9911, $9919, $9924
+sub_c9965
+    lda #1                                                            // 9965: a9 01       ..
+    bne c996e                                                         // 9967: d0 05       ..
+    jsr sub_c9e94                                                     // 9969: 20 94 9e     ..
+    bcs loop_c9964                                                    // 996c: b0 f6       ..
+// $996e referenced 11 times by $98bc, $98c4, $98df, $98f0, $98fe, $9903, $990e, $9917, $9921, $992a, $9967
+c996e
+    bit l1081                                                         // 996e: 2c 81 10    ,..
+    bpl c9978                                                         // 9971: 10 05       ..
+    sta tube_host_r3_data                                             // 9973: 8d e5 fe    ...
+    bmi c993b                                                         // 9976: 30 c3       0.
+// $9978 referenced 1 time by $9971
+c9978
+    jsr sub_c992c                                                     // 9978: 20 2c 99     ,.
+    sta (l00b8,x)                                                     // 997b: 81 b8       ..
+    jmp c993b                                                         // 997d: 4c 3b 99    L;.
+
+    jsr sub_c9988                                                     // 9980: 20 88 99     ..
+    jsr sub_c9f82                                                     // 9983: 20 82 9f     ..
+    clc                                                               // 9986: 18          .
+    rts                                                               // 9987: 60          `
+
+// $9988 referenced 1 time by $9980
+sub_c9988
+    bit l1081                                                         // 9988: 2c 81 10    ,..
+    bpl c9993                                                         // 998b: 10 06       ..
+    lda tube_host_r3_data                                             // 998d: ad e5 fe    ...
+    jmp c993b                                                         // 9990: 4c 3b 99    L;.
+
+// $9993 referenced 1 time by $998b
+c9993
+    jsr sub_c992c                                                     // 9993: 20 2c 99     ,.
+    lda (l00b8,x)                                                     // 9996: a1 b8       ..
+    jmp c993b                                                         // 9998: 4c 3b 99    L;.
+
+    bit l10c7                                                         // 999b: 2c c7 10    ,..
+    bmi c99a3                                                         // 999e: 30 03       0.
+    dec l10c7                                                         // 99a0: ce c7 10    ...
+// $99a3 referenced 5 times by $8782, $8bac, $9789, $999e, $9c25
+c99a3
+    lda #$ff                                                          // 99a3: a9 ff       ..
+    sta l10ce                                                         // 99a5: 8d ce 10    ...
+// $99a8 referenced 1 time by $99b3
+loop_c99a8
+    sta l10cd                                                         // 99a8: 8d cd 10    ...
+    rts                                                               // 99ab: 60          `
+
+// $99ac referenced 6 times by $824b, $8254, $8750, $8797, $89e6, $a463
+sub_c99ac
+    lda #$2a // '*'                                                   // 99ac: a9 2a       .*
+    sta l10ce                                                         // 99ae: 8d ce 10    ...
+    lda #$23 // '#'                                                   // 99b1: a9 23       .#
+    bne loop_c99a8                                                    // 99b3: d0 f3       ..
+    jsr sub_c9a6e                                                     // 99b5: 20 6e 9a     n.
+    jsr sub_c8386                                                     // 99b8: 20 86 83     ..
+    lda #1                                                            // 99bb: a9 01       ..
+    rts                                                               // 99bd: 60          `
+
+    jsr sub_c9a4b                                                     // 99be: 20 4b 9a     K.
+    jsr sub_c8386                                                     // 99c1: 20 86 83     ..
+    jsr sub_c830a                                                     // 99c4: 20 0a 83     ..
+    bcc c99ed                                                         // 99c7: 90 24       .$
+    jsr sub_c9a6e                                                     // 99c9: 20 6e 9a     n.
+    jsr sub_c99f3                                                     // 99cc: 20 f3 99     ..
+    jsr sub_c9a0f                                                     // 99cf: 20 0f 9a     ..
+    bvc c99ea                                                         // 99d2: 50 16       P.
+    jsr sub_c9a6e                                                     // 99d4: 20 6e 9a     n.
+    jsr sub_c9a0f                                                     // 99d7: 20 0f 9a     ..
+    bvc c99ed                                                         // 99da: 50 11       P.
+    jsr sub_c9a6e                                                     // 99dc: 20 6e 9a     n.
+    jsr sub_c99f3                                                     // 99df: 20 f3 99     ..
+    bvc c99ed                                                         // 99e2: 50 09       P.
+    jsr sub_c9a6e                                                     // 99e4: 20 6e 9a     n.
+    jsr sub_c9a63                                                     // 99e7: 20 63 9a     c.
+// $99ea referenced 1 time by $99d2
+c99ea
+    jsr sub_c9a32                                                     // 99ea: 20 32 9a     2.
+// $99ed referenced 3 times by $99c7, $99da, $99e2
+c99ed
+    jsr c89d7                                                         // 99ed: 20 d7 89     ..
+    lda #1                                                            // 99f0: a9 01       ..
+    rts                                                               // 99f2: 60          `
+
+// $99f3 referenced 2 times by $99cc, $99df
+sub_c99f3
+    jsr sub_c83e3                                                     // 99f3: 20 e3 83     ..
+    ldy #2                                                            // 99f6: a0 02       ..
+    lda (l00b0),y                                                     // 99f8: b1 b0       ..
+    sta l0f08,x                                                       // 99fa: 9d 08 0f    ...
+    iny                                                               // 99fd: c8          .
+    lda (l00b0),y                                                     // 99fe: b1 b0       ..
+    sta l0f09,x                                                       // 9a00: 9d 09 0f    ...
+    iny                                                               // 9a03: c8          .
+    lda (l00b0),y                                                     // 9a04: b1 b0       ..
+    asl                                                               // 9a06: 0a          .
+    asl                                                               // 9a07: 0a          .
+    eor l0f0e,x                                                       // 9a08: 5d 0e 0f    ]..
+    and #$0c                                                          // 9a0b: 29 0c       ).
+    bpl c9a2a                                                         // 9a0d: 10 1b       ..
+// $9a0f referenced 2 times by $99cf, $99d7
+sub_c9a0f
+    jsr sub_c83e3                                                     // 9a0f: 20 e3 83     ..
+    ldy #6                                                            // 9a12: a0 06       ..
+    lda (l00b0),y                                                     // 9a14: b1 b0       ..
+    sta l0f0a,x                                                       // 9a16: 9d 0a 0f    ...
+    iny                                                               // 9a19: c8          .
+    lda (l00b0),y                                                     // 9a1a: b1 b0       ..
+    sta l0f0b,x                                                       // 9a1c: 9d 0b 0f    ...
+    iny                                                               // 9a1f: c8          .
+    lda (l00b0),y                                                     // 9a20: b1 b0       ..
+    ror                                                               // 9a22: 6a          j
+    ror                                                               // 9a23: 6a          j
+    ror                                                               // 9a24: 6a          j
+    eor l0f0e,x                                                       // 9a25: 5d 0e 0f    ]..
+    and #$c0                                                          // 9a28: 29 c0       ).
+// $9a2a referenced 1 time by $9a0d
+c9a2a
+    eor l0f0e,x                                                       // 9a2a: 5d 0e 0f    ]..
+    sta l0f0e,x                                                       // 9a2d: 9d 0e 0f    ...
+    clv                                                               // 9a30: b8          .
+    rts                                                               // 9a31: 60          `
+
+// $9a32 referenced 1 time by $99ea
+sub_c9a32
+    jsr sub_c83e3                                                     // 9a32: 20 e3 83     ..
+    ldy #$0e                                                          // 9a35: a0 0e       ..
+    lda (l00b0),y                                                     // 9a37: b1 b0       ..
+    and #$0a                                                          // 9a39: 29 0a       ).
+    beq c9a3f                                                         // 9a3b: f0 02       ..
+    lda #$80                                                          // 9a3d: a9 80       ..
+// $9a3f referenced 1 time by $9a3b
+c9a3f
+    eor l0e0f,x                                                       // 9a3f: 5d 0f 0e    ]..
+    and #$80                                                          // 9a42: 29 80       ).
+    eor l0e0f,x                                                       // 9a44: 5d 0f 0e    ]..
+    sta l0e0f,x                                                       // 9a47: 9d 0f 0e    ...
+    rts                                                               // 9a4a: 60          `
+
+// $9a4b referenced 1 time by $99be
+sub_c9a4b
+    jsr sub_c9a78                                                     // 9a4b: 20 78 9a     x.
+    bcc c9a73                                                         // 9a4e: 90 23       .#
+// $9a50 referenced 2 times by $9a60, $9c55
+sub_c9a50
+    lda l0e0f,y                                                       // 9a50: b9 0f 0e    ...
+    bpl c9a77                                                         // 9a53: 10 22       ."
+// $9a55 referenced 1 time by $9f6b
+generate_error_precheck_locked
+    jsr generate_error_precheck                                       // 9a55: 20 38 80     8.
+    .byt $c3                                                          // 9a58: c3          .
+    .asc "Locked"                                                     // 9a59: 4c 6f 63... Loc
+    .byt 0                                                            // 9a5f: 00          .
+
+// $9a60 referenced 2 times by $830a, $8bba
+sub_c9a60
+    jsr sub_c9a50                                                     // 9a60: 20 50 9a     P.
+// $9a63 referenced 2 times by $8a00, $99e7
+sub_c9a63
+    jsr sub_c83e3                                                     // 9a63: 20 e3 83     ..
+    jsr sub_c9d1e                                                     // 9a66: 20 1e 9d     ..
+    bcc c9a8c                                                         // 9a69: 90 21       .!
+    jmp generate_error_precheck_open                                  // 9a6b: 4c 82 9c    L..
+
+// $9a6e referenced 5 times by $99b5, $99c9, $99d4, $99dc, $99e4
+sub_c9a6e
+    jsr sub_c9a78                                                     // 9a6e: 20 78 9a     x.
+    bcs c9a8c                                                         // 9a71: b0 19       ..
+// $9a73 referenced 1 time by $9a4e
+c9a73
+    pla                                                               // 9a73: 68          h
+    pla                                                               // 9a74: 68          h
+    lda #0                                                            // 9a75: a9 00       ..
+// $9a77 referenced 1 time by $9a53
+c9a77
+    rts                                                               // 9a77: 60          `
+
+// $9a78 referenced 2 times by $9a4b, $9a6e
+sub_c9a78
+    jsr sub_c80f3                                                     // 9a78: 20 f3 80     ..
+    jsr sub_c8284                                                     // 9a7b: 20 84 82     ..
+    bcc c9a8c                                                         // 9a7e: 90 0c       ..
+    tya                                                               // 9a80: 98          .
+    tax                                                               // 9a81: aa          .
+// $9a82 referenced 2 times by $881e, $885c
+sub_c9a82
+    lda l10db                                                         // 9a82: ad db 10    ...
+    sta l00b0                                                         // 9a85: 85 b0       ..
+    lda l10dc                                                         // 9a87: ad dc 10    ...
+    sta l00b1                                                         // 9a8a: 85 b1       ..
+// $9a8c referenced 3 times by $9a69, $9a71, $9a7e
+c9a8c
+    rts                                                               // 9a8c: 60          `
+
+// $9a8d referenced 4 times by $929d, $a267, $a34a, $a64f
+sub_c9a8d
+    lda #osbyte_read_oshwm                                            // 9a8d: a9 83       ..
+    jsr osbyte                                                        // 9a8f: 20 f4 ff     ..
+    sty l10cf                                                         // 9a92: 8c cf 10    ...
+    lda #osbyte_read_himem                                            // 9a95: a9 84       ..
+    jsr osbyte                                                        // 9a97: 20 f4 ff     ..
+    tya                                                               // 9a9a: 98          .
+    sec                                                               // 9a9b: 38          8
+    sbc l10cf                                                         // 9a9c: ed cf 10    ...
+    sta l10d0                                                         // 9a9f: 8d d0 10    ...
+    rts                                                               // 9aa2: 60          `
+
+// $9aa3 referenced 2 times by $95d4, $95fd
+sub_c9aa3
+    ldx #$0a                                                          // 9aa3: a2 0a       ..
+    jsr c9adf                                                         // 9aa5: 20 df 9a     ..
+    jsr sub_c9ab8                                                     // 9aa8: 20 b8 9a     ..
+    ldy #$d3                                                          // 9aab: a0 d3       ..
+    lda #$ff                                                          // 9aad: a9 ff       ..
+    sta (l00b0),y                                                     // 9aaf: 91 b0       ..
+    sta l10d3                                                         // 9ab1: 8d d3 10    ...
+    iny                                                               // 9ab4: c8          .
+    sta (l00b0),y                                                     // 9ab5: 91 b0       ..
+    rts                                                               // 9ab7: 60          `
+
+// $9ab8 referenced 5 times by $895a, $95c1, $971b, $972c, $9aa8
+sub_c9ab8
+    pha                                                               // 9ab8: 48          H
+    ldx romsel_copy                                                   // 9ab9: a6 f4       ..
+    lda #0                                                            // 9abb: a9 00       ..
+    sta l00b0                                                         // 9abd: 85 b0       ..
+    lda l0df0,x                                                       // 9abf: bd f0 0d    ...
+    and #$3f // '?'                                                   // 9ac2: 29 3f       )?
+    sta l00b1                                                         // 9ac4: 85 b1       ..
+    pla                                                               // 9ac6: 68          h
+    rts                                                               // 9ac7: 60          `
+
+// $9ac8 referenced 2 times by $a3d4, $a3fb
+sub_c9ac8
+    jsr sub_c83e3                                                     // 9ac8: 20 e3 83     ..
+    lda #$0f                                                          // 9acb: a9 0f       ..
+    ldx #1                                                            // 9acd: a2 01       ..
+    ldy #0                                                            // 9acf: a0 00       ..
+    beq c9ae9                                                         // 9ad1: f0 16       ..
+// $9ad3 referenced 1 time by $80ac
+sub_c9ad3
+    tax                                                               // 9ad3: aa          .
+// $9ad4 referenced 1 time by $80b5
+c9ad4
+    lda #3                                                            // 9ad4: a9 03       ..
+    bne c9ae9                                                         // 9ad6: d0 11       ..
+// $9ad8 referenced 2 times by $9436, $abbc
+sub_c9ad8
+    jsr sub_c83e3                                                     // 9ad8: 20 e3 83     ..
+    lda #$7e // '~'                                                   // 9adb: a9 7e       .~
+    bne c9ae9                                                         // 9add: d0 0a       ..
+// $9adf referenced 4 times by $9593, $9599, $95be, $9aa5
+c9adf
+    lda #$8f                                                          // 9adf: a9 8f       ..
+    bne c9ae9                                                         // 9ae1: d0 06       ..
+    lda #osbyte_read_write_startup_options                            // 9ae3: a9 ff       ..
+// $9ae5 referenced 8 times by $80a5, $9588, $96a0, $9e32, $9e43, $aae2, $ac7c, $aeb7
+osbyte_read
+    ldx #0                                                            // 9ae5: a2 00       ..
+    ldy #$ff                                                          // 9ae7: a0 ff       ..
+// $9ae9 referenced 4 times by $9ad1, $9ad6, $9add, $9ae1
+c9ae9
+    jmp osbyte                                                        // 9ae9: 4c f4 ff    L..
+
+// $9aec referenced 1 time by $957d
+l9aec
+    .byt $1b, $ff, $1e, $ff, $21, $ff, $24, $ff, $27, $ff, $2a, $ff   // 9aec: 1b ff 1e... ...
+    .byt $2d, $ff                                                     // 9af8: 2d ff       -.
+    .word sub_c9785                                                   // 9afa: 85 97       ..
+    .byt 0                                                            // 9afc: 00          .
+    .word sub_c9d9b                                                   // 9afd: 9b 9d       ..
+    .byt 0                                                            // 9aff: 00          .
+    .word sub_c9e94                                                   // 9b00: 94 9e       ..
+    .byt 0                                                            // 9b02: 00          .
+    .word sub_c9f82                                                   // 9b03: 82 9f       ..
+    .byt 0                                                            // 9b05: 00          .
+    .word sub_c97c9                                                   // 9b06: c9 97       ..
+    .byt 0                                                            // 9b08: 00          .
+    .word sub_c9c0c                                                   // 9b09: 0c 9c       ..
+    .byt 0                                                            // 9b0b: 00          .
+    .word sub_c97b6                                                   // 9b0c: b6 97       ..
+    .byt 0                                                            // 9b0e: 00          .
+// $9b0f referenced 1 time by $97c1
+l9b0f
+    .asc "1\o"                                                        // 9b0f: 31 5c 6f    1\o
+    .byt $fd, $6f, $82, $50, $4b, $9a                                 // 9b12: fd 6f 82... .o.
+// $9b18 referenced 1 time by $97bd
+l9b18
+    .byt $8a, $9e, $88, $86, $88, $84, $9b, $9b, $99                  // 9b18: 8a 9e 88... ...
+// $9b21 referenced 1 time by $97af
+l9b21
+    .byt $1a, $58, $c8, $db, $d3, $e3, $b4, $bd                       // 9b21: 1a 58 c8... .X.
+// $9b29 referenced 1 time by $97ab
+l9b29
+    .byt $88, $88, $99, $99, $99, $99, $99, $99                       // 9b29: 88 88 99... ...
+// $9b31 referenced 1 time by $97e8
+l9b31
+    .byt $1b, $80, $80, $69, $69, $d7,   6, $19, $8b                  // 9b31: 1b 80 80... ...
+// $9b3a referenced 1 time by $97ee
+l9b3a
+    .byt $86, $99, $99, $99, $99, $98, $99, $99, $98                  // 9b3a: 86 99 99... ...
+// $9b43 referenced 1 time by $97f4
+l9b43
+    .byt   4,   2,   3,   6,   7,   4,   4,   4,   4, $a2, $11, $a0   // 9b43: 04 02 03... ...
+    .byt $15                                                          // 9b4f: 15          .
+
+// $9b50 referenced 1 time by $9b66
+loop_c9b50
+    rts                                                               // 9b50: 60          `
+
+// $9b51 referenced 1 time by $9b5e
+sub_c9b51
+    jsr sub_c83e3                                                     // 9b51: 20 e3 83     ..
+    lda #osbyte_close_spool_exec                                      // 9b54: a9 77       .w
+    jmp osbyte                                                        // 9b56: 4c f4 ff    L..
+
+sub_c9b59
+    lda #$20 // ' '                                                   // 9b59: a9 20       .
+    sta l1086                                                         // 9b5b: 8d 86 10    ...
+// $9b5e referenced 1 time by $9b74
+loop_c9b5e
+    jsr sub_c9b51                                                     // 9b5e: 20 51 9b     Q.
+// $9b61 referenced 1 time by $9d81
+sub_c9b61
+    lda #0                                                            // 9b61: a9 00       ..
+// $9b63 referenced 1 time by $9b6c
+loop_c9b63
+    clc                                                               // 9b63: 18          .
+    adc #$20 // ' '                                                   // 9b64: 69 20       i
+    beq loop_c9b50                                                    // 9b66: f0 e8       ..
+    tay                                                               // 9b68: a8          .
+    jsr sub_c9b79                                                     // 9b69: 20 79 9b     y.
+    bne loop_c9b63                                                    // 9b6c: d0 f5       ..
+// $9b6e referenced 2 times by $9c13, $9d86
+c9b6e
+    lda #$20 // ' '                                                   // 9b6e: a9 20       .
+    sta l1086                                                         // 9b70: 8d 86 10    ...
+    tya                                                               // 9b73: 98          .
+    beq loop_c9b5e                                                    // 9b74: f0 e8       ..
+    jsr sub_c9e75                                                     // 9b76: 20 75 9e     u.
+// $9b79 referenced 2 times by $9b69, $a264
+sub_c9b79
+    pha                                                               // 9b79: 48          H
+    jsr sub_c9df4                                                     // 9b7a: 20 f4 9d     ..
+    bcs c9bc5                                                         // 9b7d: b0 46       .F
+    lda l111b,y                                                       // 9b7f: b9 1b 11    ...
+    eor #$ff                                                          // 9b82: 49 ff       I.
+    and l10c0                                                         // 9b84: 2d c0 10    -..
+    sta l10c0                                                         // 9b87: 8d c0 10    ...
+    lda l1117,y                                                       // 9b8a: b9 17 11    ...
+    and #$60 // '`'                                                   // 9b8d: 29 60       )`
+    beq c9bc5                                                         // 9b8f: f0 34       .4
+    jsr sub_c9bca                                                     // 9b91: 20 ca 9b     ..
+    lda l1117,y                                                       // 9b94: b9 17 11    ...
+    and l1086                                                         // 9b97: 2d 86 10    -..
+    beq c9bc2                                                         // 9b9a: f0 26       .&
+    ldx l10c3                                                         // 9b9c: ae c3 10    ...
+    lda l1114,y                                                       // 9b9f: b9 14 11    ...
+    sta l0f0c,x                                                       // 9ba2: 9d 0c 0f    ...
+    lda l1115,y                                                       // 9ba5: b9 15 11    ...
+    sta l0f0d,x                                                       // 9ba8: 9d 0d 0f    ...
+    lda l1116,y                                                       // 9bab: b9 16 11    ...
+    jsr sub_c81c5                                                     // 9bae: 20 c5 81     ..
+    eor l0f0e,x                                                       // 9bb1: 5d 0e 0f    ]..
+    and #$30 // '0'                                                   // 9bb4: 29 30       )0
+    eor l0f0e,x                                                       // 9bb6: 5d 0e 0f    ]..
+    sta l0f0e,x                                                       // 9bb9: 9d 0e 0f    ...
+    jsr c93e6                                                         // 9bbc: 20 e6 93     ..
+    ldy l10c2                                                         // 9bbf: ac c2 10    ...
+// $9bc2 referenced 1 time by $9b9a
+c9bc2
+    jsr sub_c9f1e                                                     // 9bc2: 20 1e 9f     ..
+// $9bc5 referenced 2 times by $9b7d, $9b8f
+c9bc5
+    ldx l10c5                                                         // 9bc5: ae c5 10    ...
+    pla                                                               // 9bc8: 68          h
+    rts                                                               // 9bc9: 60          `
+
+// $9bca referenced 1 time by $9b91
+sub_c9bca
+    jsr sub_c9be5                                                     // 9bca: 20 e5 9b     ..
+// $9bcd referenced 1 time by $9f9f
+sub_c9bcd
+    ldx #6                                                            // 9bcd: a2 06       ..
+// $9bcf referenced 1 time by $9bd7
+loop_c9bcf
+    lda l110c,y                                                       // 9bcf: b9 0c 11    ...
+    sta l00c5,x                                                       // 9bd2: 95 c5       ..
+    dey                                                               // 9bd4: 88          .
+    dey                                                               // 9bd5: 88          .
+    dex                                                               // 9bd6: ca          .
+    bpl loop_c9bcf                                                    // 9bd7: 10 f6       ..
+    jsr sub_c826d                                                     // 9bd9: 20 6d 82     m.
+    bcc generate_error_precheck_disc_changed                          // 9bdc: 90 22       ."
+    sty l10c3                                                         // 9bde: 8c c3 10    ...
+    ldy l10c2                                                         // 9be1: ac c2 10    ...
+// $9be4 referenced 1 time by $9bfe
+loop_c9be4
+    rts                                                               // 9be4: 60          `
+
+// $9be5 referenced 3 times by $9bca, $9eb8, $9f93
+sub_c9be5
+    lda l110e,y                                                       // 9be5: b9 0e 11    ...
+    and #$7f                                                          // 9be8: 29 7f       ).
+    sta l00cc                                                         // 9bea: 85 cc       ..
+    lda l1117,y                                                       // 9bec: b9 17 11    ...
+    jmp c8816                                                         // 9bef: 4c 16 88    L..
+
+// $9bf2 referenced 2 times by $8768, $87b8
+sub_c9bf2
+    jsr sub_c83e3                                                     // 9bf2: 20 e3 83     ..
+    lda l0f04                                                         // 9bf5: ad 04 0f    ...
+    jsr sub_c8380                                                     // 9bf8: 20 80 83     ..
+    cmp l0f04                                                         // 9bfb: cd 04 0f    ...
+    beq loop_c9be4                                                    // 9bfe: f0 e4       ..
+// $9c00 referenced 1 time by $9bdc
+generate_error_precheck_disc_changed
+    jsr generate_error_precheck_disc                                  // 9c00: 20 23 80     #.
+    .byt $c8                                                          // 9c03: c8          .
+    .asc "changed"                                                    // 9c04: 63 68 61... cha
+    .byt 0                                                            // 9c0b: 00          .
+
+sub_c9c0c
+    and #$c0                                                          // 9c0c: 29 c0       ).
+    bne c9c16                                                         // 9c0e: d0 06       ..
+    jsr sub_c83e3                                                     // 9c10: 20 e3 83     ..
+    jmp c9b6e                                                         // 9c13: 4c 6e 9b    Ln.
+
+// $9c16 referenced 1 time by $9c0e
+c9c16
+    jsr sub_c840c                                                     // 9c16: 20 0c 84     ..
+    stx l00ba                                                         // 9c19: 86 ba       ..
+    sty l00bb                                                         // 9c1b: 84 bb       ..
+    sta l00b4                                                         // 9c1d: 85 b4       ..
+    bit l00b4                                                         // 9c1f: 24 b4       $.
+    php                                                               // 9c21: 08          .
+    jsr sub_c80f3                                                     // 9c22: 20 f3 80     ..
+    jsr c99a3                                                         // 9c25: 20 a3 99     ..
+    jsr sub_c8284                                                     // 9c28: 20 84 82     ..
+    bcs c9c51                                                         // 9c2b: b0 24       .$
+    plp                                                               // 9c2d: 28          (
+    bvc c9c33                                                         // 9c2e: 50 03       P.
+    lda #0                                                            // 9c30: a9 00       ..
+    rts                                                               // 9c32: 60          `
+
+// $9c33 referenced 1 time by $9c2e
+c9c33
+    php                                                               // 9c33: 08          .
+    lda #0                                                            // 9c34: a9 00       ..
+    ldx #7                                                            // 9c36: a2 07       ..
+// $9c38 referenced 1 time by $9c3e
+loop_c9c38
+    sta l00bc,x                                                       // 9c38: 95 bc       ..
+    sta l1074,x                                                       // 9c3a: 9d 74 10    .t.
+    dex                                                               // 9c3d: ca          .
+    bpl loop_c9c38                                                    // 9c3e: 10 f8       ..
+    dec l00be                                                         // 9c40: c6 be       ..
+    dec l00bf                                                         // 9c42: c6 bf       ..
+    dec l1076                                                         // 9c44: ce 76 10    .v.
+    dec l1077                                                         // 9c47: ce 77 10    .w.
+    lda #$40 // '@'                                                   // 9c4a: a9 40       .@
+    sta l00c3                                                         // 9c4c: 85 c3       ..
+    jsr sub_c8a77                                                     // 9c4e: 20 77 8a     w.
+// $9c51 referenced 1 time by $9c2b
+c9c51
+    plp                                                               // 9c51: 28          (
+    php                                                               // 9c52: 08          .
+    bvs c9c58                                                         // 9c53: 70 03       p.
+    jsr sub_c9a50                                                     // 9c55: 20 50 9a     P.
+// $9c58 referenced 1 time by $9c53
+c9c58
+    jsr sub_c9d1e                                                     // 9c58: 20 1e 9d     ..
+    bcc c9c6b                                                         // 9c5b: 90 0e       ..
+// $9c5d referenced 1 time by $9c69
+loop_c9c5d
+    lda l110c,y                                                       // 9c5d: b9 0c 11    ...
+    bpl generate_error_precheck_open                                  // 9c60: 10 20       .
+    plp                                                               // 9c62: 28          (
+    php                                                               // 9c63: 08          .
+    bmi generate_error_precheck_open                                  // 9c64: 30 1c       0.
+    jsr sub_c9d19                                                     // 9c66: 20 19 9d     ..
+    bcs loop_c9c5d                                                    // 9c69: b0 f2       ..
+// $9c6b referenced 1 time by $9c5b
+c9c6b
+    ldy l10c2                                                         // 9c6b: ac c2 10    ...
+    bne c9c8b                                                         // 9c6e: d0 1b       ..
+    jsr generate_error_precheck                                       // 9c70: 20 38 80     8.
+    .byt $c0                                                          // 9c73: c0          .
+    .asc "Too many open"                                              // 9c74: 54 6f 6f... Too
+    .byt 0                                                            // 9c81: 00          .
+
+// $9c82 referenced 3 times by $9a6b, $9c60, $9c64
+generate_error_precheck_open
+    jsr generate_error_precheck                                       // 9c82: 20 38 80     8.
+    .byt $c2                                                          // 9c85: c2          .
+    .asc "Open"                                                       // 9c86: 4f 70 65... Ope
+    .byt 0                                                            // 9c8a: 00          .
+
+// $9c8b referenced 1 time by $9c6e
+c9c8b
+    lda #8                                                            // 9c8b: a9 08       ..
+    sta l10c4                                                         // 9c8d: 8d c4 10    ...
+// $9c90 referenced 1 time by $9ca2
+loop_c9c90
+    lda l0e08,x                                                       // 9c90: bd 08 0e    ...
+    sta l1100,y                                                       // 9c93: 99 00 11    ...
+    iny                                                               // 9c96: c8          .
+    lda l0f08,x                                                       // 9c97: bd 08 0f    ...
+    sta l1100,y                                                       // 9c9a: 99 00 11    ...
+    iny                                                               // 9c9d: c8          .
+    inx                                                               // 9c9e: e8          .
+    dec l10c4                                                         // 9c9f: ce c4 10    ...
+    bne loop_c9c90                                                    // 9ca2: d0 ec       ..
+    ldx #$10                                                          // 9ca4: a2 10       ..
+    lda #0                                                            // 9ca6: a9 00       ..
+// $9ca8 referenced 1 time by $9cad
+loop_c9ca8
+    sta l1100,y                                                       // 9ca8: 99 00 11    ...
+    iny                                                               // 9cab: c8          .
+    dex                                                               // 9cac: ca          .
+    bne loop_c9ca8                                                    // 9cad: d0 f9       ..
+    lda l10c2                                                         // 9caf: ad c2 10    ...
+    tay                                                               // 9cb2: a8          .
+    jsr sub_c81be                                                     // 9cb3: 20 be 81     ..
+    adc #$11                                                          // 9cb6: 69 11       i.
+    sta l1113,y                                                       // 9cb8: 99 13 11    ...
+    lda l10c1                                                         // 9cbb: ad c1 10    ...
+    sta l111b,y                                                       // 9cbe: 99 1b 11    ...
+    ora l10c0                                                         // 9cc1: 0d c0 10    ...
+    sta l10c0                                                         // 9cc4: 8d c0 10    ...
+    lda l1109,y                                                       // 9cc7: b9 09 11    ...
+    adc #$ff                                                          // 9cca: 69 ff       i.
+    lda l110b,y                                                       // 9ccc: b9 0b 11    ...
+    adc #0                                                            // 9ccf: 69 00       i.
+    sta l1119,y                                                       // 9cd1: 99 19 11    ...
+    lda l110d,y                                                       // 9cd4: b9 0d 11    ...
+    ora #$0f                                                          // 9cd7: 09 0f       ..
+    adc #0                                                            // 9cd9: 69 00       i.
+    jsr sub_c81b0                                                     // 9cdb: 20 b0 81     ..
+    sta l111a,y                                                       // 9cde: 99 1a 11    ...
+    plp                                                               // 9ce1: 28          (
+    bvc c9d12                                                         // 9ce2: 50 2e       P.
+    bmi c9cee                                                         // 9ce4: 30 08       0.
+    lda #$80                                                          // 9ce6: a9 80       ..
+    ora l110c,y                                                       // 9ce8: 19 0c 11    ...
+    sta l110c,y                                                       // 9ceb: 99 0c 11    ...
+// $9cee referenced 1 time by $9ce4
+c9cee
+    lda l1109,y                                                       // 9cee: b9 09 11    ...
+    sta l1114,y                                                       // 9cf1: 99 14 11    ...
+    lda l110b,y                                                       // 9cf4: b9 0b 11    ...
+    sta l1115,y                                                       // 9cf7: 99 15 11    ...
+    lda l110d,y                                                       // 9cfa: b9 0d 11    ...
+    jsr sub_c81b0                                                     // 9cfd: 20 b0 81     ..
+    sta l1116,y                                                       // 9d00: 99 16 11    ...
+// $9d03 referenced 1 time by $9d17
+loop_c9d03
+    lda l00cd                                                         // 9d03: a5 cd       ..
+    ora l1117,y                                                       // 9d05: 19 17 11    ...
+    sta l1117,y                                                       // 9d08: 99 17 11    ...
+    tya                                                               // 9d0b: 98          .
+    jsr sub_c81be                                                     // 9d0c: 20 be 81     ..
+    ora #$10                                                          // 9d0f: 09 10       ..
+    rts                                                               // 9d11: 60          `
+
+// $9d12 referenced 1 time by $9ce2
+c9d12
+    lda #$20 // ' '                                                   // 9d12: a9 20       .
+    sta l1117,y                                                       // 9d14: 99 17 11    ...
+    bne loop_c9d03                                                    // 9d17: d0 ea       ..
+// $9d19 referenced 1 time by $9c66
+sub_c9d19
+    txa                                                               // 9d19: 8a          .
+    pha                                                               // 9d1a: 48          H
+    jmp c9d5d                                                         // 9d1b: 4c 5d 9d    L].
+
+// $9d1e referenced 2 times by $9a66, $9c58
+sub_c9d1e
+    lda #0                                                            // 9d1e: a9 00       ..
+    sta l10c2                                                         // 9d20: 8d c2 10    ...
+    lda #8                                                            // 9d23: a9 08       ..
+    sta l00b5                                                         // 9d25: 85 b5       ..
+    tya                                                               // 9d27: 98          .
+    tax                                                               // 9d28: aa          .
+    ldy #$a0                                                          // 9d29: a0 a0       ..
+// $9d2b referenced 1 time by $9d6f
+c9d2b
+    sty l00b3                                                         // 9d2b: 84 b3       ..
+    txa                                                               // 9d2d: 8a          .
+    pha                                                               // 9d2e: 48          H
+    lda #8                                                            // 9d2f: a9 08       ..
+    sta l00b2                                                         // 9d31: 85 b2       ..
+    lda l00b5                                                         // 9d33: a5 b5       ..
+    bit l10c0                                                         // 9d35: 2c c0 10    ,..
+    beq c9d57                                                         // 9d38: f0 1d       ..
+    lda l1117,y                                                       // 9d3a: b9 17 11    ...
+    eor l00cd                                                         // 9d3d: 45 cd       E.
+    and #3                                                            // 9d3f: 29 03       ).
+    bne c9d5d                                                         // 9d41: d0 1a       ..
+// $9d43 referenced 1 time by $9d52
+loop_c9d43
+    lda l0e08,x                                                       // 9d43: bd 08 0e    ...
+    eor l1100,y                                                       // 9d46: 59 00 11    Y..
+    and #$7f                                                          // 9d49: 29 7f       ).
+    bne c9d5d                                                         // 9d4b: d0 10       ..
+    inx                                                               // 9d4d: e8          .
+    iny                                                               // 9d4e: c8          .
+    iny                                                               // 9d4f: c8          .
+    dec l00b2                                                         // 9d50: c6 b2       ..
+    bne loop_c9d43                                                    // 9d52: d0 ef       ..
+    sec                                                               // 9d54: 38          8
+    bcs c9d67                                                         // 9d55: b0 10       ..
+// $9d57 referenced 1 time by $9d38
+c9d57
+    sty l10c2                                                         // 9d57: 8c c2 10    ...
+    sta l10c1                                                         // 9d5a: 8d c1 10    ...
+// $9d5d referenced 3 times by $9d1b, $9d41, $9d4b
+c9d5d
+    sec                                                               // 9d5d: 38          8
+    lda l00b3                                                         // 9d5e: a5 b3       ..
+    sbc #$20 // ' '                                                   // 9d60: e9 20       .
+    sta l00b3                                                         // 9d62: 85 b3       ..
+    asl l00b5                                                         // 9d64: 06 b5       ..
+    clc                                                               // 9d66: 18          .
+// $9d67 referenced 1 time by $9d55
+c9d67
+    pla                                                               // 9d67: 68          h
+    tax                                                               // 9d68: aa          .
+    ldy l00b3                                                         // 9d69: a4 b3       ..
+    lda l00b5                                                         // 9d6b: a5 b5       ..
+    bcs c9d71                                                         // 9d6d: b0 02       ..
+    bne c9d2b                                                         // 9d6f: d0 ba       ..
+// $9d71 referenced 1 time by $9d6d
+c9d71
+    rts                                                               // 9d71: 60          `
+
+// $9d72 referenced 1 time by $9da0
+c9d72
+    jsr zero_stacked_XXX                                              // 9d72: 20 8e 9d     ..
+// $9d75 referenced 1 time by $9726
+sub_c9d75
+    lda l10c0                                                         // 9d75: ad c0 10    ...
+    pha                                                               // 9d78: 48          H
+    lda #0                                                            // 9d79: a9 00       ..
+    sta l1086                                                         // 9d7b: 8d 86 10    ...
+    tya                                                               // 9d7e: 98          .
+    bne c9d86                                                         // 9d7f: d0 05       ..
+    jsr sub_c9b61                                                     // 9d81: 20 61 9b     a.
+    beq c9d89                                                         // 9d84: f0 03       ..
+// $9d86 referenced 1 time by $9d7f
+c9d86
+    jsr c9b6e                                                         // 9d86: 20 6e 9b     n.
+// $9d89 referenced 1 time by $9d84
+c9d89
+    pla                                                               // 9d89: 68          h
+    sta l10c0                                                         // 9d8a: 8d c0 10    ...
+    rts                                                               // 9d8d: 60          `
+
+// $9d8e referenced 6 times by $956f, $9714, $97d0, $9d72, $9daa, $9db8
+zero_stacked_XXX
+    pha                                                               // 9d8e: 48          H
+    txa                                                               // 9d8f: 8a          .
+    pha                                                               // 9d90: 48          H
+    lda #0                                                            // 9d91: a9 00       ..
+    tsx                                                               // 9d93: ba          .
+    sta l0109,x                                                       // 9d94: 9d 09 01    ...
+    pla                                                               // 9d97: 68          h
+    tax                                                               // 9d98: aa          .
+    pla                                                               // 9d99: 68          h
+    rts                                                               // 9d9a: 60          `
+
+sub_c9d9b
+    jsr sub_c83e3                                                     // 9d9b: 20 e3 83     ..
+    cmp #$ff                                                          // 9d9e: c9 ff       ..
+    beq c9d72                                                         // 9da0: f0 d0       ..
+    cpy #0                                                            // 9da2: c0 00       ..
+    beq c9db4                                                         // 9da4: f0 0e       ..
+    cmp #3                                                            // 9da6: c9 03       ..
+    bcs c9dcd                                                         // 9da8: b0 23       .#
+    jsr zero_stacked_XXX                                              // 9daa: 20 8e 9d     ..
+    cmp #1                                                            // 9dad: c9 01       ..
+    bne c9dd5                                                         // 9daf: d0 24       .$
+    jmp ca06c                                                         // 9db1: 4c 6c a0    Ll.
+
+// $9db4 referenced 1 time by $9da4
+c9db4
+    cmp #2                                                            // 9db4: c9 02       ..
+    bcs c9dcd                                                         // 9db6: b0 15       ..
+    jsr zero_stacked_XXX                                              // 9db8: 20 8e 9d     ..
+    beq c9dce                                                         // 9dbb: f0 11       ..
+    lda #$ff                                                          // 9dbd: a9 ff       ..
+    sta l0002,x                                                       // 9dbf: 95 02       ..
+    sta l0003,x                                                       // 9dc1: 95 03       ..
+    lda l10d9                                                         // 9dc3: ad d9 10    ...
+    sta l0000,x                                                       // 9dc6: 95 00       ..
+    lda l10da                                                         // 9dc8: ad da 10    ...
+    sta l0001,x                                                       // 9dcb: 95 01       ..
+// $9dcd referenced 2 times by $9da8, $9db6
+c9dcd
+    rts                                                               // 9dcd: 60          `
+
+// $9dce referenced 1 time by $9dbb
+c9dce
+    lda #4                                                            // 9dce: a9 04       ..
+    tsx                                                               // 9dd0: ba          .
+    sta l0105,x                                                       // 9dd1: 9d 05 01    ...
+    rts                                                               // 9dd4: 60          `
+
+// $9dd5 referenced 2 times by $984c, $9daf
+c9dd5
+    jsr sub_c9e75                                                     // 9dd5: 20 75 9e     u.
+    sty l10c2                                                         // 9dd8: 8c c2 10    ...
+    asl                                                               // 9ddb: 0a          .
+    adc l10c2                                                         // 9ddc: 6d c2 10    m..
+    tay                                                               // 9ddf: a8          .
+    lda l1110,y                                                       // 9de0: b9 10 11    ...
+    sta l0000,x                                                       // 9de3: 95 00       ..
+    lda l1111,y                                                       // 9de5: b9 11 11    ...
+    sta l0001,x                                                       // 9de8: 95 01       ..
+    lda l1112,y                                                       // 9dea: b9 12 11    ...
+    sta l0002,x                                                       // 9ded: 95 02       ..
+    lda #0                                                            // 9def: a9 00       ..
+    sta l0003,x                                                       // 9df1: 95 03       ..
+    rts                                                               // 9df3: 60          `
+
+// $9df4 referenced 2 times by $9b7a, $9e78
+sub_c9df4
+    pha                                                               // 9df4: 48          H
+    stx l10c5                                                         // 9df5: 8e c5 10    ...
+    tya                                                               // 9df8: 98          .
+    and #$e0                                                          // 9df9: 29 e0       ).
+    sta l10c2                                                         // 9dfb: 8d c2 10    ...
+    beq c9e13                                                         // 9dfe: f0 13       ..
+    jsr sub_c81be                                                     // 9e00: 20 be 81     ..
+    tay                                                               // 9e03: a8          .
+    lda #0                                                            // 9e04: a9 00       ..
+    sec                                                               // 9e06: 38          8
+// $9e07 referenced 1 time by $9e09
+loop_c9e07
+    ror                                                               // 9e07: 6a          j
+    dey                                                               // 9e08: 88          .
+    bne loop_c9e07                                                    // 9e09: d0 fc       ..
+    ldy l10c2                                                         // 9e0b: ac c2 10    ...
+    bit l10c0                                                         // 9e0e: 2c c0 10    ,..
+    bne c9e16                                                         // 9e11: d0 03       ..
+// $9e13 referenced 1 time by $9dfe
+c9e13
+    pla                                                               // 9e13: 68          h
+    sec                                                               // 9e14: 38          8
+    rts                                                               // 9e15: 60          `
+
+// $9e16 referenced 1 time by $9e11
+c9e16
+    pla                                                               // 9e16: 68          h
+    clc                                                               // 9e17: 18          .
+    rts                                                               // 9e18: 60          `
+
+    .byt $48, $8a, $4c, $20, $9e                                      // 9e19: 48 8a 4c... H.L
+
+// $9e1e referenced 2 times by $9e56, $9e75
+sub_c9e1e
+    pha                                                               // 9e1e: 48          H
+    tya                                                               // 9e1f: 98          .
+    cmp #$10                                                          // 9e20: c9 10       ..
+    bcc c9e28                                                         // 9e22: 90 04       ..
+    cmp #$18                                                          // 9e24: c9 18       ..
+    bcc c9e2a                                                         // 9e26: 90 02       ..
+// $9e28 referenced 1 time by $9e22
+c9e28
+    lda #8                                                            // 9e28: a9 08       ..
+// $9e2a referenced 1 time by $9e26
+c9e2a
+    jsr sub_c81c4                                                     // 9e2a: 20 c4 81     ..
+    tay                                                               // 9e2d: a8          .
+    pla                                                               // 9e2e: 68          h
+    rts                                                               // 9e2f: 60          `
+
+// $9e30 referenced 3 times by $803d, $9e7d, $9fc5
+sub_c9e30
+    lda #osbyte_rw_exec_handle                                        // 9e30: a9 c6       ..
+    jsr osbyte_read                                                   // 9e32: 20 e5 9a     ..
+    txa                                                               // 9e35: 8a          .
+    beq c9e41                                                         // 9e36: f0 09       ..
+    jsr sub_c9e54                                                     // 9e38: 20 54 9e     T.
+    bne c9e41                                                         // 9e3b: d0 04       ..
+    lda #osbyte_rw_exec_handle                                        // 9e3d: a9 c6       ..
+    bne osbyte_write_0                                                // 9e3f: d0 0c       ..
+// $9e41 referenced 2 times by $9e36, $9e3b
+c9e41
+    lda #osbyte_read_write_spool_file_handle                          // 9e41: a9 c7       ..
+    jsr osbyte_read                                                   // 9e43: 20 e5 9a     ..
+    jsr sub_c9e54                                                     // 9e46: 20 54 9e     T.
+    bne c9e5c                                                         // 9e49: d0 11       ..
+    lda #osbyte_read_write_spool_file_handle                          // 9e4b: a9 c7       ..
+// $9e4d referenced 1 time by $9e3f
+osbyte_write_0
+    ldx #0                                                            // 9e4d: a2 00       ..
+    ldy #0                                                            // 9e4f: a0 00       ..
+    jmp osbyte                                                        // 9e51: 4c f4 ff    L..
+
+// $9e54 referenced 2 times by $9e38, $9e46
+sub_c9e54
+    txa                                                               // 9e54: 8a          .
+    tay                                                               // 9e55: a8          .
+    jsr sub_c9e1e                                                     // 9e56: 20 1e 9e     ..
+    cpy l10c2                                                         // 9e59: cc c2 10    ...
+// $9e5c referenced 1 time by $9e49
+c9e5c
+    rts                                                               // 9e5c: 60          `
+
+    pha                                                               // 9e5d: 48          H
+    tya                                                               // 9e5e: 98          .
+    pha                                                               // 9e5f: 48          H
+    txa                                                               // 9e60: 8a          .
+    tay                                                               // 9e61: a8          .
+    jsr sub_c9e75                                                     // 9e62: 20 75 9e     u.
+    tya                                                               // 9e65: 98          .
+    jsr sub_ca0de                                                     // 9e66: 20 de a0     ..
+    bne c9e6f                                                         // 9e69: d0 04       ..
+    ldx #$ff                                                          // 9e6b: a2 ff       ..
+    bne c9e71                                                         // 9e6d: d0 02       ..
+// $9e6f referenced 1 time by $9e69
+c9e6f
+    ldx #0                                                            // 9e6f: a2 00       ..
+// $9e71 referenced 1 time by $9e6d
+c9e71
+    pla                                                               // 9e71: 68          h
+    tay                                                               // 9e72: a8          .
+    pla                                                               // 9e73: 68          h
+// $9e74 referenced 1 time by $9e7b
+loop_c9e74
+    rts                                                               // 9e74: 60          `
+
+// $9e75 referenced 6 times by $9b76, $9dd5, $9e62, $9e97, $9f85, $a06f
+sub_c9e75
+    jsr sub_c9e1e                                                     // 9e75: 20 1e 9e     ..
+    jsr sub_c9df4                                                     // 9e78: 20 f4 9d     ..
+    bcc loop_c9e74                                                    // 9e7b: 90 f7       ..
+    jsr sub_c9e30                                                     // 9e7d: 20 30 9e     0.
+    jsr generate_error_precheck                                       // 9e80: 20 38 80     8.
+    .byt $de                                                          // 9e83: de          .
+    .asc "Channel"                                                    // 9e84: 43 68 61... Cha
+    .byt 0                                                            // 9e8b: 00          .
+
+// $9e8c referenced 1 time by $9ea5
+loop_c9e8c
+    jsr generate_error_precheck                                       // 9e8c: 20 38 80     8.
+    .byt $df                                                          // 9e8f: df          .
+    .asc "EOF"                                                        // 9e90: 45 4f 46    EOF
+    .byt 0                                                            // 9e93: 00          .
+
+// $9e94 referenced 1 time by $9969
+sub_c9e94
+    jsr sub_c840c                                                     // 9e94: 20 0c 84     ..
+    jsr sub_c9e75                                                     // 9e97: 20 75 9e     u.
+    tya                                                               // 9e9a: 98          .
+    jsr sub_ca0de                                                     // 9e9b: 20 de a0     ..
+    bne c9eb3                                                         // 9e9e: d0 13       ..
+    lda l1117,y                                                       // 9ea0: b9 17 11    ...
+    and #$10                                                          // 9ea3: 29 10       ).
+    bne loop_c9e8c                                                    // 9ea5: d0 e5       ..
+    lda #$10                                                          // 9ea7: a9 10       ..
+    jsr sub_c9f0f                                                     // 9ea9: 20 0f 9f     ..
+    ldx l10c5                                                         // 9eac: ae c5 10    ...
+    lda #$fe                                                          // 9eaf: a9 fe       ..
+    sec                                                               // 9eb1: 38          8
+    rts                                                               // 9eb2: 60          `
+
+// $9eb3 referenced 1 time by $9e9e
+c9eb3
+    lda l1117,y                                                       // 9eb3: b9 17 11    ...
+    bmi c9ec2                                                         // 9eb6: 30 0a       0.
+    jsr sub_c9be5                                                     // 9eb8: 20 e5 9b     ..
+    jsr sub_c9f1e                                                     // 9ebb: 20 1e 9f     ..
+    sec                                                               // 9ebe: 38          8
+    jsr sub_c9f26                                                     // 9ebf: 20 26 9f     &.
+// $9ec2 referenced 1 time by $9eb6
+c9ec2
+    lda l1110,y                                                       // 9ec2: b9 10 11    ...
+    sta l00ba                                                         // 9ec5: 85 ba       ..
+    lda l1113,y                                                       // 9ec7: b9 13 11    ...
+    sta l00bb                                                         // 9eca: 85 bb       ..
+    ldy #0                                                            // 9ecc: a0 00       ..
+    lda (l00ba),y                                                     // 9ece: b1 ba       ..
+    pha                                                               // 9ed0: 48          H
+    ldy l10c2                                                         // 9ed1: ac c2 10    ...
+    ldx l00ba                                                         // 9ed4: a6 ba       ..
+    inx                                                               // 9ed6: e8          .
+    txa                                                               // 9ed7: 8a          .
+    sta l1110,y                                                       // 9ed8: 99 10 11    ...
+    bne c9ef1                                                         // 9edb: d0 14       ..
+    clc                                                               // 9edd: 18          .
+    lda l1111,y                                                       // 9ede: b9 11 11    ...
+    adc #1                                                            // 9ee1: 69 01       i.
+    sta l1111,y                                                       // 9ee3: 99 11 11    ...
+    lda l1112,y                                                       // 9ee6: b9 12 11    ...
+    adc #0                                                            // 9ee9: 69 00       i.
+    sta l1112,y                                                       // 9eeb: 99 12 11    ...
+    jsr sub_c9f14                                                     // 9eee: 20 14 9f     ..
+// $9ef1 referenced 1 time by $9edb
+c9ef1
+    clc                                                               // 9ef1: 18          .
+    pla                                                               // 9ef2: 68          h
+    rts                                                               // 9ef3: 60          `
+
+// $9ef4 referenced 2 times by $9f5e, $a018
+sub_c9ef4
+    clc                                                               // 9ef4: 18          .
+    lda l110f,y                                                       // 9ef5: b9 0f 11    ...
+    adc l1111,y                                                       // 9ef8: 79 11 11    y..
+    sta l00c3                                                         // 9efb: 85 c3       ..
+    sta l111c,y                                                       // 9efd: 99 1c 11    ...
+    lda l110d,y                                                       // 9f00: b9 0d 11    ...
+    and #3                                                            // 9f03: 29 03       ).
+    adc l1112,y                                                       // 9f05: 79 12 11    y..
+    sta l00c2                                                         // 9f08: 85 c2       ..
+    sta l111d,y                                                       // 9f0a: 99 1d 11    ...
+// $9f0d referenced 1 time by $a0db
+c9f0d
+    lda #$80                                                          // 9f0d: a9 80       ..
+// $9f0f referenced 3 times by $9ea9, $a035, $a05c
+sub_c9f0f
+    ora l1117,y                                                       // 9f0f: 19 17 11    ...
+    bne c9f19                                                         // 9f12: d0 05       ..
+// $9f14 referenced 2 times by $9eee, $a041
+sub_c9f14
+    lda #$7f                                                          // 9f14: a9 7f       ..
+// $9f16 referenced 3 times by $95f0, $9f59, $a0ba
+sub_c9f16
+    and l1117,y                                                       // 9f16: 39 17 11    9..
+// $9f19 referenced 1 time by $9f12
+c9f19
+    sta l1117,y                                                       // 9f19: 99 17 11    ...
+    clc                                                               // 9f1c: 18          .
+    rts                                                               // 9f1d: 60          `
+
+// $9f1e referenced 3 times by $9bc2, $9ebb, $a00a
+sub_c9f1e
+    lda l1117,y                                                       // 9f1e: b9 17 11    ...
+    and #$40 // '@'                                                   // 9f21: 29 40       )@
+    beq c9f6a                                                         // 9f23: f0 45       .E
+    clc                                                               // 9f25: 18          .
+// $9f26 referenced 2 times by $9ebf, $a01e
+sub_c9f26
+    php                                                               // 9f26: 08          .
+    inc l10dd                                                         // 9f27: ee dd 10    ...
+    ldy l10c2                                                         // 9f2a: ac c2 10    ...
+    lda l1113,y                                                       // 9f2d: b9 13 11    ...
+    sta l00bd                                                         // 9f30: 85 bd       ..
+    lda #$ff                                                          // 9f32: a9 ff       ..
+    sta l1074                                                         // 9f34: 8d 74 10    .t.
+    sta l1075                                                         // 9f37: 8d 75 10    .u.
+    lda #0                                                            // 9f3a: a9 00       ..
+    sta l00bc                                                         // 9f3c: 85 bc       ..
+    sta l00c0                                                         // 9f3e: 85 c0       ..
+    lda #1                                                            // 9f40: a9 01       ..
+    sta l00c1                                                         // 9f42: 85 c1       ..
+    plp                                                               // 9f44: 28          (
+    bcs c9f5e                                                         // 9f45: b0 17       ..
+    lda l111c,y                                                       // 9f47: b9 1c 11    ...
+    sta l00c3                                                         // 9f4a: 85 c3       ..
+    lda l111d,y                                                       // 9f4c: b9 1d 11    ...
+    sta l00c2                                                         // 9f4f: 85 c2       ..
+    jsr sub_c8862                                                     // 9f51: 20 62 88     b.
+    ldy l10c2                                                         // 9f54: ac c2 10    ...
+    lda #$bf                                                          // 9f57: a9 bf       ..
+    jsr sub_c9f16                                                     // 9f59: 20 16 9f     ..
+    bcc c9f64                                                         // 9f5c: 90 06       ..
+// $9f5e referenced 1 time by $9f45
+c9f5e
+    jsr sub_c9ef4                                                     // 9f5e: 20 f4 9e     ..
+    jsr sub_c8855                                                     // 9f61: 20 55 88     U.
+// $9f64 referenced 1 time by $9f5c
+c9f64
+    dec l10dd                                                         // 9f64: ce dd 10    ...
+    ldy l10c2                                                         // 9f67: ac c2 10    ...
+// $9f6a referenced 1 time by $9f23
+c9f6a
+    rts                                                               // 9f6a: 60          `
+
+// $9f6b referenced 1 time by $9f91
+c9f6b
+    jmp generate_error_precheck_locked                                // 9f6b: 4c 55 9a    LU.
+
+// $9f6e referenced 1 time by $9f8c
+loop_c9f6e
+    jsr generate_error_precheck                                       // 9f6e: 20 38 80     8.
+    .byt $c1                                                          // 9f71: c1          .
+    .asc "Read only"                                                  // 9f72: 52 65 61... Rea
+    .byt 0                                                            // 9f7b: 00          .
+
+// $9f7c referenced 1 time by $a09a
+sub_c9f7c
+    jsr sub_c83e3                                                     // 9f7c: 20 e3 83     ..
+    jmp c9f88                                                         // 9f7f: 4c 88 9f    L..
+
+// $9f82 referenced 1 time by $9983
+sub_c9f82
+    jsr sub_c83e3                                                     // 9f82: 20 e3 83     ..
+    jsr sub_c9e75                                                     // 9f85: 20 75 9e     u.
+// $9f88 referenced 1 time by $9f7f
+c9f88
+    pha                                                               // 9f88: 48          H
+    lda l110c,y                                                       // 9f89: b9 0c 11    ...
+    bmi loop_c9f6e                                                    // 9f8c: 30 e0       0.
+    lda l110e,y                                                       // 9f8e: b9 0e 11    ...
+    bmi c9f6b                                                         // 9f91: 30 d8       0.
+    jsr sub_c9be5                                                     // 9f93: 20 e5 9b     ..
+    tya                                                               // 9f96: 98          .
+    clc                                                               // 9f97: 18          .
+    adc #4                                                            // 9f98: 69 04       i.
+    jsr sub_ca0de                                                     // 9f9a: 20 de a0     ..
+    bne ca005                                                         // 9f9d: d0 66       .f
+    jsr sub_c9bcd                                                     // 9f9f: 20 cd 9b     ..
+    ldx l10c3                                                         // 9fa2: ae c3 10    ...
+    sec                                                               // 9fa5: 38          8
+    lda l0f07,x                                                       // 9fa6: bd 07 0f    ...
+    sbc l0f0f,x                                                       // 9fa9: fd 0f 0f    ...
+    pha                                                               // 9fac: 48          H
+    lda l0f06,x                                                       // 9fad: bd 06 0f    ...
+    sbc l0f0e,x                                                       // 9fb0: fd 0e 0f    ...
+    and #3                                                            // 9fb3: 29 03       ).
+    cmp l111a,y                                                       // 9fb5: d9 1a 11    ...
+    bne c9fd9                                                         // 9fb8: d0 1f       ..
+    pla                                                               // 9fba: 68          h
+    cmp l1119,y                                                       // 9fbb: d9 19 11    ...
+    bne c9ff4                                                         // 9fbe: d0 34       .4
+    sty l00b4                                                         // 9fc0: 84 b4       ..
+    sty l10c2                                                         // 9fc2: 8c c2 10    ...
+    jsr sub_c9e30                                                     // 9fc5: 20 30 9e     0.
+    jsr generate_error_precheck                                       // 9fc8: 20 38 80     8.
+    .byt $bf                                                          // 9fcb: bf          .
+    .asc "Can't extend"                                               // 9fcc: 43 61 6e... Can
+    .byt 0                                                            // 9fd8: 00          .
+
+// $9fd9 referenced 1 time by $9fb8
+c9fd9
+    lda l111a,y                                                       // 9fd9: b9 1a 11    ...
+    clc                                                               // 9fdc: 18          .
+    adc #1                                                            // 9fdd: 69 01       i.
+    sta l111a,y                                                       // 9fdf: 99 1a 11    ...
+    asl                                                               // 9fe2: 0a          .
+    asl                                                               // 9fe3: 0a          .
+    asl                                                               // 9fe4: 0a          .
+    asl                                                               // 9fe5: 0a          .
+    eor l0f0e,x                                                       // 9fe6: 5d 0e 0f    ]..
+    and #$30 // '0'                                                   // 9fe9: 29 30       )0
+    eor l0f0e,x                                                       // 9feb: 5d 0e 0f    ]..
+    sta l0f0e,x                                                       // 9fee: 9d 0e 0f    ...
+    pla                                                               // 9ff1: 68          h
+    lda #0                                                            // 9ff2: a9 00       ..
+// $9ff4 referenced 1 time by $9fbe
+c9ff4
+    sta l0f0d,x                                                       // 9ff4: 9d 0d 0f    ...
+    sta l1119,y                                                       // 9ff7: 99 19 11    ...
+    lda #0                                                            // 9ffa: a9 00       ..
+    sta l0f0c,x                                                       // 9ffc: 9d 0c 0f    ...
+    jsr c93e6                                                         // 9fff: 20 e6 93     ..
+    ldy l10c2                                                         // a002: ac c2 10    ...
+// $a005 referenced 1 time by $9f9d
+ca005
+    lda l1117,y                                                       // a005: b9 17 11    ...
+    bmi ca021                                                         // a008: 30 17       0.
+    jsr sub_c9f1e                                                     // a00a: 20 1e 9f     ..
+    lda l1114,y                                                       // a00d: b9 14 11    ...
+    bne ca01d                                                         // a010: d0 0b       ..
+    tya                                                               // a012: 98          .
+    jsr sub_ca0de                                                     // a013: 20 de a0     ..
+    bne ca01d                                                         // a016: d0 05       ..
+    jsr sub_c9ef4                                                     // a018: 20 f4 9e     ..
+    bne ca021                                                         // a01b: d0 04       ..
+// $a01d referenced 2 times by $a010, $a016
+ca01d
+    sec                                                               // a01d: 38          8
+    jsr sub_c9f26                                                     // a01e: 20 26 9f     &.
+// $a021 referenced 2 times by $a008, $a01b
+ca021
+    lda l1110,y                                                       // a021: b9 10 11    ...
+    sta l00ba                                                         // a024: 85 ba       ..
+    lda l1113,y                                                       // a026: b9 13 11    ...
+    sta l00bb                                                         // a029: 85 bb       ..
+    pla                                                               // a02b: 68          h
+    ldy #0                                                            // a02c: a0 00       ..
+    sta (l00ba),y                                                     // a02e: 91 ba       ..
+    ldy l10c2                                                         // a030: ac c2 10    ...
+    lda #$40 // '@'                                                   // a033: a9 40       .@
+    jsr sub_c9f0f                                                     // a035: 20 0f 9f     ..
+    inc l00ba                                                         // a038: e6 ba       ..
+    lda l00ba                                                         // a03a: a5 ba       ..
+    sta l1110,y                                                       // a03c: 99 10 11    ...
+    bne ca054                                                         // a03f: d0 13       ..
+    jsr sub_c9f14                                                     // a041: 20 14 9f     ..
+    lda l1111,y                                                       // a044: b9 11 11    ...
+    adc #1                                                            // a047: 69 01       i.
+    sta l1111,y                                                       // a049: 99 11 11    ...
+    lda l1112,y                                                       // a04c: b9 12 11    ...
+    adc #0                                                            // a04f: 69 00       i.
+    sta l1112,y                                                       // a051: 99 12 11    ...
+// $a054 referenced 1 time by $a03f
+ca054
+    tya                                                               // a054: 98          .
+    jsr sub_ca0de                                                     // a055: 20 de a0     ..
+    bcc ca06b                                                         // a058: 90 11       ..
+    lda #$20 // ' '                                                   // a05a: a9 20       .
+    jsr sub_c9f0f                                                     // a05c: 20 0f 9f     ..
+    ldx #2                                                            // a05f: a2 02       ..
+// $a061 referenced 1 time by $a069
+loop_ca061
+    lda l1110,y                                                       // a061: b9 10 11    ...
+    sta l1114,y                                                       // a064: 99 14 11    ...
+    iny                                                               // a067: c8          .
+    dex                                                               // a068: ca          .
+    bpl loop_ca061                                                    // a069: 10 f6       ..
+// $a06b referenced 3 times by $a058, $a0d1, $a0d9
+ca06b
+    rts                                                               // a06b: 60          `
+
+// $a06c referenced 2 times by $9849, $9db1
+ca06c
+    jsr sub_c83e3                                                     // a06c: 20 e3 83     ..
+    jsr sub_c9e75                                                     // a06f: 20 75 9e     u.
+    ldy l10c2                                                         // a072: ac c2 10    ...
+// $a075 referenced 1 time by $a0a6
+ca075
+    jsr sub_ca0f6                                                     // a075: 20 f6 a0     ..
+    bcs ca0a9                                                         // a078: b0 2f       ./
+    lda l1114,y                                                       // a07a: b9 14 11    ...
+    sta l1110,y                                                       // a07d: 99 10 11    ...
+    lda l1115,y                                                       // a080: b9 15 11    ...
+    sta l1111,y                                                       // a083: 99 11 11    ...
+    lda l1116,y                                                       // a086: b9 16 11    ...
+    sta l1112,y                                                       // a089: 99 12 11    ...
+    jsr sub_ca0b8                                                     // a08c: 20 b8 a0     ..
+    lda l00b6                                                         // a08f: a5 b6       ..
+    pha                                                               // a091: 48          H
+    lda l00b7                                                         // a092: a5 b7       ..
+    pha                                                               // a094: 48          H
+    lda l00b8                                                         // a095: a5 b8       ..
+    pha                                                               // a097: 48          H
+    lda #0                                                            // a098: a9 00       ..
+    jsr sub_c9f7c                                                     // a09a: 20 7c 9f     |.
+    pla                                                               // a09d: 68          h
+    sta l00b8                                                         // a09e: 85 b8       ..
+    pla                                                               // a0a0: 68          h
+    sta l00b7                                                         // a0a1: 85 b7       ..
+    pla                                                               // a0a3: 68          h
+    sta l00b6                                                         // a0a4: 85 b6       ..
+    jmp ca075                                                         // a0a6: 4c 75 a0    Lu.
+
+// $a0a9 referenced 1 time by $a078
+ca0a9
+    lda l0000,x                                                       // a0a9: b5 00       ..
+    sta l1110,y                                                       // a0ab: 99 10 11    ...
+    lda l0001,x                                                       // a0ae: b5 01       ..
+    sta l1111,y                                                       // a0b0: 99 11 11    ...
+    lda l0002,x                                                       // a0b3: b5 02       ..
+    sta l1112,y                                                       // a0b5: 99 12 11    ...
+// $a0b8 referenced 1 time by $a08c
+sub_ca0b8
+    lda #$6f // 'o'                                                   // a0b8: a9 6f       .o
+    jsr sub_c9f16                                                     // a0ba: 20 16 9f     ..
+    lda l110f,y                                                       // a0bd: b9 0f 11    ...
+    adc l1111,y                                                       // a0c0: 79 11 11    y..
+    sta l10c4                                                         // a0c3: 8d c4 10    ...
+    lda l110d,y                                                       // a0c6: b9 0d 11    ...
+    and #3                                                            // a0c9: 29 03       ).
+    adc l1112,y                                                       // a0cb: 79 12 11    y..
+    cmp l111d,y                                                       // a0ce: d9 1d 11    ...
+    bne ca06b                                                         // a0d1: d0 98       ..
+    lda l10c4                                                         // a0d3: ad c4 10    ...
+    cmp l111c,y                                                       // a0d6: d9 1c 11    ...
+    bne ca06b                                                         // a0d9: d0 90       ..
+    jmp c9f0d                                                         // a0db: 4c 0d 9f    L..
+
+// $a0de referenced 5 times by $9e66, $9e9b, $9f9a, $a013, $a055
+sub_ca0de
+    tax                                                               // a0de: aa          .
+    lda l1112,y                                                       // a0df: b9 12 11    ...
+    cmp l1116,x                                                       // a0e2: dd 16 11    ...
+    bne ca0f5                                                         // a0e5: d0 0e       ..
+    lda l1111,y                                                       // a0e7: b9 11 11    ...
+    cmp l1115,x                                                       // a0ea: dd 15 11    ...
+    bne ca0f5                                                         // a0ed: d0 06       ..
+    lda l1110,y                                                       // a0ef: b9 10 11    ...
+    cmp l1114,x                                                       // a0f2: dd 14 11    ...
+// $a0f5 referenced 2 times by $a0e5, $a0ed
+ca0f5
+    rts                                                               // a0f5: 60          `
+
+// $a0f6 referenced 1 time by $a075
+sub_ca0f6
+    lda l1114,y                                                       // a0f6: b9 14 11    ...
+    cmp l0000,x                                                       // a0f9: d5 00       ..
+    lda l1115,y                                                       // a0fb: b9 15 11    ...
+    sbc l0001,x                                                       // a0fe: f5 01       ..
+    lda l1116,y                                                       // a100: b9 16 11    ...
+    sbc l0002,x                                                       // a103: f5 02       ..
+    rts                                                               // a105: 60          `
+
+sub_ca106
+    tya                                                               // a106: 98          .
+    ldx #$ff                                                          // a107: a2 ff       ..
+    ldy #$14                                                          // a109: a0 14       ..
+// $a10b referenced 2 times by $9711, $a13c
+ca10b
+    pha                                                               // a10b: 48          H
+    jsr print_inline_l809f_top_bit_clear                              // a10c: 20 77 80     w.
+    .asc $0d, "DFS 2.26", $0d                                         // a10f: 0d 44 46... .DF
+
+    stx l00bf                                                         // a119: 86 bf       ..
+    sty l00b7                                                         // a11b: 84 b7       ..
+// $a11d referenced 1 time by $a12e
+loop_ca11d
+    lda #0                                                            // a11d: a9 00       ..
+    sta l00b9                                                         // a11f: 85 b9       ..
+    ldy #2                                                            // a121: a0 02       ..
+    jsr sub_ca1c6                                                     // a123: 20 c6 a1     ..
+    jsr sub_ca168                                                     // a126: 20 68 a1     h.
+    jsr ca3dc                                                         // a129: 20 dc a3     ..
+    dec l00b7                                                         // a12c: c6 b7       ..
+    bne loop_ca11d                                                    // a12e: d0 ed       ..
+    pla                                                               // a130: 68          h
+    tay                                                               // a131: a8          .
+// $a132 referenced 1 time by $a148
+loop_ca132
+    ldx #$cf                                                          // a132: a2 cf       ..
+    jmp c8703                                                         // a134: 4c 03 87    L..
+
+sub_ca137
+    tya                                                               // a137: 98          .
+    ldx #$9d                                                          // a138: a2 9d       ..
+    ldy #6                                                            // a13a: a0 06       ..
+    bne ca10b                                                         // a13c: d0 cd       ..
+    jsr clc_jmp_gsinit                                                // a13e: 20 4c 87     L.
+    beq ca1c0                                                         // a141: f0 7d       .}
+// $a143 referenced 1 time by $a146
+loop_ca143
+    jsr sub_c8149                                                     // a143: 20 49 81     I.
+    bcc loop_ca143                                                    // a146: 90 fb       ..
+    bcs loop_ca132                                                    // a148: b0 e8       ..
+// $a14a referenced 13 times by $8257, $8753, $8785, $879a, $87ee, $89b7, $89e9, $8baf, $8bc1, $a324, $a32d, $a469, $a5cb
+sub_ca14a
+    jsr clc_jmp_gsinit                                                // a14a: 20 4c 87     L.
+    bne ca1c0                                                         // a14d: d0 71       .q
+// $a14f referenced 3 times by $8805, $a5e2, $ac25
+ca14f
+    jsr generate_error                                                // a14f: 20 48 80     H.
+    .byt $dc                                                          // a152: dc          .
+    .asc "Syntax: "                                                   // a153: 53 79 6e... Syn
+
+    stx l00b9                                                         // a15b: 86 b9       ..
+    jsr sub_ca168                                                     // a15d: 20 68 a1     h.
+    lda #0                                                            // a160: a9 00       ..
+    jsr sub_ca1b4                                                     // a162: 20 b4 a1     ..
+    jmp l0100                                                         // a165: 4c 00 01    L..
+
+// $a168 referenced 2 times by $a126, $a15d
+sub_ca168
+    ldx l00bf                                                         // a168: a6 bf       ..
+    lda #9                                                            // a16a: a9 09       ..
+    sta l00b8                                                         // a16c: 85 b8       ..
+// $a16e referenced 1 time by $a177
+loop_ca16e
+    inx                                                               // a16e: e8          .
+    lda command_table,x                                               // a16f: bd 1c 86    ...
+    bmi ca17a                                                         // a172: 30 06       0.
+    jsr sub_ca1b4                                                     // a174: 20 b4 a1     ..
+    jmp loop_ca16e                                                    // a177: 4c 6e a1    Ln.
+
+// $a17a referenced 1 time by $a172
+ca17a
+    ldy l00b8                                                         // a17a: a4 b8       ..
+    cpy #$0c                                                          // a17c: c0 0c       ..
+    beq ca183                                                         // a17e: f0 03       ..
+    jsr sub_ca1c6                                                     // a180: 20 c6 a1     ..
+// $a183 referenced 1 time by $a17e
+ca183
+    inx                                                               // a183: e8          .
+    inx                                                               // a184: e8          .
+    stx l00bf                                                         // a185: 86 bf       ..
+    lda command_table,x                                               // a187: bd 1c 86    ...
+    jsr sub_ca190                                                     // a18a: 20 90 a1     ..
+    jsr sub_c81bf                                                     // a18d: 20 bf 81     ..
+// $a190 referenced 1 time by $a18a
+sub_ca190
+    jsr sub_c83e3                                                     // a190: 20 e3 83     ..
+    and #$0f                                                          // a193: 29 0f       ).
+    beq ca1c0                                                         // a195: f0 29       .)
+    tay                                                               // a197: a8          .
+    lda #$20 // ' '                                                   // a198: a9 20       .
+    jsr sub_ca1b4                                                     // a19a: 20 b4 a1     ..
+    ldx #$ff                                                          // a19d: a2 ff       ..
+// $a19f referenced 2 times by $a1a3, $a1a6
+ca19f
+    inx                                                               // a19f: e8          .
+    lda la1d3,x                                                       // a1a0: bd d3 a1    ...
+    bpl ca19f                                                         // a1a3: 10 fa       ..
+    dey                                                               // a1a5: 88          .
+    bne ca19f                                                         // a1a6: d0 f7       ..
+    and #$7f                                                          // a1a8: 29 7f       ).
+// $a1aa referenced 1 time by $a1b1
+loop_ca1aa
+    jsr sub_ca1b4                                                     // a1aa: 20 b4 a1     ..
+    inx                                                               // a1ad: e8          .
+    lda la1d3,x                                                       // a1ae: bd d3 a1    ...
+    bpl loop_ca1aa                                                    // a1b1: 10 f7       ..
+    rts                                                               // a1b3: 60          `
+
+// $a1b4 referenced 5 times by $a162, $a174, $a19a, $a1aa, $a1cc
+sub_ca1b4
+    jsr sub_c83e3                                                     // a1b4: 20 e3 83     ..
+    ldx l00b9                                                         // a1b7: a6 b9       ..
+    beq ca1c1                                                         // a1b9: f0 06       ..
+    inc l00b9                                                         // a1bb: e6 b9       ..
+    sta l0100,x                                                       // a1bd: 9d 00 01    ...
+// $a1c0 referenced 3 times by $a141, $a14d, $a195
+ca1c0
+    rts                                                               // a1c0: 60          `
+
+// $a1c1 referenced 1 time by $a1b9
+ca1c1
+    dec l00b8                                                         // a1c1: c6 b8       ..
+    jmp c809f                                                         // a1c3: 4c 9f 80    L..
+
+// $a1c6 referenced 2 times by $a123, $a180
+sub_ca1c6
+    lda l00b9                                                         // a1c6: a5 b9       ..
+    bne ca1d2                                                         // a1c8: d0 08       ..
+    lda #$20 // ' '                                                   // a1ca: a9 20       .
+// $a1cc referenced 1 time by $a1d0
+loop_ca1cc
+    jsr sub_ca1b4                                                     // a1cc: 20 b4 a1     ..
+    dey                                                               // a1cf: 88          .
+    bne loop_ca1cc                                                    // a1d0: d0 fa       ..
+// $a1d2 referenced 1 time by $a1c8
+ca1d2
+    rts                                                               // a1d2: 60          `
+
+// $a1d3 referenced 2 times by $a1a0, $a1ae
+la1d3
+    .byt $bc                                                          // a1d3: bc          .
+    .asc "fsp>"                                                       // a1d4: 66 73 70... fsp
+    .byt $bc                                                          // a1d8: bc          .
+    .asc "afsp>"                                                      // a1d9: 61 66 73... afs
+    .byt $a8, $4c, $29, $bc                                           // a1de: a8 4c 29... .L)
+    .asc "source> <dest.>"                                            // a1e2: 73 6f 75... sou
+    .byt $bc                                                          // a1f1: bc          .
+    .asc "old fsp> <new fsp>"                                         // a1f2: 6f 6c 64... old
+    .byt $a8                                                          // a204: a8          .
+    .asc "<dir>)"                                                     // a205: 3c 64 69... <di
+    .byt $a8                                                          // a20b: a8          .
+    .asc "<drive>)"                                                   // a20c: 3c 64 72... <dr
+    .byt $bc                                                          // a214: bc          .
+    .asc "title>"                                                     // a215: 74 69 74... tit
+    .byt $bc                                                          // a21b: bc          .
+    .asc "drive> (40)(80)"                                            // a21c: 64 72 69... dri
+    .byt $b4                                                          // a22b: b4          .
+    .asc "0", $2f, "80"                                               // a22c: 30 2f 38... 0/8
+    .byt $a8                                                          // a230: a8          .
+    .asc "<drive>)..."                                                // a231: 3c 64 72... <dr
+    .byt $a8                                                          // a23c: a8          .
+    .asc "<rom>)"                                                     // a23d: 3c 72 6f... <ro
+    .byt $ff                                                          // a243: ff          .
+
+sub_ca244
+    jsr sub_c8b86                                                     // a244: 20 86 8b     ..
+    jsr print_inline_l809f_top_bit_clear                              // a247: 20 77 80     w.
+    .asc "Compacting :"                                               // a24a: 43 6f 6d... Com
+
+    sta l10d1                                                         // a256: 8d d1 10    ...
+    sta l10d2                                                         // a259: 8d d2 10    ...
+    jsr sub_c80c3                                                     // a25c: 20 c3 80     ..
+    jsr ca3dc                                                         // a25f: 20 dc a3     ..
+    ldy #0                                                            // a262: a0 00       ..
+    jsr sub_c9b79                                                     // a264: 20 79 9b     y.
+    jsr sub_c9a8d                                                     // a267: 20 8d 9a     ..
+    jsr sub_c8380                                                     // a26a: 20 80 83     ..
+    ldy l0f05                                                         // a26d: ac 05 0f    ...
+    sty l00ca                                                         // a270: 84 ca       ..
+    lda #2                                                            // a272: a9 02       ..
+    sta l00c8                                                         // a274: 85 c8       ..
+    lda #0                                                            // a276: a9 00       ..
+    sta l00c9                                                         // a278: 85 c9       ..
+// $a27a referenced 1 time by $a312
+ca27a
+    ldy l00ca                                                         // a27a: a4 ca       ..
+    jsr sub_c82b2                                                     // a27c: 20 b2 82     ..
+    cpy #$f8                                                          // a27f: c0 f8       ..
+    bne ca2ab                                                         // a281: d0 28       .(
+    lda l0f07                                                         // a283: ad 07 0f    ...
+    sec                                                               // a286: 38          8
+    sbc l00c8                                                         // a287: e5 c8       ..
+    pha                                                               // a289: 48          H
+    lda l0f06                                                         // a28a: ad 06 0f    ...
+    and #3                                                            // a28d: 29 03       ).
+    sbc l00c9                                                         // a28f: e5 c9       ..
+    jsr sub_c80c3                                                     // a291: 20 c3 80     ..
+    pla                                                               // a294: 68          h
+    jsr sub_c80bb                                                     // a295: 20 bb 80     ..
+    jsr print_inline_l809f_top_bit_clear                              // a298: 20 77 80     w.
+    .asc " free sectors", $0d                                         // a29b: 20 66 72...  fr
+
+    nop                                                               // a2a9: ea          .
+    rts                                                               // a2aa: 60          `
+
+// $a2ab referenced 1 time by $a281
+ca2ab
+    sty l00ca                                                         // a2ab: 84 ca       ..
+    jsr sub_c8335                                                     // a2ad: 20 35 83     5.
+    ldy l00ca                                                         // a2b0: a4 ca       ..
+    lda l0f0c,y                                                       // a2b2: b9 0c 0f    ...
+    cmp #1                                                            // a2b5: c9 01       ..
+    lda #0                                                            // a2b7: a9 00       ..
+    sta l00bc                                                         // a2b9: 85 bc       ..
+    sta l00c0                                                         // a2bb: 85 c0       ..
+    adc l0f0d,y                                                       // a2bd: 79 0d 0f    y..
+    sta l00c4                                                         // a2c0: 85 c4       ..
+    lda l0f0e,y                                                       // a2c2: b9 0e 0f    ...
+    php                                                               // a2c5: 08          .
+    jsr sub_c81b0                                                     // a2c6: 20 b0 81     ..
+    plp                                                               // a2c9: 28          (
+    adc #0                                                            // a2ca: 69 00       i.
+    sta l00c5                                                         // a2cc: 85 c5       ..
+    lda l0f0f,y                                                       // a2ce: b9 0f 0f    ...
+    sta l00c6                                                         // a2d1: 85 c6       ..
+    lda l0f0e,y                                                       // a2d3: b9 0e 0f    ...
+    and #3                                                            // a2d6: 29 03       ).
+    sta l00c7                                                         // a2d8: 85 c7       ..
+    cmp l00c9                                                         // a2da: c5 c9       ..
+    bne ca2f2                                                         // a2dc: d0 14       ..
+    lda l00c6                                                         // a2de: a5 c6       ..
+    cmp l00c8                                                         // a2e0: c5 c8       ..
+    bne ca2f2                                                         // a2e2: d0 0e       ..
+    clc                                                               // a2e4: 18          .
+    adc l00c4                                                         // a2e5: 65 c4       e.
+    sta l00c8                                                         // a2e7: 85 c8       ..
+    lda l00c9                                                         // a2e9: a5 c9       ..
+    adc l00c5                                                         // a2eb: 65 c5       e.
+    sta l00c9                                                         // a2ed: 85 c9       ..
+    jmp ca30d                                                         // a2ef: 4c 0d a3    L..
+
+// $a2f2 referenced 2 times by $a2dc, $a2e2
+ca2f2
+    lda l00c8                                                         // a2f2: a5 c8       ..
+    sta l0f0f,y                                                       // a2f4: 99 0f 0f    ...
+    lda l0f0e,y                                                       // a2f7: b9 0e 0f    ...
+    and #$fc                                                          // a2fa: 29 fc       ).
+    ora l00c9                                                         // a2fc: 05 c9       ..
+    sta l0f0e,y                                                       // a2fe: 99 0e 0f    ...
+    lda #0                                                            // a301: a9 00       ..
+    sta l00a8                                                         // a303: 85 a8       ..
+    sta l00a9                                                         // a305: 85 a9       ..
+    jsr sub_ca530                                                     // a307: 20 30 a5     0.
+    jsr c93e6                                                         // a30a: 20 e6 93     ..
+// $a30d referenced 1 time by $a2ef
+ca30d
+    ldy l00ca                                                         // a30d: a4 ca       ..
+    jsr sub_c833a                                                     // a30f: 20 3a 83     :.
+    jmp ca27a                                                         // a312: 4c 7a a2    Lz.
+
+// $a315 referenced 3 times by $8794, $a41a, $a64c
+sub_ca315
+    bit l10c7                                                         // a315: 2c c7 10    ,..
+    bpl ca378                                                         // a318: 10 5e       .^
+    jsr sub_ca3ec                                                     // a31a: 20 ec a3     ..
+    beq ca321                                                         // a31d: f0 02       ..
+    pla                                                               // a31f: 68          h
+    pla                                                               // a320: 68          h
+// $a321 referenced 1 time by $a31d
+ca321
+    jmp ca3dc                                                         // a321: 4c dc a3    L..
+
+// $a324 referenced 2 times by $a417, $a466
+sub_ca324
+    jsr sub_ca14a                                                     // a324: 20 4a a1     J.
+    jsr c8b8b                                                         // a327: 20 8b 8b     ..
+    sta l10d1                                                         // a32a: 8d d1 10    ...
+    jsr sub_ca14a                                                     // a32d: 20 4a a1     J.
+    jsr c8b8b                                                         // a330: 20 8b 8b     ..
+    sta l10d2                                                         // a333: 8d d2 10    ...
+    tya                                                               // a336: 98          .
+    pha                                                               // a337: 48          H
+    lda #0                                                            // a338: a9 00       ..
+    sta l00a9                                                         // a33a: 85 a9       ..
+    lda l10d2                                                         // a33c: ad d2 10    ...
+    cmp l10d1                                                         // a33f: cd d1 10    ...
+    bne ca34a                                                         // a342: d0 06       ..
+    lda #$ff                                                          // a344: a9 ff       ..
+    sta l00a9                                                         // a346: 85 a9       ..
+    sta l00aa                                                         // a348: 85 aa       ..
+// $a34a referenced 1 time by $a342
+ca34a
+    jsr sub_c9a8d                                                     // a34a: 20 8d 9a     ..
+    jsr print_inline_l809f_top_bit_clear                              // a34d: 20 77 80     w.
+    .asc "Copying from :"                                             // a350: 43 6f 70... Cop
+
+    lda l10d1                                                         // a35e: ad d1 10    ...
+    jsr sub_c80c3                                                     // a361: 20 c3 80     ..
+    jsr print_inline_l809f_top_bit_clear                              // a364: 20 77 80     w.
+    .asc " to :"                                                      // a367: 20 74 6f...  to
+
+    lda l10d2                                                         // a36c: ad d2 10    ...
+    jsr sub_c80c3                                                     // a36f: 20 c3 80     ..
+    jsr ca3dc                                                         // a372: 20 dc a3     ..
+    pla                                                               // a375: 68          h
+    tay                                                               // a376: a8          .
+    clc                                                               // a377: 18          .
+// $a378 referenced 1 time by $a318
+ca378
+    rts                                                               // a378: 60          `
+
+// $a379 referenced 4 times by $a429, $a46f, $a4c8, $a55b
+sub_ca379
+    jsr sub_c83e3                                                     // a379: 20 e3 83     ..
+    bit l00a9                                                         // a37c: 24 a9       $.
+    bpl ca38b                                                         // a37e: 10 0b       ..
+    lda #0                                                            // a380: a9 00       ..
+    beq ca38e                                                         // a382: f0 0a       ..
+// $a384 referenced 3 times by $a440, $a4e4, $a581
+sub_ca384
+    jsr sub_c83e3                                                     // a384: 20 e3 83     ..
+    bit l00a9                                                         // a387: 24 a9       $.
+    bmi ca38c                                                         // a389: 30 01       0.
+// $a38b referenced 2 times by $a37e, $a390
+ca38b
+    rts                                                               // a38b: 60          `
+
+// $a38c referenced 1 time by $a389
+ca38c
+    lda #$80                                                          // a38c: a9 80       ..
+// $a38e referenced 1 time by $a382
+ca38e
+    cmp l00aa                                                         // a38e: c5 aa       ..
+    beq ca38b                                                         // a390: f0 f9       ..
+    sta l00aa                                                         // a392: 85 aa       ..
+    jsr print_inline_l809f_top_bit_clear                              // a394: 20 77 80     w.
+    .asc "Insert "                                                    // a397: 49 6e 73... Ins
+
+    nop                                                               // a39e: ea          .
+    bit l00aa                                                         // a39f: 24 aa       $.
+    bmi ca3ae                                                         // a3a1: 30 0b       0.
+    jsr print_inline_l809f_top_bit_clear                              // a3a3: 20 77 80     w.
+    .asc "source"                                                     // a3a6: 73 6f 75... sou
+
+    bcc ca3bd                                                         // a3ac: 90 0f       ..
+// $a3ae referenced 1 time by $a3a1
+ca3ae
+    jsr print_inline_l809f_top_bit_clear                              // a3ae: 20 77 80     w.
+    .asc "destination"                                                // a3b1: 64 65 73... des
+
+    nop                                                               // a3bc: ea          .
+// $a3bd referenced 1 time by $a3ac
+ca3bd
+    jsr print_inline_l809f_top_bit_clear                              // a3bd: 20 77 80     w.
+    .asc " disc and hit a key"                                        // a3c0: 20 64 69...  di
+
+    nop                                                               // a3d3: ea          .
+    jsr sub_c9ac8                                                     // a3d4: 20 c8 9a     ..
+    jsr osrdch                                                        // a3d7: 20 e0 ff     ..
+    bcs ca411                                                         // a3da: b0 35       .5
+// $a3dc referenced 16 times by $836b, $8522, $854f, $85b2, $85b5, $8779, $87a8, $87b5, $a129, $a25f, $a321, $a372, $a62f, $a6b0, $a73a, $aa95
+ca3dc
+    pha                                                               // a3dc: 48          H
+    lda #$0d                                                          // a3dd: a9 0d       ..
+    jsr c809f                                                         // a3df: 20 9f 80     ..
+    pla                                                               // a3e2: 68          h
+    rts                                                               // a3e3: 60          `
+
+// $a3e4 referenced 1 time by $8761
+sub_ca3e4
+    jsr print_inline_l809f_top_bit_clear                              // a3e4: 20 77 80     w.
+    .asc " : "                                                        // a3e7: 20 3a 20     :
+
+    bcc ca3fb                                                         // a3ea: 90 0f       ..
+// $a3ec referenced 2 times by $87b0, $a31a
+sub_ca3ec
+    jsr print_inline_l809f_top_bit_clear                              // a3ec: 20 77 80     w.
+    .asc "Go (Y", $2f, "N) ? "                                        // a3ef: 47 6f 20... Go
+
+    nop                                                               // a3fa: ea          .
+// $a3fb referenced 1 time by $a3ea
+ca3fb
+    jsr sub_c9ac8                                                     // a3fb: 20 c8 9a     ..
+    jsr osrdch                                                        // a3fe: 20 e0 ff     ..
+    bcs ca411                                                         // a401: b0 0e       ..
+    and #$5f // '_'                                                   // a403: 29 5f       )_
+    cmp #$59 // 'Y'                                                   // a405: c9 59       .Y
+    php                                                               // a407: 08          .
+    beq ca40c                                                         // a408: f0 02       ..
+    lda #$4e // 'N'                                                   // a40a: a9 4e       .N
+// $a40c referenced 1 time by $a408
+ca40c
+    jsr c809f                                                         // a40c: 20 9f 80     ..
+    plp                                                               // a40f: 28          (
+    rts                                                               // a410: 60          `
+
+// $a411 referenced 2 times by $a3da, $a401
+ca411
+    jmp c9436                                                         // a411: 4c 36 94    L6.
+
+// $a414 referenced 2 times by $a452, $a45b
+ca414
+    jmp c8a6e                                                         // a414: 4c 6e 8a    Ln.
+
+sub_ca417
+    jsr sub_ca324                                                     // a417: 20 24 a3     $.
+    jsr sub_ca315                                                     // a41a: 20 15 a3     ..
+    lda #0                                                            // a41d: a9 00       ..
+    sta l00c7                                                         // a41f: 85 c7       ..
+    sta l00c9                                                         // a421: 85 c9       ..
+    sta l00c8                                                         // a423: 85 c8       ..
+    sta l00c6                                                         // a425: 85 c6       ..
+    sta l00a8                                                         // a427: 85 a8       ..
+    jsr sub_ca379                                                     // a429: 20 79 a3     y.
+    lda l10d1                                                         // a42c: ad d1 10    ...
+    sta l00cd                                                         // a42f: 85 cd       ..
+    jsr c940c                                                         // a431: 20 0c 94     ..
+    lda l0f07                                                         // a434: ad 07 0f    ...
+    sta l00c4                                                         // a437: 85 c4       ..
+    lda l0f06                                                         // a439: ad 06 0f    ...
+    and #3                                                            // a43c: 29 03       ).
+    sta l00c5                                                         // a43e: 85 c5       ..
+    jsr sub_ca384                                                     // a440: 20 84 a3     ..
+    lda l10d2                                                         // a443: ad d2 10    ...
+    sta l00cd                                                         // a446: 85 cd       ..
+    jsr c940c                                                         // a448: 20 0c 94     ..
+    lda l0f06                                                         // a44b: ad 06 0f    ...
+    and #3                                                            // a44e: 29 03       ).
+    cmp l00c5                                                         // a450: c5 c5       ..
+    bcc ca414                                                         // a452: 90 c0       ..
+    bne ca45d                                                         // a454: d0 07       ..
+    lda l0f07                                                         // a456: ad 07 0f    ...
+    cmp l00c4                                                         // a459: c5 c4       ..
+    bcc ca414                                                         // a45b: 90 b7       ..
+// $a45d referenced 1 time by $a454
+ca45d
+    jsr sub_ca530                                                     // a45d: 20 30 a5     0.
+    jmp c940c                                                         // a460: 4c 0c 94    L..
+
+sub_ca463
+    jsr sub_c99ac                                                     // a463: 20 ac 99     ..
+    jsr sub_ca324                                                     // a466: 20 24 a3     $.
+    jsr sub_ca14a                                                     // a469: 20 4a a1     J.
+    jsr sub_c80ed                                                     // a46c: 20 ed 80     ..
+    jsr sub_ca379                                                     // a46f: 20 79 a3     y.
+    lda l10d1                                                         // a472: ad d1 10    ...
+    jsr c8816                                                         // a475: 20 16 88     ..
+    jsr c8225                                                         // a478: 20 25 82     %.
+// $a47b referenced 1 time by $a4de
+ca47b
+    lda l00cc                                                         // a47b: a5 cc       ..
+    pha                                                               // a47d: 48          H
+    lda l00b6                                                         // a47e: a5 b6       ..
+    sta l00ab                                                         // a480: 85 ab       ..
+    jsr sub_c833a                                                     // a482: 20 3a 83     :.
+    ldx #0                                                            // a485: a2 00       ..
+// $a487 referenced 1 time by $a49b
+loop_ca487
+    lda l0e08,y                                                       // a487: b9 08 0e    ...
+    sta l00c5,x                                                       // a48a: 95 c5       ..
+    sta l1050,x                                                       // a48c: 9d 50 10    .P.
+    lda l0f08,y                                                       // a48f: b9 08 0f    ...
+    sta l00bb,x                                                       // a492: 95 bb       ..
+    sta l1047,x                                                       // a494: 9d 47 10    .G.
+    inx                                                               // a497: e8          .
+    iny                                                               // a498: c8          .
+    cpx #8                                                            // a499: e0 08       ..
+    bne loop_ca487                                                    // a49b: d0 ea       ..
+    lda l00c1                                                         // a49d: a5 c1       ..
+    jsr sub_c81b0                                                     // a49f: 20 b0 81     ..
+    sta l00c3                                                         // a4a2: 85 c3       ..
+    lda l00bf                                                         // a4a4: a5 bf       ..
+    clc                                                               // a4a6: 18          .
+    adc #$ff                                                          // a4a7: 69 ff       i.
+    lda l00c0                                                         // a4a9: a5 c0       ..
+    adc #0                                                            // a4ab: 69 00       i.
+    sta l00c4                                                         // a4ad: 85 c4       ..
+    lda l00c3                                                         // a4af: a5 c3       ..
+    adc #0                                                            // a4b1: 69 00       i.
+    sta l00c5                                                         // a4b3: 85 c5       ..
+    lda l104e                                                         // a4b5: ad 4e 10    .N.
+    sta l00c6                                                         // a4b8: 85 c6       ..
+    lda l104d                                                         // a4ba: ad 4d 10    .M.
+    and #3                                                            // a4bd: 29 03       ).
+    sta l00c7                                                         // a4bf: 85 c7       ..
+    lda #$ff                                                          // a4c1: a9 ff       ..
+    sta l00a8                                                         // a4c3: 85 a8       ..
+    jsr sub_ca530                                                     // a4c5: 20 30 a5     0.
+    jsr sub_ca379                                                     // a4c8: 20 79 a3     y.
+    lda l10d1                                                         // a4cb: ad d1 10    ...
+    jsr c8816                                                         // a4ce: 20 16 88     ..
+    jsr sub_c8380                                                     // a4d1: 20 80 83     ..
+    lda l00ab                                                         // a4d4: a5 ab       ..
+    sta l00b6                                                         // a4d6: 85 b6       ..
+    pla                                                               // a4d8: 68          h
+    sta l00cc                                                         // a4d9: 85 cc       ..
+    jsr sub_c8280                                                     // a4db: 20 80 82     ..
+    bcs ca47b                                                         // a4de: b0 9b       ..
+    rts                                                               // a4e0: 60          `
+
+// $a4e1 referenced 1 time by $a56d
+sub_ca4e1
+    jsr sub_ca51f                                                     // a4e1: 20 1f a5     ..
+    jsr sub_ca384                                                     // a4e4: 20 84 a3     ..
+    lda l10d2                                                         // a4e7: ad d2 10    ...
+    sta l00cd                                                         // a4ea: 85 cd       ..
+    lda l00cc                                                         // a4ec: a5 cc       ..
+    pha                                                               // a4ee: 48          H
+    jsr sub_c8380                                                     // a4ef: 20 80 83     ..
+    jsr sub_c826d                                                     // a4f2: 20 6d 82     m.
+    bcc ca4fa                                                         // a4f5: 90 03       ..
+    jsr sub_c830a                                                     // a4f7: 20 0a 83     ..
+// $a4fa referenced 1 time by $a4f5
+ca4fa
+    pla                                                               // a4fa: 68          h
+    sta l00cc                                                         // a4fb: 85 cc       ..
+    jsr sub_c8b4d                                                     // a4fd: 20 4d 8b     M.
+    jsr sub_c8b64                                                     // a500: 20 64 8b     d.
+    lda l00c2                                                         // a503: a5 c2       ..
+    jsr sub_c81b0                                                     // a505: 20 b0 81     ..
+    sta l00c4                                                         // a508: 85 c4       ..
+    jsr sub_c8ab3                                                     // a50a: 20 b3 8a     ..
+    lda l00c2                                                         // a50d: a5 c2       ..
+    and #3                                                            // a50f: 29 03       ).
+    pha                                                               // a511: 48          H
+    lda l00c3                                                         // a512: a5 c3       ..
+    pha                                                               // a514: 48          H
+    jsr sub_ca51f                                                     // a515: 20 1f a5     ..
+    pla                                                               // a518: 68          h
+    sta l00c8                                                         // a519: 85 c8       ..
+    pla                                                               // a51b: 68          h
+    sta l00c9                                                         // a51c: 85 c9       ..
+    rts                                                               // a51e: 60          `
+
+// $a51f referenced 2 times by $a4e1, $a515
+sub_ca51f
+    ldx #$11                                                          // a51f: a2 11       ..
+// $a521 referenced 1 time by $a52d
+loop_ca521
+    lda l1045,x                                                       // a521: bd 45 10    .E.
+    ldy l00ba,x                                                       // a524: b4 ba       ..
+    sta l00ba,x                                                       // a526: 95 ba       ..
+    tya                                                               // a528: 98          .
+    sta l1045,x                                                       // a529: 9d 45 10    .E.
+    dex                                                               // a52c: ca          .
+    bpl loop_ca521                                                    // a52d: 10 f2       ..
+    rts                                                               // a52f: 60          `
+
+// $a530 referenced 3 times by $a307, $a45d, $a4c5
+sub_ca530
+    lda #0                                                            // a530: a9 00       ..
+    sta l00bc                                                         // a532: 85 bc       ..
+    sta l00c0                                                         // a534: 85 c0       ..
+    beq ca5ab                                                         // a536: f0 73       .s
+// $a538 referenced 1 time by $a5af
+ca538
+    lda l00c4                                                         // a538: a5 c4       ..
+    tay                                                               // a53a: a8          .
+    cmp l10d0                                                         // a53b: cd d0 10    ...
+    lda l00c5                                                         // a53e: a5 c5       ..
+    sbc #0                                                            // a540: e9 00       ..
+    bcc ca547                                                         // a542: 90 03       ..
+    ldy l10d0                                                         // a544: ac d0 10    ...
+// $a547 referenced 1 time by $a542
+ca547
+    sty l00c1                                                         // a547: 84 c1       ..
+    lda l00c6                                                         // a549: a5 c6       ..
+    sta l00c3                                                         // a54b: 85 c3       ..
+    lda l00c7                                                         // a54d: a5 c7       ..
+    sta l00c2                                                         // a54f: 85 c2       ..
+    lda l10cf                                                         // a551: ad cf 10    ...
+    sta l00bd                                                         // a554: 85 bd       ..
+    lda l10d1                                                         // a556: ad d1 10    ...
+    sta l00cd                                                         // a559: 85 cd       ..
+    jsr sub_ca379                                                     // a55b: 20 79 a3     y.
+    jsr sub_ca5b2                                                     // a55e: 20 b2 a5     ..
+    jsr sub_c8855                                                     // a561: 20 55 88     U.
+    lda l10d2                                                         // a564: ad d2 10    ...
+    sta l00cd                                                         // a567: 85 cd       ..
+    bit l00a8                                                         // a569: 24 a8       $.
+    bpl ca574                                                         // a56b: 10 07       ..
+    jsr sub_ca4e1                                                     // a56d: 20 e1 a4     ..
+    lda #0                                                            // a570: a9 00       ..
+    sta l00a8                                                         // a572: 85 a8       ..
+// $a574 referenced 1 time by $a56b
+ca574
+    lda l00c8                                                         // a574: a5 c8       ..
+    sta l00c3                                                         // a576: 85 c3       ..
+    lda l00c9                                                         // a578: a5 c9       ..
+    sta l00c2                                                         // a57a: 85 c2       ..
+    lda l10cf                                                         // a57c: ad cf 10    ...
+    sta l00bd                                                         // a57f: 85 bd       ..
+    jsr sub_ca384                                                     // a581: 20 84 a3     ..
+    jsr sub_ca5b2                                                     // a584: 20 b2 a5     ..
+    jsr sub_c8862                                                     // a587: 20 62 88     b.
+    lda l00c1                                                         // a58a: a5 c1       ..
+    clc                                                               // a58c: 18          .
+    adc l00c8                                                         // a58d: 65 c8       e.
+    sta l00c8                                                         // a58f: 85 c8       ..
+    bcc ca595                                                         // a591: 90 02       ..
+    inc l00c9                                                         // a593: e6 c9       ..
+// $a595 referenced 1 time by $a591
+ca595
+    lda l00c1                                                         // a595: a5 c1       ..
+    clc                                                               // a597: 18          .
+    adc l00c6                                                         // a598: 65 c6       e.
+    sta l00c6                                                         // a59a: 85 c6       ..
+    bcc ca5a0                                                         // a59c: 90 02       ..
+    inc l00c7                                                         // a59e: e6 c7       ..
+// $a5a0 referenced 1 time by $a59c
+ca5a0
+    sec                                                               // a5a0: 38          8
+    lda l00c4                                                         // a5a1: a5 c4       ..
+    sbc l00c1                                                         // a5a3: e5 c1       ..
+    sta l00c4                                                         // a5a5: 85 c4       ..
+    bcs ca5ab                                                         // a5a7: b0 02       ..
+    dec l00c5                                                         // a5a9: c6 c5       ..
+// $a5ab referenced 2 times by $a536, $a5a7
+ca5ab
+    lda l00c4                                                         // a5ab: a5 c4       ..
+    ora l00c5                                                         // a5ad: 05 c5       ..
+    bne ca538                                                         // a5af: d0 87       ..
+    rts                                                               // a5b1: 60          `
+
+// $a5b2 referenced 2 times by $a55e, $a584
+sub_ca5b2
+    lda #$ff                                                          // a5b2: a9 ff       ..
+    sta l1074                                                         // a5b4: 8d 74 10    .t.
+    sta l1075                                                         // a5b7: 8d 75 10    .u.
+    rts                                                               // a5ba: 60          `
+
+sub_ca5bb
+    lda #0                                                            // a5bb: a9 00       ..
+    beq ca5c4                                                         // a5bd: f0 05       ..
+sub_ca5bf
+    lda #$ff                                                          // a5bf: a9 ff       ..
+    sta l1082                                                         // a5c1: 8d 82 10    ...
+// $a5c4 referenced 1 time by $a5bd
+ca5c4
+    sta l00c9                                                         // a5c4: 85 c9       ..
+    sta l1090                                                         // a5c6: 8d 90 10    ...
+    bpl ca5e5                                                         // a5c9: 10 1a       ..
+    jsr sub_ca14a                                                     // a5cb: 20 4a a1     J.
+    jsr sub_c8456                                                     // a5ce: 20 56 84     V.
+    sta l109f                                                         // a5d1: 8d 9f 10    ...
+    bcs ca5e2                                                         // a5d4: b0 0c       ..
+    cmp #$23 // '#'                                                   // a5d6: c9 23       .#
+    beq ca5e5                                                         // a5d8: f0 0b       ..
+    cmp #$28 // '('                                                   // a5da: c9 28       .(
+    beq ca5e5                                                         // a5dc: f0 07       ..
+    cmp #$50 // 'P'                                                   // a5de: c9 50       .P
+    beq ca5e5                                                         // a5e0: f0 03       ..
+// $a5e2 referenced 1 time by $a5d4
+ca5e2
+    jmp ca14f                                                         // a5e2: 4c 4f a1    LO.
+
+// $a5e5 referenced 4 times by $a5c9, $a5d8, $a5dc, $a5e0
+ca5e5
+    jsr clc_jmp_gsinit                                                // a5e5: 20 4c 87     L.
+    sty l00ca                                                         // a5e8: 84 ca       ..
+    bne ca637                                                         // a5ea: d0 4b       .K
+    bit l00c9                                                         // a5ec: 24 c9       $.
+    bmi ca5fb                                                         // a5ee: 30 0b       0.
+    jsr print_inline_l809f_top_bit_clear                              // a5f0: 20 77 80     w.
+    .asc "Verify"                                                     // a5f3: 56 65 72... Ver
+
+    bcc ca605                                                         // a5f9: 90 0a       ..
+// $a5fb referenced 1 time by $a5ee
+ca5fb
+    jsr print_inline_l809f_top_bit_clear                              // a5fb: 20 77 80     w.
+    .asc "Format"                                                     // a5fe: 46 6f 72... For
+
+    nop                                                               // a604: ea          .
+// $a605 referenced 1 time by $a5f9
+ca605
+    jsr print_inline_l809f_top_bit_clear                              // a605: 20 77 80     w.
+    .asc " which drive ? "                                            // a608: 20 77 68...  wh
+
+    nop                                                               // a617: ea          .
+    jsr osrdch                                                        // a618: 20 e0 ff     ..
+    bcs ca65d                                                         // a61b: b0 40       .@
+    cmp #$20 // ' '                                                   // a61d: c9 20       .
+    bcc ca660                                                         // a61f: 90 3f       .?
+    jsr c809f                                                         // a621: 20 9f 80     ..
+    sec                                                               // a624: 38          8
+    sbc #$30 // '0'                                                   // a625: e9 30       .0
+    bcc ca660                                                         // a627: 90 37       .7
+    cmp #4                                                            // a629: c9 04       ..
+    bcs ca660                                                         // a62b: b0 33       .3
+    sta l00cd                                                         // a62d: 85 cd       ..
+    jsr ca3dc                                                         // a62f: 20 dc a3     ..
+    ldy l00ca                                                         // a632: a4 ca       ..
+    jmp ca63a                                                         // a634: 4c 3a a6    L:.
+
+// $a637 referenced 2 times by $a5ea, $a65a
+ca637
+    jsr c8b8b                                                         // a637: 20 8b 8b     ..
+// $a63a referenced 1 time by $a634
+ca63a
+    sty l00ca                                                         // a63a: 84 ca       ..
+    bit l00c9                                                         // a63c: 24 c9       $.
+    bpl ca647                                                         // a63e: 10 07       ..
+    ldx l00cd                                                         // a640: a6 cd       ..
+    lda #0                                                            // a642: a9 00       ..
+    sta l10de,x                                                       // a644: 9d de 10    ...
+// $a647 referenced 1 time by $a63e
+ca647
+    bit l1090                                                         // a647: 2c 90 10    ,..
+    bpl ca652                                                         // a64a: 10 06       ..
+    jsr sub_ca315                                                     // a64c: 20 15 a3     ..
+    jsr sub_c9a8d                                                     // a64f: 20 8d 9a     ..
+// $a652 referenced 1 time by $a64a
+ca652
+    jsr sub_ca663                                                     // a652: 20 63 a6     c.
+    ldy l00ca                                                         // a655: a4 ca       ..
+    jsr clc_jmp_gsinit                                                // a657: 20 4c 87     L.
+    bne ca637                                                         // a65a: d0 db       ..
+    rts                                                               // a65c: 60          `
+
+// $a65d referenced 1 time by $a61b
+ca65d
+    jmp c9436                                                         // a65d: 4c 36 94    L6.
+
+// $a660 referenced 3 times by $a61f, $a627, $a62b
+ca660
+    jmp c8ba2                                                         // a660: 4c a2 8b    L..
+
+// $a663 referenced 1 time by $a652
+sub_ca663
+    bit l00c9                                                         // a663: 24 c9       $.
+    bmi ca675                                                         // a665: 30 0e       0.
+    jsr print_inline_l809f_top_bit_clear                              // a667: 20 77 80     w.
+    .asc "Verifying"                                                  // a66a: 56 65 72... Ver
+
+    bcc ca68a                                                         // a673: 90 15       ..
+// $a675 referenced 1 time by $a665
+ca675
+    jsr sub_ca76c                                                     // a675: 20 6c a7     l.
+    jsr print_inline_l809f_top_bit_clear                              // a678: 20 77 80     w.
+    .asc "Formatting"                                                 // a67b: 46 6f 72... For
+
+    ldx l00cd                                                         // a685: a6 cd       ..
+    stx l1090                                                         // a687: 8e 90 10    ...
+// $a68a referenced 1 time by $a673
+ca68a
+    jsr print_inline_l809f_top_bit_clear                              // a68a: 20 77 80     w.
+    .asc " drive "                                                    // a68d: 20 64 72...  dr
+
+    lda l00cd                                                         // a694: a5 cd       ..
+    jsr sub_c80c3                                                     // a696: 20 c3 80     ..
+    jsr print_inline_l809f_top_bit_clear                              // a699: 20 77 80     w.
+    .asc " track   "                                                  // a69c: 20 74 72...  tr
+
+    nop                                                               // a6a5: ea          .
+    bit l00c9                                                         // a6a6: 24 c9       $.
+    bmi ca6b6                                                         // a6a8: 30 0c       0.
+    jsr sub_ca7ce                                                     // a6aa: 20 ce a7     ..
+    txa                                                               // a6ad: 8a          .
+    bne ca6b3                                                         // a6ae: d0 03       ..
+    jmp ca3dc                                                         // a6b0: 4c dc a3    L..
+
+// $a6b3 referenced 1 time by $a6ae
+ca6b3
+    sta l109f                                                         // a6b3: 8d 9f 10    ...
+// $a6b6 referenced 1 time by $a6a8
+ca6b6
+    lda #0                                                            // a6b6: a9 00       ..
+    sta l1097                                                         // a6b8: 8d 97 10    ...
+// $a6bb referenced 1 time by $a731
+ca6bb
+    lda #8                                                            // a6bb: a9 08       ..
+    jsr c809f                                                         // a6bd: 20 9f 80     ..
+    jsr c809f                                                         // a6c0: 20 9f 80     ..
+    lda l1097                                                         // a6c3: ad 97 10    ...
+    jsr sub_c80bb                                                     // a6c6: 20 bb 80     ..
+    lda #6                                                            // a6c9: a9 06       ..
+    sta l109d                                                         // a6cb: 8d 9d 10    ...
+// $a6ce referenced 1 time by $a708
+ca6ce
+    jsr sub_ca73d                                                     // a6ce: 20 3d a7     =.
+    bit l00c9                                                         // a6d1: 24 c9       $.
+    bpl ca6e2                                                         // a6d3: 10 0d       ..
+    jsr sub_ca788                                                     // a6d5: 20 88 a7     ..
+    ldx #$90                                                          // a6d8: a2 90       ..
+    ldy #$10                                                          // a6da: a0 10       ..
+    jsr c91af                                                         // a6dc: 20 af 91     ..
+    tax                                                               // a6df: aa          .
+    bne ca70a                                                         // a6e0: d0 28       .(
+// $a6e2 referenced 1 time by $a6d3
+ca6e2
+    lda #0                                                            // a6e2: a9 00       ..
+    sta l1098                                                         // a6e4: 8d 98 10    ...
+    lda l1099                                                         // a6e7: ad 99 10    ...
+    and #$1f                                                          // a6ea: 29 1f       ).
+    sta l1099                                                         // a6ec: 8d 99 10    ...
+    lda #3                                                            // a6ef: a9 03       ..
+    sta l1095                                                         // a6f1: 8d 95 10    ...
+    lda #$5f // '_'                                                   // a6f4: a9 5f       ._
+    sta l1096                                                         // a6f6: 8d 96 10    ...
+    jsr sub_c9432                                                     // a6f9: 20 32 94     2.
+    ldx #$90                                                          // a6fc: a2 90       ..
+    ldy #$10                                                          // a6fe: a0 10       ..
+    jsr c91af                                                         // a700: 20 af 91     ..
+    beq ca712                                                         // a703: f0 0d       ..
+    dec l109d                                                         // a705: ce 9d 10    ...
+    bne ca6ce                                                         // a708: d0 c4       ..
+// $a70a referenced 1 time by $a6e0
+ca70a
+    jsr print_inline_l809f_top_bit_clear                              // a70a: 20 77 80     w.
+    .asc "?"                                                          // a70d: 3f          ?
+
+    nop                                                               // a70e: ea          .
+    jmp c94c2                                                         // a70f: 4c c2 94    L..
+
+// $a712 referenced 1 time by $a703
+ca712
+    lda l109d                                                         // a712: ad 9d 10    ...
+    cmp #6                                                            // a715: c9 06       ..
+    beq ca721                                                         // a717: f0 08       ..
+    jsr print_inline_l809f_top_bit_clear                              // a719: 20 77 80     w.
+    .asc "?   "                                                       // a71c: 3f 20 20... ?
+
+    nop                                                               // a720: ea          .
+// $a721 referenced 1 time by $a717
+ca721
+    bit l00c9                                                         // a721: 24 c9       $.
+    bpl ca728                                                         // a723: 10 03       ..
+    jsr sub_ca779                                                     // a725: 20 79 a7     y.
+// $a728 referenced 1 time by $a723
+ca728
+    inc l1097                                                         // a728: ee 97 10    ...
+    lda l1097                                                         // a72b: ad 97 10    ...
+    cmp l109f                                                         // a72e: cd 9f 10    ...
+    bne ca6bb                                                         // a731: d0 88       ..
+    bit l00c9                                                         // a733: 24 c9       $.
+    bpl ca73a                                                         // a735: 10 03       ..
+    jsr sub_c93f1                                                     // a737: 20 f1 93     ..
+// $a73a referenced 1 time by $a735
+ca73a
+    jmp ca3dc                                                         // a73a: 4c dc a3    L..
+
+// $a73d referenced 1 time by $a6ce
+sub_ca73d
+    ldx #0                                                            // a73d: a2 00       ..
+    stx l1091                                                         // a73f: 8e 91 10    ...
+    stx l109a                                                         // a742: 8e 9a 10    ...
+    dex                                                               // a745: ca          .
+    stx l1093                                                         // a746: 8e 93 10    ...
+    stx l1094                                                         // a749: 8e 94 10    ...
+    lda l10cf                                                         // a74c: ad cf 10    ...
+    sta l1092                                                         // a74f: 8d 92 10    ...
+    lda #5                                                            // a752: a9 05       ..
+    sta l1095                                                         // a754: 8d 95 10    ...
+    lda #$63 // 'c'                                                   // a757: a9 63       .c
+    sta l1096                                                         // a759: 8d 96 10    ...
+    lda #$2a // '*'                                                   // a75c: a9 2a       .*
+    sta l1099                                                         // a75e: 8d 99 10    ...
+    ldx #$10                                                          // a761: a2 10       ..
+    ldy #$13                                                          // a763: a0 13       ..
+    stx l109b                                                         // a765: 8e 9b 10    ...
+    sty l1098                                                         // a768: 8c 98 10    ...
+    rts                                                               // a76b: 60          `
+
+// $a76c referenced 1 time by $a675
+sub_ca76c
+    lda #0                                                            // a76c: a9 00       ..
+    tay                                                               // a76e: a8          .
+// $a76f referenced 1 time by $a776
+loop_ca76f
+    sta l0e00,y                                                       // a76f: 99 00 0e    ...
+    sta l0f00,y                                                       // a772: 99 00 0f    ...
+    iny                                                               // a775: c8          .
+    bne loop_ca76f                                                    // a776: d0 f7       ..
+    rts                                                               // a778: 60          `
+
+// $a779 referenced 1 time by $a725
+sub_ca779
+    lda #$0a                                                          // a779: a9 0a       ..
+    clc                                                               // a77b: 18          .
+    adc l0f07                                                         // a77c: 6d 07 0f    m..
+    sta l0f07                                                         // a77f: 8d 07 0f    ...
+    bcc ca787                                                         // a782: 90 03       ..
+    inc l0f06                                                         // a784: ee 06 0f    ...
+// $a787 referenced 1 time by $a782
+ca787
+    rts                                                               // a787: 60          `
+
+// $a788 referenced 1 time by $a6d5
+sub_ca788
+    lda #0                                                            // a788: a9 00       ..
+    sta l00b0                                                         // a78a: 85 b0       ..
+    lda l10cf                                                         // a78c: ad cf 10    ...
+    sta l00b1                                                         // a78f: 85 b1       ..
+    lda #$0a                                                          // a791: a9 0a       ..
+    sta l00b2                                                         // a793: 85 b2       ..
+    lda l1097                                                         // a795: ad 97 10    ...
+    beq ca7a4                                                         // a798: f0 0a       ..
+    ldy #2                                                            // a79a: a0 02       ..
+    lda (l00b0),y                                                     // a79c: b1 b0       ..
+    clc                                                               // a79e: 18          .
+    adc #7                                                            // a79f: 69 07       i.
+    jsr sub_ca7c5                                                     // a7a1: 20 c5 a7     ..
+// $a7a4 referenced 1 time by $a798
+ca7a4
+    tax                                                               // a7a4: aa          .
+    ldy #0                                                            // a7a5: a0 00       ..
+// $a7a7 referenced 1 time by $a7c1
+loop_ca7a7
+    lda l1097                                                         // a7a7: ad 97 10    ...
+    sta (l00b0),y                                                     // a7aa: 91 b0       ..
+    iny                                                               // a7ac: c8          .
+    lda #0                                                            // a7ad: a9 00       ..
+    sta (l00b0),y                                                     // a7af: 91 b0       ..
+    iny                                                               // a7b1: c8          .
+    txa                                                               // a7b2: 8a          .
+    sta (l00b0),y                                                     // a7b3: 91 b0       ..
+    iny                                                               // a7b5: c8          .
+    lda #1                                                            // a7b6: a9 01       ..
+    sta (l00b0),y                                                     // a7b8: 91 b0       ..
+    iny                                                               // a7ba: c8          .
+    inx                                                               // a7bb: e8          .
+    jsr sub_ca7c4                                                     // a7bc: 20 c4 a7     ..
+    dec l00b2                                                         // a7bf: c6 b2       ..
+    bne loop_ca7a7                                                    // a7c1: d0 e4       ..
+    rts                                                               // a7c3: 60          `
+
+// $a7c4 referenced 1 time by $a7bc
+sub_ca7c4
+    txa                                                               // a7c4: 8a          .
+// $a7c5 referenced 1 time by $a7a1
+sub_ca7c5
+    sec                                                               // a7c5: 38          8
+// $a7c6 referenced 1 time by $a7c8
+loop_ca7c6
+    sbc #$0a                                                          // a7c6: e9 0a       ..
+    bcs loop_ca7c6                                                    // a7c8: b0 fc       ..
+    adc #$0a                                                          // a7ca: 69 0a       i.
+    tax                                                               // a7cc: aa          .
+    rts                                                               // a7cd: 60          `
+
+// $a7ce referenced 1 time by $a6aa
+sub_ca7ce
+    jsr sub_c93f5                                                     // a7ce: 20 f5 93     ..
+    lda l0f06                                                         // a7d1: ad 06 0f    ...
+    and #3                                                            // a7d4: 29 03       ).
+    tax                                                               // a7d6: aa          .
+    lda l0f07                                                         // a7d7: ad 07 0f    ...
+    ldy #$0a                                                          // a7da: a0 0a       ..
+    sty l00b0                                                         // a7dc: 84 b0       ..
+    ldy #$ff                                                          // a7de: a0 ff       ..
+// $a7e0 referenced 1 time by $a7e7
+loop_ca7e0
+    sec                                                               // a7e0: 38          8
+// $a7e1 referenced 1 time by $a7e4
+loop_ca7e1
+    iny                                                               // a7e1: c8          .
+    sbc l00b0                                                         // a7e2: e5 b0       ..
+    bcs loop_ca7e1                                                    // a7e4: b0 fb       ..
+    dex                                                               // a7e6: ca          .
+    bpl loop_ca7e0                                                    // a7e7: 10 f7       ..
+    adc l00b0                                                         // a7e9: 65 b0       e.
+    pha                                                               // a7eb: 48          H
+    tya                                                               // a7ec: 98          .
+    tax                                                               // a7ed: aa          .
+    pla                                                               // a7ee: 68          h
+    beq ca7f2                                                         // a7ef: f0 01       ..
+    inx                                                               // a7f1: e8          .
+// $a7f2 referenced 1 time by $a7ef
+ca7f2
+    rts                                                               // a7f2: 60          `
+
+sub_ca7f3
+    sec                                                               // a7f3: 38          8
+    bcs ca7f7                                                         // a7f4: b0 01       ..
+sub_ca7f6
+    clc                                                               // a7f6: 18          .
+// $a7f7 referenced 1 time by $a7f4
+ca7f7
+    ror l00c6                                                         // a7f7: 66 c6       f.
+    jsr sub_c8b86                                                     // a7f9: 20 86 8b     ..
+    jsr sub_c8380                                                     // a7fc: 20 80 83     ..
+    bit l00c6                                                         // a7ff: 24 c6       $.
+    bmi ca818                                                         // a801: 30 15       0.
+    jsr print_inline_osasci_top_bit_clear                             // a803: 20 9c a9     ..
+    .asc "Address :  Length", $0d                                     // a806: 41 64 64... Add
+
+// $a818 referenced 1 time by $a801
+ca818
+    lda l0f06                                                         // a818: ad 06 0f    ...
+    and #3                                                            // a81b: 29 03       ).
+    sta l00c5                                                         // a81d: 85 c5       ..
+    sta l00c2                                                         // a81f: 85 c2       ..
+    lda l0f07                                                         // a821: ad 07 0f    ...
+    sta l00c4                                                         // a824: 85 c4       ..
+    sec                                                               // a826: 38          8
+    sbc #2                                                            // a827: e9 02       ..
+    sta l00c1                                                         // a829: 85 c1       ..
+    bcs ca82f                                                         // a82b: b0 02       ..
+    dec l00c2                                                         // a82d: c6 c2       ..
+// $a82f referenced 1 time by $a82b
+ca82f
+    lda #2                                                            // a82f: a9 02       ..
+    sta l00bb                                                         // a831: 85 bb       ..
+    lda #0                                                            // a833: a9 00       ..
+    sta l00bc                                                         // a835: 85 bc       ..
+    sta l00bf                                                         // a837: 85 bf       ..
+    sta l00c0                                                         // a839: 85 c0       ..
+    lda l0f05                                                         // a83b: ad 05 0f    ...
+    and #$f8                                                          // a83e: 29 f8       ).
+    tay                                                               // a840: a8          .
+    beq ca86b                                                         // a841: f0 28       .(
+    bne ca856                                                         // a843: d0 11       ..
+// $a845 referenced 2 times by $a869, $a889
+ca845
+    jsr sub_ca8e2                                                     // a845: 20 e2 a8     ..
+    jsr sub_c82b2                                                     // a848: 20 b2 82     ..
+    lda l00c4                                                         // a84b: a5 c4       ..
+    sec                                                               // a84d: 38          8
+    sbc l00bb                                                         // a84e: e5 bb       ..
+    lda l00c5                                                         // a850: a5 c5       ..
+    sbc l00bc                                                         // a852: e5 bc       ..
+    bcc ca86b                                                         // a854: 90 15       ..
+// $a856 referenced 1 time by $a843
+ca856
+    lda l0f07,y                                                       // a856: b9 07 0f    ...
+    sec                                                               // a859: 38          8
+    sbc l00bb                                                         // a85a: e5 bb       ..
+    sta l00c1                                                         // a85c: 85 c1       ..
+    php                                                               // a85e: 08          .
+    lda l0f06,y                                                       // a85f: b9 06 0f    ...
+    and #3                                                            // a862: 29 03       ).
+    plp                                                               // a864: 28          (
+    sbc l00bc                                                         // a865: e5 bc       ..
+    sta l00c2                                                         // a867: 85 c2       ..
+    bcc ca845                                                         // a869: 90 da       ..
+// $a86b referenced 2 times by $a841, $a854
+ca86b
+    sty l00bd                                                         // a86b: 84 bd       ..
+    bit l00c6                                                         // a86d: 24 c6       $.
+    bmi ca87a                                                         // a86f: 30 09       0.
+    lda l00c1                                                         // a871: a5 c1       ..
+    ora l00c2                                                         // a873: 05 c2       ..
+    beq ca87a                                                         // a875: f0 03       ..
+    jsr sub_ca8be                                                     // a877: 20 be a8     ..
+// $a87a referenced 2 times by $a86f, $a875
+ca87a
+    lda l00c1                                                         // a87a: a5 c1       ..
+    clc                                                               // a87c: 18          .
+    adc l00bf                                                         // a87d: 65 bf       e.
+    sta l00bf                                                         // a87f: 85 bf       ..
+    lda l00c2                                                         // a881: a5 c2       ..
+    adc l00c0                                                         // a883: 65 c0       e.
+    sta l00c0                                                         // a885: 85 c0       ..
+    ldy l00bd                                                         // a887: a4 bd       ..
+    bne ca845                                                         // a889: d0 ba       ..
+    bit l00c6                                                         // a88b: 24 c6       $.
+    bpl ca8bd                                                         // a88d: 10 2e       ..
+    tay                                                               // a88f: a8          .
+    ldx l00bf                                                         // a890: a6 bf       ..
+    lda #$f8                                                          // a892: a9 f8       ..
+    sec                                                               // a894: 38          8
+    sbc l0f05                                                         // a895: ed 05 0f    ...
+    jsr sub_ca90d                                                     // a898: 20 0d a9     ..
+    jsr print_inline_osasci_top_bit_clear                             // a89b: 20 9c a9     ..
+    .asc "Free", $0d                                                  // a89e: 46 72 65... Fre
+
+    lda l00c4                                                         // a8a3: a5 c4       ..
+    sec                                                               // a8a5: 38          8
+    sbc l00bf                                                         // a8a6: e5 bf       ..
+    tax                                                               // a8a8: aa          .
+    lda l00c5                                                         // a8a9: a5 c5       ..
+    sbc l00c0                                                         // a8ab: e5 c0       ..
+    tay                                                               // a8ad: a8          .
+    lda l0f05                                                         // a8ae: ad 05 0f    ...
+    jsr sub_ca90d                                                     // a8b1: 20 0d a9     ..
+    jsr print_inline_osasci_top_bit_clear                             // a8b4: 20 9c a9     ..
+    .asc "Used", $0d                                                  // a8b7: 55 73 65... Use
+
+    nop                                                               // a8bc: ea          .
+// $a8bd referenced 1 time by $a88d
+ca8bd
+    rts                                                               // a8bd: 60          `
+
+// $a8be referenced 1 time by $a877
+sub_ca8be
+    lda l00bc                                                         // a8be: a5 bc       ..
+    jsr sub_ca9ca                                                     // a8c0: 20 ca a9     ..
+    lda l00bb                                                         // a8c3: a5 bb       ..
+    jsr sub_ca9c2                                                     // a8c5: 20 c2 a9     ..
+    jsr print_inline_osasci_top_bit_clear                             // a8c8: 20 9c a9     ..
+    .asc "     :  "                                                   // a8cb: 20 20 20...
+
+    lda l00c2                                                         // a8d3: a5 c2       ..
+    jsr sub_ca9ca                                                     // a8d5: 20 ca a9     ..
+    lda l00c1                                                         // a8d8: a5 c1       ..
+    jsr sub_ca9c2                                                     // a8da: 20 c2 a9     ..
+    lda #$0d                                                          // a8dd: a9 0d       ..
+    jsr osasci                                                        // a8df: 20 e3 ff     ..
+// $a8e2 referenced 1 time by $a845
+sub_ca8e2
+    lda l0f06,y                                                       // a8e2: b9 06 0f    ...
+    pha                                                               // a8e5: 48          H
+    jsr sub_c81b0                                                     // a8e6: 20 b0 81     ..
+    sta l00bc                                                         // a8e9: 85 bc       ..
+    pla                                                               // a8eb: 68          h
+    and #3                                                            // a8ec: 29 03       ).
+    clc                                                               // a8ee: 18          .
+    adc l00bc                                                         // a8ef: 65 bc       e.
+    sta l00bc                                                         // a8f1: 85 bc       ..
+    lda l0f04,y                                                       // a8f3: b9 04 0f    ...
+    beq ca8fa                                                         // a8f6: f0 02       ..
+    lda #1                                                            // a8f8: a9 01       ..
+// $a8fa referenced 1 time by $a8f6
+ca8fa
+    clc                                                               // a8fa: 18          .
+    adc l0f05,y                                                       // a8fb: 79 05 0f    y..
+    bcc ca902                                                         // a8fe: 90 02       ..
+    inc l00bc                                                         // a900: e6 bc       ..
+// $a902 referenced 1 time by $a8fe
+ca902
+    clc                                                               // a902: 18          .
+    adc l0f07,y                                                       // a903: 79 07 0f    y..
+    sta l00bb                                                         // a906: 85 bb       ..
+    bcc ca90c                                                         // a908: 90 02       ..
+    inc l00bc                                                         // a90a: e6 bc       ..
+// $a90c referenced 1 time by $a908
+ca90c
+    rts                                                               // a90c: 60          `
+
+// $a90d referenced 2 times by $a898, $a8b1
+sub_ca90d
+    jsr sub_c81c0                                                     // a90d: 20 c0 81     ..
+    jsr sub_ca9bf                                                     // a910: 20 bf a9     ..
+    jsr print_inline_osasci_top_bit_clear                             // a913: 20 9c a9     ..
+    .asc " Files "                                                    // a916: 20 46 69...  Fi
+
+    stx l00bc                                                         // a91d: 86 bc       ..
+    sty l00bd                                                         // a91f: 84 bd       ..
+    tya                                                               // a921: 98          .
+    jsr sub_ca9ca                                                     // a922: 20 ca a9     ..
+    txa                                                               // a925: 8a          .
+    jsr sub_ca9c2                                                     // a926: 20 c2 a9     ..
+    jsr print_inline_osasci_top_bit_clear                             // a929: 20 9c a9     ..
+    .asc " Sectors "                                                  // a92c: 20 53 65...  Se
+
+    lda #0                                                            // a935: a9 00       ..
+    sta l00bb                                                         // a937: 85 bb       ..
+    sta l00be                                                         // a939: 85 be       ..
+    ldx #$1f                                                          // a93b: a2 1f       ..
+    stx l00c1                                                         // a93d: 86 c1       ..
+    ldx #9                                                            // a93f: a2 09       ..
+// $a941 referenced 1 time by $a945
+loop_ca941
+    sta l1000,x                                                       // a941: 9d 00 10    ...
+    dex                                                               // a944: ca          .
+    bpl loop_ca941                                                    // a945: 10 fa       ..
+// $a947 referenced 1 time by $a966
+loop_ca947
+    asl l00bb                                                         // a947: 06 bb       ..
+    rol l00bc                                                         // a949: 26 bc       &.
+    rol l00bd                                                         // a94b: 26 bd       &.
+    rol l00be                                                         // a94d: 26 be       &.
+    ldx #0                                                            // a94f: a2 00       ..
+    ldy #9                                                            // a951: a0 09       ..
+// $a953 referenced 1 time by $a962
+loop_ca953
+    lda l1000,x                                                       // a953: bd 00 10    ...
+    rol                                                               // a956: 2a          *
+    cmp #$0a                                                          // a957: c9 0a       ..
+    bcc ca95d                                                         // a959: 90 02       ..
+    sbc #$0a                                                          // a95b: e9 0a       ..
+// $a95d referenced 1 time by $a959
+ca95d
+    sta l1000,x                                                       // a95d: 9d 00 10    ...
+    inx                                                               // a960: e8          .
+    dey                                                               // a961: 88          .
+    bpl loop_ca953                                                    // a962: 10 ef       ..
+    dec l00c1                                                         // a964: c6 c1       ..
+    bpl loop_ca947                                                    // a966: 10 df       ..
+    ldy #$20 // ' '                                                   // a968: a0 20       .
+    ldx #5                                                            // a96a: a2 05       ..
+// $a96c referenced 1 time by $a98e
+ca96c
+    bne ca970                                                         // a96c: d0 02       ..
+    ldy #$2c // ','                                                   // a96e: a0 2c       .,
+// $a970 referenced 1 time by $a96c
+ca970
+    lda l1000,x                                                       // a970: bd 00 10    ...
+    bne ca97d                                                         // a973: d0 08       ..
+    cpy #$2c // ','                                                   // a975: c0 2c       .,
+    beq ca97d                                                         // a977: f0 04       ..
+    lda #$20 // ' '                                                   // a979: a9 20       .
+    bne ca982                                                         // a97b: d0 05       ..
+// $a97d referenced 2 times by $a973, $a977
+ca97d
+    ldy #$2c // ','                                                   // a97d: a0 2c       .,
+    clc                                                               // a97f: 18          .
+    adc #'0'                                                          // a980: 69 30       i0
+// $a982 referenced 1 time by $a97b
+ca982
+    jsr osasci                                                        // a982: 20 e3 ff     ..
+    cpx #3                                                            // a985: e0 03       ..
+    bne ca98d                                                         // a987: d0 04       ..
+    tya                                                               // a989: 98          .
+    jsr osasci                                                        // a98a: 20 e3 ff     ..
+// $a98d referenced 1 time by $a987
+ca98d
+    dex                                                               // a98d: ca          .
+    bpl ca96c                                                         // a98e: 10 dc       ..
+    jsr print_inline_osasci_top_bit_clear                             // a990: 20 9c a9     ..
+    .asc " Bytes "                                                    // a993: 20 42 79...  By
+
+    nop                                                               // a99a: ea          .
+    rts                                                               // a99b: 60          `
+
+// $a99c referenced 7 times by $a803, $a89b, $a8b4, $a8c8, $a913, $a929, $a990
+print_inline_osasci_top_bit_clear
+    sta l00b3                                                         // a99c: 85 b3       ..
+    pla                                                               // a99e: 68          h
+    sta l00ae                                                         // a99f: 85 ae       ..
+    pla                                                               // a9a1: 68          h
+    sta l00af                                                         // a9a2: 85 af       ..
+    lda l00b3                                                         // a9a4: a5 b3       ..
+    pha                                                               // a9a6: 48          H
+    tya                                                               // a9a7: 98          .
+    pha                                                               // a9a8: 48          H
+    ldy #0                                                            // a9a9: a0 00       ..
+// $a9ab referenced 1 time by $a9b5
+loop_ca9ab
+    jsr inc16_ae                                                      // a9ab: 20 dc 83     ..
+    lda (l00ae),y                                                     // a9ae: b1 ae       ..
+    bmi ca9b8                                                         // a9b0: 30 06       0.
+    jsr osasci                                                        // a9b2: 20 e3 ff     ..
+    jmp loop_ca9ab                                                    // a9b5: 4c ab a9    L..
+
+// $a9b8 referenced 1 time by $a9b0
+ca9b8
+    pla                                                               // a9b8: 68          h
+    tay                                                               // a9b9: a8          .
+    pla                                                               // a9ba: 68          h
+    clc                                                               // a9bb: 18          .
+    jmp (l00ae)                                                       // a9bc: 6c ae 00    l..
+
+// $a9bf referenced 1 time by $a910
+sub_ca9bf
+    jsr sub_c841b                                                     // a9bf: 20 1b 84     ..
+// $a9c2 referenced 3 times by $a8c5, $a8da, $a926
+sub_ca9c2
+    pha                                                               // a9c2: 48          H
+    jsr sub_c81bf                                                     // a9c3: 20 bf 81     ..
+    jsr sub_ca9ca                                                     // a9c6: 20 ca a9     ..
+    pla                                                               // a9c9: 68          h
+// $a9ca referenced 4 times by $a8c0, $a8d5, $a922, $a9c6
+sub_ca9ca
+    jsr sub_c80c8                                                     // a9ca: 20 c8 80     ..
+    jmp osasci                                                        // a9cd: 4c e3 ff    L..
+
+sub_ca9d0
+    lda #0                                                            // a9d0: a9 00       ..
+    sta l00a8                                                         // a9d2: 85 a8       ..
+    jsr sub_caaea                                                     // a9d4: 20 ea aa     ..
+    lda #$0f                                                          // a9d7: a9 0f       ..
+    sta l00aa                                                         // a9d9: 85 aa       ..
+    jsr sub_caadd                                                     // a9db: 20 dd aa     ..
+    sec                                                               // a9de: 38          8
+    jsr gsinit                                                        // a9df: 20 c2 ff     ..
+    sty l00ab                                                         // a9e2: 84 ab       ..
+    clc                                                               // a9e4: 18          .
+    beq ca9ff                                                         // a9e5: f0 18       ..
+// $a9e7 referenced 1 time by $a9fc
+loop_ca9e7
+    jsr sub_c8456                                                     // a9e7: 20 56 84     V.
+    bcs ca9ff                                                         // a9ea: b0 13       ..
+    sty l00ab                                                         // a9ec: 84 ab       ..
+    and #$0f                                                          // a9ee: 29 0f       ).
+    sta l00aa                                                         // a9f0: 85 aa       ..
+    jsr sub_caa53                                                     // a9f2: 20 53 aa     S.
+    ldy l00ab                                                         // a9f5: a4 ab       ..
+    jsr clc_jmp_gsinit                                                // a9f7: 20 4c 87     L.
+    sty l00ab                                                         // a9fa: 84 ab       ..
+    bne loop_ca9e7                                                    // a9fc: d0 e9       ..
+    rts                                                               // a9fe: 60          `
+
+// $a9ff referenced 2 times by $a9e5, $a9ea
+ca9ff
+    ror l00a8                                                         // a9ff: 66 a8       f.
+// $aa01 referenced 1 time by $aa0f
+loop_caa01
+    bit l00a8                                                         // aa01: 24 a8       $.
+    bpl caa0a                                                         // aa03: 10 05       ..
+    jsr sub_caa12                                                     // aa05: 20 12 aa     ..
+    bcc caa0d                                                         // aa08: 90 03       ..
+// $aa0a referenced 1 time by $aa03
+caa0a
+    jsr sub_caa53                                                     // aa0a: 20 53 aa     S.
+// $aa0d referenced 1 time by $aa08
+caa0d
+    dec l00aa                                                         // aa0d: c6 aa       ..
+    bpl loop_caa01                                                    // aa0f: 10 f0       ..
+    rts                                                               // aa11: 60          `
+
+// $aa12 referenced 1 time by $aa05
+sub_caa12
+    lda #9                                                            // aa12: a9 09       ..
+    sta osrdsc_ptr                                                    // aa14: 85 f6       ..
+    lda #$80                                                          // aa16: a9 80       ..
+    sta l00f7                                                         // aa18: 85 f7       ..
+    ldy l00ab                                                         // aa1a: a4 ab       ..
+// $aa1c referenced 2 times by $aa39, $aa40
+caa1c
+    lda (os_text_ptr),y                                               // aa1c: b1 f2       ..
+    cmp #$0d                                                          // aa1e: c9 0d       ..
+    beq caa44                                                         // aa20: f0 22       ."
+    cmp #$22 // '"'                                                   // aa22: c9 22       ."
+    beq caa44                                                         // aa24: f0 1e       ..
+    iny                                                               // aa26: c8          .
+    cmp #$2a // '*'                                                   // aa27: c9 2a       .*
+    beq caa51                                                         // aa29: f0 26       .&
+    jsr sub_c82fe                                                     // aa2b: 20 fe 82     ..
+    sta l00ae                                                         // aa2e: 85 ae       ..
+    jsr sub_caacf                                                     // aa30: 20 cf aa     ..
+    beq caa42                                                         // aa33: f0 0d       ..
+    ldx l00ae                                                         // aa35: a6 ae       ..
+    cpx #$23 // '#'                                                   // aa37: e0 23       .#
+    beq caa1c                                                         // aa39: f0 e1       ..
+    jsr sub_c82fe                                                     // aa3b: 20 fe 82     ..
+    cmp l00ae                                                         // aa3e: c5 ae       ..
+    beq caa1c                                                         // aa40: f0 da       ..
+// $aa42 referenced 3 times by $aa33, $aa4f, $aa57
+caa42
+    clc                                                               // aa42: 18          .
+    rts                                                               // aa43: 60          `
+
+// $aa44 referenced 3 times by $aa20, $aa24, $aa4b
+caa44
+    jsr sub_caacf                                                     // aa44: 20 cf aa     ..
+    beq caa51                                                         // aa47: f0 08       ..
+    cmp #$20 // ' '                                                   // aa49: c9 20       .
+    beq caa44                                                         // aa4b: f0 f7       ..
+    cmp #$0d                                                          // aa4d: c9 0d       ..
+    bne caa42                                                         // aa4f: d0 f1       ..
+// $aa51 referenced 2 times by $aa29, $aa47
+caa51
+    sec                                                               // aa51: 38          8
+    rts                                                               // aa52: 60          `
+
+// $aa53 referenced 2 times by $a9f2, $aa0a
+sub_caa53
+    ldy l00aa                                                         // aa53: a4 aa       ..
+    lda (l00b4),y                                                     // aa55: b1 b4       ..
+    beq caa42                                                         // aa57: f0 e9       ..
+    pha                                                               // aa59: 48          H
+    jsr print_inline_l809f_top_bit_clear                              // aa5a: 20 77 80     w.
+    .asc "Rom "                                                       // aa5d: 52 6f 6d... Rom
+
+    tya                                                               // aa61: 98          .
+    jsr sub_c80b8                                                     // aa62: 20 b8 80     ..
+    jsr print_inline_l809f_top_bit_clear                              // aa65: 20 77 80     w.
+    .asc " : "                                                        // aa68: 20 3a 20     :
+
+    lda #$28 // '('                                                   // aa6b: a9 28       .(
+    jsr c809f                                                         // aa6d: 20 9f 80     ..
+    pla                                                               // aa70: 68          h
+    pha                                                               // aa71: 48          H
+    bmi caa78                                                         // aa72: 30 04       0.
+    ldy #$20 // ' '                                                   // aa74: a0 20       .
+    bne caa7a                                                         // aa76: d0 02       ..
+// $aa78 referenced 1 time by $aa72
+caa78
+    ldy #$53 // 'S'                                                   // aa78: a0 53       .S
+// $aa7a referenced 1 time by $aa76
+caa7a
+    tya                                                               // aa7a: 98          .
+    jsr c809f                                                         // aa7b: 20 9f 80     ..
+    pla                                                               // aa7e: 68          h
+    ldy #$20 // ' '                                                   // aa7f: a0 20       .
+    asl                                                               // aa81: 0a          .
+    bpl caa86                                                         // aa82: 10 02       ..
+    ldy #$4c // 'L'                                                   // aa84: a0 4c       .L
+// $aa86 referenced 1 time by $aa82
+caa86
+    tya                                                               // aa86: 98          .
+    jsr c809f                                                         // aa87: 20 9f 80     ..
+    lda #$29 // ')'                                                   // aa8a: a9 29       .)
+    jsr c809f                                                         // aa8c: 20 9f 80     ..
+    jsr cac0f                                                         // aa8f: 20 0f ac     ..
+    jsr sub_caa9a                                                     // aa92: 20 9a aa     ..
+    jsr ca3dc                                                         // aa95: 20 dc a3     ..
+    sec                                                               // aa98: 38          8
+    rts                                                               // aa99: 60          `
+
+// $aa9a referenced 1 time by $aa92
+sub_caa9a
+    lda #7                                                            // aa9a: a9 07       ..
+    sta osrdsc_ptr                                                    // aa9c: 85 f6       ..
+    lda #$80                                                          // aa9e: a9 80       ..
+    sta l00f7                                                         // aaa0: 85 f7       ..
+    jsr sub_caacf                                                     // aaa2: 20 cf aa     ..
+    sta l00ae                                                         // aaa5: 85 ae       ..
+    inc osrdsc_ptr                                                    // aaa7: e6 f6       ..
+    ldy #$1e                                                          // aaa9: a0 1e       ..
+    jsr sub_caac2                                                     // aaab: 20 c2 aa     ..
+    bcs caab7                                                         // aaae: b0 07       ..
+    jsr cac0f                                                         // aab0: 20 0f ac     ..
+    dey                                                               // aab3: 88          .
+    jsr sub_caac2                                                     // aab4: 20 c2 aa     ..
+// $aab7 referenced 1 time by $aaae
+caab7
+    rts                                                               // aab7: 60          `
+
+// $aab8 referenced 1 time by $aacb
+loop_caab8
+    cmp #$20 // ' '                                                   // aab8: c9 20       .
+    bcs caabe                                                         // aaba: b0 02       ..
+    lda #$20 // ' '                                                   // aabc: a9 20       .
+// $aabe referenced 1 time by $aaba
+caabe
+    jsr c809f                                                         // aabe: 20 9f 80     ..
+    dey                                                               // aac1: 88          .
+// $aac2 referenced 2 times by $aaab, $aab4
+sub_caac2
+    lda osrdsc_ptr                                                    // aac2: a5 f6       ..
+    cmp l00ae                                                         // aac4: c5 ae       ..
+    bcs caace                                                         // aac6: b0 06       ..
+    jsr sub_caacf                                                     // aac8: 20 cf aa     ..
+    bne loop_caab8                                                    // aacb: d0 eb       ..
+    clc                                                               // aacd: 18          .
+// $aace referenced 1 time by $aac6
+caace
+    rts                                                               // aace: 60          `
+
+// $aacf referenced 4 times by $aa30, $aa44, $aaa2, $aac8
+sub_caacf
+    tya                                                               // aacf: 98          .
+    pha                                                               // aad0: 48          H
+    ldy l00aa                                                         // aad1: a4 aa       ..
+    jsr osrdsc                                                        // aad3: 20 b9 ff     ..
+    inc osrdsc_ptr                                                    // aad6: e6 f6       ..
+    tax                                                               // aad8: aa          .
+    pla                                                               // aad9: 68          h
+    tay                                                               // aada: a8          .
+    txa                                                               // aadb: 8a          .
+    rts                                                               // aadc: 60          `
+
+// $aadd referenced 1 time by $a9db
+sub_caadd
+    jsr sub_c840c                                                     // aadd: 20 0c 84     ..
+    lda #$aa                                                          // aae0: a9 aa       ..
+    jsr osbyte_read                                                   // aae2: 20 e5 9a     ..
+    stx l00b4                                                         // aae5: 86 b4       ..
+    sty l00b5                                                         // aae7: 84 b5       ..
+    rts                                                               // aae9: 60          `
+
+// $aaea referenced 1 time by $a9d4
+sub_caaea
+    tsx                                                               // aaea: ba          .
+    lda #0                                                            // aaeb: a9 00       ..
+    sta l0107,x                                                       // aaed: 9d 07 01    ...
+    rts                                                               // aaf0: 60          `
+
+// $aaf1 referenced 2 times by $ab51, $abd5
+sub_caaf1
+    ldx romsel_copy                                                   // aaf1: a6 f4       ..
+    lda l0df0,x                                                       // aaf3: bd f0 0d    ...
+    and #$3f // '?'                                                   // aaf6: 29 3f       )?
+    sta l00ad                                                         // aaf8: 85 ad       ..
+    inc l00ad                                                         // aafa: e6 ad       ..
+    rts                                                               // aafc: 60          `
+
+sub_caafd
+    jsr sub_cac18                                                     // aafd: 20 18 ac     ..
+    lda #0                                                            // ab00: a9 00       ..
+    beq cab09                                                         // ab02: f0 05       ..
+sub_cab04
+    jsr sub_cac18                                                     // ab04: 20 18 ac     ..
+    lda #$ff                                                          // ab07: a9 ff       ..
+// $ab09 referenced 1 time by $ab02
+cab09
+    sta l00ab                                                         // ab09: 85 ab       ..
+    lda #$40 // '@'                                                   // ab0b: a9 40       .@
+    jsr osfind                                                        // ab0d: 20 ce ff     ..
+    tay                                                               // ab10: a8          .
+    lda #$0d                                                          // ab11: a9 0d       ..
+    cpy #0                                                            // ab13: c0 00       ..
+    bne cab35                                                         // ab15: d0 1e       ..
+// $ab17 referenced 1 time by $ab4f
+cab17
+    jmp c822a                                                         // ab17: 4c 2a 82    L*.
+
+// $ab1a referenced 2 times by $ab21, $ab3a
+cab1a
+    jsr osbget                                                        // ab1a: 20 d7 ff     ..
+    bcs cab3d                                                         // ab1d: b0 1e       ..
+    cmp #$0a                                                          // ab1f: c9 0a       ..
+    beq cab1a                                                         // ab21: f0 f7       ..
+    plp                                                               // ab23: 28          (
+    bne cab2e                                                         // ab24: d0 08       ..
+    pha                                                               // ab26: 48          H
+    jsr sub_cac4e                                                     // ab27: 20 4e ac     N.
+    jsr cac0f                                                         // ab2a: 20 0f ac     ..
+    pla                                                               // ab2d: 68          h
+// $ab2e referenced 1 time by $ab24
+cab2e
+    jsr osasci                                                        // ab2e: 20 e3 ff     ..
+    bit l00ff                                                         // ab31: 24 ff       $.
+    bmi cab54                                                         // ab33: 30 1f       0.
+// $ab35 referenced 1 time by $ab15
+cab35
+    and l00ab                                                         // ab35: 25 ab       %.
+    cmp #$0d                                                          // ab37: c9 0d       ..
+    php                                                               // ab39: 08          .
+    jmp cab1a                                                         // ab3a: 4c 1a ab    L..
+
+// $ab3d referenced 1 time by $ab1d
+cab3d
+    plp                                                               // ab3d: 28          (
+    jsr osnewl                                                        // ab3e: 20 e7 ff     ..
+// $ab41 referenced 2 times by $aba5, $abbf
+cab41
+    lda #0                                                            // ab41: a9 00       ..
+    jmp osfind                                                        // ab43: 4c ce ff    L..
+
+sub_cab46
+    jsr sub_cac18                                                     // ab46: 20 18 ac     ..
+    lda #$40 // '@'                                                   // ab49: a9 40       .@
+    jsr osfind                                                        // ab4b: 20 ce ff     ..
+    tay                                                               // ab4e: a8          .
+    beq cab17                                                         // ab4f: f0 c6       ..
+    jsr sub_caaf1                                                     // ab51: 20 f1 aa     ..
+// $ab54 referenced 2 times by $ab33, $aba7
+cab54
+    bit l00ff                                                         // ab54: 24 ff       $.
+    bmi cabbc                                                         // ab56: 30 64       0d
+    lda l00a9                                                         // ab58: a5 a9       ..
+    jsr sub_cac62                                                     // ab5a: 20 62 ac     b.
+    lda l00a8                                                         // ab5d: a5 a8       ..
+    jsr sub_cac62                                                     // ab5f: 20 62 ac     b.
+    jsr cac0f                                                         // ab62: 20 0f ac     ..
+    lda #8                                                            // ab65: a9 08       ..
+    sta l00ac                                                         // ab67: 85 ac       ..
+    ldx #0                                                            // ab69: a2 00       ..
+// $ab6b referenced 1 time by $ab7a
+loop_cab6b
+    jsr osbget                                                        // ab6b: 20 d7 ff     ..
+    bcs cab7d                                                         // ab6e: b0 0d       ..
+    sta (l00ac,x)                                                     // ab70: 81 ac       ..
+    jsr sub_cac62                                                     // ab72: 20 62 ac     b.
+    jsr cac0f                                                         // ab75: 20 0f ac     ..
+    dec l00ac                                                         // ab78: c6 ac       ..
+    bne loop_cab6b                                                    // ab7a: d0 ef       ..
+    clc                                                               // ab7c: 18          .
+// $ab7d referenced 1 time by $ab6e
+cab7d
+    php                                                               // ab7d: 08          .
+    bcc cab93                                                         // ab7e: 90 13       ..
+// $ab80 referenced 1 time by $ab91
+loop_cab80
+    lda #$2a // '*'                                                   // ab80: a9 2a       .*
+    jsr osasci                                                        // ab82: 20 e3 ff     ..
+    jsr osasci                                                        // ab85: 20 e3 ff     ..
+    jsr cac0f                                                         // ab88: 20 0f ac     ..
+    lda #0                                                            // ab8b: a9 00       ..
+    sta (l00ac,x)                                                     // ab8d: 81 ac       ..
+    dec l00ac                                                         // ab8f: c6 ac       ..
+    bne loop_cab80                                                    // ab91: d0 ed       ..
+// $ab93 referenced 1 time by $ab7e
+cab93
+    jsr sub_caba9                                                     // ab93: 20 a9 ab     ..
+    jsr osnewl                                                        // ab96: 20 e7 ff     ..
+    lda #8                                                            // ab99: a9 08       ..
+    clc                                                               // ab9b: 18          .
+    adc l00a8                                                         // ab9c: 65 a8       e.
+    sta l00a8                                                         // ab9e: 85 a8       ..
+    bcc caba4                                                         // aba0: 90 02       ..
+    inc l00a9                                                         // aba2: e6 a9       ..
+// $aba4 referenced 1 time by $aba0
+caba4
+    plp                                                               // aba4: 28          (
+    bcs cab41                                                         // aba5: b0 9a       ..
+    bcc cab54                                                         // aba7: 90 ab       ..
+// $aba9 referenced 1 time by $ab93
+sub_caba9
+    lda #8                                                            // aba9: a9 08       ..
+    sta l00ac                                                         // abab: 85 ac       ..
+// $abad referenced 1 time by $abb9
+loop_cabad
+    ldx #0                                                            // abad: a2 00       ..
+    lda (l00ac,x)                                                     // abaf: a1 ac       ..
+    jsr sub_c842c                                                     // abb1: 20 2c 84     ,.
+    jsr osasci                                                        // abb4: 20 e3 ff     ..
+    dec l00ac                                                         // abb7: c6 ac       ..
+    bne loop_cabad                                                    // abb9: d0 f2       ..
+    rts                                                               // abbb: 60          `
+
+// $abbc referenced 2 times by $ab56, $ac02
+cabbc
+    jsr sub_c9ad8                                                     // abbc: 20 d8 9a     ..
+    jsr cab41                                                         // abbf: 20 41 ab     A.
+    jmp c9436                                                         // abc2: 4c 36 94    L6.
+
+sub_cabc5
+    jsr sub_cac18                                                     // abc5: 20 18 ac     ..
+    lda #$80                                                          // abc8: a9 80       ..
+    jsr osfind                                                        // abca: 20 ce ff     ..
+    sta l00ab                                                         // abcd: 85 ab       ..
+// $abcf referenced 1 time by $ac09
+cabcf
+    jsr sub_cac4e                                                     // abcf: 20 4e ac     N.
+    jsr cac0f                                                         // abd2: 20 0f ac     ..
+    jsr sub_caaf1                                                     // abd5: 20 f1 aa     ..
+    ldx #$ac                                                          // abd8: a2 ac       ..
+    ldy #$ff                                                          // abda: a0 ff       ..
+    sty l00ae                                                         // abdc: 84 ae       ..
+    sty l00b0                                                         // abde: 84 b0       ..
+    iny                                                               // abe0: c8          .
+    sty l00ac                                                         // abe1: 84 ac       ..
+    lda #$20 // ' '                                                   // abe3: a9 20       .
+    sta l00af                                                         // abe5: 85 af       ..
+    tya                                                               // abe7: 98          .
+    jsr osword                                                        // abe8: 20 f1 ff     ..
+    php                                                               // abeb: 08          .
+    sty l00aa                                                         // abec: 84 aa       ..
+    ldy l00ab                                                         // abee: a4 ab       ..
+    ldx #0                                                            // abf0: a2 00       ..
+    beq cabfb                                                         // abf2: f0 07       ..
+// $abf4 referenced 1 time by $abff
+loop_cabf4
+    lda (l00ac,x)                                                     // abf4: a1 ac       ..
+    jsr osbput                                                        // abf6: 20 d4 ff     ..
+    inc l00ac                                                         // abf9: e6 ac       ..
+// $abfb referenced 1 time by $abf2
+cabfb
+    lda l00ac                                                         // abfb: a5 ac       ..
+    cmp l00aa                                                         // abfd: c5 aa       ..
+    bne loop_cabf4                                                    // abff: d0 f3       ..
+    plp                                                               // ac01: 28          (
+    bcs cabbc                                                         // ac02: b0 b8       ..
+    lda #$0d                                                          // ac04: a9 0d       ..
+    jsr osbput                                                        // ac06: 20 d4 ff     ..
+    jmp cabcf                                                         // ac09: 4c cf ab    L..
+
+// $ac0c referenced 3 times by $817f, $8198, $85ca
+sub_cac0c
+    jsr cac0f                                                         // ac0c: 20 0f ac     ..
+// $ac0f referenced 11 times by $81a7, $834f, $837d, $aa8f, $aab0, $ab2a, $ab62, $ab75, $ab88, $abd2, $ac0c
+cac0f
+    pha                                                               // ac0f: 48          H
+    lda #$20 // ' '                                                   // ac10: a9 20       .
+    jsr osasci                                                        // ac12: 20 e3 ff     ..
+    pla                                                               // ac15: 68          h
+    clc                                                               // ac16: 18          .
+    rts                                                               // ac17: 60          `
+
+// $ac18 referenced 4 times by $aafd, $ab04, $ab46, $abc5
+sub_cac18
+    tsx                                                               // ac18: ba          .
+    lda #0                                                            // ac19: a9 00       ..
+    sta l0107,x                                                       // ac1b: 9d 07 01    ...
+    jsr sub_cac47                                                     // ac1e: 20 47 ac     G.
+    cmp #$0d                                                          // ac21: c9 0d       ..
+    bne cac28                                                         // ac23: d0 03       ..
+    jmp ca14f                                                         // ac25: 4c 4f a1    LO.
+
+// $ac28 referenced 1 time by $ac23
+cac28
+    lda #0                                                            // ac28: a9 00       ..
+    sta l00a8                                                         // ac2a: 85 a8       ..
+    sta l00a9                                                         // ac2c: 85 a9       ..
+    pha                                                               // ac2e: 48          H
+    tya                                                               // ac2f: 98          .
+    clc                                                               // ac30: 18          .
+    adc os_text_ptr                                                   // ac31: 65 f2       e.
+    tax                                                               // ac33: aa          .
+    lda l00f3                                                         // ac34: a5 f3       ..
+    adc #0                                                            // ac36: 69 00       i.
+    tay                                                               // ac38: a8          .
+    pla                                                               // ac39: 68          h
+    rts                                                               // ac3a: 60          `
+
+    tya                                                               // ac3b: 98          .
+    clc                                                               // ac3c: 18          .
+    adc os_text_ptr                                                   // ac3d: 65 f2       e.
+    sta os_text_ptr                                                   // ac3f: 85 f2       ..
+    bcc cac45                                                         // ac41: 90 02       ..
+    inc os_text_ptr                                                   // ac43: e6 f2       ..
+// $ac45 referenced 1 time by $ac41
+cac45
+    rts                                                               // ac45: 60          `
+
+// $ac46 referenced 1 time by $ac4b
+loop_cac46
+    iny                                                               // ac46: c8          .
+// $ac47 referenced 1 time by $ac1e
+sub_cac47
+    lda (os_text_ptr),y                                               // ac47: b1 f2       ..
+    cmp #$20 // ' '                                                   // ac49: c9 20       .
+    beq loop_cac46                                                    // ac4b: f0 f9       ..
+    rts                                                               // ac4d: 60          `
+
+// $ac4e referenced 2 times by $ab27, $abcf
+sub_cac4e
+    sed                                                               // ac4e: f8          .
+    clc                                                               // ac4f: 18          .
+    lda l00a8                                                         // ac50: a5 a8       ..
+    adc #1                                                            // ac52: 69 01       i.
+    sta l00a8                                                         // ac54: 85 a8       ..
+    lda l00a9                                                         // ac56: a5 a9       ..
+    adc #0                                                            // ac58: 69 00       i.
+    sta l00a9                                                         // ac5a: 85 a9       ..
+    cld                                                               // ac5c: d8          .
+    jsr sub_cac62                                                     // ac5d: 20 62 ac     b.
+    lda l00a8                                                         // ac60: a5 a8       ..
+// $ac62 referenced 4 times by $ab5a, $ab5f, $ab72, $ac5d
+sub_cac62
+    pha                                                               // ac62: 48          H
+    jsr sub_c81bf                                                     // ac63: 20 bf 81     ..
+    jsr sub_cac6a                                                     // ac66: 20 6a ac     j.
+    pla                                                               // ac69: 68          h
+// $ac6a referenced 1 time by $ac66
+sub_cac6a
+    jsr sub_c80c8                                                     // ac6a: 20 c8 80     ..
+    jsr osasci                                                        // ac6d: 20 e3 ff     ..
+    sec                                                               // ac70: 38          8
+    rts                                                               // ac71: 60          `
+
+// $ac72 referenced 1 time by $96e1
+sub_cac72
+    jsr sub_c83e3                                                     // ac72: 20 e3 83     ..
+    lda #$40 // '@'                                                   // ac75: a9 40       .@
+    sta l10de                                                         // ac77: 8d de 10    ...
+    lda #$a8                                                          // ac7a: a9 a8       ..
+    jsr osbyte_read                                                   // ac7c: 20 e5 9a     ..
+    stx l00b0                                                         // ac7f: 86 b0       ..
+    sty l00b1                                                         // ac81: 84 b1       ..
+    ldy #$0f                                                          // ac83: a0 0f       ..
+    lda #$4c // 'L'                                                   // ac85: a9 4c       .L
+    sta l10e2                                                         // ac87: 8d e2 10    ...
+    lda bytev                                                         // ac8a: ad 0a 02    ...
+    sta l10e3                                                         // ac8d: 8d e3 10    ...
+    lda bytev+1                                                       // ac90: ad 0b 02    ...
+    sta l10e4                                                         // ac93: 8d e4 10    ...
+    php                                                               // ac96: 08          .
+    sei                                                               // ac97: 78          x
+    lda #$0f                                                          // ac98: a9 0f       ..
+    sta bytev                                                         // ac9a: 8d 0a 02    ...
+    lda #$ff                                                          // ac9d: a9 ff       ..
+    sta bytev+1                                                       // ac9f: 8d 0b 02    ...
+    lda #$b2                                                          // aca2: a9 b2       ..
+    sta (l00b0),y                                                     // aca4: 91 b0       ..
+    iny                                                               // aca6: c8          .
+    lda #$ac                                                          // aca7: a9 ac       ..
+    sta (l00b0),y                                                     // aca9: 91 b0       ..
+    iny                                                               // acab: c8          .
+    lda romsel_copy                                                   // acac: a5 f4       ..
+    sta (l00b0),y                                                     // acae: 91 b0       ..
+    plp                                                               // acb0: 28          (
+    rts                                                               // acb1: 60          `
+
+    cmp #0                                                            // acb2: c9 00       ..
+    beq cacc7                                                         // acb4: f0 11       ..
+    cmp #$81                                                          // acb6: c9 81       ..
+    bne cacc4                                                         // acb8: d0 0a       ..
+    cpy #$ff                                                          // acba: c0 ff       ..
+    bne cacc4                                                         // acbc: d0 06       ..
+    cpx #0                                                            // acbe: e0 00       ..
+    bne cacc4                                                         // acc0: d0 02       ..
+    dex                                                               // acc2: ca          .
+    rts                                                               // acc3: 60          `
+
+// $acc4 referenced 3 times by $acb8, $acbc, $acc0
+cacc4
+    jmp l10e2                                                         // acc4: 4c e2 10    L..
+
+// $acc7 referenced 1 time by $acb4
+cacc7
+    php                                                               // acc7: 08          .
+    sei                                                               // acc8: 78          x
+    lda l10e3                                                         // acc9: ad e3 10    ...
+    sta bytev                                                         // accc: 8d 0a 02    ...
+    lda l10e4                                                         // accf: ad e4 10    ...
+    sta bytev+1                                                       // acd2: 8d 0b 02    ...
+    lda #0                                                            // acd5: a9 00       ..
+    ldx #1                                                            // acd7: a2 01       ..
+    plp                                                               // acd9: 28          (
+    rts                                                               // acda: 60          `
+
+// $acdb referenced 3 times by $0050, $af19, $af1c
+tube_host_code2
+// $acdb referenced 3 times by $0050, $af19, $af1c
+* = $0500
+// $acdb referenced 3 times by $0050, $af19, $af1c
+l0500
+    .word          sub_c0537,          sub_c0596,          sub_c05f2  // acdb: 37 05 96... 7.. :0500[2]
+    .word          sub_c0607,          sub_c0627, tube_host_osword_0  // ace1: 07 06 27... ..' :0506[2]
+    .word          sub_c055e,          sub_c052d,          sub_c0520  // ace7: 5e 05 2d... ^.- :050c[2]
+    .word          sub_c0542,          sub_c05a9,          sub_c05d1  // aced: 42 05 a9... B.. :0512[2]
+// Table of flags used by tube_entry_small_a to set up registers 1/4
+// for the
+// selected operation.
+// $acf3 referenced 1 time by $0453
+tube_entry_flags
+    .byt $86, $88, $96, $98, $18, $18, $82, $18                       // acf3: 86 88 96... ... :0518[2]
+
+sub_c0520
+    jsr read_tube_r2_data                                             // acfb: 20 c5 06     .. :0520[2]
+    tay                                                               // acfe: a8          .   :0523[2]
+    jsr read_tube_r2_data                                             // acff: 20 c5 06     .. :0524[2]
+    jsr osbput                                                        // ad02: 20 d4 ff     .. :0527[2]
+    jmp c059c                                                         // ad05: 4c 9c 05    L.. :052a[2]
+
+sub_c052d
+    jsr read_tube_r2_data                                             // ad08: 20 c5 06     .. :052d[2]
+    tay                                                               // ad0b: a8          .   :0530[2]
+    jsr osbget                                                        // ad0c: 20 d7 ff     .. :0531[2]
+    jmp c053a                                                         // ad0f: 4c 3a 05    L:. :0534[2]
+
+sub_c0537
+    jsr osrdch                                                        // ad12: 20 e0 ff     .. :0537[2]
+// $ad15 referenced 2 times by $0534, $05ef
+c053a
+    ror                                                               // ad15: 6a          j   :053a[2]
+    jsr write_tube_r2_data                                            // ad16: 20 95 06     .. :053b[2]
+    rol                                                               // ad19: 2a          *   :053e[2]
+    jmp c059e                                                         // ad1a: 4c 9e 05    L.. :053f[2]
+
+sub_c0542
+    jsr read_tube_r2_data                                             // ad1d: 20 c5 06     .. :0542[2]
+    beq c0552                                                         // ad20: f0 0b       ..  :0545[2]
+    pha                                                               // ad22: 48          H   :0547[2]
+    jsr sub_c0582                                                     // ad23: 20 82 05     .. :0548[2]
+    pla                                                               // ad26: 68          h   :054b[2]
+    jsr osfind                                                        // ad27: 20 ce ff     .. :054c[2]
+    jmp c059e                                                         // ad2a: 4c 9e 05    L.. :054f[2]
+
+// $ad2d referenced 1 time by $0545
+c0552
+    jsr read_tube_r2_data                                             // ad2d: 20 c5 06     .. :0552[2]
+    tay                                                               // ad30: a8          .   :0555[2]
+    lda #0                                                            // ad31: a9 00       ..  :0556[2]
+    jsr osfind                                                        // ad33: 20 ce ff     .. :0558[2]
+    jmp c059c                                                         // ad36: 4c 9c 05    L.. :055b[2]
+
+sub_c055e
+    jsr read_tube_r2_data                                             // ad39: 20 c5 06     .. :055e[2]
+    tay                                                               // ad3c: a8          .   :0561[2]
+    ldx #4                                                            // ad3d: a2 04       ..  :0562[2]
+// $ad3f referenced 1 time by $056a
+loop_c0564
+    jsr read_tube_r2_data                                             // ad3f: 20 c5 06     .. :0564[2]
+    sta l00ff,x                                                       // ad42: 95 ff       ..  :0567[2]
+    dex                                                               // ad44: ca          .   :0569[2]
+    bne loop_c0564                                                    // ad45: d0 f8       ..  :056a[2]
+    jsr read_tube_r2_data                                             // ad47: 20 c5 06     .. :056c[2]
+    jsr osargs                                                        // ad4a: 20 da ff     .. :056f[2]
+    jsr write_tube_r2_data                                            // ad4d: 20 95 06     .. :0572[2]
+    ldx #3                                                            // ad50: a2 03       ..  :0575[2]
+// $ad52 referenced 1 time by $057d
+loop_c0577
+    lda l0000,x                                                       // ad52: b5 00       ..  :0577[2]
+    jsr write_tube_r2_data                                            // ad54: 20 95 06     .. :0579[2]
+    dex                                                               // ad57: ca          .   :057c[2]
+    bpl loop_c0577                                                    // ad58: 10 f8       ..  :057d[2]
+    jmp c0036                                                         // ad5a: 4c 36 00    L6. :057f[2]
+
+// $ad5d referenced 3 times by $0548, $0596, $05b3
+sub_c0582
+    ldx #0                                                            // ad5d: a2 00       ..  :0582[2]
+    ldy #0                                                            // ad5f: a0 00       ..  :0584[2]
+// $ad61 referenced 1 time by $0591
+loop_c0586
+    jsr read_tube_r2_data                                             // ad61: 20 c5 06     .. :0586[2]
+    sta l0700,y                                                       // ad64: 99 00 07    ... :0589[2]
+    iny                                                               // ad67: c8          .   :058c[2]
+    beq c0593                                                         // ad68: f0 04       ..  :058d[2]
+    cmp #$0d                                                          // ad6a: c9 0d       ..  :058f[2]
+    bne loop_c0586                                                    // ad6c: d0 f3       ..  :0591[2]
+// $ad6e referenced 1 time by $058d
+c0593
+    ldy #7                                                            // ad6e: a0 07       ..  :0593[2]
+    rts                                                               // ad70: 60          `   :0595[2]
+
+sub_c0596
+    jsr sub_c0582                                                     // ad71: 20 82 05     .. :0596[2]
+    jsr oscli                                                         // ad74: 20 f7 ff     .. :0599[2]
+// $ad77 referenced 3 times by $0489, $052a, $055b
+c059c
+    lda #$7f                                                          // ad77: a9 7f       ..  :059c[2]
+// $ad79 referenced 4 times by $053f, $054f, $05a1, $067d
+c059e
+    bit tube_host_r2_status                                           // ad79: 2c e2 fe    ,.. :059e[2]
+    bvc c059e                                                         // ad7c: 50 fb       P.  :05a1[2]
+    sta tube_host_r2_data                                             // ad7e: 8d e3 fe    ... :05a3[2]
+// $ad81 referenced 1 time by $05cf
+c05a6
+    jmp c0036                                                         // ad81: 4c 36 00    L6. :05a6[2]
+
+sub_c05a9
+    ldx #$10                                                          // ad84: a2 10       ..  :05a9[2]
+// $ad86 referenced 1 time by $05b1
+loop_c05ab
+    jsr read_tube_r2_data                                             // ad86: 20 c5 06     .. :05ab[2]
+    sta l0001,x                                                       // ad89: 95 01       ..  :05ae[2]
+    dex                                                               // ad8b: ca          .   :05b0[2]
+    bne loop_c05ab                                                    // ad8c: d0 f8       ..  :05b1[2]
+    jsr sub_c0582                                                     // ad8e: 20 82 05     .. :05b3[2]
+    stx l0000                                                         // ad91: 86 00       ..  :05b6[2]
+    sty l0001                                                         // ad93: 84 01       ..  :05b8[2]
+    ldy #0                                                            // ad95: a0 00       ..  :05ba[2]
+    jsr read_tube_r2_data                                             // ad97: 20 c5 06     .. :05bc[2]
+    jsr osfile                                                        // ad9a: 20 dd ff     .. :05bf[2]
+    jsr write_tube_r2_data                                            // ad9d: 20 95 06     .. :05c2[2]
+    ldx #$10                                                          // ada0: a2 10       ..  :05c5[2]
+// $ada2 referenced 1 time by $05cd
+loop_c05c7
+    lda l0001,x                                                       // ada2: b5 01       ..  :05c7[2]
+    jsr write_tube_r2_data                                            // ada4: 20 95 06     .. :05c9[2]
+    dex                                                               // ada7: ca          .   :05cc[2]
+    bne loop_c05c7                                                    // ada8: d0 f8       ..  :05cd[2]
+    beq c05a6                                                         // adaa: f0 d5       ..  :05cf[2]
+sub_c05d1
+    ldx #$0d                                                          // adac: a2 0d       ..  :05d1[2]
+// $adae referenced 1 time by $05d9
+loop_c05d3
+    jsr read_tube_r2_data                                             // adae: 20 c5 06     .. :05d3[2]
+    sta l00ff,x                                                       // adb1: 95 ff       ..  :05d6[2]
+    dex                                                               // adb3: ca          .   :05d8[2]
+    bne loop_c05d3                                                    // adb4: d0 f8       ..  :05d9[2]
+    jsr read_tube_r2_data                                             // adb6: 20 c5 06     .. :05db[2]
+    ldy #0                                                            // adb9: a0 00       ..  :05de[2]
+    jsr osgbpb                                                        // adbb: 20 d1 ff     .. :05e0[2]
+    pha                                                               // adbe: 48          H   :05e3[2]
+    ldx #$0c                                                          // adbf: a2 0c       ..  :05e4[2]
+// $adc1 referenced 1 time by $05ec
+loop_c05e6
+    lda l0000,x                                                       // adc1: b5 00       ..  :05e6[2]
+    jsr write_tube_r2_data                                            // adc3: 20 95 06     .. :05e8[2]
+    dex                                                               // adc6: ca          .   :05eb[2]
+    bpl loop_c05e6                                                    // adc7: 10 f8       ..  :05ec[2]
+    pla                                                               // adc9: 68          h   :05ee[2]
+    jmp c053a                                                         // adca: 4c 3a 05    L:. :05ef[2]
+
+sub_c05f2
+    jsr read_tube_r2_data                                             // adcd: 20 c5 06     .. :05f2[2]
+    tax                                                               // add0: aa          .   :05f5[2]
+    jsr read_tube_r2_data                                             // add1: 20 c5 06     .. :05f6[2]
+    jsr osbyte                                                        // add4: 20 f4 ff     .. :05f9[2]
+// $add7 referenced 2 times by $05ff, $0625
+c05fc
+    bit tube_host_r2_status                                           // add7: 2c e2 fe    ,.. :05fc[2]
+sub_c05ff
+l0600 = sub_c05ff+1
+    bvc c05fc                                                         // adda: 50 fb       P.  :05ff[2]
+// $addb referenced 2 times by $af1f, $af22
+    stx tube_host_r2_data                                             // addc: 8e e3 fe    ... :0601[2]
+// $addf referenced 1 time by $0617
+loop_c0604
+    jmp c0036                                                         // addf: 4c 36 00    L6. :0604[2]
+
+sub_c0607
+    jsr read_tube_r2_data                                             // ade2: 20 c5 06     .. :0607[2]
+    tax                                                               // ade5: aa          .   :060a[2]
+    jsr read_tube_r2_data                                             // ade6: 20 c5 06     .. :060b[2]
+    tay                                                               // ade9: a8          .   :060e[2]
+    jsr read_tube_r2_data                                             // adea: 20 c5 06     .. :060f[2]
+    jsr osbyte                                                        // aded: 20 f4 ff     .. :0612[2]
+    eor #$9d                                                          // adf0: 49 9d       I.  :0615[2]
+    beq loop_c0604                                                    // adf2: f0 eb       ..  :0617[2]
+    ror                                                               // adf4: 6a          j   :0619[2]
+    jsr write_tube_r2_data                                            // adf5: 20 95 06     .. :061a[2]
+// $adf8 referenced 1 time by $0620
+loop_c061d
+    bit tube_host_r2_status                                           // adf8: 2c e2 fe    ,.. :061d[2]
+    bvc loop_c061d                                                    // adfb: 50 fb       P.  :0620[2]
+    sty tube_host_r2_data                                             // adfd: 8c e3 fe    ... :0622[2]
+    bvs c05fc                                                         // ae00: 70 d5       p.  :0625[2]
+sub_c0627
+    jsr read_tube_r2_data                                             // ae02: 20 c5 06     .. :0627[2]
+    tay                                                               // ae05: a8          .   :062a[2]
+// $ae06 referenced 1 time by $062e
+loop_c062b
+    bit tube_host_r2_status                                           // ae06: 2c e2 fe    ,.. :062b[2]
+    bpl loop_c062b                                                    // ae09: 10 fb       ..  :062e[2]
+    ldx tube_host_r2_data                                             // ae0b: ae e3 fe    ... :0630[2]
+    dex                                                               // ae0e: ca          .   :0633[2]
+    bmi c0645                                                         // ae0f: 30 0f       0.  :0634[2]
+// $ae11 referenced 2 times by $0639, $0642
+c0636
+    bit tube_host_r2_status                                           // ae11: 2c e2 fe    ,.. :0636[2]
+    bpl c0636                                                         // ae14: 10 fb       ..  :0639[2]
+    lda tube_host_r2_data                                             // ae16: ad e3 fe    ... :063b[2]
+    sta l0128,x                                                       // ae19: 9d 28 01    .(. :063e[2]
+    dex                                                               // ae1c: ca          .   :0641[2]
+    bpl c0636                                                         // ae1d: 10 f2       ..  :0642[2]
+    tya                                                               // ae1f: 98          .   :0644[2]
+// $ae20 referenced 1 time by $0634
+c0645
+    ldx #<(l0128)                                                     // ae20: a2 28       .(  :0645[2]
+    ldy #>(l0128)                                                     // ae22: a0 01       ..  :0647[2]
+    jsr osword                                                        // ae24: 20 f1 ff     .. :0649[2]
+// $ae27 referenced 1 time by $064f
+loop_c064c
+    bit tube_host_r2_status                                           // ae27: 2c e2 fe    ,.. :064c[2]
+    bpl loop_c064c                                                    // ae2a: 10 fb       ..  :064f[2]
+    ldx tube_host_r2_data                                             // ae2c: ae e3 fe    ... :0651[2]
+    dex                                                               // ae2f: ca          .   :0654[2]
+    bmi c0665                                                         // ae30: 30 0e       0.  :0655[2]
+// $ae32 referenced 1 time by $0663
+loop_c0657
+    ldy l0128,x                                                       // ae32: bc 28 01    .(. :0657[2]
+// $ae35 referenced 1 time by $065d
+loop_c065a
+    bit tube_host_r2_status                                           // ae35: 2c e2 fe    ,.. :065a[2]
+    bvc loop_c065a                                                    // ae38: 50 fb       P.  :065d[2]
+    sty tube_host_r2_data                                             // ae3a: 8c e3 fe    ... :065f[2]
+    dex                                                               // ae3d: ca          .   :0662[2]
+    bpl loop_c0657                                                    // ae3e: 10 f2       ..  :0663[2]
+// $ae40 referenced 1 time by $0655
+c0665
+    jmp c0036                                                         // ae40: 4c 36 00    L6. :0665[2]
+
+tube_host_osword_0
+    ldx #4                                                            // ae43: a2 04       ..  :0668[2]
+// $ae45 referenced 1 time by $0670
+tube_host_osword_0_loop
+    jsr read_tube_r2_data                                             // ae45: 20 c5 06     .. :066a[2]
+    sta l0000,x                                                       // ae48: 95 00       ..  :066d[2]
+    dex                                                               // ae4a: ca          .   :066f[2]
+    bpl tube_host_osword_0_loop                                       // ae4b: 10 f8       ..  :0670[2]
+    inx                                                               // ae4d: e8          .   :0672[2]
+    ldy #0                                                            // ae4e: a0 00       ..  :0673[2]
+    txa                                                               // ae50: 8a          .   :0675[2]
+    jsr osword                                                        // ae51: 20 f1 ff     .. :0676[2]
+    bcc tube_host_osword_0_no_escape                                  // ae54: 90 05       ..  :0679[2]
+    lda #$ff                                                          // ae56: a9 ff       ..  :067b[2]
+    jmp c059e                                                         // ae58: 4c 9e 05    L.. :067d[2]
+
+// $ae5b referenced 1 time by $0679
+tube_host_osword_0_no_escape
+    ldx #0                                                            // ae5b: a2 00       ..  :0680[2]
+    lda #$7f                                                          // ae5d: a9 7f       ..  :0682[2]
+    jsr write_tube_r2_data                                            // ae5f: 20 95 06     .. :0684[2]
+// $ae62 referenced 1 time by $0690
+tube_host_osword_0_no_escape_loop
+    lda l0700,x                                                       // ae62: bd 00 07    ... :0687[2]
+    jsr write_tube_r2_data                                            // ae65: 20 95 06     .. :068a[2]
+    inx                                                               // ae68: e8          .   :068d[2]
+    cmp #$0d                                                          // ae69: c9 0d       ..  :068e[2]
+    bne tube_host_osword_0_no_escape_loop                             // ae6b: d0 f5       ..  :0690[2]
+    jmp c0036                                                         // ae6d: 4c 36 00    L6. :0692[2]
+
+// Wait for register 2 to have space and write A to it.
+// $ae70 referenced 14 times by $0020, $0026, $002c, $0474, $053b, $0572, $0579, $05c2, $05c9, $05e8, $061a, $0684, $068a, $0698
+write_tube_r2_data
+    bit tube_host_r2_status                                           // ae70: 2c e2 fe    ,.. :0695[2]
+    bvc write_tube_r2_data                                            // ae73: 50 fb       P.  :0698[2]
+    sta tube_host_r2_data                                             // ae75: 8d e3 fe    ... :069a[2]
+    rts                                                               // ae78: 60          `   :069d[2]
+
+// Wait for register 4 to have space and write A to it.
+// $ae79 referenced 8 times by $0018, $0418, $041d, $043b, $0443, $0448, $0463, $06a1
+write_tube_r4_data
+    bit tube_host_r4_status                                           // ae79: 2c e6 fe    ,.. :069e[2]
+    bvc write_tube_r4_data                                            // ae7c: 50 fb       P.  :06a1[2]
+    sta tube_host_r4_data                                             // ae7e: 8d e7 fe    ... :06a3[2]
+    rts                                                               // ae81: 60          `   :06a6[2]
+
+// $ae82 referenced 1 time by $0403
+c06a7
+    lda l00ff                                                         // ae82: a5 ff       ..  :06a7[2]
+    sec                                                               // ae84: 38          8   :06a9[2]
+    ror                                                               // ae85: 6a          j   :06aa[2]
+    bmi write_tube_r1_data                                            // ae86: 30 0f       0.  :06ab[2]
+tube_evntv_handler
+    pha                                                               // ae88: 48          H   :06ad[2]
+    lda #0                                                            // ae89: a9 00       ..  :06ae[2]
+    jsr write_tube_r1_data                                            // ae8b: 20 bc 06     .. :06b0[2]
+    tya                                                               // ae8e: 98          .   :06b3[2]
+    jsr write_tube_r1_data                                            // ae8f: 20 bc 06     .. :06b4[2]
+    txa                                                               // ae92: 8a          .   :06b7[2]
+    jsr write_tube_r1_data                                            // ae93: 20 bc 06     .. :06b8[2]
+    pla                                                               // ae96: 68          h   :06bb[2]
+// Wait for register 1 to have space and write A to it.
+// $ae97 referenced 5 times by $06ab, $06b0, $06b4, $06b8, $06bf
+write_tube_r1_data
+    bit tube_host_r1_status                                           // ae97: 2c e0 fe    ,.. :06bc[2]
+    bvc write_tube_r1_data                                            // ae9a: 50 fb       P.  :06bf[2]
+    sta tube_host_r1_data                                             // ae9c: 8d e1 fe    ... :06c1[2]
+    rts                                                               // ae9f: 60          `   :06c4[2]
+
+// Wait for register 2 to have data and read A from it.
+// $aea0 referenced 21 times by $0520, $0524, $052d, $0542, $0552, $055e, $0564, $056c, $0586, $05ab, $05bc, $05d3, $05db, $05f2, $05f6, $0607, $060b, $060f, $0627, $066a, $06c8
+read_tube_r2_data
+    bit tube_host_r2_status                                           // aea0: 2c e2 fe    ,.. :06c5[2]
+    bpl read_tube_r2_data                                             // aea3: 10 fb       ..  :06c8[2]
+    lda tube_host_r2_data                                             // aea5: ad e3 fe    ... :06ca[2]
+    rts                                                               // aea8: 60          `   :06cd[2]
+
+// $aea9 referenced 1 time by $965d
+* = $aea9
+// $aea9 referenced 1 time by $965d
+service_handler_help_and_tube
+// $aea9 referenced 1 time by $965d
+    cmp #service_help                                                 // aea9: c9 09       ..
+    bne caed7                                                         // aeab: d0 2a       .*
+    tya                                                               // aead: 98          .
+    pha                                                               // aeae: 48          H
+    lda (os_text_ptr),y                                               // aeaf: b1 f2       ..
+    cmp #$0d                                                          // aeb1: c9 0d       ..
+    bne caed3                                                         // aeb3: d0 1e       ..
+    lda #$e9                                                          // aeb5: a9 e9       ..
+    jsr osbyte_read                                                   // aeb7: 20 e5 9a     ..
+    ldx romsel_copy                                                   // aeba: a6 f4       ..
+    tya                                                               // aebc: 98          .
+    beq caed3                                                         // aebd: f0 14       ..
+    jsr print_inline_l809f_top_bit_clear                              // aebf: 20 77 80     w.
+    .asc $0d, "TUBE HOST 2.30", $0d                                   // aec2: 0d 54 55... .TU
+
+    nop                                                               // aed2: ea          .
+// $aed3 referenced 2 times by $aeb3, $aebd
+caed3
+    pla                                                               // aed3: 68          h
+    tay                                                               // aed4: a8          .
+    lda #9                                                            // aed5: a9 09       ..
+// $aed7 referenced 1 time by $aeab
+caed7
+    cmp #service_tube_post_init                                       // aed7: c9 fe       ..
+    bcc just_rts                                                      // aed9: 90 5c       .\ 
+    bne service_handler_tube_main_init                                // aedb: d0 1b       ..
+    cpy #0                                                            // aedd: c0 00       ..
+    beq just_rts                                                      // aedf: f0 56       .V
+    ldx #6                                                            // aee1: a2 06       ..
+    lda #osbyte_explode_chars                                         // aee3: a9 14       ..
+    jsr osbyte                                                        // aee5: 20 f4 ff     ..
+// $aee8 referenced 2 times by $aeeb, $aef5
+tube_banner_loop
+    bit tube_host_r1_status                                           // aee8: 2c e0 fe    ,..
+    bpl tube_banner_loop                                              // aeeb: 10 fb       ..
+    lda tube_host_r1_data                                             // aeed: ad e1 fe    ...
+    beq lda_0_rts                                                     // aef0: f0 43       .C
+    jsr oswrch                                                        // aef2: 20 ee ff     ..
+    jmp tube_banner_loop                                              // aef5: 4c e8 ae    L..
+
+// $aef8 referenced 1 time by $aedb
+service_handler_tube_main_init
+    lda #<tube_evntv_handler                                          // aef8: a9 ad       ..
+    sta evntv                                                         // aefa: 8d 20 02    . .
+    lda #>tube_evntv_handler                                          // aefd: a9 06       ..
+    sta evntv+1                                                       // aeff: 8d 21 02    .!.
+    lda #<tube_brkv_handler                                           // af02: a9 16       ..
+    sta brkv                                                          // af04: 8d 02 02    ...
+    lda #>tube_brkv_handler                                           // af07: a9 00       ..
+    sta brkv+1                                                        // af09: 8d 03 02    ...
+    lda #$8e                                                          // af0c: a9 8e       ..
+    sta tube_host_r1_status                                           // af0e: 8d e0 fe    ...
+    ldy #0                                                            // af11: a0 00       ..
+// $af13 referenced 1 time by $af26
+loop_caf13
+    lda tube_host_code1,y                                             // af13: b9 79 af    .y.
+    sta c0400,y                                                       // af16: 99 00 04    ...
+    lda tube_host_code2,y                                             // af19: b9 db ac    ...
+    sta l0500,y                                                       // af1c: 99 00 05    ...
+    lda tube_host_code2+256,y                                         // af1f: b9 db ad    ...
+    sta l0600,y                                                       // af22: 99 00 06    ...
+    dey                                                               // af25: 88          .
+    bne loop_caf13                                                    // af26: d0 eb       ..
+    jsr sub_c0421                                                     // af28: 20 21 04     !.
+    ldx #$41 // 'A'                                                   // af2b: a2 41       .A
+// $af2d referenced 1 time by $af33
+loop_caf2d
+    lda tube_host_code3,x                                             // af2d: bd 38 af    .8.
+    sta tube_brkv_handler_fwd,x                                       // af30: 95 16       ..
+    dex                                                               // af32: ca          .
+    bpl loop_caf2d                                                    // af33: 10 f8       ..
+// $af35 referenced 1 time by $aef0
+lda_0_rts
+    lda #0                                                            // af35: a9 00       ..
+// $af37 referenced 2 times by $aed9, $aedf
+just_rts
+    rts                                                               // af37: 60          `
+
+// $af38 referenced 2 times by $af2d, $af30
+tube_host_code3
+// $af38 referenced 2 times by $af2d, $af30
+* = $16
+// $af38 referenced 2 times by $af2d, $af30
+tube_brkv_handler
+    lda #$ff                                                          // af38: a9 ff       ..  :0016[3]
+    jsr write_tube_r4_data                                            // af3a: 20 9e 06     .. :0018[3]
+    lda tube_host_r2_data                                             // af3d: ad e3 fe    ... :001b[3]
+    lda #0                                                            // af40: a9 00       ..  :001e[3]
+    jsr write_tube_r2_data                                            // af42: 20 95 06     .. :0020[3]
+    tay                                                               // af45: a8          .   :0023[3]
+    lda (l00fd),y                                                     // af46: b1 fd       ..  :0024[3]
+    jsr write_tube_r2_data                                            // af48: 20 95 06     .. :0026[3]
+// $af4b referenced 1 time by $0030
+loop_c0029
+    iny                                                               // af4b: c8          .   :0029[3]
+    lda (l00fd),y                                                     // af4c: b1 fd       ..  :002a[3]
+    jsr write_tube_r2_data                                            // af4e: 20 95 06     .. :002c[3]
+    tax                                                               // af51: aa          .   :002f[3]
+    bne loop_c0029                                                    // af52: d0 f7       ..  :0030[3]
+// $af54 referenced 1 time by $0477
+c0032
+    ldx #$ff                                                          // af54: a2 ff       ..  :0032[3]
+    txs                                                               // af56: 9a          .   :0034[3]
+    cli                                                               // af57: 58          X   :0035[3]
+// $af58 referenced 6 times by $0044, $057f, $05a6, $0604, $0665, $0692
+c0036
+    bit tube_host_r1_status                                           // af58: 2c e0 fe    ,.. :0036[3]
+    bpl c0041                                                         // af5b: 10 06       ..  :0039[3]
+// $af5d referenced 1 time by $0049
+loop_c003b
+    lda tube_host_r1_data                                             // af5d: ad e1 fe    ... :003b[3]
+    jsr oswrch                                                        // af60: 20 ee ff     .. :003e[3]
+// $af63 referenced 1 time by $0039
+c0041
+    bit tube_host_r2_status                                           // af63: 2c e2 fe    ,.. :0041[3]
+    bpl c0036                                                         // af66: 10 f0       ..  :0044[3]
+    bit tube_host_r1_status                                           // af68: 2c e0 fe    ,.. :0046[3]
+    bmi loop_c003b                                                    // af6b: 30 f0       0.  :0049[3]
+    ldx tube_host_r2_data                                             // af6d: ae e3 fe    ... :004b[3]
+// Patch the following JMP so we effectively do JMP (&500,X)
+
+// Extra comment after a blank line
+; manually-created comment
+    stx `jump_address_low                                             // af70: 86 51       .Q  :004e[3]
+sub_c0050
+jump_address_low = sub_c0050+1
+    jmp (l0500)                                                       // af72: 6c 00 05    l.. :0050[3]
+
+// $af73 referenced 1 time by $004e
+// $af75 referenced 2 times by $04da, $04ea
+l0053
+    .byt 0                                                            // af75: 00          .   :0053[3]
+// $af76 referenced 3 times by $04b2, $04d0, $04ef
+l0054
+    .byt $80                                                          // af76: 80          .   :0054[3]
+// $af77 referenced 2 times by $04b6, $04f9
+l0055
+    .byt 0                                                            // af77: 00          .   :0055[3]
+// $af78 referenced 2 times by $04ba, $04f7
+l0056
+    .byt 0                                                            // af78: 00          .   :0056[3]
+// $af79 referenced 2 times by $af13, $af16
+* = $af79
+// $af79 referenced 2 times by $af13, $af16
+tube_host_code1
+// $af79 referenced 2 times by $af13, $af16
+* = $0400
+// $af79 referenced 2 times by $af13, $af16
+c0400
+    jmp c0484                                                         // af79: 4c 84 04    L.. :0400[1]
+
+    jmp c06a7                                                         // af7c: 4c a7 06    L.. :0403[1]
+
+// $af7f referenced 14 times by $0493, $04cb, $892a, $8cae, $8f6e, $8f7d, $9346, $982b, $bd64, $bd91, $be09, $be2c, $be7d, $be85
+tube_entry
+    cmp #$80                                                          // af7f: c9 80       ..  :0406[1]
+    bcc tube_entry_small_a                                            // af81: 90 2b       .+  :0408[1]
+    cmp #$c0                                                          // af83: c9 c0       ..  :040a[1]
+    bcs tube_entry_claim_tube                                         // af85: b0 1a       ..  :040c[1]
+// This is a call to release the tube.
+    ora #$40 // '@'                                                   // af87: 09 40       .@  :040e[1]
+    cmp l0015                                                         // af89: c5 15       ..  :0410[1]
+    bne c0434                                                         // af8b: d0 20       .   :0412[1]
+// $af8d referenced 1 time by $0471
+sub_c0414
+    php                                                               // af8d: 08          .   :0414[1]
+    sei                                                               // af8e: 78          x   :0415[1]
+    lda #5                                                            // af8f: a9 05       ..  :0416[1]
+    jsr write_tube_r4_data                                            // af91: 20 9e 06     .. :0418[1]
+    lda l0015                                                         // af94: a5 15       ..  :041b[1]
+    jsr write_tube_r4_data                                            // af96: 20 9e 06     .. :041d[1]
+    plp                                                               // af99: 28          (   :0420[1]
+// $af9a referenced 1 time by $af28
+sub_c0421
+    lda #$80                                                          // af9a: a9 80       ..  :0421[1]
+    sta l0015                                                         // af9c: 85 15       ..  :0423[1]
+    sta l0014                                                         // af9e: 85 14       ..  :0425[1]
+    rts                                                               // afa0: 60          `   :0427[1]
+
+// $afa1 referenced 1 time by $040c
+tube_entry_claim_tube
+    asl l0014                                                         // afa1: 06 14       ..  :0428[1]
+    bcs c0432                                                         // afa3: b0 06       ..  :042a[1]
+    cmp l0015                                                         // afa5: c5 15       ..  :042c[1]
+    beq c0434                                                         // afa7: f0 04       ..  :042e[1]
+    clc                                                               // afa9: 18          .   :0430[1]
+    rts                                                               // afaa: 60          `   :0431[1]
+
+// $afab referenced 1 time by $042a
+c0432
+    sta l0015                                                         // afab: 85 15       ..  :0432[1]
+// $afad referenced 2 times by $0412, $042e
+c0434
+    rts                                                               // afad: 60          `   :0434[1]
+
+// $afae referenced 1 time by $0408
+tube_entry_small_a
+    php                                                               // afae: 08          .   :0435[1]
+    sei                                                               // afaf: 78          x   :0436[1]
+    sty l0013                                                         // afb0: 84 13       ..  :0437[1]
+    stx l0012                                                         // afb2: 86 12       ..  :0439[1]
+    jsr write_tube_r4_data                                            // afb4: 20 9e 06     .. :043b[1]
+    tax                                                               // afb7: aa          .   :043e[1]
+    ldy #3                                                            // afb8: a0 03       ..  :043f[1]
+    lda l0015                                                         // afba: a5 15       ..  :0441[1]
+    jsr write_tube_r4_data                                            // afbc: 20 9e 06     .. :0443[1]
+// $afbf referenced 1 time by $044c
+loop_c0446
+    lda (l0012),y                                                     // afbf: b1 12       ..  :0446[1]
+    jsr write_tube_r4_data                                            // afc1: 20 9e 06     .. :0448[1]
+    dey                                                               // afc4: 88          .   :044b[1]
+    bpl loop_c0446                                                    // afc5: 10 f8       ..  :044c[1]
+    ldy #$18                                                          // afc7: a0 18       ..  :044e[1]
+    sty tube_host_r1_status                                           // afc9: 8c e0 fe    ... :0450[1]
+    lda tube_entry_flags,x                                            // afcc: bd 18 05    ... :0453[1]
+    sta tube_host_r1_status                                           // afcf: 8d e0 fe    ... :0456[1]
+    lsr                                                               // afd2: 4a          J   :0459[1]
+    lsr                                                               // afd3: 4a          J   :045a[1]
+    bcc c0463                                                         // afd4: 90 06       ..  :045b[1]
+    bit tube_host_r3_data                                             // afd6: 2c e5 fe    ,.. :045d[1]
+    bit tube_host_r3_data                                             // afd9: 2c e5 fe    ,.. :0460[1]
+// $afdc referenced 1 time by $045b
+c0463
+    jsr write_tube_r4_data                                            // afdc: 20 9e 06     .. :0463[1]
+// $afdf referenced 1 time by $0469
+loop_c0466
+    bit tube_host_r4_status                                           // afdf: 2c e6 fe    ,.. :0466[1]
+    bvc loop_c0466                                                    // afe2: 50 fb       P.  :0469[1]
+    bcs c047a                                                         // afe4: b0 0d       ..  :046b[1]
+    cpx #4                                                            // afe6: e0 04       ..  :046d[1]
+    bne c0482                                                         // afe8: d0 11       ..  :046f[1]
+// $afea referenced 1 time by $048f
+loop_c0471
+    jsr sub_c0414                                                     // afea: 20 14 04     .. :0471[1]
+    jsr write_tube_r2_data                                            // afed: 20 95 06     .. :0474[1]
+    jmp c0032                                                         // aff0: 4c 32 00    L2. :0477[1]
+
+// $aff3 referenced 1 time by $046b
+c047a
+    lsr                                                               // aff3: 4a          J   :047a[1]
+    bcc c0482                                                         // aff4: 90 05       ..  :047b[1]
+    ldy #$88                                                          // aff6: a0 88       ..  :047d[1]
+    sty tube_host_r1_status                                           // aff8: 8c e0 fe    ... :047f[1]
+// $affb referenced 2 times by $046f, $047b
+c0482
+    plp                                                               // affb: 28          (   :0482[1]
+    rts                                                               // affc: 60          `   :0483[1]
+
+// $affd referenced 1 time by $0400
+c0484
+    cli                                                               // affd: 58          X   :0484[1]
+    bcs c0491                                                         // affe: b0 0a       ..  :0485[1]
+    bne c048c                                                         // b000: d0 03       ..  :0487[1]
+    jmp c059c                                                         // b002: 4c 9c 05    L.. :0489[1]
+
+// $b005 referenced 1 time by $0487
+c048c
+    ldx l028d                                                         // b005: ae 8d 02    ... :048c[1]
+    beq loop_c0471                                                    // b008: f0 e0       ..  :048f[1]
+// $b00a referenced 2 times by $0485, $0496
+c0491
+    lda #$ff                                                          // b00a: a9 ff       ..  :0491[1]
+    jsr tube_entry                                                    // b00c: 20 06 04     .. :0493[1]
+    bcc c0491                                                         // b00f: 90 f9       ..  :0496[1]
+    jsr sub_c04ce                                                     // b011: 20 ce 04     .. :0498[1]
+// $b014 referenced 1 time by $04c0
+c049b
+    php                                                               // b014: 08          .   :049b[1]
+    sei                                                               // b015: 78          x   :049c[1]
+    lda #7                                                            // b016: a9 07       ..  :049d[1]
+    jsr sub_c04c7                                                     // b018: 20 c7 04     .. :049f[1]
+    ldy #0                                                            // b01b: a0 00       ..  :04a2[1]
+    sty l0000                                                         // b01d: 84 00       ..  :04a4[1]
+// $b01f referenced 1 time by $04af
+loop_c04a6
+    lda (l0000),y                                                     // b01f: b1 00       ..  :04a6[1]
+    sta tube_host_r3_data                                             // b021: 8d e5 fe    ... :04a8[1]
+    nop                                                               // b024: ea          .   :04ab[1]
+    nop                                                               // b025: ea          .   :04ac[1]
+    nop                                                               // b026: ea          .   :04ad[1]
+    iny                                                               // b027: c8          .   :04ae[1]
+    bne loop_c04a6                                                    // b028: d0 f5       ..  :04af[1]
+    plp                                                               // b02a: 28          (   :04b1[1]
+    inc l0054                                                         // b02b: e6 54       .T  :04b2[1]
+    bne c04bc                                                         // b02d: d0 06       ..  :04b4[1]
+    inc l0055                                                         // b02f: e6 55       .U  :04b6[1]
+    bne c04bc                                                         // b031: d0 02       ..  :04b8[1]
+    inc l0056                                                         // b033: e6 56       .V  :04ba[1]
+// $b035 referenced 2 times by $04b4, $04b8
+c04bc
+    inc l0001                                                         // b035: e6 01       ..  :04bc[1]
+    bit l0001                                                         // b037: 24 01       $.  :04be[1]
+    bvc c049b                                                         // b039: 50 d9       P.  :04c0[1]
+    jsr sub_c04ce                                                     // b03b: 20 ce 04     .. :04c2[1]
+    lda #4                                                            // b03e: a9 04       ..  :04c5[1]
+// $b040 referenced 1 time by $049f
+sub_c04c7
+    ldy #0                                                            // b040: a0 00       ..  :04c7[1]
+    ldx #$53 // 'S'                                                   // b042: a2 53       .S  :04c9[1]
+    jmp tube_entry                                                    // b044: 4c 06 04    L.. :04cb[1]
+
+// $b047 referenced 2 times by $0498, $04c2
+sub_c04ce
+    lda #$80                                                          // b047: a9 80       ..  :04ce[1]
+    sta l0054                                                         // b049: 85 54       .T  :04d0[1]
+    sta l0001                                                         // b04b: 85 01       ..  :04d2[1]
+    lda #$20 // ' '                                                   // b04d: a9 20       .   :04d4[1]
+    and rom_type                                                      // b04f: 2d 06 80    -.. :04d6[1]
+    tay                                                               // b052: a8          .   :04d9[1]
+    sty l0053                                                         // b053: 84 53       .S  :04da[1]
+    beq c04f7                                                         // b055: f0 19       ..  :04dc[1]
+    ldx copyright_offset                                              // b057: ae 07 80    ... :04de[1]
+// $b05a referenced 1 time by $04e5
+loop_c04e1
+    inx                                                               // b05a: e8          .   :04e1[1]
+    lda rom_header,x                                                  // b05b: bd 00 80    ... :04e2[1]
+    bne loop_c04e1                                                    // b05e: d0 fa       ..  :04e5[1]
+    lda l8001,x                                                       // b060: bd 01 80    ... :04e7[1]
+    sta l0053                                                         // b063: 85 53       .S  :04ea[1]
+    lda l8002,x                                                       // b065: bd 02 80    ... :04ec[1]
+    sta l0054                                                         // b068: 85 54       .T  :04ef[1]
+    ldy service_entry,x                                               // b06a: bc 03 80    ... :04f1[1]
+    lda l8004,x                                                       // b06d: bd 04 80    ... :04f4[1]
+// $b070 referenced 1 time by $04dc
+c04f7
+    sta l0056                                                         // b070: 85 56       .V  :04f7[1]
+    sty l0055                                                         // b072: 84 55       .U  :04f9[1]
+    rts                                                               // b074: 60          `   :04fb[1]
+
+// $b075 referenced 1 time by $b2b4
+* = $b075
+// $b075 referenced 1 time by $b2b4
+lb075
+// $b075 referenced 1 time by $b2b4
+    .byt $0a                                                          // b075: 0a          .
+    .asc "SRAM 1.05"                                                  // b076: 53 52 41... SRA
+    .byt $0d, $0a                                                     // b07f: 0d 0a       ..
+    .asc "  SRDATA  <id.>"                                            // b081: 20 20 53...   S
+    .byt $0d, $0a                                                     // b090: 0d 0a       ..
+    .asc "  SRLOAD  <filename> <sram address> (<id.>) (Q)"            // b092: 20 20 53...   S
+    .byt $0d, $0a                                                     // b0c1: 0d 0a       ..
+    .asc "  SRREAD  <dest. start> <dest. end> <sram start> (<id.>)"   // b0c3: 20 20 53...   S
+    .byt $0d, $0a                                                     // b0fb: 0d 0a       ..
+    .asc "  SRROM   <id.>"                                            // b0fd: 20 20 53...   S
+    .byt $0d, $0a                                                     // b10c: 0d 0a       ..
+    .asc "  SRSAVE  <filename> <sram start> <sram end> (<id.>) (Q)"   // b10e: 20 20 53...   S
+    .byt $0d, $0a                                                     // b146: 0d 0a       ..
+    .asc "  SRWRITE <source start> <source end> <sram s"              // b148: 20 20 53...   S
+// $b175 referenced 1 time by $b2bd
+lb175
+    .asc "tart> (<id.>)"                                              // b175: 74 61 72... tar
+    .byt $0d, $0a                                                     // b182: 0d 0a       ..
+    .asc "End addresses may be replaced by +<length>"                 // b184: 45 6e 64... End
+    .byt $0d, $0a,   0                                                // b1ae: 0d 0a 00    ...
+
+// $b1b1 referenced 1 time by $bedd
+general_service_handler
+    jsr sub_c965d                                                     // b1b1: 20 5d 96     ].
+    pha                                                               // b1b4: 48          H
+    tax                                                               // b1b5: aa          .
+    lda l00b8                                                         // b1b6: a5 b8       ..
+    pha                                                               // b1b8: 48          H
+    lda l00b9                                                         // b1b9: a5 b9       ..
+    pha                                                               // b1bb: 48          H
+    tya                                                               // b1bc: 98          .
+    pha                                                               // b1bd: 48          H
+    txa                                                               // b1be: 8a          .
+    ldx romsel_copy                                                   // b1bf: a6 f4       ..
+    jsr cb82b                                                         // b1c1: 20 2b b8     +.
+    bit l00b9                                                         // b1c4: 24 b9       $.
+    bmi cb203                                                         // b1c6: 30 3b       0;
+    cmp #8                                                            // b1c8: c9 08       ..
+    bne cb1fc                                                         // b1ca: d0 30       .0
+    lda l00ef                                                         // b1cc: a5 ef       ..
+    cmp #$43 // 'C'                                                   // b1ce: c9 43       .C
+    bne cb1dd                                                         // b1d0: d0 0b       ..
+    jsr sub_cb2c8                                                     // b1d2: 20 c8 b2     ..
+// $b1d5 referenced 3 times by $b1f9, $b231, $b25d
+cb1d5
+    tsx                                                               // b1d5: ba          .
+    lda #0                                                            // b1d6: a9 00       ..
+    sta l0104,x                                                       // b1d8: 9d 04 01    ...
+    beq cb203                                                         // b1db: f0 26       .&
+// $b1dd referenced 1 time by $b1d0
+cb1dd
+    cmp #$42 // 'B'                                                   // b1dd: c9 42       .B
+    bne cb203                                                         // b1df: d0 22       ."
+    ldy #9                                                            // b1e1: a0 09       ..
+// $b1e3 referenced 1 time by $b1eb
+loop_cb1e3
+    lda (l00f0),y                                                     // b1e3: b1 f0       ..
+    sta l00b4,y                                                       // b1e5: 99 b4 00    ...
+    dey                                                               // b1e8: 88          .
+    cpy #8                                                            // b1e9: c0 08       ..
+    bcs loop_cb1e3                                                    // b1eb: b0 f6       ..
+// $b1ed referenced 1 time by $b1f3
+loop_cb1ed
+    lda (l00f0),y                                                     // b1ed: b1 f0       ..
+    sta l00b0,y                                                       // b1ef: 99 b0 00    ...
+    dey                                                               // b1f2: 88          .
+    bpl loop_cb1ed                                                    // b1f3: 10 f8       ..
+    cli                                                               // b1f5: 58          X
+    jsr cbcb9                                                         // b1f6: 20 b9 bc     ..
+    jmp cb1d5                                                         // b1f9: 4c d5 b1    L..
+
+// $b1fc referenced 1 time by $b1ca
+cb1fc
+    cmp #2                                                            // b1fc: c9 02       ..
+    bne cb20f                                                         // b1fe: d0 0f       ..
+    jsr sub_cb882                                                     // b200: 20 82 b8     ..
+// $b203 referenced 10 times by $b1c6, $b1db, $b1df, $b219, $b21e, $b228, $b22c, $b262, $b26a, $b280
+cb203
+    pla                                                               // b203: 68          h
+    tay                                                               // b204: a8          .
+    pla                                                               // b205: 68          h
+    sta l00b9                                                         // b206: 85 b9       ..
+    pla                                                               // b208: 68          h
+    sta l00b8                                                         // b209: 85 b8       ..
+    pla                                                               // b20b: 68          h
+    ldx romsel_copy                                                   // b20c: a6 f4       ..
+    rts                                                               // b20e: 60          `
+
+// $b20f referenced 1 time by $b1fe
+cb20f
+    cmp #6                                                            // b20f: c9 06       ..
+    bne cb221                                                         // b211: d0 0e       ..
+    ldy #$ff                                                          // b213: a0 ff       ..
+    lda (l00b8),y                                                     // b215: b1 b8       ..
+    cmp #$4e // 'N'                                                   // b217: c9 4e       .N
+    bne cb203                                                         // b219: d0 e8       ..
+    jsr sub_cb5f2                                                     // b21b: 20 f2 b5     ..
+    jmp cb203                                                         // b21e: 4c 03 b2    L..
+
+// $b221 referenced 1 time by $b211
+cb221
+    cmp #4                                                            // b221: c9 04       ..
+    bne cb23d                                                         // b223: d0 18       ..
+    jsr sub_cb9f5                                                     // b225: 20 f5 b9     ..
+    bcs cb203                                                         // b228: b0 d9       ..
+    cpx #4                                                            // b22a: e0 04       ..
+    beq cb203                                                         // b22c: f0 d5       ..
+    jsr sub_cb234                                                     // b22e: 20 34 b2     4.
+    jmp cb1d5                                                         // b231: 4c d5 b1    L..
+
+// $b234 referenced 1 time by $b22e
+sub_cb234
+    lda sram_table,x                                                  // b234: bd 30 ba    .0.
+    pha                                                               // b237: 48          H
+    lda sram_table+1,x                                                // b238: bd 31 ba    .1.
+    pha                                                               // b23b: 48          H
+    rts                                                               // b23c: 60          `
+
+// $b23d referenced 1 time by $b223
+cb23d
+    cmp #7                                                            // b23d: c9 07       ..
+    bne cb268                                                         // b23f: d0 27       .'
+    lda l00ef                                                         // b241: a5 ef       ..
+    cmp #$44 // 'D'                                                   // b243: c9 44       .D
+    bne cb260                                                         // b245: d0 19       ..
+    ldy #$ee                                                          // b247: a0 ee       ..
+// $b249 referenced 1 time by $b266
+loop_cb249
+    lda (l00b8),y                                                     // b249: b1 b8       ..
+    and #$3f // '?'                                                   // b24b: 29 3f       )?
+    sta l00b0                                                         // b24d: 85 b0       ..
+    ldy #$fe                                                          // b24f: a0 fe       ..
+    lda (l00b8),y                                                     // b251: b1 b8       ..
+    and #8                                                            // b253: 29 08       ).
+    asl                                                               // b255: 0a          .
+    asl                                                               // b256: 0a          .
+    asl                                                               // b257: 0a          .
+    asl                                                               // b258: 0a          .
+    ora l00b0                                                         // b259: 05 b0       ..
+    sta l00f0                                                         // b25b: 85 f0       ..
+    jmp cb1d5                                                         // b25d: 4c d5 b1    L..
+
+// $b260 referenced 1 time by $b245
+cb260
+    cmp #$45 // 'E'                                                   // b260: c9 45       .E
+    bne cb203                                                         // b262: d0 9f       ..
+    ldy #$fd                                                          // b264: a0 fd       ..
+    bne loop_cb249                                                    // b266: d0 e1       ..
+// $b268 referenced 1 time by $b23f
+cb268
+    cmp #9                                                            // b268: c9 09       ..
+    bne cb203                                                         // b26a: d0 97       ..
+    lda #$0d                                                          // b26c: a9 0d       ..
+    jsr sub_cbac4                                                     // b26e: 20 c4 ba     ..
+    bcs cb297                                                         // b271: b0 24       .$
+    ldx #0                                                            // b273: a2 00       ..
+// $b275 referenced 1 time by $b27e
+loop_cb275
+    lda lb283,x                                                       // b275: bd 83 b2    ...
+    jsr oswrch                                                        // b278: 20 ee ff     ..
+    inx                                                               // b27b: e8          .
+    cpx #$14                                                          // b27c: e0 14       ..
+    bne loop_cb275                                                    // b27e: d0 f5       ..
+// $b280 referenced 2 times by $b2a6, $b2c0
+cb280
+    jmp cb203                                                         // b280: 4c 03 b2    L..
+
+// $b283 referenced 1 time by $b275
+lb283
+    .byt $0a                                                          // b283: 0a          .
+    .asc "SRAM 1.05"                                                  // b284: 53 52 41... SRA
+    .byt $0d, $0a                                                     // b28d: 0d 0a       ..
+    .asc "  SRAM"                                                     // b28f: 20 20 53...   S
+    .byt $0d, $0a                                                     // b295: 0d 0a       ..
+
+// $b297 referenced 2 times by $b271, $b2b0
+cb297
+    jsr sub_cb9f5                                                     // b297: 20 f5 b9     ..
+    cpx #4                                                            // b29a: e0 04       ..
+    beq cb2b2                                                         // b29c: f0 14       ..
+    lda #0                                                            // b29e: a9 00       ..
+// $b2a0 referenced 2 times by $b2aa, $b2ae
+cb2a0
+    tax                                                               // b2a0: aa          .
+    iny                                                               // b2a1: c8          .
+    lda (os_text_ptr),y                                               // b2a2: b1 f2       ..
+    cmp #$0d                                                          // b2a4: c9 0d       ..
+    beq cb280                                                         // b2a6: f0 d8       ..
+    cmp #$20 // ' '                                                   // b2a8: c9 20       .
+    beq cb2a0                                                         // b2aa: f0 f4       ..
+    cpx #$20 // ' '                                                   // b2ac: e0 20       .
+    bne cb2a0                                                         // b2ae: d0 f0       ..
+    beq cb297                                                         // b2b0: f0 e5       ..
+// $b2b2 referenced 1 time by $b29c
+cb2b2
+    ldy #0                                                            // b2b2: a0 00       ..
+// $b2b4 referenced 1 time by $b2bb
+loop_cb2b4
+    lda lb075,y                                                       // b2b4: b9 75 b0    .u.
+    jsr oswrch                                                        // b2b7: 20 ee ff     ..
+    iny                                                               // b2ba: c8          .
+    bne loop_cb2b4                                                    // b2bb: d0 f7       ..
+// $b2bd referenced 1 time by $b2c6
+loop_cb2bd
+    lda lb175,y                                                       // b2bd: b9 75 b1    .u.
+    beq cb280                                                         // b2c0: f0 be       ..
+    jsr oswrch                                                        // b2c2: 20 ee ff     ..
+    iny                                                               // b2c5: c8          .
+    bne loop_cb2bd                                                    // b2c6: d0 f5       ..
+// $b2c8 referenced 1 time by $b1d2
+sub_cb2c8
+    jsr cb82b                                                         // b2c8: 20 2b b8     +.
+    lda #$ee                                                          // b2cb: a9 ee       ..
+    sta l00b8                                                         // b2cd: 85 b8       ..
+    ldy #$0b                                                          // b2cf: a0 0b       ..
+// $b2d1 referenced 1 time by $b2e4
+loop_cb2d1
+    lda (l00f0),y                                                     // b2d1: b1 f0       ..
+    cpy #0                                                            // b2d3: c0 00       ..
+    bne cb2e1                                                         // b2d5: d0 0a       ..
+    and #$c0                                                          // b2d7: 29 c0       ).
+    sta l00bc                                                         // b2d9: 85 bc       ..
+    lda (l00b8),y                                                     // b2db: b1 b8       ..
+    and #$3f // '?'                                                   // b2dd: 29 3f       )?
+    ora l00bc                                                         // b2df: 05 bc       ..
+// $b2e1 referenced 1 time by $b2d5
+cb2e1
+    sta (l00b8),y                                                     // b2e1: 91 b8       ..
+    dey                                                               // b2e3: 88          .
+    bpl loop_cb2d1                                                    // b2e4: 10 eb       ..
+    cli                                                               // b2e6: 58          X
+// $b2e7 referenced 1 time by $bbcd
+cb2e7
+    jsr cb82b                                                         // b2e7: 20 2b b8     +.
+    ldy #$f2                                                          // b2ea: a0 f2       ..
+    lda (l00b8),y                                                     // b2ec: b1 b8       ..
+    tax                                                               // b2ee: aa          .
+    iny                                                               // b2ef: c8          .
+    lda (l00b8),y                                                     // b2f0: b1 b8       ..
+    jsr sub_cb85d                                                     // b2f2: 20 5d b8     ].
+    bvs cb305                                                         // b2f5: 70 0e       p.
+    ldy #$f1                                                          // b2f7: a0 f1       ..
+    lda (l00b8),y                                                     // b2f9: b1 b8       ..
+    tay                                                               // b2fb: a8          .
+    cpy #$14                                                          // b2fc: c0 14       ..
+    bcc cb314                                                         // b2fe: 90 14       ..
+// $b300 referenced 2 times by $b324, $bcd3
+cb300
+    ldx #0                                                            // b300: a2 00       ..
+    jmp cb8fb                                                         // b302: 4c fb b8    L..
+
+// $b305 referenced 1 time by $b2f5
+cb305
+    jsr sub_cb6b1                                                     // b305: 20 b1 b6     ..
+    sty l00ba                                                         // b308: 84 ba       ..
+    ldy #$f3                                                          // b30a: a0 f3       ..
+    sta (l00b8),y                                                     // b30c: 91 b8       ..
+    txa                                                               // b30e: 8a          .
+    dey                                                               // b30f: 88          .
+    sta (l00b8),y                                                     // b310: 91 b8       ..
+    ldy l00ba                                                         // b312: a4 ba       ..
+// $b314 referenced 1 time by $b2fe
+cb314
+    jsr sub_cb6fe                                                     // b314: 20 fe b6     ..
+    tax                                                               // b317: aa          .
+    tya                                                               // b318: 98          .
+    ldy #$f1                                                          // b319: a0 f1       ..
+    sta (l00b8),y                                                     // b31b: 91 b8       ..
+    txa                                                               // b31d: 8a          .
+    ldy #$ee                                                          // b31e: a0 ee       ..
+    eor (l00b8),y                                                     // b320: 51 b8       Q.
+    and #$40 // '@'                                                   // b322: 29 40       )@
+    bne cb300                                                         // b324: d0 da       ..
+    tay                                                               // b326: a8          .
+    ldx #$ba                                                          // b327: a2 ba       ..
+    jsr osargs                                                        // b329: 20 da ff     ..
+    jsr cb82b                                                         // b32c: 20 2b b8     +.
+    tax                                                               // b32f: aa          .
+    bne cb337                                                         // b330: d0 05       ..
+    ldx #2                                                            // b332: a2 02       ..
+    jmp cb8fb                                                         // b334: 4c fb b8    L..
+
+// $b337 referenced 1 time by $b330
+cb337
+    pha                                                               // b337: 48          H
+    jsr sub_cbe9d                                                     // b338: 20 9d be     ..
+    pla                                                               // b33b: 68          h
+    cmp #4                                                            // b33c: c9 04       ..
+    bcs cb3ba                                                         // b33e: b0 7a       .z
+    jsr sub_cb85d                                                     // b340: 20 5d b8     ].
+    bpl cb375                                                         // b343: 10 30       .0
+    jsr sub_cb5ce                                                     // b345: 20 ce b5     ..
+    jsr sub_cb607                                                     // b348: 20 07 b6     ..
+    bne cb371                                                         // b34b: d0 24       .$
+    beq cb352                                                         // b34d: f0 03       ..
+// $b34f referenced 1 time by $b36f
+cb34f
+    jsr sub_cb65f                                                     // b34f: 20 5f b6     _.
+// $b352 referenced 1 time by $b34d
+cb352
+    ldy #$fa                                                          // b352: a0 fa       ..
+    lda (l00b8),y                                                     // b354: b1 b8       ..
+    tay                                                               // b356: a8          .
+    jsr osbget                                                        // b357: 20 d7 ff     ..
+    jsr cb82b                                                         // b35a: 20 2b b8     +.
+    ldy #$f2                                                          // b35d: a0 f2       ..
+    jsr sub_cb83f                                                     // b35f: 20 3f b8     ?.
+    tax                                                               // b362: aa          .
+    ldy #$f1                                                          // b363: a0 f1       ..
+    lda (l00b8),y                                                     // b365: b1 b8       ..
+    tay                                                               // b367: a8          .
+    txa                                                               // b368: 8a          .
+    jsr sub_cb745                                                     // b369: 20 45 b7     E.
+    jsr sub_cb607                                                     // b36c: 20 07 b6     ..
+    beq cb34f                                                         // b36f: f0 de       ..
+// $b371 referenced 3 times by $b34b, $b37b, $b3b8
+cb371
+    jsr sub_cb5f2                                                     // b371: 20 f2 b5     ..
+    rts                                                               // b374: 60          `
+
+// $b375 referenced 1 time by $b343
+cb375
+    jsr sub_cb5ee                                                     // b375: 20 ee b5     ..
+    jsr sub_cb616                                                     // b378: 20 16 b6     ..
+    beq cb371                                                         // b37b: f0 f4       ..
+    bne cb382                                                         // b37d: d0 03       ..
+// $b37f referenced 1 time by $b3b6
+cb37f
+    jsr sub_cb65f                                                     // b37f: 20 5f b6     _.
+// $b382 referenced 1 time by $b37d
+cb382
+    ldy #$f4                                                          // b382: a0 f4       ..
+    lda (l00b8),y                                                     // b384: b1 b8       ..
+    sec                                                               // b386: 38          8
+    sbc #1                                                            // b387: e9 01       ..
+    sta (l00b8),y                                                     // b389: 91 b8       ..
+    cmp #$ff                                                          // b38b: c9 ff       ..
+    bne cb397                                                         // b38d: d0 08       ..
+    iny                                                               // b38f: c8          .
+    lda (l00b8),y                                                     // b390: b1 b8       ..
+    sec                                                               // b392: 38          8
+    sbc #1                                                            // b393: e9 01       ..
+    sta (l00b8),y                                                     // b395: 91 b8       ..
+// $b397 referenced 1 time by $b38d
+cb397
+    ldx #$f6                                                          // b397: a2 f6       ..
+    ldy #$f2                                                          // b399: a0 f2       ..
+    jsr sub_cb841                                                     // b39b: 20 41 b8     A.
+    ldy #$f1                                                          // b39e: a0 f1       ..
+    lda (l00b8),y                                                     // b3a0: b1 b8       ..
+    tay                                                               // b3a2: a8          .
+    jsr osrdsc                                                        // b3a3: 20 b9 ff     ..
+    tax                                                               // b3a6: aa          .
+    ldy #$fa                                                          // b3a7: a0 fa       ..
+    lda (l00b8),y                                                     // b3a9: b1 b8       ..
+    tay                                                               // b3ab: a8          .
+    txa                                                               // b3ac: 8a          .
+    jsr osbput                                                        // b3ad: 20 d4 ff     ..
+    jsr cb82b                                                         // b3b0: 20 2b b8     +.
+    jsr sub_cb616                                                     // b3b3: 20 16 b6     ..
+    bne cb37f                                                         // b3b6: d0 c7       ..
+    beq cb371                                                         // b3b8: f0 b7       ..
+// $b3ba referenced 1 time by $b33e
+cb3ba
+    ldy #$f9                                                          // b3ba: a0 f9       ..
+    lda (l00b8),y                                                     // b3bc: b1 b8       ..
+    bmi cb3de                                                         // b3be: 30 1e       0.
+    dey                                                               // b3c0: 88          .
+    ora (l00b8),y                                                     // b3c1: 11 b8       ..
+    bne cb406                                                         // b3c3: d0 41       .A
+    lda #0                                                            // b3c5: a9 00       ..
+    sta (l00b8),y                                                     // b3c7: 91 b8       ..
+    lda #1                                                            // b3c9: a9 01       ..
+    iny                                                               // b3cb: c8          .
+    sta (l00b8),y                                                     // b3cc: 91 b8       ..
+    ldy #$f6                                                          // b3ce: a0 f6       ..
+    lda #0                                                            // b3d0: a9 00       ..
+    sta (l00b8),y                                                     // b3d2: 91 b8       ..
+    ldx l00b9                                                         // b3d4: a6 b9       ..
+    inx                                                               // b3d6: e8          .
+    txa                                                               // b3d7: 8a          .
+    iny                                                               // b3d8: c8          .
+    sta (l00b8),y                                                     // b3d9: 91 b8       ..
+    jmp cb406                                                         // b3db: 4c 06 b4    L..
+
+// $b3de referenced 1 time by $b3be
+cb3de
+    lda #osbyte_read_himem                                            // b3de: a9 84       ..
+    jsr osbyte                                                        // b3e0: 20 f4 ff     ..
+    tya                                                               // b3e3: 98          .
+    pha                                                               // b3e4: 48          H
+    txa                                                               // b3e5: 8a          .
+    pha                                                               // b3e6: 48          H
+    lda #osbyte_read_oshwm                                            // b3e7: a9 83       ..
+    jsr osbyte                                                        // b3e9: 20 f4 ff     ..
+    jsr cb82b                                                         // b3ec: 20 2b b8     +.
+    stx l00ba                                                         // b3ef: 86 ba       ..
+    sty l00bb                                                         // b3f1: 84 bb       ..
+    ldy #$f6                                                          // b3f3: a0 f6       ..
+    jsr sub_cb84e                                                     // b3f5: 20 4e b8     N.
+    pla                                                               // b3f8: 68          h
+    sec                                                               // b3f9: 38          8
+    sbc l00ba                                                         // b3fa: e5 ba       ..
+    ldy #$f8                                                          // b3fc: a0 f8       ..
+    sta (l00b8),y                                                     // b3fe: 91 b8       ..
+    pla                                                               // b400: 68          h
+    sbc l00bb                                                         // b401: e5 bb       ..
+    iny                                                               // b403: c8          .
+    sta (l00b8),y                                                     // b404: 91 b8       ..
+// $b406 referenced 2 times by $b3c3, $b3db
+cb406
+    jsr sub_cb85d                                                     // b406: 20 5d b8     ].
+    bmi cb40e                                                         // b409: 30 03       0.
+    jmp cb4d8                                                         // b40b: 4c d8 b4    L..
+
+// $b40e referenced 1 time by $b409
+cb40e
+    jsr sub_cb5ce                                                     // b40e: 20 ce b5     ..
+    tsx                                                               // b411: ba          .
+    txa                                                               // b412: 8a          .
+    sec                                                               // b413: 38          8
+    sbc #$10                                                          // b414: e9 10       ..
+    tax                                                               // b416: aa          .
+    txs                                                               // b417: 9a          .
+    ldy #$f0                                                          // b418: a0 f0       ..
+    lda (l00b8),y                                                     // b41a: b1 b8       ..
+    pha                                                               // b41c: 48          H
+    dey                                                               // b41d: 88          .
+    lda (l00b8),y                                                     // b41e: b1 b8       ..
+    pha                                                               // b420: 48          H
+    dex                                                               // b421: ca          .
+    ldy #1                                                            // b422: a0 01       ..
+    lda #osfile_read_catalogue_info                                   // b424: a9 05       ..
+    jsr osfile                                                        // b426: 20 dd ff     ..
+    jsr cb82b                                                         // b429: 20 2b b8     +.
+    tsx                                                               // b42c: ba          .
+    lda l010b,x                                                       // b42d: bd 0b 01    ...
+    ldy #$f4                                                          // b430: a0 f4       ..
+    sta (l00b8),y                                                     // b432: 91 b8       ..
+    sta l00ba                                                         // b434: 85 ba       ..
+    lda l010c,x                                                       // b436: bd 0c 01    ...
+    iny                                                               // b439: c8          .
+    sta (l00b8),y                                                     // b43a: 91 b8       ..
+    sta l00bb                                                         // b43c: 85 bb       ..
+    lda l010d,x                                                       // b43e: bd 0d 01    ...
+    ora l010e,x                                                       // b441: 1d 0e 01    ...
+    beq cb44b                                                         // b444: f0 05       ..
+// $b446 referenced 4 times by $b68c, $b6c7, $b715, $bc10
+cb446
+    ldx #1                                                            // b446: a2 01       ..
+    jmp cb8fb                                                         // b448: 4c fb b8    L..
+
+// $b44b referenced 1 time by $b444
+cb44b
+    ldx #$12                                                          // b44b: a2 12       ..
+// $b44d referenced 1 time by $b44f
+loop_cb44d
+    pla                                                               // b44d: 68          h
+    dex                                                               // b44e: ca          .
+    bne loop_cb44d                                                    // b44f: d0 fc       ..
+    bit lb57f                                                         // b451: 2c 7f b5    ,..
+    lda l00ba                                                         // b454: a5 ba       ..
+    ora l00bb                                                         // b456: 05 bb       ..
+    bne cb45e                                                         // b458: d0 04       ..
+// $b45a referenced 1 time by $b4d2
+cb45a
+    jsr sub_cb5f2                                                     // b45a: 20 f2 b5     ..
+    rts                                                               // b45d: 60          `
+
+// $b45e referenced 2 times by $b458, $b4d5
+cb45e
+    ldx #$bc                                                          // b45e: a2 bc       ..
+    ldy #$f8                                                          // b460: a0 f8       ..
+    jsr sub_cb841                                                     // b462: 20 41 b8     A.
+    ldy #$ba                                                          // b465: a0 ba       ..
+    jsr sub_cb58b                                                     // b467: 20 8b b5     ..
+    bcs cb470                                                         // b46a: b0 04       ..
+    jsr sub_cb580                                                     // b46c: 20 80 b5     ..
+    clv                                                               // b46f: b8          .
+// $b470 referenced 1 time by $b46a
+cb470
+    ldy #$fb                                                          // b470: a0 fb       ..
+    jsr sub_cb84e                                                     // b472: 20 4e b8     N.
+    bvc cb4af                                                         // b475: 50 38       P8
+    jsr sub_cb5f2                                                     // b477: 20 f2 b5     ..
+    tsx                                                               // b47a: ba          .
+    txa                                                               // b47b: 8a          .
+    sec                                                               // b47c: 38          8
+    sbc #$0b                                                          // b47d: e9 0b       ..
+    tax                                                               // b47f: aa          .
+    txs                                                               // b480: 9a          .
+    lda #0                                                            // b481: a9 00       ..
+    pha                                                               // b483: 48          H
+    lda #$ff                                                          // b484: a9 ff       ..
+    pha                                                               // b486: 48          H
+    pha                                                               // b487: 48          H
+    ldy #$f7                                                          // b488: a0 f7       ..
+    lda (l00b8),y                                                     // b48a: b1 b8       ..
+    pha                                                               // b48c: 48          H
+    dey                                                               // b48d: 88          .
+    lda (l00b8),y                                                     // b48e: b1 b8       ..
+    pha                                                               // b490: 48          H
+    ldy #$f0                                                          // b491: a0 f0       ..
+    lda (l00b8),y                                                     // b493: b1 b8       ..
+    pha                                                               // b495: 48          H
+    dey                                                               // b496: 88          .
+    lda (l00b8),y                                                     // b497: b1 b8       ..
+    pha                                                               // b499: 48          H
+    tsx                                                               // b49a: ba          .
+    inx                                                               // b49b: e8          .
+    ldy #1                                                            // b49c: a0 01       ..
+    lda #osfile_load                                                  // b49e: a9 ff       ..
+    jsr osfile                                                        // b4a0: 20 dd ff     ..
+    jsr cb82b                                                         // b4a3: 20 2b b8     +.
+    ldx #$12                                                          // b4a6: a2 12       ..
+// $b4a8 referenced 1 time by $b4aa
+loop_cb4a8
+    pla                                                               // b4a8: 68          h
+    dex                                                               // b4a9: ca          .
+    bne loop_cb4a8                                                    // b4aa: d0 fc       ..
+    jmp cb4b4                                                         // b4ac: 4c b4 b4    L..
+
+// $b4af referenced 1 time by $b475
+cb4af
+    lda #4                                                            // b4af: a9 04       ..
+    jsr sub_cb598                                                     // b4b1: 20 98 b5     ..
+// $b4b4 referenced 1 time by $b4ac
+cb4b4
+    ldx #$b1                                                          // b4b4: a2 b1       ..
+    ldy #$f6                                                          // b4b6: a0 f6       ..
+    jsr sub_cb841                                                     // b4b8: 20 41 b8     A.
+    ldx #$b3                                                          // b4bb: a2 b3       ..
+    ldy #$f2                                                          // b4bd: a0 f2       ..
+    jsr sub_cb841                                                     // b4bf: 20 41 b8     A.
+    ldx #$be                                                          // b4c2: a2 be       ..
+    ldy #$fb                                                          // b4c4: a0 fb       ..
+    jsr sub_cb841                                                     // b4c6: 20 41 b8     A.
+    sec                                                               // b4c9: 38          8
+    jsr cb795                                                         // b4ca: 20 95 b7     ..
+    ldx #$b3                                                          // b4cd: a2 b3       ..
+    jsr sub_cb61e                                                     // b4cf: 20 1e b6     ..
+    beq cb45a                                                         // b4d2: f0 86       ..
+    clv                                                               // b4d4: b8          .
+    jmp cb45e                                                         // b4d5: 4c 5e b4    L^.
+
+// $b4d8 referenced 1 time by $b40b
+cb4d8
+    jsr sub_cb5ee                                                     // b4d8: 20 ee b5     ..
+    bit lb57f                                                         // b4db: 2c 7f b5    ,..
+    php                                                               // b4de: 08          .
+// $b4df referenced 1 time by $b531
+cb4df
+    ldy #$f4                                                          // b4df: a0 f4       ..
+    jsr sub_cb83f                                                     // b4e1: 20 3f b8     ?.
+    jsr sub_cb616                                                     // b4e4: 20 16 b6     ..
+    bne cb4ee                                                         // b4e7: d0 05       ..
+// $b4e9 referenced 1 time by $b57c
+cb4e9
+    plp                                                               // b4e9: 28          (
+    jsr sub_cb5f2                                                     // b4ea: 20 f2 b5     ..
+    rts                                                               // b4ed: 60          `
+
+// $b4ee referenced 1 time by $b4e7
+cb4ee
+    ldx #$bc                                                          // b4ee: a2 bc       ..
+    ldy #$f8                                                          // b4f0: a0 f8       ..
+    jsr sub_cb841                                                     // b4f2: 20 41 b8     A.
+    ldy #$ba                                                          // b4f5: a0 ba       ..
+    jsr sub_cb58b                                                     // b4f7: 20 8b b5     ..
+    bcs cb502                                                         // b4fa: b0 06       ..
+    jsr sub_cb580                                                     // b4fc: 20 80 b5     ..
+    plp                                                               // b4ff: 28          (
+    clv                                                               // b500: b8          .
+    php                                                               // b501: 08          .
+// $b502 referenced 1 time by $b4fa
+cb502
+    ldy #$fb                                                          // b502: a0 fb       ..
+    jsr sub_cb84e                                                     // b504: 20 4e b8     N.
+    ldx #$b1                                                          // b507: a2 b1       ..
+    ldy #$f2                                                          // b509: a0 f2       ..
+    jsr sub_cb841                                                     // b50b: 20 41 b8     A.
+    ldx #$b3                                                          // b50e: a2 b3       ..
+    ldy #$f6                                                          // b510: a0 f6       ..
+    jsr sub_cb841                                                     // b512: 20 41 b8     A.
+    ldx #$be                                                          // b515: a2 be       ..
+    ldy #$fb                                                          // b517: a0 fb       ..
+    jsr sub_cb841                                                     // b519: 20 41 b8     A.
+    clc                                                               // b51c: 18          .
+    jsr cb795                                                         // b51d: 20 95 b7     ..
+    ldx #$b1                                                          // b520: a2 b1       ..
+    jsr sub_cb61e                                                     // b522: 20 1e b6     ..
+    plp                                                               // b525: 28          (
+    php                                                               // b526: 08          .
+    bvs cb534                                                         // b527: 70 0b       p.
+    lda #2                                                            // b529: a9 02       ..
+    jsr sub_cb598                                                     // b52b: 20 98 b5     ..
+    plp                                                               // b52e: 28          (
+    clv                                                               // b52f: b8          .
+    php                                                               // b530: 08          .
+    jmp cb4df                                                         // b531: 4c df b4    L..
+
+// $b534 referenced 1 time by $b527
+cb534
+    jsr sub_cb5f2                                                     // b534: 20 f2 b5     ..
+    lda #$ff                                                          // b537: a9 ff       ..
+    pha                                                               // b539: 48          H
+    pha                                                               // b53a: 48          H
+    ldy #$f6                                                          // b53b: a0 f6       ..
+    jsr sub_cb83f                                                     // b53d: 20 3f b8     ?.
+    ldy #$fb                                                          // b540: a0 fb       ..
+    lda l00ba                                                         // b542: a5 ba       ..
+    clc                                                               // b544: 18          .
+    adc (l00b8),y                                                     // b545: 71 b8       q.
+    tax                                                               // b547: aa          .
+    lda l00bb                                                         // b548: a5 bb       ..
+    iny                                                               // b54a: c8          .
+    adc (l00b8),y                                                     // b54b: 71 b8       q.
+    pha                                                               // b54d: 48          H
+    txa                                                               // b54e: 8a          .
+    pha                                                               // b54f: 48          H
+    lda #$ff                                                          // b550: a9 ff       ..
+    pha                                                               // b552: 48          H
+    pha                                                               // b553: 48          H
+    lda l00bb                                                         // b554: a5 bb       ..
+    pha                                                               // b556: 48          H
+    lda l00ba                                                         // b557: a5 ba       ..
+    pha                                                               // b559: 48          H
+    lda #$ff                                                          // b55a: a9 ff       ..
+    ldx #8                                                            // b55c: a2 08       ..
+// $b55e referenced 1 time by $b560
+loop_cb55e
+    pha                                                               // b55e: 48          H
+    dex                                                               // b55f: ca          .
+    bne loop_cb55e                                                    // b560: d0 fc       ..
+    ldy #$f0                                                          // b562: a0 f0       ..
+    lda (l00b8),y                                                     // b564: b1 b8       ..
+    pha                                                               // b566: 48          H
+    dey                                                               // b567: 88          .
+    tsx                                                               // b568: ba          .
+    lda (l00b8),y                                                     // b569: b1 b8       ..
+    pha                                                               // b56b: 48          H
+    ldy #1                                                            // b56c: a0 01       ..
+    lda #osfile_save                                                  // b56e: a9 00       ..
+    jsr osfile                                                        // b570: 20 dd ff     ..
+    jsr cb82b                                                         // b573: 20 2b b8     +.
+    ldx #$12                                                          // b576: a2 12       ..
+// $b578 referenced 1 time by $b57a
+loop_cb578
+    pla                                                               // b578: 68          h
+    dex                                                               // b579: ca          .
+    bne loop_cb578                                                    // b57a: d0 fc       ..
+    jmp cb4e9                                                         // b57c: 4c e9 b4    L..
+
+// $b57f referenced 4 times by $b451, $b4db, $bae7, $bbda
+lb57f
+    .byt $40                                                          // b57f: 40          @
+
+// $b580 referenced 7 times by $b46c, $b4fc, $bcfd, $bd08, $bd12, $bdaa, $bde4
+sub_cb580
+    lda l0000,x                                                       // b580: b5 00       ..
+    sta l0000,y                                                       // b582: 99 00 00    ...
+    lda l0001,x                                                       // b585: b5 01       ..
+    sta l0001,y                                                       // b587: 99 01 00    ...
+    rts                                                               // b58a: 60          `
+
+// $b58b referenced 3 times by $b467, $b4f7, $b800
+sub_cb58b
+    lda l0001,x                                                       // b58b: b5 01       ..
+    cmp l0001,y                                                       // b58d: d9 01 00    ...
+    bne cb597                                                         // b590: d0 05       ..
+    lda l0000,x                                                       // b592: b5 00       ..
+    cmp l0000,y                                                       // b594: d9 00 00    ...
+// $b597 referenced 1 time by $b590
+cb597
+    rts                                                               // b597: 60          `
+
+// $b598 referenced 2 times by $b4b1, $b52b
+sub_cb598
+    pha                                                               // b598: 48          H
+    pha                                                               // b599: 48          H
+    pha                                                               // b59a: 48          H
+    pha                                                               // b59b: 48          H
+    lda #0                                                            // b59c: a9 00       ..
+    pha                                                               // b59e: 48          H
+    pha                                                               // b59f: 48          H
+    ldy #$fc                                                          // b5a0: a0 fc       ..
+    lda (l00b8),y                                                     // b5a2: b1 b8       ..
+    pha                                                               // b5a4: 48          H
+    dey                                                               // b5a5: 88          .
+    lda (l00b8),y                                                     // b5a6: b1 b8       ..
+    pha                                                               // b5a8: 48          H
+    lda #$ff                                                          // b5a9: a9 ff       ..
+    pha                                                               // b5ab: 48          H
+    pha                                                               // b5ac: 48          H
+    ldy #$f7                                                          // b5ad: a0 f7       ..
+    lda (l00b8),y                                                     // b5af: b1 b8       ..
+    pha                                                               // b5b1: 48          H
+    dey                                                               // b5b2: 88          .
+    lda (l00b8),y                                                     // b5b3: b1 b8       ..
+    pha                                                               // b5b5: 48          H
+    tsx                                                               // b5b6: ba          .
+    ldy #$fa                                                          // b5b7: a0 fa       ..
+    lda (l00b8),y                                                     // b5b9: b1 b8       ..
+    pha                                                               // b5bb: 48          H
+    lda l0109,x                                                       // b5bc: bd 09 01    ...
+    ldy #1                                                            // b5bf: a0 01       ..
+    jsr osgbpb                                                        // b5c1: 20 d1 ff     ..
+    ldx #$0d                                                          // b5c4: a2 0d       ..
+// $b5c6 referenced 1 time by $b5c8
+loop_cb5c6
+    pla                                                               // b5c6: 68          h
+    dex                                                               // b5c7: ca          .
+    bne loop_cb5c6                                                    // b5c8: d0 fc       ..
+    jsr cb82b                                                         // b5ca: 20 2b b8     +.
+    rts                                                               // b5cd: 60          `
+
+// $b5ce referenced 2 times by $b345, $b40e
+sub_cb5ce
+    lda #$40 // '@'                                                   // b5ce: a9 40       .@
+// $b5d0 referenced 1 time by $b5f0
+cb5d0
+    pha                                                               // b5d0: 48          H
+    ldy #$ef                                                          // b5d1: a0 ef       ..
+    lda (l00b8),y                                                     // b5d3: b1 b8       ..
+    tax                                                               // b5d5: aa          .
+    iny                                                               // b5d6: c8          .
+    lda (l00b8),y                                                     // b5d7: b1 b8       ..
+    tay                                                               // b5d9: a8          .
+    pla                                                               // b5da: 68          h
+    jsr osfind                                                        // b5db: 20 ce ff     ..
+    tax                                                               // b5de: aa          .
+    bne cb5e6                                                         // b5df: d0 05       ..
+    ldx #4                                                            // b5e1: a2 04       ..
+    jmp cb8fb                                                         // b5e3: 4c fb b8    L..
+
+// $b5e6 referenced 1 time by $b5df
+cb5e6
+    ldy #$fa                                                          // b5e6: a0 fa       ..
+    jsr cb82b                                                         // b5e8: 20 2b b8     +.
+    sta (l00b8),y                                                     // b5eb: 91 b8       ..
+// $b5ed referenced 1 time by $b5f6
+loop_cb5ed
+    rts                                                               // b5ed: 60          `
+
+// $b5ee referenced 2 times by $b375, $b4d8
+sub_cb5ee
+    lda #$80                                                          // b5ee: a9 80       ..
+    bne cb5d0                                                         // b5f0: d0 de       ..
+// $b5f2 referenced 6 times by $b21b, $b371, $b45a, $b477, $b4ea, $b534
+sub_cb5f2
+    ldy #$fa                                                          // b5f2: a0 fa       ..
+    lda (l00b8),y                                                     // b5f4: b1 b8       ..
+    beq loop_cb5ed                                                    // b5f6: f0 f5       ..
+    pha                                                               // b5f8: 48          H
+    lda #0                                                            // b5f9: a9 00       ..
+    sta (l00b8),y                                                     // b5fb: 91 b8       ..
+    pla                                                               // b5fd: 68          h
+    tay                                                               // b5fe: a8          .
+    lda #0                                                            // b5ff: a9 00       ..
+    jsr osfind                                                        // b601: 20 ce ff     ..
+    jmp cb82b                                                         // b604: 4c 2b b8    L+.
+
+// $b607 referenced 2 times by $b348, $b36c
+sub_cb607
+    ldy #$fa                                                          // b607: a0 fa       ..
+    lda (l00b8),y                                                     // b609: b1 b8       ..
+    tax                                                               // b60b: aa          .
+    lda #1                                                            // b60c: a9 01       ..
+    jsr sub_cb86f                                                     // b60e: 20 6f b8     o.
+    jsr cb82b                                                         // b611: 20 2b b8     +.
+    txa                                                               // b614: 8a          .
+    rts                                                               // b615: 60          `
+
+// $b616 referenced 4 times by $b378, $b3b3, $b4e4, $be5d
+sub_cb616
+    ldy #$f4                                                          // b616: a0 f4       ..
+    lda (l00b8),y                                                     // b618: b1 b8       ..
+    iny                                                               // b61a: c8          .
+    ora (l00b8),y                                                     // b61b: 11 b8       ..
+    rts                                                               // b61d: 60          `
+
+// $b61e referenced 2 times by $b4cf, $b522
+sub_cb61e
+    stx l00bc                                                         // b61e: 86 bc       ..
+    ldy #$fb                                                          // b620: a0 fb       ..
+    jsr sub_cb83f                                                     // b622: 20 3f b8     ?.
+    ldy #$f4                                                          // b625: a0 f4       ..
+    lda (l00b8),y                                                     // b627: b1 b8       ..
+    sec                                                               // b629: 38          8
+    sbc l00ba                                                         // b62a: e5 ba       ..
+    sta (l00b8),y                                                     // b62c: 91 b8       ..
+    sta l00ba                                                         // b62e: 85 ba       ..
+    iny                                                               // b630: c8          .
+    lda (l00b8),y                                                     // b631: b1 b8       ..
+    sbc l00bb                                                         // b633: e5 bb       ..
+    sta (l00b8),y                                                     // b635: 91 b8       ..
+    sta l00bb                                                         // b637: 85 bb       ..
+    ora l00ba                                                         // b639: 05 ba       ..
+    beq cb65e                                                         // b63b: f0 21       .!
+    ldx l00bc                                                         // b63d: a6 bc       ..
+    jsr sub_cb85d                                                     // b63f: 20 5d b8     ].
+    bvc cb655                                                         // b642: 50 11       P.
+    lda l0001,x                                                       // b644: b5 01       ..
+    cmp #$c0                                                          // b646: c9 c0       ..
+    bcc cb655                                                         // b648: 90 0b       ..
+    lda #$10                                                          // b64a: a9 10       ..
+    sta l0000,x                                                       // b64c: 95 00       ..
+    lda #$80                                                          // b64e: a9 80       ..
+    sta l0001,x                                                       // b650: 95 01       ..
+    jsr sub_cb68f                                                     // b652: 20 8f b6     ..
+// $b655 referenced 2 times by $b642, $b648
+cb655
+    ldx l00bc                                                         // b655: a6 bc       ..
+    ldy #$f2                                                          // b657: a0 f2       ..
+    jsr sub_cb850                                                     // b659: 20 50 b8     P.
+    lda #$ff                                                          // b65c: a9 ff       ..
+// $b65e referenced 1 time by $b63b
+cb65e
+    rts                                                               // b65e: 60          `
+
+// $b65f referenced 2 times by $b34f, $b37f
+sub_cb65f
+    ldx #$bd                                                          // b65f: a2 bd       ..
+    ldy #$f2                                                          // b661: a0 f2       ..
+    jsr sub_cb841                                                     // b663: 20 41 b8     A.
+    inc l00bd                                                         // b666: e6 bd       ..
+    bne cb684                                                         // b668: d0 1a       ..
+    inc l00be                                                         // b66a: e6 be       ..
+    beq cb68c                                                         // b66c: f0 1e       ..
+    jsr sub_cb85d                                                     // b66e: 20 5d b8     ].
+    bvc cb684                                                         // b671: 50 11       P.
+    lda l00be                                                         // b673: a5 be       ..
+    cmp #$c0                                                          // b675: c9 c0       ..
+    bne cb684                                                         // b677: d0 0b       ..
+    jsr sub_cb68f                                                     // b679: 20 8f b6     ..
+    lda #$10                                                          // b67c: a9 10       ..
+    sta l00bd                                                         // b67e: 85 bd       ..
+    lda #$80                                                          // b680: a9 80       ..
+    sta l00be                                                         // b682: 85 be       ..
+// $b684 referenced 3 times by $b668, $b671, $b677
+cb684
+    ldx #$bd                                                          // b684: a2 bd       ..
+    ldy #$f2                                                          // b686: a0 f2       ..
+    jsr sub_cb850                                                     // b688: 20 50 b8     P.
+    rts                                                               // b68b: 60          `
+
+// $b68c referenced 4 times by $b66c, $b698, $b69c, $b6ae
+cb68c
+    jmp cb446                                                         // b68c: 4c 46 b4    LF.
+
+// $b68f referenced 4 times by $b652, $b679, $b81f, $be77
+sub_cb68f
+    ldy #$f1                                                          // b68f: a0 f1       ..
+    lda (l00b8),y                                                     // b691: b1 b8       ..
+    clc                                                               // b693: 18          .
+    adc #1                                                            // b694: 69 01       i.
+    cmp #$10                                                          // b696: c9 10       ..
+    bcs cb68c                                                         // b698: b0 f2       ..
+    cmp #2                                                            // b69a: c9 02       ..
+    beq cb68c                                                         // b69c: f0 ee       ..
+    cmp #$0e                                                          // b69e: c9 0e       ..
+    bne cb6a6                                                         // b6a0: d0 04       ..
+    ldy #$fe                                                          // b6a2: a0 fe       ..
+    and (l00b8),y                                                     // b6a4: 31 b8       1.
+// $b6a6 referenced 1 time by $b6a0
+cb6a6
+    ldy #$f1                                                          // b6a6: a0 f1       ..
+    sta (l00b8),y                                                     // b6a8: 91 b8       ..
+    tay                                                               // b6aa: a8          .
+    jsr sub_cb6fe                                                     // b6ab: 20 fe b6     ..
+    beq cb68c                                                         // b6ae: f0 dc       ..
+    rts                                                               // b6b0: 60          `
+
+// $b6b1 referenced 2 times by $b305, $bcda
+sub_cb6b1
+    ldy #$10                                                          // b6b1: a0 10       ..
+// $b6b3 referenced 1 time by $b6c5
+loop_cb6b3
+    cmp cb6ca,y                                                       // b6b3: d9 ca b6    ...
+    bcc cb6ca                                                         // b6b6: 90 12       ..
+    bne cb6c2                                                         // b6b8: d0 08       ..
+    pha                                                               // b6ba: 48          H
+    txa                                                               // b6bb: 8a          .
+    cmp lb6c6,y                                                       // b6bc: d9 c6 b6    ...
+    pla                                                               // b6bf: 68          h
+    bcc cb6ca                                                         // b6c0: 90 08       ..
+// $b6c2 referenced 1 time by $b6b8
+cb6c2
+    iny                                                               // b6c2: c8          .
+    cpy #$14                                                          // b6c3: c0 14       ..
+sub_cb6c5
+lb6c6 = sub_cb6c5+1
+    bcc loop_cb6b3                                                    // b6c5: 90 ec       ..
+// $b6c6 referenced 1 time by $b6bc
+    jmp cb446                                                         // b6c7: 4c 46 b4    LF.
+
+// $b6ca referenced 3 times by $b6b3, $b6b6, $b6c0
+cb6ca
+    pha                                                               // b6ca: 48          H
+    txa                                                               // b6cb: 8a          .
+    clc                                                               // b6cc: 18          .
+sub_cb6cd
+lb6ce = sub_cb6cd+1
+    adc lb6ce,y                                                       // b6cd: 79 ce b6    y..
+// $b6ce referenced 1 time by $b6cd
+    tax                                                               // b6d0: aa          .
+    pla                                                               // b6d1: 68          h
+// $b6d2 referenced 1 time by $b6d2
+cb6d2
+    adc cb6d2,y                                                       // b6d2: 79 d2 b6    y..
+    rts                                                               // b6d5: 60          `
+
+    .byt $f0, $e0, $d0, $c0, $3f, $7f, $bf, $ff, $10                  // b6d6: f0 e0 d0... ...
+    .asc " 0@"                                                        // b6df: 20 30 40     0@
+    .byt $80, $40,   0, $c0                                           // b6e2: 80 40 00... .@.
+
+// $b6e6 referenced 1 time by $b6fe
+sub_cb6e6
+    cpy #$10                                                          // b6e6: c0 10       ..
+    bcs cb6eb                                                         // b6e8: b0 01       ..
+    rts                                                               // b6ea: 60          `
+
+// $b6eb referenced 1 time by $b6e8
+cb6eb
+    tya                                                               // b6eb: 98          .
+    sec                                                               // b6ec: 38          8
+    sbc #4                                                            // b6ed: e9 04       ..
+    tay                                                               // b6ef: a8          .
+    cpy #$0e                                                          // b6f0: c0 0e       ..
+    bcs cb6f5                                                         // b6f2: b0 01       ..
+    rts                                                               // b6f4: 60          `
+
+// $b6f5 referenced 1 time by $b6f2
+cb6f5
+    tya                                                               // b6f5: 98          .
+    and #1                                                            // b6f6: 29 01       ).
+    ldy #$fe                                                          // b6f8: a0 fe       ..
+    ora (l00b8),y                                                     // b6fa: 11 b8       ..
+    tay                                                               // b6fc: a8          .
+    rts                                                               // b6fd: 60          `
+
+// $b6fe referenced 5 times by $b314, $b6ab, $bc44, $bc8e, $bce1
+sub_cb6fe
+    jsr sub_cb6e6                                                     // b6fe: 20 e6 b6     ..
+    tya                                                               // b701: 98          .
+    tax                                                               // b702: aa          .
+    lda lb726,y                                                       // b703: b9 26 b7    .&.
+    pha                                                               // b706: 48          H
+    ldy #$ee                                                          // b707: a0 ee       ..
+    and (l00b8),y                                                     // b709: 31 b8       1.
+    bne cb718                                                         // b70b: d0 0b       ..
+    lda (l00b8),y                                                     // b70d: b1 b8       ..
+    and #$c0                                                          // b70f: 29 c0       ).
+    cmp #$80                                                          // b711: c9 80       ..
+    beq cb718                                                         // b713: f0 03       ..
+    jmp cb446                                                         // b715: 4c 46 b4    LF.
+
+// $b718 referenced 2 times by $b70b, $b713
+cb718
+    pla                                                               // b718: 68          h
+    ldy #$fd                                                          // b719: a0 fd       ..
+    and (l00b8),y                                                     // b71b: 31 b8       1.
+    pha                                                               // b71d: 48          H
+    txa                                                               // b71e: 8a          .
+    tay                                                               // b71f: a8          .
+    pla                                                               // b720: 68          h
+    beq cb725                                                         // b721: f0 02       ..
+    lda #$ff                                                          // b723: a9 ff       ..
+// $b725 referenced 1 time by $b721
+cb725
+    rts                                                               // b725: 60          `
+
+// $b726 referenced 6 times by $b703, $b898, $b8c8, $b8db, $bc56, $bca1
+lb726
+    .byt   4,   8,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0   // b726: 04 08 00... ...
+    .byt   1,   2, $10, $20                                           // b732: 01 02 10... ...
+
+// $b736 referenced 1 time by $b75a
+cb736
+    sty romsel_copy                                                   // b736: 84 f4       ..
+    sty romsel                                                        // b738: 8c 30 fe    .0.
+    ldy #0                                                            // b73b: a0 00       ..
+    sta (l00ba),y                                                     // b73d: 91 ba       ..
+    stx romsel_copy                                                   // b73f: 86 f4       ..
+    stx romsel                                                        // b741: 8e 30 fe    .0.
+    rts                                                               // b744: 60          `
+
+// $b745 referenced 5 times by $b369, $b8b7, $b8d1, $bc78, $bc9e
+sub_cb745
+    sta l00bf                                                         // b745: 85 bf       ..
+    txa                                                               // b747: 8a          .
+    pha                                                               // b748: 48          H
+    tya                                                               // b749: 98          .
+    pha                                                               // b74a: 48          H
+    ldx romsel_copy                                                   // b74b: a6 f4       ..
+    lda l0df0,x                                                       // b74d: bd f0 0d    ...
+    sta l00b1                                                         // b750: 85 b1       ..
+    inc l00b1                                                         // b752: e6 b1       ..
+    lda #0                                                            // b754: a9 00       ..
+    sta l00b0                                                         // b756: 85 b0       ..
+    ldy #$0e                                                          // b758: a0 0e       ..
+// $b75a referenced 1 time by $b760
+loop_cb75a
+    lda cb736,y                                                       // b75a: b9 36 b7    .6.
+    sta (l00b0),y                                                     // b75d: 91 b0       ..
+    dey                                                               // b75f: 88          .
+    bpl loop_cb75a                                                    // b760: 10 f8       ..
+    pla                                                               // b762: 68          h
+    pha                                                               // b763: 48          H
+    tay                                                               // b764: a8          .
+    lda l00bf                                                         // b765: a5 bf       ..
+    jsr sub_cb771                                                     // b767: 20 71 b7     q.
+    pla                                                               // b76a: 68          h
+    tay                                                               // b76b: a8          .
+    pla                                                               // b76c: 68          h
+    tax                                                               // b76d: aa          .
+    lda l00bf                                                         // b76e: a5 bf       ..
+    rts                                                               // b770: 60          `
+
+// $b771 referenced 1 time by $b767
+sub_cb771
+    jmp (l00b0)                                                       // b771: 6c b0 00    l..
+
+// $b774 referenced 1 time by $b7be
+lb774
+    .byt $85, $f4, $8d, $30, $fe, $b1, $b1, $91, $b3, $c8, $d0,   5   // b774: 85 f4 8d... ...
+    .byt $e6, $b2, $e6, $b4, $ca, $c4, $b5, $d0, $f0, $8a, $d0, $ed   // b780: e6 b2 e6... ...
+    .byt $68, $85, $f4, $8d, $30, $fe, $4c, $d5, $b7                  // b78c: 68 85 f4... h..
+
+// $b795 referenced 5 times by $b4ca, $b51d, $bd0b, $bdb0, $bded
+cb795
+    ldy #$f1                                                          // b795: a0 f1       ..
+    lda (l00b8),y                                                     // b797: b1 b8       ..
+    sta l00b0                                                         // b799: 85 b0       ..
+    ldx l00be                                                         // b79b: a6 be       ..
+    ldy l00bf                                                         // b79d: a4 bf       ..
+    lda #0                                                            // b79f: a9 00       ..
+    rol                                                               // b7a1: 2a          *
+    asl                                                               // b7a2: 0a          .
+    sta l00b7                                                         // b7a3: 85 b7       ..
+    inc l00b7                                                         // b7a5: e6 b7       ..
+    jsr sub_cb85d                                                     // b7a7: 20 5d b8     ].
+    bvs cb7ed                                                         // b7aa: 70 41       pA
+    bvc cb7b2                                                         // b7ac: 50 04       P.
+// $b7ae referenced 1 time by $b803
+cb7ae
+    ldx l00be                                                         // b7ae: a6 be       ..
+    ldy l00bf                                                         // b7b0: a4 bf       ..
+// $b7b2 referenced 1 time by $b7ac
+cb7b2
+    stx l00b5                                                         // b7b2: 86 b5       ..
+    sty l00b6                                                         // b7b4: 84 b6       ..
+// $b7b6 referenced 1 time by $b812
+sub_cb7b6
+    lda l00b5                                                         // b7b6: a5 b5       ..
+    ora l00b6                                                         // b7b8: 05 b6       ..
+    beq cb7ec                                                         // b7ba: f0 30       .0
+    ldx #$20 // ' '                                                   // b7bc: a2 20       .
+// $b7be referenced 1 time by $b7c3
+loop_cb7be
+    lda lb774,x                                                       // b7be: bd 74 b7    .t.
+    pha                                                               // b7c1: 48          H
+    dex                                                               // b7c2: ca          .
+    bpl loop_cb7be                                                    // b7c3: 10 f9       ..
+    tsx                                                               // b7c5: ba          .
+    lda romsel_copy                                                   // b7c6: a5 f4       ..
+    pha                                                               // b7c8: 48          H
+    lda #1                                                            // b7c9: a9 01       ..
+    pha                                                               // b7cb: 48          H
+    txa                                                               // b7cc: 8a          .
+    pha                                                               // b7cd: 48          H
+    lda l00b0                                                         // b7ce: a5 b0       ..
+    ldx l00b6                                                         // b7d0: a6 b6       ..
+    ldy #0                                                            // b7d2: a0 00       ..
+    rts                                                               // b7d4: 60          `
+
+    ldx #$21 // '!'                                                   // b7d5: a2 21       .!
+// $b7d7 referenced 1 time by $b7d9
+loop_cb7d7
+    pla                                                               // b7d7: 68          h
+    dex                                                               // b7d8: ca          .
+    bne loop_cb7d7                                                    // b7d9: d0 fc       ..
+    ldx #2                                                            // b7db: a2 02       ..
+// $b7dd referenced 1 time by $b7ea
+loop_cb7dd
+    lda l00b1,x                                                       // b7dd: b5 b1       ..
+    clc                                                               // b7df: 18          .
+    adc l00b5                                                         // b7e0: 65 b5       e.
+    sta l00b1,x                                                       // b7e2: 95 b1       ..
+    bcc cb7e8                                                         // b7e4: 90 02       ..
+    inc l00b2,x                                                       // b7e6: f6 b2       ..
+// $b7e8 referenced 1 time by $b7e4
+cb7e8
+    dex                                                               // b7e8: ca          .
+    dex                                                               // b7e9: ca          .
+    bpl loop_cb7dd                                                    // b7ea: 10 f1       ..
+// $b7ec referenced 1 time by $b7ba
+cb7ec
+    rts                                                               // b7ec: 60          `
+
+// $b7ed referenced 2 times by $b7aa, $b828
+cb7ed
+    lda #0                                                            // b7ed: a9 00       ..
+    sec                                                               // b7ef: 38          8
+    ldx l00b7                                                         // b7f0: a6 b7       ..
+    sbc l00b0,x                                                       // b7f2: f5 b0       ..
+    sta l00b5                                                         // b7f4: 85 b5       ..
+    lda #$c0                                                          // b7f6: a9 c0       ..
+    sbc l00b1,x                                                       // b7f8: f5 b1       ..
+    sta l00b6                                                         // b7fa: 85 b6       ..
+    ldx #$b5                                                          // b7fc: a2 b5       ..
+    ldy #$be                                                          // b7fe: a0 be       ..
+    jsr sub_cb58b                                                     // b800: 20 8b b5     ..
+    bcs cb7ae                                                         // b803: b0 a9       ..
+    lda l00be                                                         // b805: a5 be       ..
+    sec                                                               // b807: 38          8
+    sbc l00b5                                                         // b808: e5 b5       ..
+    sta l00be                                                         // b80a: 85 be       ..
+    lda l00bf                                                         // b80c: a5 bf       ..
+    sbc l00b6                                                         // b80e: e5 b6       ..
+    sta l00bf                                                         // b810: 85 bf       ..
+    jsr sub_cb7b6                                                     // b812: 20 b6 b7     ..
+    lda #$10                                                          // b815: a9 10       ..
+    ldx l00b7                                                         // b817: a6 b7       ..
+    sta l00b0,x                                                       // b819: 95 b0       ..
+    lda #$80                                                          // b81b: a9 80       ..
+    sta l00b1,x                                                       // b81d: 95 b1       ..
+    jsr sub_cb68f                                                     // b81f: 20 8f b6     ..
+    ldy #$f1                                                          // b822: a0 f1       ..
+    lda (l00b8),y                                                     // b824: b1 b8       ..
+    sta l00b0                                                         // b826: 85 b0       ..
+    jmp cb7ed                                                         // b828: 4c ed b7    L..
+
+// $b82b referenced 16 times by $b1c1, $b2c8, $b2e7, $b32c, $b35a, $b3b0, $b3ec, $b429, $b4a3, $b573, $b5ca, $b5e8, $b604, $b611, $b86b, $beb5
+cb82b
+    php                                                               // b82b: 08          .
+    pha                                                               // b82c: 48          H
+    txa                                                               // b82d: 8a          .
+    pha                                                               // b82e: 48          H
+    lda #0                                                            // b82f: a9 00       ..
+    sta l00b8                                                         // b831: 85 b8       ..
+    ldx romsel_copy                                                   // b833: a6 f4       ..
+    lda l0df0,x                                                       // b835: bd f0 0d    ...
+    sta l00b9                                                         // b838: 85 b9       ..
+    pla                                                               // b83a: 68          h
+    tax                                                               // b83b: aa          .
+    pla                                                               // b83c: 68          h
+    plp                                                               // b83d: 28          (
+    rts                                                               // b83e: 60          `
+
+// $b83f referenced 4 times by $b35f, $b4e1, $b53d, $b622
+sub_cb83f
+    ldx #$ba                                                          // b83f: a2 ba       ..
+// $b841 referenced 12 times by $b39b, $b462, $b4b8, $b4bf, $b4c6, $b4f2, $b50b, $b512, $b519, $b663, $bd4a, $bdc4
+sub_cb841
+    pha                                                               // b841: 48          H
+    lda (l00b8),y                                                     // b842: b1 b8       ..
+    sta l0000,x                                                       // b844: 95 00       ..
+    iny                                                               // b846: c8          .
+    lda (l00b8),y                                                     // b847: b1 b8       ..
+    sta l0001,x                                                       // b849: 95 01       ..
+    dey                                                               // b84b: 88          .
+    pla                                                               // b84c: 68          h
+    rts                                                               // b84d: 60          `
+
+// $b84e referenced 3 times by $b3f5, $b472, $b504
+sub_cb84e
+    ldx #$ba                                                          // b84e: a2 ba       ..
+// $b850 referenced 5 times by $b659, $b688, $bb5c, $bb8d, $bd36
+sub_cb850
+    pha                                                               // b850: 48          H
+    lda l0000,x                                                       // b851: b5 00       ..
+    sta (l00b8),y                                                     // b853: 91 b8       ..
+    iny                                                               // b855: c8          .
+    lda l0001,x                                                       // b856: b5 01       ..
+    sta (l00b8),y                                                     // b858: 91 b8       ..
+    dey                                                               // b85a: 88          .
+    pla                                                               // b85b: 68          h
+    rts                                                               // b85c: 60          `
+
+// $b85d referenced 8 times by $b2f2, $b340, $b406, $b63f, $b66e, $b7a7, $be64, $be9d
+sub_cb85d
+    pha                                                               // b85d: 48          H
+    tya                                                               // b85e: 98          .
+    pha                                                               // b85f: 48          H
+    ldy #$ee                                                          // b860: a0 ee       ..
+    lda (l00b8),y                                                     // b862: b1 b8       ..
+    sta l00b8                                                         // b864: 85 b8       ..
+    pla                                                               // b866: 68          h
+    tay                                                               // b867: a8          .
+    pla                                                               // b868: 68          h
+    bit l00b8                                                         // b869: 24 b8       $.
+    jsr cb82b                                                         // b86b: 20 2b b8     +.
+    rts                                                               // b86e: 60          `
+
+// $b86f referenced 1 time by $b60e
+sub_cb86f
+    jmp (fscv)                                                        // b86f: 6c 1e 02    l..
+
+// $b872 referenced 2 times by $b9c7, $bc70
+lb872
+    .byt $60,   0,   0, $60,   0,   0,   2, $0c, $ff                  // b872: 60 00 00... `..
+    .asc "RAM"                                                        // b87b: 52 41 4d    RAM
+// $b87e referenced 1 time by $b9a3
+lb87e
+    .byt 0                                                            // b87e: 00          .
+    .asc "(C)"                                                        // b87f: 28 43 29    (C)
+
+// $b882 referenced 1 time by $b200
+sub_cb882
+    lda #0                                                            // b882: a9 00       ..
+    ldy #$fd                                                          // b884: a0 fd       ..
+    sta (l00b8),y                                                     // b886: 91 b8       ..
+    ldy #$ee                                                          // b888: a0 ee       ..
+    sta (l00b8),y                                                     // b88a: 91 b8       ..
+    ldy #$fa                                                          // b88c: a0 fa       ..
+    sta (l00b8),y                                                     // b88e: 91 b8       ..
+    ldy #$ff                                                          // b890: a0 ff       ..
+    lda #$4e // 'N'                                                   // b892: a9 4e       .N
+    sta (l00b8),y                                                     // b894: 91 b8       ..
+    ldy #$0f                                                          // b896: a0 0f       ..
+// $b898 referenced 1 time by $b8e7
+cb898
+    lda lb726,y                                                       // b898: b9 26 b7    .&.
+    beq cb8e6                                                         // b89b: f0 49       .I
+    tya                                                               // b89d: 98          .
+    pha                                                               // b89e: 48          H
+    lda #8                                                            // b89f: a9 08       ..
+    sta osrdsc_ptr                                                    // b8a1: 85 f6       ..
+    sta l00ba                                                         // b8a3: 85 ba       ..
+    lda #$80                                                          // b8a5: a9 80       ..
+    sta l00f7                                                         // b8a7: 85 f7       ..
+    sta l00bb                                                         // b8a9: 85 bb       ..
+    jsr osrdsc                                                        // b8ab: 20 b9 ff     ..
+    sta l00bd                                                         // b8ae: 85 bd       ..
+    pla                                                               // b8b0: 68          h
+    pha                                                               // b8b1: 48          H
+    tay                                                               // b8b2: a8          .
+    lda l00bd                                                         // b8b3: a5 bd       ..
+    eor #$ff                                                          // b8b5: 49 ff       I.
+    jsr sub_cb745                                                     // b8b7: 20 45 b7     E.
+    jsr osrdsc                                                        // b8ba: 20 b9 ff     ..
+    cmp l00bd                                                         // b8bd: c5 bd       ..
+    beq cb8e4                                                         // b8bf: f0 23       .#
+    pla                                                               // b8c1: 68          h
+    pha                                                               // b8c2: 48          H
+    tax                                                               // b8c3: aa          .
+    ldy #$ee                                                          // b8c4: a0 ee       ..
+    lda (l00b8),y                                                     // b8c6: b1 b8       ..
+    ora lb726,x                                                       // b8c8: 1d 26 b7    .&.
+    sta (l00b8),y                                                     // b8cb: 91 b8       ..
+    txa                                                               // b8cd: 8a          .
+    tay                                                               // b8ce: a8          .
+    lda l00bd                                                         // b8cf: a5 bd       ..
+    jsr sub_cb745                                                     // b8d1: 20 45 b7     E.
+    jsr sub_cb986                                                     // b8d4: 20 86 b9     ..
+    cmp #2                                                            // b8d7: c9 02       ..
+    bne cb8e4                                                         // b8d9: d0 09       ..
+    lda lb726,y                                                       // b8db: b9 26 b7    .&.
+    ldy #$fd                                                          // b8de: a0 fd       ..
+    ora (l00b8),y                                                     // b8e0: 11 b8       ..
+    sta (l00b8),y                                                     // b8e2: 91 b8       ..
+// $b8e4 referenced 2 times by $b8bf, $b8d9
+cb8e4
+    pla                                                               // b8e4: 68          h
+    tay                                                               // b8e5: a8          .
+// $b8e6 referenced 1 time by $b89b
+cb8e6
+    dey                                                               // b8e6: 88          .
+    bpl cb898                                                         // b8e7: 10 af       ..
+    ldy #$ee                                                          // b8e9: a0 ee       ..
+    lda (l00b8),y                                                     // b8eb: b1 b8       ..
+    ldx #0                                                            // b8ed: a2 00       ..
+    and #$0c                                                          // b8ef: 29 0c       ).
+    bne cb8f5                                                         // b8f1: d0 02       ..
+    ldx #$0e                                                          // b8f3: a2 0e       ..
+// $b8f5 referenced 1 time by $b8f1
+cb8f5
+    txa                                                               // b8f5: 8a          .
+    ldy #$fe                                                          // b8f6: a0 fe       ..
+    sta (l00b8),y                                                     // b8f8: 91 b8       ..
+    rts                                                               // b8fa: 60          `
+
+// $b8fb referenced 6 times by $b302, $b334, $b448, $b5e3, $bafa, $bc51
+cb8fb
+    lda #0                                                            // b8fb: a9 00       ..
+    sta l0100                                                         // b8fd: 8d 00 01    ...
+    lda lb980,x                                                       // b900: bd 80 b9    ...
+    sta l0101                                                         // b903: 8d 01 01    ...
+    lda lb97a,x                                                       // b906: bd 7a b9    .z.
+    sta l00bf                                                         // b909: 85 bf       ..
+    ldy lb979,x                                                       // b90b: bc 79 b9    .y.
+    ldx #0                                                            // b90e: a2 00       ..
+// $b910 referenced 1 time by $b91a
+loop_cb910
+    lda lb924,y                                                       // b910: b9 24 b9    .$.
+    sta l0102,x                                                       // b913: 9d 02 01    ...
+    inx                                                               // b916: e8          .
+    iny                                                               // b917: c8          .
+    cpy l00bf                                                         // b918: c4 bf       ..
+    bcc loop_cb910                                                    // b91a: 90 f4       ..
+    lda #0                                                            // b91c: a9 00       ..
+    sta l0102,x                                                       // b91e: 9d 02 01    ...
+    jmp l0100                                                         // b921: 4c 00 01    L..
+
+// $b924 referenced 1 time by $b910
+lb924
+    .asc "Illegal parameterIllegal addressNo filing systemBad comm"   // b924: 49 6c 6c... Ill
+    .asc "andFile not foundRAM occupied"                              // b95c: 61 6e 64... and
+// $b979 referenced 1 time by $b90b
+lb979
+    .byt 0                                                            // b979: 00          .
+// $b97a referenced 1 time by $b906
+lb97a
+    .byt $11                                                          // b97a: 11          .
+    .asc " 0;IU"                                                      // b97b: 20 30 3b...  0;
+// $b980 referenced 1 time by $b900
+lb980
+    .byt $80, $81, $82, $fe, $d6, $83                                 // b980: 80 81 82... ...
+
+// $b986 referenced 3 times by $b8d4, $bc49, $bcb2
+sub_cb986
+    txa                                                               // b986: 8a          .
+    pha                                                               // b987: 48          H
+    tya                                                               // b988: 98          .
+    pha                                                               // b989: 48          H
+    ldx #7                                                            // b98a: a2 07       ..
+    stx osrdsc_ptr                                                    // b98c: 86 f6       ..
+    lda #$80                                                          // b98e: a9 80       ..
+    sta l00f7                                                         // b990: 85 f7       ..
+    jsr osrdsc                                                        // b992: 20 b9 ff     ..
+    sta osrdsc_ptr                                                    // b995: 85 f6       ..
+    ldx #0                                                            // b997: a2 00       ..
+// $b999 referenced 1 time by $b9b1
+loop_cb999
+    stx l00bf                                                         // b999: 86 bf       ..
+    pla                                                               // b99b: 68          h
+    pha                                                               // b99c: 48          H
+    tay                                                               // b99d: a8          .
+    jsr osrdsc                                                        // b99e: 20 b9 ff     ..
+    ldx l00bf                                                         // b9a1: a6 bf       ..
+    cmp lb87e,x                                                       // b9a3: dd 7e b8    .~.
+    bne cb9ee                                                         // b9a6: d0 46       .F
+    inc osrdsc_ptr                                                    // b9a8: e6 f6       ..
+    bne cb9ae                                                         // b9aa: d0 02       ..
+    inc l00f7                                                         // b9ac: e6 f7       ..
+// $b9ae referenced 1 time by $b9aa
+cb9ae
+    inx                                                               // b9ae: e8          .
+    cpx #4                                                            // b9af: e0 04       ..
+    bcc loop_cb999                                                    // b9b1: 90 e6       ..
+    lda #2                                                            // b9b3: a9 02       ..
+    sta l00bf                                                         // b9b5: 85 bf       ..
+    ldx #$0f                                                          // b9b7: a2 0f       ..
+    lda #$80                                                          // b9b9: a9 80       ..
+    sta l00f7                                                         // b9bb: 85 f7       ..
+// $b9bd referenced 1 time by $b9cf
+loop_cb9bd
+    stx osrdsc_ptr                                                    // b9bd: 86 f6       ..
+    pla                                                               // b9bf: 68          h
+    pha                                                               // b9c0: 48          H
+    tay                                                               // b9c1: a8          .
+    jsr osrdsc                                                        // b9c2: 20 b9 ff     ..
+    ldx osrdsc_ptr                                                    // b9c5: a6 f6       ..
+    cmp lb872,x                                                       // b9c7: dd 72 b8    .r.
+    bne cb9d9                                                         // b9ca: d0 0d       ..
+// $b9cc referenced 1 time by $b9e5
+loop_cb9cc
+    dex                                                               // b9cc: ca          .
+    cpx #6                                                            // b9cd: e0 06       ..
+    bcs loop_cb9bd                                                    // b9cf: b0 ec       ..
+// $b9d1 referenced 1 time by $b9ec
+loop_cb9d1
+    clc                                                               // b9d1: 18          .
+// $b9d2 referenced 1 time by $b9f3
+cb9d2
+    pla                                                               // b9d2: 68          h
+    tay                                                               // b9d3: a8          .
+    pla                                                               // b9d4: 68          h
+    tax                                                               // b9d5: aa          .
+    lda l00bf                                                         // b9d6: a5 bf       ..
+    rts                                                               // b9d8: 60          `
+
+// $b9d9 referenced 1 time by $b9ca
+cb9d9
+    cpx #$0a                                                          // b9d9: e0 0a       ..
+    bne cb9e8                                                         // b9db: d0 0b       ..
+    cmp #$4f // 'O'                                                   // b9dd: c9 4f       .O
+    bne cb9e8                                                         // b9df: d0 07       ..
+    lda #1                                                            // b9e1: a9 01       ..
+    sta l00bf                                                         // b9e3: 85 bf       ..
+    jmp loop_cb9cc                                                    // b9e5: 4c cc b9    L..
+
+// $b9e8 referenced 2 times by $b9db, $b9df
+cb9e8
+    lda #0                                                            // b9e8: a9 00       ..
+    sta l00bf                                                         // b9ea: 85 bf       ..
+    beq loop_cb9d1                                                    // b9ec: f0 e3       ..
+// $b9ee referenced 1 time by $b9a6
+cb9ee
+    lda #$ff                                                          // b9ee: a9 ff       ..
+    sta l00bf                                                         // b9f0: 85 bf       ..
+    sec                                                               // b9f2: 38          8
+    bcs cb9d2                                                         // b9f3: b0 dd       ..
+// $b9f5 referenced 2 times by $b225, $b297
+sub_cb9f5
+    ldx #0                                                            // b9f5: a2 00       ..
+// $b9f7 referenced 1 time by $ba25
+cb9f7
+    tya                                                               // b9f7: 98          .
+    pha                                                               // b9f8: 48          H
+// $b9f9 referenced 1 time by $ba0e
+loop_cb9f9
+    lda (os_text_ptr),y                                               // b9f9: b1 f2       ..
+    bmi cba10                                                         // b9fb: 30 13       0.
+    cmp #$2e // '.'                                                   // b9fd: c9 2e       ..
+    beq cba19                                                         // b9ff: f0 18       ..
+    cmp #$41 // 'A'                                                   // ba01: c9 41       .A
+    bcc cba10                                                         // ba03: 90 0b       ..
+    eor sram_table,x                                                  // ba05: 5d 30 ba    ]0.
+    and #$df                                                          // ba08: 29 df       ).
+    bne cba15                                                         // ba0a: d0 09       ..
+    iny                                                               // ba0c: c8          .
+    inx                                                               // ba0d: e8          .
+    bne loop_cb9f9                                                    // ba0e: d0 e9       ..
+// $ba10 referenced 2 times by $b9fb, $ba03
+cba10
+    lda sram_table,x                                                  // ba10: bd 30 ba    .0.
+    bmi cba28                                                         // ba13: 30 13       0.
+// $ba15 referenced 1 time by $ba0a
+cba15
+    clc                                                               // ba15: 18          .
+    pla                                                               // ba16: 68          h
+    tay                                                               // ba17: a8          .
+    dey                                                               // ba18: 88          .
+// $ba19 referenced 1 time by $b9ff
+cba19
+    iny                                                               // ba19: c8          .
+// $ba1a referenced 1 time by $ba20
+loop_cba1a
+    inx                                                               // ba1a: e8          .
+    lda cba2f,x                                                       // ba1b: bd 2f ba    ./.
+    beq cba2e                                                         // ba1e: f0 0e       ..
+    bpl loop_cba1a                                                    // ba20: 10 f8       ..
+    bcs cba27                                                         // ba22: b0 03       ..
+    inx                                                               // ba24: e8          .
+    bcc cb9f7                                                         // ba25: 90 d0       ..
+// $ba27 referenced 1 time by $ba22
+cba27
+    dex                                                               // ba27: ca          .
+// $ba28 referenced 1 time by $ba13
+cba28
+    pla                                                               // ba28: 68          h
+    jsr sub_cbab9                                                     // ba29: 20 b9 ba     ..
+    clc                                                               // ba2c: 18          .
+    rts                                                               // ba2d: 60          `
+
+// $ba2e referenced 1 time by $ba1e
+cba2e
+    sec                                                               // ba2e: 38          8
+// $ba2f referenced 1 time by $ba1b
+cba2f
+    rts                                                               // ba2f: 60          `
+
+// $ba30 referenced 3 times by $b234, $ba05, $ba10
+sram_table
+    .asc "SRAM"                                                       // ba30: 53 52 41... SRA
+// $ba31 referenced 1 time by $b238
+    .byt $ff, $ff                                                     // ba34: ff ff       ..
+    .asc "SRLOAD"                                                     // ba36: 53 52 4c... SRL
+    .byt >(sub_cbb46-1)                                               // ba3c: bb          .
+    .byt <(sub_cbb46-1)                                               // ba3d: 45          E
+    .asc "SRSAVE"                                                     // ba3e: 53 52 53... SRS
+    .byt >(sub_cbb4a-1)                                               // ba44: bb          .
+    .byt <(sub_cbb4a-1)                                               // ba45: 49          I
+    .asc "SRWRITE"                                                    // ba46: 53 52 57... SRW
+    .byt >(sub_cbbd3-1)                                               // ba4d: bb          .
+    .byt <(sub_cbbd3-1)                                               // ba4e: d2          .
+    .asc "SRREAD"                                                     // ba4f: 53 52 52... SRR
+    .byt >(sub_cbbd7-1)                                               // ba55: bb          .
+    .byt <(sub_cbbd7-1)                                               // ba56: d6          .
+    .asc "SRDATA"                                                     // ba57: 53 52 44... SRD
+    .byt >(sub_cbc37-1)                                               // ba5d: bc          .
+    .byt <(sub_cbc37-1)                                               // ba5e: 36          6
+    .asc "SRROM"                                                      // ba5f: 53 52 52... SRR
+    .byt >(sub_cbc81-1)                                               // ba64: bc          .
+    .byt <(sub_cbc81-1)                                               // ba65: 80          .
+    .byt 0                                                            // ba66: 00          .
+
+// $ba67 referenced 5 times by $bb51, $bb6c, $bbdd, $bbf3, $bc1c
+sub_cba67
+    txa                                                               // ba67: 8a          .
+    pha                                                               // ba68: 48          H
+    jsr sub_cbab9                                                     // ba69: 20 b9 ba     ..
+    lda #0                                                            // ba6c: a9 00       ..
+    sta l00bc                                                         // ba6e: 85 bc       ..
+    sta l00bd                                                         // ba70: 85 bd       ..
+    sta l00be                                                         // ba72: 85 be       ..
+    sta l00bf                                                         // ba74: 85 bf       ..
+    sec                                                               // ba76: 38          8
+    php                                                               // ba77: 08          .
+// $ba78 referenced 1 time by $baae
+cba78
+    lda (os_text_ptr),y                                               // ba78: b1 f2       ..
+    cmp #$30 // '0'                                                   // ba7a: c9 30       .0
+    bcc cbab4                                                         // ba7c: 90 36       .6
+    cmp #$3a // ':'                                                   // ba7e: c9 3a       .:
+    bcc cba8c                                                         // ba80: 90 0a       ..
+    cmp #$47 // 'G'                                                   // ba82: c9 47       .G
+    bcs cbab4                                                         // ba84: b0 2e       ..
+    cmp #$41 // 'A'                                                   // ba86: c9 41       .A
+    bcc cbab4                                                         // ba88: 90 2a       .*
+    sbc #7                                                            // ba8a: e9 07       ..
+// $ba8c referenced 1 time by $ba80
+cba8c
+    sec                                                               // ba8c: 38          8
+    sbc #$30 // '0'                                                   // ba8d: e9 30       .0
+    plp                                                               // ba8f: 28          (
+    php                                                               // ba90: 08          .
+    pha                                                               // ba91: 48          H
+    ldx #4                                                            // ba92: a2 04       ..
+// $ba94 referenced 1 time by $baa1
+loop_cba94
+    asl l00bc                                                         // ba94: 06 bc       ..
+    rol l00bd                                                         // ba96: 26 bd       &.
+    bvc cba9e                                                         // ba98: 50 04       P.
+    rol l00be                                                         // ba9a: 26 be       &.
+    rol l00bf                                                         // ba9c: 26 bf       &.
+// $ba9e referenced 1 time by $ba98
+cba9e
+    bcs cbab0                                                         // ba9e: b0 10       ..
+    dex                                                               // baa0: ca          .
+    bne loop_cba94                                                    // baa1: d0 f1       ..
+    pla                                                               // baa3: 68          h
+    ora l00bc                                                         // baa4: 05 bc       ..
+    sta l00bc                                                         // baa6: 85 bc       ..
+    plp                                                               // baa8: 28          (
+    clc                                                               // baa9: 18          .
+    php                                                               // baaa: 08          .
+    iny                                                               // baab: c8          .
+    beq cbab1                                                         // baac: f0 03       ..
+    bcc cba78                                                         // baae: 90 c8       ..
+// $bab0 referenced 1 time by $ba9e
+cbab0
+    pla                                                               // bab0: 68          h
+// $bab1 referenced 1 time by $baac
+cbab1
+    plp                                                               // bab1: 28          (
+    sec                                                               // bab2: 38          8
+    php                                                               // bab3: 08          .
+// $bab4 referenced 3 times by $ba7c, $ba84, $ba88
+cbab4
+    plp                                                               // bab4: 28          (
+    pla                                                               // bab5: 68          h
+    tax                                                               // bab6: aa          .
+    rts                                                               // bab7: 60          `
+
+// $bab8 referenced 1 time by $babd
+loop_cbab8
+    iny                                                               // bab8: c8          .
+// $bab9 referenced 7 times by $ba29, $ba69, $bac5, $bad2, $bb02, $bb2b, $bbb0
+sub_cbab9
+    lda (os_text_ptr),y                                               // bab9: b1 f2       ..
+    cmp #$20 // ' '                                                   // babb: c9 20       .
+    beq loop_cbab8                                                    // babd: f0 f9       ..
+    cmp #$0d                                                          // babf: c9 0d       ..
+    rts                                                               // bac1: 60          `
+
+// $bac2 referenced 4 times by $bbbe, $bc2c, $bc3d, $bc87
+sub_cbac2
+    lda #$0d                                                          // bac2: a9 0d       ..
+// $bac4 referenced 3 times by $b26e, $bb67, $bbed
+sub_cbac4
+    pha                                                               // bac4: 48          H
+    jsr sub_cbab9                                                     // bac5: 20 b9 ba     ..
+    pla                                                               // bac8: 68          h
+    cmp (os_text_ptr),y                                               // bac9: d1 f2       ..
+    bne cbad0                                                         // bacb: d0 03       ..
+    clc                                                               // bacd: 18          .
+    iny                                                               // bace: c8          .
+    rts                                                               // bacf: 60          `
+
+// $bad0 referenced 1 time by $bacb
+cbad0
+    sec                                                               // bad0: 38          8
+    rts                                                               // bad1: 60          `
+
+// $bad2 referenced 1 time by $bb4d
+sub_cbad2
+    jsr sub_cbab9                                                     // bad2: 20 b9 ba     ..
+    tya                                                               // bad5: 98          .
+    pha                                                               // bad6: 48          H
+    clc                                                               // bad7: 18          .
+    adc os_text_ptr                                                   // bad8: 65 f2       e.
+    ldy #$ef                                                          // bada: a0 ef       ..
+    sta (l00b8),y                                                     // badc: 91 b8       ..
+    lda l00f3                                                         // bade: a5 f3       ..
+    adc #0                                                            // bae0: 69 00       i.
+    iny                                                               // bae2: c8          .
+    sta (l00b8),y                                                     // bae3: 91 b8       ..
+    pla                                                               // bae5: 68          h
+    tay                                                               // bae6: a8          .
+    bit lb57f                                                         // bae7: 2c 7f b5    ,..
+// $baea referenced 1 time by $baf6
+loop_cbaea
+    lda (os_text_ptr),y                                               // baea: b1 f2       ..
+    cmp #$20 // ' '                                                   // baec: c9 20       .
+    beq cbafd                                                         // baee: f0 0d       ..
+    cmp #$0d                                                          // baf0: c9 0d       ..
+    beq cbafd                                                         // baf2: f0 09       ..
+    clv                                                               // baf4: b8          .
+    iny                                                               // baf5: c8          .
+    bne loop_cbaea                                                    // baf6: d0 f2       ..
+// $baf8 referenced 2 times by $bafd, $bbd0
+cbaf8
+    ldx #3                                                            // baf8: a2 03       ..
+    jmp cb8fb                                                         // bafa: 4c fb b8    L..
+
+// $bafd referenced 2 times by $baee, $baf2
+cbafd
+    bvs cbaf8                                                         // bafd: 70 f9       p.
+    rts                                                               // baff: 60          `
+
+// $bb00 referenced 4 times by $bb92, $bc21, $bc37, $bc81
+sub_cbb00
+    stx l00bf                                                         // bb00: 86 bf       ..
+    jsr sub_cbab9                                                     // bb02: 20 b9 ba     ..
+    ldx #3                                                            // bb05: a2 03       ..
+// $bb07 referenced 1 time by $bb34
+cbb07
+    cmp lbb3e,x                                                       // bb07: dd 3e bb    .>.
+    bcs cbb36                                                         // bb0a: b0 2a       .*
+    cmp lbb3a,x                                                       // bb0c: dd 3a bb    .:.
+    bcc cbb33                                                         // bb0f: 90 22       ."
+    sbc lbb42,x                                                       // bb11: fd 42 bb    .B.
+    iny                                                               // bb14: c8          .
+    cmp #1                                                            // bb15: c9 01       ..
+    bne cbb2a                                                         // bb17: d0 11       ..
+    lda (os_text_ptr),y                                               // bb19: b1 f2       ..
+    cmp #$36 // '6'                                                   // bb1b: c9 36       .6
+    bcs cbb28                                                         // bb1d: b0 09       ..
+    cmp #$30 // '0'                                                   // bb1f: c9 30       .0
+    bcc cbb28                                                         // bb21: 90 05       ..
+    sbc #$26 // '&'                                                   // bb23: e9 26       .&
+    iny                                                               // bb25: c8          .
+    bne cbb2a                                                         // bb26: d0 02       ..
+// $bb28 referenced 2 times by $bb1d, $bb21
+cbb28
+    lda #1                                                            // bb28: a9 01       ..
+// $bb2a referenced 2 times by $bb17, $bb26
+cbb2a
+    pha                                                               // bb2a: 48          H
+    jsr sub_cbab9                                                     // bb2b: 20 b9 ba     ..
+    pla                                                               // bb2e: 68          h
+    ldx l00bf                                                         // bb2f: a6 bf       ..
+    clc                                                               // bb31: 18          .
+    rts                                                               // bb32: 60          `
+
+// $bb33 referenced 1 time by $bb0f
+cbb33
+    dex                                                               // bb33: ca          .
+    bpl cbb07                                                         // bb34: 10 d1       ..
+// $bb36 referenced 1 time by $bb0a
+cbb36
+    ldx l00bf                                                         // bb36: a6 bf       ..
+    sec                                                               // bb38: 38          8
+    rts                                                               // bb39: 60          `
+
+// $bb3a referenced 1 time by $bb0c
+lbb3a
+    .asc "0AWw"                                                       // bb3a: 30 41 57... 0AW
+// $bb3e referenced 1 time by $bb07
+lbb3e
+    .asc ":G[{"                                                       // bb3e: 3a 47 5b... :G[
+// $bb42 referenced 1 time by $bb11
+lbb42
+    .asc "07Gg"                                                       // bb42: 30 37 47... 07G
+
+sub_cbb46
+    lda #$c0                                                          // bb46: a9 c0       ..
+    bne cbb4c                                                         // bb48: d0 02       ..
+sub_cbb4a
+    lda #$40 // '@'                                                   // bb4a: a9 40       .@
+// $bb4c referenced 1 time by $bb48
+cbb4c
+    pha                                                               // bb4c: 48          H
+    jsr sub_cbad2                                                     // bb4d: 20 d2 ba     ..
+    clv                                                               // bb50: b8          .
+    jsr sub_cba67                                                     // bb51: 20 67 ba     g.
+    bcs cbb6f                                                         // bb54: b0 19       ..
+    sty l00ba                                                         // bb56: 84 ba       ..
+    ldx #$bc                                                          // bb58: a2 bc       ..
+    ldy #$f2                                                          // bb5a: a0 f2       ..
+    jsr sub_cb850                                                     // bb5c: 20 50 b8     P.
+    ldy l00ba                                                         // bb5f: a4 ba       ..
+    pla                                                               // bb61: 68          h
+    pha                                                               // bb62: 48          H
+    bmi cbb90                                                         // bb63: 30 2b       0+
+    lda #$2b // '+'                                                   // bb65: a9 2b       .+
+    jsr sub_cbac4                                                     // bb67: 20 c4 ba     ..
+    php                                                               // bb6a: 08          .
+    clv                                                               // bb6b: b8          .
+    jsr sub_cba67                                                     // bb6c: 20 67 ba     g.
+// $bb6f referenced 1 time by $bb54
+cbb6f
+    bcs cbbd0                                                         // bb6f: b0 5f       ._
+    sty l00ba                                                         // bb71: 84 ba       ..
+    plp                                                               // bb73: 28          (
+    bcc cbb89                                                         // bb74: 90 13       ..
+    ldy #$f2                                                          // bb76: a0 f2       ..
+    sec                                                               // bb78: 38          8
+    lda l00bc                                                         // bb79: a5 bc       ..
+    sec                                                               // bb7b: 38          8
+    sbc (l00b8),y                                                     // bb7c: f1 b8       ..
+    sta l00bc                                                         // bb7e: 85 bc       ..
+    iny                                                               // bb80: c8          .
+    lda l00bd                                                         // bb81: a5 bd       ..
+    sbc (l00b8),y                                                     // bb83: f1 b8       ..
+    bcc cbbd0                                                         // bb85: 90 49       .I
+    sta l00bd                                                         // bb87: 85 bd       ..
+// $bb89 referenced 1 time by $bb74
+cbb89
+    ldx #$bc                                                          // bb89: a2 bc       ..
+    ldy #$f4                                                          // bb8b: a0 f4       ..
+    jsr sub_cb850                                                     // bb8d: 20 50 b8     P.
+// $bb90 referenced 1 time by $bb63
+cbb90
+    ldy l00ba                                                         // bb90: a4 ba       ..
+    jsr sub_cbb00                                                     // bb92: 20 00 bb     ..
+    sty l00ba                                                         // bb95: 84 ba       ..
+    bcs cbba1                                                         // bb97: b0 08       ..
+    ldy #$f1                                                          // bb99: a0 f1       ..
+    sta (l00b8),y                                                     // bb9b: 91 b8       ..
+    pla                                                               // bb9d: 68          h
+    and #$80                                                          // bb9e: 29 80       ).
+    pha                                                               // bba0: 48          H
+// $bba1 referenced 1 time by $bb97
+cbba1
+    pla                                                               // bba1: 68          h
+    sta l00bb                                                         // bba2: 85 bb       ..
+    ldy #$ee                                                          // bba4: a0 ee       ..
+    lda (l00b8),y                                                     // bba6: b1 b8       ..
+    and #$3f // '?'                                                   // bba8: 29 3f       )?
+    ora l00bb                                                         // bbaa: 05 bb       ..
+    sta (l00b8),y                                                     // bbac: 91 b8       ..
+    ldy l00ba                                                         // bbae: a4 ba       ..
+    jsr sub_cbab9                                                     // bbb0: 20 b9 ba     ..
+    and #$df                                                          // bbb3: 29 df       ).
+    ldx #0                                                            // bbb5: a2 00       ..
+    cmp #$51 // 'Q'                                                   // bbb7: c9 51       .Q
+    bne cbbbe                                                         // bbb9: d0 03       ..
+    iny                                                               // bbbb: c8          .
+    ldx #$ff                                                          // bbbc: a2 ff       ..
+// $bbbe referenced 1 time by $bbb9
+cbbbe
+    jsr sub_cbac2                                                     // bbbe: 20 c2 ba     ..
+    bcs cbbd0                                                         // bbc1: b0 0d       ..
+    ldy #$f8                                                          // bbc3: a0 f8       ..
+    lda #0                                                            // bbc5: a9 00       ..
+    sta (l00b8),y                                                     // bbc7: 91 b8       ..
+    iny                                                               // bbc9: c8          .
+    txa                                                               // bbca: 8a          .
+    sta (l00b8),y                                                     // bbcb: 91 b8       ..
+    jmp cb2e7                                                         // bbcd: 4c e7 b2    L..
+
+// $bbd0 referenced 9 times by $bb6f, $bb85, $bbc1, $bbe0, $bbf6, $bc1f, $bc2f, $bc3a, $bc40
+cbbd0
+    jmp cbaf8                                                         // bbd0: 4c f8 ba    L..
+
+sub_cbbd3
+    lda #$c0                                                          // bbd3: a9 c0       ..
+    bne cbbd9                                                         // bbd5: d0 02       ..
+sub_cbbd7
+    lda #$40 // '@'                                                   // bbd7: a9 40       .@
+// $bbd9 referenced 1 time by $bbd5
+cbbd9
+    pha                                                               // bbd9: 48          H
+    bit lb57f                                                         // bbda: 2c 7f b5    ,..
+    jsr sub_cba67                                                     // bbdd: 20 67 ba     g.
+    bcs cbbd0                                                         // bbe0: b0 ee       ..
+    ldx #3                                                            // bbe2: a2 03       ..
+// $bbe4 referenced 1 time by $bbe9
+loop_cbbe4
+    lda l00bc,x                                                       // bbe4: b5 bc       ..
+    sta l00b1,x                                                       // bbe6: 95 b1       ..
+    dex                                                               // bbe8: ca          .
+    bpl loop_cbbe4                                                    // bbe9: 10 f9       ..
+    lda #$2b // '+'                                                   // bbeb: a9 2b       .+
+    jsr sub_cbac4                                                     // bbed: 20 c4 ba     ..
+    bcs cbbf3                                                         // bbf0: b0 01       ..
+    clv                                                               // bbf2: b8          .
+// $bbf3 referenced 1 time by $bbf0
+cbbf3
+    jsr sub_cba67                                                     // bbf3: 20 67 ba     g.
+    bcs cbbd0                                                         // bbf6: b0 d8       ..
+    bvc cbc13                                                         // bbf8: 50 19       P.
+    sec                                                               // bbfa: 38          8
+    ldx #0                                                            // bbfb: a2 00       ..
+    sec                                                               // bbfd: 38          8
+// $bbfe referenced 1 time by $bc08
+loop_cbbfe
+    lda l00bc,x                                                       // bbfe: b5 bc       ..
+    sbc l00b1,x                                                       // bc00: f5 b1       ..
+    sta l00bc,x                                                       // bc02: 95 bc       ..
+    inx                                                               // bc04: e8          .
+    txa                                                               // bc05: 8a          .
+    and #4                                                            // bc06: 29 04       ).
+    beq loop_cbbfe                                                    // bc08: f0 f4       ..
+    lda l00be                                                         // bc0a: a5 be       ..
+    ora l00bf                                                         // bc0c: 05 bf       ..
+    beq cbc13                                                         // bc0e: f0 03       ..
+    jmp cb446                                                         // bc10: 4c 46 b4    LF.
+
+// $bc13 referenced 2 times by $bbf8, $bc0e
+cbc13
+    lda l00bc                                                         // bc13: a5 bc       ..
+    sta l00b5                                                         // bc15: 85 b5       ..
+    lda l00bd                                                         // bc17: a5 bd       ..
+    sta l00b6                                                         // bc19: 85 b6       ..
+    clv                                                               // bc1b: b8          .
+    jsr sub_cba67                                                     // bc1c: 20 67 ba     g.
+    bcs cbbd0                                                         // bc1f: b0 af       ..
+    jsr sub_cbb00                                                     // bc21: 20 00 bb     ..
+    bcs cbc2c                                                         // bc24: b0 06       ..
+    sta l00b7                                                         // bc26: 85 b7       ..
+    pla                                                               // bc28: 68          h
+    and #$bf                                                          // bc29: 29 bf       ).
+    pha                                                               // bc2b: 48          H
+// $bc2c referenced 1 time by $bc24
+cbc2c
+    jsr sub_cbac2                                                     // bc2c: 20 c2 ba     ..
+    bcs cbbd0                                                         // bc2f: b0 9f       ..
+    pla                                                               // bc31: 68          h
+    sta l00b0                                                         // bc32: 85 b0       ..
+    jmp cbcb9                                                         // bc34: 4c b9 bc    L..
+
+sub_cbc37
+    jsr sub_cbb00                                                     // bc37: 20 00 bb     ..
+// $bc3a referenced 2 times by $bc84, $bc8a
+cbc3a
+    bcs cbbd0                                                         // bc3a: b0 94       ..
+    pha                                                               // bc3c: 48          H
+    jsr sub_cbac2                                                     // bc3d: 20 c2 ba     ..
+    bcs cbbd0                                                         // bc40: b0 8e       ..
+    pla                                                               // bc42: 68          h
+    tay                                                               // bc43: a8          .
+    jsr sub_cb6fe                                                     // bc44: 20 fe b6     ..
+    bne cbc64                                                         // bc47: d0 1b       ..
+    jsr sub_cb986                                                     // bc49: 20 86 b9     ..
+    tax                                                               // bc4c: aa          .
+    bne cbc54                                                         // bc4d: d0 05       ..
+    ldx #5                                                            // bc4f: a2 05       ..
+    jmp cb8fb                                                         // bc51: 4c fb b8    L..
+
+// $bc54 referenced 1 time by $bc4d
+cbc54
+    sty l00bf                                                         // bc54: 84 bf       ..
+    lda lb726,y                                                       // bc56: b9 26 b7    .&.
+    ldy #$fd                                                          // bc59: a0 fd       ..
+    ora (l00b8),y                                                     // bc5b: 11 b8       ..
+    sta (l00b8),y                                                     // bc5d: 91 b8       ..
+    ldy l00bf                                                         // bc5f: a4 bf       ..
+    jsr sub_cbc68                                                     // bc61: 20 68 bc     h.
+// $bc64 referenced 1 time by $bc47
+cbc64
+    jsr sub_cbec2                                                     // bc64: 20 c2 be     ..
+    rts                                                               // bc67: 60          `
+
+// $bc68 referenced 2 times by $bc61, $bc95
+sub_cbc68
+    ldx #$0f                                                          // bc68: a2 0f       ..
+    stx l00ba                                                         // bc6a: 86 ba       ..
+    lda #$80                                                          // bc6c: a9 80       ..
+    sta l00bb                                                         // bc6e: 85 bb       ..
+// $bc70 referenced 1 time by $bc7e
+loop_cbc70
+    lda lb872,x                                                       // bc70: bd 72 b8    .r.
+    cpx #1                                                            // bc73: e0 01       ..
+    bne cbc78                                                         // bc75: d0 01       ..
+    tya                                                               // bc77: 98          .
+// $bc78 referenced 1 time by $bc75
+cbc78
+    jsr sub_cb745                                                     // bc78: 20 45 b7     E.
+    dex                                                               // bc7b: ca          .
+    stx l00ba                                                         // bc7c: 86 ba       ..
+    bpl loop_cbc70                                                    // bc7e: 10 f0       ..
+    rts                                                               // bc80: 60          `
+
+sub_cbc81
+    jsr sub_cbb00                                                     // bc81: 20 00 bb     ..
+    bcs cbc3a                                                         // bc84: b0 b4       ..
+    pha                                                               // bc86: 48          H
+    jsr sub_cbac2                                                     // bc87: 20 c2 ba     ..
+    bcs cbc3a                                                         // bc8a: b0 ae       ..
+    pla                                                               // bc8c: 68          h
+    tay                                                               // bc8d: a8          .
+    jsr sub_cb6fe                                                     // bc8e: 20 fe b6     ..
+    beq cbcb2                                                         // bc91: f0 1f       ..
+// $bc93 referenced 1 time by $bcb6
+cbc93
+    sty l00bc                                                         // bc93: 84 bc       ..
+    jsr sub_cbc68                                                     // bc95: 20 68 bc     h.
+    lda #$0a                                                          // bc98: a9 0a       ..
+    sta l00ba                                                         // bc9a: 85 ba       ..
+    lda #$4f // 'O'                                                   // bc9c: a9 4f       .O
+    jsr sub_cb745                                                     // bc9e: 20 45 b7     E.
+    lda lb726,y                                                       // bca1: b9 26 b7    .&.
+    eor #$ff                                                          // bca4: 49 ff       I.
+    ldy #$fd                                                          // bca6: a0 fd       ..
+    and (l00b8),y                                                     // bca8: 31 b8       1.
+    sta (l00b8),y                                                     // bcaa: 91 b8       ..
+    ldy l00bc                                                         // bcac: a4 bc       ..
+    jsr sub_cbec2                                                     // bcae: 20 c2 be     ..
+    rts                                                               // bcb1: 60          `
+
+// $bcb2 referenced 1 time by $bc91
+cbcb2
+    jsr sub_cb986                                                     // bcb2: 20 86 b9     ..
+    tax                                                               // bcb5: aa          .
+    bne cbc93                                                         // bcb6: d0 db       ..
+    rts                                                               // bcb8: 60          `
+
+// $bcb9 referenced 2 times by $b1f6, $bc34
+cbcb9
+    lda l00b0                                                         // bcb9: a5 b0       ..
+    and #$c0                                                          // bcbb: 29 c0       ).
+    sta l00be                                                         // bcbd: 85 be       ..
+    ldy #$ee                                                          // bcbf: a0 ee       ..
+    lda (l00b8),y                                                     // bcc1: b1 b8       ..
+    and #$3f // '?'                                                   // bcc3: 29 3f       )?
+    ora l00be                                                         // bcc5: 05 be       ..
+    sta (l00b8),y                                                     // bcc7: 91 b8       ..
+    bit l00b0                                                         // bcc9: 24 b0       $.
+    bvs cbcd6                                                         // bccb: 70 09       p.
+    ldy l00b7                                                         // bccd: a4 b7       ..
+    cpy #$14                                                          // bccf: c0 14       ..
+    bcc cbce1                                                         // bcd1: 90 0e       ..
+// $bcd3 referenced 1 time by $bcef
+loop_cbcd3
+    jmp cb300                                                         // bcd3: 4c 00 b3    L..
+
+// $bcd6 referenced 1 time by $bccb
+cbcd6
+    ldx l00bc                                                         // bcd6: a6 bc       ..
+    lda l00bd                                                         // bcd8: a5 bd       ..
+    jsr sub_cb6b1                                                     // bcda: 20 b1 b6     ..
+    stx l00bc                                                         // bcdd: 86 bc       ..
+    sta l00bd                                                         // bcdf: 85 bd       ..
+// $bce1 referenced 1 time by $bcd1
+cbce1
+    jsr sub_cb6fe                                                     // bce1: 20 fe b6     ..
+    pha                                                               // bce4: 48          H
+    tya                                                               // bce5: 98          .
+    ldy #$f1                                                          // bce6: a0 f1       ..
+    sta (l00b8),y                                                     // bce8: 91 b8       ..
+    pla                                                               // bcea: 68          h
+    eor l00b0                                                         // bceb: 45 b0       E.
+    and #$40 // '@'                                                   // bced: 29 40       )@
+    bne loop_cbcd3                                                    // bcef: d0 e2       ..
+    jsr sub_cbe9d                                                     // bcf1: 20 9d be     ..
+    jsr sub_cbe91                                                     // bcf4: 20 91 be     ..
+    bcs cbd1b                                                         // bcf7: b0 22       ."
+// $bcf9 referenced 1 time by $bd21
+cbcf9
+    ldx #$b5                                                          // bcf9: a2 b5       ..
+    ldy #$be                                                          // bcfb: a0 be       ..
+    jsr sub_cb580                                                     // bcfd: 20 80 b5     ..
+    rol l00b0                                                         // bd00: 26 b0       &.
+    bcc cbd0e                                                         // bd02: 90 0a       ..
+    ldx #$bc                                                          // bd04: a2 bc       ..
+    ldy #$b3                                                          // bd06: a0 b3       ..
+// $bd08 referenced 1 time by $bd19
+loop_cbd08
+    jsr sub_cb580                                                     // bd08: 20 80 b5     ..
+    jmp cb795                                                         // bd0b: 4c 95 b7    L..
+
+// $bd0e referenced 1 time by $bd02
+cbd0e
+    ldx #$b1                                                          // bd0e: a2 b1       ..
+    ldy #$b3                                                          // bd10: a0 b3       ..
+    jsr sub_cb580                                                     // bd12: 20 80 b5     ..
+    ldx #$bc                                                          // bd15: a2 bc       ..
+    ldy #$b1                                                          // bd17: a0 b1       ..
+    bne loop_cbd08                                                    // bd19: d0 ed       ..
+// $bd1b referenced 1 time by $bcf7
+cbd1b
+    lda l00b3                                                         // bd1b: a5 b3       ..
+    and l00b4                                                         // bd1d: 25 b4       %.
+    cmp #$ff                                                          // bd1f: c9 ff       ..
+    beq cbcf9                                                         // bd21: f0 d6       ..
+    lda l00bc                                                         // bd23: a5 bc       ..
+    pha                                                               // bd25: 48          H
+    lda l00bd                                                         // bd26: a5 bd       ..
+    pha                                                               // bd28: 48          H
+    ldx #3                                                            // bd29: a2 03       ..
+// $bd2b referenced 1 time by $bd30
+loop_cbd2b
+    lda l00b1,x                                                       // bd2b: b5 b1       ..
+    sta l00ba,x                                                       // bd2d: 95 ba       ..
+    dex                                                               // bd2f: ca          .
+    bpl loop_cbd2b                                                    // bd30: 10 f9       ..
+    ldx #$b5                                                          // bd32: a2 b5       ..
+    ldy #$f4                                                          // bd34: a0 f4       ..
+    jsr sub_cb850                                                     // bd36: 20 50 b8     P.
+    bit l00b0                                                         // bd39: 24 b0       $.
+    bmi cbd40                                                         // bd3b: 30 03       0.
+    jmp cbdba                                                         // bd3d: 4c ba bd    L..
+
+// $bd40 referenced 1 time by $bd3b
+cbd40
+    pla                                                               // bd40: 68          h
+    sta l00b4                                                         // bd41: 85 b4       ..
+    pla                                                               // bd43: 68          h
+    sta l00b3                                                         // bd44: 85 b3       ..
+// $bd46 referenced 1 time by $bdb6
+cbd46
+    ldx #$be                                                          // bd46: a2 be       ..
+    ldy #$f4                                                          // bd48: a0 f4       ..
+    jsr sub_cb841                                                     // bd4a: 20 41 b8     A.
+    lda l00bf                                                         // bd4d: a5 bf       ..
+    bne cbd7e                                                         // bd4f: d0 2d       .-
+    ldx l00be                                                         // bd51: a6 be       ..
+    beq cbdb9                                                         // bd53: f0 64       .d
+    lda #0                                                            // bd55: a9 00       ..
+    sta (l00b8),y                                                     // bd57: 91 b8       ..
+    inc l00b9                                                         // bd59: e6 b9       ..
+    jsr cbe7b                                                         // bd5b: 20 7b be     {.
+    lda #0                                                            // bd5e: a9 00       ..
+    ldx #$ba                                                          // bd60: a2 ba       ..
+    ldy #0                                                            // bd62: a0 00       ..
+    jsr tube_entry                                                    // bd64: 20 06 04     ..
+    ldy #7                                                            // bd67: a0 07       ..
+    jsr cbe89                                                         // bd69: 20 89 be     ..
+// $bd6c referenced 1 time by $bd7a
+loop_cbd6c
+    lda tube_host_r3_data                                             // bd6c: ad e5 fe    ...
+    sta (l00b8),y                                                     // bd6f: 91 b8       ..
+    ldx #3                                                            // bd71: a2 03       ..
+    jsr cbe8d                                                         // bd73: 20 8d be     ..
+    nop                                                               // bd76: ea          .
+    iny                                                               // bd77: c8          .
+    cpy l00be                                                         // bd78: c4 be       ..
+    bne loop_cbd6c                                                    // bd7a: d0 f0       ..
+    beq cbda3                                                         // bd7c: f0 25       .%
+// $bd7e referenced 1 time by $bd4f
+cbd7e
+    lda #0                                                            // bd7e: a9 00       ..
+    sta l00be                                                         // bd80: 85 be       ..
+    lda #1                                                            // bd82: a9 01       ..
+    sta l00bf                                                         // bd84: 85 bf       ..
+    inc l00b9                                                         // bd86: e6 b9       ..
+    jsr cbe7b                                                         // bd88: 20 7b be     {.
+    lda #6                                                            // bd8b: a9 06       ..
+    ldx #$ba                                                          // bd8d: a2 ba       ..
+    ldy #0                                                            // bd8f: a0 00       ..
+    jsr tube_entry                                                    // bd91: 20 06 04     ..
+    ldy #5                                                            // bd94: a0 05       ..
+    jsr cbe89                                                         // bd96: 20 89 be     ..
+// $bd99 referenced 1 time by $bda1
+loop_cbd99
+    lda tube_host_r3_data                                             // bd99: ad e5 fe    ...
+    sta (l00b8),y                                                     // bd9c: 91 b8       ..
+    lda (l00b8),y                                                     // bd9e: b1 b8       ..
+    iny                                                               // bda0: c8          .
+    bne loop_cbd99                                                    // bda1: d0 f6       ..
+// $bda3 referenced 1 time by $bd7c
+cbda3
+    jsr sub_cbe83                                                     // bda3: 20 83 be     ..
+    ldx #$b8                                                          // bda6: a2 b8       ..
+    ldy #$b1                                                          // bda8: a0 b1       ..
+    jsr sub_cb580                                                     // bdaa: 20 80 b5     ..
+    dec l00b9                                                         // bdad: c6 b9       ..
+    sec                                                               // bdaf: 38          8
+    jsr cb795                                                         // bdb0: 20 95 b7     ..
+    jsr cbe47                                                         // bdb3: 20 47 be     G.
+    jmp cbd46                                                         // bdb6: 4c 46 bd    LF.
+
+// $bdb9 referenced 2 times by $bd53, $bdcd
+cbdb9
+    rts                                                               // bdb9: 60          `
+
+// $bdba referenced 1 time by $bd3d
+cbdba
+    pla                                                               // bdba: 68          h
+    sta l00b2                                                         // bdbb: 85 b2       ..
+    pla                                                               // bdbd: 68          h
+    sta l00b1                                                         // bdbe: 85 b1       ..
+// $bdc0 referenced 1 time by $be44
+cbdc0
+    ldx #$be                                                          // bdc0: a2 be       ..
+    ldy #$f4                                                          // bdc2: a0 f4       ..
+    jsr sub_cb841                                                     // bdc4: 20 41 b8     A.
+    lda l00bf                                                         // bdc7: a5 bf       ..
+    bne cbdd3                                                         // bdc9: d0 08       ..
+    ldx l00be                                                         // bdcb: a6 be       ..
+    beq cbdb9                                                         // bdcd: f0 ea       ..
+    lda #1                                                            // bdcf: a9 01       ..
+    bne cbddd                                                         // bdd1: d0 0a       ..
+// $bdd3 referenced 1 time by $bdc9
+cbdd3
+    lda #0                                                            // bdd3: a9 00       ..
+    sta l00be                                                         // bdd5: 85 be       ..
+    lda #1                                                            // bdd7: a9 01       ..
+    sta l00bf                                                         // bdd9: 85 bf       ..
+    lda #7                                                            // bddb: a9 07       ..
+// $bddd referenced 1 time by $bdd1
+cbddd
+    pha                                                               // bddd: 48          H
+    inc l00b9                                                         // bdde: e6 b9       ..
+    ldx #$b8                                                          // bde0: a2 b8       ..
+    ldy #$b3                                                          // bde2: a0 b3       ..
+    jsr sub_cb580                                                     // bde4: 20 80 b5     ..
+    lda l00be                                                         // bde7: a5 be       ..
+    pha                                                               // bde9: 48          H
+    dec l00b9                                                         // bdea: c6 b9       ..
+    clc                                                               // bdec: 18          .
+    jsr cb795                                                         // bded: 20 95 b7     ..
+    pla                                                               // bdf0: 68          h
+    sta l00be                                                         // bdf1: 85 be       ..
+    pla                                                               // bdf3: 68          h
+    cmp #1                                                            // bdf4: c9 01       ..
+    bne cbe21                                                         // bdf6: d0 29       .)
+    lda #0                                                            // bdf8: a9 00       ..
+    ldy #$f4                                                          // bdfa: a0 f4       ..
+    sta (l00b8),y                                                     // bdfc: 91 b8       ..
+    inc l00b9                                                         // bdfe: e6 b9       ..
+    jsr cbe7b                                                         // be00: 20 7b be     {.
+    lda #1                                                            // be03: a9 01       ..
+    ldx #$ba                                                          // be05: a2 ba       ..
+    ldy #0                                                            // be07: a0 00       ..
+    jsr tube_entry                                                    // be09: 20 06 04     ..
+    ldy #0                                                            // be0c: a0 00       ..
+// $be0e referenced 1 time by $be1d
+loop_cbe0e
+    lda (l00b8),y                                                     // be0e: b1 b8       ..
+    sta tube_host_r3_data                                             // be10: 8d e5 fe    ...
+    ldx #3                                                            // be13: a2 03       ..
+    jsr cbe8d                                                         // be15: 20 8d be     ..
+    iny                                                               // be18: c8          .
+    cpy l00be                                                         // be19: c4 be       ..
+    cpy l00be                                                         // be1b: c4 be       ..
+    bne loop_cbe0e                                                    // be1d: d0 ef       ..
+    beq cbe3c                                                         // be1f: f0 1b       ..
+// $be21 referenced 1 time by $bdf6
+cbe21
+    inc l00b9                                                         // be21: e6 b9       ..
+    jsr cbe7b                                                         // be23: 20 7b be     {.
+    lda #7                                                            // be26: a9 07       ..
+    ldx #$ba                                                          // be28: a2 ba       ..
+    ldy #0                                                            // be2a: a0 00       ..
+    jsr tube_entry                                                    // be2c: 20 06 04     ..
+    ldy #0                                                            // be2f: a0 00       ..
+// $be31 referenced 1 time by $be3a
+loop_cbe31
+    lda (l00b8),y                                                     // be31: b1 b8       ..
+    sta tube_host_r3_data                                             // be33: 8d e5 fe    ...
+    nop                                                               // be36: ea          .
+    nop                                                               // be37: ea          .
+    nop                                                               // be38: ea          .
+    iny                                                               // be39: c8          .
+    bne loop_cbe31                                                    // be3a: d0 f5       ..
+// $be3c referenced 1 time by $be1f
+cbe3c
+    jsr sub_cbe83                                                     // be3c: 20 83 be     ..
+    dec l00b9                                                         // be3f: c6 b9       ..
+    jsr cbe47                                                         // be41: 20 47 be     G.
+    jmp cbdc0                                                         // be44: 4c c0 bd    L..
+
+// $be47 referenced 3 times by $bdb3, $be41, $be50
+cbe47
+    ldx #1                                                            // be47: a2 01       ..
+    inc l00ba,x                                                       // be49: f6 ba       ..
+    bne cbe52                                                         // be4b: d0 05       ..
+    inx                                                               // be4d: e8          .
+    cpx #4                                                            // be4e: e0 04       ..
+    bcc cbe47                                                         // be50: 90 f5       ..
+// $be52 referenced 1 time by $be4b
+cbe52
+    ldy #$f5                                                          // be52: a0 f5       ..
+    lda (l00b8),y                                                     // be54: b1 b8       ..
+    sec                                                               // be56: 38          8
+    sbc #1                                                            // be57: e9 01       ..
+    bcc cbe7a                                                         // be59: 90 1f       ..
+    sta (l00b8),y                                                     // be5b: 91 b8       ..
+    jsr sub_cb616                                                     // be5d: 20 16 b6     ..
+    beq cbe7a                                                         // be60: f0 18       ..
+    ldx l00b7                                                         // be62: a6 b7       ..
+    jsr sub_cb85d                                                     // be64: 20 5d b8     ].
+    bvc cbe7a                                                         // be67: 50 11       P.
+    lda l00b1,x                                                       // be69: b5 b1       ..
+    cmp #$c0                                                          // be6b: c9 c0       ..
+    bcc cbe7a                                                         // be6d: 90 0b       ..
+    lda #$10                                                          // be6f: a9 10       ..
+    sta l00b0,x                                                       // be71: 95 b0       ..
+    lda #$80                                                          // be73: a9 80       ..
+    sta l00b1,x                                                       // be75: 95 b1       ..
+    jsr sub_cb68f                                                     // be77: 20 8f b6     ..
+// $be7a referenced 4 times by $be59, $be60, $be67, $be6d
+cbe7a
+    rts                                                               // be7a: 60          `
+
+// $be7b referenced 5 times by $bd5b, $bd88, $be00, $be23, $be80
+cbe7b
+    lda #$c8                                                          // be7b: a9 c8       ..
+    jsr tube_entry                                                    // be7d: 20 06 04     ..
+    bcc cbe7b                                                         // be80: 90 f9       ..
+    rts                                                               // be82: 60          `
+
+// $be83 referenced 2 times by $bda3, $be3c
+sub_cbe83
+    lda #$88                                                          // be83: a9 88       ..
+    jsr tube_entry                                                    // be85: 20 06 04     ..
+    rts                                                               // be88: 60          `
+
+// $be89 referenced 3 times by $bd69, $bd96, $be8a
+cbe89
+    dey                                                               // be89: 88          .
+    bne cbe89                                                         // be8a: d0 fd       ..
+    rts                                                               // be8c: 60          `
+
+// $be8d referenced 3 times by $bd73, $be15, $be8e
+cbe8d
+    dex                                                               // be8d: ca          .
+    bne cbe8d                                                         // be8e: d0 fd       ..
+    rts                                                               // be90: 60          `
+
+// $be91 referenced 1 time by $bcf4
+sub_cbe91
+    lda #osbyte_read_tube_presence                                    // be91: a9 ea       ..
+    ldx #0                                                            // be93: a2 00       ..
+    ldy #$ff                                                          // be95: a0 ff       ..
+    jsr osbyte                                                        // be97: 20 f4 ff     ..
+    cpx #$ff                                                          // be9a: e0 ff       ..
+    rts                                                               // be9c: 60          `
+
+// $be9d referenced 2 times by $b338, $bcf1
+sub_cbe9d
+    jsr sub_cb85d                                                     // be9d: 20 5d b8     ].
+    bpl cbec1                                                         // bea0: 10 1f       ..
+    bvs cbec1                                                         // bea2: 70 1d       p.
+    lda #0                                                            // bea4: a9 00       ..
+    pha                                                               // bea6: 48          H
+    ldy #$f1                                                          // bea7: a0 f1       ..
+    lda (l00b8),y                                                     // bea9: b1 b8       ..
+// $beab referenced 1 time by $bec6
+loop_cbeab
+    pha                                                               // beab: 48          H
+    lda #osbyte_read_rom_info_table_low                               // beac: a9 aa       ..
+    ldx #0                                                            // beae: a2 00       ..
+    ldy #$ff                                                          // beb0: a0 ff       ..
+    jsr osbyte                                                        // beb2: 20 f4 ff     ..
+    jsr cb82b                                                         // beb5: 20 2b b8     +.
+    stx l00ba                                                         // beb8: 86 ba       ..
+    sty l00bb                                                         // beba: 84 bb       ..
+    pla                                                               // bebc: 68          h
+    tay                                                               // bebd: a8          .
+    pla                                                               // bebe: 68          h
+    sta (l00ba),y                                                     // bebf: 91 ba       ..
+// $bec1 referenced 2 times by $bea0, $bea2
+cbec1
+    rts                                                               // bec1: 60          `
+
+// $bec2 referenced 2 times by $bc64, $bcae
+sub_cbec2
+    lda #2                                                            // bec2: a9 02       ..
+    pha                                                               // bec4: 48          H
+    tya                                                               // bec5: 98          .
+    bpl loop_cbeab                                                    // bec6: 10 e3       ..
+// $bec8 referenced 1 time by $8003
+service_handler
+    cmp #service_claim_absolute_workspace                             // bec8: c9 01       ..
+    bne cbee0                                                         // beca: d0 14       ..
+    pha                                                               // becc: 48          H
+    tya                                                               // becd: 98          .
+    pha                                                               // bece: 48          H
+    lda #osbyte_issue_service_request                                 // becf: a9 8f       ..
+    ldx #service_check_swr_presence                                   // bed1: a2 2b       .+
+    ldy romsel_copy                                                   // bed3: a4 f4       ..
+    jsr osbyte                                                        // bed5: 20 f4 ff     ..
+    pla                                                               // bed8: 68          h
+    tay                                                               // bed9: a8          .
+    ldx romsel_copy                                                   // beda: a6 f4       ..
+    pla                                                               // bedc: 68          h
+// $bedd referenced 2 times by $bee2, $beec
+general_service_handler_indirect
+    jmp general_service_handler                                       // bedd: 4c b1 b1    L..
+
+// $bee0 referenced 1 time by $beca
+cbee0
+    cmp #service_check_swr_presence                                   // bee0: c9 2b       .+
+    bne general_service_handler_indirect                              // bee2: d0 f9       ..
+    cpy romsel_copy                                                   // bee4: c4 f4       ..
+    beq cbeee                                                         // bee6: f0 06       ..
+// $bee8 referenced 4 times by $bef8, $beff, $bf08, $bf4c
+cbee8
+    ldx romsel_copy                                                   // bee8: a6 f4       ..
+    lda #0                                                            // beea: a9 00       ..
+    beq general_service_handler_indirect                              // beec: f0 ef       ..
+// $beee referenced 1 time by $bee6
+cbeee
+    lda #$72 // 'r'                                                   // beee: a9 72       .r
+    ldx #0                                                            // bef0: a2 00       ..
+    jsr osbyte                                                        // bef2: 20 f4 ff     ..
+    jsr osbyte                                                        // bef5: 20 f4 ff     ..
+    bvs cbee8                                                         // bef8: 70 ee       p.
+    lda #$ea                                                          // befa: a9 ea       ..
+    jsr sub_cbf82                                                     // befc: 20 82 bf     ..
+    bne cbee8                                                         // beff: d0 e7       ..
+    lda #$d7                                                          // bf01: a9 d7       ..
+    ldy #$7f                                                          // bf03: a0 7f       ..
+    jsr sub_cbf84                                                     // bf05: 20 84 bf     ..
+    bpl cbee8                                                         // bf08: 10 de       ..
+    jsr osnewl                                                        // bf0a: 20 e7 ff     ..
+    ldx #0                                                            // bf0d: a2 00       ..
+    jsr sub_cbf7c                                                     // bf0f: 20 7c bf     |.
+    lda #$fd                                                          // bf12: a9 fd       ..
+    jsr sub_cbf82                                                     // bf14: 20 82 bf     ..
+    beq cbf46                                                         // bf17: f0 2d       .-
+    tsx                                                               // bf19: ba          .
+    ldy #$30 // '0'                                                   // bf1a: a0 30       .0
+// $bf1c referenced 1 time by $bf21
+loop_cbf1c
+    lda cbf8a,y                                                       // bf1c: b9 8a bf    ...
+    pha                                                               // bf1f: 48          H
+    dey                                                               // bf20: 88          .
+    bne loop_cbf1c                                                    // bf21: d0 f9       ..
+    txa                                                               // bf23: 8a          .
+    tay                                                               // bf24: a8          .
+    lda #1                                                            // bf25: a9 01       ..
+    pha                                                               // bf27: 48          H
+    tsx                                                               // bf28: ba          .
+    inx                                                               // bf29: e8          .
+    txa                                                               // bf2a: 8a          .
+    pha                                                               // bf2b: 48          H
+    ldx #$0f                                                          // bf2c: a2 0f       ..
+    lda #0                                                            // bf2e: a9 00       ..
+    sta l00b0                                                         // bf30: 85 b0       ..
+    rts                                                               // bf32: 60          `
+
+// $bf33 referenced 1 time by $bfb8
+cbf33
+    tya                                                               // bf33: 98          .
+    tax                                                               // bf34: aa          .
+    txs                                                               // bf35: 9a          .
+    lda l00b0                                                         // bf36: a5 b0       ..
+    asl                                                               // bf38: 0a          .
+    asl                                                               // bf39: 0a          .
+    clc                                                               // bf3a: 18          .
+    adc #$0d                                                          // bf3b: 69 0d       i.
+    tax                                                               // bf3d: aa          .
+    jsr sub_cbf7c                                                     // bf3e: 20 7c bf     |.
+    ldx #$0a                                                          // bf41: a2 0a       ..
+    jsr sub_cbf7c                                                     // bf43: 20 7c bf     |.
+// $bf46 referenced 1 time by $bf17
+cbf46
+    jsr osnewl                                                        // bf46: 20 e7 ff     ..
+    jsr osnewl                                                        // bf49: 20 e7 ff     ..
+    jmp cbee8                                                         // bf4c: 4c e8 be    L..
+
+// $bf4f referenced 1 time by $bf7c
+lbf4f
+    .asc "Acorn OS "                                                  // bf4f: 41 63 6f... Aco
+    .byt   0, $4b,   7,   0, $36, $34,   0,   0, $38, $30,   0,   0   // bf58: 00 4b 07... .K.
+    .byt $39, $36,   0,   0                                           // bf64: 39 36 00... 96.
+    .asc "112"                                                        // bf68: 31 31 32    112
+    .byt 0                                                            // bf6b: 00          .
+    .asc "128"                                                        // bf6c: 31 32 38    128
+    .byt 0                                                            // bf6f: 00          .
+    .asc "144"                                                        // bf70: 31 34 34    144
+    .byt 0                                                            // bf73: 00          .
+    .asc "160"                                                        // bf74: 31 36 30    160
+    .byt 0                                                            // bf77: 00          .
+
+// $bf78 referenced 1 time by $bf7f
+loop_cbf78
+    jsr oswrch                                                        // bf78: 20 ee ff     ..
+    inx                                                               // bf7b: e8          .
+// $bf7c referenced 3 times by $bf0f, $bf3e, $bf43
+sub_cbf7c
+    lda lbf4f,x                                                       // bf7c: bd 4f bf    .O.
+    bne loop_cbf78                                                    // bf7f: d0 f7       ..
+    rts                                                               // bf81: 60          `
+
+// $bf82 referenced 2 times by $befc, $bf14
+sub_cbf82
+    ldy #$ff                                                          // bf82: a0 ff       ..
+// $bf84 referenced 1 time by $bf05
+sub_cbf84
+    ldx #0                                                            // bf84: a2 00       ..
+    jsr osbyte                                                        // bf86: 20 f4 ff     ..
+    txa                                                               // bf89: 8a          .
+// $bf8a referenced 1 time by $bf1c
+cbf8a
+    rts                                                               // bf8a: 60          `
+
+    lda romsel_copy                                                   // bf8b: a5 f4       ..
+    pha                                                               // bf8d: 48          H
+// $bf8e referenced 2 times by $bfac, $bfb0
+cbf8e
+    stx romsel_copy                                                   // bf8e: 86 f4       ..
+    stx romsel                                                        // bf90: 8e 30 fe    .0.
+    lda lbfff                                                         // bf93: ad ff bf    ...
+    pha                                                               // bf96: 48          H
+    eor #$a5                                                          // bf97: 49 a5       I.
+    sta lbfff                                                         // bf99: 8d ff bf    ...
+    cmp lbfff                                                         // bf9c: cd ff bf    ...
+    bne cbfa3                                                         // bf9f: d0 02       ..
+    inc l00b0                                                         // bfa1: e6 b0       ..
+// $bfa3 referenced 1 time by $bf9f
+cbfa3
+    pla                                                               // bfa3: 68          h
+    sta lbfff                                                         // bfa4: 8d ff bf    ...
+    dex                                                               // bfa7: ca          .
+    bmi cbfb2                                                         // bfa8: 30 08       0.
+    cpx #$0b                                                          // bfaa: e0 0b       ..
+    bne cbf8e                                                         // bfac: d0 e0       ..
+    ldx #1                                                            // bfae: a2 01       ..
+    bne cbf8e                                                         // bfb0: d0 dc       ..
+// $bfb2 referenced 1 time by $bfa8
+cbfb2
+    pla                                                               // bfb2: 68          h
+    sta romsel_copy                                                   // bfb3: 85 f4       ..
+    sta romsel                                                        // bfb5: 8d 30 fe    .0.
+    jmp cbf33                                                         // bfb8: 4c 33 bf    L3.
+
+    .byt $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff   // bfbb: ff ff ff... ...
+    .byt $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff   // bfc7: ff ff ff... ...
+    .byt $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff   // bfd3: ff ff ff... ...
+    .byt $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff   // bfdf: ff ff ff... ...
+    .byt $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff   // bfeb: ff ff ff... ...
+    .byt $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff                       // bff7: ff ff ff... ...
+// $bfff referenced 4 times by $bf93, $bf99, $bf9c, $bfa4
+lbfff
+    .byt $ff                                                          // bfff: ff          .
+pydis_end
+
+// Label references by decreasing frequency:
+//     l00b8:                                125
+//     l00b0:                                105
+//     l00ba:                                 44
+//     l00bf:                                 42
+//     l00bc:                                 41
+//     l00b6:                                 35
+//     l00be:                                 31
+//     l00cd:                                 31
+//     print_inline_l809f_top_bit_clear:      31
+//     l00c2:                                 30
+//     l00b1:                                 29
+//     sub_c83e3:                             29
+//     l00b9:                                 28
+//     l00bb:                                 28
+//     l00b5:                                 26
+//     l00bd:                                 26
+//     l00b4:                                 25
+//     l00b3:                                 23
+//     l00c1:                                 23
+//     os_text_ptr:                           23
+//     osbyte:                                22
+//     romsel_copy:                           21
+//     l0f0e:                                 21
+//     caea0:                                 21
+//     l00c4:                                 20
+//     c809f:                                 20
+//     l00b2:                                 19
+//     l10c2:                                 19
+//     l0001:                                 18
+//     l00a8:                                 18
+//     l00aa:                                 18
+//     l00c5:                                 18
+//     l00c9:                                 18
+//     l10de:                                 18
+//     l0000:                                 17
+//     l00b7:                                 17
+//     l0e0f:                                 17
+//     l0f06:                                 17
+//     l1000:                                 17
+//     l00a2:                                 16
+//     l00ab:                                 16
+//     l00ae:                                 16
+//     ca3dc:                                 16
+//     cb82b:                                 16
+//     l00c0:                                 15
+//     l00c3:                                 15
+//     l00c7:                                 15
+//     l0f05:                                 15
+//     l00cc:                                 14
+//     l1117:                                 14
+//     cae70:                                 14
+//     caf7f:                                 14
+//     l00a1:                                 13
+//     l00a5:                                 13
+//     l00c8:                                 13
+//     l0f07:                                 13
+//     sub_ca14a:                             13
+//     tube_host_r3_data:                     13
+//     l00ac:                                 12
+//     clc_jmp_gsinit:                        12
+//     sub_cb841:                             12
+//     osasci:                                12
+//     l00c6:                                 11
+//     osrdsc_ptr:                            11
+//     l0e08:                                 11
+//     generate_error_precheck:               11
+//     sub_c8149:                             11
+//     c996e:                                 11
+//     cac0f:                                 11
+//     lfe84:                                 11
+//     tube_host_r2_data:                     11
+//     l00a9:                                 10
+//     l1111:                                 10
+//     l1112:                                 10
+//     sub_c80c3:                             10
+//     c93e6:                                 10
+//     cb203:                                 10
+//     lfe87:                                 10
+//     tube_host_r2_status:                   10
+//     l00ca:                                  9
+//     l1074:                                  9
+//     l108a:                                  9
+//     l1097:                                  9
+//     l10c0:                                  9
+//     l1110:                                  9
+//     cbbd0:                                  9
+//     l00ce:                                  8
+//     l00ff:                                  8
+//     l0100:                                  8
+//     l0df0:                                  8
+//     l0f04:                                  8
+//     l1060:                                  8
+//     l1082:                                  8
+//     l108b:                                  8
+//     l1090:                                  8
+//     l1096:                                  8
+//     l10ca:                                  8
+//     l10cf:                                  8
+//     l10d1:                                  8
+//     sub_c81b0:                              8
+//     sub_c81bf:                              8
+//     c8816:                                  8
+//     sub_c8b7b:                              8
+//     osbyte_read:                            8
+//     cae79:                                  8
+//     sub_cb85d:                              8
+//     tube_host_r1_status:                    8
+//     osfind:                                 8
+//     l00a7:                                  7
+//     l00cf:                                  7
+//     l0f08:                                  7
+//     l1075:                                  7
+//     l10c9:                                  7
+//     l10d2:                                  7
+//     l1114:                                  7
+//     generate_error2:                        7
+//     sub_c8284:                              7
+//     sub_c8380:                              7
+//     c8b8b:                                  7
+//     print_inline_osasci_top_bit_clear:      7
+//     sub_cb580:                              7
+//     sub_cbab9:                              7
+//     osrdsc:                                 7
+//     l0015:                                  6
+//     l00f3:                                  6
+//     l00f7:                                  6
+//     l0f0f:                                  6
+//     l1100:                                  6
+//     generate_error_precheck_bad:            6
+//     sub_c8280:                              6
+//     sub_c82fe:                              6
+//     command_table:                          6
+//     sub_c87da:                              6
+//     c940c:                                  6
+//     sub_c99ac:                              6
+//     zero_stacked_XXX:                       6
+//     sub_c9e75:                              6
+//     caf58:                                  6
+//     sub_cb5f2:                              6
+//     lb726:                                  6
+//     cb8fb:                                  6
+//     oswrch:                                 6
+//     l00a6:                                  5
+//     l00af:                                  5
+//     l00f0:                                  5
+//     l1087:                                  5
+//     l1088:                                  5
+//     l1099:                                  5
+//     l10c7:                                  5
+//     l10dd:                                  5
+//     l110c:                                  5
+//     l1115:                                  5
+//     l1116:                                  5
+//     sub_c80bb:                              5
+//     sub_c80ed:                              5
+//     sub_c80f3:                              5
+//     c8125:                                  5
+//     sub_c830a:                              5
+//     sub_c8335:                              5
+//     sub_c8386:                              5
+//     sub_c840c:                              5
+//     c8ba2:                                  5
+//     sub_c8f3f:                              5
+//     c9257:                                  5
+//     c99a3:                                  5
+//     sub_c9a6e:                              5
+//     sub_c9ab8:                              5
+//     sub_ca0de:                              5
+//     sub_ca1b4:                              5
+//     cae97:                                  5
+//     sub_cb6fe:                              5
+//     sub_cb745:                              5
+//     cb795:                                  5
+//     sub_cb850:                              5
+//     sub_cba67:                              5
+//     cbe7b:                                  5
+//     osnewl:                                 5
+//     l0002:                                  4
+//     l0e00:                                  4
+//     l0f0c:                                  4
+//     l0f0d:                                  4
+//     l1069:                                  4
+//     l1076:                                  4
+//     l1077:                                  4
+//     l1081:                                  4
+//     l1086:                                  4
+//     l1095:                                  4
+//     l10c4:                                  4
+//     l10cb:                                  4
+//     l10cc:                                  4
+//     l10ce:                                  4
+//     l10d9:                                  4
+//     l10da:                                  4
+//     l110d:                                  4
+//     l1113:                                  4
+//     l111a:                                  4
+//     l111d:                                  4
+//     generate_error_precheck_disc:           4
+//     generate_error:                         4
+//     sub_c80c8:                              4
+//     sub_c8174:                              4
+//     c81a7:                                  4
+//     sub_c821d:                              4
+//     c8225:                                  4
+//     sub_c82b2:                              4
+//     sub_c8327:                              4
+//     inc16_ae:                               4
+//     c8d74:                                  4
+//     c8d91:                                  4
+//     c8e0e:                                  4
+//     c8e12:                                  4
+//     c8e64:                                  4
+//     sub_c8f6b:                              4
+//     c940e:                                  4
+//     c9436:                                  4
+//     c993b:                                  4
+//     sub_c9965:                              4
+//     sub_c9a8d:                              4
+//     c9adf:                                  4
+//     c9ae9:                                  4
+//     sub_ca379:                              4
+//     ca5e5:                                  4
+//     sub_ca9ca:                              4
+//     sub_caacf:                              4
+//     sub_cac18:                              4
+//     sub_cac62:                              4
+//     cad79:                                  4
+//     cb446:                                  4
+//     lb57f:                                  4
+//     sub_cb616:                              4
+//     cb68c:                                  4
+//     sub_cb68f:                              4
+//     sub_cb83f:                              4
+//     sub_cbac2:                              4
+//     sub_cbb00:                              4
+//     cbe7a:                                  4
+//     cbee8:                                  4
+//     lbfff:                                  4
+//     romsel:                                 4
+//     lfe85:                                  4
+//     lfe86:                                  4
+//     osbput:                                 4
+//     osbget:                                 4
+//     osfile:                                 4
+//     osrdch:                                 4
+//     l00ef:                                  3
+//     l0107:                                  3
+//     l0109:                                  3
+//     bytev:                                  3
+//     bytev+1:                                3
+//     l0ef8:                                  3
+//     l1092:                                  3
+//     l1093:                                  3
+//     l1094:                                  3
+//     l1098:                                  3
+//     l109d:                                  3
+//     l109f:                                  3
+//     l10c3:                                  3
+//     l10c5:                                  3
+//     l10c6:                                  3
+//     l10d0:                                  3
+//     l10d3:                                  3
+//     l10d6:                                  3
+//     l10d7:                                  3
+//     l1119:                                  3
+//     l111c:                                  3
+//     c8103:                                  3
+//     sub_c81be:                              3
+//     c8290:                                  3
+//     c82e6:                                  3
+//     sub_c833a:                              3
+//     sub_c836e:                              3
+//     c8454:                                  3
+//     sub_c8456:                              3
+//     c89d7:                                  3
+//     sub_c8b86:                              3
+//     c8d41:                                  3
+//     c8e53:                                  3
+//     c8ecc:                                  3
+//     c8f2a:                                  3
+//     sub_c8f7a:                              3
+//     nmi_handler2_rom_end:                   3
+//     c91af:                                  3
+//     c9214:                                  3
+//     sub_c93fd:                              3
+//     c9444:                                  3
+//     c94bc:                                  3
+//     sub_c9526:                              3
+//     c9738:                                  3
+//     sub_c9940:                              3
+//     c99ed:                                  3
+//     c9a8c:                                  3
+//     sub_c9be5:                              3
+//     generate_error_precheck_open:           3
+//     c9d5d:                                  3
+//     sub_c9e30:                              3
+//     sub_c9f0f:                              3
+//     sub_c9f16:                              3
+//     sub_c9f1e:                              3
+//     ca06b:                                  3
+//     ca14f:                                  3
+//     ca1c0:                                  3
+//     sub_ca315:                              3
+//     sub_ca384:                              3
+//     sub_ca530:                              3
+//     ca660:                                  3
+//     sub_ca9c2:                              3
+//     caa42:                                  3
+//     caa44:                                  3
+//     sub_cac0c:                              3
+//     cacc4:                                  3
+//     tube_host_code2:                        3
+//     sub_cad5d:                              3
+//     cad77:                                  3
+//     laf76:                                  3
+//     cb1d5:                                  3
+//     cb371:                                  3
+//     sub_cb58b:                              3
+//     cb684:                                  3
+//     cb6ca:                                  3
+//     sub_cb84e:                              3
+//     sub_cb986:                              3
+//     sram_table:                             3
+//     cbab4:                                  3
+//     sub_cbac4:                              3
+//     cbe47:                                  3
+//     cbe89:                                  3
+//     cbe8d:                                  3
+//     sub_cbf7c:                              3
+//     lfe80:                                  3
+//     tube_host_r1_data:                      3
+//     osword:                                 3
+//     oscli:                                  3
+//     l0003:                                  2
+//     l0012:                                  2
+//     l0014:                                  2
+//     l00a0:                                  2
+//     l00a3:                                  2
+//     l00a4:                                  2
+//     l00ad:                                  2
+//     l00fd:                                  2
+//     l0101:                                  2
+//     l0102:                                  2
+//     l0105:                                  2
+//     l010b:                                  2
+//     l0128:                                  2
+//     fscv:                                   2
+//     l0700:                                  2
+//     l0e07:                                  2
+//     l0f0a:                                  2
+//     l0f0b:                                  2
+//     l1045:                                  2
+//     l1062:                                  2
+//     l1065:                                  2
+//     l1067:                                  2
+//     l1078:                                  2
+//     l107d:                                  2
+//     l107e:                                  2
+//     l107f:                                  2
+//     l1089:                                  2
+//     l108c:                                  2
+//     l1091:                                  2
+//     l109a:                                  2
+//     l109b:                                  2
+//     l109e:                                  2
+//     l10c1:                                  2
+//     l10cd:                                  2
+//     l10d8:                                  2
+//     l10db:                                  2
+//     l10dc:                                  2
+//     l10e2:                                  2
+//     l10e3:                                  2
+//     l10e4:                                  2
+//     l1109:                                  2
+//     l110b:                                  2
+//     l110e:                                  2
+//     l110f:                                  2
+//     l111b:                                  2
+//     sub_c809a:                              2
+//     sub_c80e3:                              2
+//     c815d:                                  2
+//     sub_c81ae:                              2
+//     sub_c81c5:                              2
+//     c822a:                                  2
+//     c825d:                                  2
+//     sub_c8266:                              2
+//     sub_c826d:                              2
+//     sub_c82bb:                              2
+//     sub_c82e8:                              2
+//     c82fd:                                  2
+//     sub_c841b:                              2
+//     sub_c8439:                              2
+//     c8543:                                  2
+//     sub_c8555:                              2
+//     c8560:                                  2
+//     c85bc:                                  2
+//     c8703:                                  2
+//     c8705:                                  2
+//     c873b:                                  2
+//     sub_c8745:                              2
+//     sub_c87db:                              2
+//     sub_c87e3:                              2
+//     c8808:                                  2
+//     c883f:                                  2
+//     sub_c8855:                              2
+//     sub_c8862:                              2
+//     c88a6:                                  2
+//     c88f4:                                  2
+//     sub_c8951:                              2
+//     c898a:                                  2
+//     c89a5:                                  2
+//     c89b4:                                  2
+//     sub_c89da:                              2
+//     c8a00:                                  2
+//     c8a6e:                                  2
+//     sub_c8a77:                              2
+//     sub_c8ab3:                              2
+//     sub_c8b4d:                              2
+//     sub_c8b64:                              2
+//     c8be3:                                  2
+//     c8c12:                                  2
+//     c8cb2:                                  2
+//     c8d0d:                                  2
+//     c8d13:                                  2
+//     c8e0d:                                  2
+//     c8e32:                                  2
+//     c8e9f:                                  2
+//     c8ea5:                                  2
+//     c8eb7:                                  2
+//     c8eeb:                                  2
+//     c8f3e:                                  2
+//     c90c7:                                  2
+//     c91df:                                  2
+//     sub_c9279:                              2
+//     c9289:                                  2
+//     sub_c928a:                              2
+//     c9367:                                  2
+//     sub_c93c5:                              2
+//     sub_c93d3:                              2
+//     sub_c93f5:                              2
+//     sub_c9432:                              2
+//     sub_c9445:                              2
+//     c94a9:                                  2
+//     c94c6:                                  2
+//     sub_c9516:                              2
+//     sub_c952e:                              2
+//     c95fd:                                  2
+//     c9628:                                  2
+//     c965a:                                  2
+//     c96b7:                                  2
+//     c97b3:                                  2
+//     sub_c992c:                              2
+//     invert_l1065:                           2
+//     sub_c995a:                              2
+//     sub_c99f3:                              2
+//     sub_c9a0f:                              2
+//     sub_c9a50:                              2
+//     sub_c9a60:                              2
+//     sub_c9a63:                              2
+//     sub_c9a78:                              2
+//     sub_c9a82:                              2
+//     sub_c9aa3:                              2
+//     sub_c9ac8:                              2
+//     sub_c9ad8:                              2
+//     c9b6e:                                  2
+//     sub_c9b79:                              2
+//     c9bc5:                                  2
+//     sub_c9bf2:                              2
+//     sub_c9d1e:                              2
+//     c9dcd:                                  2
+//     c9dd5:                                  2
+//     sub_c9df4:                              2
+//     sub_c9e1e:                              2
+//     c9e41:                                  2
+//     sub_c9e54:                              2
+//     sub_c9ef4:                              2
+//     sub_c9f14:                              2
+//     sub_c9f26:                              2
+//     ca01d:                                  2
+//     ca021:                                  2
+//     ca06c:                                  2
+//     ca0f5:                                  2
+//     ca10b:                                  2
+//     sub_ca168:                              2
+//     ca19f:                                  2
+//     sub_ca1c6:                              2
+//     la1d3:                                  2
+//     ca2f2:                                  2
+//     sub_ca324:                              2
+//     ca38b:                                  2
+//     sub_ca3ec:                              2
+//     ca411:                                  2
+//     ca414:                                  2
+//     sub_ca51f:                              2
+//     ca5ab:                                  2
+//     sub_ca5b2:                              2
+//     ca637:                                  2
+//     ca845:                                  2
+//     ca86b:                                  2
+//     ca87a:                                  2
+//     sub_ca90d:                              2
+//     ca97d:                                  2
+//     ca9ff:                                  2
+//     caa1c:                                  2
+//     caa51:                                  2
+//     sub_caa53:                              2
+//     sub_caac2:                              2
+//     sub_caaf1:                              2
+//     cab1a:                                  2
+//     cab41:                                  2
+//     cab54:                                  2
+//     cabbc:                                  2
+//     sub_cac4e:                              2
+//     cad15:                                  2
+//     cadd7:                                  2
+//     tube_host_code2+256:                    2
+//     cae11:                                  2
+//     caed3:                                  2
+//     tube_banner_loop:                       2
+//     just_rts:                               2
+//     tube_host_code3:                        2
+//     laf75:                                  2
+//     laf77:                                  2
+//     laf78:                                  2
+//     tube_host_code1:                        2
+//     cafad:                                  2
+//     caffb:                                  2
+//     cb00a:                                  2
+//     cb035:                                  2
+//     sub_cb047:                              2
+//     cb280:                                  2
+//     cb297:                                  2
+//     cb2a0:                                  2
+//     cb300:                                  2
+//     cb406:                                  2
+//     cb45e:                                  2
+//     sub_cb598:                              2
+//     sub_cb5ce:                              2
+//     sub_cb5ee:                              2
+//     sub_cb607:                              2
+//     sub_cb61e:                              2
+//     cb655:                                  2
+//     sub_cb65f:                              2
+//     sub_cb6b1:                              2
+//     cb718:                                  2
+//     cb7ed:                                  2
+//     lb872:                                  2
+//     cb8e4:                                  2
+//     cb9e8:                                  2
+//     sub_cb9f5:                              2
+//     cba10:                                  2
+//     cbaf8:                                  2
+//     cbafd:                                  2
+//     cbb28:                                  2
+//     cbb2a:                                  2
+//     cbc13:                                  2
+//     cbc3a:                                  2
+//     sub_cbc68:                              2
+//     cbcb9:                                  2
+//     cbdb9:                                  2
+//     sub_cbe83:                              2
+//     sub_cbe9d:                              2
+//     cbec1:                                  2
+//     sub_cbec2:                              2
+//     general_service_handler_indirect:       2
+//     sub_cbf82:                              2
+//     cbf8e:                                  2
+//     tube_host_r4_status:                    2
+//     gsinit:                                 2
+//     gsread:                                 2
+//     osgbpb:                                 2
+//     osargs:                                 2
+//     l0013:                                  1
+//     l00f1:                                  1
+//     l0103:                                  1
+//     l0104:                                  1
+//     l010c:                                  1
+//     l010d:                                  1
+//     l010e:                                  1
+//     brkv:                                   1
+//     brkv+1:                                 1
+//     filev:                                  1
+//     evntv:                                  1
+//     evntv+1:                                1
+//     l028d:                                  1
+//     l0cff:                                  1
+//     l0e0e:                                  1
+//     l0e10:                                  1
+//     l0f00:                                  1
+//     l0f09:                                  1
+//     l0f10:                                  1
+//     l1001:                                  1
+//     l1002:                                  1
+//     l1003:                                  1
+//     l1004:                                  1
+//     l1005:                                  1
+//     l1006:                                  1
+//     l1007:                                  1
+//     l100e:                                  1
+//     l1047:                                  1
+//     l104d:                                  1
+//     l104e:                                  1
+//     l1050:                                  1
+//     l1058:                                  1
+//     l105f:                                  1
+//     l1061:                                  1
+//     l1063:                                  1
+//     l1064:                                  1
+//     l1072:                                  1
+//     l1079:                                  1
+//     l107a:                                  1
+//     l1083:                                  1
+//     l108f:                                  1
+//     rom_header:                             1
+//     l8001:                                  1
+//     l8002:                                  1
+//     service_entry:                          1
+//     l8004:                                  1
+//     rom_type:                               1
+//     copyright_offset:                       1
+//     sub_c8020:                              1
+//     c8040:                                  1
+//     loop_c8064:                             1
+//     loop_c8086:                             1
+//     c8093:                                  1
+//     c8096:                                  1
+//     sub_c809d:                              1
+//     sub_c80b8:                              1
+//     c80d0:                                  1
+//     sub_c80d3:                              1
+//     sub_c80db:                              1
+//     sub_c80e6:                              1
+//     sub_c80f6:                              1
+//     c8111:                                  1
+//     c8115:                                  1
+//     c812e:                                  1
+//     loop_c813a:                             1
+//     c815b:                                  1
+//     c815f:                                  1
+//     loop_c8161:                             1
+//     loop_c816b:                             1
+//     c8184:                                  1
+//     c818a:                                  1
+//     loop_c818c:                             1
+//     c81a2:                                  1
+//     sub_c81b7:                              1
+//     c81bd:                                  1
+//     sub_c81c0:                              1
+//     sub_c81c4:                              1
+//     sub_c81ca:                              1
+//     loop_c820c:                             1
+//     loop_c820d:                             1
+//     loop_c821c:                             1
+//     sub_c8222:                              1
+//     c8243:                                  1
+//     loop_c826f:                             1
+//     c8286:                                  1
+//     c828b:                                  1
+//     c82be:                                  1
+//     loop_c82c7:                             1
+//     loop_c82d1:                             1
+//     c82d9:                                  1
+//     c82e7:                                  1
+//     c82fb:                                  1
+//     c8306:                                  1
+//     loop_c830d:                             1
+//     loop_c8326:                             1
+//     c8332:                                  1
+//     c8333:                                  1
+//     loop_c8370:                             1
+//     loop_c8390:                             1
+//     loop_c8397:                             1
+//     c83ab:                                  1
+//     sub_c83bf:                              1
+//     c83cd:                                  1
+//     sub_c83d1:                              1
+//     sub_c83d4:                              1
+//     c83e2:                                  1
+//     sub_c83ee:                              1
+//     loop_c83f0:                             1
+//     loop_c83fa:                             1
+//     loop_c8406:                             1
+//     loop_c8425:                             1
+//     c842b:                                  1
+//     sub_c842c:                              1
+//     c8436:                                  1
+//     c8438:                                  1
+//     c8453:                                  1
+//     loop_c8463:                             1
+//     c8477:                                  1
+//     c8481:                                  1
+//     c8482:                                  1
+//     loop_c8493:                             1
+//     c849d:                                  1
+//     loop_c84e7:                             1
+//     loop_c8527:                             1
+//     c853e:                                  1
+//     loop_c8552:                             1
+//     c855f:                                  1
+//     loop_c8564:                             1
+//     c8573:                                  1
+//     loop_c857b:                             1
+//     c859b:                                  1
+//     loop_c85b5:                             1
+//     c85c5:                                  1
+//     opt4_table:                             1
+//     sub_c85e3:                              1
+//     sub_c8602:                              1
+//     command_table+1:                        1
+//     loop_c8717:                             1
+//     loop_c8725:                             1
+//     c8734:                                  1
+//     c8759:                                  1
+//     c8779:                                  1
+//     c877c:                                  1
+//     loop_c87a0:                             1
+//     c87ab:                                  1
+//     c87b8:                                  1
+//     loop_c87be:                             1
+//     c87c6:                                  1
+//     c8815:                                  1
+//     sub_c8826:                              1
+//     c8837:                                  1
+//     c8864:                                  1
+//     c8867:                                  1
+//     loop_c88bc:                             1
+//     c892d:                                  1
+//     sub_c8932:                              1
+//     c8945:                                  1
+//     loop_c895f:                             1
+//     c8968:                                  1
+//     c896b:                                  1
+//     sub_c8979:                              1
+//     loop_c8990:                             1
+//     c89ad:                                  1
+//     loop_c89c4:                             1
+//     loop_c89ca:                             1
+//     c89e2:                                  1
+//     c89f6:                                  1
+//     loop_c8a17:                             1
+//     c8a19:                                  1
+//     c8a49:                                  1
+//     c8a50:                                  1
+//     c8a54:                                  1
+//     c8a82:                                  1
+//     loop_c8ac8:                             1
+//     c8ad0:                                  1
+//     loop_c8ad8:                             1
+//     c8aeb:                                  1
+//     loop_c8af0:                             1
+//     loop_c8afb:                             1
+//     c8b18:                                  1
+//     sub_c8b25:                              1
+//     c8b60:                                  1
+//     c8b77:                                  1
+//     loop_c8b80:                             1
+//     loop_c8bea:                             1
+//     sub_c8bf6:                              1
+//     sub_c8bf9:                              1
+//     c8bfb:                                  1
+//     c8c2e:                                  1
+//     c8c3a:                                  1
+//     c8c4e:                                  1
+//     sub_c8c56:                              1
+//     loop_c8c58:                             1
+//     c8c61:                                  1
+//     sub_c8c65:                              1
+//     loop_c8c71:                             1
+//     c8c87:                                  1
+//     c8cae:                                  1
+//     c8cc1:                                  1
+//     c8cd6:                                  1
+//     c8ce7:                                  1
+//     c8cfc:                                  1
+//     c8d03:                                  1
+//     loop_c8d14:                             1
+//     loop_c8d17:                             1
+//     sub_c8d1a:                              1
+//     c8d5d:                                  1
+//     c8d92:                                  1
+//     loop_c8dac:                             1
+//     loop_c8dba:                             1
+//     sub_c8dc6:                              1
+//     c8dd2:                                  1
+//     c8de2:                                  1
+//     loop_c8de9:                             1
+//     loop_c8df0:                             1
+//     c8e03:                                  1
+//     loop_c8e14:                             1
+//     c8e4d:                                  1
+//     c8e6f:                                  1
+//     c8e72:                                  1
+//     loop_c8e85:                             1
+//     c8e9e:                                  1
+//     c8eaf:                                  1
+//     c8ecb:                                  1
+//     c8edf:                                  1
+//     sub_c8eec:                              1
+//     c8ef8:                                  1
+//     sub_c8efa:                              1
+//     sub_c8eff:                              1
+//     c8f12:                                  1
+//     loop_c8f17:                             1
+//     c8f21:                                  1
+//     sub_c8f33:                              1
+//     sub_c8f37:                              1
+//     sub_c8f4f:                              1
+//     sub_c8f5e:                              1
+//     loop_c8f6c:                             1
+//     sub_c8f75:                              1
+//     c8f81:                                  1
+//     sub_c8f82:                              1
+//     sub_c8f94:                              1
+//     loop_c8f96:                             1
+//     loop_c8fac:                             1
+//     c8fb5:                                  1
+//     c8fc7:                                  1
+//     nmi_handler_rom_start:                  1
+//     nmi3_handler_rom_start-1:               1
+//     nmi3_handler_rom_end:                   1
+//     loop_c9047:                             1
+//     c9060:                                  1
+//     nmi_handler2_rom_start-1:               1
+//     c90db:                                  1
+//     c90e7:                                  1
+//     set_c_iff_have_fdc:                     1
+//     loop_c9108:                             1
+//     loop_c9113:                             1
+//     c9115:                                  1
+//     l911d:                                  1
+//     l9121:                                  1
+//     nmi_and_table:                          1
+//     l9139:                                  1
+//     l913f:                                  1
+//     l9145:                                  1
+//     l9146:                                  1
+//     l9191:                                  1
+//     l91a0:                                  1
+//     loop_c91ba:                             1
+//     c91cc:                                  1
+//     loop_c91e7:                             1
+//     c91eb:                                  1
+//     c91f3:                                  1
+//     c91f9:                                  1
+//     c9201:                                  1
+//     c920d:                                  1
+//     c921f:                                  1
+//     c922b:                                  1
+//     c9238:                                  1
+//     c923b:                                  1
+//     c923f:                                  1
+//     c9249:                                  1
+//     c925a:                                  1
+//     c926a:                                  1
+//     c9276:                                  1
+//     c929c:                                  1
+//     sub_c929d:                              1
+//     c92bd:                                  1
+//     c92c4:                                  1
+//     c92c7:                                  1
+//     c92d6:                                  1
+//     c92e3:                                  1
+//     loop_c92ef:                             1
+//     c9302:                                  1
+//     loop_c9355:                             1
+//     loop_c9357:                             1
+//     c936b:                                  1
+//     loop_c936f:                             1
+//     c9379:                                  1
+//     loop_c9382:                             1
+//     c938d:                                  1
+//     c9390:                                  1
+//     c93a8:                                  1
+//     c93b1:                                  1
+//     sub_c93b4:                              1
+//     loop_c93bd:                             1
+//     c93c4:                                  1
+//     sub_c93d8:                              1
+//     loop_c93da:                             1
+//     c93e2:                                  1
+//     c93e5:                                  1
+//     sub_c93f1:                              1
+//     sub_c93f9:                              1
+//     c93ff:                                  1
+//     c9450:                                  1
+//     c945c:                                  1
+//     c948d:                                  1
+//     c94c1:                                  1
+//     c94c2:                                  1
+//     c94d4:                                  1
+//     c9504:                                  1
+//     c9535:                                  1
+//     sub_c9536:                              1
+//     loop_c953a:                             1
+//     c9556:                                  1
+//     c956d:                                  1
+//     c956f:                                  1
+//     loop_c957d:                             1
+//     loop_c9593:                             1
+//     loop_c95b6:                             1
+//     loop_c95d9:                             1
+//     c95e4:                                  1
+//     c95e7:                                  1
+//     loop_c95ec:                             1
+//     loop_c9618:                             1
+//     c9649:                                  1
+//     c964a:                                  1
+//     c9658:                                  1
+//     sub_c965d:                              1
+//     c967a:                                  1
+//     c9682:                                  1
+//     c9683:                                  1
+//     c969e:                                  1
+//     pla_rts:                                1
+//     loop_c96c2:                             1
+//     c96c3:                                  1
+//     c96e4:                                  1
+//     c96e9:                                  1
+//     c96ec:                                  1
+//     loop_c96f2:                             1
+//     c96f5:                                  1
+//     c9700:                                  1
+//     c9714:                                  1
+//     c9736:                                  1
+//     c973c:                                  1
+//     c973d:                                  1
+//     c975b:                                  1
+//     c976c:                                  1
+//     loop_c979d:                             1
+//     loop_c97c8:                             1
+//     c97e6:                                  1
+//     sub_c97e8:                              1
+//     loop_c9803:                             1
+//     c981f:                                  1
+//     c982e:                                  1
+//     sub_c9832:                              1
+//     c9835:                                  1
+//     loop_c9837:                             1
+//     c984c:                                  1
+//     loop_c9851:                             1
+//     c9859:                                  1
+//     loop_c985e:                             1
+//     c986b:                                  1
+//     c9873:                                  1
+//     loop_c9881:                             1
+//     loop_c98a0:                             1
+//     c98b1:                                  1
+//     c98ba:                                  1
+//     loop_c98c1:                             1
+//     c98cd:                                  1
+//     loop_c98e4:                             1
+//     c98ed:                                  1
+//     c98f0:                                  1
+//     loop_c9942:                             1
+//     c994b:                                  1
+//     loop_c994e:                             1
+//     loop_c9964:                             1
+//     c9978:                                  1
+//     sub_c9988:                              1
+//     c9993:                                  1
+//     loop_c99a8:                             1
+//     c99ea:                                  1
+//     c9a2a:                                  1
+//     sub_c9a32:                              1
+//     c9a3f:                                  1
+//     sub_c9a4b:                              1
+//     generate_error_precheck_locked:         1
+//     c9a73:                                  1
+//     c9a77:                                  1
+//     sub_c9ad3:                              1
+//     c9ad4:                                  1
+//     l9aec:                                  1
+//     l9b0f:                                  1
+//     l9b18:                                  1
+//     l9b21:                                  1
+//     l9b29:                                  1
+//     l9b31:                                  1
+//     l9b3a:                                  1
+//     l9b43:                                  1
+//     loop_c9b50:                             1
+//     sub_c9b51:                              1
+//     loop_c9b5e:                             1
+//     sub_c9b61:                              1
+//     loop_c9b63:                             1
+//     c9bc2:                                  1
+//     sub_c9bca:                              1
+//     sub_c9bcd:                              1
+//     loop_c9bcf:                             1
+//     loop_c9be4:                             1
+//     generate_error_precheck_disc_changed:   1
+//     c9c16:                                  1
+//     c9c33:                                  1
+//     loop_c9c38:                             1
+//     c9c51:                                  1
+//     c9c58:                                  1
+//     loop_c9c5d:                             1
+//     c9c6b:                                  1
+//     c9c8b:                                  1
+//     loop_c9c90:                             1
+//     loop_c9ca8:                             1
+//     c9cee:                                  1
+//     loop_c9d03:                             1
+//     c9d12:                                  1
+//     sub_c9d19:                              1
+//     c9d2b:                                  1
+//     loop_c9d43:                             1
+//     c9d57:                                  1
+//     c9d67:                                  1
+//     c9d71:                                  1
+//     c9d72:                                  1
+//     sub_c9d75:                              1
+//     c9d86:                                  1
+//     c9d89:                                  1
+//     c9db4:                                  1
+//     c9dce:                                  1
+//     loop_c9e07:                             1
+//     c9e13:                                  1
+//     c9e16:                                  1
+//     c9e28:                                  1
+//     c9e2a:                                  1
+//     osbyte_write_0:                         1
+//     c9e5c:                                  1
+//     c9e6f:                                  1
+//     c9e71:                                  1
+//     loop_c9e74:                             1
+//     loop_c9e8c:                             1
+//     sub_c9e94:                              1
+//     c9eb3:                                  1
+//     c9ec2:                                  1
+//     c9ef1:                                  1
+//     c9f0d:                                  1
+//     c9f19:                                  1
+//     c9f5e:                                  1
+//     c9f64:                                  1
+//     c9f6a:                                  1
+//     c9f6b:                                  1
+//     loop_c9f6e:                             1
+//     sub_c9f7c:                              1
+//     sub_c9f82:                              1
+//     c9f88:                                  1
+//     c9fd9:                                  1
+//     c9ff4:                                  1
+//     ca005:                                  1
+//     ca054:                                  1
+//     loop_ca061:                             1
+//     ca075:                                  1
+//     ca0a9:                                  1
+//     sub_ca0b8:                              1
+//     sub_ca0f6:                              1
+//     loop_ca11d:                             1
+//     loop_ca132:                             1
+//     loop_ca143:                             1
+//     loop_ca16e:                             1
+//     ca17a:                                  1
+//     ca183:                                  1
+//     sub_ca190:                              1
+//     loop_ca1aa:                             1
+//     ca1c1:                                  1
+//     loop_ca1cc:                             1
+//     ca1d2:                                  1
+//     ca27a:                                  1
+//     ca2ab:                                  1
+//     ca30d:                                  1
+//     ca321:                                  1
+//     ca34a:                                  1
+//     ca378:                                  1
+//     ca38c:                                  1
+//     ca38e:                                  1
+//     ca3ae:                                  1
+//     ca3bd:                                  1
+//     sub_ca3e4:                              1
+//     ca3fb:                                  1
+//     ca40c:                                  1
+//     ca45d:                                  1
+//     ca47b:                                  1
+//     loop_ca487:                             1
+//     sub_ca4e1:                              1
+//     ca4fa:                                  1
+//     loop_ca521:                             1
+//     ca538:                                  1
+//     ca547:                                  1
+//     ca574:                                  1
+//     ca595:                                  1
+//     ca5a0:                                  1
+//     ca5c4:                                  1
+//     ca5e2:                                  1
+//     ca5fb:                                  1
+//     ca605:                                  1
+//     ca63a:                                  1
+//     ca647:                                  1
+//     ca652:                                  1
+//     ca65d:                                  1
+//     sub_ca663:                              1
+//     ca675:                                  1
+//     ca68a:                                  1
+//     ca6b3:                                  1
+//     ca6b6:                                  1
+//     ca6bb:                                  1
+//     ca6ce:                                  1
+//     ca6e2:                                  1
+//     ca70a:                                  1
+//     ca712:                                  1
+//     ca721:                                  1
+//     ca728:                                  1
+//     ca73a:                                  1
+//     sub_ca73d:                              1
+//     sub_ca76c:                              1
+//     loop_ca76f:                             1
+//     sub_ca779:                              1
+//     ca787:                                  1
+//     sub_ca788:                              1
+//     ca7a4:                                  1
+//     loop_ca7a7:                             1
+//     sub_ca7c4:                              1
+//     sub_ca7c5:                              1
+//     loop_ca7c6:                             1
+//     sub_ca7ce:                              1
+//     loop_ca7e0:                             1
+//     loop_ca7e1:                             1
+//     ca7f2:                                  1
+//     ca7f7:                                  1
+//     ca818:                                  1
+//     ca82f:                                  1
+//     ca856:                                  1
+//     ca8bd:                                  1
+//     sub_ca8be:                              1
+//     sub_ca8e2:                              1
+//     ca8fa:                                  1
+//     ca902:                                  1
+//     ca90c:                                  1
+//     loop_ca941:                             1
+//     loop_ca947:                             1
+//     loop_ca953:                             1
+//     ca95d:                                  1
+//     ca96c:                                  1
+//     ca970:                                  1
+//     ca982:                                  1
+//     ca98d:                                  1
+//     loop_ca9ab:                             1
+//     ca9b8:                                  1
+//     sub_ca9bf:                              1
+//     loop_ca9e7:                             1
+//     loop_caa01:                             1
+//     caa0a:                                  1
+//     caa0d:                                  1
+//     sub_caa12:                              1
+//     caa78:                                  1
+//     caa7a:                                  1
+//     caa86:                                  1
+//     sub_caa9a:                              1
+//     caab7:                                  1
+//     loop_caab8:                             1
+//     caabe:                                  1
+//     caace:                                  1
+//     sub_caadd:                              1
+//     sub_caaea:                              1
+//     cab09:                                  1
+//     cab17:                                  1
+//     cab2e:                                  1
+//     cab35:                                  1
+//     cab3d:                                  1
+//     loop_cab6b:                             1
+//     cab7d:                                  1
+//     loop_cab80:                             1
+//     cab93:                                  1
+//     caba4:                                  1
+//     sub_caba9:                              1
+//     loop_cabad:                             1
+//     cabcf:                                  1
+//     loop_cabf4:                             1
+//     cabfb:                                  1
+//     cac28:                                  1
+//     cac45:                                  1
+//     loop_cac46:                             1
+//     sub_cac47:                              1
+//     sub_cac6a:                              1
+//     sub_cac72:                              1
+//     cacc7:                                  1
+//     lacf3:                                  1
+//     cad2d:                                  1
+//     cad3f:                                  1
+//     cad52:                                  1
+//     cad61:                                  1
+//     cad6e:                                  1
+//     cad81:                                  1
+//     cad86:                                  1
+//     cada2:                                  1
+//     cadae:                                  1
+//     cadc1:                                  1
+//     caddf:                                  1
+//     cadf8:                                  1
+//     cae06:                                  1
+//     cae20:                                  1
+//     cae27:                                  1
+//     cae32:                                  1
+//     cae35:                                  1
+//     cae40:                                  1
+//     cae45:                                  1
+//     cae5b:                                  1
+//     cae62:                                  1
+//     cae82:                                  1
+//     service_handler_help_and_tube:          1
+//     caed7:                                  1
+//     service_handler_tube_main_init:         1
+//     loop_caf13:                             1
+//     loop_caf2d:                             1
+//     lda_0_rts:                              1
+//     caf4b:                                  1
+//     caf54:                                  1
+//     caf5d:                                  1
+//     caf63:                                  1
+//     laf73:                                  1
+//     sub_caf8d:                              1
+//     sub_caf9a:                              1
+//     cafa1:                                  1
+//     cafab:                                  1
+//     cafae:                                  1
+//     cafbf:                                  1
+//     cafdc:                                  1
+//     cafdf:                                  1
+//     cafea:                                  1
+//     caff3:                                  1
+//     caffd:                                  1
+//     cb005:                                  1
+//     cb014:                                  1
+//     cb01f:                                  1
+//     sub_cb040:                              1
+//     cb05a:                                  1
+//     cb070:                                  1
+//     lb075:                                  1
+//     lb175:                                  1
+//     general_service_handler:                1
+//     cb1dd:                                  1
+//     loop_cb1e3:                             1
+//     loop_cb1ed:                             1
+//     cb1fc:                                  1
+//     cb20f:                                  1
+//     cb221:                                  1
+//     sub_cb234:                              1
+//     cb23d:                                  1
+//     loop_cb249:                             1
+//     cb260:                                  1
+//     cb268:                                  1
+//     loop_cb275:                             1
+//     lb283:                                  1
+//     cb2b2:                                  1
+//     loop_cb2b4:                             1
+//     loop_cb2bd:                             1
+//     sub_cb2c8:                              1
+//     loop_cb2d1:                             1
+//     cb2e1:                                  1
+//     cb2e7:                                  1
+//     cb305:                                  1
+//     cb314:                                  1
+//     cb337:                                  1
+//     cb34f:                                  1
+//     cb352:                                  1
+//     cb375:                                  1
+//     cb37f:                                  1
+//     cb382:                                  1
+//     cb397:                                  1
+//     cb3ba:                                  1
+//     cb3de:                                  1
+//     cb40e:                                  1
+//     cb44b:                                  1
+//     loop_cb44d:                             1
+//     cb45a:                                  1
+//     cb470:                                  1
+//     loop_cb4a8:                             1
+//     cb4af:                                  1
+//     cb4b4:                                  1
+//     cb4d8:                                  1
+//     cb4df:                                  1
+//     cb4e9:                                  1
+//     cb4ee:                                  1
+//     cb502:                                  1
+//     cb534:                                  1
+//     loop_cb55e:                             1
+//     loop_cb578:                             1
+//     cb597:                                  1
+//     loop_cb5c6:                             1
+//     cb5d0:                                  1
+//     cb5e6:                                  1
+//     loop_cb5ed:                             1
+//     cb65e:                                  1
+//     cb6a6:                                  1
+//     loop_cb6b3:                             1
+//     cb6c2:                                  1
+//     lb6c6:                                  1
+//     lb6ce:                                  1
+//     cb6d2:                                  1
+//     sub_cb6e6:                              1
+//     cb6eb:                                  1
+//     cb6f5:                                  1
+//     cb725:                                  1
+//     cb736:                                  1
+//     loop_cb75a:                             1
+//     sub_cb771:                              1
+//     lb774:                                  1
+//     cb7ae:                                  1
+//     cb7b2:                                  1
+//     sub_cb7b6:                              1
+//     loop_cb7be:                             1
+//     loop_cb7d7:                             1
+//     loop_cb7dd:                             1
+//     cb7e8:                                  1
+//     cb7ec:                                  1
+//     sub_cb86f:                              1
+//     lb87e:                                  1
+//     sub_cb882:                              1
+//     cb898:                                  1
+//     cb8e6:                                  1
+//     cb8f5:                                  1
+//     loop_cb910:                             1
+//     lb924:                                  1
+//     lb979:                                  1
+//     lb97a:                                  1
+//     lb980:                                  1
+//     loop_cb999:                             1
+//     cb9ae:                                  1
+//     loop_cb9bd:                             1
+//     loop_cb9cc:                             1
+//     loop_cb9d1:                             1
+//     cb9d2:                                  1
+//     cb9d9:                                  1
+//     cb9ee:                                  1
+//     cb9f7:                                  1
+//     loop_cb9f9:                             1
+//     cba15:                                  1
+//     cba19:                                  1
+//     loop_cba1a:                             1
+//     cba27:                                  1
+//     cba28:                                  1
+//     cba2e:                                  1
+//     cba2f:                                  1
+//     sram_table+1:                           1
+//     cba78:                                  1
+//     cba8c:                                  1
+//     loop_cba94:                             1
+//     cba9e:                                  1
+//     cbab0:                                  1
+//     cbab1:                                  1
+//     loop_cbab8:                             1
+//     cbad0:                                  1
+//     sub_cbad2:                              1
+//     loop_cbaea:                             1
+//     cbb07:                                  1
+//     cbb33:                                  1
+//     cbb36:                                  1
+//     lbb3a:                                  1
+//     lbb3e:                                  1
+//     lbb42:                                  1
+//     cbb4c:                                  1
+//     cbb6f:                                  1
+//     cbb89:                                  1
+//     cbb90:                                  1
+//     cbba1:                                  1
+//     cbbbe:                                  1
+//     cbbd9:                                  1
+//     loop_cbbe4:                             1
+//     cbbf3:                                  1
+//     loop_cbbfe:                             1
+//     cbc2c:                                  1
+//     cbc54:                                  1
+//     cbc64:                                  1
+//     loop_cbc70:                             1
+//     cbc78:                                  1
+//     cbc93:                                  1
+//     cbcb2:                                  1
+//     loop_cbcd3:                             1
+//     cbcd6:                                  1
+//     cbce1:                                  1
+//     cbcf9:                                  1
+//     loop_cbd08:                             1
+//     cbd0e:                                  1
+//     cbd1b:                                  1
+//     loop_cbd2b:                             1
+//     cbd40:                                  1
+//     cbd46:                                  1
+//     loop_cbd6c:                             1
+//     cbd7e:                                  1
+//     loop_cbd99:                             1
+//     cbda3:                                  1
+//     cbdba:                                  1
+//     cbdc0:                                  1
+//     cbdd3:                                  1
+//     cbddd:                                  1
+//     loop_cbe0e:                             1
+//     cbe21:                                  1
+//     loop_cbe31:                             1
+//     cbe3c:                                  1
+//     cbe52:                                  1
+//     sub_cbe91:                              1
+//     loop_cbeab:                             1
+//     service_handler:                        1
+//     cbee0:                                  1
+//     cbeee:                                  1
+//     loop_cbf1c:                             1
+//     cbf33:                                  1
+//     cbf46:                                  1
+//     lbf4f:                                  1
+//     loop_cbf78:                             1
+//     sub_cbf84:                              1
+//     cbf8a:                                  1
+//     cbfa3:                                  1
+//     cbfb2:                                  1
+//     tube_host_r4_data:                      1
+
+// Automatically generated labels:
+//     c0032
+//     c0036
+//     c0041
+//     c0400
+//     c0432
+//     c0434
+//     c0463
+//     c047a
+//     c0482
+//     c0484
+//     c048c
+//     c0491
+//     c049b
+//     c04bc
+//     c04f7
+//     c053a
+//     c0552
+//     c0593
+//     c059c
+//     c059e
+//     c05a6
+//     c05fc
+//     c0636
+//     c0645
+//     c0665
+//     c06a7
+//     c0d60
+//     c0d74
+//     c0d80
+//     c8040
+//     c8093
+//     c8096
+//     c809f
+//     c80d0
+//     c8103
+//     c8111
+//     c8115
+//     c8125
+//     c812e
+//     c815b
+//     c815d
+//     c815f
+//     c8184
+//     c818a
+//     c81a2
+//     c81a7
+//     c81bd
+//     c8225
+//     c822a
+//     c8243
+//     c825d
+//     c8286
+//     c828b
+//     c8290
+//     c82be
+//     c82d9
+//     c82e6
+//     c82e7
+//     c82fb
+//     c82fd
+//     c8306
+//     c8332
+//     c8333
+//     c83ab
+//     c83cd
+//     c83e2
+//     c842b
+//     c8436
+//     c8438
+//     c8453
+//     c8454
+//     c8477
+//     c8481
+//     c8482
+//     c849d
+//     c853e
+//     c8543
+//     c855f
+//     c8560
+//     c8573
+//     c859b
+//     c85bc
+//     c85c5
+//     c8703
+//     c8705
+//     c8734
+//     c873b
+//     c8759
+//     c8779
+//     c877c
+//     c87ab
+//     c87b8
+//     c87c6
+//     c8808
+//     c8815
+//     c8816
+//     c8837
+//     c883f
+//     c8864
+//     c8867
+//     c88a6
+//     c88f4
+//     c892d
+//     c8945
+//     c8968
+//     c896b
+//     c898a
+//     c89a5
+//     c89ad
+//     c89b4
+//     c89d7
+//     c89e2
+//     c89f6
+//     c8a00
+//     c8a19
+//     c8a49
+//     c8a50
+//     c8a54
+//     c8a6e
+//     c8a82
+//     c8ad0
+//     c8aeb
+//     c8b18
+//     c8b60
+//     c8b77
+//     c8b8b
+//     c8ba2
+//     c8be3
+//     c8bfb
+//     c8c12
+//     c8c2e
+//     c8c3a
+//     c8c4e
+//     c8c61
+//     c8c87
+//     c8cae
+//     c8cb2
+//     c8cc1
+//     c8cd6
+//     c8ce7
+//     c8cfc
+//     c8d03
+//     c8d0d
+//     c8d13
+//     c8d41
+//     c8d5d
+//     c8d74
+//     c8d91
+//     c8d92
+//     c8dd2
+//     c8de2
+//     c8e03
+//     c8e0d
+//     c8e0e
+//     c8e12
+//     c8e32
+//     c8e4d
+//     c8e53
+//     c8e64
+//     c8e6f
+//     c8e72
+//     c8e9e
+//     c8e9f
+//     c8ea5
+//     c8eaf
+//     c8eb7
+//     c8ecb
+//     c8ecc
+//     c8edf
+//     c8eeb
+//     c8ef8
+//     c8f12
+//     c8f21
+//     c8f2a
+//     c8f3e
+//     c8f81
+//     c8fb5
+//     c8fc7
+//     c9060
+//     c90c7
+//     c90db
+//     c90e7
+//     c9115
+//     c91af
+//     c91cc
+//     c91df
+//     c91eb
+//     c91f3
+//     c91f9
+//     c9201
+//     c920d
+//     c9214
+//     c921f
+//     c922b
+//     c9238
+//     c923b
+//     c923f
+//     c9249
+//     c9257
+//     c925a
+//     c926a
+//     c9276
+//     c9289
+//     c929c
+//     c92bd
+//     c92c4
+//     c92c7
+//     c92d6
+//     c92e3
+//     c9302
+//     c9367
+//     c936b
+//     c9379
+//     c938d
+//     c9390
+//     c93a8
+//     c93b1
+//     c93c4
+//     c93e2
+//     c93e5
+//     c93e6
+//     c93ff
+//     c940c
+//     c940e
+//     c9436
+//     c9444
+//     c9450
+//     c945c
+//     c948d
+//     c94a9
+//     c94bc
+//     c94c1
+//     c94c2
+//     c94c6
+//     c94d4
+//     c9504
+//     c9535
+//     c9556
+//     c956d
+//     c956f
+//     c95e4
+//     c95e7
+//     c95fd
+//     c9628
+//     c9649
+//     c964a
+//     c9658
+//     c965a
+//     c967a
+//     c9682
+//     c9683
+//     c969e
+//     c96b7
+//     c96c3
+//     c96e4
+//     c96e9
+//     c96ec
+//     c96f5
+//     c9700
+//     c9714
+//     c9736
+//     c9738
+//     c973c
+//     c973d
+//     c975b
+//     c976c
+//     c97b3
+//     c97e6
+//     c981f
+//     c982e
+//     c9835
+//     c984c
+//     c9859
+//     c986b
+//     c9873
+//     c98b1
+//     c98ba
+//     c98cd
+//     c98ed
+//     c98f0
+//     c993b
+//     c994b
+//     c996e
+//     c9978
+//     c9993
+//     c99a3
+//     c99ea
+//     c99ed
+//     c9a2a
+//     c9a3f
+//     c9a73
+//     c9a77
+//     c9a8c
+//     c9ad4
+//     c9adf
+//     c9ae9
+//     c9b6e
+//     c9bc2
+//     c9bc5
+//     c9c16
+//     c9c33
+//     c9c51
+//     c9c58
+//     c9c6b
+//     c9c8b
+//     c9cee
+//     c9d12
+//     c9d2b
+//     c9d57
+//     c9d5d
+//     c9d67
+//     c9d71
+//     c9d72
+//     c9d86
+//     c9d89
+//     c9db4
+//     c9dcd
+//     c9dce
+//     c9dd5
+//     c9e13
+//     c9e16
+//     c9e28
+//     c9e2a
+//     c9e41
+//     c9e5c
+//     c9e6f
+//     c9e71
+//     c9eb3
+//     c9ec2
+//     c9ef1
+//     c9f0d
+//     c9f19
+//     c9f5e
+//     c9f64
+//     c9f6a
+//     c9f6b
+//     c9f88
+//     c9fd9
+//     c9ff4
+//     ca005
+//     ca01d
+//     ca021
+//     ca054
+//     ca06b
+//     ca06c
+//     ca075
+//     ca0a9
+//     ca0f5
+//     ca10b
+//     ca14f
+//     ca17a
+//     ca183
+//     ca19f
+//     ca1c0
+//     ca1c1
+//     ca1d2
+//     ca27a
+//     ca2ab
+//     ca2f2
+//     ca30d
+//     ca321
+//     ca34a
+//     ca378
+//     ca38b
+//     ca38c
+//     ca38e
+//     ca3ae
+//     ca3bd
+//     ca3dc
+//     ca3fb
+//     ca40c
+//     ca411
+//     ca414
+//     ca45d
+//     ca47b
+//     ca4fa
+//     ca538
+//     ca547
+//     ca574
+//     ca595
+//     ca5a0
+//     ca5ab
+//     ca5c4
+//     ca5e2
+//     ca5e5
+//     ca5fb
+//     ca605
+//     ca637
+//     ca63a
+//     ca647
+//     ca652
+//     ca65d
+//     ca660
+//     ca675
+//     ca68a
+//     ca6b3
+//     ca6b6
+//     ca6bb
+//     ca6ce
+//     ca6e2
+//     ca70a
+//     ca712
+//     ca721
+//     ca728
+//     ca73a
+//     ca787
+//     ca7a4
+//     ca7f2
+//     ca7f7
+//     ca818
+//     ca82f
+//     ca845
+//     ca856
+//     ca86b
+//     ca87a
+//     ca8bd
+//     ca8fa
+//     ca902
+//     ca90c
+//     ca95d
+//     ca96c
+//     ca970
+//     ca97d
+//     ca982
+//     ca98d
+//     ca9b8
+//     ca9ff
+//     caa0a
+//     caa0d
+//     caa1c
+//     caa42
+//     caa44
+//     caa51
+//     caa78
+//     caa7a
+//     caa86
+//     caab7
+//     caabe
+//     caace
+//     cab09
+//     cab17
+//     cab1a
+//     cab2e
+//     cab35
+//     cab3d
+//     cab41
+//     cab54
+//     cab7d
+//     cab93
+//     caba4
+//     cabbc
+//     cabcf
+//     cabfb
+//     cac0f
+//     cac28
+//     cac45
+//     cacc4
+//     cacc7
+//     cad15
+//     cad2d
+//     cad3f
+//     cad52
+//     cad61
+//     cad6e
+//     cad77
+//     cad79
+//     cad81
+//     cad86
+//     cada2
+//     cadae
+//     cadc1
+//     cadd7
+//     caddf
+//     cadf8
+//     cae06
+//     cae11
+//     cae20
+//     cae27
+//     cae32
+//     cae35
+//     cae40
+//     cae45
+//     cae5b
+//     cae62
+//     cae70
+//     cae79
+//     cae82
+//     cae97
+//     caea0
+//     caed3
+//     caed7
+//     caf4b
+//     caf54
+//     caf58
+//     caf5d
+//     caf63
+//     caf7f
+//     cafa1
+//     cafab
+//     cafad
+//     cafae
+//     cafbf
+//     cafdc
+//     cafdf
+//     cafea
+//     caff3
+//     caffb
+//     caffd
+//     cb005
+//     cb00a
+//     cb014
+//     cb01f
+//     cb035
+//     cb05a
+//     cb070
+//     cb1d5
+//     cb1dd
+//     cb1fc
+//     cb203
+//     cb20f
+//     cb221
+//     cb23d
+//     cb260
+//     cb268
+//     cb280
+//     cb297
+//     cb2a0
+//     cb2b2
+//     cb2e1
+//     cb2e7
+//     cb300
+//     cb305
+//     cb314
+//     cb337
+//     cb34f
+//     cb352
+//     cb371
+//     cb375
+//     cb37f
+//     cb382
+//     cb397
+//     cb3ba
+//     cb3de
+//     cb406
+//     cb40e
+//     cb446
+//     cb44b
+//     cb45a
+//     cb45e
+//     cb470
+//     cb4af
+//     cb4b4
+//     cb4d8
+//     cb4df
+//     cb4e9
+//     cb4ee
+//     cb502
+//     cb534
+//     cb597
+//     cb5d0
+//     cb5e6
+//     cb655
+//     cb65e
+//     cb684
+//     cb68c
+//     cb6a6
+//     cb6c2
+//     cb6ca
+//     cb6d2
+//     cb6eb
+//     cb6f5
+//     cb718
+//     cb725
+//     cb736
+//     cb795
+//     cb7ae
+//     cb7b2
+//     cb7e8
+//     cb7ec
+//     cb7ed
+//     cb82b
+//     cb898
+//     cb8e4
+//     cb8e6
+//     cb8f5
+//     cb8fb
+//     cb9ae
+//     cb9d2
+//     cb9d9
+//     cb9e8
+//     cb9ee
+//     cb9f7
+//     cba10
+//     cba15
+//     cba19
+//     cba27
+//     cba28
+//     cba2e
+//     cba2f
+//     cba78
+//     cba8c
+//     cba9e
+//     cbab0
+//     cbab1
+//     cbab4
+//     cbad0
+//     cbaf8
+//     cbafd
+//     cbb07
+//     cbb28
+//     cbb2a
+//     cbb33
+//     cbb36
+//     cbb4c
+//     cbb6f
+//     cbb89
+//     cbb90
+//     cbba1
+//     cbbbe
+//     cbbd0
+//     cbbd9
+//     cbbf3
+//     cbc13
+//     cbc2c
+//     cbc3a
+//     cbc54
+//     cbc64
+//     cbc78
+//     cbc93
+//     cbcb2
+//     cbcb9
+//     cbcd6
+//     cbce1
+//     cbcf9
+//     cbd0e
+//     cbd1b
+//     cbd40
+//     cbd46
+//     cbd7e
+//     cbda3
+//     cbdb9
+//     cbdba
+//     cbdc0
+//     cbdd3
+//     cbddd
+//     cbe21
+//     cbe3c
+//     cbe47
+//     cbe52
+//     cbe7a
+//     cbe7b
+//     cbe89
+//     cbe8d
+//     cbec1
+//     cbee0
+//     cbee8
+//     cbeee
+//     cbf33
+//     cbf46
+//     cbf8a
+//     cbf8e
+//     cbfa3
+//     cbfb2
+//     l0000
+//     l0001
+//     l0002
+//     l0003
+//     l0012
+//     l0013
+//     l0014
+//     l0015
+//     l0053
+//     l0054
+//     l0055
+//     l0056
+//     l00a0
+//     l00a1
+//     l00a2
+//     l00a3
+//     l00a4
+//     l00a5
+//     l00a6
+//     l00a7
+//     l00a8
+//     l00a9
+//     l00aa
+//     l00ab
+//     l00ac
+//     l00ad
+//     l00ae
+//     l00af
+//     l00b0
+//     l00b1
+//     l00b2
+//     l00b3
+//     l00b4
+//     l00b5
+//     l00b6
+//     l00b7
+//     l00b8
+//     l00b9
+//     l00ba
+//     l00bb
+//     l00bc
+//     l00bd
+//     l00be
+//     l00bf
+//     l00c0
+//     l00c1
+//     l00c2
+//     l00c3
+//     l00c4
+//     l00c5
+//     l00c6
+//     l00c7
+//     l00c8
+//     l00c9
+//     l00ca
+//     l00cc
+//     l00cd
+//     l00ce
+//     l00cf
+//     l00ef
+//     l00f0
+//     l00f1
+//     l00f3
+//     l00f7
+//     l00fd
+//     l00ff
+//     l0100
+//     l0101
+//     l0102
+//     l0103
+//     l0104
+//     l0105
+//     l0107
+//     l0109
+//     l010b
+//     l010c
+//     l010d
+//     l010e
+//     l0128
+//     l028d
+//     l0500
+//     l0600
+//     l0700
+//     l0cff
+//     l0d0f
+//     l0d12
+//     l0d1f
+//     l0d26
+//     l0d2a
+//     l0d30
+//     l0d3d
+//     l0d50
+//     l0df0
+//     l0e00
+//     l0e07
+//     l0e08
+//     l0e0e
+//     l0e0f
+//     l0e10
+//     l0ef8
+//     l0f00
+//     l0f04
+//     l0f05
+//     l0f06
+//     l0f07
+//     l0f08
+//     l0f09
+//     l0f0a
+//     l0f0b
+//     l0f0c
+//     l0f0d
+//     l0f0e
+//     l0f0f
+//     l0f10
+//     l1000
+//     l1001
+//     l1002
+//     l1003
+//     l1004
+//     l1005
+//     l1006
+//     l1007
+//     l100e
+//     l1045
+//     l1047
+//     l104d
+//     l104e
+//     l1050
+//     l1058
+//     l105f
+//     l1060
+//     l1061
+//     l1062
+//     l1063
+//     l1064
+//     l1065
+//     l1067
+//     l1069
+//     l1072
+//     l1074
+//     l1075
+//     l1076
+//     l1077
+//     l1078
+//     l1079
+//     l107a
+//     l107d
+//     l107e
+//     l107f
+//     l1081
+//     l1082
+//     l1083
+//     l1086
+//     l1087
+//     l1088
+//     l1089
+//     l108a
+//     l108b
+//     l108c
+//     l108f
+//     l1090
+//     l1091
+//     l1092
+//     l1093
+//     l1094
+//     l1095
+//     l1096
+//     l1097
+//     l1098
+//     l1099
+//     l109a
+//     l109b
+//     l109d
+//     l109e
+//     l109f
+//     l10c0
+//     l10c1
+//     l10c2
+//     l10c3
+//     l10c4
+//     l10c5
+//     l10c6
+//     l10c7
+//     l10c9
+//     l10ca
+//     l10cb
+//     l10cc
+//     l10cd
+//     l10ce
+//     l10cf
+//     l10d0
+//     l10d1
+//     l10d2
+//     l10d3
+//     l10d6
+//     l10d7
+//     l10d8
+//     l10d9
+//     l10da
+//     l10db
+//     l10dc
+//     l10dd
+//     l10de
+//     l10e2
+//     l10e3
+//     l10e4
+//     l1100
+//     l1109
+//     l110b
+//     l110c
+//     l110d
+//     l110e
+//     l110f
+//     l1110
+//     l1111
+//     l1112
+//     l1113
+//     l1114
+//     l1115
+//     l1116
+//     l1117
+//     l1119
+//     l111a
+//     l111b
+//     l111c
+//     l111d
+//     l8001
+//     l8002
+//     l8004
+//     l911d
+//     l9121
+//     l9139
+//     l913f
+//     l9145
+//     l9146
+//     l9191
+//     l91a0
+//     l9aec
+//     l9b0f
+//     l9b18
+//     l9b21
+//     l9b29
+//     l9b31
+//     l9b3a
+//     l9b43
+//     la1d3
+//     lacf3
+//     laf73
+//     laf75
+//     laf76
+//     laf77
+//     laf78
+//     lb075
+//     lb175
+//     lb283
+//     lb57f
+//     lb6c6
+//     lb6ce
+//     lb726
+//     lb774
+//     lb872
+//     lb87e
+//     lb924
+//     lb979
+//     lb97a
+//     lb980
+//     lbb3a
+//     lbb3e
+//     lbb42
+//     lbf4f
+//     lbfff
+//     lfe80
+//     lfe84
+//     lfe85
+//     lfe86
+//     lfe87
+//     loop_c0029
+//     loop_c003b
+//     loop_c0446
+//     loop_c0466
+//     loop_c0471
+//     loop_c04a6
+//     loop_c04e1
+//     loop_c0564
+//     loop_c0577
+//     loop_c0586
+//     loop_c05ab
+//     loop_c05c7
+//     loop_c05d3
+//     loop_c05e6
+//     loop_c0604
+//     loop_c061d
+//     loop_c062b
+//     loop_c064c
+//     loop_c0657
+//     loop_c065a
+//     loop_c8064
+//     loop_c8086
+//     loop_c813a
+//     loop_c8161
+//     loop_c816b
+//     loop_c818c
+//     loop_c820c
+//     loop_c820d
+//     loop_c821c
+//     loop_c826f
+//     loop_c82c7
+//     loop_c82d1
+//     loop_c830d
+//     loop_c8326
+//     loop_c8370
+//     loop_c8390
+//     loop_c8397
+//     loop_c83f0
+//     loop_c83fa
+//     loop_c8406
+//     loop_c8425
+//     loop_c8463
+//     loop_c8493
+//     loop_c84e7
+//     loop_c8527
+//     loop_c8552
+//     loop_c8564
+//     loop_c857b
+//     loop_c85b5
+//     loop_c8717
+//     loop_c8725
+//     loop_c87a0
+//     loop_c87be
+//     loop_c88bc
+//     loop_c895f
+//     loop_c8990
+//     loop_c89c4
+//     loop_c89ca
+//     loop_c8a17
+//     loop_c8ac8
+//     loop_c8ad8
+//     loop_c8af0
+//     loop_c8afb
+//     loop_c8b80
+//     loop_c8bea
+//     loop_c8c58
+//     loop_c8c71
+//     loop_c8d14
+//     loop_c8d17
+//     loop_c8dac
+//     loop_c8dba
+//     loop_c8de9
+//     loop_c8df0
+//     loop_c8e14
+//     loop_c8e85
+//     loop_c8f17
+//     loop_c8f6c
+//     loop_c8f96
+//     loop_c8fac
+//     loop_c9047
+//     loop_c9108
+//     loop_c9113
+//     loop_c91ba
+//     loop_c91e7
+//     loop_c92ef
+//     loop_c9355
+//     loop_c9357
+//     loop_c936f
+//     loop_c9382
+//     loop_c93bd
+//     loop_c93da
+//     loop_c953a
+//     loop_c957d
+//     loop_c9593
+//     loop_c95b6
+//     loop_c95d9
+//     loop_c95ec
+//     loop_c9618
+//     loop_c96c2
+//     loop_c96f2
+//     loop_c979d
+//     loop_c97c8
+//     loop_c9803
+//     loop_c9837
+//     loop_c9851
+//     loop_c985e
+//     loop_c9881
+//     loop_c98a0
+//     loop_c98c1
+//     loop_c98e4
+//     loop_c9942
+//     loop_c994e
+//     loop_c9964
+//     loop_c99a8
+//     loop_c9b50
+//     loop_c9b5e
+//     loop_c9b63
+//     loop_c9bcf
+//     loop_c9be4
+//     loop_c9c38
+//     loop_c9c5d
+//     loop_c9c90
+//     loop_c9ca8
+//     loop_c9d03
+//     loop_c9d43
+//     loop_c9e07
+//     loop_c9e74
+//     loop_c9e8c
+//     loop_c9f6e
+//     loop_ca061
+//     loop_ca11d
+//     loop_ca132
+//     loop_ca143
+//     loop_ca16e
+//     loop_ca1aa
+//     loop_ca1cc
+//     loop_ca487
+//     loop_ca521
+//     loop_ca76f
+//     loop_ca7a7
+//     loop_ca7c6
+//     loop_ca7e0
+//     loop_ca7e1
+//     loop_ca941
+//     loop_ca947
+//     loop_ca953
+//     loop_ca9ab
+//     loop_ca9e7
+//     loop_caa01
+//     loop_caab8
+//     loop_cab6b
+//     loop_cab80
+//     loop_cabad
+//     loop_cabf4
+//     loop_cac46
+//     loop_caf13
+//     loop_caf2d
+//     loop_cb1e3
+//     loop_cb1ed
+//     loop_cb249
+//     loop_cb275
+//     loop_cb2b4
+//     loop_cb2bd
+//     loop_cb2d1
+//     loop_cb44d
+//     loop_cb4a8
+//     loop_cb55e
+//     loop_cb578
+//     loop_cb5c6
+//     loop_cb5ed
+//     loop_cb6b3
+//     loop_cb75a
+//     loop_cb7be
+//     loop_cb7d7
+//     loop_cb7dd
+//     loop_cb910
+//     loop_cb999
+//     loop_cb9bd
+//     loop_cb9cc
+//     loop_cb9d1
+//     loop_cb9f9
+//     loop_cba1a
+//     loop_cba94
+//     loop_cbab8
+//     loop_cbaea
+//     loop_cbbe4
+//     loop_cbbfe
+//     loop_cbc70
+//     loop_cbcd3
+//     loop_cbd08
+//     loop_cbd2b
+//     loop_cbd6c
+//     loop_cbd99
+//     loop_cbe0e
+//     loop_cbe31
+//     loop_cbeab
+//     loop_cbf1c
+//     loop_cbf78
+//     sub_c0050
+//     sub_c0414
+//     sub_c0421
+//     sub_c04c7
+//     sub_c04ce
+//     sub_c0520
+//     sub_c052d
+//     sub_c0537
+//     sub_c0542
+//     sub_c055e
+//     sub_c0582
+//     sub_c0596
+//     sub_c05a9
+//     sub_c05d1
+//     sub_c05f2
+//     sub_c05ff
+//     sub_c0607
+//     sub_c0627
+//     sub_c8020
+//     sub_c809a
+//     sub_c809d
+//     sub_c80b8
+//     sub_c80bb
+//     sub_c80c3
+//     sub_c80c8
+//     sub_c80d3
+//     sub_c80db
+//     sub_c80e3
+//     sub_c80e6
+//     sub_c80ed
+//     sub_c80f3
+//     sub_c80f6
+//     sub_c8149
+//     sub_c8174
+//     sub_c81ae
+//     sub_c81b0
+//     sub_c81b7
+//     sub_c81be
+//     sub_c81bf
+//     sub_c81c0
+//     sub_c81c4
+//     sub_c81c5
+//     sub_c81ca
+//     sub_c821d
+//     sub_c8222
+//     sub_c8238
+//     sub_c8254
+//     sub_c8266
+//     sub_c826d
+//     sub_c8280
+//     sub_c8284
+//     sub_c82b2
+//     sub_c82bb
+//     sub_c82e8
+//     sub_c82fe
+//     sub_c830a
+//     sub_c8327
+//     sub_c8335
+//     sub_c833a
+//     sub_c836e
+//     sub_c8380
+//     sub_c8386
+//     sub_c83bf
+//     sub_c83d1
+//     sub_c83d4
+//     sub_c83e3
+//     sub_c83ee
+//     sub_c840c
+//     sub_c841b
+//     sub_c842c
+//     sub_c8439
+//     sub_c8456
+//     sub_c8555
+//     sub_c85e3
+//     sub_c8602
+//     sub_c8745
+//     sub_c8750
+//     sub_c8782
+//     sub_c8794
+//     sub_c87da
+//     sub_c87db
+//     sub_c87e3
+//     sub_c87ee
+//     sub_c8826
+//     sub_c8855
+//     sub_c8862
+//     sub_c8932
+//     sub_c893f
+//     sub_c8943
+//     sub_c8951
+//     sub_c8979
+//     sub_c89b7
+//     sub_c89da
+//     sub_c89e6
+//     sub_c8a77
+//     sub_c8ab3
+//     sub_c8b25
+//     sub_c8b47
+//     sub_c8b4d
+//     sub_c8b64
+//     sub_c8b7b
+//     sub_c8b86
+//     sub_c8bac
+//     sub_c8bf6
+//     sub_c8bf9
+//     sub_c8c56
+//     sub_c8c65
+//     sub_c8d1a
+//     sub_c8dc6
+//     sub_c8eec
+//     sub_c8efa
+//     sub_c8eff
+//     sub_c8f33
+//     sub_c8f37
+//     sub_c8f3f
+//     sub_c8f4f
+//     sub_c8f5e
+//     sub_c8f6b
+//     sub_c8f75
+//     sub_c8f7a
+//     sub_c8f82
+//     sub_c8f94
+//     sub_c9279
+//     sub_c928a
+//     sub_c929d
+//     sub_c93b4
+//     sub_c93c5
+//     sub_c93d3
+//     sub_c93d8
+//     sub_c93f1
+//     sub_c93f5
+//     sub_c93f9
+//     sub_c93fd
+//     sub_c9432
+//     sub_c9445
+//     sub_c9516
+//     sub_c9526
+//     sub_c952e
+//     sub_c9536
+//     sub_c965d
+//     sub_c9785
+//     sub_c97b6
+//     sub_c97c9
+//     sub_c97e8
+//     sub_c9832
+//     sub_c992c
+//     sub_c9940
+//     sub_c995a
+//     sub_c9965
+//     sub_c9988
+//     sub_c99ac
+//     sub_c99f3
+//     sub_c9a0f
+//     sub_c9a32
+//     sub_c9a4b
+//     sub_c9a50
+//     sub_c9a60
+//     sub_c9a63
+//     sub_c9a6e
+//     sub_c9a78
+//     sub_c9a82
+//     sub_c9a8d
+//     sub_c9aa3
+//     sub_c9ab8
+//     sub_c9ac8
+//     sub_c9ad3
+//     sub_c9ad8
+//     sub_c9b51
+//     sub_c9b59
+//     sub_c9b61
+//     sub_c9b79
+//     sub_c9bca
+//     sub_c9bcd
+//     sub_c9be5
+//     sub_c9bf2
+//     sub_c9c0c
+//     sub_c9d19
+//     sub_c9d1e
+//     sub_c9d75
+//     sub_c9d9b
+//     sub_c9df4
+//     sub_c9e1e
+//     sub_c9e30
+//     sub_c9e54
+//     sub_c9e75
+//     sub_c9e94
+//     sub_c9ef4
+//     sub_c9f0f
+//     sub_c9f14
+//     sub_c9f16
+//     sub_c9f1e
+//     sub_c9f26
+//     sub_c9f7c
+//     sub_c9f82
+//     sub_ca0b8
+//     sub_ca0de
+//     sub_ca0f6
+//     sub_ca106
+//     sub_ca137
+//     sub_ca14a
+//     sub_ca168
+//     sub_ca190
+//     sub_ca1b4
+//     sub_ca1c6
+//     sub_ca244
+//     sub_ca315
+//     sub_ca324
+//     sub_ca379
+//     sub_ca384
+//     sub_ca3e4
+//     sub_ca3ec
+//     sub_ca417
+//     sub_ca463
+//     sub_ca4e1
+//     sub_ca51f
+//     sub_ca530
+//     sub_ca5b2
+//     sub_ca5bb
+//     sub_ca5bf
+//     sub_ca663
+//     sub_ca73d
+//     sub_ca76c
+//     sub_ca779
+//     sub_ca788
+//     sub_ca7c4
+//     sub_ca7c5
+//     sub_ca7ce
+//     sub_ca7f3
+//     sub_ca7f6
+//     sub_ca8be
+//     sub_ca8e2
+//     sub_ca90d
+//     sub_ca9bf
+//     sub_ca9c2
+//     sub_ca9ca
+//     sub_ca9d0
+//     sub_caa12
+//     sub_caa53
+//     sub_caa9a
+//     sub_caac2
+//     sub_caacf
+//     sub_caadd
+//     sub_caaea
+//     sub_caaf1
+//     sub_caafd
+//     sub_cab04
+//     sub_cab46
+//     sub_caba9
+//     sub_cabc5
+//     sub_cac0c
+//     sub_cac18
+//     sub_cac47
+//     sub_cac4e
+//     sub_cac62
+//     sub_cac6a
+//     sub_cac72
+//     sub_cad5d
+//     sub_caf8d
+//     sub_caf9a
+//     sub_cb040
+//     sub_cb047
+//     sub_cb234
+//     sub_cb2c8
+//     sub_cb580
+//     sub_cb58b
+//     sub_cb598
+//     sub_cb5ce
+//     sub_cb5ee
+//     sub_cb5f2
+//     sub_cb607
+//     sub_cb616
+//     sub_cb61e
+//     sub_cb65f
+//     sub_cb68f
+//     sub_cb6b1
+//     sub_cb6c5
+//     sub_cb6cd
+//     sub_cb6e6
+//     sub_cb6fe
+//     sub_cb745
+//     sub_cb771
+//     sub_cb7b6
+//     sub_cb83f
+//     sub_cb841
+//     sub_cb84e
+//     sub_cb850
+//     sub_cb85d
+//     sub_cb86f
+//     sub_cb882
+//     sub_cb986
+//     sub_cb9f5
+//     sub_cba67
+//     sub_cbab9
+//     sub_cbac2
+//     sub_cbac4
+//     sub_cbad2
+//     sub_cbb00
+//     sub_cbb46
+//     sub_cbb4a
+//     sub_cbbd3
+//     sub_cbbd7
+//     sub_cbc37
+//     sub_cbc68
+//     sub_cbc81
+//     sub_cbe83
+//     sub_cbe91
+//     sub_cbe9d
+//     sub_cbec2
+//     sub_cbf7c
+//     sub_cbf82
+//     sub_cbf84

--- a/examples/known_good/dfs226b_acme.asm
+++ b/examples/known_good/dfs226b_acme.asm
@@ -1,0 +1,15100 @@
+; Constants
+opcode_bcs                            = 176
+opcode_rti                            = 64
+osbyte_close_spool_exec               = 119
+osbyte_explode_chars                  = 20
+osbyte_issue_service_request          = 143
+osbyte_read_himem                     = 132
+osbyte_read_oshwm                     = 131
+osbyte_read_rom_info_table_low        = 170
+osbyte_read_tube_presence             = 234
+osbyte_read_write_spool_file_handle   = 199
+osbyte_read_write_startup_options     = 255
+osbyte_rw_exec_handle                 = 198
+osbyte_scan_keyboard_from_16          = 122
+osbyte_write_keys_pressed             = 120
+osfile_load                           = 255
+osfile_read_catalogue_info            = 5
+osfile_save                           = 0
+service_absolute_workspace_claimed    = 10
+service_boot                          = 3
+service_check_swr_presence            = 43
+service_claim_absolute_workspace      = 1
+service_claim_private_workspace       = 2
+service_help                          = 9
+service_select_filing_system          = 18
+service_tube_post_init                = 254
+service_unrecognised_command          = 4
+service_unrecognised_osword           = 8
+tube_brkv_handler_fwd                 = 22
+
+; Memory locations
+l0000                   = $00
+l0001                   = $01
+l0002                   = $02
+l0003                   = $03
+l0012                   = $12
+l0013                   = $13
+l0014                   = $14
+l0015                   = $15
+l00a0                   = $a0
+l00a1                   = $a1
+l00a2                   = $a2
+l00a3                   = $a3
+l00a4                   = $a4
+l00a5                   = $a5
+l00a6                   = $a6
+l00a7                   = $a7
+l00a8                   = $a8
+l00a9                   = $a9
+l00aa                   = $aa
+l00ab                   = $ab
+l00ac                   = $ac
+l00ad                   = $ad
+l00ae                   = $ae
+l00af                   = $af
+l00b0                   = $b0
+l00b1                   = $b1
+l00b2                   = $b2
+l00b3                   = $b3
+l00b4                   = $b4
+l00b5                   = $b5
+l00b6                   = $b6
+l00b7                   = $b7
+l00b8                   = $b8
+l00b9                   = $b9
+l00ba                   = $ba
+l00bb                   = $bb
+l00bc                   = $bc
+l00bd                   = $bd
+l00be                   = $be
+l00bf                   = $bf
+l00c0                   = $c0
+l00c1                   = $c1
+l00c2                   = $c2
+l00c3                   = $c3
+l00c4                   = $c4
+l00c5                   = $c5
+l00c6                   = $c6
+l00c7                   = $c7
+l00c8                   = $c8
+l00c9                   = $c9
+l00ca                   = $ca
+l00cc                   = $cc
+l00cd                   = $cd
+l00ce                   = $ce
+l00cf                   = $cf
+l00ef                   = $ef
+l00f0                   = $f0
+l00f1                   = $f1
+os_text_ptr             = $f2
+l00f3                   = $f3
+romsel_copy             = $f4
+osrdsc_ptr              = $f6
+l00f7                   = $f7
+l00fd                   = $fd
+l00ff                   = $ff
+l0100                   = $0100
+l0101                   = $0101
+l0102                   = $0102
+l0103                   = $0103
+l0104                   = $0104
+l0105                   = $0105
+l0107                   = $0107
+l0109                   = $0109
+l010b                   = $010b
+l010c                   = $010c
+l010d                   = $010d
+l010e                   = $010e
+l0128                   = $0128
+brkv                    = $0202
+bytev                   = $020a
+filev                   = $0212
+fscv                    = $021e
+evntv                   = $0220
+l028d                   = $028d
+l0700                   = $0700
+l0cff                   = $0cff
+l0df0                   = $0df0
+l0e00                   = $0e00
+l0e07                   = $0e07
+l0e08                   = $0e08
+l0e0e                   = $0e0e
+l0e0f                   = $0e0f
+l0e10                   = $0e10
+l0ef8                   = $0ef8
+l0f00                   = $0f00
+l0f04                   = $0f04
+l0f05                   = $0f05
+l0f06                   = $0f06
+l0f07                   = $0f07
+l0f08                   = $0f08
+l0f09                   = $0f09
+l0f0a                   = $0f0a
+l0f0b                   = $0f0b
+l0f0c                   = $0f0c
+l0f0d                   = $0f0d
+l0f0e                   = $0f0e
+l0f0f                   = $0f0f
+l0f10                   = $0f10
+l1000                   = $1000
+l1001                   = $1001
+l1002                   = $1002
+l1003                   = $1003
+l1004                   = $1004
+l1005                   = $1005
+l1006                   = $1006
+l1007                   = $1007
+l100e                   = $100e
+l1045                   = $1045
+l1047                   = $1047
+l104d                   = $104d
+l104e                   = $104e
+l1050                   = $1050
+l1058                   = $1058
+l105f                   = $105f
+l1060                   = $1060
+l1061                   = $1061
+l1062                   = $1062
+l1063                   = $1063
+l1064                   = $1064
+l1065                   = $1065
+l1067                   = $1067
+l1069                   = $1069
+l1072                   = $1072
+l1074                   = $1074
+l1075                   = $1075
+l1076                   = $1076
+l1077                   = $1077
+l1078                   = $1078
+l1079                   = $1079
+l107a                   = $107a
+l107d                   = $107d
+l107e                   = $107e
+l107f                   = $107f
+l1081                   = $1081
+l1082                   = $1082
+l1083                   = $1083
+l1086                   = $1086
+l1087                   = $1087
+l1088                   = $1088
+l1089                   = $1089
+l108a                   = $108a
+l108b                   = $108b
+l108c                   = $108c
+l108f                   = $108f
+l1090                   = $1090
+l1091                   = $1091
+l1092                   = $1092
+l1093                   = $1093
+l1094                   = $1094
+l1095                   = $1095
+l1096                   = $1096
+l1097                   = $1097
+l1098                   = $1098
+l1099                   = $1099
+l109a                   = $109a
+l109b                   = $109b
+l109d                   = $109d
+l109e                   = $109e
+l109f                   = $109f
+l10c0                   = $10c0
+l10c1                   = $10c1
+l10c2                   = $10c2
+l10c3                   = $10c3
+l10c4                   = $10c4
+l10c5                   = $10c5
+l10c6                   = $10c6
+l10c7                   = $10c7
+l10c9                   = $10c9
+l10ca                   = $10ca
+l10cb                   = $10cb
+l10cc                   = $10cc
+l10cd                   = $10cd
+l10ce                   = $10ce
+l10cf                   = $10cf
+l10d0                   = $10d0
+l10d1                   = $10d1
+l10d2                   = $10d2
+l10d3                   = $10d3
+l10d6                   = $10d6
+l10d7                   = $10d7
+l10d8                   = $10d8
+l10d9                   = $10d9
+l10da                   = $10da
+l10db                   = $10db
+l10dc                   = $10dc
+l10dd                   = $10dd
+l10de                   = $10de
+l10e2                   = $10e2
+l10e3                   = $10e3
+l10e4                   = $10e4
+l1100                   = $1100
+l1109                   = $1109
+l110b                   = $110b
+l110c                   = $110c
+l110d                   = $110d
+l110e                   = $110e
+l110f                   = $110f
+l1110                   = $1110
+l1111                   = $1111
+l1112                   = $1112
+l1113                   = $1113
+l1114                   = $1114
+l1115                   = $1115
+l1116                   = $1116
+l1117                   = $1117
+l1119                   = $1119
+l111a                   = $111a
+l111b                   = $111b
+l111c                   = $111c
+l111d                   = $111d
+nmi_handler_rom_end     = $9030
+nmi3_handler_rom_start  = $9030
+tube_host_code1         = $af79
+romsel                  = $fe30
+lfe80                   = $fe80
+lfe84                   = $fe84
+lfe85                   = $fe85
+lfe86                   = $fe86
+lfe87                   = $fe87
+tube_host_r1_status     = $fee0
+tube_host_r1_data       = $fee1
+tube_host_r2_status     = $fee2
+tube_host_r2_data       = $fee3
+tube_host_r3_data       = $fee5
+tube_host_r4_status     = $fee6
+tube_host_r4_data       = $fee7
+osrdsc                  = $ffb9
+gsinit                  = $ffc2
+gsread                  = $ffc5
+osfind                  = $ffce
+osgbpb                  = $ffd1
+osbput                  = $ffd4
+osbget                  = $ffd7
+osargs                  = $ffda
+osfile                  = $ffdd
+osrdch                  = $ffe0
+osasci                  = $ffe3
+osnewl                  = $ffe7
+oswrch                  = $ffee
+osword                  = $fff1
+osbyte                  = $fff4
+oscli                   = $fff7
+
+    * = $2000
+
+; Sideways ROM header
+; $2000 referenced 1 time by $04e2
+pydis_start
+
+!pseudopc $8000 {
+; Sideways ROM header
+; $2000 referenced 1 time by $04e2
+rom_header
+language_entry
+l8001 = rom_header+1
+l8002 = rom_header+2
+    !byte 0, 0, 0                                                     ; 2000: 00 00 00    ... :8000[1]
+; $2001 referenced 1 time by $04e7
+; $2002 referenced 1 time by $04ec
+
+; $2003 referenced 1 time by $04f1
+service_entry
+l8004 = service_entry+1
+    jmp service_handler                                               ; 2003: 4c c8 be    L.. :8003[1]
+
+; $2004 referenced 1 time by $04f4
+; $2006 referenced 1 time by $04d6
+rom_type
+    !byte $82                                                         ; 2006: 82          .   :8006[1]
+; $2007 referenced 1 time by $04de
+copyright_offset
+    !byte copyright - rom_header                                      ; 2007: 11          .   :8007[1]
+binary_version
+    !byte $7b                                                         ; 2008: 7b          {   :8008[1]
+title
+    !text "DFS"                                                       ; 2009: 44 46 53    DFS :8009[1]
+version
+    !byte 0                                                           ; 200c: 00          .   :800c[1]
+    !text "2.26"                                                      ; 200d: 32 2e 32... 2.2 :800d[1]
+copyright
+    !byte 0                                                           ; 2011: 00          .   :8011[1]
+    !text "(C)1985 Acorn", 0                                          ; 2012: 28 43 29... (C) :8012[1]
+
+; $2020 referenced 1 time by $9575
+sub_c8020
+    jmp (fscv)                                                        ; 2020: 6c 1e 02    l.. :8020[1]
+
+; $2023 referenced 4 times by $8a6e, $94c6, $94d5, $9c00
+generate_error_precheck_disc
+    jsr generate_error_precheck                                       ; 2023: 20 38 80     8. :8023[1]
+    !byte 0                                                           ; 2026: 00          .   :8026[1]
+    !text "Disc "                                                     ; 2027: 44 69 73... Dis :8027[1]
+
+    bcc generate_error2                                               ; 202c: 90 21       .!  :802c[1]
+; $202e referenced 6 times by $8125, $889a, $89a5, $8a24, $8a3e, $8ba2
+generate_error_precheck_bad
+    jsr generate_error_precheck                                       ; 202e: 20 38 80     8. :802e[1]
+    !byte 0                                                           ; 2031: 00          .   :8031[1]
+    !text "Bad "                                                      ; 2032: 42 61 64... Bad :8032[1]
+
+    bcc generate_error2                                               ; 2036: 90 17       ..  :8036[1]
+; $2038 referenced 11 times by $8023, $802e, $8b18, $8bd8, $9a55, $9c70, $9c82, $9e80, $9e8c, $9f6e, $9fc8
+generate_error_precheck
+    lda l10dd                                                         ; 2038: ad dd 10    ... :8038[1]
+    bne c8040                                                         ; 203b: d0 03       ..  :803b[1]
+    jsr sub_c9e30                                                     ; 203d: 20 30 9e     0. :803d[1]
+; $2040 referenced 1 time by $803b
+c8040
+    lda #$ff                                                          ; 2040: a9 ff       ..  :8040[1]
+    sta l1082                                                         ; 2042: 8d 82 10    ... :8042[1]
+    sta l10dd                                                         ; 2045: 8d dd 10    ... :8045[1]
+; Generate an OS error using inline data. Called as either:
+;         jsr XXX:equb errnum, "error message", 0
+;     to actually generate an error now, or as:
+;         jsr XXX:equb errnum, "partial error message", instruction...
+;     to partially construct an error (on the stack) and continue
+; executing
+;     'instruction' afterwards; its opcode must have its top bit set.
+; Carry is
+;     always clear on exit.
+; $2048 referenced 4 times by $822a, $9439, $947c, $a14f
+generate_error
+    ldx #2                                                            ; 2048: a2 02       ..  :8048[1]
+    lda #0                                                            ; 204a: a9 00       ..  :804a[1]
+    sta l0100                                                         ; 204c: 8d 00 01    ... :804c[1]
+; $204f referenced 7 times by $802c, $8036, $94da, $94e9, $94f7, $9507, $9511
+generate_error2
+    sta l00b3                                                         ; 204f: 85 b3       ..  :804f[1]
+    pla                                                               ; 2051: 68          h   :8051[1]
+    sta l00ae                                                         ; 2052: 85 ae       ..  :8052[1]
+    pla                                                               ; 2054: 68          h   :8054[1]
+    sta l00af                                                         ; 2055: 85 af       ..  :8055[1]
+; XXX: Redundant lda l00b3? Is sta l00b3 above redundant too?
+    lda l00b3                                                         ; 2057: a5 b3       ..  :8057[1]
+    ldy #0                                                            ; 2059: a0 00       ..  :8059[1]
+    jsr inc16_ae                                                      ; 205b: 20 dc 83     .. :805b[1]
+    lda (l00ae),y                                                     ; 205e: b1 ae       ..  :805e[1]
+    sta l0101                                                         ; 2060: 8d 01 01    ... :8060[1]
+    dex                                                               ; 2063: ca          .   :8063[1]
+; $2064 referenced 1 time by $806f
+loop_c8064
+    jsr inc16_ae                                                      ; 2064: 20 dc 83     .. :8064[1]
+    inx                                                               ; 2067: e8          .   :8067[1]
+    lda (l00ae),y                                                     ; 2068: b1 ae       ..  :8068[1]
+    sta l0100,x                                                       ; 206a: 9d 00 01    ... :806a[1]
+    bmi c8096                                                         ; 206d: 30 27       0'  :806d[1]
+    bne loop_c8064                                                    ; 206f: d0 f3       ..  :806f[1]
+    jsr sub_c8f75                                                     ; 2071: 20 75 8f     u. :8071[1]
+    jmp l0100                                                         ; 2074: 4c 00 01    L.. :8074[1]
+
+; Print (XXX: using l809f, which seems to be quite fancy) an inline
+; string
+;     terminated by a top-bit set instruction to execute after
+; printing the string.
+;     Carry is always clear on exit.
+; $2077 referenced 31 times by $84a5, $84b0, $84c8, $84dc, $84f1, $850d, $87ce, $9558, $a10c, $a247, $a298, $a34d, $a364, $a394, $a3a3, $a3ae, $a3bd, $a3e4, $a3ec, $a5f0, $a5fb, $a605, $a667, $a678, $a68a, $a699, $a70a, $a719, $aa5a, $aa65, $aebf
+print_inline_l809f_top_bit_clear
+    sta l00b3                                                         ; 2077: 85 b3       ..  :8077[1]
+    pla                                                               ; 2079: 68          h   :8079[1]
+    sta l00ae                                                         ; 207a: 85 ae       ..  :807a[1]
+    pla                                                               ; 207c: 68          h   :807c[1]
+    sta l00af                                                         ; 207d: 85 af       ..  :807d[1]
+    lda l00b3                                                         ; 207f: a5 b3       ..  :807f[1]
+    pha                                                               ; 2081: 48          H   :8081[1]
+    tya                                                               ; 2082: 98          .   :8082[1]
+    pha                                                               ; 2083: 48          H   :8083[1]
+    ldy #0                                                            ; 2084: a0 00       ..  :8084[1]
+; $2086 referenced 1 time by $8090
+loop_c8086
+    jsr inc16_ae                                                      ; 2086: 20 dc 83     .. :8086[1]
+    lda (l00ae),y                                                     ; 2089: b1 ae       ..  :8089[1]
+    bmi c8093                                                         ; 208b: 30 06       0.  :808b[1]
+    jsr c809f                                                         ; 208d: 20 9f 80     .. :808d[1]
+    jmp loop_c8086                                                    ; 2090: 4c 86 80    L.. :8090[1]
+
+; $2093 referenced 1 time by $808b
+c8093
+    pla                                                               ; 2093: 68          h   :8093[1]
+    tay                                                               ; 2094: a8          .   :8094[1]
+    pla                                                               ; 2095: 68          h   :8095[1]
+; $2096 referenced 1 time by $806d
+c8096
+    clc                                                               ; 2096: 18          .   :8096[1]
+    jmp (l00ae)                                                       ; 2097: 6c ae 00    l.. :8097[1]
+
+; $209a referenced 2 times by $84ff, $8519
+sub_c809a
+    jsr sub_c80c3                                                     ; 209a: 20 c3 80     .. :809a[1]
+; $209d referenced 1 time by $8187
+sub_c809d
+    lda #$2e ; '.'                                                    ; 209d: a9 2e       ..  :809d[1]
+; $209f referenced 20 times by $808d, $80c6, $8184, $8191, $81a2, $849d, $84ea, $8505, $851f, $a1c3, $a3df, $a40c, $a621, $a6bd, $a6c0, $aa6d, $aa7b, $aa87, $aa8c, $aabe
+c809f
+    jsr sub_c83e3                                                     ; 209f: 20 e3 83     .. :809f[1]
+    pha                                                               ; 20a2: 48          H   :80a2[1]
+    lda #$ec                                                          ; 20a3: a9 ec       ..  :80a3[1]
+    jsr osbyte_read                                                   ; 20a5: 20 e5 9a     .. :80a5[1]
+    txa                                                               ; 20a8: 8a          .   :80a8[1]
+    pha                                                               ; 20a9: 48          H   :80a9[1]
+    ora #$10                                                          ; 20aa: 09 10       ..  :80aa[1]
+    jsr sub_c9ad3                                                     ; 20ac: 20 d3 9a     .. :80ac[1]
+    pla                                                               ; 20af: 68          h   :80af[1]
+    tax                                                               ; 20b0: aa          .   :80b0[1]
+    pla                                                               ; 20b1: 68          h   :80b1[1]
+    jsr osasci                                                        ; 20b2: 20 e3 ff     .. :80b2[1]
+    jmp c9ad4                                                         ; 20b5: 4c d4 9a    L.. :80b5[1]
+
+; $20b8 referenced 1 time by $aa62
+sub_c80b8
+    jsr sub_c841b                                                     ; 20b8: 20 1b 84     .. :80b8[1]
+; $20bb referenced 5 times by $8368, $8373, $84ad, $a295, $a6c6
+sub_c80bb
+    pha                                                               ; 20bb: 48          H   :80bb[1]
+    jsr sub_c81bf                                                     ; 20bc: 20 bf 81     .. :80bc[1]
+    jsr sub_c80c3                                                     ; 20bf: 20 c3 80     .. :80bf[1]
+    pla                                                               ; 20c2: 68          h   :80c2[1]
+; $20c3 referenced 10 times by $809a, $80bf, $8362, $84c0, $84d9, $a25c, $a291, $a361, $a36f, $a696
+sub_c80c3
+    jsr sub_c80c8                                                     ; 20c3: 20 c8 80     .. :80c3[1]
+    bne c809f                                                         ; 20c6: d0 d7       ..  :80c6[1]
+; $20c8 referenced 4 times by $80c3, $952e, $a9ca, $ac6a
+sub_c80c8
+    and #$0f                                                          ; 20c8: 29 0f       ).  :80c8[1]
+    cmp #$0a                                                          ; 20ca: c9 0a       ..  :80ca[1]
+    bcc c80d0                                                         ; 20cc: 90 02       ..  :80cc[1]
+    adc #6                                                            ; 20ce: 69 06       i.  :80ce[1]
+; $20d0 referenced 1 time by $80cc
+c80d0
+    adc #$30 ; '0'                                                    ; 20d0: 69 30       i0  :80d0[1]
+    rts                                                               ; 20d2: 60          `   :80d2[1]
+
+; $20d3 referenced 1 time by $979d
+sub_c80d3
+    jsr sub_c80e3                                                     ; 20d3: 20 e3 80     .. :80d3[1]
+    dex                                                               ; 20d6: ca          .   :80d6[1]
+    dex                                                               ; 20d7: ca          .   :80d7[1]
+    jsr sub_c80db                                                     ; 20d8: 20 db 80     .. :80d8[1]
+; $20db referenced 1 time by $80d8
+sub_c80db
+    lda (l00b0),y                                                     ; 20db: b1 b0       ..  :80db[1]
+    sta l1072,x                                                       ; 20dd: 9d 72 10    .r. :80dd[1]
+    inx                                                               ; 20e0: e8          .   :80e0[1]
+    iny                                                               ; 20e1: c8          .   :80e1[1]
+    rts                                                               ; 20e2: 60          `   :80e2[1]
+
+; $20e3 referenced 2 times by $80d3, $979a
+sub_c80e3
+    jsr sub_c80e6                                                     ; 20e3: 20 e6 80     .. :80e3[1]
+; $20e6 referenced 1 time by $80e3
+sub_c80e6
+    lda (l00b0),y                                                     ; 20e6: b1 b0       ..  :80e6[1]
+    sta l00ba,x                                                       ; 20e8: 95 ba       ..  :80e8[1]
+    inx                                                               ; 20ea: e8          .   :80ea[1]
+    iny                                                               ; 20eb: c8          .   :80eb[1]
+    rts                                                               ; 20ec: 60          `   :80ec[1]
+
+; $20ed referenced 5 times by $821d, $89ec, $8bb2, $8bc7, $a46c
+sub_c80ed
+    jsr sub_c8b7b                                                     ; 20ed: 20 7b 8b     {. :80ed[1]
+    jmp c8103                                                         ; 20f0: 4c 03 81    L.. :80f0[1]
+
+; $20f3 referenced 5 times by $8222, $8879, $8a77, $9a78, $9c22
+sub_c80f3
+    jsr sub_c8b7b                                                     ; 20f3: 20 7b 8b     {. :80f3[1]
+; $20f6 referenced 1 time by $8892
+sub_c80f6
+    lda l00ba                                                         ; 20f6: a5 ba       ..  :80f6[1]
+    sta os_text_ptr                                                   ; 20f8: 85 f2       ..  :80f8[1]
+    lda l00bb                                                         ; 20fa: a5 bb       ..  :80fa[1]
+    sta l00f3                                                         ; 20fc: 85 f3       ..  :80fc[1]
+    ldy #0                                                            ; 20fe: a0 00       ..  :80fe[1]
+    jsr clc_jmp_gsinit                                                ; 2100: 20 4c 87     L. :8100[1]
+; $2103 referenced 3 times by $80f0, $8113, $8123
+c8103
+    ldx #$20 ; ' '                                                    ; 2103: a2 20       .   :8103[1]
+    jsr sub_c8149                                                     ; 2105: 20 49 81     I. :8105[1]
+    bcs c8125                                                         ; 2108: b0 1b       ..  :8108[1]
+    sta l1000                                                         ; 210a: 8d 00 10    ... :810a[1]
+    cmp #$2e ; '.'                                                    ; 210d: c9 2e       ..  :810d[1]
+    bne c8115                                                         ; 210f: d0 04       ..  :810f[1]
+; $2111 referenced 1 time by $8136
+c8111
+    stx l00cc                                                         ; 2111: 86 cc       ..  :8111[1]
+    beq c8103                                                         ; 2113: f0 ee       ..  :8113[1]
+; $2115 referenced 1 time by $810f
+c8115
+    cmp #$3a ; ':'                                                    ; 2115: c9 3a       .:  :8115[1]
+    bne c812e                                                         ; 2117: d0 15       ..  :8117[1]
+    jsr c8b8b                                                         ; 2119: 20 8b 8b     .. :8119[1]
+    jsr sub_c8149                                                     ; 211c: 20 49 81     I. :811c[1]
+    bcs c8125                                                         ; 211f: b0 04       ..  :811f[1]
+    cmp #$2e ; '.'                                                    ; 2121: c9 2e       ..  :8121[1]
+    beq c8103                                                         ; 2123: f0 de       ..  :8123[1]
+; $2125 referenced 5 times by $8108, $811f, $8147, $8155, $8159
+c8125
+    jsr generate_error_precheck_bad                                   ; 2125: 20 2e 80     .. :8125[1]
+    !byte $cc                                                         ; 2128: cc          .   :8128[1]
+    !text "name"                                                      ; 2129: 6e 61 6d... nam :8129[1]
+    !byte 0                                                           ; 212d: 00          .   :812d[1]
+
+; $212e referenced 1 time by $8117
+c812e
+    tax                                                               ; 212e: aa          .   :812e[1]
+    jsr sub_c8149                                                     ; 212f: 20 49 81     I. :812f[1]
+    bcs c815d                                                         ; 2132: b0 29       .)  :8132[1]
+    cmp #$2e ; '.'                                                    ; 2134: c9 2e       ..  :8134[1]
+    beq c8111                                                         ; 2136: f0 d9       ..  :8136[1]
+    ldx #1                                                            ; 2138: a2 01       ..  :8138[1]
+; $213a referenced 1 time by $8145
+loop_c813a
+    sta l1000,x                                                       ; 213a: 9d 00 10    ... :813a[1]
+    inx                                                               ; 213d: e8          .   :813d[1]
+    jsr sub_c8149                                                     ; 213e: 20 49 81     I. :813e[1]
+    bcs c815f                                                         ; 2141: b0 1c       ..  :8141[1]
+    cpx #7                                                            ; 2143: e0 07       ..  :8143[1]
+    bne loop_c813a                                                    ; 2145: d0 f3       ..  :8145[1]
+    beq c8125                                                         ; 2147: f0 dc       ..  :8147[1]
+; $2149 referenced 11 times by $8105, $811c, $812f, $813e, $8990, $899c, $89af, $89cb, $8a19, $8b8b, $a143
+sub_c8149
+    jsr gsread                                                        ; 2149: 20 c5 ff     .. :8149[1]
+    php                                                               ; 214c: 08          .   :814c[1]
+    and #$7f                                                          ; 214d: 29 7f       ).  :814d[1]
+    cmp #$0d                                                          ; 214f: c9 0d       ..  :814f[1]
+    beq c815b                                                         ; 2151: f0 08       ..  :8151[1]
+    cmp #$20 ; ' '                                                    ; 2153: c9 20       .   :8153[1]
+    bcc c8125                                                         ; 2155: 90 ce       ..  :8155[1]
+    cmp #$7f                                                          ; 2157: c9 7f       ..  :8157[1]
+    beq c8125                                                         ; 2159: f0 ca       ..  :8159[1]
+; $215b referenced 1 time by $8151
+c815b
+    plp                                                               ; 215b: 28          (   :815b[1]
+    rts                                                               ; 215c: 60          `   :815c[1]
+
+; $215d referenced 2 times by $8132, $8248
+c815d
+    ldx #1                                                            ; 215d: a2 01       ..  :815d[1]
+; $215f referenced 1 time by $8141
+c815f
+    lda #$20 ; ' '                                                    ; 215f: a9 20       .   :815f[1]
+; $2161 referenced 1 time by $8167
+loop_c8161
+    sta l1000,x                                                       ; 2161: 9d 00 10    ... :8161[1]
+    inx                                                               ; 2164: e8          .   :8164[1]
+    cpx #$40 ; '@'                                                    ; 2165: e0 40       .@  :8165[1]
+    bne loop_c8161                                                    ; 2167: d0 f8       ..  :8167[1]
+    ldx #6                                                            ; 2169: a2 06       ..  :8169[1]
+; $216b referenced 1 time by $8171
+loop_c816b
+    lda l1000,x                                                       ; 216b: bd 00 10    ... :816b[1]
+    sta l00c5,x                                                       ; 216e: 95 c5       ..  :816e[1]
+    dex                                                               ; 2170: ca          .   :8170[1]
+    bpl loop_c816b                                                    ; 2171: 10 f8       ..  :8171[1]
+    rts                                                               ; 2173: 60          `   :8173[1]
+
+; $2174 referenced 4 times by $833d, $85cd, $875e, $87a5
+sub_c8174
+    jsr sub_c83e3                                                     ; 2174: 20 e3 83     .. :8174[1]
+    lda l0e0f,y                                                       ; 2177: b9 0f 0e    ... :8177[1]
+    php                                                               ; 217a: 08          .   :817a[1]
+    and #$7f                                                          ; 217b: 29 7f       ).  :817b[1]
+    bne c8184                                                         ; 217d: d0 05       ..  :817d[1]
+    jsr sub_cac0c                                                     ; 217f: 20 0c ac     .. :817f[1]
+    beq c818a                                                         ; 2182: f0 06       ..  :8182[1]
+; $2184 referenced 1 time by $817d
+c8184
+    jsr c809f                                                         ; 2184: 20 9f 80     .. :8184[1]
+    jsr sub_c809d                                                     ; 2187: 20 9d 80     .. :8187[1]
+; $218a referenced 1 time by $8182
+c818a
+    ldx #6                                                            ; 218a: a2 06       ..  :818a[1]
+; $218c referenced 1 time by $8196
+loop_c818c
+    lda l0e08,y                                                       ; 218c: b9 08 0e    ... :818c[1]
+    and #$7f                                                          ; 218f: 29 7f       ).  :818f[1]
+    jsr c809f                                                         ; 2191: 20 9f 80     .. :8191[1]
+    iny                                                               ; 2194: c8          .   :8194[1]
+    dex                                                               ; 2195: ca          .   :8195[1]
+    bpl loop_c818c                                                    ; 2196: 10 f4       ..  :8196[1]
+    jsr sub_cac0c                                                     ; 2198: 20 0c ac     .. :8198[1]
+    lda #$20 ; ' '                                                    ; 219b: a9 20       .   :819b[1]
+    plp                                                               ; 219d: 28          (   :819d[1]
+    bpl c81a2                                                         ; 219e: 10 02       ..  :819e[1]
+    lda #$4c ; 'L'                                                    ; 21a0: a9 4c       .L  :81a0[1]
+; $21a2 referenced 1 time by $819e
+c81a2
+    jsr c809f                                                         ; 21a2: 20 9f 80     .. :81a2[1]
+    ldy #1                                                            ; 21a5: a0 01       ..  :81a5[1]
+; $21a7 referenced 4 times by $81ab, $84c5, $850a, $85c2
+c81a7
+    jsr cac0f                                                         ; 21a7: 20 0f ac     .. :81a7[1]
+    dey                                                               ; 21aa: 88          .   :81aa[1]
+    bne c81a7                                                         ; 21ab: d0 fa       ..  :81ab[1]
+    rts                                                               ; 21ad: 60          `   :81ad[1]
+
+; $21ae referenced 2 times by $88a9, $8b6b
+sub_c81ae
+    lsr                                                               ; 21ae: 4a          J   :81ae[1]
+    lsr                                                               ; 21af: 4a          J   :81af[1]
+; $21b0 referenced 8 times by $81f5, $85e6, $9cdb, $9cfd, $a2c6, $a49f, $a505, $a8e6
+sub_c81b0
+    lsr                                                               ; 21b0: 4a          J   :81b0[1]
+    lsr                                                               ; 21b1: 4a          J   :81b1[1]
+    lsr                                                               ; 21b2: 4a          J   :81b2[1]
+    lsr                                                               ; 21b3: 4a          J   :81b3[1]
+    and #3                                                            ; 21b4: 29 03       ).  :81b4[1]
+    rts                                                               ; 21b6: 60          `   :81b6[1]
+
+; $21b7 referenced 1 time by $8b54
+sub_c81b7
+    and #8                                                            ; 21b7: 29 08       ).  :81b7[1]
+    beq c81bd                                                         ; 21b9: f0 02       ..  :81b9[1]
+    lda #3                                                            ; 21bb: a9 03       ..  :81bb[1]
+; $21bd referenced 1 time by $81b9
+c81bd
+    rts                                                               ; 21bd: 60          `   :81bd[1]
+
+; $21be referenced 3 times by $9cb3, $9d0c, $9e00
+sub_c81be
+    lsr                                                               ; 21be: 4a          J   :81be[1]
+; $21bf referenced 8 times by $80bc, $84d5, $9527, $9644, $98fb, $a18d, $a9c3, $ac63
+sub_c81bf
+    lsr                                                               ; 21bf: 4a          J   :81bf[1]
+; $21c0 referenced 1 time by $a90d
+sub_c81c0
+    lsr                                                               ; 21c0: 4a          J   :81c0[1]
+    lsr                                                               ; 21c1: 4a          J   :81c1[1]
+    lsr                                                               ; 21c2: 4a          J   :81c2[1]
+    rts                                                               ; 21c3: 60          `   :81c3[1]
+
+; $21c4 referenced 1 time by $9e2a
+sub_c81c4
+    asl                                                               ; 21c4: 0a          .   :81c4[1]
+; $21c5 referenced 2 times by $8a5d, $9bae
+sub_c81c5
+    asl                                                               ; 21c5: 0a          .   :81c5[1]
+    asl                                                               ; 21c6: 0a          .   :81c6[1]
+    asl                                                               ; 21c7: 0a          .   :81c7[1]
+    asl                                                               ; 21c8: 0a          .   :81c8[1]
+    rts                                                               ; 21c9: 60          `   :81c9[1]
+
+; $21ca referenced 1 time by $8867
+sub_c81ca
+    lda #5                                                            ; 21ca: a9 05       ..  :81ca[1]
+    sta l1095                                                         ; 21cc: 8d 95 10    ... :81cc[1]
+    lda l00cd                                                         ; 21cf: a5 cd       ..  :81cf[1]
+    sta l1090                                                         ; 21d1: 8d 90 10    ... :81d1[1]
+    lda #$0a                                                          ; 21d4: a9 0a       ..  :81d4[1]
+    sta l00b0                                                         ; 21d6: 85 b0       ..  :81d6[1]
+    lda l00bc                                                         ; 21d8: a5 bc       ..  :81d8[1]
+    sta l1091                                                         ; 21da: 8d 91 10    ... :81da[1]
+    lda l00bd                                                         ; 21dd: a5 bd       ..  :81dd[1]
+    sta l1092                                                         ; 21df: 8d 92 10    ... :81df[1]
+    lda l1074                                                         ; 21e2: ad 74 10    .t. :81e2[1]
+    sta l1093                                                         ; 21e5: 8d 93 10    ... :81e5[1]
+    lda l1075                                                         ; 21e8: ad 75 10    .u. :81e8[1]
+    sta l1094                                                         ; 21eb: 8d 94 10    ... :81eb[1]
+    lda #$ff                                                          ; 21ee: a9 ff       ..  :81ee[1]
+    sta l1097                                                         ; 21f0: 8d 97 10    ... :81f0[1]
+    lda l00c2                                                         ; 21f3: a5 c2       ..  :81f3[1]
+    jsr sub_c81b0                                                     ; 21f5: 20 b0 81     .. :81f5[1]
+    sta l109a                                                         ; 21f8: 8d 9a 10    ... :81f8[1]
+    lda l00c0                                                         ; 21fb: a5 c0       ..  :81fb[1]
+    sta l109b                                                         ; 21fd: 8d 9b 10    ... :81fd[1]
+    lda l00c1                                                         ; 2200: a5 c1       ..  :8200[1]
+    sta l1099                                                         ; 2202: 8d 99 10    ... :8202[1]
+    lda l00c2                                                         ; 2205: a5 c2       ..  :8205[1]
+    and #3                                                            ; 2207: 29 03       ).  :8207[1]
+    tax                                                               ; 2209: aa          .   :8209[1]
+    lda l00c3                                                         ; 220a: a5 c3       ..  :820a[1]
+; $220c referenced 1 time by $8215
+loop_c820c
+    sec                                                               ; 220c: 38          8   :820c[1]
+; $220d referenced 1 time by $8212
+loop_c820d
+    inc l1097                                                         ; 220d: ee 97 10    ... :820d[1]
+    sbc l00b0                                                         ; 2210: e5 b0       ..  :8210[1]
+    bcs loop_c820d                                                    ; 2212: b0 f9       ..  :8212[1]
+    dex                                                               ; 2214: ca          .   :8214[1]
+    bpl loop_c820c                                                    ; 2215: 10 f5       ..  :8215[1]
+    adc l00b0                                                         ; 2217: 65 b0       e.  :8217[1]
+    sta l1098                                                         ; 2219: 8d 98 10    ... :8219[1]
+; $221c referenced 1 time by $8228
+loop_c821c
+    rts                                                               ; 221c: 60          `   :821c[1]
+
+; $221d referenced 4 times by $825a, $8756, $8788, $879d
+sub_c821d
+    jsr sub_c80ed                                                     ; 221d: 20 ed 80     .. :821d[1]
+    bmi c8225                                                         ; 2220: 30 03       0.  :8220[1]
+; $2222 referenced 1 time by $881b
+sub_c8222
+    jsr sub_c80f3                                                     ; 2222: 20 f3 80     .. :8222[1]
+; $2225 referenced 4 times by $8220, $824e, $8bb7, $a478
+c8225
+    jsr sub_c8284                                                     ; 2225: 20 84 82     .. :8225[1]
+    bcs loop_c821c                                                    ; 2228: b0 f2       ..  :8228[1]
+; $222a referenced 2 times by $89fd, $ab17
+c822a
+    jsr generate_error                                                ; 222a: 20 48 80     H. :822a[1]
+    !byte $d6                                                         ; 222d: d6          .   :822d[1]
+    !text "Not found"                                                 ; 222e: 4e 6f 74... Not :822e[1]
+    !byte 0                                                           ; 2237: 00          .   :8237[1]
+
+sub_c8238
+    jsr sub_c8b7b                                                     ; 2238: 20 7b 8b     {. :8238[1]
+    jsr clc_jmp_gsinit                                                ; 223b: 20 4c 87     L. :823b[1]
+    beq c8243                                                         ; 223e: f0 03       ..  :823e[1]
+    jsr c898a                                                         ; 2240: 20 8a 89     .. :8240[1]
+; $2243 referenced 1 time by $823e
+c8243
+    lda #$2a ; '*'                                                    ; 2243: a9 2a       .*  :8243[1]
+    sta l1000                                                         ; 2245: 8d 00 10    ... :8245[1]
+    jsr c815d                                                         ; 2248: 20 5d 81     ]. :8248[1]
+    jsr sub_c99ac                                                     ; 224b: 20 ac 99     .. :824b[1]
+    jsr c8225                                                         ; 224e: 20 25 82     %. :824e[1]
+    jmp c825d                                                         ; 2251: 4c 5d 82    L]. :8251[1]
+
+sub_c8254
+    jsr sub_c99ac                                                     ; 2254: 20 ac 99     .. :8254[1]
+    jsr sub_ca14a                                                     ; 2257: 20 4a a1     J. :8257[1]
+    jsr sub_c821d                                                     ; 225a: 20 1d 82     .. :825a[1]
+; $225d referenced 2 times by $8251, $8263
+c825d
+    jsr sub_c833a                                                     ; 225d: 20 3a 83     :. :825d[1]
+    jsr sub_c8280                                                     ; 2260: 20 80 82     .. :8260[1]
+    bcs c825d                                                         ; 2263: b0 f8       ..  :8263[1]
+    rts                                                               ; 2265: 60          `   :8265[1]
+
+; $2266 referenced 2 times by $887f, $8895
+sub_c8266
+    jsr sub_c93f9                                                     ; 2266: 20 f9 93     .. :8266[1]
+    lda #0                                                            ; 2269: a9 00       ..  :8269[1]
+    beq c828b                                                         ; 226b: f0 1e       ..  :826b[1]
+; $226d referenced 2 times by $9bd9, $a4f2
+sub_c826d
+    ldx #6                                                            ; 226d: a2 06       ..  :826d[1]
+; $226f referenced 1 time by $8275
+loop_c826f
+    lda l00c5,x                                                       ; 226f: b5 c5       ..  :826f[1]
+    sta l1058,x                                                       ; 2271: 9d 58 10    .X. :8271[1]
+    dex                                                               ; 2274: ca          .   :8274[1]
+    bpl loop_c826f                                                    ; 2275: 10 f8       ..  :8275[1]
+    lda #$20 ; ' '                                                    ; 2277: a9 20       .   :8277[1]
+    sta l105f                                                         ; 2279: 8d 5f 10    ._. :8279[1]
+    lda #$58 ; 'X'                                                    ; 227c: a9 58       .X  :827c[1]
+    bne c8286                                                         ; 227e: d0 06       ..  :827e[1]
+; $2280 referenced 6 times by $8260, $877c, $87ab, $87c6, $8a10, $a4db
+sub_c8280
+    ldx #0                                                            ; 2280: a2 00       ..  :8280[1]
+    beq c8290                                                         ; 2282: f0 0c       ..  :8282[1]
+; $2284 referenced 7 times by $8225, $87bb, $89f8, $8a7a, $8bcf, $9a7b, $9c28
+sub_c8284
+    lda #0                                                            ; 2284: a9 00       ..  :8284[1]
+; $2286 referenced 1 time by $827e
+c8286
+    pha                                                               ; 2286: 48          H   :8286[1]
+    jsr sub_c93fd                                                     ; 2287: 20 fd 93     .. :8287[1]
+    pla                                                               ; 228a: 68          h   :828a[1]
+; $228b referenced 1 time by $826b
+c828b
+    tax                                                               ; 228b: aa          .   :828b[1]
+    lda #0                                                            ; 228c: a9 00       ..  :828c[1]
+    sta l00b6                                                         ; 228e: 85 b6       ..  :828e[1]
+; $2290 referenced 3 times by $8282, $82a4, $82ad
+c8290
+    ldy #0                                                            ; 2290: a0 00       ..  :8290[1]
+    lda #$0e                                                          ; 2292: a9 0e       ..  :8292[1]
+    sta l00b7                                                         ; 2294: 85 b7       ..  :8294[1]
+    lda l00b6                                                         ; 2296: a5 b6       ..  :8296[1]
+    cmp l0f05                                                         ; 2298: cd 05 0f    ... :8298[1]
+    bcs c82e6                                                         ; 229b: b0 49       .I  :829b[1]
+    adc #8                                                            ; 229d: 69 08       i.  :829d[1]
+    sta l00b6                                                         ; 229f: 85 b6       ..  :829f[1]
+    jsr sub_c82bb                                                     ; 22a1: 20 bb 82     .. :82a1[1]
+    bcc c8290                                                         ; 22a4: 90 ea       ..  :82a4[1]
+    lda l00cc                                                         ; 22a6: a5 cc       ..  :82a6[1]
+    ldy #7                                                            ; 22a8: a0 07       ..  :82a8[1]
+    jsr sub_c82e8                                                     ; 22aa: 20 e8 82     .. :82aa[1]
+    bne c8290                                                         ; 22ad: d0 e1       ..  :82ad[1]
+    ldy l00b6                                                         ; 22af: a4 b6       ..  :82af[1]
+    sec                                                               ; 22b1: 38          8   :82b1[1]
+; $22b2 referenced 4 times by $87e8, $8aca, $a27c, $a848
+sub_c82b2
+    dey                                                               ; 22b2: 88          .   :82b2[1]
+    dey                                                               ; 22b3: 88          .   :82b3[1]
+    dey                                                               ; 22b4: 88          .   :82b4[1]
+    dey                                                               ; 22b5: 88          .   :82b5[1]
+    dey                                                               ; 22b6: 88          .   :82b6[1]
+    dey                                                               ; 22b7: 88          .   :82b7[1]
+    dey                                                               ; 22b8: 88          .   :82b8[1]
+    dey                                                               ; 22b9: 88          .   :82b9[1]
+    rts                                                               ; 22ba: 60          `   :82ba[1]
+
+; $22bb referenced 2 times by $82a1, $82c7
+sub_c82bb
+    jsr sub_c83e3                                                     ; 22bb: 20 e3 83     .. :82bb[1]
+; $22be referenced 1 time by $82e4
+c82be
+    lda l1000,x                                                       ; 22be: bd 00 10    ... :82be[1]
+    cmp l10ce                                                         ; 22c1: cd ce 10    ... :82c1[1]
+    bne c82d9                                                         ; 22c4: d0 13       ..  :82c4[1]
+    inx                                                               ; 22c6: e8          .   :82c6[1]
+; $22c7 referenced 1 time by $82cf
+loop_c82c7
+    jsr sub_c82bb                                                     ; 22c7: 20 bb 82     .. :82c7[1]
+    bcs c82e7                                                         ; 22ca: b0 1b       ..  :82ca[1]
+    iny                                                               ; 22cc: c8          .   :82cc[1]
+    cpy #7                                                            ; 22cd: c0 07       ..  :82cd[1]
+    bcc loop_c82c7                                                    ; 22cf: 90 f6       ..  :82cf[1]
+; $22d1 referenced 1 time by $82db
+loop_c82d1
+    lda l1000,x                                                       ; 22d1: bd 00 10    ... :82d1[1]
+    cmp #$20 ; ' '                                                    ; 22d4: c9 20       .   :82d4[1]
+    bne c82e6                                                         ; 22d6: d0 0e       ..  :82d6[1]
+    rts                                                               ; 22d8: 60          `   :82d8[1]
+
+; $22d9 referenced 1 time by $82c4
+c82d9
+    cpy #7                                                            ; 22d9: c0 07       ..  :82d9[1]
+    bcs loop_c82d1                                                    ; 22db: b0 f4       ..  :82db[1]
+    jsr sub_c82e8                                                     ; 22dd: 20 e8 82     .. :82dd[1]
+    bne c82e6                                                         ; 22e0: d0 04       ..  :82e0[1]
+    inx                                                               ; 22e2: e8          .   :82e2[1]
+    iny                                                               ; 22e3: c8          .   :82e3[1]
+    bne c82be                                                         ; 22e4: d0 d8       ..  :82e4[1]
+; $22e6 referenced 3 times by $829b, $82d6, $82e0
+c82e6
+    clc                                                               ; 22e6: 18          .   :82e6[1]
+; $22e7 referenced 1 time by $82ca
+c82e7
+    rts                                                               ; 22e7: 60          `   :82e7[1]
+
+; $22e8 referenced 2 times by $82aa, $82dd
+sub_c82e8
+    cmp l10ce                                                         ; 22e8: cd ce 10    ... :82e8[1]
+    beq c82fd                                                         ; 22eb: f0 10       ..  :82eb[1]
+    cmp l10cd                                                         ; 22ed: cd cd 10    ... :82ed[1]
+    beq c82fd                                                         ; 22f0: f0 0b       ..  :82f0[1]
+    jsr sub_c8327                                                     ; 22f2: 20 27 83     '. :82f2[1]
+    eor (l00b6),y                                                     ; 22f5: 51 b6       Q.  :82f5[1]
+    bcs c82fb                                                         ; 22f7: b0 02       ..  :82f7[1]
+    and #$5f ; '_'                                                    ; 22f9: 29 5f       )_  :82f9[1]
+; $22fb referenced 1 time by $82f7
+c82fb
+    and #$7f                                                          ; 22fb: 29 7f       ).  :82fb[1]
+; $22fd referenced 2 times by $82eb, $82f0
+c82fd
+    rts                                                               ; 22fd: 60          `   :82fd[1]
+
+; $22fe referenced 6 times by $8441, $8567, $857e, $858e, $aa2b, $aa3b
+sub_c82fe
+    php                                                               ; 22fe: 08          .   :82fe[1]
+    jsr sub_c8327                                                     ; 22ff: 20 27 83     '. :82ff[1]
+    bcs c8306                                                         ; 2302: b0 02       ..  :8302[1]
+    and #$5f ; '_'                                                    ; 2304: 29 5f       )_  :8304[1]
+; $2306 referenced 1 time by $8302
+c8306
+    and #$7f                                                          ; 2306: 29 7f       ).  :8306[1]
+    plp                                                               ; 2308: 28          (   :8308[1]
+    rts                                                               ; 2309: 60          `   :8309[1]
+
+; $230a referenced 5 times by $878e, $87e3, $8a7f, $99c4, $a4f7
+sub_c830a
+    jsr sub_c9a60                                                     ; 230a: 20 60 9a     `. :830a[1]
+; $230d referenced 1 time by $831d
+loop_c830d
+    lda l0e10,y                                                       ; 230d: b9 10 0e    ... :830d[1]
+    sta l0e08,y                                                       ; 2310: 99 08 0e    ... :8310[1]
+    lda l0f10,y                                                       ; 2313: b9 10 0f    ... :8313[1]
+    sta l0f08,y                                                       ; 2316: 99 08 0f    ... :8316[1]
+    iny                                                               ; 2319: c8          .   :8319[1]
+    cpy l0f05                                                         ; 231a: cc 05 0f    ... :831a[1]
+    bcc loop_c830d                                                    ; 231d: 90 ee       ..  :831d[1]
+    tya                                                               ; 231f: 98          .   :831f[1]
+    sbc #8                                                            ; 2320: e9 08       ..  :8320[1]
+    sta l0f05                                                         ; 2322: 8d 05 0f    ... :8322[1]
+    clc                                                               ; 2325: 18          .   :8325[1]
+; $2326 referenced 1 time by $8338
+loop_c8326
+    rts                                                               ; 2326: 60          `   :8326[1]
+
+; $2327 referenced 4 times by $82f2, $82ff, $8736, $98a8
+sub_c8327
+    pha                                                               ; 2327: 48          H   :8327[1]
+    and #$5f ; '_'                                                    ; 2328: 29 5f       )_  :8328[1]
+    cmp #$41 ; 'A'                                                    ; 232a: c9 41       .A  :832a[1]
+    bcc c8332                                                         ; 232c: 90 04       ..  :832c[1]
+    cmp #$5b ; '['                                                    ; 232e: c9 5b       .[  :832e[1]
+    bcc c8333                                                         ; 2330: 90 01       ..  :8330[1]
+; $2332 referenced 1 time by $832c
+c8332
+    sec                                                               ; 2332: 38          8   :8332[1]
+; $2333 referenced 1 time by $8330
+c8333
+    pla                                                               ; 2333: 68          h   :8333[1]
+    rts                                                               ; 2334: 60          `   :8334[1]
+
+; $2335 referenced 5 times by $878b, $884f, $8a0d, $8b04, $a2ad
+sub_c8335
+    bit l10c6                                                         ; 2335: 2c c6 10    ,.. :8335[1]
+    bmi loop_c8326                                                    ; 2338: 30 ec       0.  :8338[1]
+; $233a referenced 3 times by $825d, $a30f, $a482
+sub_c833a
+    jsr sub_c83e3                                                     ; 233a: 20 e3 83     .. :833a[1]
+    jsr sub_c8174                                                     ; 233d: 20 74 81     t. :833d[1]
+    tya                                                               ; 2340: 98          .   :8340[1]
+    pha                                                               ; 2341: 48          H   :8341[1]
+    lda #$60 ; '`'                                                    ; 2342: a9 60       .`  :8342[1]
+    sta l00b0                                                         ; 2344: 85 b0       ..  :8344[1]
+    lda #$10                                                          ; 2346: a9 10       ..  :8346[1]
+    sta l00b1                                                         ; 2348: 85 b1       ..  :8348[1]
+    jsr sub_c8386                                                     ; 234a: 20 86 83     .. :834a[1]
+    ldy #2                                                            ; 234d: a0 02       ..  :834d[1]
+    jsr cac0f                                                         ; 234f: 20 0f ac     .. :834f[1]
+    jsr sub_c836e                                                     ; 2352: 20 6e 83     n. :8352[1]
+    jsr sub_c836e                                                     ; 2355: 20 6e 83     n. :8355[1]
+    jsr sub_c836e                                                     ; 2358: 20 6e 83     n. :8358[1]
+    pla                                                               ; 235b: 68          h   :835b[1]
+    tay                                                               ; 235c: a8          .   :835c[1]
+    lda l0f0e,y                                                       ; 235d: b9 0e 0f    ... :835d[1]
+    and #3                                                            ; 2360: 29 03       ).  :8360[1]
+    jsr sub_c80c3                                                     ; 2362: 20 c3 80     .. :8362[1]
+    lda l0f0f,y                                                       ; 2365: b9 0f 0f    ... :8365[1]
+    jsr sub_c80bb                                                     ; 2368: 20 bb 80     .. :8368[1]
+    jmp ca3dc                                                         ; 236b: 4c dc a3    L.. :836b[1]
+
+; $236e referenced 3 times by $8352, $8355, $8358
+sub_c836e
+    ldx #3                                                            ; 236e: a2 03       ..  :836e[1]
+; $2370 referenced 1 time by $8378
+loop_c8370
+    lda l1062,y                                                       ; 2370: b9 62 10    .b. :8370[1]
+    jsr sub_c80bb                                                     ; 2373: 20 bb 80     .. :8373[1]
+    dey                                                               ; 2376: 88          .   :8376[1]
+    dex                                                               ; 2377: ca          .   :8377[1]
+    bne loop_c8370                                                    ; 2378: d0 f6       ..  :8378[1]
+    jsr sub_c87db                                                     ; 237a: 20 db 87     .. :837a[1]
+    jmp cac0f                                                         ; 237d: 4c 0f ac    L.. :837d[1]
+
+; $2380 referenced 7 times by $89bd, $975e, $9bf8, $a26a, $a4d1, $a4ef, $a7fc
+sub_c8380
+    jsr sub_c83e3                                                     ; 2380: 20 e3 83     .. :8380[1]
+    jmp c940c                                                         ; 2383: 4c 0c 94    L.. :8383[1]
+
+; $2386 referenced 5 times by $834a, $8821, $885f, $99b8, $99c1
+sub_c8386
+    jsr sub_c83e3                                                     ; 2386: 20 e3 83     .. :8386[1]
+    tya                                                               ; 2389: 98          .   :8389[1]
+    pha                                                               ; 238a: 48          H   :838a[1]
+    tax                                                               ; 238b: aa          .   :838b[1]
+    ldy #$12                                                          ; 238c: a0 12       ..  :838c[1]
+    lda #0                                                            ; 238e: a9 00       ..  :838e[1]
+; $2390 referenced 1 time by $8395
+loop_c8390
+    dey                                                               ; 2390: 88          .   :8390[1]
+    sta (l00b0),y                                                     ; 2391: 91 b0       ..  :8391[1]
+    cpy #2                                                            ; 2393: c0 02       ..  :8393[1]
+    bne loop_c8390                                                    ; 2395: d0 f9       ..  :8395[1]
+; $2397 referenced 1 time by $839e
+loop_c8397
+    jsr sub_c83d1                                                     ; 2397: 20 d1 83     .. :8397[1]
+    iny                                                               ; 239a: c8          .   :839a[1]
+    iny                                                               ; 239b: c8          .   :839b[1]
+    cpy #$0e                                                          ; 239c: c0 0e       ..  :839c[1]
+    bne loop_c8397                                                    ; 239e: d0 f7       ..  :839e[1]
+    pla                                                               ; 23a0: 68          h   :83a0[1]
+    tax                                                               ; 23a1: aa          .   :83a1[1]
+    lda l0e0f,x                                                       ; 23a2: bd 0f 0e    ... :83a2[1]
+    bpl c83ab                                                         ; 23a5: 10 04       ..  :83a5[1]
+    lda #8                                                            ; 23a7: a9 08       ..  :83a7[1]
+    sta (l00b0),y                                                     ; 23a9: 91 b0       ..  :83a9[1]
+; $23ab referenced 1 time by $83a5
+c83ab
+    lda l0f0e,x                                                       ; 23ab: bd 0e 0f    ... :83ab[1]
+    ldy #4                                                            ; 23ae: a0 04       ..  :83ae[1]
+    jsr sub_c83bf                                                     ; 23b0: 20 bf 83     .. :83b0[1]
+    ldy #$0c                                                          ; 23b3: a0 0c       ..  :83b3[1]
+    lsr                                                               ; 23b5: 4a          J   :83b5[1]
+    lsr                                                               ; 23b6: 4a          J   :83b6[1]
+    pha                                                               ; 23b7: 48          H   :83b7[1]
+    and #3                                                            ; 23b8: 29 03       ).  :83b8[1]
+    sta (l00b0),y                                                     ; 23ba: 91 b0       ..  :83ba[1]
+    pla                                                               ; 23bc: 68          h   :83bc[1]
+    ldy #8                                                            ; 23bd: a0 08       ..  :83bd[1]
+; $23bf referenced 1 time by $83b0
+sub_c83bf
+    lsr                                                               ; 23bf: 4a          J   :83bf[1]
+    lsr                                                               ; 23c0: 4a          J   :83c0[1]
+    pha                                                               ; 23c1: 48          H   :83c1[1]
+    and #3                                                            ; 23c2: 29 03       ).  :83c2[1]
+    cmp #3                                                            ; 23c4: c9 03       ..  :83c4[1]
+    bne c83cd                                                         ; 23c6: d0 05       ..  :83c6[1]
+    lda #$ff                                                          ; 23c8: a9 ff       ..  :83c8[1]
+    sta (l00b0),y                                                     ; 23ca: 91 b0       ..  :83ca[1]
+    iny                                                               ; 23cc: c8          .   :83cc[1]
+; $23cd referenced 1 time by $83c6
+c83cd
+    sta (l00b0),y                                                     ; 23cd: 91 b0       ..  :83cd[1]
+    pla                                                               ; 23cf: 68          h   :83cf[1]
+    rts                                                               ; 23d0: 60          `   :83d0[1]
+
+; $23d1 referenced 1 time by $8397
+sub_c83d1
+    jsr sub_c83d4                                                     ; 23d1: 20 d4 83     .. :83d1[1]
+; $23d4 referenced 1 time by $83d1
+sub_c83d4
+    lda l0f08,x                                                       ; 23d4: bd 08 0f    ... :83d4[1]
+    sta (l00b0),y                                                     ; 23d7: 91 b0       ..  :83d7[1]
+    inx                                                               ; 23d9: e8          .   :83d9[1]
+    iny                                                               ; 23da: c8          .   :83da[1]
+    rts                                                               ; 23db: 60          `   :83db[1]
+
+; $23dc referenced 4 times by $805b, $8064, $8086, $a9ab
+inc16_ae
+    inc l00ae                                                         ; 23dc: e6 ae       ..  :83dc[1]
+    bne c83e2                                                         ; 23de: d0 02       ..  :83de[1]
+    inc l00af                                                         ; 23e0: e6 af       ..  :83e0[1]
+; $23e2 referenced 1 time by $83de
+c83e2
+    rts                                                               ; 23e2: 60          `   :83e2[1]
+
+; $23e3 referenced 29 times by $809f, $8174, $82bb, $833a, $8380, $8386, $8951, $8a32, $96c3, $97cd, $993b, $99f3, $9a0f, $9a32, $9a63, $9ac8, $9ad8, $9b51, $9bf2, $9c10, $9d9b, $9f7c, $9f82, $a06c, $a190, $a1b4, $a379, $a384, $ac72
+sub_c83e3
+    pha                                                               ; 23e3: 48          H   :83e3[1]
+    txa                                                               ; 23e4: 8a          .   :83e4[1]
+    pha                                                               ; 23e5: 48          H   :83e5[1]
+    tya                                                               ; 23e6: 98          .   :83e6[1]
+    pha                                                               ; 23e7: 48          H   :83e7[1]
+    lda #$84                                                          ; 23e8: a9 84       ..  :83e8[1]
+    pha                                                               ; 23ea: 48          H   :83ea[1]
+    lda #5                                                            ; 23eb: a9 05       ..  :83eb[1]
+    pha                                                               ; 23ed: 48          H   :83ed[1]
+; $23ee referenced 1 time by $8411
+sub_c83ee
+    ldy #5                                                            ; 23ee: a0 05       ..  :83ee[1]
+; $23f0 referenced 1 time by $83f6
+loop_c83f0
+    tsx                                                               ; 23f0: ba          .   :83f0[1]
+    lda l0107,x                                                       ; 23f1: bd 07 01    ... :83f1[1]
+    pha                                                               ; 23f4: 48          H   :83f4[1]
+    dey                                                               ; 23f5: 88          .   :83f5[1]
+    bne loop_c83f0                                                    ; 23f6: d0 f8       ..  :83f6[1]
+    ldy #$0a                                                          ; 23f8: a0 0a       ..  :83f8[1]
+; $23fa referenced 1 time by $8402
+loop_c83fa
+    lda l0109,x                                                       ; 23fa: bd 09 01    ... :83fa[1]
+    sta l010b,x                                                       ; 23fd: 9d 0b 01    ... :83fd[1]
+    dex                                                               ; 2400: ca          .   :8400[1]
+    dey                                                               ; 2401: 88          .   :8401[1]
+    bne loop_c83fa                                                    ; 2402: d0 f6       ..  :8402[1]
+    pla                                                               ; 2404: 68          h   :8404[1]
+    pla                                                               ; 2405: 68          h   :8405[1]
+; $2406 referenced 1 time by $8418
+loop_c8406
+    pla                                                               ; 2406: 68          h   :8406[1]
+    tay                                                               ; 2407: a8          .   :8407[1]
+    pla                                                               ; 2408: 68          h   :8408[1]
+    tax                                                               ; 2409: aa          .   :8409[1]
+    pla                                                               ; 240a: 68          h   :840a[1]
+    rts                                                               ; 240b: 60          `   :840b[1]
+
+; $240c referenced 5 times by $841b, $9785, $9c16, $9e94, $aadd
+sub_c840c
+    pha                                                               ; 240c: 48          H   :840c[1]
+    txa                                                               ; 240d: 8a          .   :840d[1]
+    pha                                                               ; 240e: 48          H   :840e[1]
+    tya                                                               ; 240f: 98          .   :840f[1]
+    pha                                                               ; 2410: 48          H   :8410[1]
+    jsr sub_c83ee                                                     ; 2411: 20 ee 83     .. :8411[1]
+    tsx                                                               ; 2414: ba          .   :8414[1]
+    sta l0103,x                                                       ; 2415: 9d 03 01    ... :8415[1]
+    jmp loop_c8406                                                    ; 2418: 4c 06 84    L.. :8418[1]
+
+; $241b referenced 2 times by $80b8, $a9bf
+sub_c841b
+    jsr sub_c840c                                                     ; 241b: 20 0c 84     .. :841b[1]
+    tay                                                               ; 241e: a8          .   :841e[1]
+    beq c842b                                                         ; 241f: f0 0a       ..  :841f[1]
+    clc                                                               ; 2421: 18          .   :8421[1]
+    sed                                                               ; 2422: f8          .   :8422[1]
+    lda #0                                                            ; 2423: a9 00       ..  :8423[1]
+; $2425 referenced 1 time by $8428
+loop_c8425
+    adc #1                                                            ; 2425: 69 01       i.  :8425[1]
+    dey                                                               ; 2427: 88          .   :8427[1]
+    bne loop_c8425                                                    ; 2428: d0 fb       ..  :8428[1]
+    cld                                                               ; 242a: d8          .   :842a[1]
+; $242b referenced 1 time by $841f
+c842b
+    rts                                                               ; 242b: 60          `   :842b[1]
+
+; $242c referenced 1 time by $abb1
+sub_c842c
+    and #$7f                                                          ; 242c: 29 7f       ).  :842c[1]
+    cmp #$7f                                                          ; 242e: c9 7f       ..  :842e[1]
+    beq c8436                                                         ; 2430: f0 04       ..  :8430[1]
+    cmp #$20 ; ' '                                                    ; 2432: c9 20       .   :8432[1]
+    bcs c8438                                                         ; 2434: b0 02       ..  :8434[1]
+; $2436 referenced 1 time by $8430
+c8436
+    lda #$2e ; '.'                                                    ; 2436: a9 2e       ..  :8436[1]
+; $2438 referenced 1 time by $8434
+c8438
+    rts                                                               ; 2438: 60          `   :8438[1]
+
+; $2439 referenced 2 times by $8444, $8463
+sub_c8439
+    sec                                                               ; 2439: 38          8   :8439[1]
+    sbc #$30 ; '0'                                                    ; 243a: e9 30       .0  :843a[1]
+    bcc c8454                                                         ; 243c: 90 16       ..  :843c[1]
+    cmp #$0a                                                          ; 243e: c9 0a       ..  :843e[1]
+    rts                                                               ; 2440: 60          `   :8440[1]
+
+    jsr sub_c82fe                                                     ; 2441: 20 fe 82     .. :8441[1]
+    jsr sub_c8439                                                     ; 2444: 20 39 84     9. :8444[1]
+    bcc c8453                                                         ; 2447: 90 0a       ..  :8447[1]
+    sbc #7                                                            ; 2449: e9 07       ..  :8449[1]
+    bcc c8454                                                         ; 244b: 90 07       ..  :844b[1]
+    cmp #$0a                                                          ; 244d: c9 0a       ..  :844d[1]
+    bcc c8454                                                         ; 244f: 90 03       ..  :844f[1]
+    cmp #$10                                                          ; 2451: c9 10       ..  :8451[1]
+; $2453 referenced 1 time by $8447
+c8453
+    rts                                                               ; 2453: 60          `   :8453[1]
+
+; $2454 referenced 3 times by $843c, $844b, $844f
+c8454
+    sec                                                               ; 2454: 38          8   :8454[1]
+    rts                                                               ; 2455: 60          `   :8455[1]
+
+; $2456 referenced 3 times by $87f7, $a5ce, $a9e7
+sub_c8456
+    jsr clc_jmp_gsinit                                                ; 2456: 20 4c 87     L. :8456[1]
+    sec                                                               ; 2459: 38          8   :8459[1]
+    beq c8482                                                         ; 245a: f0 26       .&  :845a[1]
+    php                                                               ; 245c: 08          .   :845c[1]
+    lda #0                                                            ; 245d: a9 00       ..  :845d[1]
+    sta l00b9                                                         ; 245f: 85 b9       ..  :845f[1]
+    beq c8477                                                         ; 2461: f0 14       ..  :8461[1]
+; $2463 referenced 1 time by $847a
+loop_c8463
+    jsr sub_c8439                                                     ; 2463: 20 39 84     9. :8463[1]
+    bcs c8481                                                         ; 2466: b0 19       ..  :8466[1]
+    sta l00b8                                                         ; 2468: 85 b8       ..  :8468[1]
+    lda l00b9                                                         ; 246a: a5 b9       ..  :846a[1]
+    asl                                                               ; 246c: 0a          .   :846c[1]
+    sta l00b9                                                         ; 246d: 85 b9       ..  :846d[1]
+    asl                                                               ; 246f: 0a          .   :846f[1]
+    asl                                                               ; 2470: 0a          .   :8470[1]
+    adc l00b9                                                         ; 2471: 65 b9       e.  :8471[1]
+    adc l00b8                                                         ; 2473: 65 b8       e.  :8473[1]
+    sta l00b9                                                         ; 2475: 85 b9       ..  :8475[1]
+; $2477 referenced 1 time by $8461
+c8477
+    jsr gsread                                                        ; 2477: 20 c5 ff     .. :8477[1]
+    bcc loop_c8463                                                    ; 247a: 90 e7       ..  :847a[1]
+    lda l00b9                                                         ; 247c: a5 b9       ..  :847c[1]
+    plp                                                               ; 247e: 28          (   :847e[1]
+    clc                                                               ; 247f: 18          .   :847f[1]
+    rts                                                               ; 2480: 60          `   :8480[1]
+
+; $2481 referenced 1 time by $8466
+c8481
+    plp                                                               ; 2481: 28          (   :8481[1]
+; $2482 referenced 1 time by $845a
+c8482
+    rts                                                               ; 2482: 60          `   :8482[1]
+
+    jsr sub_c8745                                                     ; 2483: 20 45 87     E. :8483[1]
+    jsr sub_c8b86                                                     ; 2486: 20 86 8b     .. :8486[1]
+    jsr c940c                                                         ; 2489: 20 0c 94     .. :8489[1]
+    ldy #$ff                                                          ; 248c: a0 ff       ..  :848c[1]
+    sty l00a8                                                         ; 248e: 84 a8       ..  :848e[1]
+    iny                                                               ; 2490: c8          .   :8490[1]
+    sty l00aa                                                         ; 2491: 84 aa       ..  :8491[1]
+; $2493 referenced 1 time by $84a3
+loop_c8493
+    lda l0e00,y                                                       ; 2493: b9 00 0e    ... :8493[1]
+    cpy #8                                                            ; 2496: c0 08       ..  :8496[1]
+    bcc c849d                                                         ; 2498: 90 03       ..  :8498[1]
+    lda l0ef8,y                                                       ; 249a: b9 f8 0e    ... :849a[1]
+; $249d referenced 1 time by $8498
+c849d
+    jsr c809f                                                         ; 249d: 20 9f 80     .. :849d[1]
+    iny                                                               ; 24a0: c8          .   :84a0[1]
+    cpy #$0c                                                          ; 24a1: c0 0c       ..  :84a1[1]
+    bne loop_c8493                                                    ; 24a3: d0 ee       ..  :84a3[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 24a5: 20 77 80     w. :84a5[1]
+    !text " ("                                                        ; 24a8: 20 28        (  :84a8[1]
+
+    lda l0f04                                                         ; 24aa: ad 04 0f    ... :84aa[1]
+    jsr sub_c80bb                                                     ; 24ad: 20 bb 80     .. :84ad[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 24b0: 20 77 80     w. :84b0[1]
+    !text ") FM", $0d, "Drive "                                       ; 24b3: 29 20 46... ) F :84b3[1]
+
+    lda l00cd                                                         ; 24be: a5 cd       ..  :84be[1]
+    jsr sub_c80c3                                                     ; 24c0: 20 c3 80     .. :84c0[1]
+    ldy #$0d                                                          ; 24c3: a0 0d       ..  :84c3[1]
+    jsr c81a7                                                         ; 24c5: 20 a7 81     .. :84c5[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 24c8: 20 77 80     w. :84c8[1]
+    !text "Option "                                                   ; 24cb: 4f 70 74... Opt :84cb[1]
+
+    lda l0f06                                                         ; 24d2: ad 06 0f    ... :84d2[1]
+    jsr sub_c81bf                                                     ; 24d5: 20 bf 81     .. :84d5[1]
+    pha                                                               ; 24d8: 48          H   :84d8[1]
+    jsr sub_c80c3                                                     ; 24d9: 20 c3 80     .. :84d9[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 24dc: 20 77 80     w. :84dc[1]
+    !text " ("                                                        ; 24df: 20 28        (  :84df[1]
+
+    ldy #3                                                            ; 24e1: a0 03       ..  :84e1[1]
+    pla                                                               ; 24e3: 68          h   :84e3[1]
+    asl                                                               ; 24e4: 0a          .   :84e4[1]
+    asl                                                               ; 24e5: 0a          .   :84e5[1]
+    tax                                                               ; 24e6: aa          .   :84e6[1]
+; $24e7 referenced 1 time by $84ef
+loop_c84e7
+    lda opt4_table,x                                                  ; 24e7: bd d3 85    ... :84e7[1]
+    jsr c809f                                                         ; 24ea: 20 9f 80     .. :84ea[1]
+    inx                                                               ; 24ed: e8          .   :84ed[1]
+    dey                                                               ; 24ee: 88          .   :84ee[1]
+    bpl loop_c84e7                                                    ; 24ef: 10 f6       ..  :84ef[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 24f1: 20 77 80     w. :84f1[1]
+    !text ")", $0d, "Dir. :"                                          ; 24f4: 29 0d 44... ).D :84f4[1]
+
+    lda l10ca                                                         ; 24fc: ad ca 10    ... :84fc[1]
+    jsr sub_c809a                                                     ; 24ff: 20 9a 80     .. :84ff[1]
+    lda l10c9                                                         ; 2502: ad c9 10    ... :8502[1]
+    jsr c809f                                                         ; 2505: 20 9f 80     .. :8505[1]
+    ldy #$0b                                                          ; 2508: a0 0b       ..  :8508[1]
+    jsr c81a7                                                         ; 250a: 20 a7 81     .. :850a[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 250d: 20 77 80     w. :850d[1]
+    !text "Lib. :"                                                    ; 2510: 4c 69 62... Lib :8510[1]
+
+    lda l10cc                                                         ; 2516: ad cc 10    ... :8516[1]
+    jsr sub_c809a                                                     ; 2519: 20 9a 80     .. :8519[1]
+    lda l10cb                                                         ; 251c: ad cb 10    ... :851c[1]
+    jsr c809f                                                         ; 251f: 20 9f 80     .. :851f[1]
+    jsr ca3dc                                                         ; 2522: 20 dc a3     .. :8522[1]
+    ldy #0                                                            ; 2525: a0 00       ..  :8525[1]
+; $2527 referenced 1 time by $8541
+loop_c8527
+    cpy l0f05                                                         ; 2527: cc 05 0f    ... :8527[1]
+    bcs c8543                                                         ; 252a: b0 17       ..  :852a[1]
+    lda l0e0f,y                                                       ; 252c: b9 0f 0e    ... :852c[1]
+    eor l10c9                                                         ; 252f: 4d c9 10    M.. :852f[1]
+    and #$5f ; '_'                                                    ; 2532: 29 5f       )_  :8532[1]
+    bne c853e                                                         ; 2534: d0 08       ..  :8534[1]
+    lda l0e0f,y                                                       ; 2536: b9 0f 0e    ... :8536[1]
+    and #$80                                                          ; 2539: 29 80       ).  :8539[1]
+    sta l0e0f,y                                                       ; 253b: 99 0f 0e    ... :853b[1]
+; $253e referenced 1 time by $8534
+c853e
+    jsr sub_c87da                                                     ; 253e: 20 da 87     .. :853e[1]
+    bcc loop_c8527                                                    ; 2541: 90 e4       ..  :8541[1]
+; $2543 referenced 2 times by $852a, $85d0
+c8543
+    ldy #0                                                            ; 2543: a0 00       ..  :8543[1]
+    jsr sub_c8555                                                     ; 2545: 20 55 85     U. :8545[1]
+    bcc c8560                                                         ; 2548: 90 16       ..  :8548[1]
+    lda #$ff                                                          ; 254a: a9 ff       ..  :854a[1]
+    sta l1082                                                         ; 254c: 8d 82 10    ... :854c[1]
+    jmp ca3dc                                                         ; 254f: 4c dc a3    L.. :854f[1]
+
+; $2552 referenced 1 time by $855d
+loop_c8552
+    jsr sub_c87da                                                     ; 2552: 20 da 87     .. :8552[1]
+; $2555 referenced 2 times by $8545, $8573
+sub_c8555
+    cpy l0f05                                                         ; 2555: cc 05 0f    ... :8555[1]
+    bcs c855f                                                         ; 2558: b0 05       ..  :8558[1]
+    lda l0e08,y                                                       ; 255a: b9 08 0e    ... :855a[1]
+    bmi loop_c8552                                                    ; 255d: 30 f3       0.  :855d[1]
+; $255f referenced 1 time by $8558
+c855f
+    rts                                                               ; 255f: 60          `   :855f[1]
+
+; $2560 referenced 2 times by $8548, $8594
+c8560
+    sty l00ab                                                         ; 2560: 84 ab       ..  :8560[1]
+    ldx #0                                                            ; 2562: a2 00       ..  :8562[1]
+; $2564 referenced 1 time by $8571
+loop_c8564
+    lda l0e08,y                                                       ; 2564: b9 08 0e    ... :8564[1]
+    jsr sub_c82fe                                                     ; 2567: 20 fe 82     .. :8567[1]
+    sta l1060,x                                                       ; 256a: 9d 60 10    .`. :856a[1]
+    iny                                                               ; 256d: c8          .   :856d[1]
+    inx                                                               ; 256e: e8          .   :856e[1]
+    cpx #8                                                            ; 256f: e0 08       ..  :856f[1]
+    bne loop_c8564                                                    ; 2571: d0 f1       ..  :8571[1]
+; $2573 referenced 1 time by $8599
+c8573
+    jsr sub_c8555                                                     ; 2573: 20 55 85     U. :8573[1]
+    bcs c859b                                                         ; 2576: b0 23       .#  :8576[1]
+    sec                                                               ; 2578: 38          8   :8578[1]
+    ldx #6                                                            ; 2579: a2 06       ..  :8579[1]
+; $257b referenced 1 time by $8586
+loop_c857b
+    lda l0e0e,y                                                       ; 257b: b9 0e 0e    ... :857b[1]
+    jsr sub_c82fe                                                     ; 257e: 20 fe 82     .. :857e[1]
+    sbc l1060,x                                                       ; 2581: fd 60 10    .`. :8581[1]
+    dey                                                               ; 2584: 88          .   :8584[1]
+    dex                                                               ; 2585: ca          .   :8585[1]
+    bpl loop_c857b                                                    ; 2586: 10 f3       ..  :8586[1]
+    jsr sub_c87db                                                     ; 2588: 20 db 87     .. :8588[1]
+    lda l0e0f,y                                                       ; 258b: b9 0f 0e    ... :858b[1]
+    jsr sub_c82fe                                                     ; 258e: 20 fe 82     .. :858e[1]
+    sbc l1067                                                         ; 2591: ed 67 10    .g. :8591[1]
+    bcc c8560                                                         ; 2594: 90 ca       ..  :8594[1]
+    jsr sub_c87da                                                     ; 2596: 20 da 87     .. :8596[1]
+    bcs c8573                                                         ; 2599: b0 d8       ..  :8599[1]
+; $259b referenced 1 time by $8576
+c859b
+    ldy l00ab                                                         ; 259b: a4 ab       ..  :859b[1]
+    lda l0e08,y                                                       ; 259d: b9 08 0e    ... :859d[1]
+    ora #$80                                                          ; 25a0: 09 80       ..  :85a0[1]
+    sta l0e08,y                                                       ; 25a2: 99 08 0e    ... :85a2[1]
+    lda l1067                                                         ; 25a5: ad 67 10    .g. :85a5[1]
+    cmp l00aa                                                         ; 25a8: c5 aa       ..  :85a8[1]
+    beq c85bc                                                         ; 25aa: f0 10       ..  :85aa[1]
+    ldx l00aa                                                         ; 25ac: a6 aa       ..  :85ac[1]
+    sta l00aa                                                         ; 25ae: 85 aa       ..  :85ae[1]
+    bne c85bc                                                         ; 25b0: d0 0a       ..  :85b0[1]
+    jsr ca3dc                                                         ; 25b2: 20 dc a3     .. :85b2[1]
+; $25b5 referenced 1 time by $85be
+loop_c85b5
+    jsr ca3dc                                                         ; 25b5: 20 dc a3     .. :85b5[1]
+    ldy #$ff                                                          ; 25b8: a0 ff       ..  :85b8[1]
+    bne c85c5                                                         ; 25ba: d0 09       ..  :85ba[1]
+; $25bc referenced 2 times by $85aa, $85b0
+c85bc
+    ldy l00a8                                                         ; 25bc: a4 a8       ..  :85bc[1]
+    bne loop_c85b5                                                    ; 25be: d0 f5       ..  :85be[1]
+    ldy #5                                                            ; 25c0: a0 05       ..  :85c0[1]
+    jsr c81a7                                                         ; 25c2: 20 a7 81     .. :85c2[1]
+; $25c5 referenced 1 time by $85ba
+c85c5
+    iny                                                               ; 25c5: c8          .   :85c5[1]
+    sty l00a8                                                         ; 25c6: 84 a8       ..  :85c6[1]
+    ldy l00ab                                                         ; 25c8: a4 ab       ..  :85c8[1]
+    jsr sub_cac0c                                                     ; 25ca: 20 0c ac     .. :85ca[1]
+    jsr sub_c8174                                                     ; 25cd: 20 74 81     t. :85cd[1]
+    jmp c8543                                                         ; 25d0: 4c 43 85    LC. :85d0[1]
+
+; $25d3 referenced 1 time by $84e7
+opt4_table
+    !text "off", 0                                                    ; 25d3: 6f 66 66... off :85d3[1]
+    !text "LOAD"                                                      ; 25d7: 4c 4f 41... LOA :85d7[1]
+    !text "RUN", 0                                                    ; 25db: 52 55 4e... RUN :85db[1]
+    !text "EXEC"                                                      ; 25df: 45 58 45... EXE :85df[1]
+
+; $25e3 referenced 1 time by $8acd
+sub_c85e3
+    lda l0f0e,y                                                       ; 25e3: b9 0e 0f    ... :85e3[1]
+    jsr sub_c81b0                                                     ; 25e6: 20 b0 81     .. :85e6[1]
+    sta l00c2                                                         ; 25e9: 85 c2       ..  :85e9[1]
+    clc                                                               ; 25eb: 18          .   :85eb[1]
+    lda #$ff                                                          ; 25ec: a9 ff       ..  :85ec[1]
+    adc l0f0c,y                                                       ; 25ee: 79 0c 0f    y.. :85ee[1]
+    lda l0f0f,y                                                       ; 25f1: b9 0f 0f    ... :85f1[1]
+    adc l0f0d,y                                                       ; 25f4: 79 0d 0f    y.. :85f4[1]
+    sta l00c3                                                         ; 25f7: 85 c3       ..  :85f7[1]
+    lda l0f0e,y                                                       ; 25f9: b9 0e 0f    ... :85f9[1]
+    and #3                                                            ; 25fc: 29 03       ).  :85fc[1]
+    adc l00c2                                                         ; 25fe: 65 c2       e.  :85fe[1]
+    sta l00c2                                                         ; 2600: 85 c2       ..  :8600[1]
+; $2602 referenced 1 time by $8ac2
+sub_c8602
+    sec                                                               ; 2602: 38          8   :8602[1]
+    lda l0f07,y                                                       ; 2603: b9 07 0f    ... :8603[1]
+    sbc l00c3                                                         ; 2606: e5 c3       ..  :8606[1]
+    pha                                                               ; 2608: 48          H   :8608[1]
+    lda l0f06,y                                                       ; 2609: b9 06 0f    ... :8609[1]
+    and #3                                                            ; 260c: 29 03       ).  :860c[1]
+    sbc l00c2                                                         ; 260e: e5 c2       ..  :860e[1]
+    tax                                                               ; 2610: aa          .   :8610[1]
+    lda #0                                                            ; 2611: a9 00       ..  :8611[1]
+    cmp l00c0                                                         ; 2613: c5 c0       ..  :8613[1]
+    pla                                                               ; 2615: 68          h   :8615[1]
+    sbc l00c1                                                         ; 2616: e5 c1       ..  :8616[1]
+    txa                                                               ; 2618: 8a          .   :8618[1]
+    sbc l00c4                                                         ; 2619: e5 c4       ..  :8619[1]
+    rts                                                               ; 261b: 60          `   :861b[1]
+
+; $261c referenced 6 times by $870e, $8719, $8726, $873c, $a16f, $a187
+command_table
+    !text "ACCESS"                                                    ; 261c: 41 43 43... ACC :861c[1]
+; $261d referenced 1 time by $8740
+    !byte >(sub_c89e6-1)                                              ; 2622: 89          .   :8622[1]
+    !byte <(sub_c89e6-1)                                              ; 2623: e5          .   :8623[1]
+    !byte $32                                                         ; 2624: 32          2   :8624[1]
+    !text "BACKUP"                                                    ; 2625: 42 41 43... BAC :8625[1]
+    !byte >(sub_ca417-1)                                              ; 262b: a4          .   :862b[1]
+    !byte <(sub_ca417-1)                                              ; 262c: 16          .   :862c[1]
+    !byte 4                                                           ; 262d: 04          .   :862d[1]
+    !text "CLOSE"                                                     ; 262e: 43 4c 4f... CLO :862e[1]
+    !byte >(sub_c9b59-1)                                              ; 2633: 9b          .   :8633[1]
+    !byte <(sub_c9b59-1)                                              ; 2634: 58          X   :8634[1]
+    !byte 0                                                           ; 2635: 00          .   :8635[1]
+    !text "COMPACT"                                                   ; 2636: 43 4f 4d... COM :8636[1]
+    !byte >(sub_ca244-1)                                              ; 263d: a2          .   :863d[1]
+    !byte <(sub_ca244-1)                                              ; 263e: 43          C   :863e[1]
+    !byte 7                                                           ; 263f: 07          .   :863f[1]
+    !text "COPY"                                                      ; 2640: 43 4f 50... COP :8640[1]
+    !byte >(sub_ca463-1)                                              ; 2644: a4          .   :8644[1]
+    !byte <(sub_ca463-1)                                              ; 2645: 62          b   :8645[1]
+    !byte $24                                                         ; 2646: 24          $   :8646[1]
+    !text "DELETE"                                                    ; 2647: 44 45 4c... DEL :8647[1]
+    !byte >(sub_c8782-1)                                              ; 264d: 87          .   :864d[1]
+    !byte <(sub_c8782-1)                                              ; 264e: 81          .   :864e[1]
+    !byte 1                                                           ; 264f: 01          .   :864f[1]
+    !text "DESTROY"                                                   ; 2650: 44 45 53... DES :8650[1]
+    !byte >(sub_c8794-1)                                              ; 2657: 87          .   :8657[1]
+    !byte <(sub_c8794-1)                                              ; 2658: 93          .   :8658[1]
+    !byte 2                                                           ; 2659: 02          .   :8659[1]
+    !text "DIR"                                                       ; 265a: 44 49 52    DIR :865a[1]
+    !byte >(sub_c893f-1)                                              ; 265d: 89          .   :865d[1]
+    !byte <(sub_c893f-1)                                              ; 265e: 3e          >   :865e[1]
+    !byte 6                                                           ; 265f: 06          .   :865f[1]
+    !text "DRIVE"                                                     ; 2660: 44 52 49... DRI :8660[1]
+    !byte >(sub_c87ee-1)                                              ; 2665: 87          .   :8665[1]
+    !byte <(sub_c87ee-1)                                              ; 2666: ed          .   :8666[1]
+    !byte 9                                                           ; 2667: 09          .   :8667[1]
+    !text "ENABLE"                                                    ; 2668: 45 4e 41... ENA :8668[1]
+    !byte >(sub_c8b47-1)                                              ; 266e: 8b          .   :866e[1]
+    !byte <(sub_c8b47-1)                                              ; 266f: 46          F   :866f[1]
+    !byte 0                                                           ; 2670: 00          .   :8670[1]
+    !text "EX"                                                        ; 2671: 45 58       EX  :8671[1]
+    !byte >(sub_c8238-1)                                              ; 2673: 82          .   :8673[1]
+    !byte <(sub_c8238-1)                                              ; 2674: 37          7   :8674[1]
+    !byte 6                                                           ; 2675: 06          .   :8675[1]
+    !text "FORM"                                                      ; 2676: 46 4f 52... FOR :8676[1]
+    !byte >(sub_ca5bf-1)                                              ; 267a: a5          .   :867a[1]
+    !byte <(sub_ca5bf-1)                                              ; 267b: be          .   :867b[1]
+    !byte $ba                                                         ; 267c: ba          .   :867c[1]
+    !text "FREE"                                                      ; 267d: 46 52 45... FRE :867d[1]
+    !byte >(sub_ca7f3-1)                                              ; 2681: a7          .   :8681[1]
+    !byte <(sub_ca7f3-1)                                              ; 2682: f2          .   :8682[1]
+    !byte 7                                                           ; 2683: 07          .   :8683[1]
+    !text "INFO"                                                      ; 2684: 49 4e 46... INF :8684[1]
+    !byte >(sub_c8254-1)                                              ; 2688: 82          .   :8688[1]
+    !byte <(sub_c8254-1)                                              ; 2689: 53          S   :8689[1]
+    !byte 2                                                           ; 268a: 02          .   :868a[1]
+    !text "LIB"                                                       ; 268b: 4c 49 42    LIB :868b[1]
+    !byte >(sub_c8943-1)                                              ; 268e: 89          .   :868e[1]
+    !byte <(sub_c8943-1)                                              ; 268f: 42          B   :868f[1]
+    !byte 6                                                           ; 2690: 06          .   :8690[1]
+    !text "MAP"                                                       ; 2691: 4d 41 50    MAP :8691[1]
+    !byte >(sub_ca7f6-1)                                              ; 2694: a7          .   :8694[1]
+    !byte <(sub_ca7f6-1)                                              ; 2695: f5          .   :8695[1]
+    !byte 7                                                           ; 2696: 07          .   :8696[1]
+    !text "RENAME"                                                    ; 2697: 52 45 4e... REN :8697[1]
+    !byte >(sub_c8bac-1)                                              ; 269d: 8b          .   :869d[1]
+    !byte <(sub_c8bac-1)                                              ; 269e: ab          .   :869e[1]
+    !byte 5                                                           ; 269f: 05          .   :869f[1]
+    !text "TITLE"                                                     ; 26a0: 54 49 54... TIT :86a0[1]
+    !byte >(sub_c89b7-1)                                              ; 26a5: 89          .   :86a5[1]
+    !byte <(sub_c89b7-1)                                              ; 26a6: b6          .   :86a6[1]
+    !byte 8                                                           ; 26a7: 08          .   :86a7[1]
+    !text "VERIFY"                                                    ; 26a8: 56 45 52... VER :86a8[1]
+    !byte >(sub_ca5bb-1)                                              ; 26ae: a5          .   :86ae[1]
+    !byte <(sub_ca5bb-1)                                              ; 26af: ba          .   :86af[1]
+    !byte $0b                                                         ; 26b0: 0b          .   :86b0[1]
+    !text "WIPE"                                                      ; 26b1: 57 49 50... WIP :86b1[1]
+    !byte >(sub_c8750-1)                                              ; 26b5: 87          .   :86b5[1]
+    !byte <(sub_c8750-1)                                              ; 26b6: 4f          O   :86b6[1]
+    !byte   2, $88, $72                                               ; 26b7: 02 88 72    ..r :86b7[1]
+    !text "BUILD"                                                     ; 26ba: 42 55 49... BUI :86ba[1]
+    !byte >(sub_cabc5-1)                                              ; 26bf: ab          .   :86bf[1]
+    !byte <(sub_cabc5-1)                                              ; 26c0: c4          .   :86c0[1]
+    !byte 1                                                           ; 26c1: 01          .   :86c1[1]
+    !text "DISC"                                                      ; 26c2: 44 49 53... DIS :86c2[1]
+    !byte >(c956d-1)                                                  ; 26c6: 95          .   :86c6[1]
+    !byte <(c956d-1)                                                  ; 26c7: 6c          l   :86c7[1]
+    !byte 0                                                           ; 26c8: 00          .   :86c8[1]
+    !text "DUMP"                                                      ; 26c9: 44 55 4d... DUM :86c9[1]
+    !byte >(sub_cab46-1)                                              ; 26cd: ab          .   :86cd[1]
+    !byte <(sub_cab46-1)                                              ; 26ce: 45          E   :86ce[1]
+    !byte 1                                                           ; 26cf: 01          .   :86cf[1]
+    !text "LIST"                                                      ; 26d0: 4c 49 53... LIS :86d0[1]
+    !byte >(sub_cab04-1)                                              ; 26d4: ab          .   :86d4[1]
+    !byte <(sub_cab04-1)                                              ; 26d5: 03          .   :86d5[1]
+    !byte 1                                                           ; 26d6: 01          .   :86d6[1]
+    !text "ROMS"                                                      ; 26d7: 52 4f 4d... ROM :86d7[1]
+    !byte >(sub_ca9d0-1)                                              ; 26db: a9          .   :86db[1]
+    !byte <(sub_ca9d0-1)                                              ; 26dc: cf          .   :86dc[1]
+    !byte $0c                                                         ; 26dd: 0c          .   :86dd[1]
+    !text "TYPE"                                                      ; 26de: 54 59 50... TYP :86de[1]
+    !byte >(sub_caafd-1)                                              ; 26e2: aa          .   :86e2[1]
+    !byte <(sub_caafd-1)                                              ; 26e3: fc          .   :86e3[1]
+    !byte 1                                                           ; 26e4: 01          .   :86e4[1]
+    !text "DISK"                                                      ; 26e5: 44 49 53... DIS :86e5[1]
+    !byte >(c956d-1)                                                  ; 26e9: 95          .   :86e9[1]
+    !byte <(c956d-1)                                                  ; 26ea: 6c          l   :86ea[1]
+    !byte   0, $86, $1a                                               ; 26eb: 00 86 1a    ... :86eb[1]
+    !text "DFS"                                                       ; 26ee: 44 46 53    DFS :86ee[1]
+    !byte >(sub_ca106-1)                                              ; 26f1: a1          .   :86f1[1]
+    !byte <(sub_ca106-1)                                              ; 26f2: 05          .   :86f2[1]
+    !byte 0                                                           ; 26f3: 00          .   :86f3[1]
+    !text "UTILS"                                                     ; 26f4: 55 54 49... UTI :86f4[1]
+    !byte >(sub_ca137-1)                                              ; 26f9: a1          .   :86f9[1]
+    !byte <(sub_ca137-1)                                              ; 26fa: 36          6   :86fa[1]
+    !byte   0, $a1                                                    ; 26fb: 00 a1       ..  :86fb[1]
+    !text "= E"                                                       ; 26fd: 3d 20 45    = E :86fd[1]
+    !byte $87, $a2, $fd                                               ; 2700: 87 a2 fd    ... :8700[1]
+
+; $2703 referenced 2 times by $96f2, $a134
+c8703
+    tya                                                               ; 2703: 98          .   :8703[1]
+    pha                                                               ; 2704: 48          H   :8704[1]
+; $2705 referenced 2 times by $872f, $8739
+c8705
+    inx                                                               ; 2705: e8          .   :8705[1]
+    inx                                                               ; 2706: e8          .   :8706[1]
+    pla                                                               ; 2707: 68          h   :8707[1]
+    pha                                                               ; 2708: 48          H   :8708[1]
+    tay                                                               ; 2709: a8          .   :8709[1]
+    jsr clc_jmp_gsinit                                                ; 270a: 20 4c 87     L. :870a[1]
+    inx                                                               ; 270d: e8          .   :870d[1]
+    lda command_table,x                                               ; 270e: bd 1c 86    ... :870e[1]
+    bmi c873b                                                         ; 2711: 30 28       0(  :8711[1]
+    dex                                                               ; 2713: ca          .   :8713[1]
+    dey                                                               ; 2714: 88          .   :8714[1]
+    stx l00bf                                                         ; 2715: 86 bf       ..  :8715[1]
+; $2717 referenced 1 time by $8722
+loop_c8717
+    inx                                                               ; 2717: e8          .   :8717[1]
+    iny                                                               ; 2718: c8          .   :8718[1]
+    lda command_table,x                                               ; 2719: bd 1c 86    ... :8719[1]
+    bmi c8734                                                         ; 271c: 30 16       0.  :871c[1]
+    eor (os_text_ptr),y                                               ; 271e: 51 f2       Q.  :871e[1]
+    and #$5f ; '_'                                                    ; 2720: 29 5f       )_  :8720[1]
+    beq loop_c8717                                                    ; 2722: f0 f3       ..  :8722[1]
+    dex                                                               ; 2724: ca          .   :8724[1]
+; $2725 referenced 1 time by $8729
+loop_c8725
+    inx                                                               ; 2725: e8          .   :8725[1]
+    lda command_table,x                                               ; 2726: bd 1c 86    ... :8726[1]
+    bpl loop_c8725                                                    ; 2729: 10 fa       ..  :8729[1]
+    lda (os_text_ptr),y                                               ; 272b: b1 f2       ..  :872b[1]
+    cmp #$2e ; '.'                                                    ; 272d: c9 2e       ..  :872d[1]
+    bne c8705                                                         ; 272f: d0 d4       ..  :872f[1]
+    iny                                                               ; 2731: c8          .   :8731[1]
+    bcs c873b                                                         ; 2732: b0 07       ..  :8732[1]
+; $2734 referenced 1 time by $871c
+c8734
+    lda (os_text_ptr),y                                               ; 2734: b1 f2       ..  :8734[1]
+    jsr sub_c8327                                                     ; 2736: 20 27 83     '. :8736[1]
+    bcc c8705                                                         ; 2739: 90 ca       ..  :8739[1]
+; $273b referenced 2 times by $8711, $8732
+c873b
+    pla                                                               ; 273b: 68          h   :873b[1]
+    lda command_table,x                                               ; 273c: bd 1c 86    ... :873c[1]
+    pha                                                               ; 273f: 48          H   :873f[1]
+    lda command_table+1,x                                             ; 2740: bd 1d 86    ... :8740[1]
+    pha                                                               ; 2743: 48          H   :8743[1]
+    rts                                                               ; 2744: 60          `   :8744[1]
+
+; $2745 referenced 2 times by $8483, $8870
+sub_c8745
+    stx os_text_ptr                                                   ; 2745: 86 f2       ..  :8745[1]
+    sty l00f3                                                         ; 2747: 84 f3       ..  :8747[1]
+    ldy #0                                                            ; 2749: a0 00       ..  :8749[1]
+    rts                                                               ; 274b: 60          `   :874b[1]
+
+; $274c referenced 12 times by $8100, $823b, $8456, $870a, $897e, $89f1, $8b86, $a13e, $a14a, $a5e5, $a657, $a9f7
+clc_jmp_gsinit
+    clc                                                               ; 274c: 18          .   :874c[1]
+    jmp gsinit                                                        ; 274d: 4c c2 ff    L.. :874d[1]
+
+sub_c8750
+    jsr sub_c99ac                                                     ; 2750: 20 ac 99     .. :8750[1]
+    jsr sub_ca14a                                                     ; 2753: 20 4a a1     J. :8753[1]
+    jsr sub_c821d                                                     ; 2756: 20 1d 82     .. :8756[1]
+; $2759 referenced 1 time by $877f
+c8759
+    lda l0e0f,y                                                       ; 2759: b9 0f 0e    ... :8759[1]
+    bmi c877c                                                         ; 275c: 30 1e       0.  :875c[1]
+    jsr sub_c8174                                                     ; 275e: 20 74 81     t. :875e[1]
+    jsr sub_ca3e4                                                     ; 2761: 20 e4 a3     .. :8761[1]
+    bne c8779                                                         ; 2764: d0 13       ..  :8764[1]
+    ldx l00b6                                                         ; 2766: a6 b6       ..  :8766[1]
+    jsr sub_c9bf2                                                     ; 2768: 20 f2 9b     .. :8768[1]
+    stx l00b6                                                         ; 276b: 86 b6       ..  :876b[1]
+    jsr sub_c87e3                                                     ; 276d: 20 e3 87     .. :876d[1]
+    sty l00ab                                                         ; 2770: 84 ab       ..  :8770[1]
+    jsr c93e6                                                         ; 2772: 20 e6 93     .. :8772[1]
+    lda l00ab                                                         ; 2775: a5 ab       ..  :8775[1]
+    sta l00b6                                                         ; 2777: 85 b6       ..  :8777[1]
+; $2779 referenced 1 time by $8764
+c8779
+    jsr ca3dc                                                         ; 2779: 20 dc a3     .. :8779[1]
+; $277c referenced 1 time by $875c
+c877c
+    jsr sub_c8280                                                     ; 277c: 20 80 82     .. :877c[1]
+    bcs c8759                                                         ; 277f: b0 d8       ..  :877f[1]
+    rts                                                               ; 2781: 60          `   :8781[1]
+
+sub_c8782
+    jsr c99a3                                                         ; 2782: 20 a3 99     .. :8782[1]
+    jsr sub_ca14a                                                     ; 2785: 20 4a a1     J. :8785[1]
+    jsr sub_c821d                                                     ; 2788: 20 1d 82     .. :8788[1]
+    jsr sub_c8335                                                     ; 278b: 20 35 83     5. :878b[1]
+    jsr sub_c830a                                                     ; 278e: 20 0a 83     .. :878e[1]
+    jmp c93e6                                                         ; 2791: 4c e6 93    L.. :8791[1]
+
+sub_c8794
+    jsr sub_ca315                                                     ; 2794: 20 15 a3     .. :8794[1]
+    jsr sub_c99ac                                                     ; 2797: 20 ac 99     .. :8797[1]
+    jsr sub_ca14a                                                     ; 279a: 20 4a a1     J. :879a[1]
+    jsr sub_c821d                                                     ; 279d: 20 1d 82     .. :879d[1]
+; $27a0 referenced 1 time by $87ae
+loop_c87a0
+    lda l0e0f,y                                                       ; 27a0: b9 0f 0e    ... :87a0[1]
+    bmi c87ab                                                         ; 27a3: 30 06       0.  :87a3[1]
+    jsr sub_c8174                                                     ; 27a5: 20 74 81     t. :87a5[1]
+    jsr ca3dc                                                         ; 27a8: 20 dc a3     .. :87a8[1]
+; $27ab referenced 1 time by $87a3
+c87ab
+    jsr sub_c8280                                                     ; 27ab: 20 80 82     .. :87ab[1]
+    bcs loop_c87a0                                                    ; 27ae: b0 f0       ..  :87ae[1]
+    jsr sub_ca3ec                                                     ; 27b0: 20 ec a3     .. :87b0[1]
+    beq c87b8                                                         ; 27b3: f0 03       ..  :87b3[1]
+    jmp ca3dc                                                         ; 27b5: 4c dc a3    L.. :87b5[1]
+
+; $27b8 referenced 1 time by $87b3
+c87b8
+    jsr sub_c9bf2                                                     ; 27b8: 20 f2 9b     .. :87b8[1]
+    jsr sub_c8284                                                     ; 27bb: 20 84 82     .. :87bb[1]
+; $27be referenced 1 time by $87c9
+loop_c87be
+    lda l0e0f,y                                                       ; 27be: b9 0f 0e    ... :87be[1]
+    bmi c87c6                                                         ; 27c1: 30 03       0.  :87c1[1]
+    jsr sub_c87e3                                                     ; 27c3: 20 e3 87     .. :87c3[1]
+; $27c6 referenced 1 time by $87c1
+c87c6
+    jsr sub_c8280                                                     ; 27c6: 20 80 82     .. :87c6[1]
+    bcs loop_c87be                                                    ; 27c9: b0 f3       ..  :87c9[1]
+    jsr c93e6                                                         ; 27cb: 20 e6 93     .. :87cb[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 27ce: 20 77 80     w. :87ce[1]
+    !text $0d, "Deleted", $0d                                         ; 27d1: 0d 44 65... .De :87d1[1]
+
+; $27da referenced 6 times by $853e, $8552, $8596, $8b0c, $8be5, $98b5
+sub_c87da
+    iny                                                               ; 27da: c8          .   :87da[1]
+; $27db referenced 2 times by $837a, $8588
+sub_c87db
+    iny                                                               ; 27db: c8          .   :87db[1]
+    iny                                                               ; 27dc: c8          .   :87dc[1]
+    iny                                                               ; 27dd: c8          .   :87dd[1]
+    iny                                                               ; 27de: c8          .   :87de[1]
+    iny                                                               ; 27df: c8          .   :87df[1]
+    iny                                                               ; 27e0: c8          .   :87e0[1]
+    iny                                                               ; 27e1: c8          .   :87e1[1]
+    rts                                                               ; 27e2: 60          `   :87e2[1]
+
+; $27e3 referenced 2 times by $876d, $87c3
+sub_c87e3
+    jsr sub_c830a                                                     ; 27e3: 20 0a 83     .. :87e3[1]
+    ldy l00b6                                                         ; 27e6: a4 b6       ..  :87e6[1]
+    jsr sub_c82b2                                                     ; 27e8: 20 b2 82     .. :87e8[1]
+    sty l00b6                                                         ; 27eb: 84 b6       ..  :87eb[1]
+    rts                                                               ; 27ed: 60          `   :87ed[1]
+
+sub_c87ee
+    jsr sub_ca14a                                                     ; 27ee: 20 4a a1     J. :87ee[1]
+    jsr c8b8b                                                         ; 27f1: 20 8b 8b     .. :87f1[1]
+    sta l10ca                                                         ; 27f4: 8d ca 10    ... :87f4[1]
+    jsr sub_c8456                                                     ; 27f7: 20 56 84     V. :87f7[1]
+    beq c8815                                                         ; 27fa: f0 19       ..  :87fa[1]
+    cmp #$28 ; '('                                                    ; 27fc: c9 28       .(  :87fc[1]
+    beq c8808                                                         ; 27fe: f0 08       ..  :87fe[1]
+    cmp #$50 ; 'P'                                                    ; 2800: c9 50       .P  :8800[1]
+    clc                                                               ; 2802: 18          .   :8802[1]
+    beq c8808                                                         ; 2803: f0 03       ..  :8803[1]
+    jmp ca14f                                                         ; 2805: 4c 4f a1    LO. :8805[1]
+
+; $2808 referenced 2 times by $87fe, $8803
+c8808
+    php                                                               ; 2808: 08          .   :8808[1]
+    ldx l10ca                                                         ; 2809: ae ca 10    ... :8809[1]
+    lda l10de,x                                                       ; 280c: bd de 10    ... :880c[1]
+    rol                                                               ; 280f: 2a          *   :880f[1]
+    plp                                                               ; 2810: 28          (   :8810[1]
+    ror                                                               ; 2811: 6a          j   :8811[1]
+    sta l10de,x                                                       ; 2812: 9d de 10    ... :8812[1]
+; $2815 referenced 1 time by $87fa
+c8815
+    rts                                                               ; 2815: 60          `   :8815[1]
+
+; $2816 referenced 8 times by $888f, $8985, $898d, $8b83, $8b9d, $9bef, $a475, $a4ce
+c8816
+    and #3                                                            ; 2816: 29 03       ).  :8816[1]
+    sta l00cd                                                         ; 2818: 85 cd       ..  :8818[1]
+    rts                                                               ; 281a: 60          `   :881a[1]
+
+    jsr sub_c8222                                                     ; 281b: 20 22 82     ". :881b[1]
+    jsr sub_c9a82                                                     ; 281e: 20 82 9a     .. :881e[1]
+    jsr sub_c8386                                                     ; 2821: 20 86 83     .. :8821[1]
+    lda #$80                                                          ; 2824: a9 80       ..  :8824[1]
+; $2826 referenced 1 time by $88f6
+sub_c8826
+    sta l1096                                                         ; 2826: 8d 96 10    ... :8826[1]
+    sty l00ba                                                         ; 2829: 84 ba       ..  :8829[1]
+    ldx #0                                                            ; 282b: a2 00       ..  :882b[1]
+    lda l00be                                                         ; 282d: a5 be       ..  :882d[1]
+    bne c8837                                                         ; 282f: d0 06       ..  :882f[1]
+    iny                                                               ; 2831: c8          .   :8831[1]
+    iny                                                               ; 2832: c8          .   :8832[1]
+    ldx #2                                                            ; 2833: a2 02       ..  :8833[1]
+    bne c883f                                                         ; 2835: d0 08       ..  :8835[1]
+; $2837 referenced 1 time by $882f
+c8837
+    lda l0f0e,y                                                       ; 2837: b9 0e 0f    ... :8837[1]
+    sta l00c2                                                         ; 283a: 85 c2       ..  :883a[1]
+    jsr sub_c8b4d                                                     ; 283c: 20 4d 8b     M. :883c[1]
+; $283f referenced 2 times by $8835, $8848
+c883f
+    lda l0f08,y                                                       ; 283f: b9 08 0f    ... :883f[1]
+    sta l00bc,x                                                       ; 2842: 95 bc       ..  :8842[1]
+    iny                                                               ; 2844: c8          .   :8844[1]
+    inx                                                               ; 2845: e8          .   :8845[1]
+    cpx #8                                                            ; 2846: e0 08       ..  :8846[1]
+    bne c883f                                                         ; 2848: d0 f5       ..  :8848[1]
+    jsr sub_c8b64                                                     ; 284a: 20 64 8b     d. :884a[1]
+    ldy l00ba                                                         ; 284d: a4 ba       ..  :884d[1]
+    jsr sub_c8335                                                     ; 284f: 20 35 83     5. :884f[1]
+    jmp c8867                                                         ; 2852: 4c 67 88    Lg. :8852[1]
+
+; $2855 referenced 2 times by $9f61, $a561
+sub_c8855
+    lda #$80                                                          ; 2855: a9 80       ..  :8855[1]
+    bne c8864                                                         ; 2857: d0 0b       ..  :8857[1]
+    jsr sub_c8a77                                                     ; 2859: 20 77 8a     w. :8859[1]
+    jsr sub_c9a82                                                     ; 285c: 20 82 9a     .. :885c[1]
+    jsr sub_c8386                                                     ; 285f: 20 86 83     .. :885f[1]
+; $2862 referenced 2 times by $9f51, $a587
+sub_c8862
+    lda #$a0                                                          ; 2862: a9 a0       ..  :8862[1]
+; $2864 referenced 1 time by $8857
+c8864
+    sta l1096                                                         ; 2864: 8d 96 10    ... :8864[1]
+; $2867 referenced 1 time by $8852
+c8867
+    jsr sub_c81ca                                                     ; 2867: 20 ca 81     .. :8867[1]
+    jsr sub_c9445                                                     ; 286a: 20 45 94     E. :886a[1]
+    lda #1                                                            ; 286d: a9 01       ..  :886d[1]
+    rts                                                               ; 286f: 60          `   :886f[1]
+
+    jsr sub_c8745                                                     ; 2870: 20 45 87     E. :8870[1]
+    jsr sub_c8932                                                     ; 2873: 20 32 89     2. :8873[1]
+    sty l10da                                                         ; 2876: 8c da 10    ... :8876[1]
+    jsr sub_c80f3                                                     ; 2879: 20 f3 80     .. :8879[1]
+    sty l10d9                                                         ; 287c: 8c d9 10    ... :887c[1]
+    jsr sub_c8266                                                     ; 287f: 20 66 82     f. :887f[1]
+    bcs c88a6                                                         ; 2882: b0 22       ."  :8882[1]
+    ldy l10da                                                         ; 2884: ac da 10    ... :8884[1]
+    lda l10cb                                                         ; 2887: ad cb 10    ... :8887[1]
+    sta l00cc                                                         ; 288a: 85 cc       ..  :888a[1]
+    lda l10cc                                                         ; 288c: ad cc 10    ... :888c[1]
+    jsr c8816                                                         ; 288f: 20 16 88     .. :888f[1]
+    jsr sub_c80f6                                                     ; 2892: 20 f6 80     .. :8892[1]
+    jsr sub_c8266                                                     ; 2895: 20 66 82     f. :8895[1]
+    bcs c88a6                                                         ; 2898: b0 0c       ..  :8898[1]
+    jsr generate_error_precheck_bad                                   ; 289a: 20 2e 80     .. :889a[1]
+    !byte $fe                                                         ; 289d: fe          .   :889d[1]
+    !text "command"                                                   ; 289e: 63 6f 6d... com :889e[1]
+    !byte 0                                                           ; 28a5: 00          .   :88a5[1]
+
+; $28a6 referenced 2 times by $8882, $8898
+c88a6
+    lda l0f0e,y                                                       ; 28a6: b9 0e 0f    ... :88a6[1]
+    jsr sub_c81ae                                                     ; 28a9: 20 ae 81     .. :88a9[1]
+    cmp #3                                                            ; 28ac: c9 03       ..  :88ac[1]
+    bne c88f4                                                         ; 28ae: d0 44       .D  :88ae[1]
+    lda l0f0a,y                                                       ; 28b0: b9 0a 0f    ... :88b0[1]
+    and l0f0b,y                                                       ; 28b3: 39 0b 0f    9.. :88b3[1]
+    cmp #$ff                                                          ; 28b6: c9 ff       ..  :88b6[1]
+    bne c88f4                                                         ; 28b8: d0 3a       .:  :88b8[1]
+    ldx #6                                                            ; 28ba: a2 06       ..  :88ba[1]
+; $28bc referenced 1 time by $88c3
+loop_c88bc
+    lda l1000,x                                                       ; 28bc: bd 00 10    ... :88bc[1]
+    sta l1007,x                                                       ; 28bf: 9d 07 10    ... :88bf[1]
+    dex                                                               ; 28c2: ca          .   :88c2[1]
+    bpl loop_c88bc                                                    ; 28c3: 10 f7       ..  :88c3[1]
+    lda #$0d                                                          ; 28c5: a9 0d       ..  :88c5[1]
+    sta l100e                                                         ; 28c7: 8d 0e 10    ... :88c7[1]
+    lda #$45 ; 'E'                                                    ; 28ca: a9 45       .E  :88ca[1]
+    sta l1000                                                         ; 28cc: 8d 00 10    ... :88cc[1]
+    lda #$2e ; '.'                                                    ; 28cf: a9 2e       ..  :88cf[1]
+    sta l1001                                                         ; 28d1: 8d 01 10    ... :88d1[1]
+    lda #$3a ; ':'                                                    ; 28d4: a9 3a       .:  :88d4[1]
+    sta l1002                                                         ; 28d6: 8d 02 10    ... :88d6[1]
+    lda l00cd                                                         ; 28d9: a5 cd       ..  :88d9[1]
+    ora #$30 ; '0'                                                    ; 28db: 09 30       .0  :88db[1]
+    sta l1003                                                         ; 28dd: 8d 03 10    ... :88dd[1]
+    lda #$2e ; '.'                                                    ; 28e0: a9 2e       ..  :88e0[1]
+    sta l1004                                                         ; 28e2: 8d 04 10    ... :88e2[1]
+    sta l1006                                                         ; 28e5: 8d 06 10    ... :88e5[1]
+    lda l00cc                                                         ; 28e8: a5 cc       ..  :88e8[1]
+    sta l1005                                                         ; 28ea: 8d 05 10    ... :88ea[1]
+    ldx #<(l1000)                                                     ; 28ed: a2 00       ..  :88ed[1]
+    ldy #>(l1000)                                                     ; 28ef: a0 10       ..  :88ef[1]
+    jmp oscli                                                         ; 28f1: 4c f7 ff    L.. :88f1[1]
+
+; $28f4 referenced 2 times by $88ae, $88b8
+c88f4
+    lda #$81                                                          ; 28f4: a9 81       ..  :88f4[1]
+    jsr sub_c8826                                                     ; 28f6: 20 26 88     &. :88f6[1]
+    clc                                                               ; 28f9: 18          .   :88f9[1]
+    lda l10d9                                                         ; 28fa: ad d9 10    ... :88fa[1]
+    tay                                                               ; 28fd: a8          .   :88fd[1]
+    adc os_text_ptr                                                   ; 28fe: 65 f2       e.  :88fe[1]
+    sta l10d9                                                         ; 2900: 8d d9 10    ... :8900[1]
+    lda l00f3                                                         ; 2903: a5 f3       ..  :8903[1]
+    adc #0                                                            ; 2905: 69 00       i.  :8905[1]
+    sta l10da                                                         ; 2907: 8d da 10    ... :8907[1]
+    lda l1076                                                         ; 290a: ad 76 10    .v. :890a[1]
+    and l1077                                                         ; 290d: 2d 77 10    -w. :890d[1]
+    ora l10d6                                                         ; 2910: 0d d6 10    ... :8910[1]
+    cmp #$ff                                                          ; 2913: c9 ff       ..  :8913[1]
+    beq c892d                                                         ; 2915: f0 16       ..  :8915[1]
+    lda l00be                                                         ; 2917: a5 be       ..  :8917[1]
+    sta l1074                                                         ; 2919: 8d 74 10    .t. :8919[1]
+    lda l00bf                                                         ; 291c: a5 bf       ..  :891c[1]
+    sta l1075                                                         ; 291e: 8d 75 10    .u. :891e[1]
+    jsr sub_c8f6b                                                     ; 2921: 20 6b 8f     k. :8921[1]
+    ldx #$74 ; 't'                                                    ; 2924: a2 74       .t  :8924[1]
+    ldy #$10                                                          ; 2926: a0 10       ..  :8926[1]
+    lda #4                                                            ; 2928: a9 04       ..  :8928[1]
+    jmp tube_entry                                                    ; 292a: 4c 06 04    L.. :892a[1]
+
+; $292d referenced 1 time by $8915
+c892d
+    lda #1                                                            ; 292d: a9 01       ..  :892d[1]
+    jmp (l00be)                                                       ; 292f: 6c be 00    l.. :892f[1]
+
+; $2932 referenced 1 time by $8873
+sub_c8932
+    lda #$ff                                                          ; 2932: a9 ff       ..  :8932[1]
+    sta l00be                                                         ; 2934: 85 be       ..  :8934[1]
+    lda os_text_ptr                                                   ; 2936: a5 f2       ..  :8936[1]
+    sta l00ba                                                         ; 2938: 85 ba       ..  :8938[1]
+    lda l00f3                                                         ; 293a: a5 f3       ..  :893a[1]
+    sta l00bb                                                         ; 293c: 85 bb       ..  :893c[1]
+    rts                                                               ; 293e: 60          `   :893e[1]
+
+sub_c893f
+    ldx #0                                                            ; 293f: a2 00       ..  :893f[1]
+    beq c8945                                                         ; 2941: f0 02       ..  :8941[1]
+sub_c8943
+    ldx #2                                                            ; 2943: a2 02       ..  :8943[1]
+; $2945 referenced 1 time by $8941
+c8945
+    jsr sub_c8979                                                     ; 2945: 20 79 89     y. :8945[1]
+    sta l10ca,x                                                       ; 2948: 9d ca 10    ... :8948[1]
+    lda l00cc                                                         ; 294b: a5 cc       ..  :894b[1]
+    sta l10c9,x                                                       ; 294d: 9d c9 10    ... :894d[1]
+    rts                                                               ; 2950: 60          `   :8950[1]
+
+; $2951 referenced 2 times by $96b4, $9729
+sub_c8951
+    jsr sub_c83e3                                                     ; 2951: 20 e3 83     .. :8951[1]
+    lda l00b0                                                         ; 2954: a5 b0       ..  :8954[1]
+    pha                                                               ; 2956: 48          H   :8956[1]
+    lda l00b1                                                         ; 2957: a5 b1       ..  :8957[1]
+    pha                                                               ; 2959: 48          H   :8959[1]
+    jsr sub_c9ab8                                                     ; 295a: 20 b8 9a     .. :895a[1]
+    ldy #0                                                            ; 295d: a0 00       ..  :895d[1]
+; $295f referenced 1 time by $8970
+loop_c895f
+    cpy #$c0                                                          ; 295f: c0 c0       ..  :895f[1]
+    bcc c8968                                                         ; 2961: 90 05       ..  :8961[1]
+    lda l1000,y                                                       ; 2963: b9 00 10    ... :8963[1]
+    bcs c896b                                                         ; 2966: b0 03       ..  :8966[1]
+; $2968 referenced 1 time by $8961
+c8968
+    lda l1100,y                                                       ; 2968: b9 00 11    ... :8968[1]
+; $296b referenced 1 time by $8966
+c896b
+    sta (l00b0),y                                                     ; 296b: 91 b0       ..  :896b[1]
+    iny                                                               ; 296d: c8          .   :896d[1]
+    cpy #$ee                                                          ; 296e: c0 ee       ..  :896e[1]
+    bne loop_c895f                                                    ; 2970: d0 ed       ..  :8970[1]
+    pla                                                               ; 2972: 68          h   :8972[1]
+    sta l00b1                                                         ; 2973: 85 b1       ..  :8973[1]
+    pla                                                               ; 2975: 68          h   :8975[1]
+    sta l00b0                                                         ; 2976: 85 b0       ..  :8976[1]
+    rts                                                               ; 2978: 60          `   :8978[1]
+
+; $2979 referenced 1 time by $8945
+sub_c8979
+    lda l10c9                                                         ; 2979: ad c9 10    ... :8979[1]
+    sta l00cc                                                         ; 297c: 85 cc       ..  :897c[1]
+    jsr clc_jmp_gsinit                                                ; 297e: 20 4c 87     L. :897e[1]
+    bne c898a                                                         ; 2981: d0 07       ..  :8981[1]
+    lda #0                                                            ; 2983: a9 00       ..  :8983[1]
+    jsr c8816                                                         ; 2985: 20 16 88     .. :8985[1]
+    beq c89b4                                                         ; 2988: f0 2a       .*  :8988[1]
+; $298a referenced 2 times by $8240, $8981
+c898a
+    lda l10ca                                                         ; 298a: ad ca 10    ... :898a[1]
+    jsr c8816                                                         ; 298d: 20 16 88     .. :898d[1]
+; $2990 referenced 1 time by $89a3
+loop_c8990
+    jsr sub_c8149                                                     ; 2990: 20 49 81     I. :8990[1]
+    bcs c89a5                                                         ; 2993: b0 10       ..  :8993[1]
+    cmp #$3a ; ':'                                                    ; 2995: c9 3a       .:  :8995[1]
+    bne c89ad                                                         ; 2997: d0 14       ..  :8997[1]
+    jsr c8b8b                                                         ; 2999: 20 8b 8b     .. :8999[1]
+    jsr sub_c8149                                                     ; 299c: 20 49 81     I. :899c[1]
+    bcs c89b4                                                         ; 299f: b0 13       ..  :899f[1]
+    cmp #$2e ; '.'                                                    ; 29a1: c9 2e       ..  :89a1[1]
+    beq loop_c8990                                                    ; 29a3: f0 eb       ..  :89a3[1]
+; $29a5 referenced 2 times by $8993, $89b2
+c89a5
+    jsr generate_error_precheck_bad                                   ; 29a5: 20 2e 80     .. :89a5[1]
+    !byte $ce                                                         ; 29a8: ce          .   :89a8[1]
+    !text "dir"                                                       ; 29a9: 64 69 72    dir :89a9[1]
+    !byte 0                                                           ; 29ac: 00          .   :89ac[1]
+
+; $29ad referenced 1 time by $8997
+c89ad
+    sta l00cc                                                         ; 29ad: 85 cc       ..  :89ad[1]
+    jsr sub_c8149                                                     ; 29af: 20 49 81     I. :89af[1]
+    bcc c89a5                                                         ; 29b2: 90 f1       ..  :89b2[1]
+; $29b4 referenced 2 times by $8988, $899f
+c89b4
+    lda l00cd                                                         ; 29b4: a5 cd       ..  :89b4[1]
+    rts                                                               ; 29b6: 60          `   :89b6[1]
+
+sub_c89b7
+    jsr sub_ca14a                                                     ; 29b7: 20 4a a1     J. :89b7[1]
+    jsr sub_c8b7b                                                     ; 29ba: 20 7b 8b     {. :89ba[1]
+    jsr sub_c8380                                                     ; 29bd: 20 80 83     .. :89bd[1]
+    ldx #$0b                                                          ; 29c0: a2 0b       ..  :89c0[1]
+    lda #0                                                            ; 29c2: a9 00       ..  :89c2[1]
+; $29c4 referenced 1 time by $89c8
+loop_c89c4
+    jsr sub_c89da                                                     ; 29c4: 20 da 89     .. :89c4[1]
+    dex                                                               ; 29c7: ca          .   :89c7[1]
+    bpl loop_c89c4                                                    ; 29c8: 10 fa       ..  :89c8[1]
+; $29ca referenced 1 time by $89d5
+loop_c89ca
+    inx                                                               ; 29ca: e8          .   :89ca[1]
+    jsr sub_c8149                                                     ; 29cb: 20 49 81     I. :89cb[1]
+    bcs c89d7                                                         ; 29ce: b0 07       ..  :89ce[1]
+    jsr sub_c89da                                                     ; 29d0: 20 da 89     .. :89d0[1]
+    cpx #$0b                                                          ; 29d3: e0 0b       ..  :89d3[1]
+    bcc loop_c89ca                                                    ; 29d5: 90 f3       ..  :89d5[1]
+; $29d7 referenced 3 times by $89ce, $8a15, $99ed
+c89d7
+    jmp c93e6                                                         ; 29d7: 4c e6 93    L.. :89d7[1]
+
+; $29da referenced 2 times by $89c4, $89d0
+sub_c89da
+    cpx #8                                                            ; 29da: e0 08       ..  :89da[1]
+    bcc c89e2                                                         ; 29dc: 90 04       ..  :89dc[1]
+    sta l0ef8,x                                                       ; 29de: 9d f8 0e    ... :89de[1]
+    rts                                                               ; 29e1: 60          `   :89e1[1]
+
+; $29e2 referenced 1 time by $89dc
+c89e2
+    sta l0e00,x                                                       ; 29e2: 9d 00 0e    ... :89e2[1]
+    rts                                                               ; 29e5: 60          `   :89e5[1]
+
+sub_c89e6
+    jsr sub_c99ac                                                     ; 29e6: 20 ac 99     .. :89e6[1]
+    jsr sub_ca14a                                                     ; 29e9: 20 4a a1     J. :89e9[1]
+    jsr sub_c80ed                                                     ; 29ec: 20 ed 80     .. :89ec[1]
+    ldx #0                                                            ; 29ef: a2 00       ..  :89ef[1]
+    jsr clc_jmp_gsinit                                                ; 29f1: 20 4c 87     L. :89f1[1]
+    bne c8a19                                                         ; 29f4: d0 23       .#  :89f4[1]
+; $29f6 referenced 1 time by $8a1c
+c89f6
+    stx l00aa                                                         ; 29f6: 86 aa       ..  :89f6[1]
+    jsr sub_c8284                                                     ; 29f8: 20 84 82     .. :89f8[1]
+    bcs c8a00                                                         ; 29fb: b0 03       ..  :89fb[1]
+    jmp c822a                                                         ; 29fd: 4c 2a 82    L*. :89fd[1]
+
+; $2a00 referenced 2 times by $89fb, $8a13
+c8a00
+    jsr sub_c9a63                                                     ; 2a00: 20 63 9a     c. :8a00[1]
+    lda l0e0f,y                                                       ; 2a03: b9 0f 0e    ... :8a03[1]
+    and #$7f                                                          ; 2a06: 29 7f       ).  :8a06[1]
+    ora l00aa                                                         ; 2a08: 05 aa       ..  :8a08[1]
+    sta l0e0f,y                                                       ; 2a0a: 99 0f 0e    ... :8a0a[1]
+    jsr sub_c8335                                                     ; 2a0d: 20 35 83     5. :8a0d[1]
+    jsr sub_c8280                                                     ; 2a10: 20 80 82     .. :8a10[1]
+    bcs c8a00                                                         ; 2a13: b0 eb       ..  :8a13[1]
+    bcc c89d7                                                         ; 2a15: 90 c0       ..  :8a15[1]
+; $2a17 referenced 1 time by $8a22
+loop_c8a17
+    ldx #$80                                                          ; 2a17: a2 80       ..  :8a17[1]
+; $2a19 referenced 1 time by $89f4
+c8a19
+    jsr sub_c8149                                                     ; 2a19: 20 49 81     I. :8a19[1]
+    bcs c89f6                                                         ; 2a1c: b0 d8       ..  :8a1c[1]
+    and #$5f ; '_'                                                    ; 2a1e: 29 5f       )_  :8a1e[1]
+    cmp #$4c ; 'L'                                                    ; 2a20: c9 4c       .L  :8a20[1]
+    beq loop_c8a17                                                    ; 2a22: f0 f3       ..  :8a22[1]
+    jsr generate_error_precheck_bad                                   ; 2a24: 20 2e 80     .. :8a24[1]
+    !byte $cf                                                         ; 2a27: cf          .   :8a27[1]
+    !text "attribute"                                                 ; 2a28: 61 74 74... att :8a28[1]
+    !byte 0                                                           ; 2a31: 00          .   :8a31[1]
+
+    jsr sub_c83e3                                                     ; 2a32: 20 e3 83     .. :8a32[1]
+    txa                                                               ; 2a35: 8a          .   :8a35[1]
+    cmp #4                                                            ; 2a36: c9 04       ..  :8a36[1]
+    beq c8a54                                                         ; 2a38: f0 1a       ..  :8a38[1]
+    cmp #2                                                            ; 2a3a: c9 02       ..  :8a3a[1]
+    bcc c8a49                                                         ; 2a3c: 90 0b       ..  :8a3c[1]
+    jsr generate_error_precheck_bad                                   ; 2a3e: 20 2e 80     .. :8a3e[1]
+    !byte $cb                                                         ; 2a41: cb          .   :8a41[1]
+    !text "option"                                                    ; 2a42: 6f 70 74... opt :8a42[1]
+    !byte 0                                                           ; 2a48: 00          .   :8a48[1]
+
+; $2a49 referenced 1 time by $8a3c
+c8a49
+    ldx #$ff                                                          ; 2a49: a2 ff       ..  :8a49[1]
+    tya                                                               ; 2a4b: 98          .   :8a4b[1]
+    beq c8a50                                                         ; 2a4c: f0 02       ..  :8a4c[1]
+    ldx #0                                                            ; 2a4e: a2 00       ..  :8a4e[1]
+; $2a50 referenced 1 time by $8a4c
+c8a50
+    stx l10c6                                                         ; 2a50: 8e c6 10    ... :8a50[1]
+    rts                                                               ; 2a53: 60          `   :8a53[1]
+
+; $2a54 referenced 1 time by $8a38
+c8a54
+    tya                                                               ; 2a54: 98          .   :8a54[1]
+    pha                                                               ; 2a55: 48          H   :8a55[1]
+    jsr sub_c8b7b                                                     ; 2a56: 20 7b 8b     {. :8a56[1]
+    jsr c940c                                                         ; 2a59: 20 0c 94     .. :8a59[1]
+    pla                                                               ; 2a5c: 68          h   :8a5c[1]
+    jsr sub_c81c5                                                     ; 2a5d: 20 c5 81     .. :8a5d[1]
+    eor l0f06                                                         ; 2a60: 4d 06 0f    M.. :8a60[1]
+    and #$30 ; '0'                                                    ; 2a63: 29 30       )0  :8a63[1]
+    eor l0f06                                                         ; 2a65: 4d 06 0f    M.. :8a65[1]
+    sta l0f06                                                         ; 2a68: 8d 06 0f    ... :8a68[1]
+    jmp c93e6                                                         ; 2a6b: 4c e6 93    L.. :8a6b[1]
+
+; $2a6e referenced 2 times by $8ac8, $a414
+c8a6e
+    jsr generate_error_precheck_disc                                  ; 2a6e: 20 23 80     #. :8a6e[1]
+    !byte $c6                                                         ; 2a71: c6          .   :8a71[1]
+    !text "full"                                                      ; 2a72: 66 75 6c... ful :8a72[1]
+    !byte 0                                                           ; 2a76: 00          .   :8a76[1]
+
+; $2a77 referenced 2 times by $8859, $9c4e
+sub_c8a77
+    jsr sub_c80f3                                                     ; 2a77: 20 f3 80     .. :8a77[1]
+    jsr sub_c8284                                                     ; 2a7a: 20 84 82     .. :8a7a[1]
+    bcc c8a82                                                         ; 2a7d: 90 03       ..  :8a7d[1]
+    jsr sub_c830a                                                     ; 2a7f: 20 0a 83     .. :8a7f[1]
+; $2a82 referenced 1 time by $8a7d
+c8a82
+    lda l00c0                                                         ; 2a82: a5 c0       ..  :8a82[1]
+    pha                                                               ; 2a84: 48          H   :8a84[1]
+    lda l00c1                                                         ; 2a85: a5 c1       ..  :8a85[1]
+    pha                                                               ; 2a87: 48          H   :8a87[1]
+    sec                                                               ; 2a88: 38          8   :8a88[1]
+    lda l00c2                                                         ; 2a89: a5 c2       ..  :8a89[1]
+    sbc l00c0                                                         ; 2a8b: e5 c0       ..  :8a8b[1]
+    sta l00c0                                                         ; 2a8d: 85 c0       ..  :8a8d[1]
+    lda l00c3                                                         ; 2a8f: a5 c3       ..  :8a8f[1]
+    sbc l00c1                                                         ; 2a91: e5 c1       ..  :8a91[1]
+    sta l00c1                                                         ; 2a93: 85 c1       ..  :8a93[1]
+    lda l107a                                                         ; 2a95: ad 7a 10    .z. :8a95[1]
+    sbc l1078                                                         ; 2a98: ed 78 10    .x. :8a98[1]
+    sta l00c4                                                         ; 2a9b: 85 c4       ..  :8a9b[1]
+    jsr sub_c8ab3                                                     ; 2a9d: 20 b3 8a     .. :8a9d[1]
+    lda l1079                                                         ; 2aa0: ad 79 10    .y. :8aa0[1]
+    sta l1075                                                         ; 2aa3: 8d 75 10    .u. :8aa3[1]
+    lda l1078                                                         ; 2aa6: ad 78 10    .x. :8aa6[1]
+    sta l1074                                                         ; 2aa9: 8d 74 10    .t. :8aa9[1]
+    pla                                                               ; 2aac: 68          h   :8aac[1]
+    sta l00bd                                                         ; 2aad: 85 bd       ..  :8aad[1]
+    pla                                                               ; 2aaf: 68          h   :8aaf[1]
+    sta l00bc                                                         ; 2ab0: 85 bc       ..  :8ab0[1]
+    rts                                                               ; 2ab2: 60          `   :8ab2[1]
+
+; $2ab3 referenced 2 times by $8a9d, $a50a
+sub_c8ab3
+    lda #0                                                            ; 2ab3: a9 00       ..  :8ab3[1]
+    sta l00c2                                                         ; 2ab5: 85 c2       ..  :8ab5[1]
+    lda #2                                                            ; 2ab7: a9 02       ..  :8ab7[1]
+    sta l00c3                                                         ; 2ab9: 85 c3       ..  :8ab9[1]
+    ldy l0f05                                                         ; 2abb: ac 05 0f    ... :8abb[1]
+    cpy #$f8                                                          ; 2abe: c0 f8       ..  :8abe[1]
+    bcs c8b18                                                         ; 2ac0: b0 56       .V  :8ac0[1]
+    jsr sub_c8602                                                     ; 2ac2: 20 02 86     .. :8ac2[1]
+    jmp c8ad0                                                         ; 2ac5: 4c d0 8a    L.. :8ac5[1]
+
+; $2ac8 referenced 1 time by $8ad1
+loop_c8ac8
+    beq c8a6e                                                         ; 2ac8: f0 a4       ..  :8ac8[1]
+    jsr sub_c82b2                                                     ; 2aca: 20 b2 82     .. :8aca[1]
+    jsr sub_c85e3                                                     ; 2acd: 20 e3 85     .. :8acd[1]
+; $2ad0 referenced 1 time by $8ac5
+c8ad0
+    tya                                                               ; 2ad0: 98          .   :8ad0[1]
+    bcc loop_c8ac8                                                    ; 2ad1: 90 f5       ..  :8ad1[1]
+    sty l00b0                                                         ; 2ad3: 84 b0       ..  :8ad3[1]
+    ldy l0f05                                                         ; 2ad5: ac 05 0f    ... :8ad5[1]
+; $2ad8 referenced 1 time by $8ae9
+loop_c8ad8
+    cpy l00b0                                                         ; 2ad8: c4 b0       ..  :8ad8[1]
+    beq c8aeb                                                         ; 2ada: f0 0f       ..  :8ada[1]
+    lda l0e07,y                                                       ; 2adc: b9 07 0e    ... :8adc[1]
+    sta l0e0f,y                                                       ; 2adf: 99 0f 0e    ... :8adf[1]
+    lda l0f07,y                                                       ; 2ae2: b9 07 0f    ... :8ae2[1]
+    sta l0f0f,y                                                       ; 2ae5: 99 0f 0f    ... :8ae5[1]
+    dey                                                               ; 2ae8: 88          .   :8ae8[1]
+    bcs loop_c8ad8                                                    ; 2ae9: b0 ed       ..  :8ae9[1]
+; $2aeb referenced 1 time by $8ada
+c8aeb
+    ldx #0                                                            ; 2aeb: a2 00       ..  :8aeb[1]
+    jsr sub_c8b25                                                     ; 2aed: 20 25 8b     %. :8aed[1]
+; $2af0 referenced 1 time by $8af9
+loop_c8af0
+    lda l00c5,x                                                       ; 2af0: b5 c5       ..  :8af0[1]
+    sta l0e08,y                                                       ; 2af2: 99 08 0e    ... :8af2[1]
+    iny                                                               ; 2af5: c8          .   :8af5[1]
+    inx                                                               ; 2af6: e8          .   :8af6[1]
+    cpx #8                                                            ; 2af7: e0 08       ..  :8af7[1]
+    bne loop_c8af0                                                    ; 2af9: d0 f5       ..  :8af9[1]
+; $2afb referenced 1 time by $8b02
+loop_c8afb
+    lda l00bb,x                                                       ; 2afb: b5 bb       ..  :8afb[1]
+    dey                                                               ; 2afd: 88          .   :8afd[1]
+    sta l0f08,y                                                       ; 2afe: 99 08 0f    ... :8afe[1]
+    dex                                                               ; 2b01: ca          .   :8b01[1]
+    bne loop_c8afb                                                    ; 2b02: d0 f7       ..  :8b02[1]
+    jsr sub_c8335                                                     ; 2b04: 20 35 83     5. :8b04[1]
+    tya                                                               ; 2b07: 98          .   :8b07[1]
+    pha                                                               ; 2b08: 48          H   :8b08[1]
+    ldy l0f05                                                         ; 2b09: ac 05 0f    ... :8b09[1]
+    jsr sub_c87da                                                     ; 2b0c: 20 da 87     .. :8b0c[1]
+    sty l0f05                                                         ; 2b0f: 8c 05 0f    ... :8b0f[1]
+    jsr c93e6                                                         ; 2b12: 20 e6 93     .. :8b12[1]
+    pla                                                               ; 2b15: 68          h   :8b15[1]
+    tay                                                               ; 2b16: a8          .   :8b16[1]
+    rts                                                               ; 2b17: 60          `   :8b17[1]
+
+; $2b18 referenced 1 time by $8ac0
+c8b18
+    jsr generate_error_precheck                                       ; 2b18: 20 38 80     8. :8b18[1]
+    !byte $be                                                         ; 2b1b: be          .   :8b1b[1]
+    !text "Cat full"                                                  ; 2b1c: 43 61 74... Cat :8b1c[1]
+    !byte 0                                                           ; 2b24: 00          .   :8b24[1]
+
+; $2b25 referenced 1 time by $8aed
+sub_c8b25
+    lda l1076                                                         ; 2b25: ad 76 10    .v. :8b25[1]
+    and #3                                                            ; 2b28: 29 03       ).  :8b28[1]
+    asl                                                               ; 2b2a: 0a          .   :8b2a[1]
+    asl                                                               ; 2b2b: 0a          .   :8b2b[1]
+    eor l00c4                                                         ; 2b2c: 45 c4       E.  :8b2c[1]
+    and #$fc                                                          ; 2b2e: 29 fc       ).  :8b2e[1]
+    eor l00c4                                                         ; 2b30: 45 c4       E.  :8b30[1]
+    asl                                                               ; 2b32: 0a          .   :8b32[1]
+    asl                                                               ; 2b33: 0a          .   :8b33[1]
+    eor l1074                                                         ; 2b34: 4d 74 10    Mt. :8b34[1]
+    and #$fc                                                          ; 2b37: 29 fc       ).  :8b37[1]
+    eor l1074                                                         ; 2b39: 4d 74 10    Mt. :8b39[1]
+    asl                                                               ; 2b3c: 0a          .   :8b3c[1]
+    asl                                                               ; 2b3d: 0a          .   :8b3d[1]
+    eor l00c2                                                         ; 2b3e: 45 c2       E.  :8b3e[1]
+    and #$fc                                                          ; 2b40: 29 fc       ).  :8b40[1]
+    eor l00c2                                                         ; 2b42: 45 c2       E.  :8b42[1]
+    sta l00c2                                                         ; 2b44: 85 c2       ..  :8b44[1]
+    rts                                                               ; 2b46: 60          `   :8b46[1]
+
+sub_c8b47
+    lda #1                                                            ; 2b47: a9 01       ..  :8b47[1]
+    sta l10c7                                                         ; 2b49: 8d c7 10    ... :8b49[1]
+    rts                                                               ; 2b4c: 60          `   :8b4c[1]
+
+; $2b4d referenced 2 times by $883c, $a4fd
+sub_c8b4d
+    lda #0                                                            ; 2b4d: a9 00       ..  :8b4d[1]
+    sta l1075                                                         ; 2b4f: 8d 75 10    .u. :8b4f[1]
+    lda l00c2                                                         ; 2b52: a5 c2       ..  :8b52[1]
+    jsr sub_c81b7                                                     ; 2b54: 20 b7 81     .. :8b54[1]
+    cmp #3                                                            ; 2b57: c9 03       ..  :8b57[1]
+    bne c8b60                                                         ; 2b59: d0 05       ..  :8b59[1]
+    lda #$ff                                                          ; 2b5b: a9 ff       ..  :8b5b[1]
+    sta l1075                                                         ; 2b5d: 8d 75 10    .u. :8b5d[1]
+; $2b60 referenced 1 time by $8b59
+c8b60
+    sta l1074                                                         ; 2b60: 8d 74 10    .t. :8b60[1]
+    rts                                                               ; 2b63: 60          `   :8b63[1]
+
+; $2b64 referenced 2 times by $884a, $a500
+sub_c8b64
+    lda #0                                                            ; 2b64: a9 00       ..  :8b64[1]
+    sta l1077                                                         ; 2b66: 8d 77 10    .w. :8b66[1]
+    lda l00c2                                                         ; 2b69: a5 c2       ..  :8b69[1]
+    jsr sub_c81ae                                                     ; 2b6b: 20 ae 81     .. :8b6b[1]
+    cmp #3                                                            ; 2b6e: c9 03       ..  :8b6e[1]
+    bne c8b77                                                         ; 2b70: d0 05       ..  :8b70[1]
+    lda #$ff                                                          ; 2b72: a9 ff       ..  :8b72[1]
+    sta l1077                                                         ; 2b74: 8d 77 10    .w. :8b74[1]
+; $2b77 referenced 1 time by $8b70
+c8b77
+    sta l1076                                                         ; 2b77: 8d 76 10    .v. :8b77[1]
+    rts                                                               ; 2b7a: 60          `   :8b7a[1]
+
+; $2b7b referenced 8 times by $80ed, $80f3, $8238, $89ba, $8a56, $975b, $988b, $98d7
+sub_c8b7b
+    lda l10c9                                                         ; 2b7b: ad c9 10    ... :8b7b[1]
+    sta l00cc                                                         ; 2b7e: 85 cc       ..  :8b7e[1]
+; $2b80 referenced 1 time by $8b89
+loop_c8b80
+    lda l10ca                                                         ; 2b80: ad ca 10    ... :8b80[1]
+    jmp c8816                                                         ; 2b83: 4c 16 88    L.. :8b83[1]
+
+; $2b86 referenced 3 times by $8486, $a244, $a7f9
+sub_c8b86
+    jsr clc_jmp_gsinit                                                ; 2b86: 20 4c 87     L. :8b86[1]
+    beq loop_c8b80                                                    ; 2b89: f0 f5       ..  :8b89[1]
+; $2b8b referenced 7 times by $8119, $87f1, $8999, $8b92, $a327, $a330, $a637
+c8b8b
+    jsr sub_c8149                                                     ; 2b8b: 20 49 81     I. :8b8b[1]
+    bcs c8ba2                                                         ; 2b8e: b0 12       ..  :8b8e[1]
+    cmp #$3a ; ':'                                                    ; 2b90: c9 3a       .:  :8b90[1]
+    beq c8b8b                                                         ; 2b92: f0 f7       ..  :8b92[1]
+    sec                                                               ; 2b94: 38          8   :8b94[1]
+    sbc #$30 ; '0'                                                    ; 2b95: e9 30       .0  :8b95[1]
+    bcc c8ba2                                                         ; 2b97: 90 09       ..  :8b97[1]
+    cmp #4                                                            ; 2b99: c9 04       ..  :8b99[1]
+    bcs c8ba2                                                         ; 2b9b: b0 05       ..  :8b9b[1]
+    jsr c8816                                                         ; 2b9d: 20 16 88     .. :8b9d[1]
+    clc                                                               ; 2ba0: 18          .   :8ba0[1]
+    rts                                                               ; 2ba1: 60          `   :8ba1[1]
+
+; $2ba2 referenced 5 times by $8b8e, $8b97, $8b9b, $8bcd, $a660
+c8ba2
+    jsr generate_error_precheck_bad                                   ; 2ba2: 20 2e 80     .. :8ba2[1]
+    !byte $cd                                                         ; 2ba5: cd          .   :8ba5[1]
+    !text "drive"                                                     ; 2ba6: 64 72 69... dri :8ba6[1]
+    !byte 0                                                           ; 2bab: 00          .   :8bab[1]
+
+sub_c8bac
+    jsr c99a3                                                         ; 2bac: 20 a3 99     .. :8bac[1]
+    jsr sub_ca14a                                                     ; 2baf: 20 4a a1     J. :8baf[1]
+    jsr sub_c80ed                                                     ; 2bb2: 20 ed 80     .. :8bb2[1]
+    tya                                                               ; 2bb5: 98          .   :8bb5[1]
+    pha                                                               ; 2bb6: 48          H   :8bb6[1]
+    jsr c8225                                                         ; 2bb7: 20 25 82     %. :8bb7[1]
+    jsr sub_c9a60                                                     ; 2bba: 20 60 9a     `. :8bba[1]
+    sty l00c4                                                         ; 2bbd: 84 c4       ..  :8bbd[1]
+    pla                                                               ; 2bbf: 68          h   :8bbf[1]
+    tay                                                               ; 2bc0: a8          .   :8bc0[1]
+    jsr sub_ca14a                                                     ; 2bc1: 20 4a a1     J. :8bc1[1]
+    lda l00cd                                                         ; 2bc4: a5 cd       ..  :8bc4[1]
+    pha                                                               ; 2bc6: 48          H   :8bc6[1]
+    jsr sub_c80ed                                                     ; 2bc7: 20 ed 80     .. :8bc7[1]
+    pla                                                               ; 2bca: 68          h   :8bca[1]
+    cmp l00cd                                                         ; 2bcb: c5 cd       ..  :8bcb[1]
+    bne c8ba2                                                         ; 2bcd: d0 d3       ..  :8bcd[1]
+    jsr sub_c8284                                                     ; 2bcf: 20 84 82     .. :8bcf[1]
+    bcc c8be3                                                         ; 2bd2: 90 0f       ..  :8bd2[1]
+    cpy l00c4                                                         ; 2bd4: c4 c4       ..  :8bd4[1]
+    beq c8be3                                                         ; 2bd6: f0 0b       ..  :8bd6[1]
+    jsr generate_error_precheck                                       ; 2bd8: 20 38 80     8. :8bd8[1]
+    !byte $c4                                                         ; 2bdb: c4          .   :8bdb[1]
+    !text "Exists"                                                    ; 2bdc: 45 78 69... Exi :8bdc[1]
+    !byte 0                                                           ; 2be2: 00          .   :8be2[1]
+
+; $2be3 referenced 2 times by $8bd2, $8bd6
+c8be3
+    ldy l00c4                                                         ; 2be3: a4 c4       ..  :8be3[1]
+    jsr sub_c87da                                                     ; 2be5: 20 da 87     .. :8be5[1]
+    ldx #7                                                            ; 2be8: a2 07       ..  :8be8[1]
+; $2bea referenced 1 time by $8bf1
+loop_c8bea
+    lda l00c5,x                                                       ; 2bea: b5 c5       ..  :8bea[1]
+    sta l0e07,y                                                       ; 2bec: 99 07 0e    ... :8bec[1]
+    dey                                                               ; 2bef: 88          .   :8bef[1]
+    dex                                                               ; 2bf0: ca          .   :8bf0[1]
+    bpl loop_c8bea                                                    ; 2bf1: 10 f7       ..  :8bf1[1]
+    jmp c93e6                                                         ; 2bf3: 4c e6 93    L.. :8bf3[1]
+
+; $2bf6 referenced 1 time by $9466
+sub_c8bf6
+    clc                                                               ; 2bf6: 18          .   :8bf6[1]
+    bcc c8bfb                                                         ; 2bf7: 90 02       ..  :8bf7[1]
+; $2bf9 referenced 1 time by $9211
+sub_c8bf9
+    cli                                                               ; 2bf9: 58          X   :8bf9[1]
+    sec                                                               ; 2bfa: 38          8   :8bfa[1]
+; $2bfb referenced 1 time by $8bf7
+c8bfb
+    ror l00b2                                                         ; 2bfb: 66 b2       f.  :8bfb[1]
+    stx l00b0                                                         ; 2bfd: 86 b0       ..  :8bfd[1]
+    sty l00b1                                                         ; 2bff: 84 b1       ..  :8bff[1]
+    cld                                                               ; 2c01: d8          .   :8c01[1]
+    jsr sub_c8c65                                                     ; 2c02: 20 65 8c     e. :8c02[1]
+    lda l00a2                                                         ; 2c05: a5 a2       ..  :8c05[1]
+    bne c8c12                                                         ; 2c07: d0 09       ..  :8c07[1]
+    ldy #5                                                            ; 2c09: a0 05       ..  :8c09[1]
+    lda (l00b0),y                                                     ; 2c0b: b1 b0       ..  :8c0b[1]
+    beq c8c12                                                         ; 2c0d: f0 03       ..  :8c0d[1]
+    jsr sub_c8d1a                                                     ; 2c0f: 20 1a 8d     .. :8c0f[1]
+; $2c12 referenced 2 times by $8c07, $8c0d
+c8c12
+    ldy #5                                                            ; 2c12: a0 05       ..  :8c12[1]
+    lda (l00b0),y                                                     ; 2c14: b1 b0       ..  :8c14[1]
+    clc                                                               ; 2c16: 18          .   :8c16[1]
+    adc #7                                                            ; 2c17: 69 07       i.  :8c17[1]
+    tay                                                               ; 2c19: a8          .   :8c19[1]
+    lda l00a2                                                         ; 2c1a: a5 a2       ..  :8c1a[1]
+    jsr sub_c8c56                                                     ; 2c1c: 20 56 8c     V. :8c1c[1]
+    sta (l00b0),y                                                     ; 2c1f: 91 b0       ..  :8c1f[1]
+    ldx l00a7                                                         ; 2c21: a6 a7       ..  :8c21[1]
+    cpx #$80                                                          ; 2c23: e0 80       ..  :8c23[1]
+    bne c8c2e                                                         ; 2c25: d0 07       ..  :8c25[1]
+    lda lfe84                                                         ; 2c27: ad 84 fe    ... :8c27[1]
+    and #$20 ; ' '                                                    ; 2c2a: 29 20       )   :8c2a[1]
+    ora (l00b0),y                                                     ; 2c2c: 11 b0       ..  :8c2c[1]
+; $2c2e referenced 1 time by $8c25
+c8c2e
+    pha                                                               ; 2c2e: 48          H   :8c2e[1]
+    and #$df                                                          ; 2c2f: 29 df       ).  :8c2f[1]
+    cmp #$18                                                          ; 2c31: c9 18       ..  :8c31[1]
+    bne c8c3a                                                         ; 2c33: d0 05       ..  :8c33[1]
+    lda #$ff                                                          ; 2c35: a9 ff       ..  :8c35[1]
+    sta l1087                                                         ; 2c37: 8d 87 10    ... :8c37[1]
+; $2c3a referenced 1 time by $8c33
+c8c3a
+    lda l00cd                                                         ; 2c3a: a5 cd       ..  :8c3a[1]
+    and #1                                                            ; 2c3c: 29 01       ).  :8c3c[1]
+    tay                                                               ; 2c3e: a8          .   :8c3e[1]
+    lda l00ce                                                         ; 2c3f: a5 ce       ..  :8c3f[1]
+    sta l1088,y                                                       ; 2c41: 99 88 10    ... :8c41[1]
+    jsr c8f2a                                                         ; 2c44: 20 2a 8f     *. :8c44[1]
+    bit l00a1                                                         ; 2c47: 24 a1       $.  :8c47[1]
+    bpl c8c4e                                                         ; 2c49: 10 03       ..  :8c49[1]
+    jsr sub_c8f7a                                                     ; 2c4b: 20 7a 8f     z. :8c4b[1]
+; $2c4e referenced 1 time by $8c49
+c8c4e
+    jsr sub_c8f5e                                                     ; 2c4e: 20 5e 8f     ^. :8c4e[1]
+    lda lfe87                                                         ; 2c51: ad 87 fe    ... :8c51[1]
+    pla                                                               ; 2c54: 68          h   :8c54[1]
+    rts                                                               ; 2c55: 60          `   :8c55[1]
+
+; $2c56 referenced 1 time by $8c1c
+sub_c8c56
+    ldx #5                                                            ; 2c56: a2 05       ..  :8c56[1]
+; $2c58 referenced 1 time by $8c5e
+loop_c8c58
+    cmp l9139,x                                                       ; 2c58: dd 39 91    .9. :8c58[1]
+    beq c8c61                                                         ; 2c5b: f0 04       ..  :8c5b[1]
+    dex                                                               ; 2c5d: ca          .   :8c5d[1]
+    bpl loop_c8c58                                                    ; 2c5e: 10 f8       ..  :8c5e[1]
+    rts                                                               ; 2c60: 60          `   :8c60[1]
+
+; $2c61 referenced 1 time by $8c5b
+c8c61
+    lda l913f,x                                                       ; 2c61: bd 3f 91    .?. :8c61[1]
+    rts                                                               ; 2c64: 60          `   :8c64[1]
+
+; $2c65 referenced 1 time by $8c02
+sub_c8c65
+    jsr sub_c8f4f                                                     ; 2c65: 20 4f 8f     O. :8c65[1]
+    jsr sub_c8f82                                                     ; 2c68: 20 82 8f     .. :8c68[1]
+    lda #0                                                            ; 2c6b: a9 00       ..  :8c6b[1]
+    sta l00a1                                                         ; 2c6d: 85 a1       ..  :8c6d[1]
+    ldy #9                                                            ; 2c6f: a0 09       ..  :8c6f[1]
+; $2c71 referenced 1 time by $8c79
+loop_c8c71
+    lda (l00b0),y                                                     ; 2c71: b1 b0       ..  :8c71[1]
+    sta l00aa,y                                                       ; 2c73: 99 aa 00    ... :8c73[1]
+    iny                                                               ; 2c76: c8          .   :8c76[1]
+    cpy #$0c                                                          ; 2c77: c0 0c       ..  :8c77[1]
+    bne loop_c8c71                                                    ; 2c79: d0 f6       ..  :8c79[1]
+    ldy #6                                                            ; 2c7b: a0 06       ..  :8c7b[1]
+    lda (l00b0),y                                                     ; 2c7d: b1 b0       ..  :8c7d[1]
+    and #$f0                                                          ; 2c7f: 29 f0       ).  :8c7f[1]
+    cmp #$a0                                                          ; 2c81: c9 a0       ..  :8c81[1]
+    beq c8c87                                                         ; 2c83: f0 02       ..  :8c83[1]
+    cmp #$f0                                                          ; 2c85: c9 f0       ..  :8c85[1]
+; $2c87 referenced 1 time by $8c83
+c8c87
+    ror l00a1                                                         ; 2c87: 66 a1       f.  :8c87[1]
+    ldy #3                                                            ; 2c89: a0 03       ..  :8c89[1]
+    lda (l00b0),y                                                     ; 2c8b: b1 b0       ..  :8c8b[1]
+    iny                                                               ; 2c8d: c8          .   :8c8d[1]
+    and (l00b0),y                                                     ; 2c8e: 31 b0       1.  :8c8e[1]
+    cmp #$ff                                                          ; 2c90: c9 ff       ..  :8c90[1]
+    clc                                                               ; 2c92: 18          .   :8c92[1]
+    beq c8cb2                                                         ; 2c93: f0 1d       ..  :8c93[1]
+    jsr sub_c8f3f                                                     ; 2c95: 20 3f 8f     ?. :8c95[1]
+    clc                                                               ; 2c98: 18          .   :8c98[1]
+    bmi c8cb2                                                         ; 2c99: 30 17       0.  :8c99[1]
+    jsr sub_c8f6b                                                     ; 2c9b: 20 6b 8f     k. :8c9b[1]
+    lda l00a1                                                         ; 2c9e: a5 a1       ..  :8c9e[1]
+    rol                                                               ; 2ca0: 2a          *   :8ca0[1]
+    rol                                                               ; 2ca1: 2a          *   :8ca1[1]
+    and #1                                                            ; 2ca2: 29 01       ).  :8ca2[1]
+    eor #1                                                            ; 2ca4: 49 01       I.  :8ca4[1]
+    ldx l00b0                                                         ; 2ca6: a6 b0       ..  :8ca6[1]
+    ldy l00b1                                                         ; 2ca8: a4 b1       ..  :8ca8[1]
+    inx                                                               ; 2caa: e8          .   :8caa[1]
+    bne c8cae                                                         ; 2cab: d0 01       ..  :8cab[1]
+    iny                                                               ; 2cad: c8          .   :8cad[1]
+; $2cae referenced 1 time by $8cab
+c8cae
+    jsr tube_entry                                                    ; 2cae: 20 06 04     .. :8cae[1]
+    sec                                                               ; 2cb1: 38          8   :8cb1[1]
+; $2cb2 referenced 2 times by $8c93, $8c99
+c8cb2
+    ror l00a1                                                         ; 2cb2: 66 a1       f.  :8cb2[1]
+    jsr sub_c8f94                                                     ; 2cb4: 20 94 8f     .. :8cb4[1]
+    ldy #0                                                            ; 2cb7: a0 00       ..  :8cb7[1]
+    lda (l00b0),y                                                     ; 2cb9: b1 b0       ..  :8cb9[1]
+    bmi c8cc1                                                         ; 2cbb: 30 04       0.  :8cbb[1]
+    and #$0f                                                          ; 2cbd: 29 0f       ).  :8cbd[1]
+    sta l00cd                                                         ; 2cbf: 85 cd       ..  :8cbf[1]
+; $2cc1 referenced 1 time by $8cbb
+c8cc1
+    lda l00cd                                                         ; 2cc1: a5 cd       ..  :8cc1[1]
+    and #3                                                            ; 2cc3: 29 03       ).  :8cc3[1]
+    tax                                                               ; 2cc5: aa          .   :8cc5[1]
+    lda l10de,x                                                       ; 2cc6: bd de 10    ... :8cc6[1]
+    sta l108a                                                         ; 2cc9: 8d 8a 10    ... :8cc9[1]
+    lda l00cd                                                         ; 2ccc: a5 cd       ..  :8ccc[1]
+    ldy #$0a                                                          ; 2cce: a0 0a       ..  :8cce[1]
+    and #8                                                            ; 2cd0: 29 08       ).  :8cd0[1]
+    beq c8cd6                                                         ; 2cd2: f0 02       ..  :8cd2[1]
+    ldy #$10                                                          ; 2cd4: a0 10       ..  :8cd4[1]
+; $2cd6 referenced 1 time by $8cd2
+c8cd6
+    sty l00a3                                                         ; 2cd6: 84 a3       ..  :8cd6[1]
+    eor l911d,x                                                       ; 2cd8: 5d 1d 91    ].. :8cd8[1]
+    sta lfe80                                                         ; 2cdb: 8d 80 fe    ... :8cdb[1]
+    lsr                                                               ; 2cde: 4a          J   :8cde[1]
+    ldx l1088                                                         ; 2cdf: ae 88 10    ... :8cdf[1]
+    bcs c8ce7                                                         ; 2ce2: b0 03       ..  :8ce2[1]
+    ldx l1089                                                         ; 2ce4: ae 89 10    ... :8ce4[1]
+; $2ce7 referenced 1 time by $8ce2
+c8ce7
+    ldy #0                                                            ; 2ce7: a0 00       ..  :8ce7[1]
+    sty l00a2                                                         ; 2ce9: 84 a2       ..  :8ce9[1]
+    lda l1087                                                         ; 2ceb: ad 87 10    ... :8ceb[1]
+    bit l1087                                                         ; 2cee: 2c 87 10    ,.. :8cee[1]
+    bcc c8cfc                                                         ; 2cf1: 90 09       ..  :8cf1[1]
+    bpl c8d0d                                                         ; 2cf3: 10 18       ..  :8cf3[1]
+    sty l1088                                                         ; 2cf5: 8c 88 10    ... :8cf5[1]
+    and #$7f                                                          ; 2cf8: 29 7f       ).  :8cf8[1]
+    bpl c8d03                                                         ; 2cfa: 10 07       ..  :8cfa[1]
+; $2cfc referenced 1 time by $8cf1
+c8cfc
+    bvc c8d0d                                                         ; 2cfc: 50 0f       P.  :8cfc[1]
+    sty l1089                                                         ; 2cfe: 8c 89 10    ... :8cfe[1]
+    and #$bf                                                          ; 2d01: 29 bf       ).  :8d01[1]
+; $2d03 referenced 1 time by $8cfa
+c8d03
+    sta l1087                                                         ; 2d03: 8d 87 10    ... :8d03[1]
+    lda #0                                                            ; 2d06: a9 00       ..  :8d06[1]
+    jsr c8e12                                                         ; 2d08: 20 12 8e     .. :8d08[1]
+    ldx #0                                                            ; 2d0b: a2 00       ..  :8d0b[1]
+; $2d0d referenced 2 times by $8cf3, $8cfc
+c8d0d
+    txa                                                               ; 2d0d: 8a          .   :8d0d[1]
+    sta l00ce                                                         ; 2d0e: 85 ce       ..  :8d0e[1]
+    jsr c8f2a                                                         ; 2d10: 20 2a 8f     *. :8d10[1]
+; $2d13 referenced 2 times by $8d1d, $8d25
+c8d13
+    rts                                                               ; 2d13: 60          `   :8d13[1]
+
+; $2d14 referenced 1 time by $8d29
+loop_c8d14
+    jmp c8eaf                                                         ; 2d14: 4c af 8e    L.. :8d14[1]
+
+; $2d17 referenced 1 time by $8d2d
+loop_c8d17
+    jmp c8e12                                                         ; 2d17: 4c 12 8e    L.. :8d17[1]
+
+; $2d1a referenced 1 time by $8c0f
+sub_c8d1a
+    jsr sub_c8eff                                                     ; 2d1a: 20 ff 8e     .. :8d1a[1]
+    bne c8d13                                                         ; 2d1d: d0 f4       ..  :8d1d[1]
+    ldy #6                                                            ; 2d1f: a0 06       ..  :8d1f[1]
+    lda (l00b0),y                                                     ; 2d21: b1 b0       ..  :8d21[1]
+    cmp #$10                                                          ; 2d23: c9 10       ..  :8d23[1]
+    beq c8d13                                                         ; 2d25: f0 ec       ..  :8d25[1]
+    cmp #$c0                                                          ; 2d27: c9 c0       ..  :8d27[1]
+    beq loop_c8d14                                                    ; 2d29: f0 e9       ..  :8d29[1]
+    cmp #$e0                                                          ; 2d2b: c9 e0       ..  :8d2b[1]
+    bcs loop_c8d17                                                    ; 2d2d: b0 e8       ..  :8d2d[1]
+    ldy #8                                                            ; 2d2f: a0 08       ..  :8d2f[1]
+    lda (l00b0),y                                                     ; 2d31: b1 b0       ..  :8d31[1]
+    bit l00b2                                                         ; 2d33: 24 b2       $.  :8d33[1]
+    bmi c8d92                                                         ; 2d35: 30 5b       0[  :8d35[1]
+    ldx l00b5                                                         ; 2d37: a6 b5       ..  :8d37[1]
+    beq c8d41                                                         ; 2d39: f0 06       ..  :8d39[1]
+    inc l00b3                                                         ; 2d3b: e6 b3       ..  :8d3b[1]
+    bne c8d41                                                         ; 2d3d: d0 02       ..  :8d3d[1]
+    inc l00b4                                                         ; 2d3f: e6 b4       ..  :8d3f[1]
+; $2d41 referenced 3 times by $8d39, $8d3d, $8d8f
+c8d41
+    jsr nmi_handler2_rom_end                                          ; 2d41: 20 fb 90     .. :8d41[1]
+    sta l00cf                                                         ; 2d44: 85 cf       ..  :8d44[1]
+    sbc l00a3                                                         ; 2d46: e5 a3       ..  :8d46[1]
+    eor #$ff                                                          ; 2d48: 49 ff       I.  :8d48[1]
+    clc                                                               ; 2d4a: 18          .   :8d4a[1]
+    adc #1                                                            ; 2d4b: 69 01       i.  :8d4b[1]
+    sta l00a5                                                         ; 2d4d: 85 a5       ..  :8d4d[1]
+    lda l00b4                                                         ; 2d4f: a5 b4       ..  :8d4f[1]
+    bne c8d74                                                         ; 2d51: d0 21       .!  :8d51[1]
+    lda l00b3                                                         ; 2d53: a5 b3       ..  :8d53[1]
+    beq c8d91                                                         ; 2d55: f0 3a       .:  :8d55[1]
+    cmp l00a5                                                         ; 2d57: c5 a5       ..  :8d57[1]
+    beq c8d5d                                                         ; 2d59: f0 02       ..  :8d59[1]
+    bcs c8d74                                                         ; 2d5b: b0 17       ..  :8d5b[1]
+; $2d5d referenced 1 time by $8d59
+c8d5d
+    sta l00a5                                                         ; 2d5d: 85 a5       ..  :8d5d[1]
+    ldx l00b5                                                         ; 2d5f: a6 b5       ..  :8d5f[1]
+    beq c8d74                                                         ; 2d61: f0 11       ..  :8d61[1]
+    stx l00a6                                                         ; 2d63: 86 a6       ..  :8d63[1]
+    ror l00a1                                                         ; 2d65: 66 a1       f.  :8d65[1]
+    sec                                                               ; 2d67: 38          8   :8d67[1]
+    rol l00a1                                                         ; 2d68: 26 a1       &.  :8d68[1]
+    cmp #1                                                            ; 2d6a: c9 01       ..  :8d6a[1]
+    bne c8d74                                                         ; 2d6c: d0 06       ..  :8d6c[1]
+    lda nmi_lda_immXXX4+1                                             ; 2d6e: ad 22 0d    .". :8d6e[1]
+    sta nmi_lda_immXXX3+1                                             ; 2d71: 8d 4c 0d    .L. :8d71[1]
+; $2d74 referenced 4 times by $8d51, $8d5b, $8d61, $8d6c
+c8d74
+    lda l00b3                                                         ; 2d74: a5 b3       ..  :8d74[1]
+    sec                                                               ; 2d76: 38          8   :8d76[1]
+    sbc l00a5                                                         ; 2d77: e5 a5       ..  :8d77[1]
+    sta l00b3                                                         ; 2d79: 85 b3       ..  :8d79[1]
+    lda l00b4                                                         ; 2d7b: a5 b4       ..  :8d7b[1]
+    sbc #0                                                            ; 2d7d: e9 00       ..  :8d7d[1]
+    sta l00b4                                                         ; 2d7f: 85 b4       ..  :8d7f[1]
+    jsr c8e0e                                                         ; 2d81: 20 0e 8e     .. :8d81[1]
+    bne c8d91                                                         ; 2d84: d0 0b       ..  :8d84[1]
+    lda l00b3                                                         ; 2d86: a5 b3       ..  :8d86[1]
+    ora l00b4                                                         ; 2d88: 05 b4       ..  :8d88[1]
+    beq c8d91                                                         ; 2d8a: f0 05       ..  :8d8a[1]
+    jsr c8ecc                                                         ; 2d8c: 20 cc 8e     .. :8d8c[1]
+    beq c8d41                                                         ; 2d8f: f0 b0       ..  :8d8f[1]
+; $2d91 referenced 4 times by $8d55, $8d84, $8d8a, $8d9d
+c8d91
+    rts                                                               ; 2d91: 60          `   :8d91[1]
+
+; $2d92 referenced 1 time by $8d35
+c8d92
+    jsr nmi_handler2_rom_end                                          ; 2d92: 20 fb 90     .. :8d92[1]
+    sta l00cf                                                         ; 2d95: 85 cf       ..  :8d95[1]
+    ldy #9                                                            ; 2d97: a0 09       ..  :8d97[1]
+    lda (l00b0),y                                                     ; 2d99: b1 b0       ..  :8d99[1]
+    and #$1f                                                          ; 2d9b: 29 1f       ).  :8d9b[1]
+    beq c8d91                                                         ; 2d9d: f0 f2       ..  :8d9d[1]
+    sta l00a5                                                         ; 2d9f: 85 a5       ..  :8d9f[1]
+    bit l00a1                                                         ; 2da1: 24 a1       $.  :8da1[1]
+    bvs c8e0e                                                         ; 2da3: 70 69       pi  :8da3[1]
+    bit l108a                                                         ; 2da5: 2c 8a 10    ,.. :8da5[1]
+    bvc c8e0e                                                         ; 2da8: 50 64       Pd  :8da8[1]
+    ldx #$33 ; '3'                                                    ; 2daa: a2 33       .3  :8daa[1]
+; $2dac referenced 1 time by $8db3
+loop_c8dac
+    lda c0d60,x                                                       ; 2dac: bd 60 0d    .`. :8dac[1]
+    sta l1000,x                                                       ; 2daf: 9d 00 10    ... :8daf[1]
+    dex                                                               ; 2db2: ca          .   :8db2[1]
+    bpl loop_c8dac                                                    ; 2db3: 10 f7       ..  :8db3[1]
+    jsr sub_c8dc6                                                     ; 2db5: 20 c6 8d     .. :8db5[1]
+    ldx #$33 ; '3'                                                    ; 2db8: a2 33       .3  :8db8[1]
+; $2dba referenced 1 time by $8dc1
+loop_c8dba
+    lda l1000,x                                                       ; 2dba: bd 00 10    ... :8dba[1]
+    sta c0d60,x                                                       ; 2dbd: 9d 60 0d    .`. :8dbd[1]
+    dex                                                               ; 2dc0: ca          .   :8dc0[1]
+    bpl loop_c8dba                                                    ; 2dc1: 10 f7       ..  :8dc1[1]
+    lda l00a2                                                         ; 2dc3: a5 a2       ..  :8dc3[1]
+    rts                                                               ; 2dc5: 60          `   :8dc5[1]
+
+; $2dc6 referenced 1 time by $8db5
+sub_c8dc6
+    lda #0                                                            ; 2dc6: a9 00       ..  :8dc6[1]
+    sta l00b4                                                         ; 2dc8: 85 b4       ..  :8dc8[1]
+    lda (l00b0),y                                                     ; 2dca: b1 b0       ..  :8dca[1]
+    and #$e0                                                          ; 2dcc: 29 e0       ).  :8dcc[1]
+    bne c8dd2                                                         ; 2dce: d0 02       ..  :8dce[1]
+    lda #$10                                                          ; 2dd0: a9 10       ..  :8dd0[1]
+; $2dd2 referenced 1 time by $8dce
+c8dd2
+    asl                                                               ; 2dd2: 0a          .   :8dd2[1]
+    rol l00b4                                                         ; 2dd3: 26 b4       &.  :8dd3[1]
+    asl                                                               ; 2dd5: 0a          .   :8dd5[1]
+    rol l00b4                                                         ; 2dd6: 26 b4       &.  :8dd6[1]
+    asl                                                               ; 2dd8: 0a          .   :8dd8[1]
+    rol l00b4                                                         ; 2dd9: 26 b4       &.  :8dd9[1]
+    sta l00b3                                                         ; 2ddb: 85 b3       ..  :8ddb[1]
+    tax                                                               ; 2ddd: aa          .   :8ddd[1]
+    beq c8de2                                                         ; 2dde: f0 02       ..  :8dde[1]
+    inc l00b4                                                         ; 2de0: e6 b4       ..  :8de0[1]
+; $2de2 referenced 1 time by $8dde
+c8de2
+    jsr nmi3_handler_rom_end                                          ; 2de2: 20 3e 90     >. :8de2[1]
+    lda #$14                                                          ; 2de5: a9 14       ..  :8de5[1]
+    sta l00b7                                                         ; 2de7: 85 b7       ..  :8de7[1]
+; $2de9 referenced 1 time by $8dfc
+loop_c8de9
+    lda #$e0                                                          ; 2de9: a9 e0       ..  :8de9[1]
+    sta l00a2                                                         ; 2deb: 85 a2       ..  :8deb[1]
+    sta lfe84                                                         ; 2ded: 8d 84 fe    ... :8ded[1]
+; $2df0 referenced 1 time by $8df2
+loop_c8df0
+    lda l00a2                                                         ; 2df0: a5 a2       ..  :8df0[1]
+    bmi loop_c8df0                                                    ; 2df2: 30 fc       0.  :8df2[1]
+    bne c8e0d                                                         ; 2df4: d0 17       ..  :8df4[1]
+    lda l00a5                                                         ; 2df6: a5 a5       ..  :8df6[1]
+    beq c8e03                                                         ; 2df8: f0 09       ..  :8df8[1]
+    dec l00b7                                                         ; 2dfa: c6 b7       ..  :8dfa[1]
+    bne loop_c8de9                                                    ; 2dfc: d0 eb       ..  :8dfc[1]
+    lda #$10                                                          ; 2dfe: a9 10       ..  :8dfe[1]
+    sta l00a2                                                         ; 2e00: 85 a2       ..  :8e00[1]
+    rts                                                               ; 2e02: 60          `   :8e02[1]
+
+; $2e03 referenced 1 time by $8df8
+c8e03
+    lda l00b6                                                         ; 2e03: a5 b6       ..  :8e03[1]
+    eor #$fb                                                          ; 2e05: 49 fb       I.  :8e05[1]
+    beq c8e0d                                                         ; 2e07: f0 04       ..  :8e07[1]
+    lda #$20 ; ' '                                                    ; 2e09: a9 20       .   :8e09[1]
+    sta l00a2                                                         ; 2e0b: 85 a2       ..  :8e0b[1]
+; $2e0d referenced 2 times by $8df4, $8e07
+c8e0d
+    rts                                                               ; 2e0d: 60          `   :8e0d[1]
+
+; $2e0e referenced 4 times by $8d81, $8da3, $8da8, $8ec2
+c8e0e
+    ldy #6                                                            ; 2e0e: a0 06       ..  :8e0e[1]
+    lda (l00b0),y                                                     ; 2e10: b1 b0       ..  :8e10[1]
+; $2e12 referenced 4 times by $8d08, $8d17, $8efc, $8f21
+c8e12
+    ldy #$ff                                                          ; 2e12: a0 ff       ..  :8e12[1]
+; $2e14 referenced 1 time by $8e18
+loop_c8e14
+    iny                                                               ; 2e14: c8          .   :8e14[1]
+    cmp l9121,y                                                       ; 2e15: d9 21 91    .!. :8e15[1]
+    bne loop_c8e14                                                    ; 2e18: d0 fa       ..  :8e18[1]
+    pha                                                               ; 2e1a: 48          H   :8e1a[1]
+    lda nmi_and_table,y                                               ; 2e1b: b9 2d 91    .-. :8e1b[1]
+    sta nmi_and_imm+1                                                 ; 2e1e: 8d 05 0d    ... :8e1e[1]
+    ror l00a2                                                         ; 2e21: 66 a2       f.  :8e21[1]
+    pla                                                               ; 2e23: 68          h   :8e23[1]
+    bpl c8e72                                                         ; 2e24: 10 4c       .L  :8e24[1]
+    bit l00a1                                                         ; 2e26: 24 a1       $.  :8e26[1]
+    bvc c8e32                                                         ; 2e28: 50 08       P.  :8e28[1]
+    ldy l00ce                                                         ; 2e2a: a4 ce       ..  :8e2a[1]
+    cpy #$14                                                          ; 2e2c: c0 14       ..  :8e2c[1]
+    bcc c8e32                                                         ; 2e2e: 90 02       ..  :8e2e[1]
+    ora #2                                                            ; 2e30: 09 02       ..  :8e30[1]
+; $2e32 referenced 2 times by $8e28, $8e2e
+c8e32
+    sta l00a7                                                         ; 2e32: 85 a7       ..  :8e32[1]
+    ldy #1                                                            ; 2e34: a0 01       ..  :8e34[1]
+    cmp #$c0                                                          ; 2e36: c9 c0       ..  :8e36[1]
+    beq c8e53                                                         ; 2e38: f0 19       ..  :8e38[1]
+    ora #4                                                            ; 2e3a: 09 04       ..  :8e3a[1]
+    bcs c8e53                                                         ; 2e3c: b0 15       ..  :8e3c[1]
+    ldy l00a5                                                         ; 2e3e: a4 a5       ..  :8e3e[1]
+    cmp #$85                                                          ; 2e40: c9 85       ..  :8e40[1]
+    beq c8e4d                                                         ; 2e42: f0 09       ..  :8e42[1]
+    cmp #$87                                                          ; 2e44: c9 87       ..  :8e44[1]
+    bne c8e53                                                         ; 2e46: d0 0b       ..  :8e46[1]
+    lda #nmi_XXX1-(nmi_beq+2)                                         ; 2e48: a9 48       .H  :8e48[1]
+    sta nmi_beq+1                                                     ; 2e4a: 8d 09 0d    ... :8e4a[1]
+; $2e4d referenced 1 time by $8e42
+c8e4d
+    lda #$80                                                          ; 2e4d: a9 80       ..  :8e4d[1]
+    sta l00a7                                                         ; 2e4f: 85 a7       ..  :8e4f[1]
+    lda #$84                                                          ; 2e51: a9 84       ..  :8e51[1]
+; $2e53 referenced 3 times by $8e38, $8e3c, $8e46
+c8e53
+    sty l00a5                                                         ; 2e53: 84 a5       ..  :8e53[1]
+    sta lfe84                                                         ; 2e55: 8d 84 fe    ... :8e55[1]
+    cmp #$f0                                                          ; 2e58: c9 f0       ..  :8e58[1]
+    bcc c8e64                                                         ; 2e5a: 90 08       ..  :8e5a[1]
+    jsr c8e9f                                                         ; 2e5c: 20 9f 8e     .. :8e5c[1]
+    and #$5c ; '\'                                                    ; 2e5f: 29 5c       )\  :8e5f[1]
+    sta l00a2                                                         ; 2e61: 85 a2       ..  :8e61[1]
+    rts                                                               ; 2e63: 60          `   :8e63[1]
+
+; $2e64 referenced 4 times by $8e5a, $8e66, $8e7f, $8e83
+c8e64
+    lda l00a2                                                         ; 2e64: a5 a2       ..  :8e64[1]
+    bmi c8e64                                                         ; 2e66: 30 fc       0.  :8e66[1]
+    cmp #$20 ; ' '                                                    ; 2e68: c9 20       .   :8e68[1]
+    bne c8e6f                                                         ; 2e6a: d0 03       ..  :8e6a[1]
+    jsr c8ea5                                                         ; 2e6c: 20 a5 8e     .. :8e6c[1]
+; $2e6f referenced 1 time by $8e6a
+c8e6f
+    lda l00a2                                                         ; 2e6f: a5 a2       ..  :8e6f[1]
+    rts                                                               ; 2e71: 60          `   :8e71[1]
+
+; $2e72 referenced 1 time by $8e24
+c8e72
+    ldy #1                                                            ; 2e72: a0 01       ..  :8e72[1]
+    sty l00a5                                                         ; 2e74: 84 a5       ..  :8e74[1]
+    ora l00a4                                                         ; 2e76: 05 a4       ..  :8e76[1]
+    sta l00a7                                                         ; 2e78: 85 a7       ..  :8e78[1]
+    sta lfe84                                                         ; 2e7a: 8d 84 fe    ... :8e7a[1]
+    bit l00b2                                                         ; 2e7d: 24 b2       $.  :8e7d[1]
+    bmi c8e64                                                         ; 2e7f: 30 e3       0.  :8e7f[1]
+    cmp #$20 ; ' '                                                    ; 2e81: c9 20       .   :8e81[1]
+    bcs c8e64                                                         ; 2e83: b0 df       ..  :8e83[1]
+; $2e85 referenced 1 time by $8e8b
+loop_c8e85
+    lda l00a2                                                         ; 2e85: a5 a2       ..  :8e85[1]
+    bpl c8e9e                                                         ; 2e87: 10 15       ..  :8e87[1]
+    lda l00ff                                                         ; 2e89: a5 ff       ..  :8e89[1]
+    bpl loop_c8e85                                                    ; 2e8b: 10 f8       ..  :8e8b[1]
+    lda #opcode_rti                                                   ; 2e8d: a9 40       .@  :8e8d[1]
+    sta nmi_handler_ram                                               ; 2e8f: 8d 00 0d    ... :8e8f[1]
+    lda #0                                                            ; 2e92: a9 00       ..  :8e92[1]
+    sta lfe80                                                         ; 2e94: 8d 80 fe    ... :8e94[1]
+    lda l00ff                                                         ; 2e97: a5 ff       ..  :8e97[1]
+    sta l1082                                                         ; 2e99: 8d 82 10    ... :8e99[1]
+    sta l00a2                                                         ; 2e9c: 85 a2       ..  :8e9c[1]
+; $2e9e referenced 1 time by $8e87
+c8e9e
+    rts                                                               ; 2e9e: 60          `   :8e9e[1]
+
+; $2e9f referenced 2 times by $8e5c, $8ea3
+c8e9f
+    lda lfe84                                                         ; 2e9f: ad 84 fe    ... :8e9f[1]
+    ror                                                               ; 2ea2: 6a          j   :8ea2[1]
+    bcc c8e9f                                                         ; 2ea3: 90 fa       ..  :8ea3[1]
+; $2ea5 referenced 2 times by $8e6c, $8ea9
+c8ea5
+    lda lfe84                                                         ; 2ea5: ad 84 fe    ... :8ea5[1]
+    ror                                                               ; 2ea8: 6a          j   :8ea8[1]
+    bcs c8ea5                                                         ; 2ea9: b0 fa       ..  :8ea9[1]
+    lda lfe84                                                         ; 2eab: ad 84 fe    ... :8eab[1]
+    rts                                                               ; 2eae: 60          `   :8eae[1]
+
+; $2eaf referenced 1 time by $8d14
+c8eaf
+    lda #nmi_XXX1-(nmi_beq+2)                                         ; 2eaf: a9 48       .H  :8eaf[1]
+    sta nmi_lda_immXXX3+1                                             ; 2eb1: 8d 4c 0d    .L. :8eb1[1]
+    ldx nmi_beq+1                                                     ; 2eb4: ae 09 0d    ... :8eb4[1]
+; $2eb7 referenced 2 times by $8eb9, $8ec9
+c8eb7
+    sbc #1                                                            ; 2eb7: e9 01       ..  :8eb7[1]
+    bne c8eb7                                                         ; 2eb9: d0 fc       ..  :8eb9[1]
+    stx nmi_beq+1                                                     ; 2ebb: 8e 09 0d    ... :8ebb[1]
+    lda #4                                                            ; 2ebe: a9 04       ..  :8ebe[1]
+    sta l00a6                                                         ; 2ec0: 85 a6       ..  :8ec0[1]
+    jsr c8e0e                                                         ; 2ec2: 20 0e 8e     .. :8ec2[1]
+    bne c8ecb                                                         ; 2ec5: d0 04       ..  :8ec5[1]
+    dec l00b3                                                         ; 2ec7: c6 b3       ..  :8ec7[1]
+    bne c8eb7                                                         ; 2ec9: d0 ec       ..  :8ec9[1]
+; $2ecb referenced 1 time by $8ec5
+c8ecb
+    rts                                                               ; 2ecb: 60          `   :8ecb[1]
+
+; $2ecc referenced 3 times by $8d8c, $8ee2, $8ee7
+c8ecc
+    jsr sub_c8eec                                                     ; 2ecc: 20 ec 8e     .. :8ecc[1]
+    bne c8eeb                                                         ; 2ecf: d0 1a       ..  :8ecf[1]
+    lda l00cd                                                         ; 2ed1: a5 cd       ..  :8ed1[1]
+    and #1                                                            ; 2ed3: 29 01       ).  :8ed3[1]
+    asl                                                               ; 2ed5: 0a          .   :8ed5[1]
+    tay                                                               ; 2ed6: a8          .   :8ed6[1]
+    lda l00ce                                                         ; 2ed7: a5 ce       ..  :8ed7[1]
+    bit l108a                                                         ; 2ed9: 2c 8a 10    ,.. :8ed9[1]
+    bpl c8edf                                                         ; 2edc: 10 01       ..  :8edc[1]
+    lsr                                                               ; 2ede: 4a          J   :8ede[1]
+; $2edf referenced 1 time by $8edc
+c8edf
+    cmp l108b,y                                                       ; 2edf: d9 8b 10    ... :8edf[1]
+    beq c8ecc                                                         ; 2ee2: f0 e8       ..  :8ee2[1]
+    cmp l108c,y                                                       ; 2ee4: d9 8c 10    ... :8ee4[1]
+    beq c8ecc                                                         ; 2ee7: f0 e3       ..  :8ee7[1]
+    lda #0                                                            ; 2ee9: a9 00       ..  :8ee9[1]
+; $2eeb referenced 2 times by $8ecf, $8ef6
+c8eeb
+    rts                                                               ; 2eeb: 60          `   :8eeb[1]
+
+; $2eec referenced 1 time by $8ecc
+sub_c8eec
+    bit l108a                                                         ; 2eec: 2c 8a 10    ,.. :8eec[1]
+    bpl c8ef8                                                         ; 2eef: 10 07       ..  :8eef[1]
+    lda #$40 ; '@'                                                    ; 2ef1: a9 40       .@  :8ef1[1]
+    jsr sub_c8efa                                                     ; 2ef3: 20 fa 8e     .. :8ef3[1]
+    bne c8eeb                                                         ; 2ef6: d0 f3       ..  :8ef6[1]
+; $2ef8 referenced 1 time by $8eef
+c8ef8
+    lda #$50 ; 'P'                                                    ; 2ef8: a9 50       .P  :8ef8[1]
+; $2efa referenced 1 time by $8ef3
+sub_c8efa
+    inc l00ce                                                         ; 2efa: e6 ce       ..  :8efa[1]
+    jmp c8e12                                                         ; 2efc: 4c 12 8e    L.. :8efc[1]
+
+; $2eff referenced 1 time by $8d1a
+sub_c8eff
+    lda l00cd                                                         ; 2eff: a5 cd       ..  :8eff[1]
+    and #1                                                            ; 2f01: 29 01       ).  :8f01[1]
+    asl                                                               ; 2f03: 0a          .   :8f03[1]
+    tax                                                               ; 2f04: aa          .   :8f04[1]
+    ldy #7                                                            ; 2f05: a0 07       ..  :8f05[1]
+    lda (l00b0),y                                                     ; 2f07: b1 b0       ..  :8f07[1]
+    jsr sub_c8f33                                                     ; 2f09: 20 33 8f     3. :8f09[1]
+    bit l108a                                                         ; 2f0c: 2c 8a 10    ,.. :8f0c[1]
+    bpl c8f12                                                         ; 2f0f: 10 01       ..  :8f0f[1]
+    asl                                                               ; 2f11: 0a          .   :8f11[1]
+; $2f12 referenced 1 time by $8f0f
+c8f12
+    sta l00ce                                                         ; 2f12: 85 ce       ..  :8f12[1]
+    tay                                                               ; 2f14: a8          .   :8f14[1]
+    beq c8f21                                                         ; 2f15: f0 0a       ..  :8f15[1]
+; $2f17 referenced 1 time by $8f1d
+loop_c8f17
+    sta lfe87                                                         ; 2f17: 8d 87 fe    ... :8f17[1]
+    cmp lfe87                                                         ; 2f1a: cd 87 fe    ... :8f1a[1]
+    bne loop_c8f17                                                    ; 2f1d: d0 f8       ..  :8f1d[1]
+    lda #$10                                                          ; 2f1f: a9 10       ..  :8f1f[1]
+; $2f21 referenced 1 time by $8f15
+c8f21
+    jsr c8e12                                                         ; 2f21: 20 12 8e     .. :8f21[1]
+    bne c8f3e                                                         ; 2f24: d0 18       ..  :8f24[1]
+    ldy #7                                                            ; 2f26: a0 07       ..  :8f26[1]
+    lda (l00b0),y                                                     ; 2f28: b1 b0       ..  :8f28[1]
+; $2f2a referenced 3 times by $8c44, $8d10, $8f30
+c8f2a
+    sta lfe85                                                         ; 2f2a: 8d 85 fe    ... :8f2a[1]
+    cmp lfe85                                                         ; 2f2d: cd 85 fe    ... :8f2d[1]
+    bne c8f2a                                                         ; 2f30: d0 f8       ..  :8f30[1]
+    rts                                                               ; 2f32: 60          `   :8f32[1]
+
+; $2f33 referenced 1 time by $8f09
+sub_c8f33
+    jsr sub_c8f37                                                     ; 2f33: 20 37 8f     7. :8f33[1]
+    inx                                                               ; 2f36: e8          .   :8f36[1]
+; $2f37 referenced 1 time by $8f33
+sub_c8f37
+    cmp l108b,x                                                       ; 2f37: dd 8b 10    ... :8f37[1]
+    bcc c8f3e                                                         ; 2f3a: 90 02       ..  :8f3a[1]
+    adc #0                                                            ; 2f3c: 69 00       i.  :8f3c[1]
+; $2f3e referenced 2 times by $8f24, $8f3a
+c8f3e
+    rts                                                               ; 2f3e: 60          `   :8f3e[1]
+
+; $2f3f referenced 5 times by $8c95, $8f75, $92b0, $932b, $9628
+sub_c8f3f
+    lda #osbyte_read_tube_presence                                    ; 2f3f: a9 ea       ..  :8f3f[1]
+    ldx #0                                                            ; 2f41: a2 00       ..  :8f41[1]
+    ldy #$ff                                                          ; 2f43: a0 ff       ..  :8f43[1]
+    jsr osbyte                                                        ; 2f45: 20 f4 ff     .. :8f45[1]
+    txa                                                               ; 2f48: 8a          .   :8f48[1]
+    eor #$ff                                                          ; 2f49: 49 ff       I.  :8f49[1]
+    sta l10d6                                                         ; 2f4b: 8d d6 10    ... :8f4b[1]
+    rts                                                               ; 2f4e: 60          `   :8f4e[1]
+
+; $2f4f referenced 1 time by $8c65
+sub_c8f4f
+    lda #osbyte_issue_service_request                                 ; 2f4f: a9 8f       ..  :8f4f[1]
+    ldx #$0c                                                          ; 2f51: a2 0c       ..  :8f51[1]
+    ldy #$ff                                                          ; 2f53: a0 ff       ..  :8f53[1]
+    jsr osbyte                                                        ; 2f55: 20 f4 ff     .. :8f55[1]
+    sty l00a0                                                         ; 2f58: 84 a0       ..  :8f58[1]
+    inc l10d3                                                         ; 2f5a: ee d3 10    ... :8f5a[1]
+    rts                                                               ; 2f5d: 60          `   :8f5d[1]
+
+; $2f5e referenced 1 time by $8c4e
+sub_c8f5e
+    ldy l00a0                                                         ; 2f5e: a4 a0       ..  :8f5e[1]
+    lda #osbyte_issue_service_request                                 ; 2f60: a9 8f       ..  :8f60[1]
+    ldx #$0b                                                          ; 2f62: a2 0b       ..  :8f62[1]
+    jsr osbyte                                                        ; 2f64: 20 f4 ff     .. :8f64[1]
+    dec l10d3                                                         ; 2f67: ce d3 10    ... :8f67[1]
+    rts                                                               ; 2f6a: 60          `   :8f6a[1]
+
+; $2f6b referenced 4 times by $8921, $8c9b, $933e, $9819
+sub_c8f6b
+    pha                                                               ; 2f6b: 48          H   :8f6b[1]
+; $2f6c referenced 1 time by $8f71
+loop_c8f6c
+    lda #$c1                                                          ; 2f6c: a9 c1       ..  :8f6c[1]
+    jsr tube_entry                                                    ; 2f6e: 20 06 04     .. :8f6e[1]
+    bcc loop_c8f6c                                                    ; 2f71: 90 f9       ..  :8f71[1]
+    pla                                                               ; 2f73: 68          h   :8f73[1]
+    rts                                                               ; 2f74: 60          `   :8f74[1]
+
+; $2f75 referenced 1 time by $8071
+sub_c8f75
+    jsr sub_c8f3f                                                     ; 2f75: 20 3f 8f     ?. :8f75[1]
+    bmi c8f81                                                         ; 2f78: 30 07       0.  :8f78[1]
+; $2f7a referenced 3 times by $8c4b, $9364, $97e3
+sub_c8f7a
+    pha                                                               ; 2f7a: 48          H   :8f7a[1]
+    lda #$81                                                          ; 2f7b: a9 81       ..  :8f7b[1]
+    jsr tube_entry                                                    ; 2f7d: 20 06 04     .. :8f7d[1]
+    pla                                                               ; 2f80: 68          h   :8f80[1]
+; $2f81 referenced 1 time by $8f78
+c8f81
+    rts                                                               ; 2f81: 60          `   :8f81[1]
+
+; $2f82 referenced 1 time by $8c68
+sub_c8f82
+    lda #osbyte_read_write_startup_options                            ; 2f82: a9 ff       ..  :8f82[1]
+    ldx #0                                                            ; 2f84: a2 00       ..  :8f84[1]
+    tay                                                               ; 2f86: a8          .   :8f86[1]
+    jsr osbyte                                                        ; 2f87: 20 f4 ff     .. :8f87[1]
+    txa                                                               ; 2f8a: 8a          .   :8f8a[1]
+    lsr                                                               ; 2f8b: 4a          J   :8f8b[1]
+    lsr                                                               ; 2f8c: 4a          J   :8f8c[1]
+    lsr                                                               ; 2f8d: 4a          J   :8f8d[1]
+    lsr                                                               ; 2f8e: 4a          J   :8f8e[1]
+    and #3                                                            ; 2f8f: 29 03       ).  :8f8f[1]
+    sta l00a4                                                         ; 2f91: 85 a4       ..  :8f91[1]
+    rts                                                               ; 2f93: 60          `   :8f93[1]
+
+; $2f94 referenced 1 time by $8cb4
+sub_c8f94
+    ldx #nmi_handler_rom_end-nmi_handler_rom_start-1                  ; 2f94: a2 5d       .]  :8f94[1]
+; $2f96 referenced 1 time by $8f9d
+loop_c8f96
+    lda nmi_handler_rom_start,x                                       ; 2f96: bd d2 8f    ... :8f96[1]
+    sta nmi_handler_ram,x                                             ; 2f99: 9d 00 0d    ... :8f99[1]
+    dex                                                               ; 2f9c: ca          .   :8f9c[1]
+    bpl loop_c8f96                                                    ; 2f9d: 10 f7       ..  :8f9d[1]
+    ldx #3                                                            ; 2f9f: a2 03       ..  :8f9f[1]
+    bit l00a1                                                         ; 2fa1: 24 a1       $.  :8fa1[1]
+    bvc c8fb5                                                         ; 2fa3: 50 10       P.  :8fa3[1]
+    lda #nmi_XXX8-(nmi_beq+2)                                         ; 2fa5: a9 4d       .M  :8fa5[1]
+    sta nmi_lda_immXXX4+1                                             ; 2fa7: 8d 22 0d    .". :8fa7[1]
+    ldx #nmi3_handler_rom_end-nmi3_handler_rom_start                  ; 2faa: a2 0e       ..  :8faa[1]
+; $2fac referenced 1 time by $8fb3
+loop_c8fac
+    lda nmi3_handler_rom_start-1,x                                    ; 2fac: bd 2f 90    ./. :8fac[1]
+    sta nmi_XXX2-1,x                                                  ; 2faf: 9d 38 0d    .8. :8faf[1]
+    dex                                                               ; 2fb2: ca          .   :8fb2[1]
+    bne loop_c8fac                                                    ; 2fb3: d0 f7       ..  :8fb3[1]
+; $2fb5 referenced 1 time by $8fa3
+c8fb5
+    bit l00a1                                                         ; 2fb5: 24 a1       $.  :8fb5[1]
+    bmi c8fc7                                                         ; 2fb7: 30 0e       0.  :8fb7[1]
+    ldy #1                                                            ; 2fb9: a0 01       ..  :8fb9[1]
+    lda (l00b0),y                                                     ; 2fbb: b1 b0       ..  :8fbb[1]
+    sta nmi_lda_abs+1,x                                               ; 2fbd: 9d 3a 0d    .:. :8fbd[1]
+    iny                                                               ; 2fc0: c8          .   :8fc0[1]
+    lda (l00b0),y                                                     ; 2fc1: b1 b0       ..  :8fc1[1]
+    sta nmi_lda_abs+2,x                                               ; 2fc3: 9d 3b 0d    .;. :8fc3[1]
+    rts                                                               ; 2fc6: 60          `   :8fc6[1]
+
+; $2fc7 referenced 1 time by $8fb7
+c8fc7
+    lda #opcode_bcs                                                   ; 2fc7: a9 b0       ..  :8fc7[1]
+    sta nmi_XXX6                                                      ; 2fc9: 8d 3f 0d    .?. :8fc9[1]
+    lda #nmi_XXX7-(nmi_XXX6+2)                                        ; 2fcc: a9 06       ..  :8fcc[1]
+    sta nmi_XXX6+1                                                    ; 2fce: 8d 40 0d    .@. :8fce[1]
+    rts                                                               ; 2fd1: 60          `   :8fd1[1]
+
+nmi_handler_rom_start
+}
+
+
+!pseudopc $0d00 {
+nmi_handler_ram
+    pha                                                               ; 2fd2: 48          H   :0d00[5]
+    lda lfe84                                                         ; 2fd3: ad 84 fe    ... :0d01[5]
+; The operand of this and is modified at runtime.
+nmi_and_imm
+    and #$18                                                          ; 2fd6: 29 18       ).  :0d04[5]
+    cmp #3                                                            ; 2fd8: c9 03       ..  :0d06[5]
+; The operand of this "beq" is modified at runtime.
+nmi_beq
+    beq nmi_XXX2                                                      ; 2fda: f0 2f       ./  :0d08[5]
+    and #$fc                                                          ; 2fdc: 29 fc       ).  :0d0a[5]
+    bne l0d12                                                         ; 2fde: d0 04       ..  :0d0c[5]
+    dec l00a5                                                         ; 2fe0: c6 a5       ..  :0d0e[5]
+    bne nmi_lda_zp                                                    ; 2fe2: d0 04       ..  :0d10[5]
+l0d12
+    sta l00a2                                                         ; 2fe4: 85 a2       ..  :0d12[5]
+    pla                                                               ; 2fe6: 68          h   :0d14[5]
+    rti                                                               ; 2fe7: 40          @   :0d15[5]
+
+; The operand of this lda is modified at runtime.
+nmi_lda_zp
+    lda l00a5                                                         ; 2fe8: a5 a5       ..  :0d16[5]
+; This instruction is patched at runtime to toggle between cmp #/bcs.
+nmi_cmp_imm_or_bcs
+    cmp #1                                                            ; 2fea: c9 01       ..  :0d18[5]
+    bne l0d26                                                         ; 2fec: d0 0a       ..  :0d1a[5]
+    lda l00a1                                                         ; 2fee: a5 a1       ..  :0d1c[5]
+    ror                                                               ; 2ff0: 6a          j   :0d1e[5]
+l0d1f
+nmi_XXX5 = l0d1f+1
+    bcc l0d26                                                         ; 2ff1: 90 05       ..  :0d1f[5]
+; One patched variant of the code transfers control to nmi_XXX5, which
+; is the
+;     second byte of the following bcc instruction. That is always
+; &05, which is
+;     ORA #. XXX: correct?
+; The operand of this lda is modified at runtime.
+nmi_lda_immXXX4
+    lda #nmi_XXX1-(nmi_beq+2)                                         ; 2ff3: a9 48       .H  :0d21[5]
+    sta nmi_lda_immXXX3+1                                             ; 2ff5: 8d 4c 0d    .L. :0d23[5]
+l0d26
+    inc l00cf                                                         ; 2ff8: e6 cf       ..  :0d26[5]
+    lda l00cf                                                         ; 2ffa: a5 cf       ..  :0d28[5]
+l0d2a
+    sta lfe86                                                         ; 2ffc: 8d 86 fe    ... :0d2a[5]
+    cmp lfe86                                                         ; 2fff: cd 86 fe    ... :0d2d[5]
+    bne l0d2a                                                         ; 3002: d0 f8       ..  :0d30[5]
+    lda l00a7                                                         ; 3004: a5 a7       ..  :0d32[5]
+    sta lfe84                                                         ; 3006: 8d 84 fe    ... :0d34[5]
+    pla                                                               ; 3009: 68          h   :0d37[5]
+    rti                                                               ; 300a: 40          @   :0d38[5]
+
+nmi_XXX2
+    lda lfe87                                                         ; 300b: ad 87 fe    ... :0d39[5]
+; The operand of this sta is modified at runtime.
+nmi_sta_abs
+    sta tube_host_r3_data                                             ; 300e: 8d e5 fe    ... :0d3c[5]
+; The first two bytes of the following instruction may be patched at
+; runtime.
+nmi_XXX6
+    inc nmi_sta_abs+1                                                 ; 3011: ee 3d 0d    .=. :0d3f[5]
+    bne nmi_XXX7                                                      ; 3014: d0 03       ..  :0d42[5]
+    inc nmi_sta_abs+2                                                 ; 3016: ee 3e 0d    .>. :0d44[5]
+nmi_XXX7
+    dec l00a6                                                         ; 3019: c6 a6       ..  :0d47[5]
+    bne l0d50                                                         ; 301b: d0 05       ..  :0d49[5]
+; The operand of this lda is modified at runtime.
+nmi_lda_immXXX3
+    lda #nmi_XXX2-(nmi_beq+2)                                         ; 301d: a9 2f       ./  :0d4b[5]
+    sta nmi_beq+1                                                     ; 301f: 8d 09 0d    ... :0d4d[5]
+l0d50
+    pla                                                               ; 3022: 68          h   :0d50[5]
+    rti                                                               ; 3023: 40          @   :0d51[5]
+
+nmi_XXX1
+    lda lfe87                                                         ; 3024: ad 87 fe    ... :0d52[5]
+    pla                                                               ; 3027: 68          h   :0d55[5]
+    rti                                                               ; 3028: 40          @   :0d56[5]
+
+nmi_XXX8
+    lda #0                                                            ; 3029: a9 00       ..  :0d57[5]
+    sta lfe87                                                         ; 302b: 8d 87 fe    ... :0d59[5]
+    pla                                                               ; 302e: 68          h   :0d5c[5]
+    rti                                                               ; 302f: 40          @   :0d5d[5]
+
+; The operand of this lda is modified at runtime.
+}
+
+; The operand of this lda is modified at runtime.
+; The operand of this lda is modified at runtime.
+
+!pseudopc $0d39 {
+; The operand of this lda is modified at runtime.
+nmi_lda_abs
+    lda tube_host_r3_data                                             ; 3030: ad e5 fe    ... :0d39[6]
+    sta lfe87                                                         ; 3033: 8d 87 fe    ... :0d3c[6]
+    inc nmi_lda_abs+1                                                 ; 3036: ee 3a 0d    .:. :0d3f[6]
+    bne nmi_XXX7                                                      ; 3039: d0 03       ..  :0d42[6]
+    inc nmi_lda_abs+2                                                 ; 303b: ee 3b 0d    .;. :0d44[6]
+; $303e referenced 1 time by $8de2
+}
+
+; $303e referenced 1 time by $8de2
+; $303e referenced 1 time by $8de2
+
+!pseudopc $903e {
+; $303e referenced 1 time by $8de2
+nmi3_handler_rom_end
+    ldx nmi_sta_abs+1                                                 ; 303e: ae 3d 0d    .=. :903e[1]
+    lda nmi_sta_abs+2                                                 ; 3041: ad 3e 0d    .>. :9041[1]
+    pha                                                               ; 3044: 48          H   :9044[1]
+    ldy #nmi_handler2_rom_end-nmi_handler2_rom_start                  ; 3045: a0 94       ..  :9045[1]
+; $3047 referenced 1 time by $904e
+loop_c9047
+    lda nmi_handler2_rom_start-1,y                                    ; 3047: b9 66 90    .f. :9047[1]
+    sta l0cff,y                                                       ; 304a: 99 ff 0c    ... :904a[1]
+    dey                                                               ; 304d: 88          .   :904d[1]
+    bne loop_c9047                                                    ; 304e: d0 f7       ..  :904e[1]
+    pla                                                               ; 3050: 68          h   :9050[1]
+    bit l00a1                                                         ; 3051: 24 a1       $.  :9051[1]
+    bpl c9060                                                         ; 3053: 10 0b       ..  :9053[1]
+    lda #opcode_bcs                                                   ; 3055: a9 b0       ..  :9055[1]
+    sta nmi_cmp_imm_or_bcs                                            ; 3057: 8d 18 0d    ... :9057[1]
+    lda #nmi_XXX5-(nmi_cmp_imm_or_bcs+2)                              ; 305a: a9 06       ..  :905a[1]
+    sta nmi_cmp_imm_or_bcs+1                                          ; 305c: 8d 19 0d    ... :905c[1]
+    rts                                                               ; 305f: 60          `   :905f[1]
+
+; $3060 referenced 1 time by $9053
+c9060
+    stx nmi_lda_zp                                                    ; 3060: 8e 16 0d    ... :9060[1]
+    sta nmi_lda_zp+1                                                  ; 3063: 8d 17 0d    ... :9063[1]
+; $3066 referenced 1 time by $9047
+    rts                                                               ; 3066: 60          `   :9066[1]
+
+nmi_handler2_rom_start
+}
+
+
+!pseudopc $0d00 {
+    pha                                                               ; 3067: 48          H   :0d00[7]
+    lda lfe84                                                         ; 3068: ad 84 fe    ... :0d01[7]
+    and #$1b                                                          ; 306b: 29 1b       ).  :0d04[7]
+    cmp #3                                                            ; 306d: c9 03       ..  :0d06[7]
+    bne l0d0f                                                         ; 306f: d0 05       ..  :0d08[7]
+    lda lfe87                                                         ; 3071: ad 87 fe    ... :0d0a[7]
+; The operand of this bcs is modified at runtime
+nmi_bcs
+    bcs nmi_XXX21                                                     ; 3074: b0 26       .&  :0d0d[7]
+l0d0f
+    and #$fc                                                          ; 3076: 29 fc       ).  :0d0f[7]
+    sta l00a2                                                         ; 3078: 85 a2       ..  :0d11[7]
+    pla                                                               ; 307a: 68          h   :0d13[7]
+    rti                                                               ; 307b: 40          @   :0d14[7]
+
+; The operand of this sta is modified at runtime.
+nmi_XXX17
+nmi_sta_abs2
+    sta tube_host_r3_data                                             ; 307c: 8d e5 fe    ... :0d15[7]
+    inc nmi_sta_abs2+1                                                ; 307f: ee 16 0d    ... :0d18[7]
+    bne nmi_XXX18                                                     ; 3082: d0 03       ..  :0d1b[7]
+    inc nmi_sta_abs2+2                                                ; 3084: ee 17 0d    ... :0d1d[7]
+nmi_XXX18
+    dec l00a6                                                         ; 3087: c6 a6       ..  :0d20[7]
+    bne nmi_XXX23                                                     ; 3089: d0 0f       ..  :0d22[7]
+    dec l00a7                                                         ; 308b: c6 a7       ..  :0d24[7]
+    bne nmi_XXX23                                                     ; 308d: d0 0b       ..  :0d26[7]
+    lda #nmi_XXX22-(nmi_bcs+2)                                        ; 308f: a9 77       .w  :0d28[7]
+    dec l00a5                                                         ; 3091: c6 a5       ..  :0d2a[7]
+    bne l0d30                                                         ; 3093: d0 02       ..  :0d2c[7]
+    lda #nmi_XXX23-(nmi_bcs+2)                                        ; 3095: a9 24       .$  :0d2e[7]
+l0d30
+    sta nmi_bcs+1                                                     ; 3097: 8d 0e 0d    ... :0d30[7]
+nmi_XXX23
+    pla                                                               ; 309a: 68          h   :0d33[7]
+    rti                                                               ; 309b: 40          @   :0d34[7]
+
+nmi_XXX21
+    cmp #$fe                                                          ; 309c: c9 fe       ..  :0d35[7]
+    beq l0d3d                                                         ; 309e: f0 04       ..  :0d37[7]
+    cmp #$ce                                                          ; 30a0: c9 ce       ..  :0d39[7]
+    bne nmi_XXX23                                                     ; 30a2: d0 f6       ..  :0d3b[7]
+l0d3d
+    lda #nmi_XXX10-(nmi_bcs+2)                                        ; 30a4: a9 32       .2  :0d3d[7]
+    bne l0d30                                                         ; 30a6: d0 ef       ..  :0d3f[7]
+nmi_XXX10
+    sbc lfe87                                                         ; 30a8: ed 87 fe    ... :0d41[7]
+    sta l00b5                                                         ; 30ab: 85 b5       ..  :0d44[7]
+    lda #nmi_XXX11-(nmi_bcs+2)                                        ; 30ad: a9 3b       .;  :0d46[7]
+    bne l0d30                                                         ; 30af: d0 e6       ..  :0d48[7]
+nmi_XXX11
+    lda #nmi_XXX12-(nmi_bcs+2)                                        ; 30b1: a9 3f       .?  :0d4a[7]
+    bne l0d30                                                         ; 30b3: d0 e2       ..  :0d4c[7]
+nmi_XXX12
+    sbc l00cf                                                         ; 30b5: e5 cf       ..  :0d4e[7]
+    ora l00b5                                                         ; 30b7: 05 b5       ..  :0d50[7]
+    sta l00b5                                                         ; 30b9: 85 b5       ..  :0d52[7]
+    lda #nmi_XXX13-(nmi_bcs+2)                                        ; 30bb: a9 49       .I  :0d54[7]
+    bne l0d30                                                         ; 30bd: d0 d8       ..  :0d56[7]
+nmi_XXX13
+    lda #nmi_XXX14-(nmi_bcs+2)                                        ; 30bf: a9 4d       .M  :0d58[7]
+    bne l0d30                                                         ; 30c1: d0 d4       ..  :0d5a[7]
+nmi_XXX14
+    lda l00b3                                                         ; 30c3: a5 b3       ..  :0d5c[7]
+    sta l00a6                                                         ; 30c5: 85 a6       ..  :0d5e[7]
+; $30c7 referenced 2 times by $8dac, $8dbd
+c0d60
+    lda #nmi_XXX15-(nmi_bcs+2)                                        ; 30c7: a9 55       .U  :0d60[7]
+    bne l0d30                                                         ; 30c9: d0 cc       ..  :0d62[7]
+nmi_XXX15
+    lda l00b4                                                         ; 30cb: a5 b4       ..  :0d64[7]
+    sta l00a7                                                         ; 30cd: 85 a7       ..  :0d66[7]
+    lda #nmi_XXX16-(nmi_bcs+2)                                        ; 30cf: a9 5d       .]  :0d68[7]
+    bne l0d30                                                         ; 30d1: d0 c4       ..  :0d6a[7]
+nmi_XXX16
+    cmp #$fb                                                          ; 30d3: c9 fb       ..  :0d6c[7]
+    beq c0d74                                                         ; 30d5: f0 04       ..  :0d6e[7]
+    cmp #$f8                                                          ; 30d7: c9 f8       ..  :0d70[7]
+    bne nmi_XXX23                                                     ; 30d9: d0 bf       ..  :0d72[7]
+; $30db referenced 1 time by $0d6e
+c0d74
+    sta l00b6                                                         ; 30db: 85 b6       ..  :0d74[7]
+    lda l00b5                                                         ; 30dd: a5 b5       ..  :0d76[7]
+    bne c0d80                                                         ; 30df: d0 06       ..  :0d78[7]
+    inc l00cf                                                         ; 30e1: e6 cf       ..  :0d7a[7]
+    lda #nmi_XXX17-(nmi_bcs+2)                                        ; 30e3: a9 06       ..  :0d7c[7]
+    bne l0d30                                                         ; 30e5: d0 b0       ..  :0d7e[7]
+; $30e7 referenced 1 time by $0d78
+c0d80
+    inc l00a5                                                         ; 30e7: e6 a5       ..  :0d80[7]
+    lda #nmi_XXX18-(nmi_bcs+2)                                        ; 30e9: a9 11       ..  :0d82[7]
+    bne l0d30                                                         ; 30eb: d0 aa       ..  :0d84[7]
+nmi_XXX22
+    lda #nmi_XXX19-(nmi_bcs+2)                                        ; 30ed: a9 7b       .{  :0d86[7]
+    bne l0d30                                                         ; 30ef: d0 a6       ..  :0d88[7]
+nmi_XXX19
+    lda #nmi_XXX20-(nmi_bcs+2)                                        ; 30f1: a9 7f       ..  :0d8a[7]
+    bne l0d30                                                         ; 30f3: d0 a2       ..  :0d8c[7]
+nmi_XXX20
+    bne nmi_XXX23                                                     ; 30f5: d0 a3       ..  :0d8e[7]
+    lda #nmi_XXX21-(nmi_bcs+2)                                        ; 30f7: a9 26       .&  :0d90[7]
+    bne l0d30                                                         ; 30f9: d0 9c       ..  :0d92[7]
+; $30fb referenced 3 times by $8d41, $8d92, $9101
+}
+
+; $30fb referenced 3 times by $8d41, $8d92, $9101
+; $30fb referenced 3 times by $8d41, $8d92, $9101
+
+!pseudopc $90fb {
+; $30fb referenced 3 times by $8d41, $8d92, $9101
+nmi_handler2_rom_end
+    sta lfe86                                                         ; 30fb: 8d 86 fe    ... :90fb[1]
+    cmp lfe86                                                         ; 30fe: cd 86 fe    ... :90fe[1]
+    bne nmi_handler2_rom_end                                          ; 3101: d0 f8       ..  :9101[1]
+    rts                                                               ; 3103: 60          `   :9103[1]
+
+; $3104 referenced 1 time by $966b
+set_c_iff_have_fdc
+    ldx #0                                                            ; 3104: a2 00       ..  :9104[1]
+    lda #$5a ; 'Z'                                                    ; 3106: a9 5a       .Z  :9106[1]
+; $3108 referenced 1 time by $9111
+loop_c9108
+    sta lfe85                                                         ; 3108: 8d 85 fe    ... :9108[1]
+    cmp lfe85                                                         ; 310b: cd 85 fe    ... :910b[1]
+    beq c9115                                                         ; 310e: f0 05       ..  :910e[1]
+    dex                                                               ; 3110: ca          .   :9110[1]
+    bne loop_c9108                                                    ; 3111: d0 f5       ..  :9111[1]
+; $3113 referenced 1 time by $911a
+loop_c9113
+    clc                                                               ; 3113: 18          .   :9113[1]
+    rts                                                               ; 3114: 60          `   :9114[1]
+
+; $3115 referenced 1 time by $910e
+c9115
+    lda lfe80                                                         ; 3115: ad 80 fe    ... :9115[1]
+    and #3                                                            ; 3118: 29 03       ).  :9118[1]
+    beq loop_c9113                                                    ; 311a: f0 f7       ..  :911a[1]
+    rts                                                               ; 311c: 60          `   :911c[1]
+
+; $311d referenced 1 time by $8cd8
+l911d
+    !text ")*-."                                                      ; 311d: 29 2a 2d... )*- :911d[1]
+; $3121 referenced 1 time by $8e15
+l9121
+    !byte   0, $10, $40, $50, $80, $81, $83, $a0, $a1, $c0, $e0, $f0  ; 3121: 00 10 40... ..@ :9121[1]
+; $312d referenced 1 time by $8e1b
+nmi_and_table
+    !byte $18, $18, $18, $18, $3f, $1f, $1f, $5f, $5f, $17, $1b, $5f  ; 312d: 18 18 18... ... :912d[1]
+; $3139 referenced 1 time by $8c58
+l9139
+    !byte   8, $10, $18, $20, $40,   0                                ; 3139: 08 10 18... ... :9139[1]
+; $313f referenced 1 time by $8c61
+l913f
+    !byte $0e, $18, $0c, $20, $12,   0                                ; 313f: 0e 18 0c... ... :913f[1]
+; $3145 referenced 1 time by $92e3
+l9145
+    !byte $6d                                                         ; 3145: 6d          m   :9145[1]
+; $3146 referenced 1 time by $92e8
+l9146
+    !byte $91, $49, $91, $3c, $0c,   3,   1,   1,   1,   1,   1,   1  ; 3146: 91 49 91... .I. :9146[1]
+    !byte $16, $0c,   3,   1, $ff,   1,   1, $18,   4, $4e,   0, $f5  ; 3152: 16 0c 03... ... :9152[1]
+    !byte $fe,   0,   0,   0,   0, $f7, $4e,   0, $f5, $fb, $5a, $5a  ; 315e: fe 00 00... ... :915e[1]
+    !byte $f7, $4e, $4e, $10,   6,   0,   1,   1,   1,   1,   1,   1  ; 316a: f7 4e 4e... .NN :916a[1]
+    !byte $0b,   6,   0,   1, $ff,   1,   1, $13,   3, $ff,   0,   0  ; 3176: 0b 06 00... ... :9176[1]
+    !byte $fe,   0,   0,   0,   0, $f7, $ff,   0,   0, $fb, $e5, $e5  ; 3182: fe 00 00... ... :9182[1]
+    !byte $f7, $ff, $ff                                               ; 318e: f7 ff ff    ... :918e[1]
+; $3191 referenced 1 time by $91df
+l9191
+    !byte $0a, $0b, $0e, $0f, $12, $13, $16, $17, $1b, $1e, $1f       ; 3191: 0a 0b 0e... ... :9191[1]
+    !text "#) 0"                                                      ; 319c: 23 29 20... #)  :919c[1]
+; $31a0 referenced 1 time by $9201
+l91a0
+    !byte $a0, $a0, $a1, $a1, $80, $80, $81, $81, $c0, $83, $83, $f0  ; 31a0: a0 a0 a1... ... :91a0[1]
+    !byte $10, $e0, $f0                                               ; 31ac: 10 e0 f0    ... :91ac[1]
+
+; $31af referenced 3 times by $9758, $a6dc, $a700
+c91af
+    lda #$ff                                                          ; 31af: a9 ff       ..  :91af[1]
+    sta l1082                                                         ; 31b1: 8d 82 10    ... :91b1[1]
+    stx l00c7                                                         ; 31b4: 86 c7       ..  :91b4[1]
+    sty l00c8                                                         ; 31b6: 84 c8       ..  :91b6[1]
+    ldy #$0c                                                          ; 31b8: a0 0c       ..  :91b8[1]
+; $31ba referenced 1 time by $91c0
+loop_c91ba
+    lda (l00c7),y                                                     ; 31ba: b1 c7       ..  :91ba[1]
+    sta l00ba,y                                                       ; 31bc: 99 ba 00    ... :91bc[1]
+    dey                                                               ; 31bf: 88          .   :91bf[1]
+    bpl loop_c91ba                                                    ; 31c0: 10 f8       ..  :91c0[1]
+    ldx #$0c                                                          ; 31c2: a2 0c       ..  :91c2[1]
+    lda l00bf                                                         ; 31c4: a5 bf       ..  :91c4[1]
+    cmp #$0a                                                          ; 31c6: c9 0a       ..  :91c6[1]
+    bne c91cc                                                         ; 31c8: d0 02       ..  :91c8[1]
+    ldx #$0e                                                          ; 31ca: a2 0e       ..  :91ca[1]
+; $31cc referenced 1 time by $91c8
+c91cc
+    lda l00c0                                                         ; 31cc: a5 c0       ..  :91cc[1]
+    and #$3f ; '?'                                                    ; 31ce: 29 3f       )?  :91ce[1]
+    cmp #$3a ; ':'                                                    ; 31d0: c9 3a       .:  :91d0[1]
+    beq c921f                                                         ; 31d2: f0 4b       .K  :91d2[1]
+    cmp #$3d ; '='                                                    ; 31d4: c9 3d       .=  :91d4[1]
+    beq c923f                                                         ; 31d6: f0 67       .g  :91d6[1]
+    cmp #$35 ; '5'                                                    ; 31d8: c9 35       .5  :91d8[1]
+    bne c91df                                                         ; 31da: d0 03       ..  :91da[1]
+    jmp c925a                                                         ; 31dc: 4c 5a 92    LZ. :91dc[1]
+
+; $31df referenced 2 times by $91da, $91e5
+c91df
+    cmp l9191,x                                                       ; 31df: dd 91 91    ... :91df[1]
+    beq c91eb                                                         ; 31e2: f0 07       ..  :91e2[1]
+    dex                                                               ; 31e4: ca          .   :91e4[1]
+    bpl c91df                                                         ; 31e5: 10 f8       ..  :91e5[1]
+; $31e7 referenced 1 time by $91ff
+loop_c91e7
+    lda #$fe                                                          ; 31e7: a9 fe       ..  :91e7[1]
+    bmi c9214                                                         ; 31e9: 30 29       0)  :91e9[1]
+; $31eb referenced 1 time by $91e2
+c91eb
+    cmp #$23 ; '#'                                                    ; 31eb: c9 23       .#  :91eb[1]
+    beq c91f3                                                         ; 31ed: f0 04       ..  :91ed[1]
+    cpx #4                                                            ; 31ef: e0 04       ..  :91ef[1]
+    bcs c9201                                                         ; 31f1: b0 0e       ..  :91f1[1]
+; $31f3 referenced 1 time by $91ed
+c91f3
+    lda l00ba                                                         ; 31f3: a5 ba       ..  :91f3[1]
+    bpl c91f9                                                         ; 31f5: 10 02       ..  :91f5[1]
+    lda l00cd                                                         ; 31f7: a5 cd       ..  :91f7[1]
+; $31f9 referenced 1 time by $91f5
+c91f9
+    and #3                                                            ; 31f9: 29 03       ).  :91f9[1]
+    tay                                                               ; 31fb: a8          .   :91fb[1]
+    lda l10de,y                                                       ; 31fc: b9 de 10    ... :91fc[1]
+    bmi loop_c91e7                                                    ; 31ff: 30 e6       0.  :91ff[1]
+; $3201 referenced 1 time by $91f1
+c9201
+    ldy l91a0,x                                                       ; 3201: bc a0 91    ... :9201[1]
+    sty l00c0                                                         ; 3204: 84 c0       ..  :9204[1]
+    cpy #$f0                                                          ; 3206: c0 f0       ..  :9206[1]
+    bne c920d                                                         ; 3208: d0 03       ..  :9208[1]
+    jsr sub_c929d                                                     ; 320a: 20 9d 92     .. :920a[1]
+; $320d referenced 1 time by $9208
+c920d
+    ldx #$ba                                                          ; 320d: a2 ba       ..  :920d[1]
+    ldy #0                                                            ; 320f: a0 00       ..  :920f[1]
+    jsr sub_c8bf9                                                     ; 3211: 20 f9 8b     .. :9211[1]
+; $3214 referenced 3 times by $91e9, $9257, $9276
+c9214
+    pha                                                               ; 3214: 48          H   :9214[1]
+    lda l00bf                                                         ; 3215: a5 bf       ..  :9215[1]
+    clc                                                               ; 3217: 18          .   :9217[1]
+    adc #7                                                            ; 3218: 69 07       i.  :9218[1]
+    tay                                                               ; 321a: a8          .   :921a[1]
+    pla                                                               ; 321b: 68          h   :921b[1]
+    sta (l00c7),y                                                     ; 321c: 91 c7       ..  :921c[1]
+    rts                                                               ; 321e: 60          `   :921e[1]
+
+; $321f referenced 1 time by $91d2
+c921f
+    jsr sub_c928a                                                     ; 321f: 20 8a 92     .. :921f[1]
+    bcs c922b                                                         ; 3222: b0 07       ..  :9222[1]
+    lda l00c2                                                         ; 3224: a5 c2       ..  :9224[1]
+    sta l108b,x                                                       ; 3226: 9d 8b 10    ... :9226[1]
+    bcc c923b                                                         ; 3229: 90 10       ..  :9229[1]
+; $322b referenced 1 time by $9222
+c922b
+    jsr sub_c9279                                                     ; 322b: 20 79 92     y. :922b[1]
+    bcc c9257                                                         ; 322e: 90 27       .'  :922e[1]
+    lda l00c2                                                         ; 3230: a5 c2       ..  :9230[1]
+    ldy l10de,x                                                       ; 3232: bc de 10    ... :9232[1]
+    bpl c9238                                                         ; 3235: 10 01       ..  :9235[1]
+    asl                                                               ; 3237: 0a          .   :9237[1]
+; $3238 referenced 1 time by $9235
+c9238
+    sta l1088,x                                                       ; 3238: 9d 88 10    ... :9238[1]
+; $323b referenced 1 time by $9229
+c923b
+    lda #0                                                            ; 323b: a9 00       ..  :923b[1]
+    beq c9257                                                         ; 323d: f0 18       ..  :923d[1]
+; $323f referenced 1 time by $91d6
+c923f
+    jsr sub_c928a                                                     ; 323f: 20 8a 92     .. :923f[1]
+    bcs c9249                                                         ; 3242: b0 05       ..  :9242[1]
+    lda l108b,x                                                       ; 3244: bd 8b 10    ... :9244[1]
+    bcc c9257                                                         ; 3247: 90 0e       ..  :9247[1]
+; $3249 referenced 1 time by $9242
+c9249
+    jsr sub_c9279                                                     ; 3249: 20 79 92     y. :9249[1]
+    bcc c9257                                                         ; 324c: 90 09       ..  :924c[1]
+    lda l1088,x                                                       ; 324e: bd 88 10    ... :924e[1]
+    ldy l10de,x                                                       ; 3251: bc de 10    ... :9251[1]
+    bpl c9257                                                         ; 3254: 10 01       ..  :9254[1]
+    lsr                                                               ; 3256: 4a          J   :9256[1]
+; $3257 referenced 5 times by $922e, $923d, $9247, $924c, $9254
+c9257
+    jmp c9214                                                         ; 3257: 4c 14 92    L.. :9257[1]
+
+; $325a referenced 1 time by $91dc
+c925a
+    lda #$ff                                                          ; 325a: a9 ff       ..  :925a[1]
+    ldx #0                                                            ; 325c: a2 00       ..  :925c[1]
+    ldy l00c1                                                         ; 325e: a4 c1       ..  :925e[1]
+    cpy #$10                                                          ; 3260: c0 10       ..  :9260[1]
+    beq c926a                                                         ; 3262: f0 06       ..  :9262[1]
+    cpy #$18                                                          ; 3264: c0 18       ..  :9264[1]
+    bne c9276                                                         ; 3266: d0 0e       ..  :9266[1]
+    inx                                                               ; 3268: e8          .   :9268[1]
+    inx                                                               ; 3269: e8          .   :9269[1]
+; $326a referenced 1 time by $9262
+c926a
+    lda l00c2                                                         ; 326a: a5 c2       ..  :926a[1]
+    sta l108b,x                                                       ; 326c: 9d 8b 10    ... :926c[1]
+    lda l00c3                                                         ; 326f: a5 c3       ..  :926f[1]
+    sta l108c,x                                                       ; 3271: 9d 8c 10    ... :9271[1]
+    lda #0                                                            ; 3274: a9 00       ..  :9274[1]
+; $3276 referenced 1 time by $9266
+c9276
+    jmp c9214                                                         ; 3276: 4c 14 92    L.. :9276[1]
+
+; $3279 referenced 2 times by $922b, $9249
+sub_c9279
+    ldx #0                                                            ; 3279: a2 00       ..  :9279[1]
+    lda l00c1                                                         ; 327b: a5 c1       ..  :927b[1]
+    cmp #$12                                                          ; 327d: c9 12       ..  :927d[1]
+    beq c9289                                                         ; 327f: f0 08       ..  :927f[1]
+    inx                                                               ; 3281: e8          .   :9281[1]
+    cmp #$1a                                                          ; 3282: c9 1a       ..  :9282[1]
+    beq c9289                                                         ; 3284: f0 03       ..  :9284[1]
+    lda #$fe                                                          ; 3286: a9 fe       ..  :9286[1]
+    clc                                                               ; 3288: 18          .   :9288[1]
+; $3289 referenced 2 times by $927f, $9284
+c9289
+    rts                                                               ; 3289: 60          `   :9289[1]
+
+; $328a referenced 2 times by $921f, $923f
+sub_c928a
+    lda l00c1                                                         ; 328a: a5 c1       ..  :928a[1]
+    and #$f6                                                          ; 328c: 29 f6       ).  :928c[1]
+    cmp #$10                                                          ; 328e: c9 10       ..  :928e[1]
+    sec                                                               ; 3290: 38          8   :9290[1]
+    bne c929c                                                         ; 3291: d0 09       ..  :9291[1]
+    lda l00c1                                                         ; 3293: a5 c1       ..  :9293[1]
+    lsr                                                               ; 3295: 4a          J   :9295[1]
+    lsr                                                               ; 3296: 4a          J   :9296[1]
+    ora l00c1                                                         ; 3297: 05 c1       ..  :9297[1]
+    and #3                                                            ; 3299: 29 03       ).  :9299[1]
+    tax                                                               ; 329b: aa          .   :929b[1]
+; $329c referenced 1 time by $9291
+c929c
+    rts                                                               ; 329c: 60          `   :929c[1]
+
+; $329d referenced 1 time by $920a
+sub_c929d
+    jsr sub_c9a8d                                                     ; 329d: 20 8d 9a     .. :929d[1]
+    lda l00bb                                                         ; 32a0: a5 bb       ..  :92a0[1]
+    sta l00b0                                                         ; 32a2: 85 b0       ..  :92a2[1]
+    sta l00b4                                                         ; 32a4: 85 b4       ..  :92a4[1]
+    clc                                                               ; 32a6: 18          .   :92a6[1]
+    adc #$80                                                          ; 32a7: 69 80       i.  :92a7[1]
+    sta l00b2                                                         ; 32a9: 85 b2       ..  :92a9[1]
+    lda l00bc                                                         ; 32ab: a5 bc       ..  :92ab[1]
+    sta l00b1                                                         ; 32ad: 85 b1       ..  :92ad[1]
+    php                                                               ; 32af: 08          .   :92af[1]
+    jsr sub_c8f3f                                                     ; 32b0: 20 3f 8f     ?. :92b0[1]
+    bmi c92bd                                                         ; 32b3: 30 08       0.  :92b3[1]
+    lda l00bd                                                         ; 32b5: a5 bd       ..  :92b5[1]
+    ora l00be                                                         ; 32b7: 05 be       ..  :92b7[1]
+    cmp #$ff                                                          ; 32b9: c9 ff       ..  :92b9[1]
+    bne c92c4                                                         ; 32bb: d0 07       ..  :92bb[1]
+; $32bd referenced 1 time by $92b3
+c92bd
+    lda l00b1                                                         ; 32bd: a5 b1       ..  :92bd[1]
+    cmp l10cf                                                         ; 32bf: cd cf 10    ... :92bf[1]
+    bcs c92c7                                                         ; 32c2: b0 03       ..  :92c2[1]
+; $32c4 referenced 1 time by $92bb
+c92c4
+    lda l10cf                                                         ; 32c4: ad cf 10    ... :92c4[1]
+; $32c7 referenced 1 time by $92c2
+c92c7
+    plp                                                               ; 32c7: 28          (   :92c7[1]
+    sta l00b5                                                         ; 32c8: 85 b5       ..  :92c8[1]
+    adc #0                                                            ; 32ca: 69 00       i.  :92ca[1]
+    sta l00b3                                                         ; 32cc: 85 b3       ..  :92cc[1]
+    inc l00b5                                                         ; 32ce: e6 b5       ..  :92ce[1]
+    lda l00ba                                                         ; 32d0: a5 ba       ..  :92d0[1]
+    bpl c92d6                                                         ; 32d2: 10 02       ..  :92d2[1]
+    lda #0                                                            ; 32d4: a9 00       ..  :92d4[1]
+; $32d6 referenced 1 time by $92d2
+c92d6
+    rol                                                               ; 32d6: 2a          *   :92d6[1]
+    rol                                                               ; 32d7: 2a          *   :92d7[1]
+    rol                                                               ; 32d8: 2a          *   :92d8[1]
+    sta l108a                                                         ; 32d9: 8d 8a 10    ... :92d9[1]
+    ldx #2                                                            ; 32dc: a2 02       ..  :92dc[1]
+    rol                                                               ; 32de: 2a          *   :92de[1]
+    bmi c92e3                                                         ; 32df: 30 02       0.  :92df[1]
+    ldx #0                                                            ; 32e1: a2 00       ..  :92e1[1]
+; $32e3 referenced 1 time by $92df
+c92e3
+    lda l9145,x                                                       ; 32e3: bd 45 91    .E. :92e3[1]
+    sta l00b6                                                         ; 32e6: 85 b6       ..  :92e6[1]
+    lda l9146,x                                                       ; 32e8: bd 46 91    .F. :92e8[1]
+    sta l00b7                                                         ; 32eb: 85 b7       ..  :92eb[1]
+    ldy #$23 ; '#'                                                    ; 32ed: a0 23       .#  :92ed[1]
+; $32ef referenced 1 time by $92f4
+loop_c92ef
+    lda (l00b6),y                                                     ; 32ef: b1 b6       ..  :92ef[1]
+    sta (l00b2),y                                                     ; 32f1: 91 b2       ..  :92f1[1]
+    dey                                                               ; 32f3: 88          .   :92f3[1]
+    bpl loop_c92ef                                                    ; 32f4: 10 f9       ..  :92f4[1]
+    iny                                                               ; 32f6: c8          .   :92f6[1]
+    sty l00b6                                                         ; 32f7: 84 b6       ..  :92f7[1]
+    lda l00c3                                                         ; 32f9: a5 c3       ..  :92f9[1]
+    pha                                                               ; 32fb: 48          H   :92fb[1]
+    and #$e0                                                          ; 32fc: 29 e0       ).  :92fc[1]
+    bne c9302                                                         ; 32fe: d0 02       ..  :92fe[1]
+    lda #$10                                                          ; 3300: a9 10       ..  :9300[1]
+; $3302 referenced 1 time by $92fe
+c9302
+    asl                                                               ; 3302: 0a          .   :9302[1]
+    rol l00b6                                                         ; 3303: 26 b6       &.  :9303[1]
+    asl                                                               ; 3305: 0a          .   :9305[1]
+    rol l00b6                                                         ; 3306: 26 b6       &.  :9306[1]
+    asl                                                               ; 3308: 0a          .   :9308[1]
+    rol l00b6                                                         ; 3309: 26 b6       &.  :9309[1]
+    ldy #$0d                                                          ; 330b: a0 0d       ..  :930b[1]
+    sta (l00b2),y                                                     ; 330d: 91 b2       ..  :930d[1]
+    lda l00b6                                                         ; 330f: a5 b6       ..  :930f[1]
+    iny                                                               ; 3311: c8          .   :9311[1]
+    sta (l00b2),y                                                     ; 3312: 91 b2       ..  :9312[1]
+    pla                                                               ; 3314: 68          h   :9314[1]
+    and #$1f                                                          ; 3315: 29 1f       ).  :9315[1]
+    sta l00b9                                                         ; 3317: 85 b9       ..  :9317[1]
+    lda l00c2                                                         ; 3319: a5 c2       ..  :9319[1]
+    ldy #$10                                                          ; 331b: a0 10       ..  :931b[1]
+    sta (l00b2),y                                                     ; 331d: 91 b2       ..  :931d[1]
+    lda l00c5                                                         ; 331f: a5 c5       ..  :931f[1]
+    ldy #0                                                            ; 3321: a0 00       ..  :9321[1]
+    sta (l00b2),y                                                     ; 3323: 91 b2       ..  :9323[1]
+    tya                                                               ; 3325: 98          .   :9325[1]
+    sta l00b8                                                         ; 3326: 85 b8       ..  :9326[1]
+    jsr sub_c93d3                                                     ; 3328: 20 d3 93     .. :9328[1]
+    jsr sub_c8f3f                                                     ; 332b: 20 3f 8f     ?. :932b[1]
+    bmi c9367                                                         ; 332e: 30 37       07  :932e[1]
+    lda l00bd                                                         ; 3330: a5 bd       ..  :9330[1]
+    and l00be                                                         ; 3332: 25 be       %.  :9332[1]
+    cmp #$ff                                                          ; 3334: c9 ff       ..  :9334[1]
+    beq c9367                                                         ; 3336: f0 2f       ./  :9336[1]
+    lda #$ff                                                          ; 3338: a9 ff       ..  :9338[1]
+    sta l00bd                                                         ; 333a: 85 bd       ..  :933a[1]
+    sta l00be                                                         ; 333c: 85 be       ..  :933c[1]
+    jsr sub_c8f6b                                                     ; 333e: 20 6b 8f     k. :933e[1]
+    ldx #$bb                                                          ; 3341: a2 bb       ..  :9341[1]
+    ldy #0                                                            ; 3343: a0 00       ..  :9343[1]
+    tya                                                               ; 3345: 98          .   :9345[1]
+    jsr tube_entry                                                    ; 3346: 20 06 04     .. :9346[1]
+    ldx l00b5                                                         ; 3349: a6 b5       ..  :9349[1]
+    dex                                                               ; 334b: ca          .   :934b[1]
+    stx l00b1                                                         ; 334c: 86 b1       ..  :934c[1]
+    lda l00b9                                                         ; 334e: a5 b9       ..  :934e[1]
+    asl                                                               ; 3350: 0a          .   :9350[1]
+    asl                                                               ; 3351: 0a          .   :9351[1]
+    tax                                                               ; 3352: aa          .   :9352[1]
+    ldy #0                                                            ; 3353: a0 00       ..  :9353[1]
+; $3355 referenced 1 time by $9362
+loop_c9355
+    lda #7                                                            ; 3355: a9 07       ..  :9355[1]
+; $3357 referenced 1 time by $9359
+loop_c9357
+    sbc #1                                                            ; 3357: e9 01       ..  :9357[1]
+    bne loop_c9357                                                    ; 3359: d0 fc       ..  :9359[1]
+    lda tube_host_r3_data                                             ; 335b: ad e5 fe    ... :935b[1]
+    sta (l00b0),y                                                     ; 335e: 91 b0       ..  :935e[1]
+    iny                                                               ; 3360: c8          .   :9360[1]
+    dex                                                               ; 3361: ca          .   :9361[1]
+    bpl loop_c9355                                                    ; 3362: 10 f1       ..  :9362[1]
+    jsr sub_c8f7a                                                     ; 3364: 20 7a 8f     z. :9364[1]
+; $3367 referenced 2 times by $932e, $9336
+c9367
+    lda l00b5                                                         ; 3367: a5 b5       ..  :9367[1]
+    sta l00bc                                                         ; 3369: 85 bc       ..  :9369[1]
+; $336b referenced 1 time by $939c
+c936b
+    ldy #$16                                                          ; 336b: a0 16       ..  :936b[1]
+    ldx #0                                                            ; 336d: a2 00       ..  :936d[1]
+; $336f referenced 1 time by $937c
+loop_c936f
+    lda (l00b0,x)                                                     ; 336f: a1 b0       ..  :936f[1]
+    sta (l00b2),y                                                     ; 3371: 91 b2       ..  :9371[1]
+    inc l00b0                                                         ; 3373: e6 b0       ..  :9373[1]
+    bne c9379                                                         ; 3375: d0 02       ..  :9375[1]
+    inc l00b1                                                         ; 3377: e6 b1       ..  :9377[1]
+; $3379 referenced 1 time by $9375
+c9379
+    iny                                                               ; 3379: c8          .   :9379[1]
+    cpy #$1a                                                          ; 337a: c0 1a       ..  :937a[1]
+    bne loop_c936f                                                    ; 337c: d0 f1       ..  :937c[1]
+    lda #1                                                            ; 337e: a9 01       ..  :937e[1]
+    sta l00b6                                                         ; 3380: 85 b6       ..  :9380[1]
+; $3382 referenced 1 time by $9396
+loop_c9382
+    lda l00b6                                                         ; 3382: a5 b6       ..  :9382[1]
+    cmp #$0e                                                          ; 3384: c9 0e       ..  :9384[1]
+    bne c938d                                                         ; 3386: d0 05       ..  :9386[1]
+    jsr sub_c93b4                                                     ; 3388: 20 b4 93     .. :9388[1]
+    beq c9390                                                         ; 338b: f0 03       ..  :938b[1]
+; $338d referenced 1 time by $9386
+c938d
+    jsr sub_c93d3                                                     ; 338d: 20 d3 93     .. :938d[1]
+; $3390 referenced 1 time by $938b
+c9390
+    inc l00b6                                                         ; 3390: e6 b6       ..  :9390[1]
+    lda l00b6                                                         ; 3392: a5 b6       ..  :9392[1]
+    cmp #$11                                                          ; 3394: c9 11       ..  :9394[1]
+    bne loop_c9382                                                    ; 3396: d0 ea       ..  :9396[1]
+    inc l00b8                                                         ; 3398: e6 b8       ..  :9398[1]
+    dec l00b9                                                         ; 339a: c6 b9       ..  :939a[1]
+    bne c936b                                                         ; 339c: d0 cd       ..  :939c[1]
+    tay                                                               ; 339e: a8          .   :939e[1]
+    lda #$0e                                                          ; 339f: a9 0e       ..  :939f[1]
+    bit l108a                                                         ; 33a1: 2c 8a 10    ,.. :93a1[1]
+    bvc c93a8                                                         ; 33a4: 50 02       P.  :93a4[1]
+    lda #$1a                                                          ; 33a6: a9 1a       ..  :93a6[1]
+; $33a8 referenced 1 time by $93a4
+c93a8
+    clc                                                               ; 33a8: 18          .   :93a8[1]
+    adc l00bc                                                         ; 33a9: 65 bc       e.  :93a9[1]
+    sbc l00b5                                                         ; 33ab: e5 b5       ..  :93ab[1]
+    bcs c93b1                                                         ; 33ad: b0 02       ..  :93ad[1]
+    lda #1                                                            ; 33af: a9 01       ..  :93af[1]
+; $33b1 referenced 1 time by $93ad
+c93b1
+    sta (l00b2),y                                                     ; 33b1: 91 b2       ..  :93b1[1]
+    tya                                                               ; 33b3: 98          .   :93b3[1]
+; $33b4 referenced 1 time by $9388
+sub_c93b4
+    jsr sub_c93c5                                                     ; 33b4: 20 c5 93     .. :93b4[1]
+    beq c93c4                                                         ; 33b7: f0 0b       ..  :93b7[1]
+    stx l00b7                                                         ; 33b9: 86 b7       ..  :93b9[1]
+    ldx #0                                                            ; 33bb: a2 00       ..  :93bb[1]
+; $33bd referenced 1 time by $93c2
+loop_c93bd
+    jsr sub_c93d8                                                     ; 33bd: 20 d8 93     .. :93bd[1]
+    dec l00b7                                                         ; 33c0: c6 b7       ..  :93c0[1]
+    bne loop_c93bd                                                    ; 33c2: d0 f9       ..  :93c2[1]
+; $33c4 referenced 1 time by $93b7
+c93c4
+    rts                                                               ; 33c4: 60          `   :93c4[1]
+
+; $33c5 referenced 2 times by $93b4, $93d3
+sub_c93c5
+    tay                                                               ; 33c5: a8          .   :93c5[1]
+    lda (l00b2),y                                                     ; 33c6: b1 b2       ..  :93c6[1]
+    tax                                                               ; 33c8: aa          .   :93c8[1]
+    tya                                                               ; 33c9: 98          .   :93c9[1]
+    clc                                                               ; 33ca: 18          .   :93ca[1]
+    adc #$12                                                          ; 33cb: 69 12       i.  :93cb[1]
+    tay                                                               ; 33cd: a8          .   :93cd[1]
+    lda (l00b2),y                                                     ; 33ce: b1 b2       ..  :93ce[1]
+    cpx #0                                                            ; 33d0: e0 00       ..  :93d0[1]
+    rts                                                               ; 33d2: 60          `   :93d2[1]
+
+; $33d3 referenced 2 times by $9328, $938d
+sub_c93d3
+    jsr sub_c93c5                                                     ; 33d3: 20 c5 93     .. :93d3[1]
+    beq c93e5                                                         ; 33d6: f0 0d       ..  :93d6[1]
+; $33d8 referenced 1 time by $93bd
+sub_c93d8
+    ldy #0                                                            ; 33d8: a0 00       ..  :93d8[1]
+; $33da referenced 1 time by $93e3
+loop_c93da
+    sta (l00b4),y                                                     ; 33da: 91 b4       ..  :93da[1]
+    inc l00b4                                                         ; 33dc: e6 b4       ..  :93dc[1]
+    bne c93e2                                                         ; 33de: d0 02       ..  :93de[1]
+    inc l00b5                                                         ; 33e0: e6 b5       ..  :93e0[1]
+; $33e2 referenced 1 time by $93de
+c93e2
+    dex                                                               ; 33e2: ca          .   :93e2[1]
+    bne loop_c93da                                                    ; 33e3: d0 f5       ..  :93e3[1]
+; $33e5 referenced 1 time by $93d6
+c93e5
+    rts                                                               ; 33e5: 60          `   :93e5[1]
+
+; $33e6 referenced 10 times by $8772, $8791, $87cb, $89d7, $8a6b, $8b12, $8bf3, $9bbc, $9fff, $a30a
+c93e6
+    lda l0f04                                                         ; 33e6: ad 04 0f    ... :93e6[1]
+    clc                                                               ; 33e9: 18          .   :93e9[1]
+    sed                                                               ; 33ea: f8          .   :93ea[1]
+    adc #1                                                            ; 33eb: 69 01       i.  :93eb[1]
+    sta l0f04                                                         ; 33ed: 8d 04 0f    ... :93ed[1]
+    cld                                                               ; 33f0: d8          .   :93f0[1]
+; $33f1 referenced 1 time by $a737
+sub_c93f1
+    ldy #$a0                                                          ; 33f1: a0 a0       ..  :93f1[1]
+    bne c940e                                                         ; 33f3: d0 19       ..  :93f3[1]
+; $33f5 referenced 2 times by $9636, $a7ce
+sub_c93f5
+    ldy #$81                                                          ; 33f5: a0 81       ..  :93f5[1]
+    bne c940e                                                         ; 33f7: d0 15       ..  :93f7[1]
+; $33f9 referenced 1 time by $8266
+sub_c93f9
+    ldy #$81                                                          ; 33f9: a0 81       ..  :93f9[1]
+    bne c93ff                                                         ; 33fb: d0 02       ..  :93fb[1]
+; $33fd referenced 3 times by $8287, $988e, $98da
+sub_c93fd
+    ldy #$80                                                          ; 33fd: a0 80       ..  :93fd[1]
+; $33ff referenced 1 time by $93fb
+c93ff
+    bit lfe84                                                         ; 33ff: 2c 84 fe    ,.. :93ff[1]
+    bpl c940e                                                         ; 3402: 10 0a       ..  :9402[1]
+    lda l1082                                                         ; 3404: ad 82 10    ... :9404[1]
+    cmp l00cd                                                         ; 3407: c5 cd       ..  :9407[1]
+    bne c940e                                                         ; 3409: d0 03       ..  :9409[1]
+    rts                                                               ; 340b: 60          `   :940b[1]
+
+; $340c referenced 6 times by $8383, $8489, $8a59, $a431, $a448, $a460
+c940c
+    ldy #$80                                                          ; 340c: a0 80       ..  :940c[1]
+; $340e referenced 4 times by $93f3, $93f7, $9402, $9409
+c940e
+    jsr sub_c9536                                                     ; 340e: 20 36 95     6. :940e[1]
+    sty l1096                                                         ; 3411: 8c 96 10    ... :9411[1]
+    lda l00cd                                                         ; 3414: a5 cd       ..  :9414[1]
+    sta l1090                                                         ; 3416: 8d 90 10    ... :9416[1]
+    lda #2                                                            ; 3419: a9 02       ..  :9419[1]
+    sta l1099                                                         ; 341b: 8d 99 10    ... :941b[1]
+    lda #$0e                                                          ; 341e: a9 0e       ..  :941e[1]
+    sta l1092                                                         ; 3420: 8d 92 10    ... :9420[1]
+    dec l1093                                                         ; 3423: ce 93 10    ... :9423[1]
+    dec l1094                                                         ; 3426: ce 94 10    ... :9426[1]
+    jsr sub_c9445                                                     ; 3429: 20 45 94     E. :9429[1]
+    lda l00cd                                                         ; 342c: a5 cd       ..  :942c[1]
+    sta l1082                                                         ; 342e: 8d 82 10    ... :942e[1]
+    rts                                                               ; 3431: 60          `   :9431[1]
+
+; $3432 referenced 2 times by $944d, $a6f9
+sub_c9432
+    bit l00ff                                                         ; 3432: 24 ff       $.  :9432[1]
+    bpl c9444                                                         ; 3434: 10 0e       ..  :9434[1]
+; $3436 referenced 4 times by $946c, $a411, $a65d, $abc2
+c9436
+    jsr sub_c9ad8                                                     ; 3436: 20 d8 9a     .. :9436[1]
+    jsr generate_error                                                ; 3439: 20 48 80     H. :9439[1]
+    !byte $11                                                         ; 343c: 11          .   :943c[1]
+    !text "Escape"                                                    ; 343d: 45 73 63... Esc :943d[1]
+    !byte 0                                                           ; 3443: 00          .   :9443[1]
+
+; $3444 referenced 3 times by $9434, $946a, $947a
+c9444
+    rts                                                               ; 3444: 60          `   :9444[1]
+
+; $3445 referenced 2 times by $886a, $9429
+sub_c9445
+    jsr sub_c9516                                                     ; 3445: 20 16 95     .. :9445[1]
+    lda #6                                                            ; 3448: a9 06       ..  :9448[1]
+    sta l109e                                                         ; 344a: 8d 9e 10    ... :944a[1]
+    jsr sub_c9432                                                     ; 344d: 20 32 94     2. :944d[1]
+; $3450 referenced 1 time by $94bf
+c9450
+    lda l1097                                                         ; 3450: ad 97 10    ... :9450[1]
+    ldx l1090                                                         ; 3453: ae 90 10    ... :9453[1]
+    ldy l10de,x                                                       ; 3456: bc de 10    ... :9456[1]
+    bpl c945c                                                         ; 3459: 10 01       ..  :9459[1]
+    asl                                                               ; 345b: 0a          .   :945b[1]
+; $345c referenced 1 time by $9459
+c945c
+    ldy #$18                                                          ; 345c: a0 18       ..  :945c[1]
+    cmp #$50 ; 'P'                                                    ; 345e: c9 50       .P  :945e[1]
+    bcs c94c1                                                         ; 3460: b0 5f       ._  :9460[1]
+    ldx #$90                                                          ; 3462: a2 90       ..  :9462[1]
+    ldy #$10                                                          ; 3464: a0 10       ..  :9464[1]
+    jsr sub_c8bf6                                                     ; 3466: 20 f6 8b     .. :9466[1]
+    tay                                                               ; 3469: a8          .   :9469[1]
+    beq c9444                                                         ; 346a: f0 d8       ..  :946a[1]
+    bmi c9436                                                         ; 346c: 30 c8       0.  :946c[1]
+    cmp #$12                                                          ; 346e: c9 12       ..  :946e[1]
+    beq c94c6                                                         ; 3470: f0 54       .T  :9470[1]
+    cmp #$20 ; ' '                                                    ; 3472: c9 20       .   :9472[1]
+    bne c948d                                                         ; 3474: d0 17       ..  :9474[1]
+    lda l1096                                                         ; 3476: ad 96 10    ... :9476[1]
+    ror                                                               ; 3479: 6a          j   :9479[1]
+    bcs c9444                                                         ; 347a: b0 c8       ..  :947a[1]
+    jsr generate_error                                                ; 347c: 20 48 80     H. :947c[1]
+    !byte $bc                                                         ; 347f: bc          .   :947f[1]
+    !text "Execute only"                                              ; 3480: 45 78 65... Exe :9480[1]
+    !byte 0                                                           ; 348c: 00          .   :948c[1]
+
+; $348d referenced 1 time by $9474
+c948d
+    cmp #$18                                                          ; 348d: c9 18       ..  :948d[1]
+    bne c94bc                                                         ; 348f: d0 2b       .+  :948f[1]
+    lda l108a                                                         ; 3491: ad 8a 10    ... :9491[1]
+    cmp #4                                                            ; 3494: c9 04       ..  :9494[1]
+    bne c94a9                                                         ; 3496: d0 11       ..  :9496[1]
+    ldx l1096                                                         ; 3498: ae 96 10    ... :9498[1]
+    cpx #$81                                                          ; 349b: e0 81       ..  :949b[1]
+    bne c94a9                                                         ; 349d: d0 0a       ..  :949d[1]
+    lda #$ff                                                          ; 349f: a9 ff       ..  :949f[1]
+    eor l108b                                                         ; 34a1: 4d 8b 10    M.. :94a1[1]
+    sta l108b                                                         ; 34a4: 8d 8b 10    ... :94a4[1]
+    bcs c94bc                                                         ; 34a7: b0 13       ..  :94a7[1]
+; $34a9 referenced 2 times by $9496, $949d
+c94a9
+    ldx l00ce                                                         ; 34a9: a6 ce       ..  :94a9[1]
+    beq c94bc                                                         ; 34ab: f0 0f       ..  :94ab[1]
+    rol                                                               ; 34ad: 2a          *   :94ad[1]
+    and #$80                                                          ; 34ae: 29 80       ).  :94ae[1]
+    ldx l1090                                                         ; 34b0: ae 90 10    ... :94b0[1]
+    eor l10de,x                                                       ; 34b3: 5d de 10    ].. :94b3[1]
+    sta l10de,x                                                       ; 34b6: 9d de 10    ... :94b6[1]
+    jsr sub_c9516                                                     ; 34b9: 20 16 95     .. :94b9[1]
+; $34bc referenced 3 times by $948f, $94a7, $94ab
+c94bc
+    dec l109e                                                         ; 34bc: ce 9e 10    ... :94bc[1]
+    bne c9450                                                         ; 34bf: d0 8f       ..  :94bf[1]
+; $34c1 referenced 1 time by $9460
+c94c1
+    tya                                                               ; 34c1: 98          .   :94c1[1]
+; $34c2 referenced 1 time by $a70f
+c94c2
+    cmp #$12                                                          ; 34c2: c9 12       ..  :94c2[1]
+    bne c94d4                                                         ; 34c4: d0 0e       ..  :94c4[1]
+; $34c6 referenced 2 times by $9470, $9523
+c94c6
+    jsr generate_error_precheck_disc                                  ; 34c6: 20 23 80     #. :94c6[1]
+    !byte $c9                                                         ; 34c9: c9          .   :94c9[1]
+    !text "read only"                                                 ; 34ca: 72 65 61... rea :94ca[1]
+    !byte 0                                                           ; 34d3: 00          .   :94d3[1]
+
+; $34d4 referenced 1 time by $94c4
+c94d4
+    pha                                                               ; 34d4: 48          H   :94d4[1]
+    jsr generate_error_precheck_disc                                  ; 34d5: 20 23 80     #. :94d5[1]
+    !byte 0                                                           ; 34d8: 00          .   :94d8[1]
+
+    nop                                                               ; 34d9: ea          .   :94d9[1]
+    jsr generate_error2                                               ; 34da: 20 4f 80     O. :94da[1]
+    !byte $c7                                                         ; 34dd: c7          .   :94dd[1]
+    !text "fault "                                                    ; 34de: 66 61 75... fau :94de[1]
+
+    nop                                                               ; 34e4: ea          .   :94e4[1]
+    pla                                                               ; 34e5: 68          h   :94e5[1]
+    jsr sub_c9526                                                     ; 34e6: 20 26 95     &. :94e6[1]
+    jsr generate_error2                                               ; 34e9: 20 4f 80     O. :94e9[1]
+    !byte 0                                                           ; 34ec: 00          .   :94ec[1]
+    !text " at :"                                                     ; 34ed: 20 61 74...  at :94ed[1]
+
+    lda l00cd                                                         ; 34f2: a5 cd       ..  :94f2[1]
+    jsr sub_c952e                                                     ; 34f4: 20 2e 95     .. :94f4[1]
+    jsr generate_error2                                               ; 34f7: 20 4f 80     O. :94f7[1]
+    !byte 0                                                           ; 34fa: 00          .   :94fa[1]
+    !text " "                                                         ; 34fb: 20              :94fb[1]
+
+    lda l00ce                                                         ; 34fc: a5 ce       ..  :94fc[1]
+    bit l108a                                                         ; 34fe: 2c 8a 10    ,.. :94fe[1]
+    bpl c9504                                                         ; 3501: 10 01       ..  :9501[1]
+    lsr                                                               ; 3503: 4a          J   :9503[1]
+; $3504 referenced 1 time by $9501
+c9504
+    jsr sub_c9526                                                     ; 3504: 20 26 95     &. :9504[1]
+    jsr generate_error2                                               ; 3507: 20 4f 80     O. :9507[1]
+    !byte 0                                                           ; 350a: 00          .   :950a[1]
+    !text "/"                                                         ; 350b: 2f          /   :950b[1]
+
+    lda l00cf                                                         ; 350c: a5 cf       ..  :950c[1]
+    jsr sub_c9526                                                     ; 350e: 20 26 95     &. :950e[1]
+    jsr generate_error2                                               ; 3511: 20 4f 80     O. :9511[1]
+    !byte $c7,   0                                                    ; 3514: c7 00       ..  :9514[1]
+
+; $3516 referenced 2 times by $9445, $94b9
+sub_c9516
+    lda l1096                                                         ; 3516: ad 96 10    ... :9516[1]
+    cmp #$a0                                                          ; 3519: c9 a0       ..  :9519[1]
+    bcc c9535                                                         ; 351b: 90 18       ..  :951b[1]
+    ldx l1090                                                         ; 351d: ae 90 10    ... :951d[1]
+    lda l10de,x                                                       ; 3520: bd de 10    ... :9520[1]
+    bmi c94c6                                                         ; 3523: 30 a1       0.  :9523[1]
+    rts                                                               ; 3525: 60          `   :9525[1]
+
+; $3526 referenced 3 times by $94e6, $9504, $950e
+sub_c9526
+    pha                                                               ; 3526: 48          H   :9526[1]
+    jsr sub_c81bf                                                     ; 3527: 20 bf 81     .. :9527[1]
+    jsr sub_c952e                                                     ; 352a: 20 2e 95     .. :952a[1]
+    pla                                                               ; 352d: 68          h   :952d[1]
+; $352e referenced 2 times by $94f4, $952a
+sub_c952e
+    jsr sub_c80c8                                                     ; 352e: 20 c8 80     .. :952e[1]
+    sta l0100,x                                                       ; 3531: 9d 00 01    ... :9531[1]
+    inx                                                               ; 3534: e8          .   :9534[1]
+; $3535 referenced 1 time by $951b
+c9535
+    rts                                                               ; 3535: 60          `   :9535[1]
+
+; $3536 referenced 1 time by $940e
+sub_c9536
+    ldx #$0d                                                          ; 3536: a2 0d       ..  :9536[1]
+    lda #0                                                            ; 3538: a9 00       ..  :9538[1]
+; $353a referenced 1 time by $953e
+loop_c953a
+    sta l108f,x                                                       ; 353a: 9d 8f 10    ... :953a[1]
+    dex                                                               ; 353d: ca          .   :953d[1]
+    bne loop_c953a                                                    ; 353e: d0 fa       ..  :953e[1]
+    lda #5                                                            ; 3540: a9 05       ..  :9540[1]
+    sta l1095                                                         ; 3542: 8d 95 10    ... :9542[1]
+    rts                                                               ; 3545: 60          `   :9545[1]
+
+    !text "L.!BOOT", $0d                                              ; 3546: 4c 2e 21... L.! :9546[1]
+    !text "E.!BOOT", $0d                                              ; 354e: 45 2e 21... E.! :954e[1]
+
+; $3556 referenced 1 time by $96e9
+c9556
+    lda l00b3                                                         ; 3556: a5 b3       ..  :9556[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 3558: 20 77 80     w. :9558[1]
+    !text "Acorn 1770 DFS", $0d, $0d                                  ; 355b: 41 63 6f... Aco :955b[1]
+
+    bcc c956f                                                         ; 356b: 90 02       ..  :956b[1]
+; $356d referenced 1 time by $96fd
+c956d
+    lda #$ff                                                          ; 356d: a9 ff       ..  :956d[1]
+; $356f referenced 1 time by $956b
+c956f
+    jsr zero_stacked_XXX                                              ; 356f: 20 8e 9d     .. :956f[1]
+    pha                                                               ; 3572: 48          H   :9572[1]
+    lda #6                                                            ; 3573: a9 06       ..  :9573[1]
+    jsr sub_c8020                                                     ; 3575: 20 20 80      . :9575[1]
+    lda lfe87                                                         ; 3578: ad 87 fe    ... :9578[1]
+    ldx #$0d                                                          ; 357b: a2 0d       ..  :957b[1]
+; $357d referenced 1 time by $9584
+loop_c957d
+    lda l9aec,x                                                       ; 357d: bd ec 9a    ... :957d[1]
+    sta filev,x                                                       ; 3580: 9d 12 02    ... :9580[1]
+    dex                                                               ; 3583: ca          .   :9583[1]
+    bpl loop_c957d                                                    ; 3584: 10 f7       ..  :9584[1]
+    lda #$a8                                                          ; 3586: a9 a8       ..  :9586[1]
+    jsr osbyte_read                                                   ; 3588: 20 e5 9a     .. :9588[1]
+    sty l00b1                                                         ; 358b: 84 b1       ..  :958b[1]
+    stx l00b0                                                         ; 358d: 86 b0       ..  :958d[1]
+    ldx #7                                                            ; 358f: a2 07       ..  :958f[1]
+    ldy #$1b                                                          ; 3591: a0 1b       ..  :9591[1]
+; $3593 referenced 1 time by $95a5
+loop_c9593
+    lda c9adf,y                                                       ; 3593: b9 df 9a    ... :9593[1]
+    sta (l00b0),y                                                     ; 3596: 91 b0       ..  :9596[1]
+    iny                                                               ; 3598: c8          .   :9598[1]
+    lda c9adf,y                                                       ; 3599: b9 df 9a    ... :9599[1]
+    sta (l00b0),y                                                     ; 359c: 91 b0       ..  :959c[1]
+    iny                                                               ; 359e: c8          .   :959e[1]
+    lda romsel_copy                                                   ; 359f: a5 f4       ..  :959f[1]
+    sta (l00b0),y                                                     ; 35a1: 91 b0       ..  :95a1[1]
+    iny                                                               ; 35a3: c8          .   :95a3[1]
+    dex                                                               ; 35a4: ca          .   :95a4[1]
+    bne loop_c9593                                                    ; 35a5: d0 ec       ..  :95a5[1]
+    sty l1082                                                         ; 35a7: 8c 82 10    ... :95a7[1]
+    sty l1083                                                         ; 35aa: 8c 83 10    ... :95aa[1]
+    stx l00cd                                                         ; 35ad: 86 cd       ..  :95ad[1]
+    lda #$ff                                                          ; 35af: a9 ff       ..  :95af[1]
+    sta l1087                                                         ; 35b1: 8d 87 10    ... :95b1[1]
+    ldy #3                                                            ; 35b4: a0 03       ..  :95b4[1]
+; $35b6 referenced 1 time by $95ba
+loop_c95b6
+    sta l108b,y                                                       ; 35b6: 99 8b 10    ... :95b6[1]
+    dey                                                               ; 35b9: 88          .   :95b9[1]
+    bpl loop_c95b6                                                    ; 35ba: 10 fa       ..  :95ba[1]
+    ldx #$0f                                                          ; 35bc: a2 0f       ..  :95bc[1]
+    jsr c9adf                                                         ; 35be: 20 df 9a     .. :95be[1]
+    jsr sub_c9ab8                                                     ; 35c1: 20 b8 9a     .. :95c1[1]
+    ldy #$d3                                                          ; 35c4: a0 d3       ..  :95c4[1]
+    lda (l00b0),y                                                     ; 35c6: b1 b0       ..  :95c6[1]
+    bpl c95fd                                                         ; 35c8: 10 33       .3  :95c8[1]
+    pla                                                               ; 35ca: 68          h   :95ca[1]
+    pha                                                               ; 35cb: 48          H   :95cb[1]
+    beq c95fd                                                         ; 35cc: f0 2f       ./  :95cc[1]
+    ldy #$d4                                                          ; 35ce: a0 d4       ..  :95ce[1]
+    lda (l00b0),y                                                     ; 35d0: b1 b0       ..  :95d0[1]
+    bmi c9628                                                         ; 35d2: 30 54       0T  :95d2[1]
+    jsr sub_c9aa3                                                     ; 35d4: 20 a3 9a     .. :95d4[1]
+    ldy #0                                                            ; 35d7: a0 00       ..  :95d7[1]
+; $35d9 referenced 1 time by $95e8
+loop_c95d9
+    lda (l00b0),y                                                     ; 35d9: b1 b0       ..  :95d9[1]
+    cpy #$c0                                                          ; 35db: c0 c0       ..  :95db[1]
+    bcc c95e4                                                         ; 35dd: 90 05       ..  :95dd[1]
+    sta l1000,y                                                       ; 35df: 99 00 10    ... :95df[1]
+    bcs c95e7                                                         ; 35e2: b0 03       ..  :95e2[1]
+; $35e4 referenced 1 time by $95dd
+c95e4
+    sta l1100,y                                                       ; 35e4: 99 00 11    ... :95e4[1]
+; $35e7 referenced 1 time by $95e2
+c95e7
+    dey                                                               ; 35e7: 88          .   :95e7[1]
+    bne loop_c95d9                                                    ; 35e8: d0 ef       ..  :95e8[1]
+    lda #$a0                                                          ; 35ea: a9 a0       ..  :95ea[1]
+; $35ec referenced 1 time by $95f9
+loop_c95ec
+    tay                                                               ; 35ec: a8          .   :95ec[1]
+    pha                                                               ; 35ed: 48          H   :95ed[1]
+    lda #$3f ; '?'                                                    ; 35ee: a9 3f       .?  :95ee[1]
+    jsr sub_c9f16                                                     ; 35f0: 20 16 9f     .. :95f0[1]
+    pla                                                               ; 35f3: 68          h   :95f3[1]
+    sta l111d,y                                                       ; 35f4: 99 1d 11    ... :95f4[1]
+    sbc #$1f                                                          ; 35f7: e9 1f       ..  :95f7[1]
+    bne loop_c95ec                                                    ; 35f9: d0 f1       ..  :95f9[1]
+    beq c9628                                                         ; 35fb: f0 2b       .+  :95fb[1]
+; $35fd referenced 2 times by $95c8, $95cc
+c95fd
+    jsr sub_c9aa3                                                     ; 35fd: 20 a3 9a     .. :95fd[1]
+    lda #$24 ; '$'                                                    ; 3600: a9 24       .$  :9600[1]
+    sta l10c9                                                         ; 3602: 8d c9 10    ... :9602[1]
+    sta l10cb                                                         ; 3605: 8d cb 10    ... :9605[1]
+    ldy #0                                                            ; 3608: a0 00       ..  :9608[1]
+    sty l10ca                                                         ; 360a: 8c ca 10    ... :960a[1]
+    sty l10cc                                                         ; 360d: 8c cc 10    ... :960d[1]
+    ldy #0                                                            ; 3610: a0 00       ..  :9610[1]
+    sty l10c0                                                         ; 3612: 8c c0 10    ... :9612[1]
+    ldx #3                                                            ; 3615: a2 03       ..  :9615[1]
+    tya                                                               ; 3617: 98          .   :9617[1]
+; $3618 referenced 1 time by $961c
+loop_c9618
+    sta l10de,x                                                       ; 3618: 9d de 10    ... :9618[1]
+    dex                                                               ; 361b: ca          .   :961b[1]
+    bne loop_c9618                                                    ; 361c: d0 fa       ..  :961c[1]
+    dey                                                               ; 361e: 88          .   :961e[1]
+    sty l10c7                                                         ; 361f: 8c c7 10    ... :961f[1]
+    sty l10c6                                                         ; 3622: 8c c6 10    ... :9622[1]
+    sty l10dd                                                         ; 3625: 8c dd 10    ... :9625[1]
+; $3628 referenced 2 times by $95d2, $95fb
+c9628
+    jsr sub_c8f3f                                                     ; 3628: 20 3f 8f     ?. :9628[1]
+    pla                                                               ; 362b: 68          h   :962b[1]
+    bne c9649                                                         ; 362c: d0 1b       ..  :962c[1]
+    lda #4                                                            ; 362e: a9 04       ..  :962e[1]
+    ora l10de                                                         ; 3630: 0d de 10    ... :9630[1]
+    sta l10de                                                         ; 3633: 8d de 10    ... :9633[1]
+    jsr sub_c93f5                                                     ; 3636: 20 f5 93     .. :9636[1]
+    lda #$fb                                                          ; 3639: a9 fb       ..  :9639[1]
+    and l10de                                                         ; 363b: 2d de 10    -.. :963b[1]
+    sta l10de                                                         ; 363e: 8d de 10    ... :963e[1]
+    lda l0f06                                                         ; 3641: ad 06 0f    ... :9641[1]
+    jsr sub_c81bf                                                     ; 3644: 20 bf 81     .. :9644[1]
+    bne c964a                                                         ; 3647: d0 01       ..  :9647[1]
+; $3649 referenced 1 time by $962c
+c9649
+    rts                                                               ; 3649: 60          `   :9649[1]
+
+; $364a referenced 1 time by $9647
+c964a
+    ldy #$95                                                          ; 364a: a0 95       ..  :964a[1]
+    ldx #$46 ; 'F'                                                    ; 364c: a2 46       .F  :964c[1]
+    cmp #2                                                            ; 364e: c9 02       ..  :964e[1]
+    bcc c965a                                                         ; 3650: 90 08       ..  :9650[1]
+    beq c9658                                                         ; 3652: f0 04       ..  :9652[1]
+    ldx #$4e ; 'N'                                                    ; 3654: a2 4e       .N  :9654[1]
+    bne c965a                                                         ; 3656: d0 02       ..  :9656[1]
+; $3658 referenced 1 time by $9652
+c9658
+    ldx #$50 ; 'P'                                                    ; 3658: a2 50       .P  :9658[1]
+; $365a referenced 2 times by $9650, $9656
+c965a
+    jmp oscli                                                         ; 365a: 4c f7 ff    L.. :965a[1]
+
+; $365d referenced 1 time by $b1b1
+sub_c965d
+    jsr service_handler_help_and_tube                                 ; 365d: 20 a9 ae     .. :965d[1]
+    pha                                                               ; 3660: 48          H   :9660[1]
+    lda l0df0,x                                                       ; 3661: bd f0 0d    ... :9661[1]
+    bmi pla_rts                                                       ; 3664: 30 5b       0[  :9664[1]
+    pla                                                               ; 3666: 68          h   :9666[1]
+    cmp #service_claim_absolute_workspace                             ; 3667: c9 01       ..  :9667[1]
+    bne c9683                                                         ; 3669: d0 18       ..  :9669[1]
+    jsr set_c_iff_have_fdc                                            ; 366b: 20 04 91     .. :966b[1]
+    ldx romsel_copy                                                   ; 366e: a6 f4       ..  :966e[1]
+    bcs c967a                                                         ; 3670: b0 08       ..  :9670[1]
+    lda #$80                                                          ; 3672: a9 80       ..  :9672[1]
+    sta l0df0,x                                                       ; 3674: 9d f0 0d    ... :9674[1]
+    lda #1                                                            ; 3677: a9 01       ..  :9677[1]
+    rts                                                               ; 3679: 60          `   :9679[1]
+
+; $367a referenced 1 time by $9670
+c967a
+    lda #service_claim_absolute_workspace                             ; 367a: a9 01       ..  :967a[1]
+    cpy #$17                                                          ; 367c: c0 17       ..  :967c[1]
+    bcs c9682                                                         ; 367e: b0 02       ..  :967e[1]
+    ldy #$17                                                          ; 3680: a0 17       ..  :9680[1]
+; $3682 referenced 1 time by $967e
+c9682
+    rts                                                               ; 3682: 60          `   :9682[1]
+
+; $3683 referenced 1 time by $9669
+c9683
+    cmp #service_claim_private_workspace                              ; 3683: c9 02       ..  :9683[1]
+    bne c96c3                                                         ; 3685: d0 3c       .<  :9685[1]
+    pha                                                               ; 3687: 48          H   :9687[1]
+    tya                                                               ; 3688: 98          .   :9688[1]
+    pha                                                               ; 3689: 48          H   :9689[1]
+    sta l00b1                                                         ; 368a: 85 b1       ..  :968a[1]
+    ldy l0df0,x                                                       ; 368c: bc f0 0d    ... :968c[1]
+    sta l0df0,x                                                       ; 368f: 9d f0 0d    ... :968f[1]
+    lda #0                                                            ; 3692: a9 00       ..  :9692[1]
+    sta l00b0                                                         ; 3694: 85 b0       ..  :9694[1]
+    cpy l00b1                                                         ; 3696: c4 b1       ..  :9696[1]
+    beq c969e                                                         ; 3698: f0 04       ..  :9698[1]
+    ldy #$d3                                                          ; 369a: a0 d3       ..  :969a[1]
+    sta (l00b0),y                                                     ; 369c: 91 b0       ..  :969c[1]
+; $369e referenced 1 time by $9698
+c969e
+    lda #$fd                                                          ; 369e: a9 fd       ..  :969e[1]
+    jsr osbyte_read                                                   ; 36a0: 20 e5 9a     .. :96a0[1]
+    dex                                                               ; 36a3: ca          .   :96a3[1]
+    txa                                                               ; 36a4: 8a          .   :96a4[1]
+    ldy #$d3                                                          ; 36a5: a0 d3       ..  :96a5[1]
+    and (l00b0),y                                                     ; 36a7: 31 b0       1.  :96a7[1]
+    sta (l00b0),y                                                     ; 36a9: 91 b0       ..  :96a9[1]
+    php                                                               ; 36ab: 08          .   :96ab[1]
+    iny                                                               ; 36ac: c8          .   :96ac[1]
+    plp                                                               ; 36ad: 28          (   :96ad[1]
+    bpl c96b7                                                         ; 36ae: 10 07       ..  :96ae[1]
+    lda (l00b0),y                                                     ; 36b0: b1 b0       ..  :96b0[1]
+    bpl c96b7                                                         ; 36b2: 10 03       ..  :96b2[1]
+    jsr sub_c8951                                                     ; 36b4: 20 51 89     Q. :96b4[1]
+; $36b7 referenced 2 times by $96ae, $96b2
+c96b7
+    lda #0                                                            ; 36b7: a9 00       ..  :96b7[1]
+    sta (l00b0),y                                                     ; 36b9: 91 b0       ..  :96b9[1]
+    ldx romsel_copy                                                   ; 36bb: a6 f4       ..  :96bb[1]
+    pla                                                               ; 36bd: 68          h   :96bd[1]
+    tay                                                               ; 36be: a8          .   :96be[1]
+    iny                                                               ; 36bf: c8          .   :96bf[1]
+    iny                                                               ; 36c0: c8          .   :96c0[1]
+; $36c1 referenced 1 time by $9664
+pla_rts
+    pla                                                               ; 36c1: 68          h   :96c1[1]
+; $36c2 referenced 1 time by $96df
+loop_c96c2
+    rts                                                               ; 36c2: 60          `   :96c2[1]
+
+; $36c3 referenced 1 time by $9685
+c96c3
+    jsr sub_c83e3                                                     ; 36c3: 20 e3 83     .. :96c3[1]
+    cmp #service_boot                                                 ; 36c6: c9 03       ..  :96c6[1]
+    bne c96ec                                                         ; 36c8: d0 22       ."  :96c8[1]
+    sty l00b3                                                         ; 36ca: 84 b3       ..  :96ca[1]
+    lda #0                                                            ; 36cc: a9 00       ..  :96cc[1]
+    sta l10de                                                         ; 36ce: 8d de 10    ... :96ce[1]
+    lda #osbyte_scan_keyboard_from_16                                 ; 36d1: a9 7a       .z  :96d1[1]
+    jsr osbyte                                                        ; 36d3: 20 f4 ff     .. :96d3[1]
+    txa                                                               ; 36d6: 8a          .   :96d6[1]
+    bmi c96e9                                                         ; 36d7: 30 10       0.  :96d7[1]
+    cmp #$32 ; '2'                                                    ; 36d9: c9 32       .2  :96d9[1]
+    beq c96e4                                                         ; 36db: f0 07       ..  :96db[1]
+    cmp #$61 ; 'a'                                                    ; 36dd: c9 61       .a  :96dd[1]
+    bne loop_c96c2                                                    ; 36df: d0 e1       ..  :96df[1]
+    jsr sub_cac72                                                     ; 36e1: 20 72 ac     r. :96e1[1]
+; $36e4 referenced 1 time by $96db
+c96e4
+    lda #osbyte_write_keys_pressed                                    ; 36e4: a9 78       .x  :96e4[1]
+    jsr osbyte                                                        ; 36e6: 20 f4 ff     .. :96e6[1]
+; $36e9 referenced 1 time by $96d7
+c96e9
+    jmp c9556                                                         ; 36e9: 4c 56 95    LV. :96e9[1]
+
+; $36ec referenced 1 time by $96c8
+c96ec
+    cmp #service_unrecognised_command                                 ; 36ec: c9 04       ..  :96ec[1]
+    bne c96f5                                                         ; 36ee: d0 05       ..  :96ee[1]
+    ldx #$9b                                                          ; 36f0: a2 9b       ..  :96f0[1]
+; $36f2 referenced 1 time by $970a
+loop_c96f2
+    jmp c8703                                                         ; 36f2: 4c 03 87    L.. :96f2[1]
+
+; $36f5 referenced 1 time by $96ee
+c96f5
+    cmp #service_select_filing_system                                 ; 36f5: c9 12       ..  :96f5[1]
+    bne c9700                                                         ; 36f7: d0 07       ..  :96f7[1]
+    cpy #4                                                            ; 36f9: c0 04       ..  :96f9[1]
+    bne c973c                                                         ; 36fb: d0 3f       .?  :96fb[1]
+    jmp c956d                                                         ; 36fd: 4c 6d 95    Lm. :96fd[1]
+
+; $3700 referenced 1 time by $96f7
+c9700
+    cmp #service_help                                                 ; 3700: c9 09       ..  :9700[1]
+    bne c9714                                                         ; 3702: d0 10       ..  :9702[1]
+    lda (os_text_ptr),y                                               ; 3704: b1 f2       ..  :9704[1]
+    ldx #$cf                                                          ; 3706: a2 cf       ..  :9706[1]
+    cmp #$0d                                                          ; 3708: c9 0d       ..  :9708[1]
+    bne loop_c96f2                                                    ; 370a: d0 e6       ..  :970a[1]
+    tya                                                               ; 370c: 98          .   :970c[1]
+    inx                                                               ; 370d: e8          .   :970d[1]
+    inx                                                               ; 370e: e8          .   :970e[1]
+    ldy #2                                                            ; 370f: a0 02       ..  :970f[1]
+    jmp ca10b                                                         ; 3711: 4c 0b a1    L.. :9711[1]
+
+; $3714 referenced 1 time by $9702
+c9714
+    jsr zero_stacked_XXX                                              ; 3714: 20 8e 9d     .. :9714[1]
+    cmp #service_absolute_workspace_claimed                           ; 3717: c9 0a       ..  :9717[1]
+    bne c973d                                                         ; 3719: d0 22       ."  :9719[1]
+    jsr sub_c9ab8                                                     ; 371b: 20 b8 9a     .. :971b[1]
+    ldy #$d4                                                          ; 371e: a0 d4       ..  :971e[1]
+    lda (l00b0),y                                                     ; 3720: b1 b0       ..  :9720[1]
+    bpl c9736                                                         ; 3722: 10 12       ..  :9722[1]
+    ldy #0                                                            ; 3724: a0 00       ..  :9724[1]
+    jsr sub_c9d75                                                     ; 3726: 20 75 9d     u. :9726[1]
+    jsr sub_c8951                                                     ; 3729: 20 51 89     Q. :9729[1]
+    jsr sub_c9ab8                                                     ; 372c: 20 b8 9a     .. :972c[1]
+    ldy #$d4                                                          ; 372f: a0 d4       ..  :972f[1]
+    lda #0                                                            ; 3731: a9 00       ..  :9731[1]
+    sta (l00b0),y                                                     ; 3733: 91 b0       ..  :9733[1]
+    rts                                                               ; 3735: 60          `   :9735[1]
+
+; $3736 referenced 1 time by $9722
+c9736
+    lda #$0a                                                          ; 3736: a9 0a       ..  :9736[1]
+; $3738 referenced 3 times by $973f, $9743, $9747
+c9738
+    tsx                                                               ; 3738: ba          .   :9738[1]
+    sta l0105,x                                                       ; 3739: 9d 05 01    ... :9739[1]
+; $373c referenced 1 time by $96fb
+c973c
+    rts                                                               ; 373c: 60          `   :973c[1]
+
+; $373d referenced 1 time by $9719
+c973d
+    cmp #service_unrecognised_osword                                  ; 373d: c9 08       ..  :973d[1]
+    bne c9738                                                         ; 373f: d0 f7       ..  :973f[1]
+    ldy l00ef                                                         ; 3741: a4 ef       ..  :9741[1]
+    bmi c9738                                                         ; 3743: 30 f3       0.  :9743[1]
+    cpy #$7d ; '}'                                                    ; 3745: c0 7d       .}  :9745[1]
+    bcc c9738                                                         ; 3747: 90 ef       ..  :9747[1]
+    ldx l00f0                                                         ; 3749: a6 f0       ..  :9749[1]
+    stx l00c7                                                         ; 374b: 86 c7       ..  :974b[1]
+    ldx l00f1                                                         ; 374d: a6 f1       ..  :974d[1]
+    stx l00c8                                                         ; 374f: 86 c8       ..  :974f[1]
+    iny                                                               ; 3751: c8          .   :9751[1]
+    bpl c975b                                                         ; 3752: 10 07       ..  :9752[1]
+    ldx l00c7                                                         ; 3754: a6 c7       ..  :9754[1]
+    ldy l00c8                                                         ; 3756: a4 c8       ..  :9756[1]
+    jmp c91af                                                         ; 3758: 4c af 91    L.. :9758[1]
+
+; $375b referenced 1 time by $9752
+c975b
+    jsr sub_c8b7b                                                     ; 375b: 20 7b 8b     {. :975b[1]
+    jsr sub_c8380                                                     ; 375e: 20 80 83     .. :975e[1]
+    iny                                                               ; 3761: c8          .   :9761[1]
+    bmi c976c                                                         ; 3762: 30 08       0.  :9762[1]
+    ldy #0                                                            ; 3764: a0 00       ..  :9764[1]
+    lda l0f04                                                         ; 3766: ad 04 0f    ... :9766[1]
+    sta (l00c7),y                                                     ; 3769: 91 c7       ..  :9769[1]
+    rts                                                               ; 376b: 60          `   :976b[1]
+
+; $376c referenced 1 time by $9762
+c976c
+    lda #0                                                            ; 376c: a9 00       ..  :976c[1]
+    tay                                                               ; 376e: a8          .   :976e[1]
+    sta (l00c7),y                                                     ; 376f: 91 c7       ..  :976f[1]
+    iny                                                               ; 3771: c8          .   :9771[1]
+    lda l0f07                                                         ; 3772: ad 07 0f    ... :9772[1]
+    sta (l00c7),y                                                     ; 3775: 91 c7       ..  :9775[1]
+    iny                                                               ; 3777: c8          .   :9777[1]
+    lda l0f06                                                         ; 3778: ad 06 0f    ... :9778[1]
+    and #3                                                            ; 377b: 29 03       ).  :977b[1]
+    sta (l00c7),y                                                     ; 377d: 91 c7       ..  :977d[1]
+    iny                                                               ; 377f: c8          .   :977f[1]
+    lda #0                                                            ; 3780: a9 00       ..  :9780[1]
+    sta (l00c7),y                                                     ; 3782: 91 c7       ..  :9782[1]
+    rts                                                               ; 3784: 60          `   :9784[1]
+
+sub_c9785
+    jsr sub_c840c                                                     ; 3785: 20 0c 84     .. :9785[1]
+    pha                                                               ; 3788: 48          H   :9788[1]
+    jsr c99a3                                                         ; 3789: 20 a3 99     .. :9789[1]
+    stx l00b0                                                         ; 378c: 86 b0       ..  :978c[1]
+    stx l10db                                                         ; 378e: 8e db 10    ... :978e[1]
+    sty l00b1                                                         ; 3791: 84 b1       ..  :9791[1]
+    sty l10dc                                                         ; 3793: 8c dc 10    ... :9793[1]
+    ldx #0                                                            ; 3796: a2 00       ..  :9796[1]
+    ldy #0                                                            ; 3798: a0 00       ..  :9798[1]
+    jsr sub_c80e3                                                     ; 379a: 20 e3 80     .. :979a[1]
+; $379d referenced 1 time by $97a2
+loop_c979d
+    jsr sub_c80d3                                                     ; 379d: 20 d3 80     .. :979d[1]
+    cpy #$12                                                          ; 37a0: c0 12       ..  :97a0[1]
+    bne loop_c979d                                                    ; 37a2: d0 f9       ..  :97a2[1]
+    pla                                                               ; 37a4: 68          h   :97a4[1]
+    tax                                                               ; 37a5: aa          .   :97a5[1]
+    inx                                                               ; 37a6: e8          .   :97a6[1]
+    cpx #8                                                            ; 37a7: e0 08       ..  :97a7[1]
+    bcs c97b3                                                         ; 37a9: b0 08       ..  :97a9[1]
+    lda l9b29,x                                                       ; 37ab: bd 29 9b    .). :97ab[1]
+    pha                                                               ; 37ae: 48          H   :97ae[1]
+    lda l9b21,x                                                       ; 37af: bd 21 9b    .!. :97af[1]
+    pha                                                               ; 37b2: 48          H   :97b2[1]
+; $37b3 referenced 2 times by $97a9, $97b8
+c97b3
+    lda #0                                                            ; 37b3: a9 00       ..  :97b3[1]
+    rts                                                               ; 37b5: 60          `   :97b5[1]
+
+sub_c97b6
+    cmp #9                                                            ; 37b6: c9 09       ..  :97b6[1]
+    bcs c97b3                                                         ; 37b8: b0 f9       ..  :97b8[1]
+    stx l00b5                                                         ; 37ba: 86 b5       ..  :97ba[1]
+    tax                                                               ; 37bc: aa          .   :97bc[1]
+    lda l9b18,x                                                       ; 37bd: bd 18 9b    ... :97bd[1]
+    pha                                                               ; 37c0: 48          H   :97c0[1]
+    lda l9b0f,x                                                       ; 37c1: bd 0f 9b    ... :97c1[1]
+    pha                                                               ; 37c4: 48          H   :97c4[1]
+    txa                                                               ; 37c5: 8a          .   :97c5[1]
+    ldx l00b5                                                         ; 37c6: a6 b5       ..  :97c6[1]
+; $37c8 referenced 1 time by $97cb
+loop_c97c8
+    rts                                                               ; 37c8: 60          `   :97c8[1]
+
+sub_c97c9
+    cmp #9                                                            ; 37c9: c9 09       ..  :97c9[1]
+    bcs loop_c97c8                                                    ; 37cb: b0 fb       ..  :97cb[1]
+    jsr sub_c83e3                                                     ; 37cd: 20 e3 83     .. :97cd[1]
+    jsr zero_stacked_XXX                                              ; 37d0: 20 8e 9d     .. :97d0[1]
+    stx l107d                                                         ; 37d3: 8e 7d 10    .}. :97d3[1]
+    sty l107e                                                         ; 37d6: 8c 7e 10    .~. :97d6[1]
+    tay                                                               ; 37d9: a8          .   :97d9[1]
+    jsr sub_c97e8                                                     ; 37da: 20 e8 97     .. :97da[1]
+    php                                                               ; 37dd: 08          .   :97dd[1]
+    bit l1081                                                         ; 37de: 2c 81 10    ,.. :97de[1]
+    bpl c97e6                                                         ; 37e1: 10 03       ..  :97e1[1]
+    jsr sub_c8f7a                                                     ; 37e3: 20 7a 8f     z. :97e3[1]
+; $37e6 referenced 1 time by $97e1
+c97e6
+    plp                                                               ; 37e6: 28          (   :97e6[1]
+    rts                                                               ; 37e7: 60          `   :97e7[1]
+
+; $37e8 referenced 1 time by $97da
+sub_c97e8
+    lda l9b31,y                                                       ; 37e8: b9 31 9b    .1. :97e8[1]
+    sta l10d7                                                         ; 37eb: 8d d7 10    ... :97eb[1]
+    lda l9b3a,y                                                       ; 37ee: b9 3a 9b    .:. :97ee[1]
+    sta l10d8                                                         ; 37f1: 8d d8 10    ... :97f1[1]
+    lda l9b43,y                                                       ; 37f4: b9 43 9b    .C. :97f4[1]
+    lsr                                                               ; 37f7: 4a          J   :97f7[1]
+    php                                                               ; 37f8: 08          .   :97f8[1]
+    lsr                                                               ; 37f9: 4a          J   :97f9[1]
+    php                                                               ; 37fa: 08          .   :97fa[1]
+    sta l107f                                                         ; 37fb: 8d 7f 10    ... :97fb[1]
+    jsr sub_c995a                                                     ; 37fe: 20 5a 99     Z. :97fe[1]
+    ldy #$0c                                                          ; 3801: a0 0c       ..  :9801[1]
+; $3803 referenced 1 time by $9809
+loop_c9803
+    lda (l00b4),y                                                     ; 3803: b1 b4       ..  :9803[1]
+    sta l1060,y                                                       ; 3805: 99 60 10    .`. :9805[1]
+    dey                                                               ; 3808: 88          .   :9808[1]
+    bpl loop_c9803                                                    ; 3809: 10 f8       ..  :9809[1]
+    lda l1063                                                         ; 380b: ad 63 10    .c. :980b[1]
+    and l1064                                                         ; 380e: 2d 64 10    -d. :980e[1]
+    ora l10d6                                                         ; 3811: 0d d6 10    ... :9811[1]
+    clc                                                               ; 3814: 18          .   :9814[1]
+    adc #1                                                            ; 3815: 69 01       i.  :9815[1]
+    beq c981f                                                         ; 3817: f0 06       ..  :9817[1]
+    jsr sub_c8f6b                                                     ; 3819: 20 6b 8f     k. :9819[1]
+    clc                                                               ; 381c: 18          .   :981c[1]
+    lda #$ff                                                          ; 381d: a9 ff       ..  :981d[1]
+; $381f referenced 1 time by $9817
+c981f
+    sta l1081                                                         ; 381f: 8d 81 10    ... :981f[1]
+    lda l107f                                                         ; 3822: ad 7f 10    ... :9822[1]
+    bcs c982e                                                         ; 3825: b0 07       ..  :9825[1]
+    ldx #$61 ; 'a'                                                    ; 3827: a2 61       .a  :9827[1]
+    ldy #$10                                                          ; 3829: a0 10       ..  :9829[1]
+    jsr tube_entry                                                    ; 382b: 20 06 04     .. :982b[1]
+; $382e referenced 1 time by $9825
+c982e
+    plp                                                               ; 382e: 28          (   :982e[1]
+    bcs c9835                                                         ; 382f: b0 04       ..  :982f[1]
+    plp                                                               ; 3831: 28          (   :9831[1]
+; $3832 referenced 1 time by $9861
+sub_c9832
+    jmp (l10d7)                                                       ; 3832: 6c d7 10    l.. :9832[1]
+
+; $3835 referenced 1 time by $982f
+c9835
+    ldx #3                                                            ; 3835: a2 03       ..  :9835[1]
+; $3837 referenced 1 time by $983d
+loop_c9837
+    lda l1069,x                                                       ; 3837: bd 69 10    .i. :9837[1]
+    sta l00b6,x                                                       ; 383a: 95 b6       ..  :983a[1]
+    dex                                                               ; 383c: ca          .   :983c[1]
+    bpl loop_c9837                                                    ; 383d: 10 f8       ..  :983d[1]
+    ldx #$b6                                                          ; 383f: a2 b6       ..  :983f[1]
+    ldy l1060                                                         ; 3841: ac 60 10    .`. :9841[1]
+    lda #0                                                            ; 3844: a9 00       ..  :9844[1]
+    plp                                                               ; 3846: 28          (   :9846[1]
+    bcs c984c                                                         ; 3847: b0 03       ..  :9847[1]
+    jsr ca06c                                                         ; 3849: 20 6c a0     l. :9849[1]
+; $384c referenced 1 time by $9847
+c984c
+    jsr c9dd5                                                         ; 384c: 20 d5 9d     .. :984c[1]
+    ldx #3                                                            ; 384f: a2 03       ..  :984f[1]
+; $3851 referenced 1 time by $9857
+loop_c9851
+    lda l00b6,x                                                       ; 3851: b5 b6       ..  :9851[1]
+    sta l1069,x                                                       ; 3853: 9d 69 10    .i. :9853[1]
+    dex                                                               ; 3856: ca          .   :9856[1]
+    bpl loop_c9851                                                    ; 3857: 10 f8       ..  :9857[1]
+; $3859 referenced 1 time by $989b
+c9859
+    jsr invert_l1065                                                  ; 3859: 20 4c 99     L. :9859[1]
+    bmi c986b                                                         ; 385c: 30 0d       0.  :985c[1]
+; $385e referenced 1 time by $9870
+loop_c985e
+    ldy l1060                                                         ; 385e: ac 60 10    .`. :985e[1]
+    jsr sub_c9832                                                     ; 3861: 20 32 98     2. :9861[1]
+    bcs c9873                                                         ; 3864: b0 0d       ..  :9864[1]
+    ldx #9                                                            ; 3866: a2 09       ..  :9866[1]
+    jsr sub_c9940                                                     ; 3868: 20 40 99     @. :9868[1]
+; $386b referenced 1 time by $985c
+c986b
+    ldx #5                                                            ; 386b: a2 05       ..  :986b[1]
+    jsr sub_c9940                                                     ; 386d: 20 40 99     @. :986d[1]
+    bne loop_c985e                                                    ; 3870: d0 ec       ..  :9870[1]
+    clc                                                               ; 3872: 18          .   :9872[1]
+; $3873 referenced 1 time by $9864
+c9873
+    php                                                               ; 3873: 08          .   :9873[1]
+    jsr invert_l1065                                                  ; 3874: 20 4c 99     L. :9874[1]
+    ldx #5                                                            ; 3877: a2 05       ..  :9877[1]
+    jsr sub_c9940                                                     ; 3879: 20 40 99     @. :9879[1]
+    ldy #$0c                                                          ; 387c: a0 0c       ..  :987c[1]
+    jsr sub_c995a                                                     ; 387e: 20 5a 99     Z. :987e[1]
+; $3881 referenced 1 time by $9887
+loop_c9881
+    lda l1060,y                                                       ; 3881: b9 60 10    .`. :9881[1]
+    sta (l00b4),y                                                     ; 3884: 91 b4       ..  :9884[1]
+    dey                                                               ; 3886: 88          .   :9886[1]
+    bpl loop_c9881                                                    ; 3887: 10 f8       ..  :9887[1]
+    plp                                                               ; 3889: 28          (   :9889[1]
+    rts                                                               ; 388a: 60          `   :988a[1]
+
+    jsr sub_c8b7b                                                     ; 388b: 20 7b 8b     {. :988b[1]
+    jsr sub_c93fd                                                     ; 388e: 20 fd 93     .. :988e[1]
+    lda #$9d                                                          ; 3891: a9 9d       ..  :9891[1]
+    sta l10d7                                                         ; 3893: 8d d7 10    ... :9893[1]
+    lda #$98                                                          ; 3896: a9 98       ..  :9896[1]
+    sta l10d8                                                         ; 3898: 8d d8 10    ... :9898[1]
+    bne c9859                                                         ; 389b: d0 bc       ..  :989b[1]
+    ldy l1069                                                         ; 389d: ac 69 10    .i. :989d[1]
+; $38a0 referenced 1 time by $98b8
+loop_c98a0
+    cpy l0f05                                                         ; 38a0: cc 05 0f    ... :98a0[1]
+    bcs c98cd                                                         ; 38a3: b0 28       .(  :98a3[1]
+    lda l0e0f,y                                                       ; 38a5: b9 0f 0e    ... :98a5[1]
+    jsr sub_c8327                                                     ; 38a8: 20 27 83     '. :98a8[1]
+    eor l00cc                                                         ; 38ab: 45 cc       E.  :98ab[1]
+    bcs c98b1                                                         ; 38ad: b0 02       ..  :98ad[1]
+    and #$df                                                          ; 38af: 29 df       ).  :98af[1]
+; $38b1 referenced 1 time by $98ad
+c98b1
+    and #$7f                                                          ; 38b1: 29 7f       ).  :98b1[1]
+    beq c98ba                                                         ; 38b3: f0 05       ..  :98b3[1]
+    jsr sub_c87da                                                     ; 38b5: 20 da 87     .. :98b5[1]
+    bne loop_c98a0                                                    ; 38b8: d0 e6       ..  :98b8[1]
+; $38ba referenced 1 time by $98b3
+c98ba
+    lda #7                                                            ; 38ba: a9 07       ..  :98ba[1]
+    jsr c996e                                                         ; 38bc: 20 6e 99     n. :98bc[1]
+    sta l00b0                                                         ; 38bf: 85 b0       ..  :98bf[1]
+; $38c1 referenced 1 time by $98ca
+loop_c98c1
+    lda l0e08,y                                                       ; 38c1: b9 08 0e    ... :98c1[1]
+    jsr c996e                                                         ; 38c4: 20 6e 99     n. :98c4[1]
+    iny                                                               ; 38c7: c8          .   :98c7[1]
+    dec l00b0                                                         ; 38c8: c6 b0       ..  :98c8[1]
+    bne loop_c98c1                                                    ; 38ca: d0 f5       ..  :98ca[1]
+    clc                                                               ; 38cc: 18          .   :98cc[1]
+; $38cd referenced 1 time by $98a3
+c98cd
+    sty l1069                                                         ; 38cd: 8c 69 10    .i. :98cd[1]
+    lda l0f04                                                         ; 38d0: ad 04 0f    ... :98d0[1]
+    sta l1060                                                         ; 38d3: 8d 60 10    .`. :98d3[1]
+    rts                                                               ; 38d6: 60          `   :98d6[1]
+
+    jsr sub_c8b7b                                                     ; 38d7: 20 7b 8b     {. :98d7[1]
+    jsr sub_c93fd                                                     ; 38da: 20 fd 93     .. :98da[1]
+    lda #$0c                                                          ; 38dd: a9 0c       ..  :98dd[1]
+    jsr c996e                                                         ; 38df: 20 6e 99     n. :98df[1]
+    ldy #0                                                            ; 38e2: a0 00       ..  :98e2[1]
+; $38e4 referenced 1 time by $98f6
+loop_c98e4
+    cpy #8                                                            ; 38e4: c0 08       ..  :98e4[1]
+    bcs c98ed                                                         ; 38e6: b0 05       ..  :98e6[1]
+    lda l0e00,y                                                       ; 38e8: b9 00 0e    ... :98e8[1]
+    bcc c98f0                                                         ; 38eb: 90 03       ..  :98eb[1]
+; $38ed referenced 1 time by $98e6
+c98ed
+    lda l0ef8,y                                                       ; 38ed: b9 f8 0e    ... :98ed[1]
+; $38f0 referenced 1 time by $98eb
+c98f0
+    jsr c996e                                                         ; 38f0: 20 6e 99     n. :98f0[1]
+    iny                                                               ; 38f3: c8          .   :98f3[1]
+    cpy #$0c                                                          ; 38f4: c0 0c       ..  :98f4[1]
+    bne loop_c98e4                                                    ; 38f6: d0 ec       ..  :98f6[1]
+    lda l0f06                                                         ; 38f8: ad 06 0f    ... :98f8[1]
+    jsr sub_c81bf                                                     ; 38fb: 20 bf 81     .. :98fb[1]
+    jsr c996e                                                         ; 38fe: 20 6e 99     n. :98fe[1]
+    lda l00cd                                                         ; 3901: a5 cd       ..  :9901[1]
+    jmp c996e                                                         ; 3903: 4c 6e 99    Ln. :9903[1]
+
+    jsr sub_c9965                                                     ; 3906: 20 65 99     e. :9906[1]
+    lda l10ca                                                         ; 3909: ad ca 10    ... :9909[1]
+    ora #$30 ; '0'                                                    ; 390c: 09 30       .0  :990c[1]
+    jsr c996e                                                         ; 390e: 20 6e 99     n. :990e[1]
+    jsr sub_c9965                                                     ; 3911: 20 65 99     e. :9911[1]
+    lda l10c9                                                         ; 3914: ad c9 10    ... :9914[1]
+    bne c996e                                                         ; 3917: d0 55       .U  :9917[1]
+    jsr sub_c9965                                                     ; 3919: 20 65 99     e. :9919[1]
+    lda l10cc                                                         ; 391c: ad cc 10    ... :991c[1]
+    ora #$30 ; '0'                                                    ; 391f: 09 30       .0  :991f[1]
+    jsr c996e                                                         ; 3921: 20 6e 99     n. :9921[1]
+    jsr sub_c9965                                                     ; 3924: 20 65 99     e. :9924[1]
+    lda l10cb                                                         ; 3927: ad cb 10    ... :9927[1]
+    bne c996e                                                         ; 392a: d0 42       .B  :992a[1]
+; $392c referenced 2 times by $9978, $9993
+sub_c992c
+    pha                                                               ; 392c: 48          H   :992c[1]
+    lda l1061                                                         ; 392d: ad 61 10    .a. :992d[1]
+    sta l00b8                                                         ; 3930: 85 b8       ..  :9930[1]
+    lda l1062                                                         ; 3932: ad 62 10    .b. :9932[1]
+    sta l00b9                                                         ; 3935: 85 b9       ..  :9935[1]
+    ldx #0                                                            ; 3937: a2 00       ..  :9937[1]
+    pla                                                               ; 3939: 68          h   :9939[1]
+    rts                                                               ; 393a: 60          `   :993a[1]
+
+; $393b referenced 4 times by $9976, $997d, $9990, $9998
+c993b
+    jsr sub_c83e3                                                     ; 393b: 20 e3 83     .. :993b[1]
+    ldx #1                                                            ; 393e: a2 01       ..  :993e[1]
+; $3940 referenced 3 times by $9868, $986d, $9879
+sub_c9940
+    ldy #4                                                            ; 3940: a0 04       ..  :9940[1]
+; $3942 referenced 1 time by $9949
+loop_c9942
+    inc l1060,x                                                       ; 3942: fe 60 10    .`. :9942[1]
+    bne c994b                                                         ; 3945: d0 04       ..  :9945[1]
+    inx                                                               ; 3947: e8          .   :9947[1]
+    dey                                                               ; 3948: 88          .   :9948[1]
+    bne loop_c9942                                                    ; 3949: d0 f7       ..  :9949[1]
+; $394b referenced 1 time by $9945
+c994b
+    rts                                                               ; 394b: 60          `   :994b[1]
+
+; Invert the 32-bit value at l1065
+; $394c referenced 2 times by $9859, $9874
+invert_l1065
+    ldx #3                                                            ; 394c: a2 03       ..  :994c[1]
+; $394e referenced 1 time by $9957
+loop_c994e
+    lda #$ff                                                          ; 394e: a9 ff       ..  :994e[1]
+    eor l1065,x                                                       ; 3950: 5d 65 10    ]e. :9950[1]
+    sta l1065,x                                                       ; 3953: 9d 65 10    .e. :9953[1]
+    dex                                                               ; 3956: ca          .   :9956[1]
+    bpl loop_c994e                                                    ; 3957: 10 f5       ..  :9957[1]
+    rts                                                               ; 3959: 60          `   :9959[1]
+
+; $395a referenced 2 times by $97fe, $987e
+sub_c995a
+    lda l107d                                                         ; 395a: ad 7d 10    .}. :995a[1]
+    sta l00b4                                                         ; 395d: 85 b4       ..  :995d[1]
+    lda l107e                                                         ; 395f: ad 7e 10    .~. :995f[1]
+    sta l00b5                                                         ; 3962: 85 b5       ..  :9962[1]
+; $3964 referenced 1 time by $996c
+loop_c9964
+    rts                                                               ; 3964: 60          `   :9964[1]
+
+; $3965 referenced 4 times by $9906, $9911, $9919, $9924
+sub_c9965
+    lda #1                                                            ; 3965: a9 01       ..  :9965[1]
+    bne c996e                                                         ; 3967: d0 05       ..  :9967[1]
+    jsr sub_c9e94                                                     ; 3969: 20 94 9e     .. :9969[1]
+    bcs loop_c9964                                                    ; 396c: b0 f6       ..  :996c[1]
+; $396e referenced 11 times by $98bc, $98c4, $98df, $98f0, $98fe, $9903, $990e, $9917, $9921, $992a, $9967
+c996e
+    bit l1081                                                         ; 396e: 2c 81 10    ,.. :996e[1]
+    bpl c9978                                                         ; 3971: 10 05       ..  :9971[1]
+    sta tube_host_r3_data                                             ; 3973: 8d e5 fe    ... :9973[1]
+    bmi c993b                                                         ; 3976: 30 c3       0.  :9976[1]
+; $3978 referenced 1 time by $9971
+c9978
+    jsr sub_c992c                                                     ; 3978: 20 2c 99     ,. :9978[1]
+    sta (l00b8,x)                                                     ; 397b: 81 b8       ..  :997b[1]
+    jmp c993b                                                         ; 397d: 4c 3b 99    L;. :997d[1]
+
+    jsr sub_c9988                                                     ; 3980: 20 88 99     .. :9980[1]
+    jsr sub_c9f82                                                     ; 3983: 20 82 9f     .. :9983[1]
+    clc                                                               ; 3986: 18          .   :9986[1]
+    rts                                                               ; 3987: 60          `   :9987[1]
+
+; $3988 referenced 1 time by $9980
+sub_c9988
+    bit l1081                                                         ; 3988: 2c 81 10    ,.. :9988[1]
+    bpl c9993                                                         ; 398b: 10 06       ..  :998b[1]
+    lda tube_host_r3_data                                             ; 398d: ad e5 fe    ... :998d[1]
+    jmp c993b                                                         ; 3990: 4c 3b 99    L;. :9990[1]
+
+; $3993 referenced 1 time by $998b
+c9993
+    jsr sub_c992c                                                     ; 3993: 20 2c 99     ,. :9993[1]
+    lda (l00b8,x)                                                     ; 3996: a1 b8       ..  :9996[1]
+    jmp c993b                                                         ; 3998: 4c 3b 99    L;. :9998[1]
+
+    bit l10c7                                                         ; 399b: 2c c7 10    ,.. :999b[1]
+    bmi c99a3                                                         ; 399e: 30 03       0.  :999e[1]
+    dec l10c7                                                         ; 39a0: ce c7 10    ... :99a0[1]
+; $39a3 referenced 5 times by $8782, $8bac, $9789, $999e, $9c25
+c99a3
+    lda #$ff                                                          ; 39a3: a9 ff       ..  :99a3[1]
+    sta l10ce                                                         ; 39a5: 8d ce 10    ... :99a5[1]
+; $39a8 referenced 1 time by $99b3
+loop_c99a8
+    sta l10cd                                                         ; 39a8: 8d cd 10    ... :99a8[1]
+    rts                                                               ; 39ab: 60          `   :99ab[1]
+
+; $39ac referenced 6 times by $824b, $8254, $8750, $8797, $89e6, $a463
+sub_c99ac
+    lda #$2a ; '*'                                                    ; 39ac: a9 2a       .*  :99ac[1]
+    sta l10ce                                                         ; 39ae: 8d ce 10    ... :99ae[1]
+    lda #$23 ; '#'                                                    ; 39b1: a9 23       .#  :99b1[1]
+    bne loop_c99a8                                                    ; 39b3: d0 f3       ..  :99b3[1]
+    jsr sub_c9a6e                                                     ; 39b5: 20 6e 9a     n. :99b5[1]
+    jsr sub_c8386                                                     ; 39b8: 20 86 83     .. :99b8[1]
+    lda #1                                                            ; 39bb: a9 01       ..  :99bb[1]
+    rts                                                               ; 39bd: 60          `   :99bd[1]
+
+    jsr sub_c9a4b                                                     ; 39be: 20 4b 9a     K. :99be[1]
+    jsr sub_c8386                                                     ; 39c1: 20 86 83     .. :99c1[1]
+    jsr sub_c830a                                                     ; 39c4: 20 0a 83     .. :99c4[1]
+    bcc c99ed                                                         ; 39c7: 90 24       .$  :99c7[1]
+    jsr sub_c9a6e                                                     ; 39c9: 20 6e 9a     n. :99c9[1]
+    jsr sub_c99f3                                                     ; 39cc: 20 f3 99     .. :99cc[1]
+    jsr sub_c9a0f                                                     ; 39cf: 20 0f 9a     .. :99cf[1]
+    bvc c99ea                                                         ; 39d2: 50 16       P.  :99d2[1]
+    jsr sub_c9a6e                                                     ; 39d4: 20 6e 9a     n. :99d4[1]
+    jsr sub_c9a0f                                                     ; 39d7: 20 0f 9a     .. :99d7[1]
+    bvc c99ed                                                         ; 39da: 50 11       P.  :99da[1]
+    jsr sub_c9a6e                                                     ; 39dc: 20 6e 9a     n. :99dc[1]
+    jsr sub_c99f3                                                     ; 39df: 20 f3 99     .. :99df[1]
+    bvc c99ed                                                         ; 39e2: 50 09       P.  :99e2[1]
+    jsr sub_c9a6e                                                     ; 39e4: 20 6e 9a     n. :99e4[1]
+    jsr sub_c9a63                                                     ; 39e7: 20 63 9a     c. :99e7[1]
+; $39ea referenced 1 time by $99d2
+c99ea
+    jsr sub_c9a32                                                     ; 39ea: 20 32 9a     2. :99ea[1]
+; $39ed referenced 3 times by $99c7, $99da, $99e2
+c99ed
+    jsr c89d7                                                         ; 39ed: 20 d7 89     .. :99ed[1]
+    lda #1                                                            ; 39f0: a9 01       ..  :99f0[1]
+    rts                                                               ; 39f2: 60          `   :99f2[1]
+
+; $39f3 referenced 2 times by $99cc, $99df
+sub_c99f3
+    jsr sub_c83e3                                                     ; 39f3: 20 e3 83     .. :99f3[1]
+    ldy #2                                                            ; 39f6: a0 02       ..  :99f6[1]
+    lda (l00b0),y                                                     ; 39f8: b1 b0       ..  :99f8[1]
+    sta l0f08,x                                                       ; 39fa: 9d 08 0f    ... :99fa[1]
+    iny                                                               ; 39fd: c8          .   :99fd[1]
+    lda (l00b0),y                                                     ; 39fe: b1 b0       ..  :99fe[1]
+    sta l0f09,x                                                       ; 3a00: 9d 09 0f    ... :9a00[1]
+    iny                                                               ; 3a03: c8          .   :9a03[1]
+    lda (l00b0),y                                                     ; 3a04: b1 b0       ..  :9a04[1]
+    asl                                                               ; 3a06: 0a          .   :9a06[1]
+    asl                                                               ; 3a07: 0a          .   :9a07[1]
+    eor l0f0e,x                                                       ; 3a08: 5d 0e 0f    ].. :9a08[1]
+    and #$0c                                                          ; 3a0b: 29 0c       ).  :9a0b[1]
+    bpl c9a2a                                                         ; 3a0d: 10 1b       ..  :9a0d[1]
+; $3a0f referenced 2 times by $99cf, $99d7
+sub_c9a0f
+    jsr sub_c83e3                                                     ; 3a0f: 20 e3 83     .. :9a0f[1]
+    ldy #6                                                            ; 3a12: a0 06       ..  :9a12[1]
+    lda (l00b0),y                                                     ; 3a14: b1 b0       ..  :9a14[1]
+    sta l0f0a,x                                                       ; 3a16: 9d 0a 0f    ... :9a16[1]
+    iny                                                               ; 3a19: c8          .   :9a19[1]
+    lda (l00b0),y                                                     ; 3a1a: b1 b0       ..  :9a1a[1]
+    sta l0f0b,x                                                       ; 3a1c: 9d 0b 0f    ... :9a1c[1]
+    iny                                                               ; 3a1f: c8          .   :9a1f[1]
+    lda (l00b0),y                                                     ; 3a20: b1 b0       ..  :9a20[1]
+    ror                                                               ; 3a22: 6a          j   :9a22[1]
+    ror                                                               ; 3a23: 6a          j   :9a23[1]
+    ror                                                               ; 3a24: 6a          j   :9a24[1]
+    eor l0f0e,x                                                       ; 3a25: 5d 0e 0f    ].. :9a25[1]
+    and #$c0                                                          ; 3a28: 29 c0       ).  :9a28[1]
+; $3a2a referenced 1 time by $9a0d
+c9a2a
+    eor l0f0e,x                                                       ; 3a2a: 5d 0e 0f    ].. :9a2a[1]
+    sta l0f0e,x                                                       ; 3a2d: 9d 0e 0f    ... :9a2d[1]
+    clv                                                               ; 3a30: b8          .   :9a30[1]
+    rts                                                               ; 3a31: 60          `   :9a31[1]
+
+; $3a32 referenced 1 time by $99ea
+sub_c9a32
+    jsr sub_c83e3                                                     ; 3a32: 20 e3 83     .. :9a32[1]
+    ldy #$0e                                                          ; 3a35: a0 0e       ..  :9a35[1]
+    lda (l00b0),y                                                     ; 3a37: b1 b0       ..  :9a37[1]
+    and #$0a                                                          ; 3a39: 29 0a       ).  :9a39[1]
+    beq c9a3f                                                         ; 3a3b: f0 02       ..  :9a3b[1]
+    lda #$80                                                          ; 3a3d: a9 80       ..  :9a3d[1]
+; $3a3f referenced 1 time by $9a3b
+c9a3f
+    eor l0e0f,x                                                       ; 3a3f: 5d 0f 0e    ].. :9a3f[1]
+    and #$80                                                          ; 3a42: 29 80       ).  :9a42[1]
+    eor l0e0f,x                                                       ; 3a44: 5d 0f 0e    ].. :9a44[1]
+    sta l0e0f,x                                                       ; 3a47: 9d 0f 0e    ... :9a47[1]
+    rts                                                               ; 3a4a: 60          `   :9a4a[1]
+
+; $3a4b referenced 1 time by $99be
+sub_c9a4b
+    jsr sub_c9a78                                                     ; 3a4b: 20 78 9a     x. :9a4b[1]
+    bcc c9a73                                                         ; 3a4e: 90 23       .#  :9a4e[1]
+; $3a50 referenced 2 times by $9a60, $9c55
+sub_c9a50
+    lda l0e0f,y                                                       ; 3a50: b9 0f 0e    ... :9a50[1]
+    bpl c9a77                                                         ; 3a53: 10 22       ."  :9a53[1]
+; $3a55 referenced 1 time by $9f6b
+generate_error_precheck_locked
+    jsr generate_error_precheck                                       ; 3a55: 20 38 80     8. :9a55[1]
+    !byte $c3                                                         ; 3a58: c3          .   :9a58[1]
+    !text "Locked"                                                    ; 3a59: 4c 6f 63... Loc :9a59[1]
+    !byte 0                                                           ; 3a5f: 00          .   :9a5f[1]
+
+; $3a60 referenced 2 times by $830a, $8bba
+sub_c9a60
+    jsr sub_c9a50                                                     ; 3a60: 20 50 9a     P. :9a60[1]
+; $3a63 referenced 2 times by $8a00, $99e7
+sub_c9a63
+    jsr sub_c83e3                                                     ; 3a63: 20 e3 83     .. :9a63[1]
+    jsr sub_c9d1e                                                     ; 3a66: 20 1e 9d     .. :9a66[1]
+    bcc c9a8c                                                         ; 3a69: 90 21       .!  :9a69[1]
+    jmp generate_error_precheck_open                                  ; 3a6b: 4c 82 9c    L.. :9a6b[1]
+
+; $3a6e referenced 5 times by $99b5, $99c9, $99d4, $99dc, $99e4
+sub_c9a6e
+    jsr sub_c9a78                                                     ; 3a6e: 20 78 9a     x. :9a6e[1]
+    bcs c9a8c                                                         ; 3a71: b0 19       ..  :9a71[1]
+; $3a73 referenced 1 time by $9a4e
+c9a73
+    pla                                                               ; 3a73: 68          h   :9a73[1]
+    pla                                                               ; 3a74: 68          h   :9a74[1]
+    lda #0                                                            ; 3a75: a9 00       ..  :9a75[1]
+; $3a77 referenced 1 time by $9a53
+c9a77
+    rts                                                               ; 3a77: 60          `   :9a77[1]
+
+; $3a78 referenced 2 times by $9a4b, $9a6e
+sub_c9a78
+    jsr sub_c80f3                                                     ; 3a78: 20 f3 80     .. :9a78[1]
+    jsr sub_c8284                                                     ; 3a7b: 20 84 82     .. :9a7b[1]
+    bcc c9a8c                                                         ; 3a7e: 90 0c       ..  :9a7e[1]
+    tya                                                               ; 3a80: 98          .   :9a80[1]
+    tax                                                               ; 3a81: aa          .   :9a81[1]
+; $3a82 referenced 2 times by $881e, $885c
+sub_c9a82
+    lda l10db                                                         ; 3a82: ad db 10    ... :9a82[1]
+    sta l00b0                                                         ; 3a85: 85 b0       ..  :9a85[1]
+    lda l10dc                                                         ; 3a87: ad dc 10    ... :9a87[1]
+    sta l00b1                                                         ; 3a8a: 85 b1       ..  :9a8a[1]
+; $3a8c referenced 3 times by $9a69, $9a71, $9a7e
+c9a8c
+    rts                                                               ; 3a8c: 60          `   :9a8c[1]
+
+; $3a8d referenced 4 times by $929d, $a267, $a34a, $a64f
+sub_c9a8d
+    lda #osbyte_read_oshwm                                            ; 3a8d: a9 83       ..  :9a8d[1]
+    jsr osbyte                                                        ; 3a8f: 20 f4 ff     .. :9a8f[1]
+    sty l10cf                                                         ; 3a92: 8c cf 10    ... :9a92[1]
+    lda #osbyte_read_himem                                            ; 3a95: a9 84       ..  :9a95[1]
+    jsr osbyte                                                        ; 3a97: 20 f4 ff     .. :9a97[1]
+    tya                                                               ; 3a9a: 98          .   :9a9a[1]
+    sec                                                               ; 3a9b: 38          8   :9a9b[1]
+    sbc l10cf                                                         ; 3a9c: ed cf 10    ... :9a9c[1]
+    sta l10d0                                                         ; 3a9f: 8d d0 10    ... :9a9f[1]
+    rts                                                               ; 3aa2: 60          `   :9aa2[1]
+
+; $3aa3 referenced 2 times by $95d4, $95fd
+sub_c9aa3
+    ldx #$0a                                                          ; 3aa3: a2 0a       ..  :9aa3[1]
+    jsr c9adf                                                         ; 3aa5: 20 df 9a     .. :9aa5[1]
+    jsr sub_c9ab8                                                     ; 3aa8: 20 b8 9a     .. :9aa8[1]
+    ldy #$d3                                                          ; 3aab: a0 d3       ..  :9aab[1]
+    lda #$ff                                                          ; 3aad: a9 ff       ..  :9aad[1]
+    sta (l00b0),y                                                     ; 3aaf: 91 b0       ..  :9aaf[1]
+    sta l10d3                                                         ; 3ab1: 8d d3 10    ... :9ab1[1]
+    iny                                                               ; 3ab4: c8          .   :9ab4[1]
+    sta (l00b0),y                                                     ; 3ab5: 91 b0       ..  :9ab5[1]
+    rts                                                               ; 3ab7: 60          `   :9ab7[1]
+
+; $3ab8 referenced 5 times by $895a, $95c1, $971b, $972c, $9aa8
+sub_c9ab8
+    pha                                                               ; 3ab8: 48          H   :9ab8[1]
+    ldx romsel_copy                                                   ; 3ab9: a6 f4       ..  :9ab9[1]
+    lda #0                                                            ; 3abb: a9 00       ..  :9abb[1]
+    sta l00b0                                                         ; 3abd: 85 b0       ..  :9abd[1]
+    lda l0df0,x                                                       ; 3abf: bd f0 0d    ... :9abf[1]
+    and #$3f ; '?'                                                    ; 3ac2: 29 3f       )?  :9ac2[1]
+    sta l00b1                                                         ; 3ac4: 85 b1       ..  :9ac4[1]
+    pla                                                               ; 3ac6: 68          h   :9ac6[1]
+    rts                                                               ; 3ac7: 60          `   :9ac7[1]
+
+; $3ac8 referenced 2 times by $a3d4, $a3fb
+sub_c9ac8
+    jsr sub_c83e3                                                     ; 3ac8: 20 e3 83     .. :9ac8[1]
+    lda #$0f                                                          ; 3acb: a9 0f       ..  :9acb[1]
+    ldx #1                                                            ; 3acd: a2 01       ..  :9acd[1]
+    ldy #0                                                            ; 3acf: a0 00       ..  :9acf[1]
+    beq c9ae9                                                         ; 3ad1: f0 16       ..  :9ad1[1]
+; $3ad3 referenced 1 time by $80ac
+sub_c9ad3
+    tax                                                               ; 3ad3: aa          .   :9ad3[1]
+; $3ad4 referenced 1 time by $80b5
+c9ad4
+    lda #3                                                            ; 3ad4: a9 03       ..  :9ad4[1]
+    bne c9ae9                                                         ; 3ad6: d0 11       ..  :9ad6[1]
+; $3ad8 referenced 2 times by $9436, $abbc
+sub_c9ad8
+    jsr sub_c83e3                                                     ; 3ad8: 20 e3 83     .. :9ad8[1]
+    lda #$7e ; '~'                                                    ; 3adb: a9 7e       .~  :9adb[1]
+    bne c9ae9                                                         ; 3add: d0 0a       ..  :9add[1]
+; $3adf referenced 4 times by $9593, $9599, $95be, $9aa5
+c9adf
+    lda #$8f                                                          ; 3adf: a9 8f       ..  :9adf[1]
+    bne c9ae9                                                         ; 3ae1: d0 06       ..  :9ae1[1]
+    lda #osbyte_read_write_startup_options                            ; 3ae3: a9 ff       ..  :9ae3[1]
+; $3ae5 referenced 8 times by $80a5, $9588, $96a0, $9e32, $9e43, $aae2, $ac7c, $aeb7
+osbyte_read
+    ldx #0                                                            ; 3ae5: a2 00       ..  :9ae5[1]
+    ldy #$ff                                                          ; 3ae7: a0 ff       ..  :9ae7[1]
+; $3ae9 referenced 4 times by $9ad1, $9ad6, $9add, $9ae1
+c9ae9
+    jmp osbyte                                                        ; 3ae9: 4c f4 ff    L.. :9ae9[1]
+
+; $3aec referenced 1 time by $957d
+l9aec
+    !byte $1b, $ff, $1e, $ff, $21, $ff, $24, $ff, $27, $ff, $2a, $ff  ; 3aec: 1b ff 1e... ... :9aec[1]
+    !byte $2d, $ff                                                    ; 3af8: 2d ff       -.  :9af8[1]
+    !word sub_c9785                                                   ; 3afa: 85 97       ..  :9afa[1]
+    !byte 0                                                           ; 3afc: 00          .   :9afc[1]
+    !word sub_c9d9b                                                   ; 3afd: 9b 9d       ..  :9afd[1]
+    !byte 0                                                           ; 3aff: 00          .   :9aff[1]
+    !word sub_c9e94                                                   ; 3b00: 94 9e       ..  :9b00[1]
+    !byte 0                                                           ; 3b02: 00          .   :9b02[1]
+    !word sub_c9f82                                                   ; 3b03: 82 9f       ..  :9b03[1]
+    !byte 0                                                           ; 3b05: 00          .   :9b05[1]
+    !word sub_c97c9                                                   ; 3b06: c9 97       ..  :9b06[1]
+    !byte 0                                                           ; 3b08: 00          .   :9b08[1]
+    !word sub_c9c0c                                                   ; 3b09: 0c 9c       ..  :9b09[1]
+    !byte 0                                                           ; 3b0b: 00          .   :9b0b[1]
+    !word sub_c97b6                                                   ; 3b0c: b6 97       ..  :9b0c[1]
+    !byte 0                                                           ; 3b0e: 00          .   :9b0e[1]
+; $3b0f referenced 1 time by $97c1
+l9b0f
+    !text "1", $5c, "o"                                               ; 3b0f: 31 5c 6f    1\o :9b0f[1]
+    !byte $fd, $6f, $82, $50, $4b, $9a                                ; 3b12: fd 6f 82... .o. :9b12[1]
+; $3b18 referenced 1 time by $97bd
+l9b18
+    !byte $8a, $9e, $88, $86, $88, $84, $9b, $9b, $99                 ; 3b18: 8a 9e 88... ... :9b18[1]
+; $3b21 referenced 1 time by $97af
+l9b21
+    !byte $1a, $58, $c8, $db, $d3, $e3, $b4, $bd                      ; 3b21: 1a 58 c8... .X. :9b21[1]
+; $3b29 referenced 1 time by $97ab
+l9b29
+    !byte $88, $88, $99, $99, $99, $99, $99, $99                      ; 3b29: 88 88 99... ... :9b29[1]
+; $3b31 referenced 1 time by $97e8
+l9b31
+    !byte $1b, $80, $80, $69, $69, $d7,   6, $19, $8b                 ; 3b31: 1b 80 80... ... :9b31[1]
+; $3b3a referenced 1 time by $97ee
+l9b3a
+    !byte $86, $99, $99, $99, $99, $98, $99, $99, $98                 ; 3b3a: 86 99 99... ... :9b3a[1]
+; $3b43 referenced 1 time by $97f4
+l9b43
+    !byte   4,   2,   3,   6,   7,   4,   4,   4,   4, $a2, $11, $a0  ; 3b43: 04 02 03... ... :9b43[1]
+    !byte $15                                                         ; 3b4f: 15          .   :9b4f[1]
+
+; $3b50 referenced 1 time by $9b66
+loop_c9b50
+    rts                                                               ; 3b50: 60          `   :9b50[1]
+
+; $3b51 referenced 1 time by $9b5e
+sub_c9b51
+    jsr sub_c83e3                                                     ; 3b51: 20 e3 83     .. :9b51[1]
+    lda #osbyte_close_spool_exec                                      ; 3b54: a9 77       .w  :9b54[1]
+    jmp osbyte                                                        ; 3b56: 4c f4 ff    L.. :9b56[1]
+
+sub_c9b59
+    lda #$20 ; ' '                                                    ; 3b59: a9 20       .   :9b59[1]
+    sta l1086                                                         ; 3b5b: 8d 86 10    ... :9b5b[1]
+; $3b5e referenced 1 time by $9b74
+loop_c9b5e
+    jsr sub_c9b51                                                     ; 3b5e: 20 51 9b     Q. :9b5e[1]
+; $3b61 referenced 1 time by $9d81
+sub_c9b61
+    lda #0                                                            ; 3b61: a9 00       ..  :9b61[1]
+; $3b63 referenced 1 time by $9b6c
+loop_c9b63
+    clc                                                               ; 3b63: 18          .   :9b63[1]
+    adc #$20 ; ' '                                                    ; 3b64: 69 20       i   :9b64[1]
+    beq loop_c9b50                                                    ; 3b66: f0 e8       ..  :9b66[1]
+    tay                                                               ; 3b68: a8          .   :9b68[1]
+    jsr sub_c9b79                                                     ; 3b69: 20 79 9b     y. :9b69[1]
+    bne loop_c9b63                                                    ; 3b6c: d0 f5       ..  :9b6c[1]
+; $3b6e referenced 2 times by $9c13, $9d86
+c9b6e
+    lda #$20 ; ' '                                                    ; 3b6e: a9 20       .   :9b6e[1]
+    sta l1086                                                         ; 3b70: 8d 86 10    ... :9b70[1]
+    tya                                                               ; 3b73: 98          .   :9b73[1]
+    beq loop_c9b5e                                                    ; 3b74: f0 e8       ..  :9b74[1]
+    jsr sub_c9e75                                                     ; 3b76: 20 75 9e     u. :9b76[1]
+; $3b79 referenced 2 times by $9b69, $a264
+sub_c9b79
+    pha                                                               ; 3b79: 48          H   :9b79[1]
+    jsr sub_c9df4                                                     ; 3b7a: 20 f4 9d     .. :9b7a[1]
+    bcs c9bc5                                                         ; 3b7d: b0 46       .F  :9b7d[1]
+    lda l111b,y                                                       ; 3b7f: b9 1b 11    ... :9b7f[1]
+    eor #$ff                                                          ; 3b82: 49 ff       I.  :9b82[1]
+    and l10c0                                                         ; 3b84: 2d c0 10    -.. :9b84[1]
+    sta l10c0                                                         ; 3b87: 8d c0 10    ... :9b87[1]
+    lda l1117,y                                                       ; 3b8a: b9 17 11    ... :9b8a[1]
+    and #$60 ; '`'                                                    ; 3b8d: 29 60       )`  :9b8d[1]
+    beq c9bc5                                                         ; 3b8f: f0 34       .4  :9b8f[1]
+    jsr sub_c9bca                                                     ; 3b91: 20 ca 9b     .. :9b91[1]
+    lda l1117,y                                                       ; 3b94: b9 17 11    ... :9b94[1]
+    and l1086                                                         ; 3b97: 2d 86 10    -.. :9b97[1]
+    beq c9bc2                                                         ; 3b9a: f0 26       .&  :9b9a[1]
+    ldx l10c3                                                         ; 3b9c: ae c3 10    ... :9b9c[1]
+    lda l1114,y                                                       ; 3b9f: b9 14 11    ... :9b9f[1]
+    sta l0f0c,x                                                       ; 3ba2: 9d 0c 0f    ... :9ba2[1]
+    lda l1115,y                                                       ; 3ba5: b9 15 11    ... :9ba5[1]
+    sta l0f0d,x                                                       ; 3ba8: 9d 0d 0f    ... :9ba8[1]
+    lda l1116,y                                                       ; 3bab: b9 16 11    ... :9bab[1]
+    jsr sub_c81c5                                                     ; 3bae: 20 c5 81     .. :9bae[1]
+    eor l0f0e,x                                                       ; 3bb1: 5d 0e 0f    ].. :9bb1[1]
+    and #$30 ; '0'                                                    ; 3bb4: 29 30       )0  :9bb4[1]
+    eor l0f0e,x                                                       ; 3bb6: 5d 0e 0f    ].. :9bb6[1]
+    sta l0f0e,x                                                       ; 3bb9: 9d 0e 0f    ... :9bb9[1]
+    jsr c93e6                                                         ; 3bbc: 20 e6 93     .. :9bbc[1]
+    ldy l10c2                                                         ; 3bbf: ac c2 10    ... :9bbf[1]
+; $3bc2 referenced 1 time by $9b9a
+c9bc2
+    jsr sub_c9f1e                                                     ; 3bc2: 20 1e 9f     .. :9bc2[1]
+; $3bc5 referenced 2 times by $9b7d, $9b8f
+c9bc5
+    ldx l10c5                                                         ; 3bc5: ae c5 10    ... :9bc5[1]
+    pla                                                               ; 3bc8: 68          h   :9bc8[1]
+    rts                                                               ; 3bc9: 60          `   :9bc9[1]
+
+; $3bca referenced 1 time by $9b91
+sub_c9bca
+    jsr sub_c9be5                                                     ; 3bca: 20 e5 9b     .. :9bca[1]
+; $3bcd referenced 1 time by $9f9f
+sub_c9bcd
+    ldx #6                                                            ; 3bcd: a2 06       ..  :9bcd[1]
+; $3bcf referenced 1 time by $9bd7
+loop_c9bcf
+    lda l110c,y                                                       ; 3bcf: b9 0c 11    ... :9bcf[1]
+    sta l00c5,x                                                       ; 3bd2: 95 c5       ..  :9bd2[1]
+    dey                                                               ; 3bd4: 88          .   :9bd4[1]
+    dey                                                               ; 3bd5: 88          .   :9bd5[1]
+    dex                                                               ; 3bd6: ca          .   :9bd6[1]
+    bpl loop_c9bcf                                                    ; 3bd7: 10 f6       ..  :9bd7[1]
+    jsr sub_c826d                                                     ; 3bd9: 20 6d 82     m. :9bd9[1]
+    bcc generate_error_precheck_disc_changed                          ; 3bdc: 90 22       ."  :9bdc[1]
+    sty l10c3                                                         ; 3bde: 8c c3 10    ... :9bde[1]
+    ldy l10c2                                                         ; 3be1: ac c2 10    ... :9be1[1]
+; $3be4 referenced 1 time by $9bfe
+loop_c9be4
+    rts                                                               ; 3be4: 60          `   :9be4[1]
+
+; $3be5 referenced 3 times by $9bca, $9eb8, $9f93
+sub_c9be5
+    lda l110e,y                                                       ; 3be5: b9 0e 11    ... :9be5[1]
+    and #$7f                                                          ; 3be8: 29 7f       ).  :9be8[1]
+    sta l00cc                                                         ; 3bea: 85 cc       ..  :9bea[1]
+    lda l1117,y                                                       ; 3bec: b9 17 11    ... :9bec[1]
+    jmp c8816                                                         ; 3bef: 4c 16 88    L.. :9bef[1]
+
+; $3bf2 referenced 2 times by $8768, $87b8
+sub_c9bf2
+    jsr sub_c83e3                                                     ; 3bf2: 20 e3 83     .. :9bf2[1]
+    lda l0f04                                                         ; 3bf5: ad 04 0f    ... :9bf5[1]
+    jsr sub_c8380                                                     ; 3bf8: 20 80 83     .. :9bf8[1]
+    cmp l0f04                                                         ; 3bfb: cd 04 0f    ... :9bfb[1]
+    beq loop_c9be4                                                    ; 3bfe: f0 e4       ..  :9bfe[1]
+; $3c00 referenced 1 time by $9bdc
+generate_error_precheck_disc_changed
+    jsr generate_error_precheck_disc                                  ; 3c00: 20 23 80     #. :9c00[1]
+    !byte $c8                                                         ; 3c03: c8          .   :9c03[1]
+    !text "changed"                                                   ; 3c04: 63 68 61... cha :9c04[1]
+    !byte 0                                                           ; 3c0b: 00          .   :9c0b[1]
+
+sub_c9c0c
+    and #$c0                                                          ; 3c0c: 29 c0       ).  :9c0c[1]
+    bne c9c16                                                         ; 3c0e: d0 06       ..  :9c0e[1]
+    jsr sub_c83e3                                                     ; 3c10: 20 e3 83     .. :9c10[1]
+    jmp c9b6e                                                         ; 3c13: 4c 6e 9b    Ln. :9c13[1]
+
+; $3c16 referenced 1 time by $9c0e
+c9c16
+    jsr sub_c840c                                                     ; 3c16: 20 0c 84     .. :9c16[1]
+    stx l00ba                                                         ; 3c19: 86 ba       ..  :9c19[1]
+    sty l00bb                                                         ; 3c1b: 84 bb       ..  :9c1b[1]
+    sta l00b4                                                         ; 3c1d: 85 b4       ..  :9c1d[1]
+    bit l00b4                                                         ; 3c1f: 24 b4       $.  :9c1f[1]
+    php                                                               ; 3c21: 08          .   :9c21[1]
+    jsr sub_c80f3                                                     ; 3c22: 20 f3 80     .. :9c22[1]
+    jsr c99a3                                                         ; 3c25: 20 a3 99     .. :9c25[1]
+    jsr sub_c8284                                                     ; 3c28: 20 84 82     .. :9c28[1]
+    bcs c9c51                                                         ; 3c2b: b0 24       .$  :9c2b[1]
+    plp                                                               ; 3c2d: 28          (   :9c2d[1]
+    bvc c9c33                                                         ; 3c2e: 50 03       P.  :9c2e[1]
+    lda #0                                                            ; 3c30: a9 00       ..  :9c30[1]
+    rts                                                               ; 3c32: 60          `   :9c32[1]
+
+; $3c33 referenced 1 time by $9c2e
+c9c33
+    php                                                               ; 3c33: 08          .   :9c33[1]
+    lda #0                                                            ; 3c34: a9 00       ..  :9c34[1]
+    ldx #7                                                            ; 3c36: a2 07       ..  :9c36[1]
+; $3c38 referenced 1 time by $9c3e
+loop_c9c38
+    sta l00bc,x                                                       ; 3c38: 95 bc       ..  :9c38[1]
+    sta l1074,x                                                       ; 3c3a: 9d 74 10    .t. :9c3a[1]
+    dex                                                               ; 3c3d: ca          .   :9c3d[1]
+    bpl loop_c9c38                                                    ; 3c3e: 10 f8       ..  :9c3e[1]
+    dec l00be                                                         ; 3c40: c6 be       ..  :9c40[1]
+    dec l00bf                                                         ; 3c42: c6 bf       ..  :9c42[1]
+    dec l1076                                                         ; 3c44: ce 76 10    .v. :9c44[1]
+    dec l1077                                                         ; 3c47: ce 77 10    .w. :9c47[1]
+    lda #$40 ; '@'                                                    ; 3c4a: a9 40       .@  :9c4a[1]
+    sta l00c3                                                         ; 3c4c: 85 c3       ..  :9c4c[1]
+    jsr sub_c8a77                                                     ; 3c4e: 20 77 8a     w. :9c4e[1]
+; $3c51 referenced 1 time by $9c2b
+c9c51
+    plp                                                               ; 3c51: 28          (   :9c51[1]
+    php                                                               ; 3c52: 08          .   :9c52[1]
+    bvs c9c58                                                         ; 3c53: 70 03       p.  :9c53[1]
+    jsr sub_c9a50                                                     ; 3c55: 20 50 9a     P. :9c55[1]
+; $3c58 referenced 1 time by $9c53
+c9c58
+    jsr sub_c9d1e                                                     ; 3c58: 20 1e 9d     .. :9c58[1]
+    bcc c9c6b                                                         ; 3c5b: 90 0e       ..  :9c5b[1]
+; $3c5d referenced 1 time by $9c69
+loop_c9c5d
+    lda l110c,y                                                       ; 3c5d: b9 0c 11    ... :9c5d[1]
+    bpl generate_error_precheck_open                                  ; 3c60: 10 20       .   :9c60[1]
+    plp                                                               ; 3c62: 28          (   :9c62[1]
+    php                                                               ; 3c63: 08          .   :9c63[1]
+    bmi generate_error_precheck_open                                  ; 3c64: 30 1c       0.  :9c64[1]
+    jsr sub_c9d19                                                     ; 3c66: 20 19 9d     .. :9c66[1]
+    bcs loop_c9c5d                                                    ; 3c69: b0 f2       ..  :9c69[1]
+; $3c6b referenced 1 time by $9c5b
+c9c6b
+    ldy l10c2                                                         ; 3c6b: ac c2 10    ... :9c6b[1]
+    bne c9c8b                                                         ; 3c6e: d0 1b       ..  :9c6e[1]
+    jsr generate_error_precheck                                       ; 3c70: 20 38 80     8. :9c70[1]
+    !byte $c0                                                         ; 3c73: c0          .   :9c73[1]
+    !text "Too many open"                                             ; 3c74: 54 6f 6f... Too :9c74[1]
+    !byte 0                                                           ; 3c81: 00          .   :9c81[1]
+
+; $3c82 referenced 3 times by $9a6b, $9c60, $9c64
+generate_error_precheck_open
+    jsr generate_error_precheck                                       ; 3c82: 20 38 80     8. :9c82[1]
+    !byte $c2                                                         ; 3c85: c2          .   :9c85[1]
+    !text "Open"                                                      ; 3c86: 4f 70 65... Ope :9c86[1]
+    !byte 0                                                           ; 3c8a: 00          .   :9c8a[1]
+
+; $3c8b referenced 1 time by $9c6e
+c9c8b
+    lda #8                                                            ; 3c8b: a9 08       ..  :9c8b[1]
+    sta l10c4                                                         ; 3c8d: 8d c4 10    ... :9c8d[1]
+; $3c90 referenced 1 time by $9ca2
+loop_c9c90
+    lda l0e08,x                                                       ; 3c90: bd 08 0e    ... :9c90[1]
+    sta l1100,y                                                       ; 3c93: 99 00 11    ... :9c93[1]
+    iny                                                               ; 3c96: c8          .   :9c96[1]
+    lda l0f08,x                                                       ; 3c97: bd 08 0f    ... :9c97[1]
+    sta l1100,y                                                       ; 3c9a: 99 00 11    ... :9c9a[1]
+    iny                                                               ; 3c9d: c8          .   :9c9d[1]
+    inx                                                               ; 3c9e: e8          .   :9c9e[1]
+    dec l10c4                                                         ; 3c9f: ce c4 10    ... :9c9f[1]
+    bne loop_c9c90                                                    ; 3ca2: d0 ec       ..  :9ca2[1]
+    ldx #$10                                                          ; 3ca4: a2 10       ..  :9ca4[1]
+    lda #0                                                            ; 3ca6: a9 00       ..  :9ca6[1]
+; $3ca8 referenced 1 time by $9cad
+loop_c9ca8
+    sta l1100,y                                                       ; 3ca8: 99 00 11    ... :9ca8[1]
+    iny                                                               ; 3cab: c8          .   :9cab[1]
+    dex                                                               ; 3cac: ca          .   :9cac[1]
+    bne loop_c9ca8                                                    ; 3cad: d0 f9       ..  :9cad[1]
+    lda l10c2                                                         ; 3caf: ad c2 10    ... :9caf[1]
+    tay                                                               ; 3cb2: a8          .   :9cb2[1]
+    jsr sub_c81be                                                     ; 3cb3: 20 be 81     .. :9cb3[1]
+    adc #$11                                                          ; 3cb6: 69 11       i.  :9cb6[1]
+    sta l1113,y                                                       ; 3cb8: 99 13 11    ... :9cb8[1]
+    lda l10c1                                                         ; 3cbb: ad c1 10    ... :9cbb[1]
+    sta l111b,y                                                       ; 3cbe: 99 1b 11    ... :9cbe[1]
+    ora l10c0                                                         ; 3cc1: 0d c0 10    ... :9cc1[1]
+    sta l10c0                                                         ; 3cc4: 8d c0 10    ... :9cc4[1]
+    lda l1109,y                                                       ; 3cc7: b9 09 11    ... :9cc7[1]
+    adc #$ff                                                          ; 3cca: 69 ff       i.  :9cca[1]
+    lda l110b,y                                                       ; 3ccc: b9 0b 11    ... :9ccc[1]
+    adc #0                                                            ; 3ccf: 69 00       i.  :9ccf[1]
+    sta l1119,y                                                       ; 3cd1: 99 19 11    ... :9cd1[1]
+    lda l110d,y                                                       ; 3cd4: b9 0d 11    ... :9cd4[1]
+    ora #$0f                                                          ; 3cd7: 09 0f       ..  :9cd7[1]
+    adc #0                                                            ; 3cd9: 69 00       i.  :9cd9[1]
+    jsr sub_c81b0                                                     ; 3cdb: 20 b0 81     .. :9cdb[1]
+    sta l111a,y                                                       ; 3cde: 99 1a 11    ... :9cde[1]
+    plp                                                               ; 3ce1: 28          (   :9ce1[1]
+    bvc c9d12                                                         ; 3ce2: 50 2e       P.  :9ce2[1]
+    bmi c9cee                                                         ; 3ce4: 30 08       0.  :9ce4[1]
+    lda #$80                                                          ; 3ce6: a9 80       ..  :9ce6[1]
+    ora l110c,y                                                       ; 3ce8: 19 0c 11    ... :9ce8[1]
+    sta l110c,y                                                       ; 3ceb: 99 0c 11    ... :9ceb[1]
+; $3cee referenced 1 time by $9ce4
+c9cee
+    lda l1109,y                                                       ; 3cee: b9 09 11    ... :9cee[1]
+    sta l1114,y                                                       ; 3cf1: 99 14 11    ... :9cf1[1]
+    lda l110b,y                                                       ; 3cf4: b9 0b 11    ... :9cf4[1]
+    sta l1115,y                                                       ; 3cf7: 99 15 11    ... :9cf7[1]
+    lda l110d,y                                                       ; 3cfa: b9 0d 11    ... :9cfa[1]
+    jsr sub_c81b0                                                     ; 3cfd: 20 b0 81     .. :9cfd[1]
+    sta l1116,y                                                       ; 3d00: 99 16 11    ... :9d00[1]
+; $3d03 referenced 1 time by $9d17
+loop_c9d03
+    lda l00cd                                                         ; 3d03: a5 cd       ..  :9d03[1]
+    ora l1117,y                                                       ; 3d05: 19 17 11    ... :9d05[1]
+    sta l1117,y                                                       ; 3d08: 99 17 11    ... :9d08[1]
+    tya                                                               ; 3d0b: 98          .   :9d0b[1]
+    jsr sub_c81be                                                     ; 3d0c: 20 be 81     .. :9d0c[1]
+    ora #$10                                                          ; 3d0f: 09 10       ..  :9d0f[1]
+    rts                                                               ; 3d11: 60          `   :9d11[1]
+
+; $3d12 referenced 1 time by $9ce2
+c9d12
+    lda #$20 ; ' '                                                    ; 3d12: a9 20       .   :9d12[1]
+    sta l1117,y                                                       ; 3d14: 99 17 11    ... :9d14[1]
+    bne loop_c9d03                                                    ; 3d17: d0 ea       ..  :9d17[1]
+; $3d19 referenced 1 time by $9c66
+sub_c9d19
+    txa                                                               ; 3d19: 8a          .   :9d19[1]
+    pha                                                               ; 3d1a: 48          H   :9d1a[1]
+    jmp c9d5d                                                         ; 3d1b: 4c 5d 9d    L]. :9d1b[1]
+
+; $3d1e referenced 2 times by $9a66, $9c58
+sub_c9d1e
+    lda #0                                                            ; 3d1e: a9 00       ..  :9d1e[1]
+    sta l10c2                                                         ; 3d20: 8d c2 10    ... :9d20[1]
+    lda #8                                                            ; 3d23: a9 08       ..  :9d23[1]
+    sta l00b5                                                         ; 3d25: 85 b5       ..  :9d25[1]
+    tya                                                               ; 3d27: 98          .   :9d27[1]
+    tax                                                               ; 3d28: aa          .   :9d28[1]
+    ldy #$a0                                                          ; 3d29: a0 a0       ..  :9d29[1]
+; $3d2b referenced 1 time by $9d6f
+c9d2b
+    sty l00b3                                                         ; 3d2b: 84 b3       ..  :9d2b[1]
+    txa                                                               ; 3d2d: 8a          .   :9d2d[1]
+    pha                                                               ; 3d2e: 48          H   :9d2e[1]
+    lda #8                                                            ; 3d2f: a9 08       ..  :9d2f[1]
+    sta l00b2                                                         ; 3d31: 85 b2       ..  :9d31[1]
+    lda l00b5                                                         ; 3d33: a5 b5       ..  :9d33[1]
+    bit l10c0                                                         ; 3d35: 2c c0 10    ,.. :9d35[1]
+    beq c9d57                                                         ; 3d38: f0 1d       ..  :9d38[1]
+    lda l1117,y                                                       ; 3d3a: b9 17 11    ... :9d3a[1]
+    eor l00cd                                                         ; 3d3d: 45 cd       E.  :9d3d[1]
+    and #3                                                            ; 3d3f: 29 03       ).  :9d3f[1]
+    bne c9d5d                                                         ; 3d41: d0 1a       ..  :9d41[1]
+; $3d43 referenced 1 time by $9d52
+loop_c9d43
+    lda l0e08,x                                                       ; 3d43: bd 08 0e    ... :9d43[1]
+    eor l1100,y                                                       ; 3d46: 59 00 11    Y.. :9d46[1]
+    and #$7f                                                          ; 3d49: 29 7f       ).  :9d49[1]
+    bne c9d5d                                                         ; 3d4b: d0 10       ..  :9d4b[1]
+    inx                                                               ; 3d4d: e8          .   :9d4d[1]
+    iny                                                               ; 3d4e: c8          .   :9d4e[1]
+    iny                                                               ; 3d4f: c8          .   :9d4f[1]
+    dec l00b2                                                         ; 3d50: c6 b2       ..  :9d50[1]
+    bne loop_c9d43                                                    ; 3d52: d0 ef       ..  :9d52[1]
+    sec                                                               ; 3d54: 38          8   :9d54[1]
+    bcs c9d67                                                         ; 3d55: b0 10       ..  :9d55[1]
+; $3d57 referenced 1 time by $9d38
+c9d57
+    sty l10c2                                                         ; 3d57: 8c c2 10    ... :9d57[1]
+    sta l10c1                                                         ; 3d5a: 8d c1 10    ... :9d5a[1]
+; $3d5d referenced 3 times by $9d1b, $9d41, $9d4b
+c9d5d
+    sec                                                               ; 3d5d: 38          8   :9d5d[1]
+    lda l00b3                                                         ; 3d5e: a5 b3       ..  :9d5e[1]
+    sbc #$20 ; ' '                                                    ; 3d60: e9 20       .   :9d60[1]
+    sta l00b3                                                         ; 3d62: 85 b3       ..  :9d62[1]
+    asl l00b5                                                         ; 3d64: 06 b5       ..  :9d64[1]
+    clc                                                               ; 3d66: 18          .   :9d66[1]
+; $3d67 referenced 1 time by $9d55
+c9d67
+    pla                                                               ; 3d67: 68          h   :9d67[1]
+    tax                                                               ; 3d68: aa          .   :9d68[1]
+    ldy l00b3                                                         ; 3d69: a4 b3       ..  :9d69[1]
+    lda l00b5                                                         ; 3d6b: a5 b5       ..  :9d6b[1]
+    bcs c9d71                                                         ; 3d6d: b0 02       ..  :9d6d[1]
+    bne c9d2b                                                         ; 3d6f: d0 ba       ..  :9d6f[1]
+; $3d71 referenced 1 time by $9d6d
+c9d71
+    rts                                                               ; 3d71: 60          `   :9d71[1]
+
+; $3d72 referenced 1 time by $9da0
+c9d72
+    jsr zero_stacked_XXX                                              ; 3d72: 20 8e 9d     .. :9d72[1]
+; $3d75 referenced 1 time by $9726
+sub_c9d75
+    lda l10c0                                                         ; 3d75: ad c0 10    ... :9d75[1]
+    pha                                                               ; 3d78: 48          H   :9d78[1]
+    lda #0                                                            ; 3d79: a9 00       ..  :9d79[1]
+    sta l1086                                                         ; 3d7b: 8d 86 10    ... :9d7b[1]
+    tya                                                               ; 3d7e: 98          .   :9d7e[1]
+    bne c9d86                                                         ; 3d7f: d0 05       ..  :9d7f[1]
+    jsr sub_c9b61                                                     ; 3d81: 20 61 9b     a. :9d81[1]
+    beq c9d89                                                         ; 3d84: f0 03       ..  :9d84[1]
+; $3d86 referenced 1 time by $9d7f
+c9d86
+    jsr c9b6e                                                         ; 3d86: 20 6e 9b     n. :9d86[1]
+; $3d89 referenced 1 time by $9d84
+c9d89
+    pla                                                               ; 3d89: 68          h   :9d89[1]
+    sta l10c0                                                         ; 3d8a: 8d c0 10    ... :9d8a[1]
+    rts                                                               ; 3d8d: 60          `   :9d8d[1]
+
+; $3d8e referenced 6 times by $956f, $9714, $97d0, $9d72, $9daa, $9db8
+zero_stacked_XXX
+    pha                                                               ; 3d8e: 48          H   :9d8e[1]
+    txa                                                               ; 3d8f: 8a          .   :9d8f[1]
+    pha                                                               ; 3d90: 48          H   :9d90[1]
+    lda #0                                                            ; 3d91: a9 00       ..  :9d91[1]
+    tsx                                                               ; 3d93: ba          .   :9d93[1]
+    sta l0109,x                                                       ; 3d94: 9d 09 01    ... :9d94[1]
+    pla                                                               ; 3d97: 68          h   :9d97[1]
+    tax                                                               ; 3d98: aa          .   :9d98[1]
+    pla                                                               ; 3d99: 68          h   :9d99[1]
+    rts                                                               ; 3d9a: 60          `   :9d9a[1]
+
+sub_c9d9b
+    jsr sub_c83e3                                                     ; 3d9b: 20 e3 83     .. :9d9b[1]
+    cmp #$ff                                                          ; 3d9e: c9 ff       ..  :9d9e[1]
+    beq c9d72                                                         ; 3da0: f0 d0       ..  :9da0[1]
+    cpy #0                                                            ; 3da2: c0 00       ..  :9da2[1]
+    beq c9db4                                                         ; 3da4: f0 0e       ..  :9da4[1]
+    cmp #3                                                            ; 3da6: c9 03       ..  :9da6[1]
+    bcs c9dcd                                                         ; 3da8: b0 23       .#  :9da8[1]
+    jsr zero_stacked_XXX                                              ; 3daa: 20 8e 9d     .. :9daa[1]
+    cmp #1                                                            ; 3dad: c9 01       ..  :9dad[1]
+    bne c9dd5                                                         ; 3daf: d0 24       .$  :9daf[1]
+    jmp ca06c                                                         ; 3db1: 4c 6c a0    Ll. :9db1[1]
+
+; $3db4 referenced 1 time by $9da4
+c9db4
+    cmp #2                                                            ; 3db4: c9 02       ..  :9db4[1]
+    bcs c9dcd                                                         ; 3db6: b0 15       ..  :9db6[1]
+    jsr zero_stacked_XXX                                              ; 3db8: 20 8e 9d     .. :9db8[1]
+    beq c9dce                                                         ; 3dbb: f0 11       ..  :9dbb[1]
+    lda #$ff                                                          ; 3dbd: a9 ff       ..  :9dbd[1]
+    sta l0002,x                                                       ; 3dbf: 95 02       ..  :9dbf[1]
+    sta l0003,x                                                       ; 3dc1: 95 03       ..  :9dc1[1]
+    lda l10d9                                                         ; 3dc3: ad d9 10    ... :9dc3[1]
+    sta l0000,x                                                       ; 3dc6: 95 00       ..  :9dc6[1]
+    lda l10da                                                         ; 3dc8: ad da 10    ... :9dc8[1]
+    sta l0001,x                                                       ; 3dcb: 95 01       ..  :9dcb[1]
+; $3dcd referenced 2 times by $9da8, $9db6
+c9dcd
+    rts                                                               ; 3dcd: 60          `   :9dcd[1]
+
+; $3dce referenced 1 time by $9dbb
+c9dce
+    lda #4                                                            ; 3dce: a9 04       ..  :9dce[1]
+    tsx                                                               ; 3dd0: ba          .   :9dd0[1]
+    sta l0105,x                                                       ; 3dd1: 9d 05 01    ... :9dd1[1]
+    rts                                                               ; 3dd4: 60          `   :9dd4[1]
+
+; $3dd5 referenced 2 times by $984c, $9daf
+c9dd5
+    jsr sub_c9e75                                                     ; 3dd5: 20 75 9e     u. :9dd5[1]
+    sty l10c2                                                         ; 3dd8: 8c c2 10    ... :9dd8[1]
+    asl                                                               ; 3ddb: 0a          .   :9ddb[1]
+    adc l10c2                                                         ; 3ddc: 6d c2 10    m.. :9ddc[1]
+    tay                                                               ; 3ddf: a8          .   :9ddf[1]
+    lda l1110,y                                                       ; 3de0: b9 10 11    ... :9de0[1]
+    sta l0000,x                                                       ; 3de3: 95 00       ..  :9de3[1]
+    lda l1111,y                                                       ; 3de5: b9 11 11    ... :9de5[1]
+    sta l0001,x                                                       ; 3de8: 95 01       ..  :9de8[1]
+    lda l1112,y                                                       ; 3dea: b9 12 11    ... :9dea[1]
+    sta l0002,x                                                       ; 3ded: 95 02       ..  :9ded[1]
+    lda #0                                                            ; 3def: a9 00       ..  :9def[1]
+    sta l0003,x                                                       ; 3df1: 95 03       ..  :9df1[1]
+    rts                                                               ; 3df3: 60          `   :9df3[1]
+
+; $3df4 referenced 2 times by $9b7a, $9e78
+sub_c9df4
+    pha                                                               ; 3df4: 48          H   :9df4[1]
+    stx l10c5                                                         ; 3df5: 8e c5 10    ... :9df5[1]
+    tya                                                               ; 3df8: 98          .   :9df8[1]
+    and #$e0                                                          ; 3df9: 29 e0       ).  :9df9[1]
+    sta l10c2                                                         ; 3dfb: 8d c2 10    ... :9dfb[1]
+    beq c9e13                                                         ; 3dfe: f0 13       ..  :9dfe[1]
+    jsr sub_c81be                                                     ; 3e00: 20 be 81     .. :9e00[1]
+    tay                                                               ; 3e03: a8          .   :9e03[1]
+    lda #0                                                            ; 3e04: a9 00       ..  :9e04[1]
+    sec                                                               ; 3e06: 38          8   :9e06[1]
+; $3e07 referenced 1 time by $9e09
+loop_c9e07
+    ror                                                               ; 3e07: 6a          j   :9e07[1]
+    dey                                                               ; 3e08: 88          .   :9e08[1]
+    bne loop_c9e07                                                    ; 3e09: d0 fc       ..  :9e09[1]
+    ldy l10c2                                                         ; 3e0b: ac c2 10    ... :9e0b[1]
+    bit l10c0                                                         ; 3e0e: 2c c0 10    ,.. :9e0e[1]
+    bne c9e16                                                         ; 3e11: d0 03       ..  :9e11[1]
+; $3e13 referenced 1 time by $9dfe
+c9e13
+    pla                                                               ; 3e13: 68          h   :9e13[1]
+    sec                                                               ; 3e14: 38          8   :9e14[1]
+    rts                                                               ; 3e15: 60          `   :9e15[1]
+
+; $3e16 referenced 1 time by $9e11
+c9e16
+    pla                                                               ; 3e16: 68          h   :9e16[1]
+    clc                                                               ; 3e17: 18          .   :9e17[1]
+    rts                                                               ; 3e18: 60          `   :9e18[1]
+
+    !byte $48, $8a, $4c, $20, $9e                                     ; 3e19: 48 8a 4c... H.L :9e19[1]
+
+; $3e1e referenced 2 times by $9e56, $9e75
+sub_c9e1e
+    pha                                                               ; 3e1e: 48          H   :9e1e[1]
+    tya                                                               ; 3e1f: 98          .   :9e1f[1]
+    cmp #$10                                                          ; 3e20: c9 10       ..  :9e20[1]
+    bcc c9e28                                                         ; 3e22: 90 04       ..  :9e22[1]
+    cmp #$18                                                          ; 3e24: c9 18       ..  :9e24[1]
+    bcc c9e2a                                                         ; 3e26: 90 02       ..  :9e26[1]
+; $3e28 referenced 1 time by $9e22
+c9e28
+    lda #8                                                            ; 3e28: a9 08       ..  :9e28[1]
+; $3e2a referenced 1 time by $9e26
+c9e2a
+    jsr sub_c81c4                                                     ; 3e2a: 20 c4 81     .. :9e2a[1]
+    tay                                                               ; 3e2d: a8          .   :9e2d[1]
+    pla                                                               ; 3e2e: 68          h   :9e2e[1]
+    rts                                                               ; 3e2f: 60          `   :9e2f[1]
+
+; $3e30 referenced 3 times by $803d, $9e7d, $9fc5
+sub_c9e30
+    lda #osbyte_rw_exec_handle                                        ; 3e30: a9 c6       ..  :9e30[1]
+    jsr osbyte_read                                                   ; 3e32: 20 e5 9a     .. :9e32[1]
+    txa                                                               ; 3e35: 8a          .   :9e35[1]
+    beq c9e41                                                         ; 3e36: f0 09       ..  :9e36[1]
+    jsr sub_c9e54                                                     ; 3e38: 20 54 9e     T. :9e38[1]
+    bne c9e41                                                         ; 3e3b: d0 04       ..  :9e3b[1]
+    lda #osbyte_rw_exec_handle                                        ; 3e3d: a9 c6       ..  :9e3d[1]
+    bne osbyte_write_0                                                ; 3e3f: d0 0c       ..  :9e3f[1]
+; $3e41 referenced 2 times by $9e36, $9e3b
+c9e41
+    lda #osbyte_read_write_spool_file_handle                          ; 3e41: a9 c7       ..  :9e41[1]
+    jsr osbyte_read                                                   ; 3e43: 20 e5 9a     .. :9e43[1]
+    jsr sub_c9e54                                                     ; 3e46: 20 54 9e     T. :9e46[1]
+    bne c9e5c                                                         ; 3e49: d0 11       ..  :9e49[1]
+    lda #osbyte_read_write_spool_file_handle                          ; 3e4b: a9 c7       ..  :9e4b[1]
+; $3e4d referenced 1 time by $9e3f
+osbyte_write_0
+    ldx #0                                                            ; 3e4d: a2 00       ..  :9e4d[1]
+    ldy #0                                                            ; 3e4f: a0 00       ..  :9e4f[1]
+    jmp osbyte                                                        ; 3e51: 4c f4 ff    L.. :9e51[1]
+
+; $3e54 referenced 2 times by $9e38, $9e46
+sub_c9e54
+    txa                                                               ; 3e54: 8a          .   :9e54[1]
+    tay                                                               ; 3e55: a8          .   :9e55[1]
+    jsr sub_c9e1e                                                     ; 3e56: 20 1e 9e     .. :9e56[1]
+    cpy l10c2                                                         ; 3e59: cc c2 10    ... :9e59[1]
+; $3e5c referenced 1 time by $9e49
+c9e5c
+    rts                                                               ; 3e5c: 60          `   :9e5c[1]
+
+    pha                                                               ; 3e5d: 48          H   :9e5d[1]
+    tya                                                               ; 3e5e: 98          .   :9e5e[1]
+    pha                                                               ; 3e5f: 48          H   :9e5f[1]
+    txa                                                               ; 3e60: 8a          .   :9e60[1]
+    tay                                                               ; 3e61: a8          .   :9e61[1]
+    jsr sub_c9e75                                                     ; 3e62: 20 75 9e     u. :9e62[1]
+    tya                                                               ; 3e65: 98          .   :9e65[1]
+    jsr sub_ca0de                                                     ; 3e66: 20 de a0     .. :9e66[1]
+    bne c9e6f                                                         ; 3e69: d0 04       ..  :9e69[1]
+    ldx #$ff                                                          ; 3e6b: a2 ff       ..  :9e6b[1]
+    bne c9e71                                                         ; 3e6d: d0 02       ..  :9e6d[1]
+; $3e6f referenced 1 time by $9e69
+c9e6f
+    ldx #0                                                            ; 3e6f: a2 00       ..  :9e6f[1]
+; $3e71 referenced 1 time by $9e6d
+c9e71
+    pla                                                               ; 3e71: 68          h   :9e71[1]
+    tay                                                               ; 3e72: a8          .   :9e72[1]
+    pla                                                               ; 3e73: 68          h   :9e73[1]
+; $3e74 referenced 1 time by $9e7b
+loop_c9e74
+    rts                                                               ; 3e74: 60          `   :9e74[1]
+
+; $3e75 referenced 6 times by $9b76, $9dd5, $9e62, $9e97, $9f85, $a06f
+sub_c9e75
+    jsr sub_c9e1e                                                     ; 3e75: 20 1e 9e     .. :9e75[1]
+    jsr sub_c9df4                                                     ; 3e78: 20 f4 9d     .. :9e78[1]
+    bcc loop_c9e74                                                    ; 3e7b: 90 f7       ..  :9e7b[1]
+    jsr sub_c9e30                                                     ; 3e7d: 20 30 9e     0. :9e7d[1]
+    jsr generate_error_precheck                                       ; 3e80: 20 38 80     8. :9e80[1]
+    !byte $de                                                         ; 3e83: de          .   :9e83[1]
+    !text "Channel"                                                   ; 3e84: 43 68 61... Cha :9e84[1]
+    !byte 0                                                           ; 3e8b: 00          .   :9e8b[1]
+
+; $3e8c referenced 1 time by $9ea5
+loop_c9e8c
+    jsr generate_error_precheck                                       ; 3e8c: 20 38 80     8. :9e8c[1]
+    !byte $df                                                         ; 3e8f: df          .   :9e8f[1]
+    !text "EOF"                                                       ; 3e90: 45 4f 46    EOF :9e90[1]
+    !byte 0                                                           ; 3e93: 00          .   :9e93[1]
+
+; $3e94 referenced 1 time by $9969
+sub_c9e94
+    jsr sub_c840c                                                     ; 3e94: 20 0c 84     .. :9e94[1]
+    jsr sub_c9e75                                                     ; 3e97: 20 75 9e     u. :9e97[1]
+    tya                                                               ; 3e9a: 98          .   :9e9a[1]
+    jsr sub_ca0de                                                     ; 3e9b: 20 de a0     .. :9e9b[1]
+    bne c9eb3                                                         ; 3e9e: d0 13       ..  :9e9e[1]
+    lda l1117,y                                                       ; 3ea0: b9 17 11    ... :9ea0[1]
+    and #$10                                                          ; 3ea3: 29 10       ).  :9ea3[1]
+    bne loop_c9e8c                                                    ; 3ea5: d0 e5       ..  :9ea5[1]
+    lda #$10                                                          ; 3ea7: a9 10       ..  :9ea7[1]
+    jsr sub_c9f0f                                                     ; 3ea9: 20 0f 9f     .. :9ea9[1]
+    ldx l10c5                                                         ; 3eac: ae c5 10    ... :9eac[1]
+    lda #$fe                                                          ; 3eaf: a9 fe       ..  :9eaf[1]
+    sec                                                               ; 3eb1: 38          8   :9eb1[1]
+    rts                                                               ; 3eb2: 60          `   :9eb2[1]
+
+; $3eb3 referenced 1 time by $9e9e
+c9eb3
+    lda l1117,y                                                       ; 3eb3: b9 17 11    ... :9eb3[1]
+    bmi c9ec2                                                         ; 3eb6: 30 0a       0.  :9eb6[1]
+    jsr sub_c9be5                                                     ; 3eb8: 20 e5 9b     .. :9eb8[1]
+    jsr sub_c9f1e                                                     ; 3ebb: 20 1e 9f     .. :9ebb[1]
+    sec                                                               ; 3ebe: 38          8   :9ebe[1]
+    jsr sub_c9f26                                                     ; 3ebf: 20 26 9f     &. :9ebf[1]
+; $3ec2 referenced 1 time by $9eb6
+c9ec2
+    lda l1110,y                                                       ; 3ec2: b9 10 11    ... :9ec2[1]
+    sta l00ba                                                         ; 3ec5: 85 ba       ..  :9ec5[1]
+    lda l1113,y                                                       ; 3ec7: b9 13 11    ... :9ec7[1]
+    sta l00bb                                                         ; 3eca: 85 bb       ..  :9eca[1]
+    ldy #0                                                            ; 3ecc: a0 00       ..  :9ecc[1]
+    lda (l00ba),y                                                     ; 3ece: b1 ba       ..  :9ece[1]
+    pha                                                               ; 3ed0: 48          H   :9ed0[1]
+    ldy l10c2                                                         ; 3ed1: ac c2 10    ... :9ed1[1]
+    ldx l00ba                                                         ; 3ed4: a6 ba       ..  :9ed4[1]
+    inx                                                               ; 3ed6: e8          .   :9ed6[1]
+    txa                                                               ; 3ed7: 8a          .   :9ed7[1]
+    sta l1110,y                                                       ; 3ed8: 99 10 11    ... :9ed8[1]
+    bne c9ef1                                                         ; 3edb: d0 14       ..  :9edb[1]
+    clc                                                               ; 3edd: 18          .   :9edd[1]
+    lda l1111,y                                                       ; 3ede: b9 11 11    ... :9ede[1]
+    adc #1                                                            ; 3ee1: 69 01       i.  :9ee1[1]
+    sta l1111,y                                                       ; 3ee3: 99 11 11    ... :9ee3[1]
+    lda l1112,y                                                       ; 3ee6: b9 12 11    ... :9ee6[1]
+    adc #0                                                            ; 3ee9: 69 00       i.  :9ee9[1]
+    sta l1112,y                                                       ; 3eeb: 99 12 11    ... :9eeb[1]
+    jsr sub_c9f14                                                     ; 3eee: 20 14 9f     .. :9eee[1]
+; $3ef1 referenced 1 time by $9edb
+c9ef1
+    clc                                                               ; 3ef1: 18          .   :9ef1[1]
+    pla                                                               ; 3ef2: 68          h   :9ef2[1]
+    rts                                                               ; 3ef3: 60          `   :9ef3[1]
+
+; $3ef4 referenced 2 times by $9f5e, $a018
+sub_c9ef4
+    clc                                                               ; 3ef4: 18          .   :9ef4[1]
+    lda l110f,y                                                       ; 3ef5: b9 0f 11    ... :9ef5[1]
+    adc l1111,y                                                       ; 3ef8: 79 11 11    y.. :9ef8[1]
+    sta l00c3                                                         ; 3efb: 85 c3       ..  :9efb[1]
+    sta l111c,y                                                       ; 3efd: 99 1c 11    ... :9efd[1]
+    lda l110d,y                                                       ; 3f00: b9 0d 11    ... :9f00[1]
+    and #3                                                            ; 3f03: 29 03       ).  :9f03[1]
+    adc l1112,y                                                       ; 3f05: 79 12 11    y.. :9f05[1]
+    sta l00c2                                                         ; 3f08: 85 c2       ..  :9f08[1]
+    sta l111d,y                                                       ; 3f0a: 99 1d 11    ... :9f0a[1]
+; $3f0d referenced 1 time by $a0db
+c9f0d
+    lda #$80                                                          ; 3f0d: a9 80       ..  :9f0d[1]
+; $3f0f referenced 3 times by $9ea9, $a035, $a05c
+sub_c9f0f
+    ora l1117,y                                                       ; 3f0f: 19 17 11    ... :9f0f[1]
+    bne c9f19                                                         ; 3f12: d0 05       ..  :9f12[1]
+; $3f14 referenced 2 times by $9eee, $a041
+sub_c9f14
+    lda #$7f                                                          ; 3f14: a9 7f       ..  :9f14[1]
+; $3f16 referenced 3 times by $95f0, $9f59, $a0ba
+sub_c9f16
+    and l1117,y                                                       ; 3f16: 39 17 11    9.. :9f16[1]
+; $3f19 referenced 1 time by $9f12
+c9f19
+    sta l1117,y                                                       ; 3f19: 99 17 11    ... :9f19[1]
+    clc                                                               ; 3f1c: 18          .   :9f1c[1]
+    rts                                                               ; 3f1d: 60          `   :9f1d[1]
+
+; $3f1e referenced 3 times by $9bc2, $9ebb, $a00a
+sub_c9f1e
+    lda l1117,y                                                       ; 3f1e: b9 17 11    ... :9f1e[1]
+    and #$40 ; '@'                                                    ; 3f21: 29 40       )@  :9f21[1]
+    beq c9f6a                                                         ; 3f23: f0 45       .E  :9f23[1]
+    clc                                                               ; 3f25: 18          .   :9f25[1]
+; $3f26 referenced 2 times by $9ebf, $a01e
+sub_c9f26
+    php                                                               ; 3f26: 08          .   :9f26[1]
+    inc l10dd                                                         ; 3f27: ee dd 10    ... :9f27[1]
+    ldy l10c2                                                         ; 3f2a: ac c2 10    ... :9f2a[1]
+    lda l1113,y                                                       ; 3f2d: b9 13 11    ... :9f2d[1]
+    sta l00bd                                                         ; 3f30: 85 bd       ..  :9f30[1]
+    lda #$ff                                                          ; 3f32: a9 ff       ..  :9f32[1]
+    sta l1074                                                         ; 3f34: 8d 74 10    .t. :9f34[1]
+    sta l1075                                                         ; 3f37: 8d 75 10    .u. :9f37[1]
+    lda #0                                                            ; 3f3a: a9 00       ..  :9f3a[1]
+    sta l00bc                                                         ; 3f3c: 85 bc       ..  :9f3c[1]
+    sta l00c0                                                         ; 3f3e: 85 c0       ..  :9f3e[1]
+    lda #1                                                            ; 3f40: a9 01       ..  :9f40[1]
+    sta l00c1                                                         ; 3f42: 85 c1       ..  :9f42[1]
+    plp                                                               ; 3f44: 28          (   :9f44[1]
+    bcs c9f5e                                                         ; 3f45: b0 17       ..  :9f45[1]
+    lda l111c,y                                                       ; 3f47: b9 1c 11    ... :9f47[1]
+    sta l00c3                                                         ; 3f4a: 85 c3       ..  :9f4a[1]
+    lda l111d,y                                                       ; 3f4c: b9 1d 11    ... :9f4c[1]
+    sta l00c2                                                         ; 3f4f: 85 c2       ..  :9f4f[1]
+    jsr sub_c8862                                                     ; 3f51: 20 62 88     b. :9f51[1]
+    ldy l10c2                                                         ; 3f54: ac c2 10    ... :9f54[1]
+    lda #$bf                                                          ; 3f57: a9 bf       ..  :9f57[1]
+    jsr sub_c9f16                                                     ; 3f59: 20 16 9f     .. :9f59[1]
+    bcc c9f64                                                         ; 3f5c: 90 06       ..  :9f5c[1]
+; $3f5e referenced 1 time by $9f45
+c9f5e
+    jsr sub_c9ef4                                                     ; 3f5e: 20 f4 9e     .. :9f5e[1]
+    jsr sub_c8855                                                     ; 3f61: 20 55 88     U. :9f61[1]
+; $3f64 referenced 1 time by $9f5c
+c9f64
+    dec l10dd                                                         ; 3f64: ce dd 10    ... :9f64[1]
+    ldy l10c2                                                         ; 3f67: ac c2 10    ... :9f67[1]
+; $3f6a referenced 1 time by $9f23
+c9f6a
+    rts                                                               ; 3f6a: 60          `   :9f6a[1]
+
+; $3f6b referenced 1 time by $9f91
+c9f6b
+    jmp generate_error_precheck_locked                                ; 3f6b: 4c 55 9a    LU. :9f6b[1]
+
+; $3f6e referenced 1 time by $9f8c
+loop_c9f6e
+    jsr generate_error_precheck                                       ; 3f6e: 20 38 80     8. :9f6e[1]
+    !byte $c1                                                         ; 3f71: c1          .   :9f71[1]
+    !text "Read only"                                                 ; 3f72: 52 65 61... Rea :9f72[1]
+    !byte 0                                                           ; 3f7b: 00          .   :9f7b[1]
+
+; $3f7c referenced 1 time by $a09a
+sub_c9f7c
+    jsr sub_c83e3                                                     ; 3f7c: 20 e3 83     .. :9f7c[1]
+    jmp c9f88                                                         ; 3f7f: 4c 88 9f    L.. :9f7f[1]
+
+; $3f82 referenced 1 time by $9983
+sub_c9f82
+    jsr sub_c83e3                                                     ; 3f82: 20 e3 83     .. :9f82[1]
+    jsr sub_c9e75                                                     ; 3f85: 20 75 9e     u. :9f85[1]
+; $3f88 referenced 1 time by $9f7f
+c9f88
+    pha                                                               ; 3f88: 48          H   :9f88[1]
+    lda l110c,y                                                       ; 3f89: b9 0c 11    ... :9f89[1]
+    bmi loop_c9f6e                                                    ; 3f8c: 30 e0       0.  :9f8c[1]
+    lda l110e,y                                                       ; 3f8e: b9 0e 11    ... :9f8e[1]
+    bmi c9f6b                                                         ; 3f91: 30 d8       0.  :9f91[1]
+    jsr sub_c9be5                                                     ; 3f93: 20 e5 9b     .. :9f93[1]
+    tya                                                               ; 3f96: 98          .   :9f96[1]
+    clc                                                               ; 3f97: 18          .   :9f97[1]
+    adc #4                                                            ; 3f98: 69 04       i.  :9f98[1]
+    jsr sub_ca0de                                                     ; 3f9a: 20 de a0     .. :9f9a[1]
+    bne ca005                                                         ; 3f9d: d0 66       .f  :9f9d[1]
+    jsr sub_c9bcd                                                     ; 3f9f: 20 cd 9b     .. :9f9f[1]
+    ldx l10c3                                                         ; 3fa2: ae c3 10    ... :9fa2[1]
+    sec                                                               ; 3fa5: 38          8   :9fa5[1]
+    lda l0f07,x                                                       ; 3fa6: bd 07 0f    ... :9fa6[1]
+    sbc l0f0f,x                                                       ; 3fa9: fd 0f 0f    ... :9fa9[1]
+    pha                                                               ; 3fac: 48          H   :9fac[1]
+    lda l0f06,x                                                       ; 3fad: bd 06 0f    ... :9fad[1]
+    sbc l0f0e,x                                                       ; 3fb0: fd 0e 0f    ... :9fb0[1]
+    and #3                                                            ; 3fb3: 29 03       ).  :9fb3[1]
+    cmp l111a,y                                                       ; 3fb5: d9 1a 11    ... :9fb5[1]
+    bne c9fd9                                                         ; 3fb8: d0 1f       ..  :9fb8[1]
+    pla                                                               ; 3fba: 68          h   :9fba[1]
+    cmp l1119,y                                                       ; 3fbb: d9 19 11    ... :9fbb[1]
+    bne c9ff4                                                         ; 3fbe: d0 34       .4  :9fbe[1]
+    sty l00b4                                                         ; 3fc0: 84 b4       ..  :9fc0[1]
+    sty l10c2                                                         ; 3fc2: 8c c2 10    ... :9fc2[1]
+    jsr sub_c9e30                                                     ; 3fc5: 20 30 9e     0. :9fc5[1]
+    jsr generate_error_precheck                                       ; 3fc8: 20 38 80     8. :9fc8[1]
+    !byte $bf                                                         ; 3fcb: bf          .   :9fcb[1]
+    !text "Can't extend"                                              ; 3fcc: 43 61 6e... Can :9fcc[1]
+    !byte 0                                                           ; 3fd8: 00          .   :9fd8[1]
+
+; $3fd9 referenced 1 time by $9fb8
+c9fd9
+    lda l111a,y                                                       ; 3fd9: b9 1a 11    ... :9fd9[1]
+    clc                                                               ; 3fdc: 18          .   :9fdc[1]
+    adc #1                                                            ; 3fdd: 69 01       i.  :9fdd[1]
+    sta l111a,y                                                       ; 3fdf: 99 1a 11    ... :9fdf[1]
+    asl                                                               ; 3fe2: 0a          .   :9fe2[1]
+    asl                                                               ; 3fe3: 0a          .   :9fe3[1]
+    asl                                                               ; 3fe4: 0a          .   :9fe4[1]
+    asl                                                               ; 3fe5: 0a          .   :9fe5[1]
+    eor l0f0e,x                                                       ; 3fe6: 5d 0e 0f    ].. :9fe6[1]
+    and #$30 ; '0'                                                    ; 3fe9: 29 30       )0  :9fe9[1]
+    eor l0f0e,x                                                       ; 3feb: 5d 0e 0f    ].. :9feb[1]
+    sta l0f0e,x                                                       ; 3fee: 9d 0e 0f    ... :9fee[1]
+    pla                                                               ; 3ff1: 68          h   :9ff1[1]
+    lda #0                                                            ; 3ff2: a9 00       ..  :9ff2[1]
+; $3ff4 referenced 1 time by $9fbe
+c9ff4
+    sta l0f0d,x                                                       ; 3ff4: 9d 0d 0f    ... :9ff4[1]
+    sta l1119,y                                                       ; 3ff7: 99 19 11    ... :9ff7[1]
+    lda #0                                                            ; 3ffa: a9 00       ..  :9ffa[1]
+    sta l0f0c,x                                                       ; 3ffc: 9d 0c 0f    ... :9ffc[1]
+    jsr c93e6                                                         ; 3fff: 20 e6 93     .. :9fff[1]
+    ldy l10c2                                                         ; 4002: ac c2 10    ... :a002[1]
+; $4005 referenced 1 time by $9f9d
+ca005
+    lda l1117,y                                                       ; 4005: b9 17 11    ... :a005[1]
+    bmi ca021                                                         ; 4008: 30 17       0.  :a008[1]
+    jsr sub_c9f1e                                                     ; 400a: 20 1e 9f     .. :a00a[1]
+    lda l1114,y                                                       ; 400d: b9 14 11    ... :a00d[1]
+    bne ca01d                                                         ; 4010: d0 0b       ..  :a010[1]
+    tya                                                               ; 4012: 98          .   :a012[1]
+    jsr sub_ca0de                                                     ; 4013: 20 de a0     .. :a013[1]
+    bne ca01d                                                         ; 4016: d0 05       ..  :a016[1]
+    jsr sub_c9ef4                                                     ; 4018: 20 f4 9e     .. :a018[1]
+    bne ca021                                                         ; 401b: d0 04       ..  :a01b[1]
+; $401d referenced 2 times by $a010, $a016
+ca01d
+    sec                                                               ; 401d: 38          8   :a01d[1]
+    jsr sub_c9f26                                                     ; 401e: 20 26 9f     &. :a01e[1]
+; $4021 referenced 2 times by $a008, $a01b
+ca021
+    lda l1110,y                                                       ; 4021: b9 10 11    ... :a021[1]
+    sta l00ba                                                         ; 4024: 85 ba       ..  :a024[1]
+    lda l1113,y                                                       ; 4026: b9 13 11    ... :a026[1]
+    sta l00bb                                                         ; 4029: 85 bb       ..  :a029[1]
+    pla                                                               ; 402b: 68          h   :a02b[1]
+    ldy #0                                                            ; 402c: a0 00       ..  :a02c[1]
+    sta (l00ba),y                                                     ; 402e: 91 ba       ..  :a02e[1]
+    ldy l10c2                                                         ; 4030: ac c2 10    ... :a030[1]
+    lda #$40 ; '@'                                                    ; 4033: a9 40       .@  :a033[1]
+    jsr sub_c9f0f                                                     ; 4035: 20 0f 9f     .. :a035[1]
+    inc l00ba                                                         ; 4038: e6 ba       ..  :a038[1]
+    lda l00ba                                                         ; 403a: a5 ba       ..  :a03a[1]
+    sta l1110,y                                                       ; 403c: 99 10 11    ... :a03c[1]
+    bne ca054                                                         ; 403f: d0 13       ..  :a03f[1]
+    jsr sub_c9f14                                                     ; 4041: 20 14 9f     .. :a041[1]
+    lda l1111,y                                                       ; 4044: b9 11 11    ... :a044[1]
+    adc #1                                                            ; 4047: 69 01       i.  :a047[1]
+    sta l1111,y                                                       ; 4049: 99 11 11    ... :a049[1]
+    lda l1112,y                                                       ; 404c: b9 12 11    ... :a04c[1]
+    adc #0                                                            ; 404f: 69 00       i.  :a04f[1]
+    sta l1112,y                                                       ; 4051: 99 12 11    ... :a051[1]
+; $4054 referenced 1 time by $a03f
+ca054
+    tya                                                               ; 4054: 98          .   :a054[1]
+    jsr sub_ca0de                                                     ; 4055: 20 de a0     .. :a055[1]
+    bcc ca06b                                                         ; 4058: 90 11       ..  :a058[1]
+    lda #$20 ; ' '                                                    ; 405a: a9 20       .   :a05a[1]
+    jsr sub_c9f0f                                                     ; 405c: 20 0f 9f     .. :a05c[1]
+    ldx #2                                                            ; 405f: a2 02       ..  :a05f[1]
+; $4061 referenced 1 time by $a069
+loop_ca061
+    lda l1110,y                                                       ; 4061: b9 10 11    ... :a061[1]
+    sta l1114,y                                                       ; 4064: 99 14 11    ... :a064[1]
+    iny                                                               ; 4067: c8          .   :a067[1]
+    dex                                                               ; 4068: ca          .   :a068[1]
+    bpl loop_ca061                                                    ; 4069: 10 f6       ..  :a069[1]
+; $406b referenced 3 times by $a058, $a0d1, $a0d9
+ca06b
+    rts                                                               ; 406b: 60          `   :a06b[1]
+
+; $406c referenced 2 times by $9849, $9db1
+ca06c
+    jsr sub_c83e3                                                     ; 406c: 20 e3 83     .. :a06c[1]
+    jsr sub_c9e75                                                     ; 406f: 20 75 9e     u. :a06f[1]
+    ldy l10c2                                                         ; 4072: ac c2 10    ... :a072[1]
+; $4075 referenced 1 time by $a0a6
+ca075
+    jsr sub_ca0f6                                                     ; 4075: 20 f6 a0     .. :a075[1]
+    bcs ca0a9                                                         ; 4078: b0 2f       ./  :a078[1]
+    lda l1114,y                                                       ; 407a: b9 14 11    ... :a07a[1]
+    sta l1110,y                                                       ; 407d: 99 10 11    ... :a07d[1]
+    lda l1115,y                                                       ; 4080: b9 15 11    ... :a080[1]
+    sta l1111,y                                                       ; 4083: 99 11 11    ... :a083[1]
+    lda l1116,y                                                       ; 4086: b9 16 11    ... :a086[1]
+    sta l1112,y                                                       ; 4089: 99 12 11    ... :a089[1]
+    jsr sub_ca0b8                                                     ; 408c: 20 b8 a0     .. :a08c[1]
+    lda l00b6                                                         ; 408f: a5 b6       ..  :a08f[1]
+    pha                                                               ; 4091: 48          H   :a091[1]
+    lda l00b7                                                         ; 4092: a5 b7       ..  :a092[1]
+    pha                                                               ; 4094: 48          H   :a094[1]
+    lda l00b8                                                         ; 4095: a5 b8       ..  :a095[1]
+    pha                                                               ; 4097: 48          H   :a097[1]
+    lda #0                                                            ; 4098: a9 00       ..  :a098[1]
+    jsr sub_c9f7c                                                     ; 409a: 20 7c 9f     |. :a09a[1]
+    pla                                                               ; 409d: 68          h   :a09d[1]
+    sta l00b8                                                         ; 409e: 85 b8       ..  :a09e[1]
+    pla                                                               ; 40a0: 68          h   :a0a0[1]
+    sta l00b7                                                         ; 40a1: 85 b7       ..  :a0a1[1]
+    pla                                                               ; 40a3: 68          h   :a0a3[1]
+    sta l00b6                                                         ; 40a4: 85 b6       ..  :a0a4[1]
+    jmp ca075                                                         ; 40a6: 4c 75 a0    Lu. :a0a6[1]
+
+; $40a9 referenced 1 time by $a078
+ca0a9
+    lda l0000,x                                                       ; 40a9: b5 00       ..  :a0a9[1]
+    sta l1110,y                                                       ; 40ab: 99 10 11    ... :a0ab[1]
+    lda l0001,x                                                       ; 40ae: b5 01       ..  :a0ae[1]
+    sta l1111,y                                                       ; 40b0: 99 11 11    ... :a0b0[1]
+    lda l0002,x                                                       ; 40b3: b5 02       ..  :a0b3[1]
+    sta l1112,y                                                       ; 40b5: 99 12 11    ... :a0b5[1]
+; $40b8 referenced 1 time by $a08c
+sub_ca0b8
+    lda #$6f ; 'o'                                                    ; 40b8: a9 6f       .o  :a0b8[1]
+    jsr sub_c9f16                                                     ; 40ba: 20 16 9f     .. :a0ba[1]
+    lda l110f,y                                                       ; 40bd: b9 0f 11    ... :a0bd[1]
+    adc l1111,y                                                       ; 40c0: 79 11 11    y.. :a0c0[1]
+    sta l10c4                                                         ; 40c3: 8d c4 10    ... :a0c3[1]
+    lda l110d,y                                                       ; 40c6: b9 0d 11    ... :a0c6[1]
+    and #3                                                            ; 40c9: 29 03       ).  :a0c9[1]
+    adc l1112,y                                                       ; 40cb: 79 12 11    y.. :a0cb[1]
+    cmp l111d,y                                                       ; 40ce: d9 1d 11    ... :a0ce[1]
+    bne ca06b                                                         ; 40d1: d0 98       ..  :a0d1[1]
+    lda l10c4                                                         ; 40d3: ad c4 10    ... :a0d3[1]
+    cmp l111c,y                                                       ; 40d6: d9 1c 11    ... :a0d6[1]
+    bne ca06b                                                         ; 40d9: d0 90       ..  :a0d9[1]
+    jmp c9f0d                                                         ; 40db: 4c 0d 9f    L.. :a0db[1]
+
+; $40de referenced 5 times by $9e66, $9e9b, $9f9a, $a013, $a055
+sub_ca0de
+    tax                                                               ; 40de: aa          .   :a0de[1]
+    lda l1112,y                                                       ; 40df: b9 12 11    ... :a0df[1]
+    cmp l1116,x                                                       ; 40e2: dd 16 11    ... :a0e2[1]
+    bne ca0f5                                                         ; 40e5: d0 0e       ..  :a0e5[1]
+    lda l1111,y                                                       ; 40e7: b9 11 11    ... :a0e7[1]
+    cmp l1115,x                                                       ; 40ea: dd 15 11    ... :a0ea[1]
+    bne ca0f5                                                         ; 40ed: d0 06       ..  :a0ed[1]
+    lda l1110,y                                                       ; 40ef: b9 10 11    ... :a0ef[1]
+    cmp l1114,x                                                       ; 40f2: dd 14 11    ... :a0f2[1]
+; $40f5 referenced 2 times by $a0e5, $a0ed
+ca0f5
+    rts                                                               ; 40f5: 60          `   :a0f5[1]
+
+; $40f6 referenced 1 time by $a075
+sub_ca0f6
+    lda l1114,y                                                       ; 40f6: b9 14 11    ... :a0f6[1]
+    cmp l0000,x                                                       ; 40f9: d5 00       ..  :a0f9[1]
+    lda l1115,y                                                       ; 40fb: b9 15 11    ... :a0fb[1]
+    sbc l0001,x                                                       ; 40fe: f5 01       ..  :a0fe[1]
+    lda l1116,y                                                       ; 4100: b9 16 11    ... :a100[1]
+    sbc l0002,x                                                       ; 4103: f5 02       ..  :a103[1]
+    rts                                                               ; 4105: 60          `   :a105[1]
+
+sub_ca106
+    tya                                                               ; 4106: 98          .   :a106[1]
+    ldx #$ff                                                          ; 4107: a2 ff       ..  :a107[1]
+    ldy #$14                                                          ; 4109: a0 14       ..  :a109[1]
+; $410b referenced 2 times by $9711, $a13c
+ca10b
+    pha                                                               ; 410b: 48          H   :a10b[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 410c: 20 77 80     w. :a10c[1]
+    !text $0d, "DFS 2.26", $0d                                        ; 410f: 0d 44 46... .DF :a10f[1]
+
+    stx l00bf                                                         ; 4119: 86 bf       ..  :a119[1]
+    sty l00b7                                                         ; 411b: 84 b7       ..  :a11b[1]
+; $411d referenced 1 time by $a12e
+loop_ca11d
+    lda #0                                                            ; 411d: a9 00       ..  :a11d[1]
+    sta l00b9                                                         ; 411f: 85 b9       ..  :a11f[1]
+    ldy #2                                                            ; 4121: a0 02       ..  :a121[1]
+    jsr sub_ca1c6                                                     ; 4123: 20 c6 a1     .. :a123[1]
+    jsr sub_ca168                                                     ; 4126: 20 68 a1     h. :a126[1]
+    jsr ca3dc                                                         ; 4129: 20 dc a3     .. :a129[1]
+    dec l00b7                                                         ; 412c: c6 b7       ..  :a12c[1]
+    bne loop_ca11d                                                    ; 412e: d0 ed       ..  :a12e[1]
+    pla                                                               ; 4130: 68          h   :a130[1]
+    tay                                                               ; 4131: a8          .   :a131[1]
+; $4132 referenced 1 time by $a148
+loop_ca132
+    ldx #$cf                                                          ; 4132: a2 cf       ..  :a132[1]
+    jmp c8703                                                         ; 4134: 4c 03 87    L.. :a134[1]
+
+sub_ca137
+    tya                                                               ; 4137: 98          .   :a137[1]
+    ldx #$9d                                                          ; 4138: a2 9d       ..  :a138[1]
+    ldy #6                                                            ; 413a: a0 06       ..  :a13a[1]
+    bne ca10b                                                         ; 413c: d0 cd       ..  :a13c[1]
+    jsr clc_jmp_gsinit                                                ; 413e: 20 4c 87     L. :a13e[1]
+    beq ca1c0                                                         ; 4141: f0 7d       .}  :a141[1]
+; $4143 referenced 1 time by $a146
+loop_ca143
+    jsr sub_c8149                                                     ; 4143: 20 49 81     I. :a143[1]
+    bcc loop_ca143                                                    ; 4146: 90 fb       ..  :a146[1]
+    bcs loop_ca132                                                    ; 4148: b0 e8       ..  :a148[1]
+; $414a referenced 13 times by $8257, $8753, $8785, $879a, $87ee, $89b7, $89e9, $8baf, $8bc1, $a324, $a32d, $a469, $a5cb
+sub_ca14a
+    jsr clc_jmp_gsinit                                                ; 414a: 20 4c 87     L. :a14a[1]
+    bne ca1c0                                                         ; 414d: d0 71       .q  :a14d[1]
+; $414f referenced 3 times by $8805, $a5e2, $ac25
+ca14f
+    jsr generate_error                                                ; 414f: 20 48 80     H. :a14f[1]
+    !byte $dc                                                         ; 4152: dc          .   :a152[1]
+    !text "Syntax: "                                                  ; 4153: 53 79 6e... Syn :a153[1]
+
+    stx l00b9                                                         ; 415b: 86 b9       ..  :a15b[1]
+    jsr sub_ca168                                                     ; 415d: 20 68 a1     h. :a15d[1]
+    lda #0                                                            ; 4160: a9 00       ..  :a160[1]
+    jsr sub_ca1b4                                                     ; 4162: 20 b4 a1     .. :a162[1]
+    jmp l0100                                                         ; 4165: 4c 00 01    L.. :a165[1]
+
+; $4168 referenced 2 times by $a126, $a15d
+sub_ca168
+    ldx l00bf                                                         ; 4168: a6 bf       ..  :a168[1]
+    lda #9                                                            ; 416a: a9 09       ..  :a16a[1]
+    sta l00b8                                                         ; 416c: 85 b8       ..  :a16c[1]
+; $416e referenced 1 time by $a177
+loop_ca16e
+    inx                                                               ; 416e: e8          .   :a16e[1]
+    lda command_table,x                                               ; 416f: bd 1c 86    ... :a16f[1]
+    bmi ca17a                                                         ; 4172: 30 06       0.  :a172[1]
+    jsr sub_ca1b4                                                     ; 4174: 20 b4 a1     .. :a174[1]
+    jmp loop_ca16e                                                    ; 4177: 4c 6e a1    Ln. :a177[1]
+
+; $417a referenced 1 time by $a172
+ca17a
+    ldy l00b8                                                         ; 417a: a4 b8       ..  :a17a[1]
+    cpy #$0c                                                          ; 417c: c0 0c       ..  :a17c[1]
+    beq ca183                                                         ; 417e: f0 03       ..  :a17e[1]
+    jsr sub_ca1c6                                                     ; 4180: 20 c6 a1     .. :a180[1]
+; $4183 referenced 1 time by $a17e
+ca183
+    inx                                                               ; 4183: e8          .   :a183[1]
+    inx                                                               ; 4184: e8          .   :a184[1]
+    stx l00bf                                                         ; 4185: 86 bf       ..  :a185[1]
+    lda command_table,x                                               ; 4187: bd 1c 86    ... :a187[1]
+    jsr sub_ca190                                                     ; 418a: 20 90 a1     .. :a18a[1]
+    jsr sub_c81bf                                                     ; 418d: 20 bf 81     .. :a18d[1]
+; $4190 referenced 1 time by $a18a
+sub_ca190
+    jsr sub_c83e3                                                     ; 4190: 20 e3 83     .. :a190[1]
+    and #$0f                                                          ; 4193: 29 0f       ).  :a193[1]
+    beq ca1c0                                                         ; 4195: f0 29       .)  :a195[1]
+    tay                                                               ; 4197: a8          .   :a197[1]
+    lda #$20 ; ' '                                                    ; 4198: a9 20       .   :a198[1]
+    jsr sub_ca1b4                                                     ; 419a: 20 b4 a1     .. :a19a[1]
+    ldx #$ff                                                          ; 419d: a2 ff       ..  :a19d[1]
+; $419f referenced 2 times by $a1a3, $a1a6
+ca19f
+    inx                                                               ; 419f: e8          .   :a19f[1]
+    lda la1d3,x                                                       ; 41a0: bd d3 a1    ... :a1a0[1]
+    bpl ca19f                                                         ; 41a3: 10 fa       ..  :a1a3[1]
+    dey                                                               ; 41a5: 88          .   :a1a5[1]
+    bne ca19f                                                         ; 41a6: d0 f7       ..  :a1a6[1]
+    and #$7f                                                          ; 41a8: 29 7f       ).  :a1a8[1]
+; $41aa referenced 1 time by $a1b1
+loop_ca1aa
+    jsr sub_ca1b4                                                     ; 41aa: 20 b4 a1     .. :a1aa[1]
+    inx                                                               ; 41ad: e8          .   :a1ad[1]
+    lda la1d3,x                                                       ; 41ae: bd d3 a1    ... :a1ae[1]
+    bpl loop_ca1aa                                                    ; 41b1: 10 f7       ..  :a1b1[1]
+    rts                                                               ; 41b3: 60          `   :a1b3[1]
+
+; $41b4 referenced 5 times by $a162, $a174, $a19a, $a1aa, $a1cc
+sub_ca1b4
+    jsr sub_c83e3                                                     ; 41b4: 20 e3 83     .. :a1b4[1]
+    ldx l00b9                                                         ; 41b7: a6 b9       ..  :a1b7[1]
+    beq ca1c1                                                         ; 41b9: f0 06       ..  :a1b9[1]
+    inc l00b9                                                         ; 41bb: e6 b9       ..  :a1bb[1]
+    sta l0100,x                                                       ; 41bd: 9d 00 01    ... :a1bd[1]
+; $41c0 referenced 3 times by $a141, $a14d, $a195
+ca1c0
+    rts                                                               ; 41c0: 60          `   :a1c0[1]
+
+; $41c1 referenced 1 time by $a1b9
+ca1c1
+    dec l00b8                                                         ; 41c1: c6 b8       ..  :a1c1[1]
+    jmp c809f                                                         ; 41c3: 4c 9f 80    L.. :a1c3[1]
+
+; $41c6 referenced 2 times by $a123, $a180
+sub_ca1c6
+    lda l00b9                                                         ; 41c6: a5 b9       ..  :a1c6[1]
+    bne ca1d2                                                         ; 41c8: d0 08       ..  :a1c8[1]
+    lda #$20 ; ' '                                                    ; 41ca: a9 20       .   :a1ca[1]
+; $41cc referenced 1 time by $a1d0
+loop_ca1cc
+    jsr sub_ca1b4                                                     ; 41cc: 20 b4 a1     .. :a1cc[1]
+    dey                                                               ; 41cf: 88          .   :a1cf[1]
+    bne loop_ca1cc                                                    ; 41d0: d0 fa       ..  :a1d0[1]
+; $41d2 referenced 1 time by $a1c8
+ca1d2
+    rts                                                               ; 41d2: 60          `   :a1d2[1]
+
+; $41d3 referenced 2 times by $a1a0, $a1ae
+la1d3
+    !byte $bc                                                         ; 41d3: bc          .   :a1d3[1]
+    !text "fsp>"                                                      ; 41d4: 66 73 70... fsp :a1d4[1]
+    !byte $bc                                                         ; 41d8: bc          .   :a1d8[1]
+    !text "afsp>"                                                     ; 41d9: 61 66 73... afs :a1d9[1]
+    !byte $a8, $4c, $29, $bc                                          ; 41de: a8 4c 29... .L) :a1de[1]
+    !text "source> <dest.>"                                           ; 41e2: 73 6f 75... sou :a1e2[1]
+    !byte $bc                                                         ; 41f1: bc          .   :a1f1[1]
+    !text "old fsp> <new fsp>"                                        ; 41f2: 6f 6c 64... old :a1f2[1]
+    !byte $a8                                                         ; 4204: a8          .   :a204[1]
+    !text "<dir>)"                                                    ; 4205: 3c 64 69... <di :a205[1]
+    !byte $a8                                                         ; 420b: a8          .   :a20b[1]
+    !text "<drive>)"                                                  ; 420c: 3c 64 72... <dr :a20c[1]
+    !byte $bc                                                         ; 4214: bc          .   :a214[1]
+    !text "title>"                                                    ; 4215: 74 69 74... tit :a215[1]
+    !byte $bc                                                         ; 421b: bc          .   :a21b[1]
+    !text "drive> (40)(80)"                                           ; 421c: 64 72 69... dri :a21c[1]
+    !byte $b4                                                         ; 422b: b4          .   :a22b[1]
+    !text "0/80"                                                      ; 422c: 30 2f 38... 0/8 :a22c[1]
+    !byte $a8                                                         ; 4230: a8          .   :a230[1]
+    !text "<drive>)..."                                               ; 4231: 3c 64 72... <dr :a231[1]
+    !byte $a8                                                         ; 423c: a8          .   :a23c[1]
+    !text "<rom>)"                                                    ; 423d: 3c 72 6f... <ro :a23d[1]
+    !byte $ff                                                         ; 4243: ff          .   :a243[1]
+
+sub_ca244
+    jsr sub_c8b86                                                     ; 4244: 20 86 8b     .. :a244[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4247: 20 77 80     w. :a247[1]
+    !text "Compacting :"                                              ; 424a: 43 6f 6d... Com :a24a[1]
+
+    sta l10d1                                                         ; 4256: 8d d1 10    ... :a256[1]
+    sta l10d2                                                         ; 4259: 8d d2 10    ... :a259[1]
+    jsr sub_c80c3                                                     ; 425c: 20 c3 80     .. :a25c[1]
+    jsr ca3dc                                                         ; 425f: 20 dc a3     .. :a25f[1]
+    ldy #0                                                            ; 4262: a0 00       ..  :a262[1]
+    jsr sub_c9b79                                                     ; 4264: 20 79 9b     y. :a264[1]
+    jsr sub_c9a8d                                                     ; 4267: 20 8d 9a     .. :a267[1]
+    jsr sub_c8380                                                     ; 426a: 20 80 83     .. :a26a[1]
+    ldy l0f05                                                         ; 426d: ac 05 0f    ... :a26d[1]
+    sty l00ca                                                         ; 4270: 84 ca       ..  :a270[1]
+    lda #2                                                            ; 4272: a9 02       ..  :a272[1]
+    sta l00c8                                                         ; 4274: 85 c8       ..  :a274[1]
+    lda #0                                                            ; 4276: a9 00       ..  :a276[1]
+    sta l00c9                                                         ; 4278: 85 c9       ..  :a278[1]
+; $427a referenced 1 time by $a312
+ca27a
+    ldy l00ca                                                         ; 427a: a4 ca       ..  :a27a[1]
+    jsr sub_c82b2                                                     ; 427c: 20 b2 82     .. :a27c[1]
+    cpy #$f8                                                          ; 427f: c0 f8       ..  :a27f[1]
+    bne ca2ab                                                         ; 4281: d0 28       .(  :a281[1]
+    lda l0f07                                                         ; 4283: ad 07 0f    ... :a283[1]
+    sec                                                               ; 4286: 38          8   :a286[1]
+    sbc l00c8                                                         ; 4287: e5 c8       ..  :a287[1]
+    pha                                                               ; 4289: 48          H   :a289[1]
+    lda l0f06                                                         ; 428a: ad 06 0f    ... :a28a[1]
+    and #3                                                            ; 428d: 29 03       ).  :a28d[1]
+    sbc l00c9                                                         ; 428f: e5 c9       ..  :a28f[1]
+    jsr sub_c80c3                                                     ; 4291: 20 c3 80     .. :a291[1]
+    pla                                                               ; 4294: 68          h   :a294[1]
+    jsr sub_c80bb                                                     ; 4295: 20 bb 80     .. :a295[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4298: 20 77 80     w. :a298[1]
+    !text " free sectors", $0d                                        ; 429b: 20 66 72...  fr :a29b[1]
+
+    nop                                                               ; 42a9: ea          .   :a2a9[1]
+    rts                                                               ; 42aa: 60          `   :a2aa[1]
+
+; $42ab referenced 1 time by $a281
+ca2ab
+    sty l00ca                                                         ; 42ab: 84 ca       ..  :a2ab[1]
+    jsr sub_c8335                                                     ; 42ad: 20 35 83     5. :a2ad[1]
+    ldy l00ca                                                         ; 42b0: a4 ca       ..  :a2b0[1]
+    lda l0f0c,y                                                       ; 42b2: b9 0c 0f    ... :a2b2[1]
+    cmp #1                                                            ; 42b5: c9 01       ..  :a2b5[1]
+    lda #0                                                            ; 42b7: a9 00       ..  :a2b7[1]
+    sta l00bc                                                         ; 42b9: 85 bc       ..  :a2b9[1]
+    sta l00c0                                                         ; 42bb: 85 c0       ..  :a2bb[1]
+    adc l0f0d,y                                                       ; 42bd: 79 0d 0f    y.. :a2bd[1]
+    sta l00c4                                                         ; 42c0: 85 c4       ..  :a2c0[1]
+    lda l0f0e,y                                                       ; 42c2: b9 0e 0f    ... :a2c2[1]
+    php                                                               ; 42c5: 08          .   :a2c5[1]
+    jsr sub_c81b0                                                     ; 42c6: 20 b0 81     .. :a2c6[1]
+    plp                                                               ; 42c9: 28          (   :a2c9[1]
+    adc #0                                                            ; 42ca: 69 00       i.  :a2ca[1]
+    sta l00c5                                                         ; 42cc: 85 c5       ..  :a2cc[1]
+    lda l0f0f,y                                                       ; 42ce: b9 0f 0f    ... :a2ce[1]
+    sta l00c6                                                         ; 42d1: 85 c6       ..  :a2d1[1]
+    lda l0f0e,y                                                       ; 42d3: b9 0e 0f    ... :a2d3[1]
+    and #3                                                            ; 42d6: 29 03       ).  :a2d6[1]
+    sta l00c7                                                         ; 42d8: 85 c7       ..  :a2d8[1]
+    cmp l00c9                                                         ; 42da: c5 c9       ..  :a2da[1]
+    bne ca2f2                                                         ; 42dc: d0 14       ..  :a2dc[1]
+    lda l00c6                                                         ; 42de: a5 c6       ..  :a2de[1]
+    cmp l00c8                                                         ; 42e0: c5 c8       ..  :a2e0[1]
+    bne ca2f2                                                         ; 42e2: d0 0e       ..  :a2e2[1]
+    clc                                                               ; 42e4: 18          .   :a2e4[1]
+    adc l00c4                                                         ; 42e5: 65 c4       e.  :a2e5[1]
+    sta l00c8                                                         ; 42e7: 85 c8       ..  :a2e7[1]
+    lda l00c9                                                         ; 42e9: a5 c9       ..  :a2e9[1]
+    adc l00c5                                                         ; 42eb: 65 c5       e.  :a2eb[1]
+    sta l00c9                                                         ; 42ed: 85 c9       ..  :a2ed[1]
+    jmp ca30d                                                         ; 42ef: 4c 0d a3    L.. :a2ef[1]
+
+; $42f2 referenced 2 times by $a2dc, $a2e2
+ca2f2
+    lda l00c8                                                         ; 42f2: a5 c8       ..  :a2f2[1]
+    sta l0f0f,y                                                       ; 42f4: 99 0f 0f    ... :a2f4[1]
+    lda l0f0e,y                                                       ; 42f7: b9 0e 0f    ... :a2f7[1]
+    and #$fc                                                          ; 42fa: 29 fc       ).  :a2fa[1]
+    ora l00c9                                                         ; 42fc: 05 c9       ..  :a2fc[1]
+    sta l0f0e,y                                                       ; 42fe: 99 0e 0f    ... :a2fe[1]
+    lda #0                                                            ; 4301: a9 00       ..  :a301[1]
+    sta l00a8                                                         ; 4303: 85 a8       ..  :a303[1]
+    sta l00a9                                                         ; 4305: 85 a9       ..  :a305[1]
+    jsr sub_ca530                                                     ; 4307: 20 30 a5     0. :a307[1]
+    jsr c93e6                                                         ; 430a: 20 e6 93     .. :a30a[1]
+; $430d referenced 1 time by $a2ef
+ca30d
+    ldy l00ca                                                         ; 430d: a4 ca       ..  :a30d[1]
+    jsr sub_c833a                                                     ; 430f: 20 3a 83     :. :a30f[1]
+    jmp ca27a                                                         ; 4312: 4c 7a a2    Lz. :a312[1]
+
+; $4315 referenced 3 times by $8794, $a41a, $a64c
+sub_ca315
+    bit l10c7                                                         ; 4315: 2c c7 10    ,.. :a315[1]
+    bpl ca378                                                         ; 4318: 10 5e       .^  :a318[1]
+    jsr sub_ca3ec                                                     ; 431a: 20 ec a3     .. :a31a[1]
+    beq ca321                                                         ; 431d: f0 02       ..  :a31d[1]
+    pla                                                               ; 431f: 68          h   :a31f[1]
+    pla                                                               ; 4320: 68          h   :a320[1]
+; $4321 referenced 1 time by $a31d
+ca321
+    jmp ca3dc                                                         ; 4321: 4c dc a3    L.. :a321[1]
+
+; $4324 referenced 2 times by $a417, $a466
+sub_ca324
+    jsr sub_ca14a                                                     ; 4324: 20 4a a1     J. :a324[1]
+    jsr c8b8b                                                         ; 4327: 20 8b 8b     .. :a327[1]
+    sta l10d1                                                         ; 432a: 8d d1 10    ... :a32a[1]
+    jsr sub_ca14a                                                     ; 432d: 20 4a a1     J. :a32d[1]
+    jsr c8b8b                                                         ; 4330: 20 8b 8b     .. :a330[1]
+    sta l10d2                                                         ; 4333: 8d d2 10    ... :a333[1]
+    tya                                                               ; 4336: 98          .   :a336[1]
+    pha                                                               ; 4337: 48          H   :a337[1]
+    lda #0                                                            ; 4338: a9 00       ..  :a338[1]
+    sta l00a9                                                         ; 433a: 85 a9       ..  :a33a[1]
+    lda l10d2                                                         ; 433c: ad d2 10    ... :a33c[1]
+    cmp l10d1                                                         ; 433f: cd d1 10    ... :a33f[1]
+    bne ca34a                                                         ; 4342: d0 06       ..  :a342[1]
+    lda #$ff                                                          ; 4344: a9 ff       ..  :a344[1]
+    sta l00a9                                                         ; 4346: 85 a9       ..  :a346[1]
+    sta l00aa                                                         ; 4348: 85 aa       ..  :a348[1]
+; $434a referenced 1 time by $a342
+ca34a
+    jsr sub_c9a8d                                                     ; 434a: 20 8d 9a     .. :a34a[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 434d: 20 77 80     w. :a34d[1]
+    !text "Copying from :"                                            ; 4350: 43 6f 70... Cop :a350[1]
+
+    lda l10d1                                                         ; 435e: ad d1 10    ... :a35e[1]
+    jsr sub_c80c3                                                     ; 4361: 20 c3 80     .. :a361[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4364: 20 77 80     w. :a364[1]
+    !text " to :"                                                     ; 4367: 20 74 6f...  to :a367[1]
+
+    lda l10d2                                                         ; 436c: ad d2 10    ... :a36c[1]
+    jsr sub_c80c3                                                     ; 436f: 20 c3 80     .. :a36f[1]
+    jsr ca3dc                                                         ; 4372: 20 dc a3     .. :a372[1]
+    pla                                                               ; 4375: 68          h   :a375[1]
+    tay                                                               ; 4376: a8          .   :a376[1]
+    clc                                                               ; 4377: 18          .   :a377[1]
+; $4378 referenced 1 time by $a318
+ca378
+    rts                                                               ; 4378: 60          `   :a378[1]
+
+; $4379 referenced 4 times by $a429, $a46f, $a4c8, $a55b
+sub_ca379
+    jsr sub_c83e3                                                     ; 4379: 20 e3 83     .. :a379[1]
+    bit l00a9                                                         ; 437c: 24 a9       $.  :a37c[1]
+    bpl ca38b                                                         ; 437e: 10 0b       ..  :a37e[1]
+    lda #0                                                            ; 4380: a9 00       ..  :a380[1]
+    beq ca38e                                                         ; 4382: f0 0a       ..  :a382[1]
+; $4384 referenced 3 times by $a440, $a4e4, $a581
+sub_ca384
+    jsr sub_c83e3                                                     ; 4384: 20 e3 83     .. :a384[1]
+    bit l00a9                                                         ; 4387: 24 a9       $.  :a387[1]
+    bmi ca38c                                                         ; 4389: 30 01       0.  :a389[1]
+; $438b referenced 2 times by $a37e, $a390
+ca38b
+    rts                                                               ; 438b: 60          `   :a38b[1]
+
+; $438c referenced 1 time by $a389
+ca38c
+    lda #$80                                                          ; 438c: a9 80       ..  :a38c[1]
+; $438e referenced 1 time by $a382
+ca38e
+    cmp l00aa                                                         ; 438e: c5 aa       ..  :a38e[1]
+    beq ca38b                                                         ; 4390: f0 f9       ..  :a390[1]
+    sta l00aa                                                         ; 4392: 85 aa       ..  :a392[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4394: 20 77 80     w. :a394[1]
+    !text "Insert "                                                   ; 4397: 49 6e 73... Ins :a397[1]
+
+    nop                                                               ; 439e: ea          .   :a39e[1]
+    bit l00aa                                                         ; 439f: 24 aa       $.  :a39f[1]
+    bmi ca3ae                                                         ; 43a1: 30 0b       0.  :a3a1[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 43a3: 20 77 80     w. :a3a3[1]
+    !text "source"                                                    ; 43a6: 73 6f 75... sou :a3a6[1]
+
+    bcc ca3bd                                                         ; 43ac: 90 0f       ..  :a3ac[1]
+; $43ae referenced 1 time by $a3a1
+ca3ae
+    jsr print_inline_l809f_top_bit_clear                              ; 43ae: 20 77 80     w. :a3ae[1]
+    !text "destination"                                               ; 43b1: 64 65 73... des :a3b1[1]
+
+    nop                                                               ; 43bc: ea          .   :a3bc[1]
+; $43bd referenced 1 time by $a3ac
+ca3bd
+    jsr print_inline_l809f_top_bit_clear                              ; 43bd: 20 77 80     w. :a3bd[1]
+    !text " disc and hit a key"                                       ; 43c0: 20 64 69...  di :a3c0[1]
+
+    nop                                                               ; 43d3: ea          .   :a3d3[1]
+    jsr sub_c9ac8                                                     ; 43d4: 20 c8 9a     .. :a3d4[1]
+    jsr osrdch                                                        ; 43d7: 20 e0 ff     .. :a3d7[1]
+    bcs ca411                                                         ; 43da: b0 35       .5  :a3da[1]
+; $43dc referenced 16 times by $836b, $8522, $854f, $85b2, $85b5, $8779, $87a8, $87b5, $a129, $a25f, $a321, $a372, $a62f, $a6b0, $a73a, $aa95
+ca3dc
+    pha                                                               ; 43dc: 48          H   :a3dc[1]
+    lda #$0d                                                          ; 43dd: a9 0d       ..  :a3dd[1]
+    jsr c809f                                                         ; 43df: 20 9f 80     .. :a3df[1]
+    pla                                                               ; 43e2: 68          h   :a3e2[1]
+    rts                                                               ; 43e3: 60          `   :a3e3[1]
+
+; $43e4 referenced 1 time by $8761
+sub_ca3e4
+    jsr print_inline_l809f_top_bit_clear                              ; 43e4: 20 77 80     w. :a3e4[1]
+    !text " : "                                                       ; 43e7: 20 3a 20     :  :a3e7[1]
+
+    bcc ca3fb                                                         ; 43ea: 90 0f       ..  :a3ea[1]
+; $43ec referenced 2 times by $87b0, $a31a
+sub_ca3ec
+    jsr print_inline_l809f_top_bit_clear                              ; 43ec: 20 77 80     w. :a3ec[1]
+    !text "Go (Y/N) ? "                                               ; 43ef: 47 6f 20... Go  :a3ef[1]
+
+    nop                                                               ; 43fa: ea          .   :a3fa[1]
+; $43fb referenced 1 time by $a3ea
+ca3fb
+    jsr sub_c9ac8                                                     ; 43fb: 20 c8 9a     .. :a3fb[1]
+    jsr osrdch                                                        ; 43fe: 20 e0 ff     .. :a3fe[1]
+    bcs ca411                                                         ; 4401: b0 0e       ..  :a401[1]
+    and #$5f ; '_'                                                    ; 4403: 29 5f       )_  :a403[1]
+    cmp #$59 ; 'Y'                                                    ; 4405: c9 59       .Y  :a405[1]
+    php                                                               ; 4407: 08          .   :a407[1]
+    beq ca40c                                                         ; 4408: f0 02       ..  :a408[1]
+    lda #$4e ; 'N'                                                    ; 440a: a9 4e       .N  :a40a[1]
+; $440c referenced 1 time by $a408
+ca40c
+    jsr c809f                                                         ; 440c: 20 9f 80     .. :a40c[1]
+    plp                                                               ; 440f: 28          (   :a40f[1]
+    rts                                                               ; 4410: 60          `   :a410[1]
+
+; $4411 referenced 2 times by $a3da, $a401
+ca411
+    jmp c9436                                                         ; 4411: 4c 36 94    L6. :a411[1]
+
+; $4414 referenced 2 times by $a452, $a45b
+ca414
+    jmp c8a6e                                                         ; 4414: 4c 6e 8a    Ln. :a414[1]
+
+sub_ca417
+    jsr sub_ca324                                                     ; 4417: 20 24 a3     $. :a417[1]
+    jsr sub_ca315                                                     ; 441a: 20 15 a3     .. :a41a[1]
+    lda #0                                                            ; 441d: a9 00       ..  :a41d[1]
+    sta l00c7                                                         ; 441f: 85 c7       ..  :a41f[1]
+    sta l00c9                                                         ; 4421: 85 c9       ..  :a421[1]
+    sta l00c8                                                         ; 4423: 85 c8       ..  :a423[1]
+    sta l00c6                                                         ; 4425: 85 c6       ..  :a425[1]
+    sta l00a8                                                         ; 4427: 85 a8       ..  :a427[1]
+    jsr sub_ca379                                                     ; 4429: 20 79 a3     y. :a429[1]
+    lda l10d1                                                         ; 442c: ad d1 10    ... :a42c[1]
+    sta l00cd                                                         ; 442f: 85 cd       ..  :a42f[1]
+    jsr c940c                                                         ; 4431: 20 0c 94     .. :a431[1]
+    lda l0f07                                                         ; 4434: ad 07 0f    ... :a434[1]
+    sta l00c4                                                         ; 4437: 85 c4       ..  :a437[1]
+    lda l0f06                                                         ; 4439: ad 06 0f    ... :a439[1]
+    and #3                                                            ; 443c: 29 03       ).  :a43c[1]
+    sta l00c5                                                         ; 443e: 85 c5       ..  :a43e[1]
+    jsr sub_ca384                                                     ; 4440: 20 84 a3     .. :a440[1]
+    lda l10d2                                                         ; 4443: ad d2 10    ... :a443[1]
+    sta l00cd                                                         ; 4446: 85 cd       ..  :a446[1]
+    jsr c940c                                                         ; 4448: 20 0c 94     .. :a448[1]
+    lda l0f06                                                         ; 444b: ad 06 0f    ... :a44b[1]
+    and #3                                                            ; 444e: 29 03       ).  :a44e[1]
+    cmp l00c5                                                         ; 4450: c5 c5       ..  :a450[1]
+    bcc ca414                                                         ; 4452: 90 c0       ..  :a452[1]
+    bne ca45d                                                         ; 4454: d0 07       ..  :a454[1]
+    lda l0f07                                                         ; 4456: ad 07 0f    ... :a456[1]
+    cmp l00c4                                                         ; 4459: c5 c4       ..  :a459[1]
+    bcc ca414                                                         ; 445b: 90 b7       ..  :a45b[1]
+; $445d referenced 1 time by $a454
+ca45d
+    jsr sub_ca530                                                     ; 445d: 20 30 a5     0. :a45d[1]
+    jmp c940c                                                         ; 4460: 4c 0c 94    L.. :a460[1]
+
+sub_ca463
+    jsr sub_c99ac                                                     ; 4463: 20 ac 99     .. :a463[1]
+    jsr sub_ca324                                                     ; 4466: 20 24 a3     $. :a466[1]
+    jsr sub_ca14a                                                     ; 4469: 20 4a a1     J. :a469[1]
+    jsr sub_c80ed                                                     ; 446c: 20 ed 80     .. :a46c[1]
+    jsr sub_ca379                                                     ; 446f: 20 79 a3     y. :a46f[1]
+    lda l10d1                                                         ; 4472: ad d1 10    ... :a472[1]
+    jsr c8816                                                         ; 4475: 20 16 88     .. :a475[1]
+    jsr c8225                                                         ; 4478: 20 25 82     %. :a478[1]
+; $447b referenced 1 time by $a4de
+ca47b
+    lda l00cc                                                         ; 447b: a5 cc       ..  :a47b[1]
+    pha                                                               ; 447d: 48          H   :a47d[1]
+    lda l00b6                                                         ; 447e: a5 b6       ..  :a47e[1]
+    sta l00ab                                                         ; 4480: 85 ab       ..  :a480[1]
+    jsr sub_c833a                                                     ; 4482: 20 3a 83     :. :a482[1]
+    ldx #0                                                            ; 4485: a2 00       ..  :a485[1]
+; $4487 referenced 1 time by $a49b
+loop_ca487
+    lda l0e08,y                                                       ; 4487: b9 08 0e    ... :a487[1]
+    sta l00c5,x                                                       ; 448a: 95 c5       ..  :a48a[1]
+    sta l1050,x                                                       ; 448c: 9d 50 10    .P. :a48c[1]
+    lda l0f08,y                                                       ; 448f: b9 08 0f    ... :a48f[1]
+    sta l00bb,x                                                       ; 4492: 95 bb       ..  :a492[1]
+    sta l1047,x                                                       ; 4494: 9d 47 10    .G. :a494[1]
+    inx                                                               ; 4497: e8          .   :a497[1]
+    iny                                                               ; 4498: c8          .   :a498[1]
+    cpx #8                                                            ; 4499: e0 08       ..  :a499[1]
+    bne loop_ca487                                                    ; 449b: d0 ea       ..  :a49b[1]
+    lda l00c1                                                         ; 449d: a5 c1       ..  :a49d[1]
+    jsr sub_c81b0                                                     ; 449f: 20 b0 81     .. :a49f[1]
+    sta l00c3                                                         ; 44a2: 85 c3       ..  :a4a2[1]
+    lda l00bf                                                         ; 44a4: a5 bf       ..  :a4a4[1]
+    clc                                                               ; 44a6: 18          .   :a4a6[1]
+    adc #$ff                                                          ; 44a7: 69 ff       i.  :a4a7[1]
+    lda l00c0                                                         ; 44a9: a5 c0       ..  :a4a9[1]
+    adc #0                                                            ; 44ab: 69 00       i.  :a4ab[1]
+    sta l00c4                                                         ; 44ad: 85 c4       ..  :a4ad[1]
+    lda l00c3                                                         ; 44af: a5 c3       ..  :a4af[1]
+    adc #0                                                            ; 44b1: 69 00       i.  :a4b1[1]
+    sta l00c5                                                         ; 44b3: 85 c5       ..  :a4b3[1]
+    lda l104e                                                         ; 44b5: ad 4e 10    .N. :a4b5[1]
+    sta l00c6                                                         ; 44b8: 85 c6       ..  :a4b8[1]
+    lda l104d                                                         ; 44ba: ad 4d 10    .M. :a4ba[1]
+    and #3                                                            ; 44bd: 29 03       ).  :a4bd[1]
+    sta l00c7                                                         ; 44bf: 85 c7       ..  :a4bf[1]
+    lda #$ff                                                          ; 44c1: a9 ff       ..  :a4c1[1]
+    sta l00a8                                                         ; 44c3: 85 a8       ..  :a4c3[1]
+    jsr sub_ca530                                                     ; 44c5: 20 30 a5     0. :a4c5[1]
+    jsr sub_ca379                                                     ; 44c8: 20 79 a3     y. :a4c8[1]
+    lda l10d1                                                         ; 44cb: ad d1 10    ... :a4cb[1]
+    jsr c8816                                                         ; 44ce: 20 16 88     .. :a4ce[1]
+    jsr sub_c8380                                                     ; 44d1: 20 80 83     .. :a4d1[1]
+    lda l00ab                                                         ; 44d4: a5 ab       ..  :a4d4[1]
+    sta l00b6                                                         ; 44d6: 85 b6       ..  :a4d6[1]
+    pla                                                               ; 44d8: 68          h   :a4d8[1]
+    sta l00cc                                                         ; 44d9: 85 cc       ..  :a4d9[1]
+    jsr sub_c8280                                                     ; 44db: 20 80 82     .. :a4db[1]
+    bcs ca47b                                                         ; 44de: b0 9b       ..  :a4de[1]
+    rts                                                               ; 44e0: 60          `   :a4e0[1]
+
+; $44e1 referenced 1 time by $a56d
+sub_ca4e1
+    jsr sub_ca51f                                                     ; 44e1: 20 1f a5     .. :a4e1[1]
+    jsr sub_ca384                                                     ; 44e4: 20 84 a3     .. :a4e4[1]
+    lda l10d2                                                         ; 44e7: ad d2 10    ... :a4e7[1]
+    sta l00cd                                                         ; 44ea: 85 cd       ..  :a4ea[1]
+    lda l00cc                                                         ; 44ec: a5 cc       ..  :a4ec[1]
+    pha                                                               ; 44ee: 48          H   :a4ee[1]
+    jsr sub_c8380                                                     ; 44ef: 20 80 83     .. :a4ef[1]
+    jsr sub_c826d                                                     ; 44f2: 20 6d 82     m. :a4f2[1]
+    bcc ca4fa                                                         ; 44f5: 90 03       ..  :a4f5[1]
+    jsr sub_c830a                                                     ; 44f7: 20 0a 83     .. :a4f7[1]
+; $44fa referenced 1 time by $a4f5
+ca4fa
+    pla                                                               ; 44fa: 68          h   :a4fa[1]
+    sta l00cc                                                         ; 44fb: 85 cc       ..  :a4fb[1]
+    jsr sub_c8b4d                                                     ; 44fd: 20 4d 8b     M. :a4fd[1]
+    jsr sub_c8b64                                                     ; 4500: 20 64 8b     d. :a500[1]
+    lda l00c2                                                         ; 4503: a5 c2       ..  :a503[1]
+    jsr sub_c81b0                                                     ; 4505: 20 b0 81     .. :a505[1]
+    sta l00c4                                                         ; 4508: 85 c4       ..  :a508[1]
+    jsr sub_c8ab3                                                     ; 450a: 20 b3 8a     .. :a50a[1]
+    lda l00c2                                                         ; 450d: a5 c2       ..  :a50d[1]
+    and #3                                                            ; 450f: 29 03       ).  :a50f[1]
+    pha                                                               ; 4511: 48          H   :a511[1]
+    lda l00c3                                                         ; 4512: a5 c3       ..  :a512[1]
+    pha                                                               ; 4514: 48          H   :a514[1]
+    jsr sub_ca51f                                                     ; 4515: 20 1f a5     .. :a515[1]
+    pla                                                               ; 4518: 68          h   :a518[1]
+    sta l00c8                                                         ; 4519: 85 c8       ..  :a519[1]
+    pla                                                               ; 451b: 68          h   :a51b[1]
+    sta l00c9                                                         ; 451c: 85 c9       ..  :a51c[1]
+    rts                                                               ; 451e: 60          `   :a51e[1]
+
+; $451f referenced 2 times by $a4e1, $a515
+sub_ca51f
+    ldx #$11                                                          ; 451f: a2 11       ..  :a51f[1]
+; $4521 referenced 1 time by $a52d
+loop_ca521
+    lda l1045,x                                                       ; 4521: bd 45 10    .E. :a521[1]
+    ldy l00ba,x                                                       ; 4524: b4 ba       ..  :a524[1]
+    sta l00ba,x                                                       ; 4526: 95 ba       ..  :a526[1]
+    tya                                                               ; 4528: 98          .   :a528[1]
+    sta l1045,x                                                       ; 4529: 9d 45 10    .E. :a529[1]
+    dex                                                               ; 452c: ca          .   :a52c[1]
+    bpl loop_ca521                                                    ; 452d: 10 f2       ..  :a52d[1]
+    rts                                                               ; 452f: 60          `   :a52f[1]
+
+; $4530 referenced 3 times by $a307, $a45d, $a4c5
+sub_ca530
+    lda #0                                                            ; 4530: a9 00       ..  :a530[1]
+    sta l00bc                                                         ; 4532: 85 bc       ..  :a532[1]
+    sta l00c0                                                         ; 4534: 85 c0       ..  :a534[1]
+    beq ca5ab                                                         ; 4536: f0 73       .s  :a536[1]
+; $4538 referenced 1 time by $a5af
+ca538
+    lda l00c4                                                         ; 4538: a5 c4       ..  :a538[1]
+    tay                                                               ; 453a: a8          .   :a53a[1]
+    cmp l10d0                                                         ; 453b: cd d0 10    ... :a53b[1]
+    lda l00c5                                                         ; 453e: a5 c5       ..  :a53e[1]
+    sbc #0                                                            ; 4540: e9 00       ..  :a540[1]
+    bcc ca547                                                         ; 4542: 90 03       ..  :a542[1]
+    ldy l10d0                                                         ; 4544: ac d0 10    ... :a544[1]
+; $4547 referenced 1 time by $a542
+ca547
+    sty l00c1                                                         ; 4547: 84 c1       ..  :a547[1]
+    lda l00c6                                                         ; 4549: a5 c6       ..  :a549[1]
+    sta l00c3                                                         ; 454b: 85 c3       ..  :a54b[1]
+    lda l00c7                                                         ; 454d: a5 c7       ..  :a54d[1]
+    sta l00c2                                                         ; 454f: 85 c2       ..  :a54f[1]
+    lda l10cf                                                         ; 4551: ad cf 10    ... :a551[1]
+    sta l00bd                                                         ; 4554: 85 bd       ..  :a554[1]
+    lda l10d1                                                         ; 4556: ad d1 10    ... :a556[1]
+    sta l00cd                                                         ; 4559: 85 cd       ..  :a559[1]
+    jsr sub_ca379                                                     ; 455b: 20 79 a3     y. :a55b[1]
+    jsr sub_ca5b2                                                     ; 455e: 20 b2 a5     .. :a55e[1]
+    jsr sub_c8855                                                     ; 4561: 20 55 88     U. :a561[1]
+    lda l10d2                                                         ; 4564: ad d2 10    ... :a564[1]
+    sta l00cd                                                         ; 4567: 85 cd       ..  :a567[1]
+    bit l00a8                                                         ; 4569: 24 a8       $.  :a569[1]
+    bpl ca574                                                         ; 456b: 10 07       ..  :a56b[1]
+    jsr sub_ca4e1                                                     ; 456d: 20 e1 a4     .. :a56d[1]
+    lda #0                                                            ; 4570: a9 00       ..  :a570[1]
+    sta l00a8                                                         ; 4572: 85 a8       ..  :a572[1]
+; $4574 referenced 1 time by $a56b
+ca574
+    lda l00c8                                                         ; 4574: a5 c8       ..  :a574[1]
+    sta l00c3                                                         ; 4576: 85 c3       ..  :a576[1]
+    lda l00c9                                                         ; 4578: a5 c9       ..  :a578[1]
+    sta l00c2                                                         ; 457a: 85 c2       ..  :a57a[1]
+    lda l10cf                                                         ; 457c: ad cf 10    ... :a57c[1]
+    sta l00bd                                                         ; 457f: 85 bd       ..  :a57f[1]
+    jsr sub_ca384                                                     ; 4581: 20 84 a3     .. :a581[1]
+    jsr sub_ca5b2                                                     ; 4584: 20 b2 a5     .. :a584[1]
+    jsr sub_c8862                                                     ; 4587: 20 62 88     b. :a587[1]
+    lda l00c1                                                         ; 458a: a5 c1       ..  :a58a[1]
+    clc                                                               ; 458c: 18          .   :a58c[1]
+    adc l00c8                                                         ; 458d: 65 c8       e.  :a58d[1]
+    sta l00c8                                                         ; 458f: 85 c8       ..  :a58f[1]
+    bcc ca595                                                         ; 4591: 90 02       ..  :a591[1]
+    inc l00c9                                                         ; 4593: e6 c9       ..  :a593[1]
+; $4595 referenced 1 time by $a591
+ca595
+    lda l00c1                                                         ; 4595: a5 c1       ..  :a595[1]
+    clc                                                               ; 4597: 18          .   :a597[1]
+    adc l00c6                                                         ; 4598: 65 c6       e.  :a598[1]
+    sta l00c6                                                         ; 459a: 85 c6       ..  :a59a[1]
+    bcc ca5a0                                                         ; 459c: 90 02       ..  :a59c[1]
+    inc l00c7                                                         ; 459e: e6 c7       ..  :a59e[1]
+; $45a0 referenced 1 time by $a59c
+ca5a0
+    sec                                                               ; 45a0: 38          8   :a5a0[1]
+    lda l00c4                                                         ; 45a1: a5 c4       ..  :a5a1[1]
+    sbc l00c1                                                         ; 45a3: e5 c1       ..  :a5a3[1]
+    sta l00c4                                                         ; 45a5: 85 c4       ..  :a5a5[1]
+    bcs ca5ab                                                         ; 45a7: b0 02       ..  :a5a7[1]
+    dec l00c5                                                         ; 45a9: c6 c5       ..  :a5a9[1]
+; $45ab referenced 2 times by $a536, $a5a7
+ca5ab
+    lda l00c4                                                         ; 45ab: a5 c4       ..  :a5ab[1]
+    ora l00c5                                                         ; 45ad: 05 c5       ..  :a5ad[1]
+    bne ca538                                                         ; 45af: d0 87       ..  :a5af[1]
+    rts                                                               ; 45b1: 60          `   :a5b1[1]
+
+; $45b2 referenced 2 times by $a55e, $a584
+sub_ca5b2
+    lda #$ff                                                          ; 45b2: a9 ff       ..  :a5b2[1]
+    sta l1074                                                         ; 45b4: 8d 74 10    .t. :a5b4[1]
+    sta l1075                                                         ; 45b7: 8d 75 10    .u. :a5b7[1]
+    rts                                                               ; 45ba: 60          `   :a5ba[1]
+
+sub_ca5bb
+    lda #0                                                            ; 45bb: a9 00       ..  :a5bb[1]
+    beq ca5c4                                                         ; 45bd: f0 05       ..  :a5bd[1]
+sub_ca5bf
+    lda #$ff                                                          ; 45bf: a9 ff       ..  :a5bf[1]
+    sta l1082                                                         ; 45c1: 8d 82 10    ... :a5c1[1]
+; $45c4 referenced 1 time by $a5bd
+ca5c4
+    sta l00c9                                                         ; 45c4: 85 c9       ..  :a5c4[1]
+    sta l1090                                                         ; 45c6: 8d 90 10    ... :a5c6[1]
+    bpl ca5e5                                                         ; 45c9: 10 1a       ..  :a5c9[1]
+    jsr sub_ca14a                                                     ; 45cb: 20 4a a1     J. :a5cb[1]
+    jsr sub_c8456                                                     ; 45ce: 20 56 84     V. :a5ce[1]
+    sta l109f                                                         ; 45d1: 8d 9f 10    ... :a5d1[1]
+    bcs ca5e2                                                         ; 45d4: b0 0c       ..  :a5d4[1]
+    cmp #$23 ; '#'                                                    ; 45d6: c9 23       .#  :a5d6[1]
+    beq ca5e5                                                         ; 45d8: f0 0b       ..  :a5d8[1]
+    cmp #$28 ; '('                                                    ; 45da: c9 28       .(  :a5da[1]
+    beq ca5e5                                                         ; 45dc: f0 07       ..  :a5dc[1]
+    cmp #$50 ; 'P'                                                    ; 45de: c9 50       .P  :a5de[1]
+    beq ca5e5                                                         ; 45e0: f0 03       ..  :a5e0[1]
+; $45e2 referenced 1 time by $a5d4
+ca5e2
+    jmp ca14f                                                         ; 45e2: 4c 4f a1    LO. :a5e2[1]
+
+; $45e5 referenced 4 times by $a5c9, $a5d8, $a5dc, $a5e0
+ca5e5
+    jsr clc_jmp_gsinit                                                ; 45e5: 20 4c 87     L. :a5e5[1]
+    sty l00ca                                                         ; 45e8: 84 ca       ..  :a5e8[1]
+    bne ca637                                                         ; 45ea: d0 4b       .K  :a5ea[1]
+    bit l00c9                                                         ; 45ec: 24 c9       $.  :a5ec[1]
+    bmi ca5fb                                                         ; 45ee: 30 0b       0.  :a5ee[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 45f0: 20 77 80     w. :a5f0[1]
+    !text "Verify"                                                    ; 45f3: 56 65 72... Ver :a5f3[1]
+
+    bcc ca605                                                         ; 45f9: 90 0a       ..  :a5f9[1]
+; $45fb referenced 1 time by $a5ee
+ca5fb
+    jsr print_inline_l809f_top_bit_clear                              ; 45fb: 20 77 80     w. :a5fb[1]
+    !text "Format"                                                    ; 45fe: 46 6f 72... For :a5fe[1]
+
+    nop                                                               ; 4604: ea          .   :a604[1]
+; $4605 referenced 1 time by $a5f9
+ca605
+    jsr print_inline_l809f_top_bit_clear                              ; 4605: 20 77 80     w. :a605[1]
+    !text " which drive ? "                                           ; 4608: 20 77 68...  wh :a608[1]
+
+    nop                                                               ; 4617: ea          .   :a617[1]
+    jsr osrdch                                                        ; 4618: 20 e0 ff     .. :a618[1]
+    bcs ca65d                                                         ; 461b: b0 40       .@  :a61b[1]
+    cmp #$20 ; ' '                                                    ; 461d: c9 20       .   :a61d[1]
+    bcc ca660                                                         ; 461f: 90 3f       .?  :a61f[1]
+    jsr c809f                                                         ; 4621: 20 9f 80     .. :a621[1]
+    sec                                                               ; 4624: 38          8   :a624[1]
+    sbc #$30 ; '0'                                                    ; 4625: e9 30       .0  :a625[1]
+    bcc ca660                                                         ; 4627: 90 37       .7  :a627[1]
+    cmp #4                                                            ; 4629: c9 04       ..  :a629[1]
+    bcs ca660                                                         ; 462b: b0 33       .3  :a62b[1]
+    sta l00cd                                                         ; 462d: 85 cd       ..  :a62d[1]
+    jsr ca3dc                                                         ; 462f: 20 dc a3     .. :a62f[1]
+    ldy l00ca                                                         ; 4632: a4 ca       ..  :a632[1]
+    jmp ca63a                                                         ; 4634: 4c 3a a6    L:. :a634[1]
+
+; $4637 referenced 2 times by $a5ea, $a65a
+ca637
+    jsr c8b8b                                                         ; 4637: 20 8b 8b     .. :a637[1]
+; $463a referenced 1 time by $a634
+ca63a
+    sty l00ca                                                         ; 463a: 84 ca       ..  :a63a[1]
+    bit l00c9                                                         ; 463c: 24 c9       $.  :a63c[1]
+    bpl ca647                                                         ; 463e: 10 07       ..  :a63e[1]
+    ldx l00cd                                                         ; 4640: a6 cd       ..  :a640[1]
+    lda #0                                                            ; 4642: a9 00       ..  :a642[1]
+    sta l10de,x                                                       ; 4644: 9d de 10    ... :a644[1]
+; $4647 referenced 1 time by $a63e
+ca647
+    bit l1090                                                         ; 4647: 2c 90 10    ,.. :a647[1]
+    bpl ca652                                                         ; 464a: 10 06       ..  :a64a[1]
+    jsr sub_ca315                                                     ; 464c: 20 15 a3     .. :a64c[1]
+    jsr sub_c9a8d                                                     ; 464f: 20 8d 9a     .. :a64f[1]
+; $4652 referenced 1 time by $a64a
+ca652
+    jsr sub_ca663                                                     ; 4652: 20 63 a6     c. :a652[1]
+    ldy l00ca                                                         ; 4655: a4 ca       ..  :a655[1]
+    jsr clc_jmp_gsinit                                                ; 4657: 20 4c 87     L. :a657[1]
+    bne ca637                                                         ; 465a: d0 db       ..  :a65a[1]
+    rts                                                               ; 465c: 60          `   :a65c[1]
+
+; $465d referenced 1 time by $a61b
+ca65d
+    jmp c9436                                                         ; 465d: 4c 36 94    L6. :a65d[1]
+
+; $4660 referenced 3 times by $a61f, $a627, $a62b
+ca660
+    jmp c8ba2                                                         ; 4660: 4c a2 8b    L.. :a660[1]
+
+; $4663 referenced 1 time by $a652
+sub_ca663
+    bit l00c9                                                         ; 4663: 24 c9       $.  :a663[1]
+    bmi ca675                                                         ; 4665: 30 0e       0.  :a665[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4667: 20 77 80     w. :a667[1]
+    !text "Verifying"                                                 ; 466a: 56 65 72... Ver :a66a[1]
+
+    bcc ca68a                                                         ; 4673: 90 15       ..  :a673[1]
+; $4675 referenced 1 time by $a665
+ca675
+    jsr sub_ca76c                                                     ; 4675: 20 6c a7     l. :a675[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4678: 20 77 80     w. :a678[1]
+    !text "Formatting"                                                ; 467b: 46 6f 72... For :a67b[1]
+
+    ldx l00cd                                                         ; 4685: a6 cd       ..  :a685[1]
+    stx l1090                                                         ; 4687: 8e 90 10    ... :a687[1]
+; $468a referenced 1 time by $a673
+ca68a
+    jsr print_inline_l809f_top_bit_clear                              ; 468a: 20 77 80     w. :a68a[1]
+    !text " drive "                                                   ; 468d: 20 64 72...  dr :a68d[1]
+
+    lda l00cd                                                         ; 4694: a5 cd       ..  :a694[1]
+    jsr sub_c80c3                                                     ; 4696: 20 c3 80     .. :a696[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4699: 20 77 80     w. :a699[1]
+    !text " track   "                                                 ; 469c: 20 74 72...  tr :a69c[1]
+
+    nop                                                               ; 46a5: ea          .   :a6a5[1]
+    bit l00c9                                                         ; 46a6: 24 c9       $.  :a6a6[1]
+    bmi ca6b6                                                         ; 46a8: 30 0c       0.  :a6a8[1]
+    jsr sub_ca7ce                                                     ; 46aa: 20 ce a7     .. :a6aa[1]
+    txa                                                               ; 46ad: 8a          .   :a6ad[1]
+    bne ca6b3                                                         ; 46ae: d0 03       ..  :a6ae[1]
+    jmp ca3dc                                                         ; 46b0: 4c dc a3    L.. :a6b0[1]
+
+; $46b3 referenced 1 time by $a6ae
+ca6b3
+    sta l109f                                                         ; 46b3: 8d 9f 10    ... :a6b3[1]
+; $46b6 referenced 1 time by $a6a8
+ca6b6
+    lda #0                                                            ; 46b6: a9 00       ..  :a6b6[1]
+    sta l1097                                                         ; 46b8: 8d 97 10    ... :a6b8[1]
+; $46bb referenced 1 time by $a731
+ca6bb
+    lda #8                                                            ; 46bb: a9 08       ..  :a6bb[1]
+    jsr c809f                                                         ; 46bd: 20 9f 80     .. :a6bd[1]
+    jsr c809f                                                         ; 46c0: 20 9f 80     .. :a6c0[1]
+    lda l1097                                                         ; 46c3: ad 97 10    ... :a6c3[1]
+    jsr sub_c80bb                                                     ; 46c6: 20 bb 80     .. :a6c6[1]
+    lda #6                                                            ; 46c9: a9 06       ..  :a6c9[1]
+    sta l109d                                                         ; 46cb: 8d 9d 10    ... :a6cb[1]
+; $46ce referenced 1 time by $a708
+ca6ce
+    jsr sub_ca73d                                                     ; 46ce: 20 3d a7     =. :a6ce[1]
+    bit l00c9                                                         ; 46d1: 24 c9       $.  :a6d1[1]
+    bpl ca6e2                                                         ; 46d3: 10 0d       ..  :a6d3[1]
+    jsr sub_ca788                                                     ; 46d5: 20 88 a7     .. :a6d5[1]
+    ldx #$90                                                          ; 46d8: a2 90       ..  :a6d8[1]
+    ldy #$10                                                          ; 46da: a0 10       ..  :a6da[1]
+    jsr c91af                                                         ; 46dc: 20 af 91     .. :a6dc[1]
+    tax                                                               ; 46df: aa          .   :a6df[1]
+    bne ca70a                                                         ; 46e0: d0 28       .(  :a6e0[1]
+; $46e2 referenced 1 time by $a6d3
+ca6e2
+    lda #0                                                            ; 46e2: a9 00       ..  :a6e2[1]
+    sta l1098                                                         ; 46e4: 8d 98 10    ... :a6e4[1]
+    lda l1099                                                         ; 46e7: ad 99 10    ... :a6e7[1]
+    and #$1f                                                          ; 46ea: 29 1f       ).  :a6ea[1]
+    sta l1099                                                         ; 46ec: 8d 99 10    ... :a6ec[1]
+    lda #3                                                            ; 46ef: a9 03       ..  :a6ef[1]
+    sta l1095                                                         ; 46f1: 8d 95 10    ... :a6f1[1]
+    lda #$5f ; '_'                                                    ; 46f4: a9 5f       ._  :a6f4[1]
+    sta l1096                                                         ; 46f6: 8d 96 10    ... :a6f6[1]
+    jsr sub_c9432                                                     ; 46f9: 20 32 94     2. :a6f9[1]
+    ldx #$90                                                          ; 46fc: a2 90       ..  :a6fc[1]
+    ldy #$10                                                          ; 46fe: a0 10       ..  :a6fe[1]
+    jsr c91af                                                         ; 4700: 20 af 91     .. :a700[1]
+    beq ca712                                                         ; 4703: f0 0d       ..  :a703[1]
+    dec l109d                                                         ; 4705: ce 9d 10    ... :a705[1]
+    bne ca6ce                                                         ; 4708: d0 c4       ..  :a708[1]
+; $470a referenced 1 time by $a6e0
+ca70a
+    jsr print_inline_l809f_top_bit_clear                              ; 470a: 20 77 80     w. :a70a[1]
+    !text "?"                                                         ; 470d: 3f          ?   :a70d[1]
+
+    nop                                                               ; 470e: ea          .   :a70e[1]
+    jmp c94c2                                                         ; 470f: 4c c2 94    L.. :a70f[1]
+
+; $4712 referenced 1 time by $a703
+ca712
+    lda l109d                                                         ; 4712: ad 9d 10    ... :a712[1]
+    cmp #6                                                            ; 4715: c9 06       ..  :a715[1]
+    beq ca721                                                         ; 4717: f0 08       ..  :a717[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4719: 20 77 80     w. :a719[1]
+    !text "?   "                                                      ; 471c: 3f 20 20... ?   :a71c[1]
+
+    nop                                                               ; 4720: ea          .   :a720[1]
+; $4721 referenced 1 time by $a717
+ca721
+    bit l00c9                                                         ; 4721: 24 c9       $.  :a721[1]
+    bpl ca728                                                         ; 4723: 10 03       ..  :a723[1]
+    jsr sub_ca779                                                     ; 4725: 20 79 a7     y. :a725[1]
+; $4728 referenced 1 time by $a723
+ca728
+    inc l1097                                                         ; 4728: ee 97 10    ... :a728[1]
+    lda l1097                                                         ; 472b: ad 97 10    ... :a72b[1]
+    cmp l109f                                                         ; 472e: cd 9f 10    ... :a72e[1]
+    bne ca6bb                                                         ; 4731: d0 88       ..  :a731[1]
+    bit l00c9                                                         ; 4733: 24 c9       $.  :a733[1]
+    bpl ca73a                                                         ; 4735: 10 03       ..  :a735[1]
+    jsr sub_c93f1                                                     ; 4737: 20 f1 93     .. :a737[1]
+; $473a referenced 1 time by $a735
+ca73a
+    jmp ca3dc                                                         ; 473a: 4c dc a3    L.. :a73a[1]
+
+; $473d referenced 1 time by $a6ce
+sub_ca73d
+    ldx #0                                                            ; 473d: a2 00       ..  :a73d[1]
+    stx l1091                                                         ; 473f: 8e 91 10    ... :a73f[1]
+    stx l109a                                                         ; 4742: 8e 9a 10    ... :a742[1]
+    dex                                                               ; 4745: ca          .   :a745[1]
+    stx l1093                                                         ; 4746: 8e 93 10    ... :a746[1]
+    stx l1094                                                         ; 4749: 8e 94 10    ... :a749[1]
+    lda l10cf                                                         ; 474c: ad cf 10    ... :a74c[1]
+    sta l1092                                                         ; 474f: 8d 92 10    ... :a74f[1]
+    lda #5                                                            ; 4752: a9 05       ..  :a752[1]
+    sta l1095                                                         ; 4754: 8d 95 10    ... :a754[1]
+    lda #$63 ; 'c'                                                    ; 4757: a9 63       .c  :a757[1]
+    sta l1096                                                         ; 4759: 8d 96 10    ... :a759[1]
+    lda #$2a ; '*'                                                    ; 475c: a9 2a       .*  :a75c[1]
+    sta l1099                                                         ; 475e: 8d 99 10    ... :a75e[1]
+    ldx #$10                                                          ; 4761: a2 10       ..  :a761[1]
+    ldy #$13                                                          ; 4763: a0 13       ..  :a763[1]
+    stx l109b                                                         ; 4765: 8e 9b 10    ... :a765[1]
+    sty l1098                                                         ; 4768: 8c 98 10    ... :a768[1]
+    rts                                                               ; 476b: 60          `   :a76b[1]
+
+; $476c referenced 1 time by $a675
+sub_ca76c
+    lda #0                                                            ; 476c: a9 00       ..  :a76c[1]
+    tay                                                               ; 476e: a8          .   :a76e[1]
+; $476f referenced 1 time by $a776
+loop_ca76f
+    sta l0e00,y                                                       ; 476f: 99 00 0e    ... :a76f[1]
+    sta l0f00,y                                                       ; 4772: 99 00 0f    ... :a772[1]
+    iny                                                               ; 4775: c8          .   :a775[1]
+    bne loop_ca76f                                                    ; 4776: d0 f7       ..  :a776[1]
+    rts                                                               ; 4778: 60          `   :a778[1]
+
+; $4779 referenced 1 time by $a725
+sub_ca779
+    lda #$0a                                                          ; 4779: a9 0a       ..  :a779[1]
+    clc                                                               ; 477b: 18          .   :a77b[1]
+    adc l0f07                                                         ; 477c: 6d 07 0f    m.. :a77c[1]
+    sta l0f07                                                         ; 477f: 8d 07 0f    ... :a77f[1]
+    bcc ca787                                                         ; 4782: 90 03       ..  :a782[1]
+    inc l0f06                                                         ; 4784: ee 06 0f    ... :a784[1]
+; $4787 referenced 1 time by $a782
+ca787
+    rts                                                               ; 4787: 60          `   :a787[1]
+
+; $4788 referenced 1 time by $a6d5
+sub_ca788
+    lda #0                                                            ; 4788: a9 00       ..  :a788[1]
+    sta l00b0                                                         ; 478a: 85 b0       ..  :a78a[1]
+    lda l10cf                                                         ; 478c: ad cf 10    ... :a78c[1]
+    sta l00b1                                                         ; 478f: 85 b1       ..  :a78f[1]
+    lda #$0a                                                          ; 4791: a9 0a       ..  :a791[1]
+    sta l00b2                                                         ; 4793: 85 b2       ..  :a793[1]
+    lda l1097                                                         ; 4795: ad 97 10    ... :a795[1]
+    beq ca7a4                                                         ; 4798: f0 0a       ..  :a798[1]
+    ldy #2                                                            ; 479a: a0 02       ..  :a79a[1]
+    lda (l00b0),y                                                     ; 479c: b1 b0       ..  :a79c[1]
+    clc                                                               ; 479e: 18          .   :a79e[1]
+    adc #7                                                            ; 479f: 69 07       i.  :a79f[1]
+    jsr sub_ca7c5                                                     ; 47a1: 20 c5 a7     .. :a7a1[1]
+; $47a4 referenced 1 time by $a798
+ca7a4
+    tax                                                               ; 47a4: aa          .   :a7a4[1]
+    ldy #0                                                            ; 47a5: a0 00       ..  :a7a5[1]
+; $47a7 referenced 1 time by $a7c1
+loop_ca7a7
+    lda l1097                                                         ; 47a7: ad 97 10    ... :a7a7[1]
+    sta (l00b0),y                                                     ; 47aa: 91 b0       ..  :a7aa[1]
+    iny                                                               ; 47ac: c8          .   :a7ac[1]
+    lda #0                                                            ; 47ad: a9 00       ..  :a7ad[1]
+    sta (l00b0),y                                                     ; 47af: 91 b0       ..  :a7af[1]
+    iny                                                               ; 47b1: c8          .   :a7b1[1]
+    txa                                                               ; 47b2: 8a          .   :a7b2[1]
+    sta (l00b0),y                                                     ; 47b3: 91 b0       ..  :a7b3[1]
+    iny                                                               ; 47b5: c8          .   :a7b5[1]
+    lda #1                                                            ; 47b6: a9 01       ..  :a7b6[1]
+    sta (l00b0),y                                                     ; 47b8: 91 b0       ..  :a7b8[1]
+    iny                                                               ; 47ba: c8          .   :a7ba[1]
+    inx                                                               ; 47bb: e8          .   :a7bb[1]
+    jsr sub_ca7c4                                                     ; 47bc: 20 c4 a7     .. :a7bc[1]
+    dec l00b2                                                         ; 47bf: c6 b2       ..  :a7bf[1]
+    bne loop_ca7a7                                                    ; 47c1: d0 e4       ..  :a7c1[1]
+    rts                                                               ; 47c3: 60          `   :a7c3[1]
+
+; $47c4 referenced 1 time by $a7bc
+sub_ca7c4
+    txa                                                               ; 47c4: 8a          .   :a7c4[1]
+; $47c5 referenced 1 time by $a7a1
+sub_ca7c5
+    sec                                                               ; 47c5: 38          8   :a7c5[1]
+; $47c6 referenced 1 time by $a7c8
+loop_ca7c6
+    sbc #$0a                                                          ; 47c6: e9 0a       ..  :a7c6[1]
+    bcs loop_ca7c6                                                    ; 47c8: b0 fc       ..  :a7c8[1]
+    adc #$0a                                                          ; 47ca: 69 0a       i.  :a7ca[1]
+    tax                                                               ; 47cc: aa          .   :a7cc[1]
+    rts                                                               ; 47cd: 60          `   :a7cd[1]
+
+; $47ce referenced 1 time by $a6aa
+sub_ca7ce
+    jsr sub_c93f5                                                     ; 47ce: 20 f5 93     .. :a7ce[1]
+    lda l0f06                                                         ; 47d1: ad 06 0f    ... :a7d1[1]
+    and #3                                                            ; 47d4: 29 03       ).  :a7d4[1]
+    tax                                                               ; 47d6: aa          .   :a7d6[1]
+    lda l0f07                                                         ; 47d7: ad 07 0f    ... :a7d7[1]
+    ldy #$0a                                                          ; 47da: a0 0a       ..  :a7da[1]
+    sty l00b0                                                         ; 47dc: 84 b0       ..  :a7dc[1]
+    ldy #$ff                                                          ; 47de: a0 ff       ..  :a7de[1]
+; $47e0 referenced 1 time by $a7e7
+loop_ca7e0
+    sec                                                               ; 47e0: 38          8   :a7e0[1]
+; $47e1 referenced 1 time by $a7e4
+loop_ca7e1
+    iny                                                               ; 47e1: c8          .   :a7e1[1]
+    sbc l00b0                                                         ; 47e2: e5 b0       ..  :a7e2[1]
+    bcs loop_ca7e1                                                    ; 47e4: b0 fb       ..  :a7e4[1]
+    dex                                                               ; 47e6: ca          .   :a7e6[1]
+    bpl loop_ca7e0                                                    ; 47e7: 10 f7       ..  :a7e7[1]
+    adc l00b0                                                         ; 47e9: 65 b0       e.  :a7e9[1]
+    pha                                                               ; 47eb: 48          H   :a7eb[1]
+    tya                                                               ; 47ec: 98          .   :a7ec[1]
+    tax                                                               ; 47ed: aa          .   :a7ed[1]
+    pla                                                               ; 47ee: 68          h   :a7ee[1]
+    beq ca7f2                                                         ; 47ef: f0 01       ..  :a7ef[1]
+    inx                                                               ; 47f1: e8          .   :a7f1[1]
+; $47f2 referenced 1 time by $a7ef
+ca7f2
+    rts                                                               ; 47f2: 60          `   :a7f2[1]
+
+sub_ca7f3
+    sec                                                               ; 47f3: 38          8   :a7f3[1]
+    bcs ca7f7                                                         ; 47f4: b0 01       ..  :a7f4[1]
+sub_ca7f6
+    clc                                                               ; 47f6: 18          .   :a7f6[1]
+; $47f7 referenced 1 time by $a7f4
+ca7f7
+    ror l00c6                                                         ; 47f7: 66 c6       f.  :a7f7[1]
+    jsr sub_c8b86                                                     ; 47f9: 20 86 8b     .. :a7f9[1]
+    jsr sub_c8380                                                     ; 47fc: 20 80 83     .. :a7fc[1]
+    bit l00c6                                                         ; 47ff: 24 c6       $.  :a7ff[1]
+    bmi ca818                                                         ; 4801: 30 15       0.  :a801[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 4803: 20 9c a9     .. :a803[1]
+    !text "Address :  Length", $0d                                    ; 4806: 41 64 64... Add :a806[1]
+
+; $4818 referenced 1 time by $a801
+ca818
+    lda l0f06                                                         ; 4818: ad 06 0f    ... :a818[1]
+    and #3                                                            ; 481b: 29 03       ).  :a81b[1]
+    sta l00c5                                                         ; 481d: 85 c5       ..  :a81d[1]
+    sta l00c2                                                         ; 481f: 85 c2       ..  :a81f[1]
+    lda l0f07                                                         ; 4821: ad 07 0f    ... :a821[1]
+    sta l00c4                                                         ; 4824: 85 c4       ..  :a824[1]
+    sec                                                               ; 4826: 38          8   :a826[1]
+    sbc #2                                                            ; 4827: e9 02       ..  :a827[1]
+    sta l00c1                                                         ; 4829: 85 c1       ..  :a829[1]
+    bcs ca82f                                                         ; 482b: b0 02       ..  :a82b[1]
+    dec l00c2                                                         ; 482d: c6 c2       ..  :a82d[1]
+; $482f referenced 1 time by $a82b
+ca82f
+    lda #2                                                            ; 482f: a9 02       ..  :a82f[1]
+    sta l00bb                                                         ; 4831: 85 bb       ..  :a831[1]
+    lda #0                                                            ; 4833: a9 00       ..  :a833[1]
+    sta l00bc                                                         ; 4835: 85 bc       ..  :a835[1]
+    sta l00bf                                                         ; 4837: 85 bf       ..  :a837[1]
+    sta l00c0                                                         ; 4839: 85 c0       ..  :a839[1]
+    lda l0f05                                                         ; 483b: ad 05 0f    ... :a83b[1]
+    and #$f8                                                          ; 483e: 29 f8       ).  :a83e[1]
+    tay                                                               ; 4840: a8          .   :a840[1]
+    beq ca86b                                                         ; 4841: f0 28       .(  :a841[1]
+    bne ca856                                                         ; 4843: d0 11       ..  :a843[1]
+; $4845 referenced 2 times by $a869, $a889
+ca845
+    jsr sub_ca8e2                                                     ; 4845: 20 e2 a8     .. :a845[1]
+    jsr sub_c82b2                                                     ; 4848: 20 b2 82     .. :a848[1]
+    lda l00c4                                                         ; 484b: a5 c4       ..  :a84b[1]
+    sec                                                               ; 484d: 38          8   :a84d[1]
+    sbc l00bb                                                         ; 484e: e5 bb       ..  :a84e[1]
+    lda l00c5                                                         ; 4850: a5 c5       ..  :a850[1]
+    sbc l00bc                                                         ; 4852: e5 bc       ..  :a852[1]
+    bcc ca86b                                                         ; 4854: 90 15       ..  :a854[1]
+; $4856 referenced 1 time by $a843
+ca856
+    lda l0f07,y                                                       ; 4856: b9 07 0f    ... :a856[1]
+    sec                                                               ; 4859: 38          8   :a859[1]
+    sbc l00bb                                                         ; 485a: e5 bb       ..  :a85a[1]
+    sta l00c1                                                         ; 485c: 85 c1       ..  :a85c[1]
+    php                                                               ; 485e: 08          .   :a85e[1]
+    lda l0f06,y                                                       ; 485f: b9 06 0f    ... :a85f[1]
+    and #3                                                            ; 4862: 29 03       ).  :a862[1]
+    plp                                                               ; 4864: 28          (   :a864[1]
+    sbc l00bc                                                         ; 4865: e5 bc       ..  :a865[1]
+    sta l00c2                                                         ; 4867: 85 c2       ..  :a867[1]
+    bcc ca845                                                         ; 4869: 90 da       ..  :a869[1]
+; $486b referenced 2 times by $a841, $a854
+ca86b
+    sty l00bd                                                         ; 486b: 84 bd       ..  :a86b[1]
+    bit l00c6                                                         ; 486d: 24 c6       $.  :a86d[1]
+    bmi ca87a                                                         ; 486f: 30 09       0.  :a86f[1]
+    lda l00c1                                                         ; 4871: a5 c1       ..  :a871[1]
+    ora l00c2                                                         ; 4873: 05 c2       ..  :a873[1]
+    beq ca87a                                                         ; 4875: f0 03       ..  :a875[1]
+    jsr sub_ca8be                                                     ; 4877: 20 be a8     .. :a877[1]
+; $487a referenced 2 times by $a86f, $a875
+ca87a
+    lda l00c1                                                         ; 487a: a5 c1       ..  :a87a[1]
+    clc                                                               ; 487c: 18          .   :a87c[1]
+    adc l00bf                                                         ; 487d: 65 bf       e.  :a87d[1]
+    sta l00bf                                                         ; 487f: 85 bf       ..  :a87f[1]
+    lda l00c2                                                         ; 4881: a5 c2       ..  :a881[1]
+    adc l00c0                                                         ; 4883: 65 c0       e.  :a883[1]
+    sta l00c0                                                         ; 4885: 85 c0       ..  :a885[1]
+    ldy l00bd                                                         ; 4887: a4 bd       ..  :a887[1]
+    bne ca845                                                         ; 4889: d0 ba       ..  :a889[1]
+    bit l00c6                                                         ; 488b: 24 c6       $.  :a88b[1]
+    bpl ca8bd                                                         ; 488d: 10 2e       ..  :a88d[1]
+    tay                                                               ; 488f: a8          .   :a88f[1]
+    ldx l00bf                                                         ; 4890: a6 bf       ..  :a890[1]
+    lda #$f8                                                          ; 4892: a9 f8       ..  :a892[1]
+    sec                                                               ; 4894: 38          8   :a894[1]
+    sbc l0f05                                                         ; 4895: ed 05 0f    ... :a895[1]
+    jsr sub_ca90d                                                     ; 4898: 20 0d a9     .. :a898[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 489b: 20 9c a9     .. :a89b[1]
+    !text "Free", $0d                                                 ; 489e: 46 72 65... Fre :a89e[1]
+
+    lda l00c4                                                         ; 48a3: a5 c4       ..  :a8a3[1]
+    sec                                                               ; 48a5: 38          8   :a8a5[1]
+    sbc l00bf                                                         ; 48a6: e5 bf       ..  :a8a6[1]
+    tax                                                               ; 48a8: aa          .   :a8a8[1]
+    lda l00c5                                                         ; 48a9: a5 c5       ..  :a8a9[1]
+    sbc l00c0                                                         ; 48ab: e5 c0       ..  :a8ab[1]
+    tay                                                               ; 48ad: a8          .   :a8ad[1]
+    lda l0f05                                                         ; 48ae: ad 05 0f    ... :a8ae[1]
+    jsr sub_ca90d                                                     ; 48b1: 20 0d a9     .. :a8b1[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 48b4: 20 9c a9     .. :a8b4[1]
+    !text "Used", $0d                                                 ; 48b7: 55 73 65... Use :a8b7[1]
+
+    nop                                                               ; 48bc: ea          .   :a8bc[1]
+; $48bd referenced 1 time by $a88d
+ca8bd
+    rts                                                               ; 48bd: 60          `   :a8bd[1]
+
+; $48be referenced 1 time by $a877
+sub_ca8be
+    lda l00bc                                                         ; 48be: a5 bc       ..  :a8be[1]
+    jsr sub_ca9ca                                                     ; 48c0: 20 ca a9     .. :a8c0[1]
+    lda l00bb                                                         ; 48c3: a5 bb       ..  :a8c3[1]
+    jsr sub_ca9c2                                                     ; 48c5: 20 c2 a9     .. :a8c5[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 48c8: 20 9c a9     .. :a8c8[1]
+    !text "     :  "                                                  ; 48cb: 20 20 20...     :a8cb[1]
+
+    lda l00c2                                                         ; 48d3: a5 c2       ..  :a8d3[1]
+    jsr sub_ca9ca                                                     ; 48d5: 20 ca a9     .. :a8d5[1]
+    lda l00c1                                                         ; 48d8: a5 c1       ..  :a8d8[1]
+    jsr sub_ca9c2                                                     ; 48da: 20 c2 a9     .. :a8da[1]
+    lda #$0d                                                          ; 48dd: a9 0d       ..  :a8dd[1]
+    jsr osasci                                                        ; 48df: 20 e3 ff     .. :a8df[1]
+; $48e2 referenced 1 time by $a845
+sub_ca8e2
+    lda l0f06,y                                                       ; 48e2: b9 06 0f    ... :a8e2[1]
+    pha                                                               ; 48e5: 48          H   :a8e5[1]
+    jsr sub_c81b0                                                     ; 48e6: 20 b0 81     .. :a8e6[1]
+    sta l00bc                                                         ; 48e9: 85 bc       ..  :a8e9[1]
+    pla                                                               ; 48eb: 68          h   :a8eb[1]
+    and #3                                                            ; 48ec: 29 03       ).  :a8ec[1]
+    clc                                                               ; 48ee: 18          .   :a8ee[1]
+    adc l00bc                                                         ; 48ef: 65 bc       e.  :a8ef[1]
+    sta l00bc                                                         ; 48f1: 85 bc       ..  :a8f1[1]
+    lda l0f04,y                                                       ; 48f3: b9 04 0f    ... :a8f3[1]
+    beq ca8fa                                                         ; 48f6: f0 02       ..  :a8f6[1]
+    lda #1                                                            ; 48f8: a9 01       ..  :a8f8[1]
+; $48fa referenced 1 time by $a8f6
+ca8fa
+    clc                                                               ; 48fa: 18          .   :a8fa[1]
+    adc l0f05,y                                                       ; 48fb: 79 05 0f    y.. :a8fb[1]
+    bcc ca902                                                         ; 48fe: 90 02       ..  :a8fe[1]
+    inc l00bc                                                         ; 4900: e6 bc       ..  :a900[1]
+; $4902 referenced 1 time by $a8fe
+ca902
+    clc                                                               ; 4902: 18          .   :a902[1]
+    adc l0f07,y                                                       ; 4903: 79 07 0f    y.. :a903[1]
+    sta l00bb                                                         ; 4906: 85 bb       ..  :a906[1]
+    bcc ca90c                                                         ; 4908: 90 02       ..  :a908[1]
+    inc l00bc                                                         ; 490a: e6 bc       ..  :a90a[1]
+; $490c referenced 1 time by $a908
+ca90c
+    rts                                                               ; 490c: 60          `   :a90c[1]
+
+; $490d referenced 2 times by $a898, $a8b1
+sub_ca90d
+    jsr sub_c81c0                                                     ; 490d: 20 c0 81     .. :a90d[1]
+    jsr sub_ca9bf                                                     ; 4910: 20 bf a9     .. :a910[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 4913: 20 9c a9     .. :a913[1]
+    !text " Files "                                                   ; 4916: 20 46 69...  Fi :a916[1]
+
+    stx l00bc                                                         ; 491d: 86 bc       ..  :a91d[1]
+    sty l00bd                                                         ; 491f: 84 bd       ..  :a91f[1]
+    tya                                                               ; 4921: 98          .   :a921[1]
+    jsr sub_ca9ca                                                     ; 4922: 20 ca a9     .. :a922[1]
+    txa                                                               ; 4925: 8a          .   :a925[1]
+    jsr sub_ca9c2                                                     ; 4926: 20 c2 a9     .. :a926[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 4929: 20 9c a9     .. :a929[1]
+    !text " Sectors "                                                 ; 492c: 20 53 65...  Se :a92c[1]
+
+    lda #0                                                            ; 4935: a9 00       ..  :a935[1]
+    sta l00bb                                                         ; 4937: 85 bb       ..  :a937[1]
+    sta l00be                                                         ; 4939: 85 be       ..  :a939[1]
+    ldx #$1f                                                          ; 493b: a2 1f       ..  :a93b[1]
+    stx l00c1                                                         ; 493d: 86 c1       ..  :a93d[1]
+    ldx #9                                                            ; 493f: a2 09       ..  :a93f[1]
+; $4941 referenced 1 time by $a945
+loop_ca941
+    sta l1000,x                                                       ; 4941: 9d 00 10    ... :a941[1]
+    dex                                                               ; 4944: ca          .   :a944[1]
+    bpl loop_ca941                                                    ; 4945: 10 fa       ..  :a945[1]
+; $4947 referenced 1 time by $a966
+loop_ca947
+    asl l00bb                                                         ; 4947: 06 bb       ..  :a947[1]
+    rol l00bc                                                         ; 4949: 26 bc       &.  :a949[1]
+    rol l00bd                                                         ; 494b: 26 bd       &.  :a94b[1]
+    rol l00be                                                         ; 494d: 26 be       &.  :a94d[1]
+    ldx #0                                                            ; 494f: a2 00       ..  :a94f[1]
+    ldy #9                                                            ; 4951: a0 09       ..  :a951[1]
+; $4953 referenced 1 time by $a962
+loop_ca953
+    lda l1000,x                                                       ; 4953: bd 00 10    ... :a953[1]
+    rol                                                               ; 4956: 2a          *   :a956[1]
+    cmp #$0a                                                          ; 4957: c9 0a       ..  :a957[1]
+    bcc ca95d                                                         ; 4959: 90 02       ..  :a959[1]
+    sbc #$0a                                                          ; 495b: e9 0a       ..  :a95b[1]
+; $495d referenced 1 time by $a959
+ca95d
+    sta l1000,x                                                       ; 495d: 9d 00 10    ... :a95d[1]
+    inx                                                               ; 4960: e8          .   :a960[1]
+    dey                                                               ; 4961: 88          .   :a961[1]
+    bpl loop_ca953                                                    ; 4962: 10 ef       ..  :a962[1]
+    dec l00c1                                                         ; 4964: c6 c1       ..  :a964[1]
+    bpl loop_ca947                                                    ; 4966: 10 df       ..  :a966[1]
+    ldy #$20 ; ' '                                                    ; 4968: a0 20       .   :a968[1]
+    ldx #5                                                            ; 496a: a2 05       ..  :a96a[1]
+; $496c referenced 1 time by $a98e
+ca96c
+    bne ca970                                                         ; 496c: d0 02       ..  :a96c[1]
+    ldy #$2c ; ','                                                    ; 496e: a0 2c       .,  :a96e[1]
+; $4970 referenced 1 time by $a96c
+ca970
+    lda l1000,x                                                       ; 4970: bd 00 10    ... :a970[1]
+    bne ca97d                                                         ; 4973: d0 08       ..  :a973[1]
+    cpy #$2c ; ','                                                    ; 4975: c0 2c       .,  :a975[1]
+    beq ca97d                                                         ; 4977: f0 04       ..  :a977[1]
+    lda #$20 ; ' '                                                    ; 4979: a9 20       .   :a979[1]
+    bne ca982                                                         ; 497b: d0 05       ..  :a97b[1]
+; $497d referenced 2 times by $a973, $a977
+ca97d
+    ldy #$2c ; ','                                                    ; 497d: a0 2c       .,  :a97d[1]
+    clc                                                               ; 497f: 18          .   :a97f[1]
+    adc #$30 ; '0'                                                    ; 4980: 69 30       i0  :a980[1]
+; $4982 referenced 1 time by $a97b
+ca982
+    jsr osasci                                                        ; 4982: 20 e3 ff     .. :a982[1]
+    cpx #3                                                            ; 4985: e0 03       ..  :a985[1]
+    bne ca98d                                                         ; 4987: d0 04       ..  :a987[1]
+    tya                                                               ; 4989: 98          .   :a989[1]
+    jsr osasci                                                        ; 498a: 20 e3 ff     .. :a98a[1]
+; $498d referenced 1 time by $a987
+ca98d
+    dex                                                               ; 498d: ca          .   :a98d[1]
+    bpl ca96c                                                         ; 498e: 10 dc       ..  :a98e[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 4990: 20 9c a9     .. :a990[1]
+    !text " Bytes "                                                   ; 4993: 20 42 79...  By :a993[1]
+
+    nop                                                               ; 499a: ea          .   :a99a[1]
+    rts                                                               ; 499b: 60          `   :a99b[1]
+
+; $499c referenced 7 times by $a803, $a89b, $a8b4, $a8c8, $a913, $a929, $a990
+print_inline_osasci_top_bit_clear
+    sta l00b3                                                         ; 499c: 85 b3       ..  :a99c[1]
+    pla                                                               ; 499e: 68          h   :a99e[1]
+    sta l00ae                                                         ; 499f: 85 ae       ..  :a99f[1]
+    pla                                                               ; 49a1: 68          h   :a9a1[1]
+    sta l00af                                                         ; 49a2: 85 af       ..  :a9a2[1]
+    lda l00b3                                                         ; 49a4: a5 b3       ..  :a9a4[1]
+    pha                                                               ; 49a6: 48          H   :a9a6[1]
+    tya                                                               ; 49a7: 98          .   :a9a7[1]
+    pha                                                               ; 49a8: 48          H   :a9a8[1]
+    ldy #0                                                            ; 49a9: a0 00       ..  :a9a9[1]
+; $49ab referenced 1 time by $a9b5
+loop_ca9ab
+    jsr inc16_ae                                                      ; 49ab: 20 dc 83     .. :a9ab[1]
+    lda (l00ae),y                                                     ; 49ae: b1 ae       ..  :a9ae[1]
+    bmi ca9b8                                                         ; 49b0: 30 06       0.  :a9b0[1]
+    jsr osasci                                                        ; 49b2: 20 e3 ff     .. :a9b2[1]
+    jmp loop_ca9ab                                                    ; 49b5: 4c ab a9    L.. :a9b5[1]
+
+; $49b8 referenced 1 time by $a9b0
+ca9b8
+    pla                                                               ; 49b8: 68          h   :a9b8[1]
+    tay                                                               ; 49b9: a8          .   :a9b9[1]
+    pla                                                               ; 49ba: 68          h   :a9ba[1]
+    clc                                                               ; 49bb: 18          .   :a9bb[1]
+    jmp (l00ae)                                                       ; 49bc: 6c ae 00    l.. :a9bc[1]
+
+; $49bf referenced 1 time by $a910
+sub_ca9bf
+    jsr sub_c841b                                                     ; 49bf: 20 1b 84     .. :a9bf[1]
+; $49c2 referenced 3 times by $a8c5, $a8da, $a926
+sub_ca9c2
+    pha                                                               ; 49c2: 48          H   :a9c2[1]
+    jsr sub_c81bf                                                     ; 49c3: 20 bf 81     .. :a9c3[1]
+    jsr sub_ca9ca                                                     ; 49c6: 20 ca a9     .. :a9c6[1]
+    pla                                                               ; 49c9: 68          h   :a9c9[1]
+; $49ca referenced 4 times by $a8c0, $a8d5, $a922, $a9c6
+sub_ca9ca
+    jsr sub_c80c8                                                     ; 49ca: 20 c8 80     .. :a9ca[1]
+    jmp osasci                                                        ; 49cd: 4c e3 ff    L.. :a9cd[1]
+
+sub_ca9d0
+    lda #0                                                            ; 49d0: a9 00       ..  :a9d0[1]
+    sta l00a8                                                         ; 49d2: 85 a8       ..  :a9d2[1]
+    jsr sub_caaea                                                     ; 49d4: 20 ea aa     .. :a9d4[1]
+    lda #$0f                                                          ; 49d7: a9 0f       ..  :a9d7[1]
+    sta l00aa                                                         ; 49d9: 85 aa       ..  :a9d9[1]
+    jsr sub_caadd                                                     ; 49db: 20 dd aa     .. :a9db[1]
+    sec                                                               ; 49de: 38          8   :a9de[1]
+    jsr gsinit                                                        ; 49df: 20 c2 ff     .. :a9df[1]
+    sty l00ab                                                         ; 49e2: 84 ab       ..  :a9e2[1]
+    clc                                                               ; 49e4: 18          .   :a9e4[1]
+    beq ca9ff                                                         ; 49e5: f0 18       ..  :a9e5[1]
+; $49e7 referenced 1 time by $a9fc
+loop_ca9e7
+    jsr sub_c8456                                                     ; 49e7: 20 56 84     V. :a9e7[1]
+    bcs ca9ff                                                         ; 49ea: b0 13       ..  :a9ea[1]
+    sty l00ab                                                         ; 49ec: 84 ab       ..  :a9ec[1]
+    and #$0f                                                          ; 49ee: 29 0f       ).  :a9ee[1]
+    sta l00aa                                                         ; 49f0: 85 aa       ..  :a9f0[1]
+    jsr sub_caa53                                                     ; 49f2: 20 53 aa     S. :a9f2[1]
+    ldy l00ab                                                         ; 49f5: a4 ab       ..  :a9f5[1]
+    jsr clc_jmp_gsinit                                                ; 49f7: 20 4c 87     L. :a9f7[1]
+    sty l00ab                                                         ; 49fa: 84 ab       ..  :a9fa[1]
+    bne loop_ca9e7                                                    ; 49fc: d0 e9       ..  :a9fc[1]
+    rts                                                               ; 49fe: 60          `   :a9fe[1]
+
+; $49ff referenced 2 times by $a9e5, $a9ea
+ca9ff
+    ror l00a8                                                         ; 49ff: 66 a8       f.  :a9ff[1]
+; $4a01 referenced 1 time by $aa0f
+loop_caa01
+    bit l00a8                                                         ; 4a01: 24 a8       $.  :aa01[1]
+    bpl caa0a                                                         ; 4a03: 10 05       ..  :aa03[1]
+    jsr sub_caa12                                                     ; 4a05: 20 12 aa     .. :aa05[1]
+    bcc caa0d                                                         ; 4a08: 90 03       ..  :aa08[1]
+; $4a0a referenced 1 time by $aa03
+caa0a
+    jsr sub_caa53                                                     ; 4a0a: 20 53 aa     S. :aa0a[1]
+; $4a0d referenced 1 time by $aa08
+caa0d
+    dec l00aa                                                         ; 4a0d: c6 aa       ..  :aa0d[1]
+    bpl loop_caa01                                                    ; 4a0f: 10 f0       ..  :aa0f[1]
+    rts                                                               ; 4a11: 60          `   :aa11[1]
+
+; $4a12 referenced 1 time by $aa05
+sub_caa12
+    lda #9                                                            ; 4a12: a9 09       ..  :aa12[1]
+    sta osrdsc_ptr                                                    ; 4a14: 85 f6       ..  :aa14[1]
+    lda #$80                                                          ; 4a16: a9 80       ..  :aa16[1]
+    sta l00f7                                                         ; 4a18: 85 f7       ..  :aa18[1]
+    ldy l00ab                                                         ; 4a1a: a4 ab       ..  :aa1a[1]
+; $4a1c referenced 2 times by $aa39, $aa40
+caa1c
+    lda (os_text_ptr),y                                               ; 4a1c: b1 f2       ..  :aa1c[1]
+    cmp #$0d                                                          ; 4a1e: c9 0d       ..  :aa1e[1]
+    beq caa44                                                         ; 4a20: f0 22       ."  :aa20[1]
+    cmp #$22 ; '"'                                                    ; 4a22: c9 22       ."  :aa22[1]
+    beq caa44                                                         ; 4a24: f0 1e       ..  :aa24[1]
+    iny                                                               ; 4a26: c8          .   :aa26[1]
+    cmp #$2a ; '*'                                                    ; 4a27: c9 2a       .*  :aa27[1]
+    beq caa51                                                         ; 4a29: f0 26       .&  :aa29[1]
+    jsr sub_c82fe                                                     ; 4a2b: 20 fe 82     .. :aa2b[1]
+    sta l00ae                                                         ; 4a2e: 85 ae       ..  :aa2e[1]
+    jsr sub_caacf                                                     ; 4a30: 20 cf aa     .. :aa30[1]
+    beq caa42                                                         ; 4a33: f0 0d       ..  :aa33[1]
+    ldx l00ae                                                         ; 4a35: a6 ae       ..  :aa35[1]
+    cpx #$23 ; '#'                                                    ; 4a37: e0 23       .#  :aa37[1]
+    beq caa1c                                                         ; 4a39: f0 e1       ..  :aa39[1]
+    jsr sub_c82fe                                                     ; 4a3b: 20 fe 82     .. :aa3b[1]
+    cmp l00ae                                                         ; 4a3e: c5 ae       ..  :aa3e[1]
+    beq caa1c                                                         ; 4a40: f0 da       ..  :aa40[1]
+; $4a42 referenced 3 times by $aa33, $aa4f, $aa57
+caa42
+    clc                                                               ; 4a42: 18          .   :aa42[1]
+    rts                                                               ; 4a43: 60          `   :aa43[1]
+
+; $4a44 referenced 3 times by $aa20, $aa24, $aa4b
+caa44
+    jsr sub_caacf                                                     ; 4a44: 20 cf aa     .. :aa44[1]
+    beq caa51                                                         ; 4a47: f0 08       ..  :aa47[1]
+    cmp #$20 ; ' '                                                    ; 4a49: c9 20       .   :aa49[1]
+    beq caa44                                                         ; 4a4b: f0 f7       ..  :aa4b[1]
+    cmp #$0d                                                          ; 4a4d: c9 0d       ..  :aa4d[1]
+    bne caa42                                                         ; 4a4f: d0 f1       ..  :aa4f[1]
+; $4a51 referenced 2 times by $aa29, $aa47
+caa51
+    sec                                                               ; 4a51: 38          8   :aa51[1]
+    rts                                                               ; 4a52: 60          `   :aa52[1]
+
+; $4a53 referenced 2 times by $a9f2, $aa0a
+sub_caa53
+    ldy l00aa                                                         ; 4a53: a4 aa       ..  :aa53[1]
+    lda (l00b4),y                                                     ; 4a55: b1 b4       ..  :aa55[1]
+    beq caa42                                                         ; 4a57: f0 e9       ..  :aa57[1]
+    pha                                                               ; 4a59: 48          H   :aa59[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4a5a: 20 77 80     w. :aa5a[1]
+    !text "Rom "                                                      ; 4a5d: 52 6f 6d... Rom :aa5d[1]
+
+    tya                                                               ; 4a61: 98          .   :aa61[1]
+    jsr sub_c80b8                                                     ; 4a62: 20 b8 80     .. :aa62[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4a65: 20 77 80     w. :aa65[1]
+    !text " : "                                                       ; 4a68: 20 3a 20     :  :aa68[1]
+
+    lda #$28 ; '('                                                    ; 4a6b: a9 28       .(  :aa6b[1]
+    jsr c809f                                                         ; 4a6d: 20 9f 80     .. :aa6d[1]
+    pla                                                               ; 4a70: 68          h   :aa70[1]
+    pha                                                               ; 4a71: 48          H   :aa71[1]
+    bmi caa78                                                         ; 4a72: 30 04       0.  :aa72[1]
+    ldy #$20 ; ' '                                                    ; 4a74: a0 20       .   :aa74[1]
+    bne caa7a                                                         ; 4a76: d0 02       ..  :aa76[1]
+; $4a78 referenced 1 time by $aa72
+caa78
+    ldy #$53 ; 'S'                                                    ; 4a78: a0 53       .S  :aa78[1]
+; $4a7a referenced 1 time by $aa76
+caa7a
+    tya                                                               ; 4a7a: 98          .   :aa7a[1]
+    jsr c809f                                                         ; 4a7b: 20 9f 80     .. :aa7b[1]
+    pla                                                               ; 4a7e: 68          h   :aa7e[1]
+    ldy #$20 ; ' '                                                    ; 4a7f: a0 20       .   :aa7f[1]
+    asl                                                               ; 4a81: 0a          .   :aa81[1]
+    bpl caa86                                                         ; 4a82: 10 02       ..  :aa82[1]
+    ldy #$4c ; 'L'                                                    ; 4a84: a0 4c       .L  :aa84[1]
+; $4a86 referenced 1 time by $aa82
+caa86
+    tya                                                               ; 4a86: 98          .   :aa86[1]
+    jsr c809f                                                         ; 4a87: 20 9f 80     .. :aa87[1]
+    lda #$29 ; ')'                                                    ; 4a8a: a9 29       .)  :aa8a[1]
+    jsr c809f                                                         ; 4a8c: 20 9f 80     .. :aa8c[1]
+    jsr cac0f                                                         ; 4a8f: 20 0f ac     .. :aa8f[1]
+    jsr sub_caa9a                                                     ; 4a92: 20 9a aa     .. :aa92[1]
+    jsr ca3dc                                                         ; 4a95: 20 dc a3     .. :aa95[1]
+    sec                                                               ; 4a98: 38          8   :aa98[1]
+    rts                                                               ; 4a99: 60          `   :aa99[1]
+
+; $4a9a referenced 1 time by $aa92
+sub_caa9a
+    lda #7                                                            ; 4a9a: a9 07       ..  :aa9a[1]
+    sta osrdsc_ptr                                                    ; 4a9c: 85 f6       ..  :aa9c[1]
+    lda #$80                                                          ; 4a9e: a9 80       ..  :aa9e[1]
+    sta l00f7                                                         ; 4aa0: 85 f7       ..  :aaa0[1]
+    jsr sub_caacf                                                     ; 4aa2: 20 cf aa     .. :aaa2[1]
+    sta l00ae                                                         ; 4aa5: 85 ae       ..  :aaa5[1]
+    inc osrdsc_ptr                                                    ; 4aa7: e6 f6       ..  :aaa7[1]
+    ldy #$1e                                                          ; 4aa9: a0 1e       ..  :aaa9[1]
+    jsr sub_caac2                                                     ; 4aab: 20 c2 aa     .. :aaab[1]
+    bcs caab7                                                         ; 4aae: b0 07       ..  :aaae[1]
+    jsr cac0f                                                         ; 4ab0: 20 0f ac     .. :aab0[1]
+    dey                                                               ; 4ab3: 88          .   :aab3[1]
+    jsr sub_caac2                                                     ; 4ab4: 20 c2 aa     .. :aab4[1]
+; $4ab7 referenced 1 time by $aaae
+caab7
+    rts                                                               ; 4ab7: 60          `   :aab7[1]
+
+; $4ab8 referenced 1 time by $aacb
+loop_caab8
+    cmp #$20 ; ' '                                                    ; 4ab8: c9 20       .   :aab8[1]
+    bcs caabe                                                         ; 4aba: b0 02       ..  :aaba[1]
+    lda #$20 ; ' '                                                    ; 4abc: a9 20       .   :aabc[1]
+; $4abe referenced 1 time by $aaba
+caabe
+    jsr c809f                                                         ; 4abe: 20 9f 80     .. :aabe[1]
+    dey                                                               ; 4ac1: 88          .   :aac1[1]
+; $4ac2 referenced 2 times by $aaab, $aab4
+sub_caac2
+    lda osrdsc_ptr                                                    ; 4ac2: a5 f6       ..  :aac2[1]
+    cmp l00ae                                                         ; 4ac4: c5 ae       ..  :aac4[1]
+    bcs caace                                                         ; 4ac6: b0 06       ..  :aac6[1]
+    jsr sub_caacf                                                     ; 4ac8: 20 cf aa     .. :aac8[1]
+    bne loop_caab8                                                    ; 4acb: d0 eb       ..  :aacb[1]
+    clc                                                               ; 4acd: 18          .   :aacd[1]
+; $4ace referenced 1 time by $aac6
+caace
+    rts                                                               ; 4ace: 60          `   :aace[1]
+
+; $4acf referenced 4 times by $aa30, $aa44, $aaa2, $aac8
+sub_caacf
+    tya                                                               ; 4acf: 98          .   :aacf[1]
+    pha                                                               ; 4ad0: 48          H   :aad0[1]
+    ldy l00aa                                                         ; 4ad1: a4 aa       ..  :aad1[1]
+    jsr osrdsc                                                        ; 4ad3: 20 b9 ff     .. :aad3[1]
+    inc osrdsc_ptr                                                    ; 4ad6: e6 f6       ..  :aad6[1]
+    tax                                                               ; 4ad8: aa          .   :aad8[1]
+    pla                                                               ; 4ad9: 68          h   :aad9[1]
+    tay                                                               ; 4ada: a8          .   :aada[1]
+    txa                                                               ; 4adb: 8a          .   :aadb[1]
+    rts                                                               ; 4adc: 60          `   :aadc[1]
+
+; $4add referenced 1 time by $a9db
+sub_caadd
+    jsr sub_c840c                                                     ; 4add: 20 0c 84     .. :aadd[1]
+    lda #$aa                                                          ; 4ae0: a9 aa       ..  :aae0[1]
+    jsr osbyte_read                                                   ; 4ae2: 20 e5 9a     .. :aae2[1]
+    stx l00b4                                                         ; 4ae5: 86 b4       ..  :aae5[1]
+    sty l00b5                                                         ; 4ae7: 84 b5       ..  :aae7[1]
+    rts                                                               ; 4ae9: 60          `   :aae9[1]
+
+; $4aea referenced 1 time by $a9d4
+sub_caaea
+    tsx                                                               ; 4aea: ba          .   :aaea[1]
+    lda #0                                                            ; 4aeb: a9 00       ..  :aaeb[1]
+    sta l0107,x                                                       ; 4aed: 9d 07 01    ... :aaed[1]
+    rts                                                               ; 4af0: 60          `   :aaf0[1]
+
+; $4af1 referenced 2 times by $ab51, $abd5
+sub_caaf1
+    ldx romsel_copy                                                   ; 4af1: a6 f4       ..  :aaf1[1]
+    lda l0df0,x                                                       ; 4af3: bd f0 0d    ... :aaf3[1]
+    and #$3f ; '?'                                                    ; 4af6: 29 3f       )?  :aaf6[1]
+    sta l00ad                                                         ; 4af8: 85 ad       ..  :aaf8[1]
+    inc l00ad                                                         ; 4afa: e6 ad       ..  :aafa[1]
+    rts                                                               ; 4afc: 60          `   :aafc[1]
+
+sub_caafd
+    jsr sub_cac18                                                     ; 4afd: 20 18 ac     .. :aafd[1]
+    lda #0                                                            ; 4b00: a9 00       ..  :ab00[1]
+    beq cab09                                                         ; 4b02: f0 05       ..  :ab02[1]
+sub_cab04
+    jsr sub_cac18                                                     ; 4b04: 20 18 ac     .. :ab04[1]
+    lda #$ff                                                          ; 4b07: a9 ff       ..  :ab07[1]
+; $4b09 referenced 1 time by $ab02
+cab09
+    sta l00ab                                                         ; 4b09: 85 ab       ..  :ab09[1]
+    lda #$40 ; '@'                                                    ; 4b0b: a9 40       .@  :ab0b[1]
+    jsr osfind                                                        ; 4b0d: 20 ce ff     .. :ab0d[1]
+    tay                                                               ; 4b10: a8          .   :ab10[1]
+    lda #$0d                                                          ; 4b11: a9 0d       ..  :ab11[1]
+    cpy #0                                                            ; 4b13: c0 00       ..  :ab13[1]
+    bne cab35                                                         ; 4b15: d0 1e       ..  :ab15[1]
+; $4b17 referenced 1 time by $ab4f
+cab17
+    jmp c822a                                                         ; 4b17: 4c 2a 82    L*. :ab17[1]
+
+; $4b1a referenced 2 times by $ab21, $ab3a
+cab1a
+    jsr osbget                                                        ; 4b1a: 20 d7 ff     .. :ab1a[1]
+    bcs cab3d                                                         ; 4b1d: b0 1e       ..  :ab1d[1]
+    cmp #$0a                                                          ; 4b1f: c9 0a       ..  :ab1f[1]
+    beq cab1a                                                         ; 4b21: f0 f7       ..  :ab21[1]
+    plp                                                               ; 4b23: 28          (   :ab23[1]
+    bne cab2e                                                         ; 4b24: d0 08       ..  :ab24[1]
+    pha                                                               ; 4b26: 48          H   :ab26[1]
+    jsr sub_cac4e                                                     ; 4b27: 20 4e ac     N. :ab27[1]
+    jsr cac0f                                                         ; 4b2a: 20 0f ac     .. :ab2a[1]
+    pla                                                               ; 4b2d: 68          h   :ab2d[1]
+; $4b2e referenced 1 time by $ab24
+cab2e
+    jsr osasci                                                        ; 4b2e: 20 e3 ff     .. :ab2e[1]
+    bit l00ff                                                         ; 4b31: 24 ff       $.  :ab31[1]
+    bmi cab54                                                         ; 4b33: 30 1f       0.  :ab33[1]
+; $4b35 referenced 1 time by $ab15
+cab35
+    and l00ab                                                         ; 4b35: 25 ab       %.  :ab35[1]
+    cmp #$0d                                                          ; 4b37: c9 0d       ..  :ab37[1]
+    php                                                               ; 4b39: 08          .   :ab39[1]
+    jmp cab1a                                                         ; 4b3a: 4c 1a ab    L.. :ab3a[1]
+
+; $4b3d referenced 1 time by $ab1d
+cab3d
+    plp                                                               ; 4b3d: 28          (   :ab3d[1]
+    jsr osnewl                                                        ; 4b3e: 20 e7 ff     .. :ab3e[1]
+; $4b41 referenced 2 times by $aba5, $abbf
+cab41
+    lda #0                                                            ; 4b41: a9 00       ..  :ab41[1]
+    jmp osfind                                                        ; 4b43: 4c ce ff    L.. :ab43[1]
+
+sub_cab46
+    jsr sub_cac18                                                     ; 4b46: 20 18 ac     .. :ab46[1]
+    lda #$40 ; '@'                                                    ; 4b49: a9 40       .@  :ab49[1]
+    jsr osfind                                                        ; 4b4b: 20 ce ff     .. :ab4b[1]
+    tay                                                               ; 4b4e: a8          .   :ab4e[1]
+    beq cab17                                                         ; 4b4f: f0 c6       ..  :ab4f[1]
+    jsr sub_caaf1                                                     ; 4b51: 20 f1 aa     .. :ab51[1]
+; $4b54 referenced 2 times by $ab33, $aba7
+cab54
+    bit l00ff                                                         ; 4b54: 24 ff       $.  :ab54[1]
+    bmi cabbc                                                         ; 4b56: 30 64       0d  :ab56[1]
+    lda l00a9                                                         ; 4b58: a5 a9       ..  :ab58[1]
+    jsr sub_cac62                                                     ; 4b5a: 20 62 ac     b. :ab5a[1]
+    lda l00a8                                                         ; 4b5d: a5 a8       ..  :ab5d[1]
+    jsr sub_cac62                                                     ; 4b5f: 20 62 ac     b. :ab5f[1]
+    jsr cac0f                                                         ; 4b62: 20 0f ac     .. :ab62[1]
+    lda #8                                                            ; 4b65: a9 08       ..  :ab65[1]
+    sta l00ac                                                         ; 4b67: 85 ac       ..  :ab67[1]
+    ldx #0                                                            ; 4b69: a2 00       ..  :ab69[1]
+; $4b6b referenced 1 time by $ab7a
+loop_cab6b
+    jsr osbget                                                        ; 4b6b: 20 d7 ff     .. :ab6b[1]
+    bcs cab7d                                                         ; 4b6e: b0 0d       ..  :ab6e[1]
+    sta (l00ac,x)                                                     ; 4b70: 81 ac       ..  :ab70[1]
+    jsr sub_cac62                                                     ; 4b72: 20 62 ac     b. :ab72[1]
+    jsr cac0f                                                         ; 4b75: 20 0f ac     .. :ab75[1]
+    dec l00ac                                                         ; 4b78: c6 ac       ..  :ab78[1]
+    bne loop_cab6b                                                    ; 4b7a: d0 ef       ..  :ab7a[1]
+    clc                                                               ; 4b7c: 18          .   :ab7c[1]
+; $4b7d referenced 1 time by $ab6e
+cab7d
+    php                                                               ; 4b7d: 08          .   :ab7d[1]
+    bcc cab93                                                         ; 4b7e: 90 13       ..  :ab7e[1]
+; $4b80 referenced 1 time by $ab91
+loop_cab80
+    lda #$2a ; '*'                                                    ; 4b80: a9 2a       .*  :ab80[1]
+    jsr osasci                                                        ; 4b82: 20 e3 ff     .. :ab82[1]
+    jsr osasci                                                        ; 4b85: 20 e3 ff     .. :ab85[1]
+    jsr cac0f                                                         ; 4b88: 20 0f ac     .. :ab88[1]
+    lda #0                                                            ; 4b8b: a9 00       ..  :ab8b[1]
+    sta (l00ac,x)                                                     ; 4b8d: 81 ac       ..  :ab8d[1]
+    dec l00ac                                                         ; 4b8f: c6 ac       ..  :ab8f[1]
+    bne loop_cab80                                                    ; 4b91: d0 ed       ..  :ab91[1]
+; $4b93 referenced 1 time by $ab7e
+cab93
+    jsr sub_caba9                                                     ; 4b93: 20 a9 ab     .. :ab93[1]
+    jsr osnewl                                                        ; 4b96: 20 e7 ff     .. :ab96[1]
+    lda #8                                                            ; 4b99: a9 08       ..  :ab99[1]
+    clc                                                               ; 4b9b: 18          .   :ab9b[1]
+    adc l00a8                                                         ; 4b9c: 65 a8       e.  :ab9c[1]
+    sta l00a8                                                         ; 4b9e: 85 a8       ..  :ab9e[1]
+    bcc caba4                                                         ; 4ba0: 90 02       ..  :aba0[1]
+    inc l00a9                                                         ; 4ba2: e6 a9       ..  :aba2[1]
+; $4ba4 referenced 1 time by $aba0
+caba4
+    plp                                                               ; 4ba4: 28          (   :aba4[1]
+    bcs cab41                                                         ; 4ba5: b0 9a       ..  :aba5[1]
+    bcc cab54                                                         ; 4ba7: 90 ab       ..  :aba7[1]
+; $4ba9 referenced 1 time by $ab93
+sub_caba9
+    lda #8                                                            ; 4ba9: a9 08       ..  :aba9[1]
+    sta l00ac                                                         ; 4bab: 85 ac       ..  :abab[1]
+; $4bad referenced 1 time by $abb9
+loop_cabad
+    ldx #0                                                            ; 4bad: a2 00       ..  :abad[1]
+    lda (l00ac,x)                                                     ; 4baf: a1 ac       ..  :abaf[1]
+    jsr sub_c842c                                                     ; 4bb1: 20 2c 84     ,. :abb1[1]
+    jsr osasci                                                        ; 4bb4: 20 e3 ff     .. :abb4[1]
+    dec l00ac                                                         ; 4bb7: c6 ac       ..  :abb7[1]
+    bne loop_cabad                                                    ; 4bb9: d0 f2       ..  :abb9[1]
+    rts                                                               ; 4bbb: 60          `   :abbb[1]
+
+; $4bbc referenced 2 times by $ab56, $ac02
+cabbc
+    jsr sub_c9ad8                                                     ; 4bbc: 20 d8 9a     .. :abbc[1]
+    jsr cab41                                                         ; 4bbf: 20 41 ab     A. :abbf[1]
+    jmp c9436                                                         ; 4bc2: 4c 36 94    L6. :abc2[1]
+
+sub_cabc5
+    jsr sub_cac18                                                     ; 4bc5: 20 18 ac     .. :abc5[1]
+    lda #$80                                                          ; 4bc8: a9 80       ..  :abc8[1]
+    jsr osfind                                                        ; 4bca: 20 ce ff     .. :abca[1]
+    sta l00ab                                                         ; 4bcd: 85 ab       ..  :abcd[1]
+; $4bcf referenced 1 time by $ac09
+cabcf
+    jsr sub_cac4e                                                     ; 4bcf: 20 4e ac     N. :abcf[1]
+    jsr cac0f                                                         ; 4bd2: 20 0f ac     .. :abd2[1]
+    jsr sub_caaf1                                                     ; 4bd5: 20 f1 aa     .. :abd5[1]
+    ldx #$ac                                                          ; 4bd8: a2 ac       ..  :abd8[1]
+    ldy #$ff                                                          ; 4bda: a0 ff       ..  :abda[1]
+    sty l00ae                                                         ; 4bdc: 84 ae       ..  :abdc[1]
+    sty l00b0                                                         ; 4bde: 84 b0       ..  :abde[1]
+    iny                                                               ; 4be0: c8          .   :abe0[1]
+    sty l00ac                                                         ; 4be1: 84 ac       ..  :abe1[1]
+    lda #$20 ; ' '                                                    ; 4be3: a9 20       .   :abe3[1]
+    sta l00af                                                         ; 4be5: 85 af       ..  :abe5[1]
+    tya                                                               ; 4be7: 98          .   :abe7[1]
+    jsr osword                                                        ; 4be8: 20 f1 ff     .. :abe8[1]
+    php                                                               ; 4beb: 08          .   :abeb[1]
+    sty l00aa                                                         ; 4bec: 84 aa       ..  :abec[1]
+    ldy l00ab                                                         ; 4bee: a4 ab       ..  :abee[1]
+    ldx #0                                                            ; 4bf0: a2 00       ..  :abf0[1]
+    beq cabfb                                                         ; 4bf2: f0 07       ..  :abf2[1]
+; $4bf4 referenced 1 time by $abff
+loop_cabf4
+    lda (l00ac,x)                                                     ; 4bf4: a1 ac       ..  :abf4[1]
+    jsr osbput                                                        ; 4bf6: 20 d4 ff     .. :abf6[1]
+    inc l00ac                                                         ; 4bf9: e6 ac       ..  :abf9[1]
+; $4bfb referenced 1 time by $abf2
+cabfb
+    lda l00ac                                                         ; 4bfb: a5 ac       ..  :abfb[1]
+    cmp l00aa                                                         ; 4bfd: c5 aa       ..  :abfd[1]
+    bne loop_cabf4                                                    ; 4bff: d0 f3       ..  :abff[1]
+    plp                                                               ; 4c01: 28          (   :ac01[1]
+    bcs cabbc                                                         ; 4c02: b0 b8       ..  :ac02[1]
+    lda #$0d                                                          ; 4c04: a9 0d       ..  :ac04[1]
+    jsr osbput                                                        ; 4c06: 20 d4 ff     .. :ac06[1]
+    jmp cabcf                                                         ; 4c09: 4c cf ab    L.. :ac09[1]
+
+; $4c0c referenced 3 times by $817f, $8198, $85ca
+sub_cac0c
+    jsr cac0f                                                         ; 4c0c: 20 0f ac     .. :ac0c[1]
+; $4c0f referenced 11 times by $81a7, $834f, $837d, $aa8f, $aab0, $ab2a, $ab62, $ab75, $ab88, $abd2, $ac0c
+cac0f
+    pha                                                               ; 4c0f: 48          H   :ac0f[1]
+    lda #$20 ; ' '                                                    ; 4c10: a9 20       .   :ac10[1]
+    jsr osasci                                                        ; 4c12: 20 e3 ff     .. :ac12[1]
+    pla                                                               ; 4c15: 68          h   :ac15[1]
+    clc                                                               ; 4c16: 18          .   :ac16[1]
+    rts                                                               ; 4c17: 60          `   :ac17[1]
+
+; $4c18 referenced 4 times by $aafd, $ab04, $ab46, $abc5
+sub_cac18
+    tsx                                                               ; 4c18: ba          .   :ac18[1]
+    lda #0                                                            ; 4c19: a9 00       ..  :ac19[1]
+    sta l0107,x                                                       ; 4c1b: 9d 07 01    ... :ac1b[1]
+    jsr sub_cac47                                                     ; 4c1e: 20 47 ac     G. :ac1e[1]
+    cmp #$0d                                                          ; 4c21: c9 0d       ..  :ac21[1]
+    bne cac28                                                         ; 4c23: d0 03       ..  :ac23[1]
+    jmp ca14f                                                         ; 4c25: 4c 4f a1    LO. :ac25[1]
+
+; $4c28 referenced 1 time by $ac23
+cac28
+    lda #0                                                            ; 4c28: a9 00       ..  :ac28[1]
+    sta l00a8                                                         ; 4c2a: 85 a8       ..  :ac2a[1]
+    sta l00a9                                                         ; 4c2c: 85 a9       ..  :ac2c[1]
+    pha                                                               ; 4c2e: 48          H   :ac2e[1]
+    tya                                                               ; 4c2f: 98          .   :ac2f[1]
+    clc                                                               ; 4c30: 18          .   :ac30[1]
+    adc os_text_ptr                                                   ; 4c31: 65 f2       e.  :ac31[1]
+    tax                                                               ; 4c33: aa          .   :ac33[1]
+    lda l00f3                                                         ; 4c34: a5 f3       ..  :ac34[1]
+    adc #0                                                            ; 4c36: 69 00       i.  :ac36[1]
+    tay                                                               ; 4c38: a8          .   :ac38[1]
+    pla                                                               ; 4c39: 68          h   :ac39[1]
+    rts                                                               ; 4c3a: 60          `   :ac3a[1]
+
+    tya                                                               ; 4c3b: 98          .   :ac3b[1]
+    clc                                                               ; 4c3c: 18          .   :ac3c[1]
+    adc os_text_ptr                                                   ; 4c3d: 65 f2       e.  :ac3d[1]
+    sta os_text_ptr                                                   ; 4c3f: 85 f2       ..  :ac3f[1]
+    bcc cac45                                                         ; 4c41: 90 02       ..  :ac41[1]
+    inc os_text_ptr                                                   ; 4c43: e6 f2       ..  :ac43[1]
+; $4c45 referenced 1 time by $ac41
+cac45
+    rts                                                               ; 4c45: 60          `   :ac45[1]
+
+; $4c46 referenced 1 time by $ac4b
+loop_cac46
+    iny                                                               ; 4c46: c8          .   :ac46[1]
+; $4c47 referenced 1 time by $ac1e
+sub_cac47
+    lda (os_text_ptr),y                                               ; 4c47: b1 f2       ..  :ac47[1]
+    cmp #$20 ; ' '                                                    ; 4c49: c9 20       .   :ac49[1]
+    beq loop_cac46                                                    ; 4c4b: f0 f9       ..  :ac4b[1]
+    rts                                                               ; 4c4d: 60          `   :ac4d[1]
+
+; $4c4e referenced 2 times by $ab27, $abcf
+sub_cac4e
+    sed                                                               ; 4c4e: f8          .   :ac4e[1]
+    clc                                                               ; 4c4f: 18          .   :ac4f[1]
+    lda l00a8                                                         ; 4c50: a5 a8       ..  :ac50[1]
+    adc #1                                                            ; 4c52: 69 01       i.  :ac52[1]
+    sta l00a8                                                         ; 4c54: 85 a8       ..  :ac54[1]
+    lda l00a9                                                         ; 4c56: a5 a9       ..  :ac56[1]
+    adc #0                                                            ; 4c58: 69 00       i.  :ac58[1]
+    sta l00a9                                                         ; 4c5a: 85 a9       ..  :ac5a[1]
+    cld                                                               ; 4c5c: d8          .   :ac5c[1]
+    jsr sub_cac62                                                     ; 4c5d: 20 62 ac     b. :ac5d[1]
+    lda l00a8                                                         ; 4c60: a5 a8       ..  :ac60[1]
+; $4c62 referenced 4 times by $ab5a, $ab5f, $ab72, $ac5d
+sub_cac62
+    pha                                                               ; 4c62: 48          H   :ac62[1]
+    jsr sub_c81bf                                                     ; 4c63: 20 bf 81     .. :ac63[1]
+    jsr sub_cac6a                                                     ; 4c66: 20 6a ac     j. :ac66[1]
+    pla                                                               ; 4c69: 68          h   :ac69[1]
+; $4c6a referenced 1 time by $ac66
+sub_cac6a
+    jsr sub_c80c8                                                     ; 4c6a: 20 c8 80     .. :ac6a[1]
+    jsr osasci                                                        ; 4c6d: 20 e3 ff     .. :ac6d[1]
+    sec                                                               ; 4c70: 38          8   :ac70[1]
+    rts                                                               ; 4c71: 60          `   :ac71[1]
+
+; $4c72 referenced 1 time by $96e1
+sub_cac72
+    jsr sub_c83e3                                                     ; 4c72: 20 e3 83     .. :ac72[1]
+    lda #$40 ; '@'                                                    ; 4c75: a9 40       .@  :ac75[1]
+    sta l10de                                                         ; 4c77: 8d de 10    ... :ac77[1]
+    lda #$a8                                                          ; 4c7a: a9 a8       ..  :ac7a[1]
+    jsr osbyte_read                                                   ; 4c7c: 20 e5 9a     .. :ac7c[1]
+    stx l00b0                                                         ; 4c7f: 86 b0       ..  :ac7f[1]
+    sty l00b1                                                         ; 4c81: 84 b1       ..  :ac81[1]
+    ldy #$0f                                                          ; 4c83: a0 0f       ..  :ac83[1]
+    lda #$4c ; 'L'                                                    ; 4c85: a9 4c       .L  :ac85[1]
+    sta l10e2                                                         ; 4c87: 8d e2 10    ... :ac87[1]
+    lda bytev                                                         ; 4c8a: ad 0a 02    ... :ac8a[1]
+    sta l10e3                                                         ; 4c8d: 8d e3 10    ... :ac8d[1]
+    lda bytev+1                                                       ; 4c90: ad 0b 02    ... :ac90[1]
+    sta l10e4                                                         ; 4c93: 8d e4 10    ... :ac93[1]
+    php                                                               ; 4c96: 08          .   :ac96[1]
+    sei                                                               ; 4c97: 78          x   :ac97[1]
+    lda #$0f                                                          ; 4c98: a9 0f       ..  :ac98[1]
+    sta bytev                                                         ; 4c9a: 8d 0a 02    ... :ac9a[1]
+    lda #$ff                                                          ; 4c9d: a9 ff       ..  :ac9d[1]
+    sta bytev+1                                                       ; 4c9f: 8d 0b 02    ... :ac9f[1]
+    lda #$b2                                                          ; 4ca2: a9 b2       ..  :aca2[1]
+    sta (l00b0),y                                                     ; 4ca4: 91 b0       ..  :aca4[1]
+    iny                                                               ; 4ca6: c8          .   :aca6[1]
+    lda #$ac                                                          ; 4ca7: a9 ac       ..  :aca7[1]
+    sta (l00b0),y                                                     ; 4ca9: 91 b0       ..  :aca9[1]
+    iny                                                               ; 4cab: c8          .   :acab[1]
+    lda romsel_copy                                                   ; 4cac: a5 f4       ..  :acac[1]
+    sta (l00b0),y                                                     ; 4cae: 91 b0       ..  :acae[1]
+    plp                                                               ; 4cb0: 28          (   :acb0[1]
+    rts                                                               ; 4cb1: 60          `   :acb1[1]
+
+    cmp #0                                                            ; 4cb2: c9 00       ..  :acb2[1]
+    beq cacc7                                                         ; 4cb4: f0 11       ..  :acb4[1]
+    cmp #$81                                                          ; 4cb6: c9 81       ..  :acb6[1]
+    bne cacc4                                                         ; 4cb8: d0 0a       ..  :acb8[1]
+    cpy #$ff                                                          ; 4cba: c0 ff       ..  :acba[1]
+    bne cacc4                                                         ; 4cbc: d0 06       ..  :acbc[1]
+    cpx #0                                                            ; 4cbe: e0 00       ..  :acbe[1]
+    bne cacc4                                                         ; 4cc0: d0 02       ..  :acc0[1]
+    dex                                                               ; 4cc2: ca          .   :acc2[1]
+    rts                                                               ; 4cc3: 60          `   :acc3[1]
+
+; $4cc4 referenced 3 times by $acb8, $acbc, $acc0
+cacc4
+    jmp l10e2                                                         ; 4cc4: 4c e2 10    L.. :acc4[1]
+
+; $4cc7 referenced 1 time by $acb4
+cacc7
+    php                                                               ; 4cc7: 08          .   :acc7[1]
+    sei                                                               ; 4cc8: 78          x   :acc8[1]
+    lda l10e3                                                         ; 4cc9: ad e3 10    ... :acc9[1]
+    sta bytev                                                         ; 4ccc: 8d 0a 02    ... :accc[1]
+    lda l10e4                                                         ; 4ccf: ad e4 10    ... :accf[1]
+    sta bytev+1                                                       ; 4cd2: 8d 0b 02    ... :acd2[1]
+    lda #0                                                            ; 4cd5: a9 00       ..  :acd5[1]
+    ldx #1                                                            ; 4cd7: a2 01       ..  :acd7[1]
+    plp                                                               ; 4cd9: 28          (   :acd9[1]
+    rts                                                               ; 4cda: 60          `   :acda[1]
+
+; $4cdb referenced 2 times by $50, $af1c
+tube_host_code2
+}
+
+; $4cdb referenced 2 times by $50, $af1c
+; $4cdb referenced 2 times by $50, $af1c
+
+!pseudopc $0500 {
+; $4cdb referenced 2 times by $50, $af1c
+l0500
+    !word          sub_c0537,          sub_c0596,          sub_c05f2  ; 4cdb: 37 05 96... 7.. :0500[3]
+    !word          sub_c0607,          sub_c0627, tube_host_osword_0  ; 4ce1: 07 06 27... ..' :0506[3]
+    !word          sub_c055e,          sub_c052d,          sub_c0520  ; 4ce7: 5e 05 2d... ^.- :050c[3]
+    !word          sub_c0542,          sub_c05a9,          sub_c05d1  ; 4ced: 42 05 a9... B.. :0512[3]
+; Table of flags used by tube_entry_small_a to set up registers 1/4
+; for the
+; selected operation.
+; $4cf3 referenced 1 time by $0453
+tube_entry_flags
+    !byte $86, $88, $96, $98, $18, $18, $82, $18                      ; 4cf3: 86 88 96... ... :0518[3]
+
+sub_c0520
+    jsr read_tube_r2_data                                             ; 4cfb: 20 c5 06     .. :0520[3]
+    tay                                                               ; 4cfe: a8          .   :0523[3]
+    jsr read_tube_r2_data                                             ; 4cff: 20 c5 06     .. :0524[3]
+    jsr osbput                                                        ; 4d02: 20 d4 ff     .. :0527[3]
+    jmp c059c                                                         ; 4d05: 4c 9c 05    L.. :052a[3]
+
+sub_c052d
+    jsr read_tube_r2_data                                             ; 4d08: 20 c5 06     .. :052d[3]
+    tay                                                               ; 4d0b: a8          .   :0530[3]
+    jsr osbget                                                        ; 4d0c: 20 d7 ff     .. :0531[3]
+    jmp c053a                                                         ; 4d0f: 4c 3a 05    L:. :0534[3]
+
+sub_c0537
+    jsr osrdch                                                        ; 4d12: 20 e0 ff     .. :0537[3]
+; $4d15 referenced 2 times by $0534, $05ef
+c053a
+    ror                                                               ; 4d15: 6a          j   :053a[3]
+    jsr write_tube_r2_data                                            ; 4d16: 20 95 06     .. :053b[3]
+    rol                                                               ; 4d19: 2a          *   :053e[3]
+    jmp c059e                                                         ; 4d1a: 4c 9e 05    L.. :053f[3]
+
+sub_c0542
+    jsr read_tube_r2_data                                             ; 4d1d: 20 c5 06     .. :0542[3]
+    beq c0552                                                         ; 4d20: f0 0b       ..  :0545[3]
+    pha                                                               ; 4d22: 48          H   :0547[3]
+    jsr sub_c0582                                                     ; 4d23: 20 82 05     .. :0548[3]
+    pla                                                               ; 4d26: 68          h   :054b[3]
+    jsr osfind                                                        ; 4d27: 20 ce ff     .. :054c[3]
+    jmp c059e                                                         ; 4d2a: 4c 9e 05    L.. :054f[3]
+
+; $4d2d referenced 1 time by $0545
+c0552
+    jsr read_tube_r2_data                                             ; 4d2d: 20 c5 06     .. :0552[3]
+    tay                                                               ; 4d30: a8          .   :0555[3]
+    lda #0                                                            ; 4d31: a9 00       ..  :0556[3]
+    jsr osfind                                                        ; 4d33: 20 ce ff     .. :0558[3]
+    jmp c059c                                                         ; 4d36: 4c 9c 05    L.. :055b[3]
+
+sub_c055e
+    jsr read_tube_r2_data                                             ; 4d39: 20 c5 06     .. :055e[3]
+    tay                                                               ; 4d3c: a8          .   :0561[3]
+    ldx #4                                                            ; 4d3d: a2 04       ..  :0562[3]
+; $4d3f referenced 1 time by $056a
+loop_c0564
+    jsr read_tube_r2_data                                             ; 4d3f: 20 c5 06     .. :0564[3]
+    sta l00ff,x                                                       ; 4d42: 95 ff       ..  :0567[3]
+    dex                                                               ; 4d44: ca          .   :0569[3]
+    bne loop_c0564                                                    ; 4d45: d0 f8       ..  :056a[3]
+    jsr read_tube_r2_data                                             ; 4d47: 20 c5 06     .. :056c[3]
+    jsr osargs                                                        ; 4d4a: 20 da ff     .. :056f[3]
+    jsr write_tube_r2_data                                            ; 4d4d: 20 95 06     .. :0572[3]
+    ldx #3                                                            ; 4d50: a2 03       ..  :0575[3]
+; $4d52 referenced 1 time by $057d
+loop_c0577
+    lda l0000,x                                                       ; 4d52: b5 00       ..  :0577[3]
+    jsr write_tube_r2_data                                            ; 4d54: 20 95 06     .. :0579[3]
+    dex                                                               ; 4d57: ca          .   :057c[3]
+    bpl loop_c0577                                                    ; 4d58: 10 f8       ..  :057d[3]
+    jmp c0036                                                         ; 4d5a: 4c 36 00    L6. :057f[3]
+
+; $4d5d referenced 3 times by $0548, $0596, $05b3
+sub_c0582
+    ldx #0                                                            ; 4d5d: a2 00       ..  :0582[3]
+    ldy #0                                                            ; 4d5f: a0 00       ..  :0584[3]
+; $4d61 referenced 1 time by $0591
+loop_c0586
+    jsr read_tube_r2_data                                             ; 4d61: 20 c5 06     .. :0586[3]
+    sta l0700,y                                                       ; 4d64: 99 00 07    ... :0589[3]
+    iny                                                               ; 4d67: c8          .   :058c[3]
+    beq c0593                                                         ; 4d68: f0 04       ..  :058d[3]
+    cmp #$0d                                                          ; 4d6a: c9 0d       ..  :058f[3]
+    bne loop_c0586                                                    ; 4d6c: d0 f3       ..  :0591[3]
+; $4d6e referenced 1 time by $058d
+c0593
+    ldy #7                                                            ; 4d6e: a0 07       ..  :0593[3]
+    rts                                                               ; 4d70: 60          `   :0595[3]
+
+sub_c0596
+    jsr sub_c0582                                                     ; 4d71: 20 82 05     .. :0596[3]
+    jsr oscli                                                         ; 4d74: 20 f7 ff     .. :0599[3]
+; $4d77 referenced 3 times by $0489, $052a, $055b
+c059c
+    lda #$7f                                                          ; 4d77: a9 7f       ..  :059c[3]
+; $4d79 referenced 4 times by $053f, $054f, $05a1, $067d
+c059e
+    bit tube_host_r2_status                                           ; 4d79: 2c e2 fe    ,.. :059e[3]
+    bvc c059e                                                         ; 4d7c: 50 fb       P.  :05a1[3]
+    sta tube_host_r2_data                                             ; 4d7e: 8d e3 fe    ... :05a3[3]
+; $4d81 referenced 1 time by $05cf
+c05a6
+    jmp c0036                                                         ; 4d81: 4c 36 00    L6. :05a6[3]
+
+sub_c05a9
+    ldx #$10                                                          ; 4d84: a2 10       ..  :05a9[3]
+; $4d86 referenced 1 time by $05b1
+loop_c05ab
+    jsr read_tube_r2_data                                             ; 4d86: 20 c5 06     .. :05ab[3]
+    sta l0001,x                                                       ; 4d89: 95 01       ..  :05ae[3]
+    dex                                                               ; 4d8b: ca          .   :05b0[3]
+    bne loop_c05ab                                                    ; 4d8c: d0 f8       ..  :05b1[3]
+    jsr sub_c0582                                                     ; 4d8e: 20 82 05     .. :05b3[3]
+    stx l0000                                                         ; 4d91: 86 00       ..  :05b6[3]
+    sty l0001                                                         ; 4d93: 84 01       ..  :05b8[3]
+    ldy #0                                                            ; 4d95: a0 00       ..  :05ba[3]
+    jsr read_tube_r2_data                                             ; 4d97: 20 c5 06     .. :05bc[3]
+    jsr osfile                                                        ; 4d9a: 20 dd ff     .. :05bf[3]
+    jsr write_tube_r2_data                                            ; 4d9d: 20 95 06     .. :05c2[3]
+    ldx #$10                                                          ; 4da0: a2 10       ..  :05c5[3]
+; $4da2 referenced 1 time by $05cd
+loop_c05c7
+    lda l0001,x                                                       ; 4da2: b5 01       ..  :05c7[3]
+    jsr write_tube_r2_data                                            ; 4da4: 20 95 06     .. :05c9[3]
+    dex                                                               ; 4da7: ca          .   :05cc[3]
+    bne loop_c05c7                                                    ; 4da8: d0 f8       ..  :05cd[3]
+    beq c05a6                                                         ; 4daa: f0 d5       ..  :05cf[3]
+sub_c05d1
+    ldx #$0d                                                          ; 4dac: a2 0d       ..  :05d1[3]
+; $4dae referenced 1 time by $05d9
+loop_c05d3
+    jsr read_tube_r2_data                                             ; 4dae: 20 c5 06     .. :05d3[3]
+    sta l00ff,x                                                       ; 4db1: 95 ff       ..  :05d6[3]
+    dex                                                               ; 4db3: ca          .   :05d8[3]
+    bne loop_c05d3                                                    ; 4db4: d0 f8       ..  :05d9[3]
+    jsr read_tube_r2_data                                             ; 4db6: 20 c5 06     .. :05db[3]
+    ldy #0                                                            ; 4db9: a0 00       ..  :05de[3]
+    jsr osgbpb                                                        ; 4dbb: 20 d1 ff     .. :05e0[3]
+    pha                                                               ; 4dbe: 48          H   :05e3[3]
+    ldx #$0c                                                          ; 4dbf: a2 0c       ..  :05e4[3]
+; $4dc1 referenced 1 time by $05ec
+loop_c05e6
+    lda l0000,x                                                       ; 4dc1: b5 00       ..  :05e6[3]
+    jsr write_tube_r2_data                                            ; 4dc3: 20 95 06     .. :05e8[3]
+    dex                                                               ; 4dc6: ca          .   :05eb[3]
+    bpl loop_c05e6                                                    ; 4dc7: 10 f8       ..  :05ec[3]
+    pla                                                               ; 4dc9: 68          h   :05ee[3]
+    jmp c053a                                                         ; 4dca: 4c 3a 05    L:. :05ef[3]
+
+sub_c05f2
+    jsr read_tube_r2_data                                             ; 4dcd: 20 c5 06     .. :05f2[3]
+    tax                                                               ; 4dd0: aa          .   :05f5[3]
+    jsr read_tube_r2_data                                             ; 4dd1: 20 c5 06     .. :05f6[3]
+    jsr osbyte                                                        ; 4dd4: 20 f4 ff     .. :05f9[3]
+; $4dd7 referenced 2 times by $05ff, $0625
+c05fc
+    bit tube_host_r2_status                                           ; 4dd7: 2c e2 fe    ,.. :05fc[3]
+sub_c05ff
+l0600 = sub_c05ff+1
+    bvc c05fc                                                         ; 4dda: 50 fb       P.  :05ff[3]
+; $4ddb referenced 1 time by $af22
+    stx tube_host_r2_data                                             ; 4ddc: 8e e3 fe    ... :0601[3]
+; $4ddf referenced 1 time by $0617
+loop_c0604
+    jmp c0036                                                         ; 4ddf: 4c 36 00    L6. :0604[3]
+
+sub_c0607
+    jsr read_tube_r2_data                                             ; 4de2: 20 c5 06     .. :0607[3]
+    tax                                                               ; 4de5: aa          .   :060a[3]
+    jsr read_tube_r2_data                                             ; 4de6: 20 c5 06     .. :060b[3]
+    tay                                                               ; 4de9: a8          .   :060e[3]
+    jsr read_tube_r2_data                                             ; 4dea: 20 c5 06     .. :060f[3]
+    jsr osbyte                                                        ; 4ded: 20 f4 ff     .. :0612[3]
+    eor #$9d                                                          ; 4df0: 49 9d       I.  :0615[3]
+    beq loop_c0604                                                    ; 4df2: f0 eb       ..  :0617[3]
+    ror                                                               ; 4df4: 6a          j   :0619[3]
+    jsr write_tube_r2_data                                            ; 4df5: 20 95 06     .. :061a[3]
+; $4df8 referenced 1 time by $0620
+loop_c061d
+    bit tube_host_r2_status                                           ; 4df8: 2c e2 fe    ,.. :061d[3]
+    bvc loop_c061d                                                    ; 4dfb: 50 fb       P.  :0620[3]
+    sty tube_host_r2_data                                             ; 4dfd: 8c e3 fe    ... :0622[3]
+    bvs c05fc                                                         ; 4e00: 70 d5       p.  :0625[3]
+sub_c0627
+    jsr read_tube_r2_data                                             ; 4e02: 20 c5 06     .. :0627[3]
+    tay                                                               ; 4e05: a8          .   :062a[3]
+; $4e06 referenced 1 time by $062e
+loop_c062b
+    bit tube_host_r2_status                                           ; 4e06: 2c e2 fe    ,.. :062b[3]
+    bpl loop_c062b                                                    ; 4e09: 10 fb       ..  :062e[3]
+    ldx tube_host_r2_data                                             ; 4e0b: ae e3 fe    ... :0630[3]
+    dex                                                               ; 4e0e: ca          .   :0633[3]
+    bmi c0645                                                         ; 4e0f: 30 0f       0.  :0634[3]
+; $4e11 referenced 2 times by $0639, $0642
+c0636
+    bit tube_host_r2_status                                           ; 4e11: 2c e2 fe    ,.. :0636[3]
+    bpl c0636                                                         ; 4e14: 10 fb       ..  :0639[3]
+    lda tube_host_r2_data                                             ; 4e16: ad e3 fe    ... :063b[3]
+    sta l0128,x                                                       ; 4e19: 9d 28 01    .(. :063e[3]
+    dex                                                               ; 4e1c: ca          .   :0641[3]
+    bpl c0636                                                         ; 4e1d: 10 f2       ..  :0642[3]
+    tya                                                               ; 4e1f: 98          .   :0644[3]
+; $4e20 referenced 1 time by $0634
+c0645
+    ldx #<(l0128)                                                     ; 4e20: a2 28       .(  :0645[3]
+    ldy #>(l0128)                                                     ; 4e22: a0 01       ..  :0647[3]
+    jsr osword                                                        ; 4e24: 20 f1 ff     .. :0649[3]
+; $4e27 referenced 1 time by $064f
+loop_c064c
+    bit tube_host_r2_status                                           ; 4e27: 2c e2 fe    ,.. :064c[3]
+    bpl loop_c064c                                                    ; 4e2a: 10 fb       ..  :064f[3]
+    ldx tube_host_r2_data                                             ; 4e2c: ae e3 fe    ... :0651[3]
+    dex                                                               ; 4e2f: ca          .   :0654[3]
+    bmi c0665                                                         ; 4e30: 30 0e       0.  :0655[3]
+; $4e32 referenced 1 time by $0663
+loop_c0657
+    ldy l0128,x                                                       ; 4e32: bc 28 01    .(. :0657[3]
+; $4e35 referenced 1 time by $065d
+loop_c065a
+    bit tube_host_r2_status                                           ; 4e35: 2c e2 fe    ,.. :065a[3]
+    bvc loop_c065a                                                    ; 4e38: 50 fb       P.  :065d[3]
+    sty tube_host_r2_data                                             ; 4e3a: 8c e3 fe    ... :065f[3]
+    dex                                                               ; 4e3d: ca          .   :0662[3]
+    bpl loop_c0657                                                    ; 4e3e: 10 f2       ..  :0663[3]
+; $4e40 referenced 1 time by $0655
+c0665
+    jmp c0036                                                         ; 4e40: 4c 36 00    L6. :0665[3]
+
+tube_host_osword_0
+    ldx #4                                                            ; 4e43: a2 04       ..  :0668[3]
+; $4e45 referenced 1 time by $0670
+tube_host_osword_0_loop
+    jsr read_tube_r2_data                                             ; 4e45: 20 c5 06     .. :066a[3]
+    sta l0000,x                                                       ; 4e48: 95 00       ..  :066d[3]
+    dex                                                               ; 4e4a: ca          .   :066f[3]
+    bpl tube_host_osword_0_loop                                       ; 4e4b: 10 f8       ..  :0670[3]
+    inx                                                               ; 4e4d: e8          .   :0672[3]
+    ldy #0                                                            ; 4e4e: a0 00       ..  :0673[3]
+    txa                                                               ; 4e50: 8a          .   :0675[3]
+    jsr osword                                                        ; 4e51: 20 f1 ff     .. :0676[3]
+    bcc tube_host_osword_0_no_escape                                  ; 4e54: 90 05       ..  :0679[3]
+    lda #$ff                                                          ; 4e56: a9 ff       ..  :067b[3]
+    jmp c059e                                                         ; 4e58: 4c 9e 05    L.. :067d[3]
+
+; $4e5b referenced 1 time by $0679
+tube_host_osword_0_no_escape
+    ldx #0                                                            ; 4e5b: a2 00       ..  :0680[3]
+    lda #$7f                                                          ; 4e5d: a9 7f       ..  :0682[3]
+    jsr write_tube_r2_data                                            ; 4e5f: 20 95 06     .. :0684[3]
+; $4e62 referenced 1 time by $0690
+tube_host_osword_0_no_escape_loop
+    lda l0700,x                                                       ; 4e62: bd 00 07    ... :0687[3]
+    jsr write_tube_r2_data                                            ; 4e65: 20 95 06     .. :068a[3]
+    inx                                                               ; 4e68: e8          .   :068d[3]
+    cmp #$0d                                                          ; 4e69: c9 0d       ..  :068e[3]
+    bne tube_host_osword_0_no_escape_loop                             ; 4e6b: d0 f5       ..  :0690[3]
+    jmp c0036                                                         ; 4e6d: 4c 36 00    L6. :0692[3]
+
+; Wait for register 2 to have space and write A to it.
+; $4e70 referenced 14 times by $0474, $053b, $0572, $0579, $05c2, $05c9, $05e8, $061a, $0684, $068a, $0698, $20, $26, $2c
+write_tube_r2_data
+    bit tube_host_r2_status                                           ; 4e70: 2c e2 fe    ,.. :0695[3]
+    bvc write_tube_r2_data                                            ; 4e73: 50 fb       P.  :0698[3]
+    sta tube_host_r2_data                                             ; 4e75: 8d e3 fe    ... :069a[3]
+    rts                                                               ; 4e78: 60          `   :069d[3]
+
+; Wait for register 4 to have space and write A to it.
+; $4e79 referenced 8 times by $0418, $041d, $043b, $0443, $0448, $0463, $06a1, $18
+write_tube_r4_data
+    bit tube_host_r4_status                                           ; 4e79: 2c e6 fe    ,.. :069e[3]
+    bvc write_tube_r4_data                                            ; 4e7c: 50 fb       P.  :06a1[3]
+    sta tube_host_r4_data                                             ; 4e7e: 8d e7 fe    ... :06a3[3]
+    rts                                                               ; 4e81: 60          `   :06a6[3]
+
+; $4e82 referenced 1 time by $0403
+c06a7
+    lda l00ff                                                         ; 4e82: a5 ff       ..  :06a7[3]
+    sec                                                               ; 4e84: 38          8   :06a9[3]
+    ror                                                               ; 4e85: 6a          j   :06aa[3]
+    bmi write_tube_r1_data                                            ; 4e86: 30 0f       0.  :06ab[3]
+tube_evntv_handler
+    pha                                                               ; 4e88: 48          H   :06ad[3]
+    lda #0                                                            ; 4e89: a9 00       ..  :06ae[3]
+    jsr write_tube_r1_data                                            ; 4e8b: 20 bc 06     .. :06b0[3]
+    tya                                                               ; 4e8e: 98          .   :06b3[3]
+    jsr write_tube_r1_data                                            ; 4e8f: 20 bc 06     .. :06b4[3]
+    txa                                                               ; 4e92: 8a          .   :06b7[3]
+    jsr write_tube_r1_data                                            ; 4e93: 20 bc 06     .. :06b8[3]
+    pla                                                               ; 4e96: 68          h   :06bb[3]
+; Wait for register 1 to have space and write A to it.
+; $4e97 referenced 5 times by $06ab, $06b0, $06b4, $06b8, $06bf
+write_tube_r1_data
+    bit tube_host_r1_status                                           ; 4e97: 2c e0 fe    ,.. :06bc[3]
+    bvc write_tube_r1_data                                            ; 4e9a: 50 fb       P.  :06bf[3]
+    sta tube_host_r1_data                                             ; 4e9c: 8d e1 fe    ... :06c1[3]
+    rts                                                               ; 4e9f: 60          `   :06c4[3]
+
+; Wait for register 2 to have data and read A from it.
+; $4ea0 referenced 21 times by $0520, $0524, $052d, $0542, $0552, $055e, $0564, $056c, $0586, $05ab, $05bc, $05d3, $05db, $05f2, $05f6, $0607, $060b, $060f, $0627, $066a, $06c8
+read_tube_r2_data
+    bit tube_host_r2_status                                           ; 4ea0: 2c e2 fe    ,.. :06c5[3]
+    bpl read_tube_r2_data                                             ; 4ea3: 10 fb       ..  :06c8[3]
+    lda tube_host_r2_data                                             ; 4ea5: ad e3 fe    ... :06ca[3]
+    rts                                                               ; 4ea8: 60          `   :06cd[3]
+
+; $4ea9 referenced 1 time by $965d
+}
+
+; $4ea9 referenced 1 time by $965d
+; $4ea9 referenced 1 time by $965d
+
+!pseudopc $aea9 {
+; $4ea9 referenced 1 time by $965d
+service_handler_help_and_tube
+    cmp #service_help                                                 ; 4ea9: c9 09       ..  :aea9[1]
+    bne caed7                                                         ; 4eab: d0 2a       .*  :aeab[1]
+    tya                                                               ; 4ead: 98          .   :aead[1]
+    pha                                                               ; 4eae: 48          H   :aeae[1]
+    lda (os_text_ptr),y                                               ; 4eaf: b1 f2       ..  :aeaf[1]
+    cmp #$0d                                                          ; 4eb1: c9 0d       ..  :aeb1[1]
+    bne caed3                                                         ; 4eb3: d0 1e       ..  :aeb3[1]
+    lda #$e9                                                          ; 4eb5: a9 e9       ..  :aeb5[1]
+    jsr osbyte_read                                                   ; 4eb7: 20 e5 9a     .. :aeb7[1]
+    ldx romsel_copy                                                   ; 4eba: a6 f4       ..  :aeba[1]
+    tya                                                               ; 4ebc: 98          .   :aebc[1]
+    beq caed3                                                         ; 4ebd: f0 14       ..  :aebd[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4ebf: 20 77 80     w. :aebf[1]
+    !text $0d, "TUBE HOST 2.30", $0d                                  ; 4ec2: 0d 54 55... .TU :aec2[1]
+
+    nop                                                               ; 4ed2: ea          .   :aed2[1]
+; $4ed3 referenced 2 times by $aeb3, $aebd
+caed3
+    pla                                                               ; 4ed3: 68          h   :aed3[1]
+    tay                                                               ; 4ed4: a8          .   :aed4[1]
+    lda #9                                                            ; 4ed5: a9 09       ..  :aed5[1]
+; $4ed7 referenced 1 time by $aeab
+caed7
+    cmp #service_tube_post_init                                       ; 4ed7: c9 fe       ..  :aed7[1]
+    bcc just_rts                                                      ; 4ed9: 90 5c       .\  :aed9[1]
+    bne service_handler_tube_main_init                                ; 4edb: d0 1b       ..  :aedb[1]
+    cpy #0                                                            ; 4edd: c0 00       ..  :aedd[1]
+    beq just_rts                                                      ; 4edf: f0 56       .V  :aedf[1]
+    ldx #6                                                            ; 4ee1: a2 06       ..  :aee1[1]
+    lda #osbyte_explode_chars                                         ; 4ee3: a9 14       ..  :aee3[1]
+    jsr osbyte                                                        ; 4ee5: 20 f4 ff     .. :aee5[1]
+; $4ee8 referenced 2 times by $aeeb, $aef5
+tube_banner_loop
+    bit tube_host_r1_status                                           ; 4ee8: 2c e0 fe    ,.. :aee8[1]
+    bpl tube_banner_loop                                              ; 4eeb: 10 fb       ..  :aeeb[1]
+    lda tube_host_r1_data                                             ; 4eed: ad e1 fe    ... :aeed[1]
+    beq lda_0_rts                                                     ; 4ef0: f0 43       .C  :aef0[1]
+    jsr oswrch                                                        ; 4ef2: 20 ee ff     .. :aef2[1]
+    jmp tube_banner_loop                                              ; 4ef5: 4c e8 ae    L.. :aef5[1]
+
+; $4ef8 referenced 1 time by $aedb
+service_handler_tube_main_init
+    lda #<tube_evntv_handler                                          ; 4ef8: a9 ad       ..  :aef8[1]
+    sta evntv                                                         ; 4efa: 8d 20 02    . . :aefa[1]
+    lda #>tube_evntv_handler                                          ; 4efd: a9 06       ..  :aefd[1]
+    sta evntv+1                                                       ; 4eff: 8d 21 02    .!. :aeff[1]
+    lda #<tube_brkv_handler                                           ; 4f02: a9 16       ..  :af02[1]
+    sta brkv                                                          ; 4f04: 8d 02 02    ... :af04[1]
+    lda #>tube_brkv_handler                                           ; 4f07: a9 00       ..  :af07[1]
+    sta brkv+1                                                        ; 4f09: 8d 03 02    ... :af09[1]
+    lda #$8e                                                          ; 4f0c: a9 8e       ..  :af0c[1]
+    sta tube_host_r1_status                                           ; 4f0e: 8d e0 fe    ... :af0e[1]
+    ldy #0                                                            ; 4f11: a0 00       ..  :af11[1]
+; $4f13 referenced 1 time by $af26
+loop_caf13
+    lda tube_host_code1,y                                             ; 4f13: b9 79 af    .y. :af13[1]
+    sta c0400,y                                                       ; 4f16: 99 00 04    ... :af16[1]
+    lda tube_host_code2,y                                             ; 4f19: b9 db ac    ... :af19[1]
+    sta l0500,y                                                       ; 4f1c: 99 00 05    ... :af1c[1]
+    lda tube_host_code2+256,y                                         ; 4f1f: b9 db ad    ... :af1f[1]
+    sta l0600,y                                                       ; 4f22: 99 00 06    ... :af22[1]
+    dey                                                               ; 4f25: 88          .   :af25[1]
+    bne loop_caf13                                                    ; 4f26: d0 eb       ..  :af26[1]
+    jsr sub_c0421                                                     ; 4f28: 20 21 04     !. :af28[1]
+    ldx #$41 ; 'A'                                                    ; 4f2b: a2 41       .A  :af2b[1]
+; $4f2d referenced 1 time by $af33
+loop_caf2d
+    lda tube_host_code3,x                                             ; 4f2d: bd 38 af    .8. :af2d[1]
+    sta tube_brkv_handler_fwd,x                                       ; 4f30: 95 16       ..  :af30[1]
+    dex                                                               ; 4f32: ca          .   :af32[1]
+    bpl loop_caf2d                                                    ; 4f33: 10 f8       ..  :af33[1]
+; $4f35 referenced 1 time by $aef0
+lda_0_rts
+    lda #0                                                            ; 4f35: a9 00       ..  :af35[1]
+; $4f37 referenced 2 times by $aed9, $aedf
+just_rts
+    rts                                                               ; 4f37: 60          `   :af37[1]
+
+; $4f38 referenced 1 time by $af30
+tube_host_code3
+}
+
+; $4f38 referenced 1 time by $af30
+; $4f38 referenced 1 time by $af30
+
+!pseudopc $16 {
+; $4f38 referenced 1 time by $af30
+tube_brkv_handler
+    lda #$ff                                                          ; 4f38: a9 ff       ..  :0016[4]
+    jsr write_tube_r4_data                                            ; 4f3a: 20 9e 06     .. :0018[4]
+    lda tube_host_r2_data                                             ; 4f3d: ad e3 fe    ... :001b[4]
+    lda #0                                                            ; 4f40: a9 00       ..  :001e[4]
+    jsr write_tube_r2_data                                            ; 4f42: 20 95 06     .. :0020[4]
+    tay                                                               ; 4f45: a8          .   :0023[4]
+    lda (l00fd),y                                                     ; 4f46: b1 fd       ..  :0024[4]
+    jsr write_tube_r2_data                                            ; 4f48: 20 95 06     .. :0026[4]
+; $4f4b referenced 1 time by $30
+loop_c0029
+    iny                                                               ; 4f4b: c8          .   :0029[4]
+    lda (l00fd),y                                                     ; 4f4c: b1 fd       ..  :002a[4]
+    jsr write_tube_r2_data                                            ; 4f4e: 20 95 06     .. :002c[4]
+    tax                                                               ; 4f51: aa          .   :002f[4]
+    bne loop_c0029                                                    ; 4f52: d0 f7       ..  :0030[4]
+; $4f54 referenced 1 time by $0477
+c0032
+    ldx #$ff                                                          ; 4f54: a2 ff       ..  :0032[4]
+    txs                                                               ; 4f56: 9a          .   :0034[4]
+    cli                                                               ; 4f57: 58          X   :0035[4]
+; $4f58 referenced 6 times by $057f, $05a6, $0604, $0665, $0692, $44
+c0036
+    bit tube_host_r1_status                                           ; 4f58: 2c e0 fe    ,.. :0036[4]
+    bpl c0041                                                         ; 4f5b: 10 06       ..  :0039[4]
+; $4f5d referenced 1 time by $49
+loop_c003b
+    lda tube_host_r1_data                                             ; 4f5d: ad e1 fe    ... :003b[4]
+    jsr oswrch                                                        ; 4f60: 20 ee ff     .. :003e[4]
+; $4f63 referenced 1 time by $39
+c0041
+    bit tube_host_r2_status                                           ; 4f63: 2c e2 fe    ,.. :0041[4]
+    bpl c0036                                                         ; 4f66: 10 f0       ..  :0044[4]
+    bit tube_host_r1_status                                           ; 4f68: 2c e0 fe    ,.. :0046[4]
+    bmi loop_c003b                                                    ; 4f6b: 30 f0       0.  :0049[4]
+    ldx tube_host_r2_data                                             ; 4f6d: ae e3 fe    ... :004b[4]
+; Patch the following JMP so we effectively do JMP (&500,X)
+    stx <jump_address_low                                             ; 4f70: 86 51       .Q  :004e[4]
+sub_c0050
+jump_address_low = sub_c0050+1
+    jmp (l0500)                                                       ; 4f72: 6c 00 05    l.. :0050[4]
+
+; $4f73 referenced 1 time by $4e
+; $4f75 referenced 2 times by $04da, $04ea
+l0053
+    !byte 0                                                           ; 4f75: 00          .   :0053[4]
+; $4f76 referenced 3 times by $04b2, $04d0, $04ef
+l0054
+    !byte $80                                                         ; 4f76: 80          .   :0054[4]
+; $4f77 referenced 2 times by $04b6, $04f9
+l0055
+    !byte 0                                                           ; 4f77: 00          .   :0055[4]
+; $4f78 referenced 2 times by $04ba, $04f7
+l0056
+    !byte 0                                                           ; 4f78: 00          .   :0056[4]
+; $4f79 referenced 1 time by $af16
+}
+
+; $4f79 referenced 1 time by $af16
+; $4f79 referenced 1 time by $af16
+
+!pseudopc $0400 {
+; $4f79 referenced 1 time by $af16
+c0400
+    jmp c0484                                                         ; 4f79: 4c 84 04    L.. :0400[2]
+
+    jmp c06a7                                                         ; 4f7c: 4c a7 06    L.. :0403[2]
+
+; $4f7f referenced 14 times by $0493, $04cb, $892a, $8cae, $8f6e, $8f7d, $9346, $982b, $bd64, $bd91, $be09, $be2c, $be7d, $be85
+tube_entry
+    cmp #$80                                                          ; 4f7f: c9 80       ..  :0406[2]
+    bcc tube_entry_small_a                                            ; 4f81: 90 2b       .+  :0408[2]
+    cmp #$c0                                                          ; 4f83: c9 c0       ..  :040a[2]
+    bcs tube_entry_claim_tube                                         ; 4f85: b0 1a       ..  :040c[2]
+; This is a call to release the tube.
+    ora #$40 ; '@'                                                    ; 4f87: 09 40       .@  :040e[2]
+    cmp l0015                                                         ; 4f89: c5 15       ..  :0410[2]
+    bne c0434                                                         ; 4f8b: d0 20       .   :0412[2]
+; $4f8d referenced 1 time by $0471
+sub_c0414
+    php                                                               ; 4f8d: 08          .   :0414[2]
+    sei                                                               ; 4f8e: 78          x   :0415[2]
+    lda #5                                                            ; 4f8f: a9 05       ..  :0416[2]
+    jsr write_tube_r4_data                                            ; 4f91: 20 9e 06     .. :0418[2]
+    lda l0015                                                         ; 4f94: a5 15       ..  :041b[2]
+    jsr write_tube_r4_data                                            ; 4f96: 20 9e 06     .. :041d[2]
+    plp                                                               ; 4f99: 28          (   :0420[2]
+; $4f9a referenced 1 time by $af28
+sub_c0421
+    lda #$80                                                          ; 4f9a: a9 80       ..  :0421[2]
+    sta l0015                                                         ; 4f9c: 85 15       ..  :0423[2]
+    sta l0014                                                         ; 4f9e: 85 14       ..  :0425[2]
+    rts                                                               ; 4fa0: 60          `   :0427[2]
+
+; $4fa1 referenced 1 time by $040c
+tube_entry_claim_tube
+    asl l0014                                                         ; 4fa1: 06 14       ..  :0428[2]
+    bcs c0432                                                         ; 4fa3: b0 06       ..  :042a[2]
+    cmp l0015                                                         ; 4fa5: c5 15       ..  :042c[2]
+    beq c0434                                                         ; 4fa7: f0 04       ..  :042e[2]
+    clc                                                               ; 4fa9: 18          .   :0430[2]
+    rts                                                               ; 4faa: 60          `   :0431[2]
+
+; $4fab referenced 1 time by $042a
+c0432
+    sta l0015                                                         ; 4fab: 85 15       ..  :0432[2]
+; $4fad referenced 2 times by $0412, $042e
+c0434
+    rts                                                               ; 4fad: 60          `   :0434[2]
+
+; $4fae referenced 1 time by $0408
+tube_entry_small_a
+    php                                                               ; 4fae: 08          .   :0435[2]
+    sei                                                               ; 4faf: 78          x   :0436[2]
+    sty l0013                                                         ; 4fb0: 84 13       ..  :0437[2]
+    stx l0012                                                         ; 4fb2: 86 12       ..  :0439[2]
+    jsr write_tube_r4_data                                            ; 4fb4: 20 9e 06     .. :043b[2]
+    tax                                                               ; 4fb7: aa          .   :043e[2]
+    ldy #3                                                            ; 4fb8: a0 03       ..  :043f[2]
+    lda l0015                                                         ; 4fba: a5 15       ..  :0441[2]
+    jsr write_tube_r4_data                                            ; 4fbc: 20 9e 06     .. :0443[2]
+; $4fbf referenced 1 time by $044c
+loop_c0446
+    lda (l0012),y                                                     ; 4fbf: b1 12       ..  :0446[2]
+    jsr write_tube_r4_data                                            ; 4fc1: 20 9e 06     .. :0448[2]
+    dey                                                               ; 4fc4: 88          .   :044b[2]
+    bpl loop_c0446                                                    ; 4fc5: 10 f8       ..  :044c[2]
+    ldy #$18                                                          ; 4fc7: a0 18       ..  :044e[2]
+    sty tube_host_r1_status                                           ; 4fc9: 8c e0 fe    ... :0450[2]
+    lda tube_entry_flags,x                                            ; 4fcc: bd 18 05    ... :0453[2]
+    sta tube_host_r1_status                                           ; 4fcf: 8d e0 fe    ... :0456[2]
+    lsr                                                               ; 4fd2: 4a          J   :0459[2]
+    lsr                                                               ; 4fd3: 4a          J   :045a[2]
+    bcc c0463                                                         ; 4fd4: 90 06       ..  :045b[2]
+    bit tube_host_r3_data                                             ; 4fd6: 2c e5 fe    ,.. :045d[2]
+    bit tube_host_r3_data                                             ; 4fd9: 2c e5 fe    ,.. :0460[2]
+; $4fdc referenced 1 time by $045b
+c0463
+    jsr write_tube_r4_data                                            ; 4fdc: 20 9e 06     .. :0463[2]
+; $4fdf referenced 1 time by $0469
+loop_c0466
+    bit tube_host_r4_status                                           ; 4fdf: 2c e6 fe    ,.. :0466[2]
+    bvc loop_c0466                                                    ; 4fe2: 50 fb       P.  :0469[2]
+    bcs c047a                                                         ; 4fe4: b0 0d       ..  :046b[2]
+    cpx #4                                                            ; 4fe6: e0 04       ..  :046d[2]
+    bne c0482                                                         ; 4fe8: d0 11       ..  :046f[2]
+; $4fea referenced 1 time by $048f
+loop_c0471
+    jsr sub_c0414                                                     ; 4fea: 20 14 04     .. :0471[2]
+    jsr write_tube_r2_data                                            ; 4fed: 20 95 06     .. :0474[2]
+    jmp c0032                                                         ; 4ff0: 4c 32 00    L2. :0477[2]
+
+; $4ff3 referenced 1 time by $046b
+c047a
+    lsr                                                               ; 4ff3: 4a          J   :047a[2]
+    bcc c0482                                                         ; 4ff4: 90 05       ..  :047b[2]
+    ldy #$88                                                          ; 4ff6: a0 88       ..  :047d[2]
+    sty tube_host_r1_status                                           ; 4ff8: 8c e0 fe    ... :047f[2]
+; $4ffb referenced 2 times by $046f, $047b
+c0482
+    plp                                                               ; 4ffb: 28          (   :0482[2]
+    rts                                                               ; 4ffc: 60          `   :0483[2]
+
+; $4ffd referenced 1 time by $0400
+c0484
+    cli                                                               ; 4ffd: 58          X   :0484[2]
+    bcs c0491                                                         ; 4ffe: b0 0a       ..  :0485[2]
+    bne c048c                                                         ; 5000: d0 03       ..  :0487[2]
+    jmp c059c                                                         ; 5002: 4c 9c 05    L.. :0489[2]
+
+; $5005 referenced 1 time by $0487
+c048c
+    ldx l028d                                                         ; 5005: ae 8d 02    ... :048c[2]
+    beq loop_c0471                                                    ; 5008: f0 e0       ..  :048f[2]
+; $500a referenced 2 times by $0485, $0496
+c0491
+    lda #$ff                                                          ; 500a: a9 ff       ..  :0491[2]
+    jsr tube_entry                                                    ; 500c: 20 06 04     .. :0493[2]
+    bcc c0491                                                         ; 500f: 90 f9       ..  :0496[2]
+    jsr sub_c04ce                                                     ; 5011: 20 ce 04     .. :0498[2]
+; $5014 referenced 1 time by $04c0
+c049b
+    php                                                               ; 5014: 08          .   :049b[2]
+    sei                                                               ; 5015: 78          x   :049c[2]
+    lda #7                                                            ; 5016: a9 07       ..  :049d[2]
+    jsr sub_c04c7                                                     ; 5018: 20 c7 04     .. :049f[2]
+    ldy #0                                                            ; 501b: a0 00       ..  :04a2[2]
+    sty l0000                                                         ; 501d: 84 00       ..  :04a4[2]
+; $501f referenced 1 time by $04af
+loop_c04a6
+    lda (l0000),y                                                     ; 501f: b1 00       ..  :04a6[2]
+    sta tube_host_r3_data                                             ; 5021: 8d e5 fe    ... :04a8[2]
+    nop                                                               ; 5024: ea          .   :04ab[2]
+    nop                                                               ; 5025: ea          .   :04ac[2]
+    nop                                                               ; 5026: ea          .   :04ad[2]
+    iny                                                               ; 5027: c8          .   :04ae[2]
+    bne loop_c04a6                                                    ; 5028: d0 f5       ..  :04af[2]
+    plp                                                               ; 502a: 28          (   :04b1[2]
+    inc l0054                                                         ; 502b: e6 54       .T  :04b2[2]
+    bne c04bc                                                         ; 502d: d0 06       ..  :04b4[2]
+    inc l0055                                                         ; 502f: e6 55       .U  :04b6[2]
+    bne c04bc                                                         ; 5031: d0 02       ..  :04b8[2]
+    inc l0056                                                         ; 5033: e6 56       .V  :04ba[2]
+; $5035 referenced 2 times by $04b4, $04b8
+c04bc
+    inc l0001                                                         ; 5035: e6 01       ..  :04bc[2]
+    bit l0001                                                         ; 5037: 24 01       $.  :04be[2]
+    bvc c049b                                                         ; 5039: 50 d9       P.  :04c0[2]
+    jsr sub_c04ce                                                     ; 503b: 20 ce 04     .. :04c2[2]
+    lda #4                                                            ; 503e: a9 04       ..  :04c5[2]
+; $5040 referenced 1 time by $049f
+sub_c04c7
+    ldy #0                                                            ; 5040: a0 00       ..  :04c7[2]
+    ldx #$53 ; 'S'                                                    ; 5042: a2 53       .S  :04c9[2]
+    jmp tube_entry                                                    ; 5044: 4c 06 04    L.. :04cb[2]
+
+; $5047 referenced 2 times by $0498, $04c2
+sub_c04ce
+    lda #$80                                                          ; 5047: a9 80       ..  :04ce[2]
+    sta l0054                                                         ; 5049: 85 54       .T  :04d0[2]
+    sta l0001                                                         ; 504b: 85 01       ..  :04d2[2]
+    lda #$20 ; ' '                                                    ; 504d: a9 20       .   :04d4[2]
+    and rom_type                                                      ; 504f: 2d 06 80    -.. :04d6[2]
+    tay                                                               ; 5052: a8          .   :04d9[2]
+    sty l0053                                                         ; 5053: 84 53       .S  :04da[2]
+    beq c04f7                                                         ; 5055: f0 19       ..  :04dc[2]
+    ldx copyright_offset                                              ; 5057: ae 07 80    ... :04de[2]
+; $505a referenced 1 time by $04e5
+loop_c04e1
+    inx                                                               ; 505a: e8          .   :04e1[2]
+    lda rom_header,x                                                  ; 505b: bd 00 80    ... :04e2[2]
+    bne loop_c04e1                                                    ; 505e: d0 fa       ..  :04e5[2]
+    lda l8001,x                                                       ; 5060: bd 01 80    ... :04e7[2]
+    sta l0053                                                         ; 5063: 85 53       .S  :04ea[2]
+    lda l8002,x                                                       ; 5065: bd 02 80    ... :04ec[2]
+    sta l0054                                                         ; 5068: 85 54       .T  :04ef[2]
+    ldy service_entry,x                                               ; 506a: bc 03 80    ... :04f1[2]
+    lda l8004,x                                                       ; 506d: bd 04 80    ... :04f4[2]
+; $5070 referenced 1 time by $04dc
+c04f7
+    sta l0056                                                         ; 5070: 85 56       .V  :04f7[2]
+    sty l0055                                                         ; 5072: 84 55       .U  :04f9[2]
+    rts                                                               ; 5074: 60          `   :04fb[2]
+
+; $5075 referenced 1 time by $b2b4
+}
+
+; $5075 referenced 1 time by $b2b4
+; $5075 referenced 1 time by $b2b4
+
+!pseudopc $b075 {
+; $5075 referenced 1 time by $b2b4
+lb075
+    !byte $0a                                                         ; 5075: 0a          .   :b075[1]
+    !text "SRAM 1.05"                                                 ; 5076: 53 52 41... SRA :b076[1]
+    !byte $0d, $0a                                                    ; 507f: 0d 0a       ..  :b07f[1]
+    !text "  SRDATA  <id.>"                                           ; 5081: 20 20 53...   S :b081[1]
+    !byte $0d, $0a                                                    ; 5090: 0d 0a       ..  :b090[1]
+    !text "  SRLOAD  <filename> <sram address> (<id.>) (Q)"           ; 5092: 20 20 53...   S :b092[1]
+    !byte $0d, $0a                                                    ; 50c1: 0d 0a       ..  :b0c1[1]
+    !text "  SRREAD  <dest. start> <dest. end> <sram start> (<id.>"   ; 50c3: 20 20 53...   S :b0c3[1]
+    !text ")"                                                         ; 50fa: 29          )   :b0fa[1]
+    !byte $0d, $0a                                                    ; 50fb: 0d 0a       ..  :b0fb[1]
+    !text "  SRROM   <id.>"                                           ; 50fd: 20 20 53...   S :b0fd[1]
+    !byte $0d, $0a                                                    ; 510c: 0d 0a       ..  :b10c[1]
+    !text "  SRSAVE  <filename> <sram start> <sram end> (<id.>) (Q"   ; 510e: 20 20 53...   S :b10e[1]
+    !text ")"                                                         ; 5145: 29          )   :b145[1]
+    !byte $0d, $0a                                                    ; 5146: 0d 0a       ..  :b146[1]
+    !text "  SRWRITE <source start> <source end> <sram s"             ; 5148: 20 20 53...   S :b148[1]
+; $5175 referenced 1 time by $b2bd
+lb175
+    !text "tart> (<id.>)"                                             ; 5175: 74 61 72... tar :b175[1]
+    !byte $0d, $0a                                                    ; 5182: 0d 0a       ..  :b182[1]
+    !text "End addresses may be replaced by +<length>"                ; 5184: 45 6e 64... End :b184[1]
+    !byte $0d, $0a,   0                                               ; 51ae: 0d 0a 00    ... :b1ae[1]
+
+; $51b1 referenced 1 time by $bedd
+general_service_handler
+    jsr sub_c965d                                                     ; 51b1: 20 5d 96     ]. :b1b1[1]
+    pha                                                               ; 51b4: 48          H   :b1b4[1]
+    tax                                                               ; 51b5: aa          .   :b1b5[1]
+    lda l00b8                                                         ; 51b6: a5 b8       ..  :b1b6[1]
+    pha                                                               ; 51b8: 48          H   :b1b8[1]
+    lda l00b9                                                         ; 51b9: a5 b9       ..  :b1b9[1]
+    pha                                                               ; 51bb: 48          H   :b1bb[1]
+    tya                                                               ; 51bc: 98          .   :b1bc[1]
+    pha                                                               ; 51bd: 48          H   :b1bd[1]
+    txa                                                               ; 51be: 8a          .   :b1be[1]
+    ldx romsel_copy                                                   ; 51bf: a6 f4       ..  :b1bf[1]
+    jsr cb82b                                                         ; 51c1: 20 2b b8     +. :b1c1[1]
+    bit l00b9                                                         ; 51c4: 24 b9       $.  :b1c4[1]
+    bmi cb203                                                         ; 51c6: 30 3b       0;  :b1c6[1]
+    cmp #8                                                            ; 51c8: c9 08       ..  :b1c8[1]
+    bne cb1fc                                                         ; 51ca: d0 30       .0  :b1ca[1]
+    lda l00ef                                                         ; 51cc: a5 ef       ..  :b1cc[1]
+    cmp #$43 ; 'C'                                                    ; 51ce: c9 43       .C  :b1ce[1]
+    bne cb1dd                                                         ; 51d0: d0 0b       ..  :b1d0[1]
+    jsr sub_cb2c8                                                     ; 51d2: 20 c8 b2     .. :b1d2[1]
+; $51d5 referenced 3 times by $b1f9, $b231, $b25d
+cb1d5
+    tsx                                                               ; 51d5: ba          .   :b1d5[1]
+    lda #0                                                            ; 51d6: a9 00       ..  :b1d6[1]
+    sta l0104,x                                                       ; 51d8: 9d 04 01    ... :b1d8[1]
+    beq cb203                                                         ; 51db: f0 26       .&  :b1db[1]
+; $51dd referenced 1 time by $b1d0
+cb1dd
+    cmp #$42 ; 'B'                                                    ; 51dd: c9 42       .B  :b1dd[1]
+    bne cb203                                                         ; 51df: d0 22       ."  :b1df[1]
+    ldy #9                                                            ; 51e1: a0 09       ..  :b1e1[1]
+; $51e3 referenced 1 time by $b1eb
+loop_cb1e3
+    lda (l00f0),y                                                     ; 51e3: b1 f0       ..  :b1e3[1]
+    sta l00b4,y                                                       ; 51e5: 99 b4 00    ... :b1e5[1]
+    dey                                                               ; 51e8: 88          .   :b1e8[1]
+    cpy #8                                                            ; 51e9: c0 08       ..  :b1e9[1]
+    bcs loop_cb1e3                                                    ; 51eb: b0 f6       ..  :b1eb[1]
+; $51ed referenced 1 time by $b1f3
+loop_cb1ed
+    lda (l00f0),y                                                     ; 51ed: b1 f0       ..  :b1ed[1]
+    sta l00b0,y                                                       ; 51ef: 99 b0 00    ... :b1ef[1]
+    dey                                                               ; 51f2: 88          .   :b1f2[1]
+    bpl loop_cb1ed                                                    ; 51f3: 10 f8       ..  :b1f3[1]
+    cli                                                               ; 51f5: 58          X   :b1f5[1]
+    jsr cbcb9                                                         ; 51f6: 20 b9 bc     .. :b1f6[1]
+    jmp cb1d5                                                         ; 51f9: 4c d5 b1    L.. :b1f9[1]
+
+; $51fc referenced 1 time by $b1ca
+cb1fc
+    cmp #2                                                            ; 51fc: c9 02       ..  :b1fc[1]
+    bne cb20f                                                         ; 51fe: d0 0f       ..  :b1fe[1]
+    jsr sub_cb882                                                     ; 5200: 20 82 b8     .. :b200[1]
+; $5203 referenced 10 times by $b1c6, $b1db, $b1df, $b219, $b21e, $b228, $b22c, $b262, $b26a, $b280
+cb203
+    pla                                                               ; 5203: 68          h   :b203[1]
+    tay                                                               ; 5204: a8          .   :b204[1]
+    pla                                                               ; 5205: 68          h   :b205[1]
+    sta l00b9                                                         ; 5206: 85 b9       ..  :b206[1]
+    pla                                                               ; 5208: 68          h   :b208[1]
+    sta l00b8                                                         ; 5209: 85 b8       ..  :b209[1]
+    pla                                                               ; 520b: 68          h   :b20b[1]
+    ldx romsel_copy                                                   ; 520c: a6 f4       ..  :b20c[1]
+    rts                                                               ; 520e: 60          `   :b20e[1]
+
+; $520f referenced 1 time by $b1fe
+cb20f
+    cmp #6                                                            ; 520f: c9 06       ..  :b20f[1]
+    bne cb221                                                         ; 5211: d0 0e       ..  :b211[1]
+    ldy #$ff                                                          ; 5213: a0 ff       ..  :b213[1]
+    lda (l00b8),y                                                     ; 5215: b1 b8       ..  :b215[1]
+    cmp #$4e ; 'N'                                                    ; 5217: c9 4e       .N  :b217[1]
+    bne cb203                                                         ; 5219: d0 e8       ..  :b219[1]
+    jsr sub_cb5f2                                                     ; 521b: 20 f2 b5     .. :b21b[1]
+    jmp cb203                                                         ; 521e: 4c 03 b2    L.. :b21e[1]
+
+; $5221 referenced 1 time by $b211
+cb221
+    cmp #4                                                            ; 5221: c9 04       ..  :b221[1]
+    bne cb23d                                                         ; 5223: d0 18       ..  :b223[1]
+    jsr sub_cb9f5                                                     ; 5225: 20 f5 b9     .. :b225[1]
+    bcs cb203                                                         ; 5228: b0 d9       ..  :b228[1]
+    cpx #4                                                            ; 522a: e0 04       ..  :b22a[1]
+    beq cb203                                                         ; 522c: f0 d5       ..  :b22c[1]
+    jsr sub_cb234                                                     ; 522e: 20 34 b2     4. :b22e[1]
+    jmp cb1d5                                                         ; 5231: 4c d5 b1    L.. :b231[1]
+
+; $5234 referenced 1 time by $b22e
+sub_cb234
+    lda sram_table,x                                                  ; 5234: bd 30 ba    .0. :b234[1]
+    pha                                                               ; 5237: 48          H   :b237[1]
+    lda sram_table+1,x                                                ; 5238: bd 31 ba    .1. :b238[1]
+    pha                                                               ; 523b: 48          H   :b23b[1]
+    rts                                                               ; 523c: 60          `   :b23c[1]
+
+; $523d referenced 1 time by $b223
+cb23d
+    cmp #7                                                            ; 523d: c9 07       ..  :b23d[1]
+    bne cb268                                                         ; 523f: d0 27       .'  :b23f[1]
+    lda l00ef                                                         ; 5241: a5 ef       ..  :b241[1]
+    cmp #$44 ; 'D'                                                    ; 5243: c9 44       .D  :b243[1]
+    bne cb260                                                         ; 5245: d0 19       ..  :b245[1]
+    ldy #$ee                                                          ; 5247: a0 ee       ..  :b247[1]
+; $5249 referenced 1 time by $b266
+loop_cb249
+    lda (l00b8),y                                                     ; 5249: b1 b8       ..  :b249[1]
+    and #$3f ; '?'                                                    ; 524b: 29 3f       )?  :b24b[1]
+    sta l00b0                                                         ; 524d: 85 b0       ..  :b24d[1]
+    ldy #$fe                                                          ; 524f: a0 fe       ..  :b24f[1]
+    lda (l00b8),y                                                     ; 5251: b1 b8       ..  :b251[1]
+    and #8                                                            ; 5253: 29 08       ).  :b253[1]
+    asl                                                               ; 5255: 0a          .   :b255[1]
+    asl                                                               ; 5256: 0a          .   :b256[1]
+    asl                                                               ; 5257: 0a          .   :b257[1]
+    asl                                                               ; 5258: 0a          .   :b258[1]
+    ora l00b0                                                         ; 5259: 05 b0       ..  :b259[1]
+    sta l00f0                                                         ; 525b: 85 f0       ..  :b25b[1]
+    jmp cb1d5                                                         ; 525d: 4c d5 b1    L.. :b25d[1]
+
+; $5260 referenced 1 time by $b245
+cb260
+    cmp #$45 ; 'E'                                                    ; 5260: c9 45       .E  :b260[1]
+    bne cb203                                                         ; 5262: d0 9f       ..  :b262[1]
+    ldy #$fd                                                          ; 5264: a0 fd       ..  :b264[1]
+    bne loop_cb249                                                    ; 5266: d0 e1       ..  :b266[1]
+; $5268 referenced 1 time by $b23f
+cb268
+    cmp #9                                                            ; 5268: c9 09       ..  :b268[1]
+    bne cb203                                                         ; 526a: d0 97       ..  :b26a[1]
+    lda #$0d                                                          ; 526c: a9 0d       ..  :b26c[1]
+    jsr sub_cbac4                                                     ; 526e: 20 c4 ba     .. :b26e[1]
+    bcs cb297                                                         ; 5271: b0 24       .$  :b271[1]
+    ldx #0                                                            ; 5273: a2 00       ..  :b273[1]
+; $5275 referenced 1 time by $b27e
+loop_cb275
+    lda lb283,x                                                       ; 5275: bd 83 b2    ... :b275[1]
+    jsr oswrch                                                        ; 5278: 20 ee ff     .. :b278[1]
+    inx                                                               ; 527b: e8          .   :b27b[1]
+    cpx #$14                                                          ; 527c: e0 14       ..  :b27c[1]
+    bne loop_cb275                                                    ; 527e: d0 f5       ..  :b27e[1]
+; $5280 referenced 2 times by $b2a6, $b2c0
+cb280
+    jmp cb203                                                         ; 5280: 4c 03 b2    L.. :b280[1]
+
+; $5283 referenced 1 time by $b275
+lb283
+    !byte $0a                                                         ; 5283: 0a          .   :b283[1]
+    !text "SRAM 1.05"                                                 ; 5284: 53 52 41... SRA :b284[1]
+    !byte $0d, $0a                                                    ; 528d: 0d 0a       ..  :b28d[1]
+    !text "  SRAM"                                                    ; 528f: 20 20 53...   S :b28f[1]
+    !byte $0d, $0a                                                    ; 5295: 0d 0a       ..  :b295[1]
+
+; $5297 referenced 2 times by $b271, $b2b0
+cb297
+    jsr sub_cb9f5                                                     ; 5297: 20 f5 b9     .. :b297[1]
+    cpx #4                                                            ; 529a: e0 04       ..  :b29a[1]
+    beq cb2b2                                                         ; 529c: f0 14       ..  :b29c[1]
+    lda #0                                                            ; 529e: a9 00       ..  :b29e[1]
+; $52a0 referenced 2 times by $b2aa, $b2ae
+cb2a0
+    tax                                                               ; 52a0: aa          .   :b2a0[1]
+    iny                                                               ; 52a1: c8          .   :b2a1[1]
+    lda (os_text_ptr),y                                               ; 52a2: b1 f2       ..  :b2a2[1]
+    cmp #$0d                                                          ; 52a4: c9 0d       ..  :b2a4[1]
+    beq cb280                                                         ; 52a6: f0 d8       ..  :b2a6[1]
+    cmp #$20 ; ' '                                                    ; 52a8: c9 20       .   :b2a8[1]
+    beq cb2a0                                                         ; 52aa: f0 f4       ..  :b2aa[1]
+    cpx #$20 ; ' '                                                    ; 52ac: e0 20       .   :b2ac[1]
+    bne cb2a0                                                         ; 52ae: d0 f0       ..  :b2ae[1]
+    beq cb297                                                         ; 52b0: f0 e5       ..  :b2b0[1]
+; $52b2 referenced 1 time by $b29c
+cb2b2
+    ldy #0                                                            ; 52b2: a0 00       ..  :b2b2[1]
+; $52b4 referenced 1 time by $b2bb
+loop_cb2b4
+    lda lb075,y                                                       ; 52b4: b9 75 b0    .u. :b2b4[1]
+    jsr oswrch                                                        ; 52b7: 20 ee ff     .. :b2b7[1]
+    iny                                                               ; 52ba: c8          .   :b2ba[1]
+    bne loop_cb2b4                                                    ; 52bb: d0 f7       ..  :b2bb[1]
+; $52bd referenced 1 time by $b2c6
+loop_cb2bd
+    lda lb175,y                                                       ; 52bd: b9 75 b1    .u. :b2bd[1]
+    beq cb280                                                         ; 52c0: f0 be       ..  :b2c0[1]
+    jsr oswrch                                                        ; 52c2: 20 ee ff     .. :b2c2[1]
+    iny                                                               ; 52c5: c8          .   :b2c5[1]
+    bne loop_cb2bd                                                    ; 52c6: d0 f5       ..  :b2c6[1]
+; $52c8 referenced 1 time by $b1d2
+sub_cb2c8
+    jsr cb82b                                                         ; 52c8: 20 2b b8     +. :b2c8[1]
+    lda #$ee                                                          ; 52cb: a9 ee       ..  :b2cb[1]
+    sta l00b8                                                         ; 52cd: 85 b8       ..  :b2cd[1]
+    ldy #$0b                                                          ; 52cf: a0 0b       ..  :b2cf[1]
+; $52d1 referenced 1 time by $b2e4
+loop_cb2d1
+    lda (l00f0),y                                                     ; 52d1: b1 f0       ..  :b2d1[1]
+    cpy #0                                                            ; 52d3: c0 00       ..  :b2d3[1]
+    bne cb2e1                                                         ; 52d5: d0 0a       ..  :b2d5[1]
+    and #$c0                                                          ; 52d7: 29 c0       ).  :b2d7[1]
+    sta l00bc                                                         ; 52d9: 85 bc       ..  :b2d9[1]
+    lda (l00b8),y                                                     ; 52db: b1 b8       ..  :b2db[1]
+    and #$3f ; '?'                                                    ; 52dd: 29 3f       )?  :b2dd[1]
+    ora l00bc                                                         ; 52df: 05 bc       ..  :b2df[1]
+; $52e1 referenced 1 time by $b2d5
+cb2e1
+    sta (l00b8),y                                                     ; 52e1: 91 b8       ..  :b2e1[1]
+    dey                                                               ; 52e3: 88          .   :b2e3[1]
+    bpl loop_cb2d1                                                    ; 52e4: 10 eb       ..  :b2e4[1]
+    cli                                                               ; 52e6: 58          X   :b2e6[1]
+; $52e7 referenced 1 time by $bbcd
+cb2e7
+    jsr cb82b                                                         ; 52e7: 20 2b b8     +. :b2e7[1]
+    ldy #$f2                                                          ; 52ea: a0 f2       ..  :b2ea[1]
+    lda (l00b8),y                                                     ; 52ec: b1 b8       ..  :b2ec[1]
+    tax                                                               ; 52ee: aa          .   :b2ee[1]
+    iny                                                               ; 52ef: c8          .   :b2ef[1]
+    lda (l00b8),y                                                     ; 52f0: b1 b8       ..  :b2f0[1]
+    jsr sub_cb85d                                                     ; 52f2: 20 5d b8     ]. :b2f2[1]
+    bvs cb305                                                         ; 52f5: 70 0e       p.  :b2f5[1]
+    ldy #$f1                                                          ; 52f7: a0 f1       ..  :b2f7[1]
+    lda (l00b8),y                                                     ; 52f9: b1 b8       ..  :b2f9[1]
+    tay                                                               ; 52fb: a8          .   :b2fb[1]
+    cpy #$14                                                          ; 52fc: c0 14       ..  :b2fc[1]
+    bcc cb314                                                         ; 52fe: 90 14       ..  :b2fe[1]
+; $5300 referenced 2 times by $b324, $bcd3
+cb300
+    ldx #0                                                            ; 5300: a2 00       ..  :b300[1]
+    jmp cb8fb                                                         ; 5302: 4c fb b8    L.. :b302[1]
+
+; $5305 referenced 1 time by $b2f5
+cb305
+    jsr sub_cb6b1                                                     ; 5305: 20 b1 b6     .. :b305[1]
+    sty l00ba                                                         ; 5308: 84 ba       ..  :b308[1]
+    ldy #$f3                                                          ; 530a: a0 f3       ..  :b30a[1]
+    sta (l00b8),y                                                     ; 530c: 91 b8       ..  :b30c[1]
+    txa                                                               ; 530e: 8a          .   :b30e[1]
+    dey                                                               ; 530f: 88          .   :b30f[1]
+    sta (l00b8),y                                                     ; 5310: 91 b8       ..  :b310[1]
+    ldy l00ba                                                         ; 5312: a4 ba       ..  :b312[1]
+; $5314 referenced 1 time by $b2fe
+cb314
+    jsr sub_cb6fe                                                     ; 5314: 20 fe b6     .. :b314[1]
+    tax                                                               ; 5317: aa          .   :b317[1]
+    tya                                                               ; 5318: 98          .   :b318[1]
+    ldy #$f1                                                          ; 5319: a0 f1       ..  :b319[1]
+    sta (l00b8),y                                                     ; 531b: 91 b8       ..  :b31b[1]
+    txa                                                               ; 531d: 8a          .   :b31d[1]
+    ldy #$ee                                                          ; 531e: a0 ee       ..  :b31e[1]
+    eor (l00b8),y                                                     ; 5320: 51 b8       Q.  :b320[1]
+    and #$40 ; '@'                                                    ; 5322: 29 40       )@  :b322[1]
+    bne cb300                                                         ; 5324: d0 da       ..  :b324[1]
+    tay                                                               ; 5326: a8          .   :b326[1]
+    ldx #$ba                                                          ; 5327: a2 ba       ..  :b327[1]
+    jsr osargs                                                        ; 5329: 20 da ff     .. :b329[1]
+    jsr cb82b                                                         ; 532c: 20 2b b8     +. :b32c[1]
+    tax                                                               ; 532f: aa          .   :b32f[1]
+    bne cb337                                                         ; 5330: d0 05       ..  :b330[1]
+    ldx #2                                                            ; 5332: a2 02       ..  :b332[1]
+    jmp cb8fb                                                         ; 5334: 4c fb b8    L.. :b334[1]
+
+; $5337 referenced 1 time by $b330
+cb337
+    pha                                                               ; 5337: 48          H   :b337[1]
+    jsr sub_cbe9d                                                     ; 5338: 20 9d be     .. :b338[1]
+    pla                                                               ; 533b: 68          h   :b33b[1]
+    cmp #4                                                            ; 533c: c9 04       ..  :b33c[1]
+    bcs cb3ba                                                         ; 533e: b0 7a       .z  :b33e[1]
+    jsr sub_cb85d                                                     ; 5340: 20 5d b8     ]. :b340[1]
+    bpl cb375                                                         ; 5343: 10 30       .0  :b343[1]
+    jsr sub_cb5ce                                                     ; 5345: 20 ce b5     .. :b345[1]
+    jsr sub_cb607                                                     ; 5348: 20 07 b6     .. :b348[1]
+    bne cb371                                                         ; 534b: d0 24       .$  :b34b[1]
+    beq cb352                                                         ; 534d: f0 03       ..  :b34d[1]
+; $534f referenced 1 time by $b36f
+cb34f
+    jsr sub_cb65f                                                     ; 534f: 20 5f b6     _. :b34f[1]
+; $5352 referenced 1 time by $b34d
+cb352
+    ldy #$fa                                                          ; 5352: a0 fa       ..  :b352[1]
+    lda (l00b8),y                                                     ; 5354: b1 b8       ..  :b354[1]
+    tay                                                               ; 5356: a8          .   :b356[1]
+    jsr osbget                                                        ; 5357: 20 d7 ff     .. :b357[1]
+    jsr cb82b                                                         ; 535a: 20 2b b8     +. :b35a[1]
+    ldy #$f2                                                          ; 535d: a0 f2       ..  :b35d[1]
+    jsr sub_cb83f                                                     ; 535f: 20 3f b8     ?. :b35f[1]
+    tax                                                               ; 5362: aa          .   :b362[1]
+    ldy #$f1                                                          ; 5363: a0 f1       ..  :b363[1]
+    lda (l00b8),y                                                     ; 5365: b1 b8       ..  :b365[1]
+    tay                                                               ; 5367: a8          .   :b367[1]
+    txa                                                               ; 5368: 8a          .   :b368[1]
+    jsr sub_cb745                                                     ; 5369: 20 45 b7     E. :b369[1]
+    jsr sub_cb607                                                     ; 536c: 20 07 b6     .. :b36c[1]
+    beq cb34f                                                         ; 536f: f0 de       ..  :b36f[1]
+; $5371 referenced 3 times by $b34b, $b37b, $b3b8
+cb371
+    jsr sub_cb5f2                                                     ; 5371: 20 f2 b5     .. :b371[1]
+    rts                                                               ; 5374: 60          `   :b374[1]
+
+; $5375 referenced 1 time by $b343
+cb375
+    jsr sub_cb5ee                                                     ; 5375: 20 ee b5     .. :b375[1]
+    jsr sub_cb616                                                     ; 5378: 20 16 b6     .. :b378[1]
+    beq cb371                                                         ; 537b: f0 f4       ..  :b37b[1]
+    bne cb382                                                         ; 537d: d0 03       ..  :b37d[1]
+; $537f referenced 1 time by $b3b6
+cb37f
+    jsr sub_cb65f                                                     ; 537f: 20 5f b6     _. :b37f[1]
+; $5382 referenced 1 time by $b37d
+cb382
+    ldy #$f4                                                          ; 5382: a0 f4       ..  :b382[1]
+    lda (l00b8),y                                                     ; 5384: b1 b8       ..  :b384[1]
+    sec                                                               ; 5386: 38          8   :b386[1]
+    sbc #1                                                            ; 5387: e9 01       ..  :b387[1]
+    sta (l00b8),y                                                     ; 5389: 91 b8       ..  :b389[1]
+    cmp #$ff                                                          ; 538b: c9 ff       ..  :b38b[1]
+    bne cb397                                                         ; 538d: d0 08       ..  :b38d[1]
+    iny                                                               ; 538f: c8          .   :b38f[1]
+    lda (l00b8),y                                                     ; 5390: b1 b8       ..  :b390[1]
+    sec                                                               ; 5392: 38          8   :b392[1]
+    sbc #1                                                            ; 5393: e9 01       ..  :b393[1]
+    sta (l00b8),y                                                     ; 5395: 91 b8       ..  :b395[1]
+; $5397 referenced 1 time by $b38d
+cb397
+    ldx #$f6                                                          ; 5397: a2 f6       ..  :b397[1]
+    ldy #$f2                                                          ; 5399: a0 f2       ..  :b399[1]
+    jsr sub_cb841                                                     ; 539b: 20 41 b8     A. :b39b[1]
+    ldy #$f1                                                          ; 539e: a0 f1       ..  :b39e[1]
+    lda (l00b8),y                                                     ; 53a0: b1 b8       ..  :b3a0[1]
+    tay                                                               ; 53a2: a8          .   :b3a2[1]
+    jsr osrdsc                                                        ; 53a3: 20 b9 ff     .. :b3a3[1]
+    tax                                                               ; 53a6: aa          .   :b3a6[1]
+    ldy #$fa                                                          ; 53a7: a0 fa       ..  :b3a7[1]
+    lda (l00b8),y                                                     ; 53a9: b1 b8       ..  :b3a9[1]
+    tay                                                               ; 53ab: a8          .   :b3ab[1]
+    txa                                                               ; 53ac: 8a          .   :b3ac[1]
+    jsr osbput                                                        ; 53ad: 20 d4 ff     .. :b3ad[1]
+    jsr cb82b                                                         ; 53b0: 20 2b b8     +. :b3b0[1]
+    jsr sub_cb616                                                     ; 53b3: 20 16 b6     .. :b3b3[1]
+    bne cb37f                                                         ; 53b6: d0 c7       ..  :b3b6[1]
+    beq cb371                                                         ; 53b8: f0 b7       ..  :b3b8[1]
+; $53ba referenced 1 time by $b33e
+cb3ba
+    ldy #$f9                                                          ; 53ba: a0 f9       ..  :b3ba[1]
+    lda (l00b8),y                                                     ; 53bc: b1 b8       ..  :b3bc[1]
+    bmi cb3de                                                         ; 53be: 30 1e       0.  :b3be[1]
+    dey                                                               ; 53c0: 88          .   :b3c0[1]
+    ora (l00b8),y                                                     ; 53c1: 11 b8       ..  :b3c1[1]
+    bne cb406                                                         ; 53c3: d0 41       .A  :b3c3[1]
+    lda #0                                                            ; 53c5: a9 00       ..  :b3c5[1]
+    sta (l00b8),y                                                     ; 53c7: 91 b8       ..  :b3c7[1]
+    lda #1                                                            ; 53c9: a9 01       ..  :b3c9[1]
+    iny                                                               ; 53cb: c8          .   :b3cb[1]
+    sta (l00b8),y                                                     ; 53cc: 91 b8       ..  :b3cc[1]
+    ldy #$f6                                                          ; 53ce: a0 f6       ..  :b3ce[1]
+    lda #0                                                            ; 53d0: a9 00       ..  :b3d0[1]
+    sta (l00b8),y                                                     ; 53d2: 91 b8       ..  :b3d2[1]
+    ldx l00b9                                                         ; 53d4: a6 b9       ..  :b3d4[1]
+    inx                                                               ; 53d6: e8          .   :b3d6[1]
+    txa                                                               ; 53d7: 8a          .   :b3d7[1]
+    iny                                                               ; 53d8: c8          .   :b3d8[1]
+    sta (l00b8),y                                                     ; 53d9: 91 b8       ..  :b3d9[1]
+    jmp cb406                                                         ; 53db: 4c 06 b4    L.. :b3db[1]
+
+; $53de referenced 1 time by $b3be
+cb3de
+    lda #osbyte_read_himem                                            ; 53de: a9 84       ..  :b3de[1]
+    jsr osbyte                                                        ; 53e0: 20 f4 ff     .. :b3e0[1]
+    tya                                                               ; 53e3: 98          .   :b3e3[1]
+    pha                                                               ; 53e4: 48          H   :b3e4[1]
+    txa                                                               ; 53e5: 8a          .   :b3e5[1]
+    pha                                                               ; 53e6: 48          H   :b3e6[1]
+    lda #osbyte_read_oshwm                                            ; 53e7: a9 83       ..  :b3e7[1]
+    jsr osbyte                                                        ; 53e9: 20 f4 ff     .. :b3e9[1]
+    jsr cb82b                                                         ; 53ec: 20 2b b8     +. :b3ec[1]
+    stx l00ba                                                         ; 53ef: 86 ba       ..  :b3ef[1]
+    sty l00bb                                                         ; 53f1: 84 bb       ..  :b3f1[1]
+    ldy #$f6                                                          ; 53f3: a0 f6       ..  :b3f3[1]
+    jsr sub_cb84e                                                     ; 53f5: 20 4e b8     N. :b3f5[1]
+    pla                                                               ; 53f8: 68          h   :b3f8[1]
+    sec                                                               ; 53f9: 38          8   :b3f9[1]
+    sbc l00ba                                                         ; 53fa: e5 ba       ..  :b3fa[1]
+    ldy #$f8                                                          ; 53fc: a0 f8       ..  :b3fc[1]
+    sta (l00b8),y                                                     ; 53fe: 91 b8       ..  :b3fe[1]
+    pla                                                               ; 5400: 68          h   :b400[1]
+    sbc l00bb                                                         ; 5401: e5 bb       ..  :b401[1]
+    iny                                                               ; 5403: c8          .   :b403[1]
+    sta (l00b8),y                                                     ; 5404: 91 b8       ..  :b404[1]
+; $5406 referenced 2 times by $b3c3, $b3db
+cb406
+    jsr sub_cb85d                                                     ; 5406: 20 5d b8     ]. :b406[1]
+    bmi cb40e                                                         ; 5409: 30 03       0.  :b409[1]
+    jmp cb4d8                                                         ; 540b: 4c d8 b4    L.. :b40b[1]
+
+; $540e referenced 1 time by $b409
+cb40e
+    jsr sub_cb5ce                                                     ; 540e: 20 ce b5     .. :b40e[1]
+    tsx                                                               ; 5411: ba          .   :b411[1]
+    txa                                                               ; 5412: 8a          .   :b412[1]
+    sec                                                               ; 5413: 38          8   :b413[1]
+    sbc #$10                                                          ; 5414: e9 10       ..  :b414[1]
+    tax                                                               ; 5416: aa          .   :b416[1]
+    txs                                                               ; 5417: 9a          .   :b417[1]
+    ldy #$f0                                                          ; 5418: a0 f0       ..  :b418[1]
+    lda (l00b8),y                                                     ; 541a: b1 b8       ..  :b41a[1]
+    pha                                                               ; 541c: 48          H   :b41c[1]
+    dey                                                               ; 541d: 88          .   :b41d[1]
+    lda (l00b8),y                                                     ; 541e: b1 b8       ..  :b41e[1]
+    pha                                                               ; 5420: 48          H   :b420[1]
+    dex                                                               ; 5421: ca          .   :b421[1]
+    ldy #1                                                            ; 5422: a0 01       ..  :b422[1]
+    lda #osfile_read_catalogue_info                                   ; 5424: a9 05       ..  :b424[1]
+    jsr osfile                                                        ; 5426: 20 dd ff     .. :b426[1]
+    jsr cb82b                                                         ; 5429: 20 2b b8     +. :b429[1]
+    tsx                                                               ; 542c: ba          .   :b42c[1]
+    lda l010b,x                                                       ; 542d: bd 0b 01    ... :b42d[1]
+    ldy #$f4                                                          ; 5430: a0 f4       ..  :b430[1]
+    sta (l00b8),y                                                     ; 5432: 91 b8       ..  :b432[1]
+    sta l00ba                                                         ; 5434: 85 ba       ..  :b434[1]
+    lda l010c,x                                                       ; 5436: bd 0c 01    ... :b436[1]
+    iny                                                               ; 5439: c8          .   :b439[1]
+    sta (l00b8),y                                                     ; 543a: 91 b8       ..  :b43a[1]
+    sta l00bb                                                         ; 543c: 85 bb       ..  :b43c[1]
+    lda l010d,x                                                       ; 543e: bd 0d 01    ... :b43e[1]
+    ora l010e,x                                                       ; 5441: 1d 0e 01    ... :b441[1]
+    beq cb44b                                                         ; 5444: f0 05       ..  :b444[1]
+; $5446 referenced 4 times by $b68c, $b6c7, $b715, $bc10
+cb446
+    ldx #1                                                            ; 5446: a2 01       ..  :b446[1]
+    jmp cb8fb                                                         ; 5448: 4c fb b8    L.. :b448[1]
+
+; $544b referenced 1 time by $b444
+cb44b
+    ldx #$12                                                          ; 544b: a2 12       ..  :b44b[1]
+; $544d referenced 1 time by $b44f
+loop_cb44d
+    pla                                                               ; 544d: 68          h   :b44d[1]
+    dex                                                               ; 544e: ca          .   :b44e[1]
+    bne loop_cb44d                                                    ; 544f: d0 fc       ..  :b44f[1]
+    bit lb57f                                                         ; 5451: 2c 7f b5    ,.. :b451[1]
+    lda l00ba                                                         ; 5454: a5 ba       ..  :b454[1]
+    ora l00bb                                                         ; 5456: 05 bb       ..  :b456[1]
+    bne cb45e                                                         ; 5458: d0 04       ..  :b458[1]
+; $545a referenced 1 time by $b4d2
+cb45a
+    jsr sub_cb5f2                                                     ; 545a: 20 f2 b5     .. :b45a[1]
+    rts                                                               ; 545d: 60          `   :b45d[1]
+
+; $545e referenced 2 times by $b458, $b4d5
+cb45e
+    ldx #$bc                                                          ; 545e: a2 bc       ..  :b45e[1]
+    ldy #$f8                                                          ; 5460: a0 f8       ..  :b460[1]
+    jsr sub_cb841                                                     ; 5462: 20 41 b8     A. :b462[1]
+    ldy #$ba                                                          ; 5465: a0 ba       ..  :b465[1]
+    jsr sub_cb58b                                                     ; 5467: 20 8b b5     .. :b467[1]
+    bcs cb470                                                         ; 546a: b0 04       ..  :b46a[1]
+    jsr sub_cb580                                                     ; 546c: 20 80 b5     .. :b46c[1]
+    clv                                                               ; 546f: b8          .   :b46f[1]
+; $5470 referenced 1 time by $b46a
+cb470
+    ldy #$fb                                                          ; 5470: a0 fb       ..  :b470[1]
+    jsr sub_cb84e                                                     ; 5472: 20 4e b8     N. :b472[1]
+    bvc cb4af                                                         ; 5475: 50 38       P8  :b475[1]
+    jsr sub_cb5f2                                                     ; 5477: 20 f2 b5     .. :b477[1]
+    tsx                                                               ; 547a: ba          .   :b47a[1]
+    txa                                                               ; 547b: 8a          .   :b47b[1]
+    sec                                                               ; 547c: 38          8   :b47c[1]
+    sbc #$0b                                                          ; 547d: e9 0b       ..  :b47d[1]
+    tax                                                               ; 547f: aa          .   :b47f[1]
+    txs                                                               ; 5480: 9a          .   :b480[1]
+    lda #0                                                            ; 5481: a9 00       ..  :b481[1]
+    pha                                                               ; 5483: 48          H   :b483[1]
+    lda #$ff                                                          ; 5484: a9 ff       ..  :b484[1]
+    pha                                                               ; 5486: 48          H   :b486[1]
+    pha                                                               ; 5487: 48          H   :b487[1]
+    ldy #$f7                                                          ; 5488: a0 f7       ..  :b488[1]
+    lda (l00b8),y                                                     ; 548a: b1 b8       ..  :b48a[1]
+    pha                                                               ; 548c: 48          H   :b48c[1]
+    dey                                                               ; 548d: 88          .   :b48d[1]
+    lda (l00b8),y                                                     ; 548e: b1 b8       ..  :b48e[1]
+    pha                                                               ; 5490: 48          H   :b490[1]
+    ldy #$f0                                                          ; 5491: a0 f0       ..  :b491[1]
+    lda (l00b8),y                                                     ; 5493: b1 b8       ..  :b493[1]
+    pha                                                               ; 5495: 48          H   :b495[1]
+    dey                                                               ; 5496: 88          .   :b496[1]
+    lda (l00b8),y                                                     ; 5497: b1 b8       ..  :b497[1]
+    pha                                                               ; 5499: 48          H   :b499[1]
+    tsx                                                               ; 549a: ba          .   :b49a[1]
+    inx                                                               ; 549b: e8          .   :b49b[1]
+    ldy #1                                                            ; 549c: a0 01       ..  :b49c[1]
+    lda #osfile_load                                                  ; 549e: a9 ff       ..  :b49e[1]
+    jsr osfile                                                        ; 54a0: 20 dd ff     .. :b4a0[1]
+    jsr cb82b                                                         ; 54a3: 20 2b b8     +. :b4a3[1]
+    ldx #$12                                                          ; 54a6: a2 12       ..  :b4a6[1]
+; $54a8 referenced 1 time by $b4aa
+loop_cb4a8
+    pla                                                               ; 54a8: 68          h   :b4a8[1]
+    dex                                                               ; 54a9: ca          .   :b4a9[1]
+    bne loop_cb4a8                                                    ; 54aa: d0 fc       ..  :b4aa[1]
+    jmp cb4b4                                                         ; 54ac: 4c b4 b4    L.. :b4ac[1]
+
+; $54af referenced 1 time by $b475
+cb4af
+    lda #4                                                            ; 54af: a9 04       ..  :b4af[1]
+    jsr sub_cb598                                                     ; 54b1: 20 98 b5     .. :b4b1[1]
+; $54b4 referenced 1 time by $b4ac
+cb4b4
+    ldx #$b1                                                          ; 54b4: a2 b1       ..  :b4b4[1]
+    ldy #$f6                                                          ; 54b6: a0 f6       ..  :b4b6[1]
+    jsr sub_cb841                                                     ; 54b8: 20 41 b8     A. :b4b8[1]
+    ldx #$b3                                                          ; 54bb: a2 b3       ..  :b4bb[1]
+    ldy #$f2                                                          ; 54bd: a0 f2       ..  :b4bd[1]
+    jsr sub_cb841                                                     ; 54bf: 20 41 b8     A. :b4bf[1]
+    ldx #$be                                                          ; 54c2: a2 be       ..  :b4c2[1]
+    ldy #$fb                                                          ; 54c4: a0 fb       ..  :b4c4[1]
+    jsr sub_cb841                                                     ; 54c6: 20 41 b8     A. :b4c6[1]
+    sec                                                               ; 54c9: 38          8   :b4c9[1]
+    jsr cb795                                                         ; 54ca: 20 95 b7     .. :b4ca[1]
+    ldx #$b3                                                          ; 54cd: a2 b3       ..  :b4cd[1]
+    jsr sub_cb61e                                                     ; 54cf: 20 1e b6     .. :b4cf[1]
+    beq cb45a                                                         ; 54d2: f0 86       ..  :b4d2[1]
+    clv                                                               ; 54d4: b8          .   :b4d4[1]
+    jmp cb45e                                                         ; 54d5: 4c 5e b4    L^. :b4d5[1]
+
+; $54d8 referenced 1 time by $b40b
+cb4d8
+    jsr sub_cb5ee                                                     ; 54d8: 20 ee b5     .. :b4d8[1]
+    bit lb57f                                                         ; 54db: 2c 7f b5    ,.. :b4db[1]
+    php                                                               ; 54de: 08          .   :b4de[1]
+; $54df referenced 1 time by $b531
+cb4df
+    ldy #$f4                                                          ; 54df: a0 f4       ..  :b4df[1]
+    jsr sub_cb83f                                                     ; 54e1: 20 3f b8     ?. :b4e1[1]
+    jsr sub_cb616                                                     ; 54e4: 20 16 b6     .. :b4e4[1]
+    bne cb4ee                                                         ; 54e7: d0 05       ..  :b4e7[1]
+; $54e9 referenced 1 time by $b57c
+cb4e9
+    plp                                                               ; 54e9: 28          (   :b4e9[1]
+    jsr sub_cb5f2                                                     ; 54ea: 20 f2 b5     .. :b4ea[1]
+    rts                                                               ; 54ed: 60          `   :b4ed[1]
+
+; $54ee referenced 1 time by $b4e7
+cb4ee
+    ldx #$bc                                                          ; 54ee: a2 bc       ..  :b4ee[1]
+    ldy #$f8                                                          ; 54f0: a0 f8       ..  :b4f0[1]
+    jsr sub_cb841                                                     ; 54f2: 20 41 b8     A. :b4f2[1]
+    ldy #$ba                                                          ; 54f5: a0 ba       ..  :b4f5[1]
+    jsr sub_cb58b                                                     ; 54f7: 20 8b b5     .. :b4f7[1]
+    bcs cb502                                                         ; 54fa: b0 06       ..  :b4fa[1]
+    jsr sub_cb580                                                     ; 54fc: 20 80 b5     .. :b4fc[1]
+    plp                                                               ; 54ff: 28          (   :b4ff[1]
+    clv                                                               ; 5500: b8          .   :b500[1]
+    php                                                               ; 5501: 08          .   :b501[1]
+; $5502 referenced 1 time by $b4fa
+cb502
+    ldy #$fb                                                          ; 5502: a0 fb       ..  :b502[1]
+    jsr sub_cb84e                                                     ; 5504: 20 4e b8     N. :b504[1]
+    ldx #$b1                                                          ; 5507: a2 b1       ..  :b507[1]
+    ldy #$f2                                                          ; 5509: a0 f2       ..  :b509[1]
+    jsr sub_cb841                                                     ; 550b: 20 41 b8     A. :b50b[1]
+    ldx #$b3                                                          ; 550e: a2 b3       ..  :b50e[1]
+    ldy #$f6                                                          ; 5510: a0 f6       ..  :b510[1]
+    jsr sub_cb841                                                     ; 5512: 20 41 b8     A. :b512[1]
+    ldx #$be                                                          ; 5515: a2 be       ..  :b515[1]
+    ldy #$fb                                                          ; 5517: a0 fb       ..  :b517[1]
+    jsr sub_cb841                                                     ; 5519: 20 41 b8     A. :b519[1]
+    clc                                                               ; 551c: 18          .   :b51c[1]
+    jsr cb795                                                         ; 551d: 20 95 b7     .. :b51d[1]
+    ldx #$b1                                                          ; 5520: a2 b1       ..  :b520[1]
+    jsr sub_cb61e                                                     ; 5522: 20 1e b6     .. :b522[1]
+    plp                                                               ; 5525: 28          (   :b525[1]
+    php                                                               ; 5526: 08          .   :b526[1]
+    bvs cb534                                                         ; 5527: 70 0b       p.  :b527[1]
+    lda #2                                                            ; 5529: a9 02       ..  :b529[1]
+    jsr sub_cb598                                                     ; 552b: 20 98 b5     .. :b52b[1]
+    plp                                                               ; 552e: 28          (   :b52e[1]
+    clv                                                               ; 552f: b8          .   :b52f[1]
+    php                                                               ; 5530: 08          .   :b530[1]
+    jmp cb4df                                                         ; 5531: 4c df b4    L.. :b531[1]
+
+; $5534 referenced 1 time by $b527
+cb534
+    jsr sub_cb5f2                                                     ; 5534: 20 f2 b5     .. :b534[1]
+    lda #$ff                                                          ; 5537: a9 ff       ..  :b537[1]
+    pha                                                               ; 5539: 48          H   :b539[1]
+    pha                                                               ; 553a: 48          H   :b53a[1]
+    ldy #$f6                                                          ; 553b: a0 f6       ..  :b53b[1]
+    jsr sub_cb83f                                                     ; 553d: 20 3f b8     ?. :b53d[1]
+    ldy #$fb                                                          ; 5540: a0 fb       ..  :b540[1]
+    lda l00ba                                                         ; 5542: a5 ba       ..  :b542[1]
+    clc                                                               ; 5544: 18          .   :b544[1]
+    adc (l00b8),y                                                     ; 5545: 71 b8       q.  :b545[1]
+    tax                                                               ; 5547: aa          .   :b547[1]
+    lda l00bb                                                         ; 5548: a5 bb       ..  :b548[1]
+    iny                                                               ; 554a: c8          .   :b54a[1]
+    adc (l00b8),y                                                     ; 554b: 71 b8       q.  :b54b[1]
+    pha                                                               ; 554d: 48          H   :b54d[1]
+    txa                                                               ; 554e: 8a          .   :b54e[1]
+    pha                                                               ; 554f: 48          H   :b54f[1]
+    lda #$ff                                                          ; 5550: a9 ff       ..  :b550[1]
+    pha                                                               ; 5552: 48          H   :b552[1]
+    pha                                                               ; 5553: 48          H   :b553[1]
+    lda l00bb                                                         ; 5554: a5 bb       ..  :b554[1]
+    pha                                                               ; 5556: 48          H   :b556[1]
+    lda l00ba                                                         ; 5557: a5 ba       ..  :b557[1]
+    pha                                                               ; 5559: 48          H   :b559[1]
+    lda #$ff                                                          ; 555a: a9 ff       ..  :b55a[1]
+    ldx #8                                                            ; 555c: a2 08       ..  :b55c[1]
+; $555e referenced 1 time by $b560
+loop_cb55e
+    pha                                                               ; 555e: 48          H   :b55e[1]
+    dex                                                               ; 555f: ca          .   :b55f[1]
+    bne loop_cb55e                                                    ; 5560: d0 fc       ..  :b560[1]
+    ldy #$f0                                                          ; 5562: a0 f0       ..  :b562[1]
+    lda (l00b8),y                                                     ; 5564: b1 b8       ..  :b564[1]
+    pha                                                               ; 5566: 48          H   :b566[1]
+    dey                                                               ; 5567: 88          .   :b567[1]
+    tsx                                                               ; 5568: ba          .   :b568[1]
+    lda (l00b8),y                                                     ; 5569: b1 b8       ..  :b569[1]
+    pha                                                               ; 556b: 48          H   :b56b[1]
+    ldy #1                                                            ; 556c: a0 01       ..  :b56c[1]
+    lda #osfile_save                                                  ; 556e: a9 00       ..  :b56e[1]
+    jsr osfile                                                        ; 5570: 20 dd ff     .. :b570[1]
+    jsr cb82b                                                         ; 5573: 20 2b b8     +. :b573[1]
+    ldx #$12                                                          ; 5576: a2 12       ..  :b576[1]
+; $5578 referenced 1 time by $b57a
+loop_cb578
+    pla                                                               ; 5578: 68          h   :b578[1]
+    dex                                                               ; 5579: ca          .   :b579[1]
+    bne loop_cb578                                                    ; 557a: d0 fc       ..  :b57a[1]
+    jmp cb4e9                                                         ; 557c: 4c e9 b4    L.. :b57c[1]
+
+; $557f referenced 4 times by $b451, $b4db, $bae7, $bbda
+lb57f
+    !byte $40                                                         ; 557f: 40          @   :b57f[1]
+
+; $5580 referenced 7 times by $b46c, $b4fc, $bcfd, $bd08, $bd12, $bdaa, $bde4
+sub_cb580
+    lda l0000,x                                                       ; 5580: b5 00       ..  :b580[1]
+    sta l0000,y                                                       ; 5582: 99 00 00    ... :b582[1]
+    lda l0001,x                                                       ; 5585: b5 01       ..  :b585[1]
+    sta l0001,y                                                       ; 5587: 99 01 00    ... :b587[1]
+    rts                                                               ; 558a: 60          `   :b58a[1]
+
+; $558b referenced 3 times by $b467, $b4f7, $b800
+sub_cb58b
+    lda l0001,x                                                       ; 558b: b5 01       ..  :b58b[1]
+    cmp l0001,y                                                       ; 558d: d9 01 00    ... :b58d[1]
+    bne cb597                                                         ; 5590: d0 05       ..  :b590[1]
+    lda l0000,x                                                       ; 5592: b5 00       ..  :b592[1]
+    cmp l0000,y                                                       ; 5594: d9 00 00    ... :b594[1]
+; $5597 referenced 1 time by $b590
+cb597
+    rts                                                               ; 5597: 60          `   :b597[1]
+
+; $5598 referenced 2 times by $b4b1, $b52b
+sub_cb598
+    pha                                                               ; 5598: 48          H   :b598[1]
+    pha                                                               ; 5599: 48          H   :b599[1]
+    pha                                                               ; 559a: 48          H   :b59a[1]
+    pha                                                               ; 559b: 48          H   :b59b[1]
+    lda #0                                                            ; 559c: a9 00       ..  :b59c[1]
+    pha                                                               ; 559e: 48          H   :b59e[1]
+    pha                                                               ; 559f: 48          H   :b59f[1]
+    ldy #$fc                                                          ; 55a0: a0 fc       ..  :b5a0[1]
+    lda (l00b8),y                                                     ; 55a2: b1 b8       ..  :b5a2[1]
+    pha                                                               ; 55a4: 48          H   :b5a4[1]
+    dey                                                               ; 55a5: 88          .   :b5a5[1]
+    lda (l00b8),y                                                     ; 55a6: b1 b8       ..  :b5a6[1]
+    pha                                                               ; 55a8: 48          H   :b5a8[1]
+    lda #$ff                                                          ; 55a9: a9 ff       ..  :b5a9[1]
+    pha                                                               ; 55ab: 48          H   :b5ab[1]
+    pha                                                               ; 55ac: 48          H   :b5ac[1]
+    ldy #$f7                                                          ; 55ad: a0 f7       ..  :b5ad[1]
+    lda (l00b8),y                                                     ; 55af: b1 b8       ..  :b5af[1]
+    pha                                                               ; 55b1: 48          H   :b5b1[1]
+    dey                                                               ; 55b2: 88          .   :b5b2[1]
+    lda (l00b8),y                                                     ; 55b3: b1 b8       ..  :b5b3[1]
+    pha                                                               ; 55b5: 48          H   :b5b5[1]
+    tsx                                                               ; 55b6: ba          .   :b5b6[1]
+    ldy #$fa                                                          ; 55b7: a0 fa       ..  :b5b7[1]
+    lda (l00b8),y                                                     ; 55b9: b1 b8       ..  :b5b9[1]
+    pha                                                               ; 55bb: 48          H   :b5bb[1]
+    lda l0109,x                                                       ; 55bc: bd 09 01    ... :b5bc[1]
+    ldy #1                                                            ; 55bf: a0 01       ..  :b5bf[1]
+    jsr osgbpb                                                        ; 55c1: 20 d1 ff     .. :b5c1[1]
+    ldx #$0d                                                          ; 55c4: a2 0d       ..  :b5c4[1]
+; $55c6 referenced 1 time by $b5c8
+loop_cb5c6
+    pla                                                               ; 55c6: 68          h   :b5c6[1]
+    dex                                                               ; 55c7: ca          .   :b5c7[1]
+    bne loop_cb5c6                                                    ; 55c8: d0 fc       ..  :b5c8[1]
+    jsr cb82b                                                         ; 55ca: 20 2b b8     +. :b5ca[1]
+    rts                                                               ; 55cd: 60          `   :b5cd[1]
+
+; $55ce referenced 2 times by $b345, $b40e
+sub_cb5ce
+    lda #$40 ; '@'                                                    ; 55ce: a9 40       .@  :b5ce[1]
+; $55d0 referenced 1 time by $b5f0
+cb5d0
+    pha                                                               ; 55d0: 48          H   :b5d0[1]
+    ldy #$ef                                                          ; 55d1: a0 ef       ..  :b5d1[1]
+    lda (l00b8),y                                                     ; 55d3: b1 b8       ..  :b5d3[1]
+    tax                                                               ; 55d5: aa          .   :b5d5[1]
+    iny                                                               ; 55d6: c8          .   :b5d6[1]
+    lda (l00b8),y                                                     ; 55d7: b1 b8       ..  :b5d7[1]
+    tay                                                               ; 55d9: a8          .   :b5d9[1]
+    pla                                                               ; 55da: 68          h   :b5da[1]
+    jsr osfind                                                        ; 55db: 20 ce ff     .. :b5db[1]
+    tax                                                               ; 55de: aa          .   :b5de[1]
+    bne cb5e6                                                         ; 55df: d0 05       ..  :b5df[1]
+    ldx #4                                                            ; 55e1: a2 04       ..  :b5e1[1]
+    jmp cb8fb                                                         ; 55e3: 4c fb b8    L.. :b5e3[1]
+
+; $55e6 referenced 1 time by $b5df
+cb5e6
+    ldy #$fa                                                          ; 55e6: a0 fa       ..  :b5e6[1]
+    jsr cb82b                                                         ; 55e8: 20 2b b8     +. :b5e8[1]
+    sta (l00b8),y                                                     ; 55eb: 91 b8       ..  :b5eb[1]
+; $55ed referenced 1 time by $b5f6
+loop_cb5ed
+    rts                                                               ; 55ed: 60          `   :b5ed[1]
+
+; $55ee referenced 2 times by $b375, $b4d8
+sub_cb5ee
+    lda #$80                                                          ; 55ee: a9 80       ..  :b5ee[1]
+    bne cb5d0                                                         ; 55f0: d0 de       ..  :b5f0[1]
+; $55f2 referenced 6 times by $b21b, $b371, $b45a, $b477, $b4ea, $b534
+sub_cb5f2
+    ldy #$fa                                                          ; 55f2: a0 fa       ..  :b5f2[1]
+    lda (l00b8),y                                                     ; 55f4: b1 b8       ..  :b5f4[1]
+    beq loop_cb5ed                                                    ; 55f6: f0 f5       ..  :b5f6[1]
+    pha                                                               ; 55f8: 48          H   :b5f8[1]
+    lda #0                                                            ; 55f9: a9 00       ..  :b5f9[1]
+    sta (l00b8),y                                                     ; 55fb: 91 b8       ..  :b5fb[1]
+    pla                                                               ; 55fd: 68          h   :b5fd[1]
+    tay                                                               ; 55fe: a8          .   :b5fe[1]
+    lda #0                                                            ; 55ff: a9 00       ..  :b5ff[1]
+    jsr osfind                                                        ; 5601: 20 ce ff     .. :b601[1]
+    jmp cb82b                                                         ; 5604: 4c 2b b8    L+. :b604[1]
+
+; $5607 referenced 2 times by $b348, $b36c
+sub_cb607
+    ldy #$fa                                                          ; 5607: a0 fa       ..  :b607[1]
+    lda (l00b8),y                                                     ; 5609: b1 b8       ..  :b609[1]
+    tax                                                               ; 560b: aa          .   :b60b[1]
+    lda #1                                                            ; 560c: a9 01       ..  :b60c[1]
+    jsr sub_cb86f                                                     ; 560e: 20 6f b8     o. :b60e[1]
+    jsr cb82b                                                         ; 5611: 20 2b b8     +. :b611[1]
+    txa                                                               ; 5614: 8a          .   :b614[1]
+    rts                                                               ; 5615: 60          `   :b615[1]
+
+; $5616 referenced 4 times by $b378, $b3b3, $b4e4, $be5d
+sub_cb616
+    ldy #$f4                                                          ; 5616: a0 f4       ..  :b616[1]
+    lda (l00b8),y                                                     ; 5618: b1 b8       ..  :b618[1]
+    iny                                                               ; 561a: c8          .   :b61a[1]
+    ora (l00b8),y                                                     ; 561b: 11 b8       ..  :b61b[1]
+    rts                                                               ; 561d: 60          `   :b61d[1]
+
+; $561e referenced 2 times by $b4cf, $b522
+sub_cb61e
+    stx l00bc                                                         ; 561e: 86 bc       ..  :b61e[1]
+    ldy #$fb                                                          ; 5620: a0 fb       ..  :b620[1]
+    jsr sub_cb83f                                                     ; 5622: 20 3f b8     ?. :b622[1]
+    ldy #$f4                                                          ; 5625: a0 f4       ..  :b625[1]
+    lda (l00b8),y                                                     ; 5627: b1 b8       ..  :b627[1]
+    sec                                                               ; 5629: 38          8   :b629[1]
+    sbc l00ba                                                         ; 562a: e5 ba       ..  :b62a[1]
+    sta (l00b8),y                                                     ; 562c: 91 b8       ..  :b62c[1]
+    sta l00ba                                                         ; 562e: 85 ba       ..  :b62e[1]
+    iny                                                               ; 5630: c8          .   :b630[1]
+    lda (l00b8),y                                                     ; 5631: b1 b8       ..  :b631[1]
+    sbc l00bb                                                         ; 5633: e5 bb       ..  :b633[1]
+    sta (l00b8),y                                                     ; 5635: 91 b8       ..  :b635[1]
+    sta l00bb                                                         ; 5637: 85 bb       ..  :b637[1]
+    ora l00ba                                                         ; 5639: 05 ba       ..  :b639[1]
+    beq cb65e                                                         ; 563b: f0 21       .!  :b63b[1]
+    ldx l00bc                                                         ; 563d: a6 bc       ..  :b63d[1]
+    jsr sub_cb85d                                                     ; 563f: 20 5d b8     ]. :b63f[1]
+    bvc cb655                                                         ; 5642: 50 11       P.  :b642[1]
+    lda l0001,x                                                       ; 5644: b5 01       ..  :b644[1]
+    cmp #$c0                                                          ; 5646: c9 c0       ..  :b646[1]
+    bcc cb655                                                         ; 5648: 90 0b       ..  :b648[1]
+    lda #$10                                                          ; 564a: a9 10       ..  :b64a[1]
+    sta l0000,x                                                       ; 564c: 95 00       ..  :b64c[1]
+    lda #$80                                                          ; 564e: a9 80       ..  :b64e[1]
+    sta l0001,x                                                       ; 5650: 95 01       ..  :b650[1]
+    jsr sub_cb68f                                                     ; 5652: 20 8f b6     .. :b652[1]
+; $5655 referenced 2 times by $b642, $b648
+cb655
+    ldx l00bc                                                         ; 5655: a6 bc       ..  :b655[1]
+    ldy #$f2                                                          ; 5657: a0 f2       ..  :b657[1]
+    jsr sub_cb850                                                     ; 5659: 20 50 b8     P. :b659[1]
+    lda #$ff                                                          ; 565c: a9 ff       ..  :b65c[1]
+; $565e referenced 1 time by $b63b
+cb65e
+    rts                                                               ; 565e: 60          `   :b65e[1]
+
+; $565f referenced 2 times by $b34f, $b37f
+sub_cb65f
+    ldx #$bd                                                          ; 565f: a2 bd       ..  :b65f[1]
+    ldy #$f2                                                          ; 5661: a0 f2       ..  :b661[1]
+    jsr sub_cb841                                                     ; 5663: 20 41 b8     A. :b663[1]
+    inc l00bd                                                         ; 5666: e6 bd       ..  :b666[1]
+    bne cb684                                                         ; 5668: d0 1a       ..  :b668[1]
+    inc l00be                                                         ; 566a: e6 be       ..  :b66a[1]
+    beq cb68c                                                         ; 566c: f0 1e       ..  :b66c[1]
+    jsr sub_cb85d                                                     ; 566e: 20 5d b8     ]. :b66e[1]
+    bvc cb684                                                         ; 5671: 50 11       P.  :b671[1]
+    lda l00be                                                         ; 5673: a5 be       ..  :b673[1]
+    cmp #$c0                                                          ; 5675: c9 c0       ..  :b675[1]
+    bne cb684                                                         ; 5677: d0 0b       ..  :b677[1]
+    jsr sub_cb68f                                                     ; 5679: 20 8f b6     .. :b679[1]
+    lda #$10                                                          ; 567c: a9 10       ..  :b67c[1]
+    sta l00bd                                                         ; 567e: 85 bd       ..  :b67e[1]
+    lda #$80                                                          ; 5680: a9 80       ..  :b680[1]
+    sta l00be                                                         ; 5682: 85 be       ..  :b682[1]
+; $5684 referenced 3 times by $b668, $b671, $b677
+cb684
+    ldx #$bd                                                          ; 5684: a2 bd       ..  :b684[1]
+    ldy #$f2                                                          ; 5686: a0 f2       ..  :b686[1]
+    jsr sub_cb850                                                     ; 5688: 20 50 b8     P. :b688[1]
+    rts                                                               ; 568b: 60          `   :b68b[1]
+
+; $568c referenced 4 times by $b66c, $b698, $b69c, $b6ae
+cb68c
+    jmp cb446                                                         ; 568c: 4c 46 b4    LF. :b68c[1]
+
+; $568f referenced 4 times by $b652, $b679, $b81f, $be77
+sub_cb68f
+    ldy #$f1                                                          ; 568f: a0 f1       ..  :b68f[1]
+    lda (l00b8),y                                                     ; 5691: b1 b8       ..  :b691[1]
+    clc                                                               ; 5693: 18          .   :b693[1]
+    adc #1                                                            ; 5694: 69 01       i.  :b694[1]
+    cmp #$10                                                          ; 5696: c9 10       ..  :b696[1]
+    bcs cb68c                                                         ; 5698: b0 f2       ..  :b698[1]
+    cmp #2                                                            ; 569a: c9 02       ..  :b69a[1]
+    beq cb68c                                                         ; 569c: f0 ee       ..  :b69c[1]
+    cmp #$0e                                                          ; 569e: c9 0e       ..  :b69e[1]
+    bne cb6a6                                                         ; 56a0: d0 04       ..  :b6a0[1]
+    ldy #$fe                                                          ; 56a2: a0 fe       ..  :b6a2[1]
+    and (l00b8),y                                                     ; 56a4: 31 b8       1.  :b6a4[1]
+; $56a6 referenced 1 time by $b6a0
+cb6a6
+    ldy #$f1                                                          ; 56a6: a0 f1       ..  :b6a6[1]
+    sta (l00b8),y                                                     ; 56a8: 91 b8       ..  :b6a8[1]
+    tay                                                               ; 56aa: a8          .   :b6aa[1]
+    jsr sub_cb6fe                                                     ; 56ab: 20 fe b6     .. :b6ab[1]
+    beq cb68c                                                         ; 56ae: f0 dc       ..  :b6ae[1]
+    rts                                                               ; 56b0: 60          `   :b6b0[1]
+
+; $56b1 referenced 2 times by $b305, $bcda
+sub_cb6b1
+    ldy #$10                                                          ; 56b1: a0 10       ..  :b6b1[1]
+; $56b3 referenced 1 time by $b6c5
+loop_cb6b3
+    cmp cb6ca,y                                                       ; 56b3: d9 ca b6    ... :b6b3[1]
+    bcc cb6ca                                                         ; 56b6: 90 12       ..  :b6b6[1]
+    bne cb6c2                                                         ; 56b8: d0 08       ..  :b6b8[1]
+    pha                                                               ; 56ba: 48          H   :b6ba[1]
+    txa                                                               ; 56bb: 8a          .   :b6bb[1]
+    cmp lb6c6,y                                                       ; 56bc: d9 c6 b6    ... :b6bc[1]
+    pla                                                               ; 56bf: 68          h   :b6bf[1]
+    bcc cb6ca                                                         ; 56c0: 90 08       ..  :b6c0[1]
+; $56c2 referenced 1 time by $b6b8
+cb6c2
+    iny                                                               ; 56c2: c8          .   :b6c2[1]
+    cpy #$14                                                          ; 56c3: c0 14       ..  :b6c3[1]
+sub_cb6c5
+lb6c6 = sub_cb6c5+1
+    bcc loop_cb6b3                                                    ; 56c5: 90 ec       ..  :b6c5[1]
+; $56c6 referenced 1 time by $b6bc
+    jmp cb446                                                         ; 56c7: 4c 46 b4    LF. :b6c7[1]
+
+; $56ca referenced 3 times by $b6b3, $b6b6, $b6c0
+cb6ca
+    pha                                                               ; 56ca: 48          H   :b6ca[1]
+    txa                                                               ; 56cb: 8a          .   :b6cb[1]
+    clc                                                               ; 56cc: 18          .   :b6cc[1]
+sub_cb6cd
+lb6ce = sub_cb6cd+1
+    adc lb6ce,y                                                       ; 56cd: 79 ce b6    y.. :b6cd[1]
+; $56ce referenced 1 time by $b6cd
+    tax                                                               ; 56d0: aa          .   :b6d0[1]
+    pla                                                               ; 56d1: 68          h   :b6d1[1]
+; $56d2 referenced 1 time by $b6d2
+cb6d2
+    adc cb6d2,y                                                       ; 56d2: 79 d2 b6    y.. :b6d2[1]
+    rts                                                               ; 56d5: 60          `   :b6d5[1]
+
+    !byte $f0, $e0, $d0, $c0, $3f, $7f, $bf, $ff, $10                 ; 56d6: f0 e0 d0... ... :b6d6[1]
+    !text " 0@"                                                       ; 56df: 20 30 40     0@ :b6df[1]
+    !byte $80, $40,   0, $c0                                          ; 56e2: 80 40 00... .@. :b6e2[1]
+
+; $56e6 referenced 1 time by $b6fe
+sub_cb6e6
+    cpy #$10                                                          ; 56e6: c0 10       ..  :b6e6[1]
+    bcs cb6eb                                                         ; 56e8: b0 01       ..  :b6e8[1]
+    rts                                                               ; 56ea: 60          `   :b6ea[1]
+
+; $56eb referenced 1 time by $b6e8
+cb6eb
+    tya                                                               ; 56eb: 98          .   :b6eb[1]
+    sec                                                               ; 56ec: 38          8   :b6ec[1]
+    sbc #4                                                            ; 56ed: e9 04       ..  :b6ed[1]
+    tay                                                               ; 56ef: a8          .   :b6ef[1]
+    cpy #$0e                                                          ; 56f0: c0 0e       ..  :b6f0[1]
+    bcs cb6f5                                                         ; 56f2: b0 01       ..  :b6f2[1]
+    rts                                                               ; 56f4: 60          `   :b6f4[1]
+
+; $56f5 referenced 1 time by $b6f2
+cb6f5
+    tya                                                               ; 56f5: 98          .   :b6f5[1]
+    and #1                                                            ; 56f6: 29 01       ).  :b6f6[1]
+    ldy #$fe                                                          ; 56f8: a0 fe       ..  :b6f8[1]
+    ora (l00b8),y                                                     ; 56fa: 11 b8       ..  :b6fa[1]
+    tay                                                               ; 56fc: a8          .   :b6fc[1]
+    rts                                                               ; 56fd: 60          `   :b6fd[1]
+
+; $56fe referenced 5 times by $b314, $b6ab, $bc44, $bc8e, $bce1
+sub_cb6fe
+    jsr sub_cb6e6                                                     ; 56fe: 20 e6 b6     .. :b6fe[1]
+    tya                                                               ; 5701: 98          .   :b701[1]
+    tax                                                               ; 5702: aa          .   :b702[1]
+    lda lb726,y                                                       ; 5703: b9 26 b7    .&. :b703[1]
+    pha                                                               ; 5706: 48          H   :b706[1]
+    ldy #$ee                                                          ; 5707: a0 ee       ..  :b707[1]
+    and (l00b8),y                                                     ; 5709: 31 b8       1.  :b709[1]
+    bne cb718                                                         ; 570b: d0 0b       ..  :b70b[1]
+    lda (l00b8),y                                                     ; 570d: b1 b8       ..  :b70d[1]
+    and #$c0                                                          ; 570f: 29 c0       ).  :b70f[1]
+    cmp #$80                                                          ; 5711: c9 80       ..  :b711[1]
+    beq cb718                                                         ; 5713: f0 03       ..  :b713[1]
+    jmp cb446                                                         ; 5715: 4c 46 b4    LF. :b715[1]
+
+; $5718 referenced 2 times by $b70b, $b713
+cb718
+    pla                                                               ; 5718: 68          h   :b718[1]
+    ldy #$fd                                                          ; 5719: a0 fd       ..  :b719[1]
+    and (l00b8),y                                                     ; 571b: 31 b8       1.  :b71b[1]
+    pha                                                               ; 571d: 48          H   :b71d[1]
+    txa                                                               ; 571e: 8a          .   :b71e[1]
+    tay                                                               ; 571f: a8          .   :b71f[1]
+    pla                                                               ; 5720: 68          h   :b720[1]
+    beq cb725                                                         ; 5721: f0 02       ..  :b721[1]
+    lda #$ff                                                          ; 5723: a9 ff       ..  :b723[1]
+; $5725 referenced 1 time by $b721
+cb725
+    rts                                                               ; 5725: 60          `   :b725[1]
+
+; $5726 referenced 6 times by $b703, $b898, $b8c8, $b8db, $bc56, $bca1
+lb726
+    !byte   4,   8,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0  ; 5726: 04 08 00... ... :b726[1]
+    !byte   1,   2, $10, $20                                          ; 5732: 01 02 10... ... :b732[1]
+
+; $5736 referenced 1 time by $b75a
+cb736
+    sty romsel_copy                                                   ; 5736: 84 f4       ..  :b736[1]
+    sty romsel                                                        ; 5738: 8c 30 fe    .0. :b738[1]
+    ldy #0                                                            ; 573b: a0 00       ..  :b73b[1]
+    sta (l00ba),y                                                     ; 573d: 91 ba       ..  :b73d[1]
+    stx romsel_copy                                                   ; 573f: 86 f4       ..  :b73f[1]
+    stx romsel                                                        ; 5741: 8e 30 fe    .0. :b741[1]
+    rts                                                               ; 5744: 60          `   :b744[1]
+
+; $5745 referenced 5 times by $b369, $b8b7, $b8d1, $bc78, $bc9e
+sub_cb745
+    sta l00bf                                                         ; 5745: 85 bf       ..  :b745[1]
+    txa                                                               ; 5747: 8a          .   :b747[1]
+    pha                                                               ; 5748: 48          H   :b748[1]
+    tya                                                               ; 5749: 98          .   :b749[1]
+    pha                                                               ; 574a: 48          H   :b74a[1]
+    ldx romsel_copy                                                   ; 574b: a6 f4       ..  :b74b[1]
+    lda l0df0,x                                                       ; 574d: bd f0 0d    ... :b74d[1]
+    sta l00b1                                                         ; 5750: 85 b1       ..  :b750[1]
+    inc l00b1                                                         ; 5752: e6 b1       ..  :b752[1]
+    lda #0                                                            ; 5754: a9 00       ..  :b754[1]
+    sta l00b0                                                         ; 5756: 85 b0       ..  :b756[1]
+    ldy #$0e                                                          ; 5758: a0 0e       ..  :b758[1]
+; $575a referenced 1 time by $b760
+loop_cb75a
+    lda cb736,y                                                       ; 575a: b9 36 b7    .6. :b75a[1]
+    sta (l00b0),y                                                     ; 575d: 91 b0       ..  :b75d[1]
+    dey                                                               ; 575f: 88          .   :b75f[1]
+    bpl loop_cb75a                                                    ; 5760: 10 f8       ..  :b760[1]
+    pla                                                               ; 5762: 68          h   :b762[1]
+    pha                                                               ; 5763: 48          H   :b763[1]
+    tay                                                               ; 5764: a8          .   :b764[1]
+    lda l00bf                                                         ; 5765: a5 bf       ..  :b765[1]
+    jsr sub_cb771                                                     ; 5767: 20 71 b7     q. :b767[1]
+    pla                                                               ; 576a: 68          h   :b76a[1]
+    tay                                                               ; 576b: a8          .   :b76b[1]
+    pla                                                               ; 576c: 68          h   :b76c[1]
+    tax                                                               ; 576d: aa          .   :b76d[1]
+    lda l00bf                                                         ; 576e: a5 bf       ..  :b76e[1]
+    rts                                                               ; 5770: 60          `   :b770[1]
+
+; $5771 referenced 1 time by $b767
+sub_cb771
+    jmp (l00b0)                                                       ; 5771: 6c b0 00    l.. :b771[1]
+
+; $5774 referenced 1 time by $b7be
+lb774
+    !byte $85, $f4, $8d, $30, $fe, $b1, $b1, $91, $b3, $c8, $d0,   5  ; 5774: 85 f4 8d... ... :b774[1]
+    !byte $e6, $b2, $e6, $b4, $ca, $c4, $b5, $d0, $f0, $8a, $d0, $ed  ; 5780: e6 b2 e6... ... :b780[1]
+    !byte $68, $85, $f4, $8d, $30, $fe, $4c, $d5, $b7                 ; 578c: 68 85 f4... h.. :b78c[1]
+
+; $5795 referenced 5 times by $b4ca, $b51d, $bd0b, $bdb0, $bded
+cb795
+    ldy #$f1                                                          ; 5795: a0 f1       ..  :b795[1]
+    lda (l00b8),y                                                     ; 5797: b1 b8       ..  :b797[1]
+    sta l00b0                                                         ; 5799: 85 b0       ..  :b799[1]
+    ldx l00be                                                         ; 579b: a6 be       ..  :b79b[1]
+    ldy l00bf                                                         ; 579d: a4 bf       ..  :b79d[1]
+    lda #0                                                            ; 579f: a9 00       ..  :b79f[1]
+    rol                                                               ; 57a1: 2a          *   :b7a1[1]
+    asl                                                               ; 57a2: 0a          .   :b7a2[1]
+    sta l00b7                                                         ; 57a3: 85 b7       ..  :b7a3[1]
+    inc l00b7                                                         ; 57a5: e6 b7       ..  :b7a5[1]
+    jsr sub_cb85d                                                     ; 57a7: 20 5d b8     ]. :b7a7[1]
+    bvs cb7ed                                                         ; 57aa: 70 41       pA  :b7aa[1]
+    bvc cb7b2                                                         ; 57ac: 50 04       P.  :b7ac[1]
+; $57ae referenced 1 time by $b803
+cb7ae
+    ldx l00be                                                         ; 57ae: a6 be       ..  :b7ae[1]
+    ldy l00bf                                                         ; 57b0: a4 bf       ..  :b7b0[1]
+; $57b2 referenced 1 time by $b7ac
+cb7b2
+    stx l00b5                                                         ; 57b2: 86 b5       ..  :b7b2[1]
+    sty l00b6                                                         ; 57b4: 84 b6       ..  :b7b4[1]
+; $57b6 referenced 1 time by $b812
+sub_cb7b6
+    lda l00b5                                                         ; 57b6: a5 b5       ..  :b7b6[1]
+    ora l00b6                                                         ; 57b8: 05 b6       ..  :b7b8[1]
+    beq cb7ec                                                         ; 57ba: f0 30       .0  :b7ba[1]
+    ldx #$20 ; ' '                                                    ; 57bc: a2 20       .   :b7bc[1]
+; $57be referenced 1 time by $b7c3
+loop_cb7be
+    lda lb774,x                                                       ; 57be: bd 74 b7    .t. :b7be[1]
+    pha                                                               ; 57c1: 48          H   :b7c1[1]
+    dex                                                               ; 57c2: ca          .   :b7c2[1]
+    bpl loop_cb7be                                                    ; 57c3: 10 f9       ..  :b7c3[1]
+    tsx                                                               ; 57c5: ba          .   :b7c5[1]
+    lda romsel_copy                                                   ; 57c6: a5 f4       ..  :b7c6[1]
+    pha                                                               ; 57c8: 48          H   :b7c8[1]
+    lda #1                                                            ; 57c9: a9 01       ..  :b7c9[1]
+    pha                                                               ; 57cb: 48          H   :b7cb[1]
+    txa                                                               ; 57cc: 8a          .   :b7cc[1]
+    pha                                                               ; 57cd: 48          H   :b7cd[1]
+    lda l00b0                                                         ; 57ce: a5 b0       ..  :b7ce[1]
+    ldx l00b6                                                         ; 57d0: a6 b6       ..  :b7d0[1]
+    ldy #0                                                            ; 57d2: a0 00       ..  :b7d2[1]
+    rts                                                               ; 57d4: 60          `   :b7d4[1]
+
+    ldx #$21 ; '!'                                                    ; 57d5: a2 21       .!  :b7d5[1]
+; $57d7 referenced 1 time by $b7d9
+loop_cb7d7
+    pla                                                               ; 57d7: 68          h   :b7d7[1]
+    dex                                                               ; 57d8: ca          .   :b7d8[1]
+    bne loop_cb7d7                                                    ; 57d9: d0 fc       ..  :b7d9[1]
+    ldx #2                                                            ; 57db: a2 02       ..  :b7db[1]
+; $57dd referenced 1 time by $b7ea
+loop_cb7dd
+    lda l00b1,x                                                       ; 57dd: b5 b1       ..  :b7dd[1]
+    clc                                                               ; 57df: 18          .   :b7df[1]
+    adc l00b5                                                         ; 57e0: 65 b5       e.  :b7e0[1]
+    sta l00b1,x                                                       ; 57e2: 95 b1       ..  :b7e2[1]
+    bcc cb7e8                                                         ; 57e4: 90 02       ..  :b7e4[1]
+    inc l00b2,x                                                       ; 57e6: f6 b2       ..  :b7e6[1]
+; $57e8 referenced 1 time by $b7e4
+cb7e8
+    dex                                                               ; 57e8: ca          .   :b7e8[1]
+    dex                                                               ; 57e9: ca          .   :b7e9[1]
+    bpl loop_cb7dd                                                    ; 57ea: 10 f1       ..  :b7ea[1]
+; $57ec referenced 1 time by $b7ba
+cb7ec
+    rts                                                               ; 57ec: 60          `   :b7ec[1]
+
+; $57ed referenced 2 times by $b7aa, $b828
+cb7ed
+    lda #0                                                            ; 57ed: a9 00       ..  :b7ed[1]
+    sec                                                               ; 57ef: 38          8   :b7ef[1]
+    ldx l00b7                                                         ; 57f0: a6 b7       ..  :b7f0[1]
+    sbc l00b0,x                                                       ; 57f2: f5 b0       ..  :b7f2[1]
+    sta l00b5                                                         ; 57f4: 85 b5       ..  :b7f4[1]
+    lda #$c0                                                          ; 57f6: a9 c0       ..  :b7f6[1]
+    sbc l00b1,x                                                       ; 57f8: f5 b1       ..  :b7f8[1]
+    sta l00b6                                                         ; 57fa: 85 b6       ..  :b7fa[1]
+    ldx #$b5                                                          ; 57fc: a2 b5       ..  :b7fc[1]
+    ldy #$be                                                          ; 57fe: a0 be       ..  :b7fe[1]
+    jsr sub_cb58b                                                     ; 5800: 20 8b b5     .. :b800[1]
+    bcs cb7ae                                                         ; 5803: b0 a9       ..  :b803[1]
+    lda l00be                                                         ; 5805: a5 be       ..  :b805[1]
+    sec                                                               ; 5807: 38          8   :b807[1]
+    sbc l00b5                                                         ; 5808: e5 b5       ..  :b808[1]
+    sta l00be                                                         ; 580a: 85 be       ..  :b80a[1]
+    lda l00bf                                                         ; 580c: a5 bf       ..  :b80c[1]
+    sbc l00b6                                                         ; 580e: e5 b6       ..  :b80e[1]
+    sta l00bf                                                         ; 5810: 85 bf       ..  :b810[1]
+    jsr sub_cb7b6                                                     ; 5812: 20 b6 b7     .. :b812[1]
+    lda #$10                                                          ; 5815: a9 10       ..  :b815[1]
+    ldx l00b7                                                         ; 5817: a6 b7       ..  :b817[1]
+    sta l00b0,x                                                       ; 5819: 95 b0       ..  :b819[1]
+    lda #$80                                                          ; 581b: a9 80       ..  :b81b[1]
+    sta l00b1,x                                                       ; 581d: 95 b1       ..  :b81d[1]
+    jsr sub_cb68f                                                     ; 581f: 20 8f b6     .. :b81f[1]
+    ldy #$f1                                                          ; 5822: a0 f1       ..  :b822[1]
+    lda (l00b8),y                                                     ; 5824: b1 b8       ..  :b824[1]
+    sta l00b0                                                         ; 5826: 85 b0       ..  :b826[1]
+    jmp cb7ed                                                         ; 5828: 4c ed b7    L.. :b828[1]
+
+; $582b referenced 16 times by $b1c1, $b2c8, $b2e7, $b32c, $b35a, $b3b0, $b3ec, $b429, $b4a3, $b573, $b5ca, $b5e8, $b604, $b611, $b86b, $beb5
+cb82b
+    php                                                               ; 582b: 08          .   :b82b[1]
+    pha                                                               ; 582c: 48          H   :b82c[1]
+    txa                                                               ; 582d: 8a          .   :b82d[1]
+    pha                                                               ; 582e: 48          H   :b82e[1]
+    lda #0                                                            ; 582f: a9 00       ..  :b82f[1]
+    sta l00b8                                                         ; 5831: 85 b8       ..  :b831[1]
+    ldx romsel_copy                                                   ; 5833: a6 f4       ..  :b833[1]
+    lda l0df0,x                                                       ; 5835: bd f0 0d    ... :b835[1]
+    sta l00b9                                                         ; 5838: 85 b9       ..  :b838[1]
+    pla                                                               ; 583a: 68          h   :b83a[1]
+    tax                                                               ; 583b: aa          .   :b83b[1]
+    pla                                                               ; 583c: 68          h   :b83c[1]
+    plp                                                               ; 583d: 28          (   :b83d[1]
+    rts                                                               ; 583e: 60          `   :b83e[1]
+
+; $583f referenced 4 times by $b35f, $b4e1, $b53d, $b622
+sub_cb83f
+    ldx #$ba                                                          ; 583f: a2 ba       ..  :b83f[1]
+; $5841 referenced 12 times by $b39b, $b462, $b4b8, $b4bf, $b4c6, $b4f2, $b50b, $b512, $b519, $b663, $bd4a, $bdc4
+sub_cb841
+    pha                                                               ; 5841: 48          H   :b841[1]
+    lda (l00b8),y                                                     ; 5842: b1 b8       ..  :b842[1]
+    sta l0000,x                                                       ; 5844: 95 00       ..  :b844[1]
+    iny                                                               ; 5846: c8          .   :b846[1]
+    lda (l00b8),y                                                     ; 5847: b1 b8       ..  :b847[1]
+    sta l0001,x                                                       ; 5849: 95 01       ..  :b849[1]
+    dey                                                               ; 584b: 88          .   :b84b[1]
+    pla                                                               ; 584c: 68          h   :b84c[1]
+    rts                                                               ; 584d: 60          `   :b84d[1]
+
+; $584e referenced 3 times by $b3f5, $b472, $b504
+sub_cb84e
+    ldx #$ba                                                          ; 584e: a2 ba       ..  :b84e[1]
+; $5850 referenced 5 times by $b659, $b688, $bb5c, $bb8d, $bd36
+sub_cb850
+    pha                                                               ; 5850: 48          H   :b850[1]
+    lda l0000,x                                                       ; 5851: b5 00       ..  :b851[1]
+    sta (l00b8),y                                                     ; 5853: 91 b8       ..  :b853[1]
+    iny                                                               ; 5855: c8          .   :b855[1]
+    lda l0001,x                                                       ; 5856: b5 01       ..  :b856[1]
+    sta (l00b8),y                                                     ; 5858: 91 b8       ..  :b858[1]
+    dey                                                               ; 585a: 88          .   :b85a[1]
+    pla                                                               ; 585b: 68          h   :b85b[1]
+    rts                                                               ; 585c: 60          `   :b85c[1]
+
+; $585d referenced 8 times by $b2f2, $b340, $b406, $b63f, $b66e, $b7a7, $be64, $be9d
+sub_cb85d
+    pha                                                               ; 585d: 48          H   :b85d[1]
+    tya                                                               ; 585e: 98          .   :b85e[1]
+    pha                                                               ; 585f: 48          H   :b85f[1]
+    ldy #$ee                                                          ; 5860: a0 ee       ..  :b860[1]
+    lda (l00b8),y                                                     ; 5862: b1 b8       ..  :b862[1]
+    sta l00b8                                                         ; 5864: 85 b8       ..  :b864[1]
+    pla                                                               ; 5866: 68          h   :b866[1]
+    tay                                                               ; 5867: a8          .   :b867[1]
+    pla                                                               ; 5868: 68          h   :b868[1]
+    bit l00b8                                                         ; 5869: 24 b8       $.  :b869[1]
+    jsr cb82b                                                         ; 586b: 20 2b b8     +. :b86b[1]
+    rts                                                               ; 586e: 60          `   :b86e[1]
+
+; $586f referenced 1 time by $b60e
+sub_cb86f
+    jmp (fscv)                                                        ; 586f: 6c 1e 02    l.. :b86f[1]
+
+; $5872 referenced 2 times by $b9c7, $bc70
+lb872
+    !byte $60,   0,   0, $60,   0,   0,   2, $0c, $ff                 ; 5872: 60 00 00... `.. :b872[1]
+    !text "RAM"                                                       ; 587b: 52 41 4d    RAM :b87b[1]
+; $587e referenced 1 time by $b9a3
+lb87e
+    !byte 0                                                           ; 587e: 00          .   :b87e[1]
+    !text "(C)"                                                       ; 587f: 28 43 29    (C) :b87f[1]
+
+; $5882 referenced 1 time by $b200
+sub_cb882
+    lda #0                                                            ; 5882: a9 00       ..  :b882[1]
+    ldy #$fd                                                          ; 5884: a0 fd       ..  :b884[1]
+    sta (l00b8),y                                                     ; 5886: 91 b8       ..  :b886[1]
+    ldy #$ee                                                          ; 5888: a0 ee       ..  :b888[1]
+    sta (l00b8),y                                                     ; 588a: 91 b8       ..  :b88a[1]
+    ldy #$fa                                                          ; 588c: a0 fa       ..  :b88c[1]
+    sta (l00b8),y                                                     ; 588e: 91 b8       ..  :b88e[1]
+    ldy #$ff                                                          ; 5890: a0 ff       ..  :b890[1]
+    lda #$4e ; 'N'                                                    ; 5892: a9 4e       .N  :b892[1]
+    sta (l00b8),y                                                     ; 5894: 91 b8       ..  :b894[1]
+    ldy #$0f                                                          ; 5896: a0 0f       ..  :b896[1]
+; $5898 referenced 1 time by $b8e7
+cb898
+    lda lb726,y                                                       ; 5898: b9 26 b7    .&. :b898[1]
+    beq cb8e6                                                         ; 589b: f0 49       .I  :b89b[1]
+    tya                                                               ; 589d: 98          .   :b89d[1]
+    pha                                                               ; 589e: 48          H   :b89e[1]
+    lda #8                                                            ; 589f: a9 08       ..  :b89f[1]
+    sta osrdsc_ptr                                                    ; 58a1: 85 f6       ..  :b8a1[1]
+    sta l00ba                                                         ; 58a3: 85 ba       ..  :b8a3[1]
+    lda #$80                                                          ; 58a5: a9 80       ..  :b8a5[1]
+    sta l00f7                                                         ; 58a7: 85 f7       ..  :b8a7[1]
+    sta l00bb                                                         ; 58a9: 85 bb       ..  :b8a9[1]
+    jsr osrdsc                                                        ; 58ab: 20 b9 ff     .. :b8ab[1]
+    sta l00bd                                                         ; 58ae: 85 bd       ..  :b8ae[1]
+    pla                                                               ; 58b0: 68          h   :b8b0[1]
+    pha                                                               ; 58b1: 48          H   :b8b1[1]
+    tay                                                               ; 58b2: a8          .   :b8b2[1]
+    lda l00bd                                                         ; 58b3: a5 bd       ..  :b8b3[1]
+    eor #$ff                                                          ; 58b5: 49 ff       I.  :b8b5[1]
+    jsr sub_cb745                                                     ; 58b7: 20 45 b7     E. :b8b7[1]
+    jsr osrdsc                                                        ; 58ba: 20 b9 ff     .. :b8ba[1]
+    cmp l00bd                                                         ; 58bd: c5 bd       ..  :b8bd[1]
+    beq cb8e4                                                         ; 58bf: f0 23       .#  :b8bf[1]
+    pla                                                               ; 58c1: 68          h   :b8c1[1]
+    pha                                                               ; 58c2: 48          H   :b8c2[1]
+    tax                                                               ; 58c3: aa          .   :b8c3[1]
+    ldy #$ee                                                          ; 58c4: a0 ee       ..  :b8c4[1]
+    lda (l00b8),y                                                     ; 58c6: b1 b8       ..  :b8c6[1]
+    ora lb726,x                                                       ; 58c8: 1d 26 b7    .&. :b8c8[1]
+    sta (l00b8),y                                                     ; 58cb: 91 b8       ..  :b8cb[1]
+    txa                                                               ; 58cd: 8a          .   :b8cd[1]
+    tay                                                               ; 58ce: a8          .   :b8ce[1]
+    lda l00bd                                                         ; 58cf: a5 bd       ..  :b8cf[1]
+    jsr sub_cb745                                                     ; 58d1: 20 45 b7     E. :b8d1[1]
+    jsr sub_cb986                                                     ; 58d4: 20 86 b9     .. :b8d4[1]
+    cmp #2                                                            ; 58d7: c9 02       ..  :b8d7[1]
+    bne cb8e4                                                         ; 58d9: d0 09       ..  :b8d9[1]
+    lda lb726,y                                                       ; 58db: b9 26 b7    .&. :b8db[1]
+    ldy #$fd                                                          ; 58de: a0 fd       ..  :b8de[1]
+    ora (l00b8),y                                                     ; 58e0: 11 b8       ..  :b8e0[1]
+    sta (l00b8),y                                                     ; 58e2: 91 b8       ..  :b8e2[1]
+; $58e4 referenced 2 times by $b8bf, $b8d9
+cb8e4
+    pla                                                               ; 58e4: 68          h   :b8e4[1]
+    tay                                                               ; 58e5: a8          .   :b8e5[1]
+; $58e6 referenced 1 time by $b89b
+cb8e6
+    dey                                                               ; 58e6: 88          .   :b8e6[1]
+    bpl cb898                                                         ; 58e7: 10 af       ..  :b8e7[1]
+    ldy #$ee                                                          ; 58e9: a0 ee       ..  :b8e9[1]
+    lda (l00b8),y                                                     ; 58eb: b1 b8       ..  :b8eb[1]
+    ldx #0                                                            ; 58ed: a2 00       ..  :b8ed[1]
+    and #$0c                                                          ; 58ef: 29 0c       ).  :b8ef[1]
+    bne cb8f5                                                         ; 58f1: d0 02       ..  :b8f1[1]
+    ldx #$0e                                                          ; 58f3: a2 0e       ..  :b8f3[1]
+; $58f5 referenced 1 time by $b8f1
+cb8f5
+    txa                                                               ; 58f5: 8a          .   :b8f5[1]
+    ldy #$fe                                                          ; 58f6: a0 fe       ..  :b8f6[1]
+    sta (l00b8),y                                                     ; 58f8: 91 b8       ..  :b8f8[1]
+    rts                                                               ; 58fa: 60          `   :b8fa[1]
+
+; $58fb referenced 6 times by $b302, $b334, $b448, $b5e3, $bafa, $bc51
+cb8fb
+    lda #0                                                            ; 58fb: a9 00       ..  :b8fb[1]
+    sta l0100                                                         ; 58fd: 8d 00 01    ... :b8fd[1]
+    lda lb980,x                                                       ; 5900: bd 80 b9    ... :b900[1]
+    sta l0101                                                         ; 5903: 8d 01 01    ... :b903[1]
+    lda lb97a,x                                                       ; 5906: bd 7a b9    .z. :b906[1]
+    sta l00bf                                                         ; 5909: 85 bf       ..  :b909[1]
+    ldy lb979,x                                                       ; 590b: bc 79 b9    .y. :b90b[1]
+    ldx #0                                                            ; 590e: a2 00       ..  :b90e[1]
+; $5910 referenced 1 time by $b91a
+loop_cb910
+    lda lb924,y                                                       ; 5910: b9 24 b9    .$. :b910[1]
+    sta l0102,x                                                       ; 5913: 9d 02 01    ... :b913[1]
+    inx                                                               ; 5916: e8          .   :b916[1]
+    iny                                                               ; 5917: c8          .   :b917[1]
+    cpy l00bf                                                         ; 5918: c4 bf       ..  :b918[1]
+    bcc loop_cb910                                                    ; 591a: 90 f4       ..  :b91a[1]
+    lda #0                                                            ; 591c: a9 00       ..  :b91c[1]
+    sta l0102,x                                                       ; 591e: 9d 02 01    ... :b91e[1]
+    jmp l0100                                                         ; 5921: 4c 00 01    L.. :b921[1]
+
+; $5924 referenced 1 time by $b910
+lb924
+    !text "Illegal parameterIllegal addressNo filing systemBad com"   ; 5924: 49 6c 6c... Ill :b924[1]
+    !text "mandFile not foundRAM occupied"                            ; 595b: 6d 61 6e... man :b95b[1]
+; $5979 referenced 1 time by $b90b
+lb979
+    !byte 0                                                           ; 5979: 00          .   :b979[1]
+; $597a referenced 1 time by $b906
+lb97a
+    !byte $11                                                         ; 597a: 11          .   :b97a[1]
+    !text " 0;IU"                                                     ; 597b: 20 30 3b...  0; :b97b[1]
+; $5980 referenced 1 time by $b900
+lb980
+    !byte $80, $81, $82, $fe, $d6, $83                                ; 5980: 80 81 82... ... :b980[1]
+
+; $5986 referenced 3 times by $b8d4, $bc49, $bcb2
+sub_cb986
+    txa                                                               ; 5986: 8a          .   :b986[1]
+    pha                                                               ; 5987: 48          H   :b987[1]
+    tya                                                               ; 5988: 98          .   :b988[1]
+    pha                                                               ; 5989: 48          H   :b989[1]
+    ldx #7                                                            ; 598a: a2 07       ..  :b98a[1]
+    stx osrdsc_ptr                                                    ; 598c: 86 f6       ..  :b98c[1]
+    lda #$80                                                          ; 598e: a9 80       ..  :b98e[1]
+    sta l00f7                                                         ; 5990: 85 f7       ..  :b990[1]
+    jsr osrdsc                                                        ; 5992: 20 b9 ff     .. :b992[1]
+    sta osrdsc_ptr                                                    ; 5995: 85 f6       ..  :b995[1]
+    ldx #0                                                            ; 5997: a2 00       ..  :b997[1]
+; $5999 referenced 1 time by $b9b1
+loop_cb999
+    stx l00bf                                                         ; 5999: 86 bf       ..  :b999[1]
+    pla                                                               ; 599b: 68          h   :b99b[1]
+    pha                                                               ; 599c: 48          H   :b99c[1]
+    tay                                                               ; 599d: a8          .   :b99d[1]
+    jsr osrdsc                                                        ; 599e: 20 b9 ff     .. :b99e[1]
+    ldx l00bf                                                         ; 59a1: a6 bf       ..  :b9a1[1]
+    cmp lb87e,x                                                       ; 59a3: dd 7e b8    .~. :b9a3[1]
+    bne cb9ee                                                         ; 59a6: d0 46       .F  :b9a6[1]
+    inc osrdsc_ptr                                                    ; 59a8: e6 f6       ..  :b9a8[1]
+    bne cb9ae                                                         ; 59aa: d0 02       ..  :b9aa[1]
+    inc l00f7                                                         ; 59ac: e6 f7       ..  :b9ac[1]
+; $59ae referenced 1 time by $b9aa
+cb9ae
+    inx                                                               ; 59ae: e8          .   :b9ae[1]
+    cpx #4                                                            ; 59af: e0 04       ..  :b9af[1]
+    bcc loop_cb999                                                    ; 59b1: 90 e6       ..  :b9b1[1]
+    lda #2                                                            ; 59b3: a9 02       ..  :b9b3[1]
+    sta l00bf                                                         ; 59b5: 85 bf       ..  :b9b5[1]
+    ldx #$0f                                                          ; 59b7: a2 0f       ..  :b9b7[1]
+    lda #$80                                                          ; 59b9: a9 80       ..  :b9b9[1]
+    sta l00f7                                                         ; 59bb: 85 f7       ..  :b9bb[1]
+; $59bd referenced 1 time by $b9cf
+loop_cb9bd
+    stx osrdsc_ptr                                                    ; 59bd: 86 f6       ..  :b9bd[1]
+    pla                                                               ; 59bf: 68          h   :b9bf[1]
+    pha                                                               ; 59c0: 48          H   :b9c0[1]
+    tay                                                               ; 59c1: a8          .   :b9c1[1]
+    jsr osrdsc                                                        ; 59c2: 20 b9 ff     .. :b9c2[1]
+    ldx osrdsc_ptr                                                    ; 59c5: a6 f6       ..  :b9c5[1]
+    cmp lb872,x                                                       ; 59c7: dd 72 b8    .r. :b9c7[1]
+    bne cb9d9                                                         ; 59ca: d0 0d       ..  :b9ca[1]
+; $59cc referenced 1 time by $b9e5
+loop_cb9cc
+    dex                                                               ; 59cc: ca          .   :b9cc[1]
+    cpx #6                                                            ; 59cd: e0 06       ..  :b9cd[1]
+    bcs loop_cb9bd                                                    ; 59cf: b0 ec       ..  :b9cf[1]
+; $59d1 referenced 1 time by $b9ec
+loop_cb9d1
+    clc                                                               ; 59d1: 18          .   :b9d1[1]
+; $59d2 referenced 1 time by $b9f3
+cb9d2
+    pla                                                               ; 59d2: 68          h   :b9d2[1]
+    tay                                                               ; 59d3: a8          .   :b9d3[1]
+    pla                                                               ; 59d4: 68          h   :b9d4[1]
+    tax                                                               ; 59d5: aa          .   :b9d5[1]
+    lda l00bf                                                         ; 59d6: a5 bf       ..  :b9d6[1]
+    rts                                                               ; 59d8: 60          `   :b9d8[1]
+
+; $59d9 referenced 1 time by $b9ca
+cb9d9
+    cpx #$0a                                                          ; 59d9: e0 0a       ..  :b9d9[1]
+    bne cb9e8                                                         ; 59db: d0 0b       ..  :b9db[1]
+    cmp #$4f ; 'O'                                                    ; 59dd: c9 4f       .O  :b9dd[1]
+    bne cb9e8                                                         ; 59df: d0 07       ..  :b9df[1]
+    lda #1                                                            ; 59e1: a9 01       ..  :b9e1[1]
+    sta l00bf                                                         ; 59e3: 85 bf       ..  :b9e3[1]
+    jmp loop_cb9cc                                                    ; 59e5: 4c cc b9    L.. :b9e5[1]
+
+; $59e8 referenced 2 times by $b9db, $b9df
+cb9e8
+    lda #0                                                            ; 59e8: a9 00       ..  :b9e8[1]
+    sta l00bf                                                         ; 59ea: 85 bf       ..  :b9ea[1]
+    beq loop_cb9d1                                                    ; 59ec: f0 e3       ..  :b9ec[1]
+; $59ee referenced 1 time by $b9a6
+cb9ee
+    lda #$ff                                                          ; 59ee: a9 ff       ..  :b9ee[1]
+    sta l00bf                                                         ; 59f0: 85 bf       ..  :b9f0[1]
+    sec                                                               ; 59f2: 38          8   :b9f2[1]
+    bcs cb9d2                                                         ; 59f3: b0 dd       ..  :b9f3[1]
+; $59f5 referenced 2 times by $b225, $b297
+sub_cb9f5
+    ldx #0                                                            ; 59f5: a2 00       ..  :b9f5[1]
+; $59f7 referenced 1 time by $ba25
+cb9f7
+    tya                                                               ; 59f7: 98          .   :b9f7[1]
+    pha                                                               ; 59f8: 48          H   :b9f8[1]
+; $59f9 referenced 1 time by $ba0e
+loop_cb9f9
+    lda (os_text_ptr),y                                               ; 59f9: b1 f2       ..  :b9f9[1]
+    bmi cba10                                                         ; 59fb: 30 13       0.  :b9fb[1]
+    cmp #$2e ; '.'                                                    ; 59fd: c9 2e       ..  :b9fd[1]
+    beq cba19                                                         ; 59ff: f0 18       ..  :b9ff[1]
+    cmp #$41 ; 'A'                                                    ; 5a01: c9 41       .A  :ba01[1]
+    bcc cba10                                                         ; 5a03: 90 0b       ..  :ba03[1]
+    eor sram_table,x                                                  ; 5a05: 5d 30 ba    ]0. :ba05[1]
+    and #$df                                                          ; 5a08: 29 df       ).  :ba08[1]
+    bne cba15                                                         ; 5a0a: d0 09       ..  :ba0a[1]
+    iny                                                               ; 5a0c: c8          .   :ba0c[1]
+    inx                                                               ; 5a0d: e8          .   :ba0d[1]
+    bne loop_cb9f9                                                    ; 5a0e: d0 e9       ..  :ba0e[1]
+; $5a10 referenced 2 times by $b9fb, $ba03
+cba10
+    lda sram_table,x                                                  ; 5a10: bd 30 ba    .0. :ba10[1]
+    bmi cba28                                                         ; 5a13: 30 13       0.  :ba13[1]
+; $5a15 referenced 1 time by $ba0a
+cba15
+    clc                                                               ; 5a15: 18          .   :ba15[1]
+    pla                                                               ; 5a16: 68          h   :ba16[1]
+    tay                                                               ; 5a17: a8          .   :ba17[1]
+    dey                                                               ; 5a18: 88          .   :ba18[1]
+; $5a19 referenced 1 time by $b9ff
+cba19
+    iny                                                               ; 5a19: c8          .   :ba19[1]
+; $5a1a referenced 1 time by $ba20
+loop_cba1a
+    inx                                                               ; 5a1a: e8          .   :ba1a[1]
+    lda cba2f,x                                                       ; 5a1b: bd 2f ba    ./. :ba1b[1]
+    beq cba2e                                                         ; 5a1e: f0 0e       ..  :ba1e[1]
+    bpl loop_cba1a                                                    ; 5a20: 10 f8       ..  :ba20[1]
+    bcs cba27                                                         ; 5a22: b0 03       ..  :ba22[1]
+    inx                                                               ; 5a24: e8          .   :ba24[1]
+    bcc cb9f7                                                         ; 5a25: 90 d0       ..  :ba25[1]
+; $5a27 referenced 1 time by $ba22
+cba27
+    dex                                                               ; 5a27: ca          .   :ba27[1]
+; $5a28 referenced 1 time by $ba13
+cba28
+    pla                                                               ; 5a28: 68          h   :ba28[1]
+    jsr sub_cbab9                                                     ; 5a29: 20 b9 ba     .. :ba29[1]
+    clc                                                               ; 5a2c: 18          .   :ba2c[1]
+    rts                                                               ; 5a2d: 60          `   :ba2d[1]
+
+; $5a2e referenced 1 time by $ba1e
+cba2e
+    sec                                                               ; 5a2e: 38          8   :ba2e[1]
+; $5a2f referenced 1 time by $ba1b
+cba2f
+    rts                                                               ; 5a2f: 60          `   :ba2f[1]
+
+; $5a30 referenced 3 times by $b234, $ba05, $ba10
+sram_table
+    !text "SRAM"                                                      ; 5a30: 53 52 41... SRA :ba30[1]
+; $5a31 referenced 1 time by $b238
+    !byte $ff, $ff                                                    ; 5a34: ff ff       ..  :ba34[1]
+    !text "SRLOAD"                                                    ; 5a36: 53 52 4c... SRL :ba36[1]
+    !byte >(sub_cbb46-1)                                              ; 5a3c: bb          .   :ba3c[1]
+    !byte <(sub_cbb46-1)                                              ; 5a3d: 45          E   :ba3d[1]
+    !text "SRSAVE"                                                    ; 5a3e: 53 52 53... SRS :ba3e[1]
+    !byte >(sub_cbb4a-1)                                              ; 5a44: bb          .   :ba44[1]
+    !byte <(sub_cbb4a-1)                                              ; 5a45: 49          I   :ba45[1]
+    !text "SRWRITE"                                                   ; 5a46: 53 52 57... SRW :ba46[1]
+    !byte >(sub_cbbd3-1)                                              ; 5a4d: bb          .   :ba4d[1]
+    !byte <(sub_cbbd3-1)                                              ; 5a4e: d2          .   :ba4e[1]
+    !text "SRREAD"                                                    ; 5a4f: 53 52 52... SRR :ba4f[1]
+    !byte >(sub_cbbd7-1)                                              ; 5a55: bb          .   :ba55[1]
+    !byte <(sub_cbbd7-1)                                              ; 5a56: d6          .   :ba56[1]
+    !text "SRDATA"                                                    ; 5a57: 53 52 44... SRD :ba57[1]
+    !byte >(sub_cbc37-1)                                              ; 5a5d: bc          .   :ba5d[1]
+    !byte <(sub_cbc37-1)                                              ; 5a5e: 36          6   :ba5e[1]
+    !text "SRROM"                                                     ; 5a5f: 53 52 52... SRR :ba5f[1]
+    !byte >(sub_cbc81-1)                                              ; 5a64: bc          .   :ba64[1]
+    !byte <(sub_cbc81-1)                                              ; 5a65: 80          .   :ba65[1]
+    !byte 0                                                           ; 5a66: 00          .   :ba66[1]
+
+; $5a67 referenced 5 times by $bb51, $bb6c, $bbdd, $bbf3, $bc1c
+sub_cba67
+    txa                                                               ; 5a67: 8a          .   :ba67[1]
+    pha                                                               ; 5a68: 48          H   :ba68[1]
+    jsr sub_cbab9                                                     ; 5a69: 20 b9 ba     .. :ba69[1]
+    lda #0                                                            ; 5a6c: a9 00       ..  :ba6c[1]
+    sta l00bc                                                         ; 5a6e: 85 bc       ..  :ba6e[1]
+    sta l00bd                                                         ; 5a70: 85 bd       ..  :ba70[1]
+    sta l00be                                                         ; 5a72: 85 be       ..  :ba72[1]
+    sta l00bf                                                         ; 5a74: 85 bf       ..  :ba74[1]
+    sec                                                               ; 5a76: 38          8   :ba76[1]
+    php                                                               ; 5a77: 08          .   :ba77[1]
+; $5a78 referenced 1 time by $baae
+cba78
+    lda (os_text_ptr),y                                               ; 5a78: b1 f2       ..  :ba78[1]
+    cmp #$30 ; '0'                                                    ; 5a7a: c9 30       .0  :ba7a[1]
+    bcc cbab4                                                         ; 5a7c: 90 36       .6  :ba7c[1]
+    cmp #$3a ; ':'                                                    ; 5a7e: c9 3a       .:  :ba7e[1]
+    bcc cba8c                                                         ; 5a80: 90 0a       ..  :ba80[1]
+    cmp #$47 ; 'G'                                                    ; 5a82: c9 47       .G  :ba82[1]
+    bcs cbab4                                                         ; 5a84: b0 2e       ..  :ba84[1]
+    cmp #$41 ; 'A'                                                    ; 5a86: c9 41       .A  :ba86[1]
+    bcc cbab4                                                         ; 5a88: 90 2a       .*  :ba88[1]
+    sbc #7                                                            ; 5a8a: e9 07       ..  :ba8a[1]
+; $5a8c referenced 1 time by $ba80
+cba8c
+    sec                                                               ; 5a8c: 38          8   :ba8c[1]
+    sbc #$30 ; '0'                                                    ; 5a8d: e9 30       .0  :ba8d[1]
+    plp                                                               ; 5a8f: 28          (   :ba8f[1]
+    php                                                               ; 5a90: 08          .   :ba90[1]
+    pha                                                               ; 5a91: 48          H   :ba91[1]
+    ldx #4                                                            ; 5a92: a2 04       ..  :ba92[1]
+; $5a94 referenced 1 time by $baa1
+loop_cba94
+    asl l00bc                                                         ; 5a94: 06 bc       ..  :ba94[1]
+    rol l00bd                                                         ; 5a96: 26 bd       &.  :ba96[1]
+    bvc cba9e                                                         ; 5a98: 50 04       P.  :ba98[1]
+    rol l00be                                                         ; 5a9a: 26 be       &.  :ba9a[1]
+    rol l00bf                                                         ; 5a9c: 26 bf       &.  :ba9c[1]
+; $5a9e referenced 1 time by $ba98
+cba9e
+    bcs cbab0                                                         ; 5a9e: b0 10       ..  :ba9e[1]
+    dex                                                               ; 5aa0: ca          .   :baa0[1]
+    bne loop_cba94                                                    ; 5aa1: d0 f1       ..  :baa1[1]
+    pla                                                               ; 5aa3: 68          h   :baa3[1]
+    ora l00bc                                                         ; 5aa4: 05 bc       ..  :baa4[1]
+    sta l00bc                                                         ; 5aa6: 85 bc       ..  :baa6[1]
+    plp                                                               ; 5aa8: 28          (   :baa8[1]
+    clc                                                               ; 5aa9: 18          .   :baa9[1]
+    php                                                               ; 5aaa: 08          .   :baaa[1]
+    iny                                                               ; 5aab: c8          .   :baab[1]
+    beq cbab1                                                         ; 5aac: f0 03       ..  :baac[1]
+    bcc cba78                                                         ; 5aae: 90 c8       ..  :baae[1]
+; $5ab0 referenced 1 time by $ba9e
+cbab0
+    pla                                                               ; 5ab0: 68          h   :bab0[1]
+; $5ab1 referenced 1 time by $baac
+cbab1
+    plp                                                               ; 5ab1: 28          (   :bab1[1]
+    sec                                                               ; 5ab2: 38          8   :bab2[1]
+    php                                                               ; 5ab3: 08          .   :bab3[1]
+; $5ab4 referenced 3 times by $ba7c, $ba84, $ba88
+cbab4
+    plp                                                               ; 5ab4: 28          (   :bab4[1]
+    pla                                                               ; 5ab5: 68          h   :bab5[1]
+    tax                                                               ; 5ab6: aa          .   :bab6[1]
+    rts                                                               ; 5ab7: 60          `   :bab7[1]
+
+; $5ab8 referenced 1 time by $babd
+loop_cbab8
+    iny                                                               ; 5ab8: c8          .   :bab8[1]
+; $5ab9 referenced 7 times by $ba29, $ba69, $bac5, $bad2, $bb02, $bb2b, $bbb0
+sub_cbab9
+    lda (os_text_ptr),y                                               ; 5ab9: b1 f2       ..  :bab9[1]
+    cmp #$20 ; ' '                                                    ; 5abb: c9 20       .   :babb[1]
+    beq loop_cbab8                                                    ; 5abd: f0 f9       ..  :babd[1]
+    cmp #$0d                                                          ; 5abf: c9 0d       ..  :babf[1]
+    rts                                                               ; 5ac1: 60          `   :bac1[1]
+
+; $5ac2 referenced 4 times by $bbbe, $bc2c, $bc3d, $bc87
+sub_cbac2
+    lda #$0d                                                          ; 5ac2: a9 0d       ..  :bac2[1]
+; $5ac4 referenced 3 times by $b26e, $bb67, $bbed
+sub_cbac4
+    pha                                                               ; 5ac4: 48          H   :bac4[1]
+    jsr sub_cbab9                                                     ; 5ac5: 20 b9 ba     .. :bac5[1]
+    pla                                                               ; 5ac8: 68          h   :bac8[1]
+    cmp (os_text_ptr),y                                               ; 5ac9: d1 f2       ..  :bac9[1]
+    bne cbad0                                                         ; 5acb: d0 03       ..  :bacb[1]
+    clc                                                               ; 5acd: 18          .   :bacd[1]
+    iny                                                               ; 5ace: c8          .   :bace[1]
+    rts                                                               ; 5acf: 60          `   :bacf[1]
+
+; $5ad0 referenced 1 time by $bacb
+cbad0
+    sec                                                               ; 5ad0: 38          8   :bad0[1]
+    rts                                                               ; 5ad1: 60          `   :bad1[1]
+
+; $5ad2 referenced 1 time by $bb4d
+sub_cbad2
+    jsr sub_cbab9                                                     ; 5ad2: 20 b9 ba     .. :bad2[1]
+    tya                                                               ; 5ad5: 98          .   :bad5[1]
+    pha                                                               ; 5ad6: 48          H   :bad6[1]
+    clc                                                               ; 5ad7: 18          .   :bad7[1]
+    adc os_text_ptr                                                   ; 5ad8: 65 f2       e.  :bad8[1]
+    ldy #$ef                                                          ; 5ada: a0 ef       ..  :bada[1]
+    sta (l00b8),y                                                     ; 5adc: 91 b8       ..  :badc[1]
+    lda l00f3                                                         ; 5ade: a5 f3       ..  :bade[1]
+    adc #0                                                            ; 5ae0: 69 00       i.  :bae0[1]
+    iny                                                               ; 5ae2: c8          .   :bae2[1]
+    sta (l00b8),y                                                     ; 5ae3: 91 b8       ..  :bae3[1]
+    pla                                                               ; 5ae5: 68          h   :bae5[1]
+    tay                                                               ; 5ae6: a8          .   :bae6[1]
+    bit lb57f                                                         ; 5ae7: 2c 7f b5    ,.. :bae7[1]
+; $5aea referenced 1 time by $baf6
+loop_cbaea
+    lda (os_text_ptr),y                                               ; 5aea: b1 f2       ..  :baea[1]
+    cmp #$20 ; ' '                                                    ; 5aec: c9 20       .   :baec[1]
+    beq cbafd                                                         ; 5aee: f0 0d       ..  :baee[1]
+    cmp #$0d                                                          ; 5af0: c9 0d       ..  :baf0[1]
+    beq cbafd                                                         ; 5af2: f0 09       ..  :baf2[1]
+    clv                                                               ; 5af4: b8          .   :baf4[1]
+    iny                                                               ; 5af5: c8          .   :baf5[1]
+    bne loop_cbaea                                                    ; 5af6: d0 f2       ..  :baf6[1]
+; $5af8 referenced 2 times by $bafd, $bbd0
+cbaf8
+    ldx #3                                                            ; 5af8: a2 03       ..  :baf8[1]
+    jmp cb8fb                                                         ; 5afa: 4c fb b8    L.. :bafa[1]
+
+; $5afd referenced 2 times by $baee, $baf2
+cbafd
+    bvs cbaf8                                                         ; 5afd: 70 f9       p.  :bafd[1]
+    rts                                                               ; 5aff: 60          `   :baff[1]
+
+; $5b00 referenced 4 times by $bb92, $bc21, $bc37, $bc81
+sub_cbb00
+    stx l00bf                                                         ; 5b00: 86 bf       ..  :bb00[1]
+    jsr sub_cbab9                                                     ; 5b02: 20 b9 ba     .. :bb02[1]
+    ldx #3                                                            ; 5b05: a2 03       ..  :bb05[1]
+; $5b07 referenced 1 time by $bb34
+cbb07
+    cmp lbb3e,x                                                       ; 5b07: dd 3e bb    .>. :bb07[1]
+    bcs cbb36                                                         ; 5b0a: b0 2a       .*  :bb0a[1]
+    cmp lbb3a,x                                                       ; 5b0c: dd 3a bb    .:. :bb0c[1]
+    bcc cbb33                                                         ; 5b0f: 90 22       ."  :bb0f[1]
+    sbc lbb42,x                                                       ; 5b11: fd 42 bb    .B. :bb11[1]
+    iny                                                               ; 5b14: c8          .   :bb14[1]
+    cmp #1                                                            ; 5b15: c9 01       ..  :bb15[1]
+    bne cbb2a                                                         ; 5b17: d0 11       ..  :bb17[1]
+    lda (os_text_ptr),y                                               ; 5b19: b1 f2       ..  :bb19[1]
+    cmp #$36 ; '6'                                                    ; 5b1b: c9 36       .6  :bb1b[1]
+    bcs cbb28                                                         ; 5b1d: b0 09       ..  :bb1d[1]
+    cmp #$30 ; '0'                                                    ; 5b1f: c9 30       .0  :bb1f[1]
+    bcc cbb28                                                         ; 5b21: 90 05       ..  :bb21[1]
+    sbc #$26 ; '&'                                                    ; 5b23: e9 26       .&  :bb23[1]
+    iny                                                               ; 5b25: c8          .   :bb25[1]
+    bne cbb2a                                                         ; 5b26: d0 02       ..  :bb26[1]
+; $5b28 referenced 2 times by $bb1d, $bb21
+cbb28
+    lda #1                                                            ; 5b28: a9 01       ..  :bb28[1]
+; $5b2a referenced 2 times by $bb17, $bb26
+cbb2a
+    pha                                                               ; 5b2a: 48          H   :bb2a[1]
+    jsr sub_cbab9                                                     ; 5b2b: 20 b9 ba     .. :bb2b[1]
+    pla                                                               ; 5b2e: 68          h   :bb2e[1]
+    ldx l00bf                                                         ; 5b2f: a6 bf       ..  :bb2f[1]
+    clc                                                               ; 5b31: 18          .   :bb31[1]
+    rts                                                               ; 5b32: 60          `   :bb32[1]
+
+; $5b33 referenced 1 time by $bb0f
+cbb33
+    dex                                                               ; 5b33: ca          .   :bb33[1]
+    bpl cbb07                                                         ; 5b34: 10 d1       ..  :bb34[1]
+; $5b36 referenced 1 time by $bb0a
+cbb36
+    ldx l00bf                                                         ; 5b36: a6 bf       ..  :bb36[1]
+    sec                                                               ; 5b38: 38          8   :bb38[1]
+    rts                                                               ; 5b39: 60          `   :bb39[1]
+
+; $5b3a referenced 1 time by $bb0c
+lbb3a
+    !text "0AWw"                                                      ; 5b3a: 30 41 57... 0AW :bb3a[1]
+; $5b3e referenced 1 time by $bb07
+lbb3e
+    !text ":G[{"                                                      ; 5b3e: 3a 47 5b... :G[ :bb3e[1]
+; $5b42 referenced 1 time by $bb11
+lbb42
+    !text "07Gg"                                                      ; 5b42: 30 37 47... 07G :bb42[1]
+
+sub_cbb46
+    lda #$c0                                                          ; 5b46: a9 c0       ..  :bb46[1]
+    bne cbb4c                                                         ; 5b48: d0 02       ..  :bb48[1]
+sub_cbb4a
+    lda #$40 ; '@'                                                    ; 5b4a: a9 40       .@  :bb4a[1]
+; $5b4c referenced 1 time by $bb48
+cbb4c
+    pha                                                               ; 5b4c: 48          H   :bb4c[1]
+    jsr sub_cbad2                                                     ; 5b4d: 20 d2 ba     .. :bb4d[1]
+    clv                                                               ; 5b50: b8          .   :bb50[1]
+    jsr sub_cba67                                                     ; 5b51: 20 67 ba     g. :bb51[1]
+    bcs cbb6f                                                         ; 5b54: b0 19       ..  :bb54[1]
+    sty l00ba                                                         ; 5b56: 84 ba       ..  :bb56[1]
+    ldx #$bc                                                          ; 5b58: a2 bc       ..  :bb58[1]
+    ldy #$f2                                                          ; 5b5a: a0 f2       ..  :bb5a[1]
+    jsr sub_cb850                                                     ; 5b5c: 20 50 b8     P. :bb5c[1]
+    ldy l00ba                                                         ; 5b5f: a4 ba       ..  :bb5f[1]
+    pla                                                               ; 5b61: 68          h   :bb61[1]
+    pha                                                               ; 5b62: 48          H   :bb62[1]
+    bmi cbb90                                                         ; 5b63: 30 2b       0+  :bb63[1]
+    lda #$2b ; '+'                                                    ; 5b65: a9 2b       .+  :bb65[1]
+    jsr sub_cbac4                                                     ; 5b67: 20 c4 ba     .. :bb67[1]
+    php                                                               ; 5b6a: 08          .   :bb6a[1]
+    clv                                                               ; 5b6b: b8          .   :bb6b[1]
+    jsr sub_cba67                                                     ; 5b6c: 20 67 ba     g. :bb6c[1]
+; $5b6f referenced 1 time by $bb54
+cbb6f
+    bcs cbbd0                                                         ; 5b6f: b0 5f       ._  :bb6f[1]
+    sty l00ba                                                         ; 5b71: 84 ba       ..  :bb71[1]
+    plp                                                               ; 5b73: 28          (   :bb73[1]
+    bcc cbb89                                                         ; 5b74: 90 13       ..  :bb74[1]
+    ldy #$f2                                                          ; 5b76: a0 f2       ..  :bb76[1]
+    sec                                                               ; 5b78: 38          8   :bb78[1]
+    lda l00bc                                                         ; 5b79: a5 bc       ..  :bb79[1]
+    sec                                                               ; 5b7b: 38          8   :bb7b[1]
+    sbc (l00b8),y                                                     ; 5b7c: f1 b8       ..  :bb7c[1]
+    sta l00bc                                                         ; 5b7e: 85 bc       ..  :bb7e[1]
+    iny                                                               ; 5b80: c8          .   :bb80[1]
+    lda l00bd                                                         ; 5b81: a5 bd       ..  :bb81[1]
+    sbc (l00b8),y                                                     ; 5b83: f1 b8       ..  :bb83[1]
+    bcc cbbd0                                                         ; 5b85: 90 49       .I  :bb85[1]
+    sta l00bd                                                         ; 5b87: 85 bd       ..  :bb87[1]
+; $5b89 referenced 1 time by $bb74
+cbb89
+    ldx #$bc                                                          ; 5b89: a2 bc       ..  :bb89[1]
+    ldy #$f4                                                          ; 5b8b: a0 f4       ..  :bb8b[1]
+    jsr sub_cb850                                                     ; 5b8d: 20 50 b8     P. :bb8d[1]
+; $5b90 referenced 1 time by $bb63
+cbb90
+    ldy l00ba                                                         ; 5b90: a4 ba       ..  :bb90[1]
+    jsr sub_cbb00                                                     ; 5b92: 20 00 bb     .. :bb92[1]
+    sty l00ba                                                         ; 5b95: 84 ba       ..  :bb95[1]
+    bcs cbba1                                                         ; 5b97: b0 08       ..  :bb97[1]
+    ldy #$f1                                                          ; 5b99: a0 f1       ..  :bb99[1]
+    sta (l00b8),y                                                     ; 5b9b: 91 b8       ..  :bb9b[1]
+    pla                                                               ; 5b9d: 68          h   :bb9d[1]
+    and #$80                                                          ; 5b9e: 29 80       ).  :bb9e[1]
+    pha                                                               ; 5ba0: 48          H   :bba0[1]
+; $5ba1 referenced 1 time by $bb97
+cbba1
+    pla                                                               ; 5ba1: 68          h   :bba1[1]
+    sta l00bb                                                         ; 5ba2: 85 bb       ..  :bba2[1]
+    ldy #$ee                                                          ; 5ba4: a0 ee       ..  :bba4[1]
+    lda (l00b8),y                                                     ; 5ba6: b1 b8       ..  :bba6[1]
+    and #$3f ; '?'                                                    ; 5ba8: 29 3f       )?  :bba8[1]
+    ora l00bb                                                         ; 5baa: 05 bb       ..  :bbaa[1]
+    sta (l00b8),y                                                     ; 5bac: 91 b8       ..  :bbac[1]
+    ldy l00ba                                                         ; 5bae: a4 ba       ..  :bbae[1]
+    jsr sub_cbab9                                                     ; 5bb0: 20 b9 ba     .. :bbb0[1]
+    and #$df                                                          ; 5bb3: 29 df       ).  :bbb3[1]
+    ldx #0                                                            ; 5bb5: a2 00       ..  :bbb5[1]
+    cmp #$51 ; 'Q'                                                    ; 5bb7: c9 51       .Q  :bbb7[1]
+    bne cbbbe                                                         ; 5bb9: d0 03       ..  :bbb9[1]
+    iny                                                               ; 5bbb: c8          .   :bbbb[1]
+    ldx #$ff                                                          ; 5bbc: a2 ff       ..  :bbbc[1]
+; $5bbe referenced 1 time by $bbb9
+cbbbe
+    jsr sub_cbac2                                                     ; 5bbe: 20 c2 ba     .. :bbbe[1]
+    bcs cbbd0                                                         ; 5bc1: b0 0d       ..  :bbc1[1]
+    ldy #$f8                                                          ; 5bc3: a0 f8       ..  :bbc3[1]
+    lda #0                                                            ; 5bc5: a9 00       ..  :bbc5[1]
+    sta (l00b8),y                                                     ; 5bc7: 91 b8       ..  :bbc7[1]
+    iny                                                               ; 5bc9: c8          .   :bbc9[1]
+    txa                                                               ; 5bca: 8a          .   :bbca[1]
+    sta (l00b8),y                                                     ; 5bcb: 91 b8       ..  :bbcb[1]
+    jmp cb2e7                                                         ; 5bcd: 4c e7 b2    L.. :bbcd[1]
+
+; $5bd0 referenced 9 times by $bb6f, $bb85, $bbc1, $bbe0, $bbf6, $bc1f, $bc2f, $bc3a, $bc40
+cbbd0
+    jmp cbaf8                                                         ; 5bd0: 4c f8 ba    L.. :bbd0[1]
+
+sub_cbbd3
+    lda #$c0                                                          ; 5bd3: a9 c0       ..  :bbd3[1]
+    bne cbbd9                                                         ; 5bd5: d0 02       ..  :bbd5[1]
+sub_cbbd7
+    lda #$40 ; '@'                                                    ; 5bd7: a9 40       .@  :bbd7[1]
+; $5bd9 referenced 1 time by $bbd5
+cbbd9
+    pha                                                               ; 5bd9: 48          H   :bbd9[1]
+    bit lb57f                                                         ; 5bda: 2c 7f b5    ,.. :bbda[1]
+    jsr sub_cba67                                                     ; 5bdd: 20 67 ba     g. :bbdd[1]
+    bcs cbbd0                                                         ; 5be0: b0 ee       ..  :bbe0[1]
+    ldx #3                                                            ; 5be2: a2 03       ..  :bbe2[1]
+; $5be4 referenced 1 time by $bbe9
+loop_cbbe4
+    lda l00bc,x                                                       ; 5be4: b5 bc       ..  :bbe4[1]
+    sta l00b1,x                                                       ; 5be6: 95 b1       ..  :bbe6[1]
+    dex                                                               ; 5be8: ca          .   :bbe8[1]
+    bpl loop_cbbe4                                                    ; 5be9: 10 f9       ..  :bbe9[1]
+    lda #$2b ; '+'                                                    ; 5beb: a9 2b       .+  :bbeb[1]
+    jsr sub_cbac4                                                     ; 5bed: 20 c4 ba     .. :bbed[1]
+    bcs cbbf3                                                         ; 5bf0: b0 01       ..  :bbf0[1]
+    clv                                                               ; 5bf2: b8          .   :bbf2[1]
+; $5bf3 referenced 1 time by $bbf0
+cbbf3
+    jsr sub_cba67                                                     ; 5bf3: 20 67 ba     g. :bbf3[1]
+    bcs cbbd0                                                         ; 5bf6: b0 d8       ..  :bbf6[1]
+    bvc cbc13                                                         ; 5bf8: 50 19       P.  :bbf8[1]
+    sec                                                               ; 5bfa: 38          8   :bbfa[1]
+    ldx #0                                                            ; 5bfb: a2 00       ..  :bbfb[1]
+    sec                                                               ; 5bfd: 38          8   :bbfd[1]
+; $5bfe referenced 1 time by $bc08
+loop_cbbfe
+    lda l00bc,x                                                       ; 5bfe: b5 bc       ..  :bbfe[1]
+    sbc l00b1,x                                                       ; 5c00: f5 b1       ..  :bc00[1]
+    sta l00bc,x                                                       ; 5c02: 95 bc       ..  :bc02[1]
+    inx                                                               ; 5c04: e8          .   :bc04[1]
+    txa                                                               ; 5c05: 8a          .   :bc05[1]
+    and #4                                                            ; 5c06: 29 04       ).  :bc06[1]
+    beq loop_cbbfe                                                    ; 5c08: f0 f4       ..  :bc08[1]
+    lda l00be                                                         ; 5c0a: a5 be       ..  :bc0a[1]
+    ora l00bf                                                         ; 5c0c: 05 bf       ..  :bc0c[1]
+    beq cbc13                                                         ; 5c0e: f0 03       ..  :bc0e[1]
+    jmp cb446                                                         ; 5c10: 4c 46 b4    LF. :bc10[1]
+
+; $5c13 referenced 2 times by $bbf8, $bc0e
+cbc13
+    lda l00bc                                                         ; 5c13: a5 bc       ..  :bc13[1]
+    sta l00b5                                                         ; 5c15: 85 b5       ..  :bc15[1]
+    lda l00bd                                                         ; 5c17: a5 bd       ..  :bc17[1]
+    sta l00b6                                                         ; 5c19: 85 b6       ..  :bc19[1]
+    clv                                                               ; 5c1b: b8          .   :bc1b[1]
+    jsr sub_cba67                                                     ; 5c1c: 20 67 ba     g. :bc1c[1]
+    bcs cbbd0                                                         ; 5c1f: b0 af       ..  :bc1f[1]
+    jsr sub_cbb00                                                     ; 5c21: 20 00 bb     .. :bc21[1]
+    bcs cbc2c                                                         ; 5c24: b0 06       ..  :bc24[1]
+    sta l00b7                                                         ; 5c26: 85 b7       ..  :bc26[1]
+    pla                                                               ; 5c28: 68          h   :bc28[1]
+    and #$bf                                                          ; 5c29: 29 bf       ).  :bc29[1]
+    pha                                                               ; 5c2b: 48          H   :bc2b[1]
+; $5c2c referenced 1 time by $bc24
+cbc2c
+    jsr sub_cbac2                                                     ; 5c2c: 20 c2 ba     .. :bc2c[1]
+    bcs cbbd0                                                         ; 5c2f: b0 9f       ..  :bc2f[1]
+    pla                                                               ; 5c31: 68          h   :bc31[1]
+    sta l00b0                                                         ; 5c32: 85 b0       ..  :bc32[1]
+    jmp cbcb9                                                         ; 5c34: 4c b9 bc    L.. :bc34[1]
+
+sub_cbc37
+    jsr sub_cbb00                                                     ; 5c37: 20 00 bb     .. :bc37[1]
+; $5c3a referenced 2 times by $bc84, $bc8a
+cbc3a
+    bcs cbbd0                                                         ; 5c3a: b0 94       ..  :bc3a[1]
+    pha                                                               ; 5c3c: 48          H   :bc3c[1]
+    jsr sub_cbac2                                                     ; 5c3d: 20 c2 ba     .. :bc3d[1]
+    bcs cbbd0                                                         ; 5c40: b0 8e       ..  :bc40[1]
+    pla                                                               ; 5c42: 68          h   :bc42[1]
+    tay                                                               ; 5c43: a8          .   :bc43[1]
+    jsr sub_cb6fe                                                     ; 5c44: 20 fe b6     .. :bc44[1]
+    bne cbc64                                                         ; 5c47: d0 1b       ..  :bc47[1]
+    jsr sub_cb986                                                     ; 5c49: 20 86 b9     .. :bc49[1]
+    tax                                                               ; 5c4c: aa          .   :bc4c[1]
+    bne cbc54                                                         ; 5c4d: d0 05       ..  :bc4d[1]
+    ldx #5                                                            ; 5c4f: a2 05       ..  :bc4f[1]
+    jmp cb8fb                                                         ; 5c51: 4c fb b8    L.. :bc51[1]
+
+; $5c54 referenced 1 time by $bc4d
+cbc54
+    sty l00bf                                                         ; 5c54: 84 bf       ..  :bc54[1]
+    lda lb726,y                                                       ; 5c56: b9 26 b7    .&. :bc56[1]
+    ldy #$fd                                                          ; 5c59: a0 fd       ..  :bc59[1]
+    ora (l00b8),y                                                     ; 5c5b: 11 b8       ..  :bc5b[1]
+    sta (l00b8),y                                                     ; 5c5d: 91 b8       ..  :bc5d[1]
+    ldy l00bf                                                         ; 5c5f: a4 bf       ..  :bc5f[1]
+    jsr sub_cbc68                                                     ; 5c61: 20 68 bc     h. :bc61[1]
+; $5c64 referenced 1 time by $bc47
+cbc64
+    jsr sub_cbec2                                                     ; 5c64: 20 c2 be     .. :bc64[1]
+    rts                                                               ; 5c67: 60          `   :bc67[1]
+
+; $5c68 referenced 2 times by $bc61, $bc95
+sub_cbc68
+    ldx #$0f                                                          ; 5c68: a2 0f       ..  :bc68[1]
+    stx l00ba                                                         ; 5c6a: 86 ba       ..  :bc6a[1]
+    lda #$80                                                          ; 5c6c: a9 80       ..  :bc6c[1]
+    sta l00bb                                                         ; 5c6e: 85 bb       ..  :bc6e[1]
+; $5c70 referenced 1 time by $bc7e
+loop_cbc70
+    lda lb872,x                                                       ; 5c70: bd 72 b8    .r. :bc70[1]
+    cpx #1                                                            ; 5c73: e0 01       ..  :bc73[1]
+    bne cbc78                                                         ; 5c75: d0 01       ..  :bc75[1]
+    tya                                                               ; 5c77: 98          .   :bc77[1]
+; $5c78 referenced 1 time by $bc75
+cbc78
+    jsr sub_cb745                                                     ; 5c78: 20 45 b7     E. :bc78[1]
+    dex                                                               ; 5c7b: ca          .   :bc7b[1]
+    stx l00ba                                                         ; 5c7c: 86 ba       ..  :bc7c[1]
+    bpl loop_cbc70                                                    ; 5c7e: 10 f0       ..  :bc7e[1]
+    rts                                                               ; 5c80: 60          `   :bc80[1]
+
+sub_cbc81
+    jsr sub_cbb00                                                     ; 5c81: 20 00 bb     .. :bc81[1]
+    bcs cbc3a                                                         ; 5c84: b0 b4       ..  :bc84[1]
+    pha                                                               ; 5c86: 48          H   :bc86[1]
+    jsr sub_cbac2                                                     ; 5c87: 20 c2 ba     .. :bc87[1]
+    bcs cbc3a                                                         ; 5c8a: b0 ae       ..  :bc8a[1]
+    pla                                                               ; 5c8c: 68          h   :bc8c[1]
+    tay                                                               ; 5c8d: a8          .   :bc8d[1]
+    jsr sub_cb6fe                                                     ; 5c8e: 20 fe b6     .. :bc8e[1]
+    beq cbcb2                                                         ; 5c91: f0 1f       ..  :bc91[1]
+; $5c93 referenced 1 time by $bcb6
+cbc93
+    sty l00bc                                                         ; 5c93: 84 bc       ..  :bc93[1]
+    jsr sub_cbc68                                                     ; 5c95: 20 68 bc     h. :bc95[1]
+    lda #$0a                                                          ; 5c98: a9 0a       ..  :bc98[1]
+    sta l00ba                                                         ; 5c9a: 85 ba       ..  :bc9a[1]
+    lda #$4f ; 'O'                                                    ; 5c9c: a9 4f       .O  :bc9c[1]
+    jsr sub_cb745                                                     ; 5c9e: 20 45 b7     E. :bc9e[1]
+    lda lb726,y                                                       ; 5ca1: b9 26 b7    .&. :bca1[1]
+    eor #$ff                                                          ; 5ca4: 49 ff       I.  :bca4[1]
+    ldy #$fd                                                          ; 5ca6: a0 fd       ..  :bca6[1]
+    and (l00b8),y                                                     ; 5ca8: 31 b8       1.  :bca8[1]
+    sta (l00b8),y                                                     ; 5caa: 91 b8       ..  :bcaa[1]
+    ldy l00bc                                                         ; 5cac: a4 bc       ..  :bcac[1]
+    jsr sub_cbec2                                                     ; 5cae: 20 c2 be     .. :bcae[1]
+    rts                                                               ; 5cb1: 60          `   :bcb1[1]
+
+; $5cb2 referenced 1 time by $bc91
+cbcb2
+    jsr sub_cb986                                                     ; 5cb2: 20 86 b9     .. :bcb2[1]
+    tax                                                               ; 5cb5: aa          .   :bcb5[1]
+    bne cbc93                                                         ; 5cb6: d0 db       ..  :bcb6[1]
+    rts                                                               ; 5cb8: 60          `   :bcb8[1]
+
+; $5cb9 referenced 2 times by $b1f6, $bc34
+cbcb9
+    lda l00b0                                                         ; 5cb9: a5 b0       ..  :bcb9[1]
+    and #$c0                                                          ; 5cbb: 29 c0       ).  :bcbb[1]
+    sta l00be                                                         ; 5cbd: 85 be       ..  :bcbd[1]
+    ldy #$ee                                                          ; 5cbf: a0 ee       ..  :bcbf[1]
+    lda (l00b8),y                                                     ; 5cc1: b1 b8       ..  :bcc1[1]
+    and #$3f ; '?'                                                    ; 5cc3: 29 3f       )?  :bcc3[1]
+    ora l00be                                                         ; 5cc5: 05 be       ..  :bcc5[1]
+    sta (l00b8),y                                                     ; 5cc7: 91 b8       ..  :bcc7[1]
+    bit l00b0                                                         ; 5cc9: 24 b0       $.  :bcc9[1]
+    bvs cbcd6                                                         ; 5ccb: 70 09       p.  :bccb[1]
+    ldy l00b7                                                         ; 5ccd: a4 b7       ..  :bccd[1]
+    cpy #$14                                                          ; 5ccf: c0 14       ..  :bccf[1]
+    bcc cbce1                                                         ; 5cd1: 90 0e       ..  :bcd1[1]
+; $5cd3 referenced 1 time by $bcef
+loop_cbcd3
+    jmp cb300                                                         ; 5cd3: 4c 00 b3    L.. :bcd3[1]
+
+; $5cd6 referenced 1 time by $bccb
+cbcd6
+    ldx l00bc                                                         ; 5cd6: a6 bc       ..  :bcd6[1]
+    lda l00bd                                                         ; 5cd8: a5 bd       ..  :bcd8[1]
+    jsr sub_cb6b1                                                     ; 5cda: 20 b1 b6     .. :bcda[1]
+    stx l00bc                                                         ; 5cdd: 86 bc       ..  :bcdd[1]
+    sta l00bd                                                         ; 5cdf: 85 bd       ..  :bcdf[1]
+; $5ce1 referenced 1 time by $bcd1
+cbce1
+    jsr sub_cb6fe                                                     ; 5ce1: 20 fe b6     .. :bce1[1]
+    pha                                                               ; 5ce4: 48          H   :bce4[1]
+    tya                                                               ; 5ce5: 98          .   :bce5[1]
+    ldy #$f1                                                          ; 5ce6: a0 f1       ..  :bce6[1]
+    sta (l00b8),y                                                     ; 5ce8: 91 b8       ..  :bce8[1]
+    pla                                                               ; 5cea: 68          h   :bcea[1]
+    eor l00b0                                                         ; 5ceb: 45 b0       E.  :bceb[1]
+    and #$40 ; '@'                                                    ; 5ced: 29 40       )@  :bced[1]
+    bne loop_cbcd3                                                    ; 5cef: d0 e2       ..  :bcef[1]
+    jsr sub_cbe9d                                                     ; 5cf1: 20 9d be     .. :bcf1[1]
+    jsr sub_cbe91                                                     ; 5cf4: 20 91 be     .. :bcf4[1]
+    bcs cbd1b                                                         ; 5cf7: b0 22       ."  :bcf7[1]
+; $5cf9 referenced 1 time by $bd21
+cbcf9
+    ldx #$b5                                                          ; 5cf9: a2 b5       ..  :bcf9[1]
+    ldy #$be                                                          ; 5cfb: a0 be       ..  :bcfb[1]
+    jsr sub_cb580                                                     ; 5cfd: 20 80 b5     .. :bcfd[1]
+    rol l00b0                                                         ; 5d00: 26 b0       &.  :bd00[1]
+    bcc cbd0e                                                         ; 5d02: 90 0a       ..  :bd02[1]
+    ldx #$bc                                                          ; 5d04: a2 bc       ..  :bd04[1]
+    ldy #$b3                                                          ; 5d06: a0 b3       ..  :bd06[1]
+; $5d08 referenced 1 time by $bd19
+loop_cbd08
+    jsr sub_cb580                                                     ; 5d08: 20 80 b5     .. :bd08[1]
+    jmp cb795                                                         ; 5d0b: 4c 95 b7    L.. :bd0b[1]
+
+; $5d0e referenced 1 time by $bd02
+cbd0e
+    ldx #$b1                                                          ; 5d0e: a2 b1       ..  :bd0e[1]
+    ldy #$b3                                                          ; 5d10: a0 b3       ..  :bd10[1]
+    jsr sub_cb580                                                     ; 5d12: 20 80 b5     .. :bd12[1]
+    ldx #$bc                                                          ; 5d15: a2 bc       ..  :bd15[1]
+    ldy #$b1                                                          ; 5d17: a0 b1       ..  :bd17[1]
+    bne loop_cbd08                                                    ; 5d19: d0 ed       ..  :bd19[1]
+; $5d1b referenced 1 time by $bcf7
+cbd1b
+    lda l00b3                                                         ; 5d1b: a5 b3       ..  :bd1b[1]
+    and l00b4                                                         ; 5d1d: 25 b4       %.  :bd1d[1]
+    cmp #$ff                                                          ; 5d1f: c9 ff       ..  :bd1f[1]
+    beq cbcf9                                                         ; 5d21: f0 d6       ..  :bd21[1]
+    lda l00bc                                                         ; 5d23: a5 bc       ..  :bd23[1]
+    pha                                                               ; 5d25: 48          H   :bd25[1]
+    lda l00bd                                                         ; 5d26: a5 bd       ..  :bd26[1]
+    pha                                                               ; 5d28: 48          H   :bd28[1]
+    ldx #3                                                            ; 5d29: a2 03       ..  :bd29[1]
+; $5d2b referenced 1 time by $bd30
+loop_cbd2b
+    lda l00b1,x                                                       ; 5d2b: b5 b1       ..  :bd2b[1]
+    sta l00ba,x                                                       ; 5d2d: 95 ba       ..  :bd2d[1]
+    dex                                                               ; 5d2f: ca          .   :bd2f[1]
+    bpl loop_cbd2b                                                    ; 5d30: 10 f9       ..  :bd30[1]
+    ldx #$b5                                                          ; 5d32: a2 b5       ..  :bd32[1]
+    ldy #$f4                                                          ; 5d34: a0 f4       ..  :bd34[1]
+    jsr sub_cb850                                                     ; 5d36: 20 50 b8     P. :bd36[1]
+    bit l00b0                                                         ; 5d39: 24 b0       $.  :bd39[1]
+    bmi cbd40                                                         ; 5d3b: 30 03       0.  :bd3b[1]
+    jmp cbdba                                                         ; 5d3d: 4c ba bd    L.. :bd3d[1]
+
+; $5d40 referenced 1 time by $bd3b
+cbd40
+    pla                                                               ; 5d40: 68          h   :bd40[1]
+    sta l00b4                                                         ; 5d41: 85 b4       ..  :bd41[1]
+    pla                                                               ; 5d43: 68          h   :bd43[1]
+    sta l00b3                                                         ; 5d44: 85 b3       ..  :bd44[1]
+; $5d46 referenced 1 time by $bdb6
+cbd46
+    ldx #$be                                                          ; 5d46: a2 be       ..  :bd46[1]
+    ldy #$f4                                                          ; 5d48: a0 f4       ..  :bd48[1]
+    jsr sub_cb841                                                     ; 5d4a: 20 41 b8     A. :bd4a[1]
+    lda l00bf                                                         ; 5d4d: a5 bf       ..  :bd4d[1]
+    bne cbd7e                                                         ; 5d4f: d0 2d       .-  :bd4f[1]
+    ldx l00be                                                         ; 5d51: a6 be       ..  :bd51[1]
+    beq cbdb9                                                         ; 5d53: f0 64       .d  :bd53[1]
+    lda #0                                                            ; 5d55: a9 00       ..  :bd55[1]
+    sta (l00b8),y                                                     ; 5d57: 91 b8       ..  :bd57[1]
+    inc l00b9                                                         ; 5d59: e6 b9       ..  :bd59[1]
+    jsr cbe7b                                                         ; 5d5b: 20 7b be     {. :bd5b[1]
+    lda #0                                                            ; 5d5e: a9 00       ..  :bd5e[1]
+    ldx #$ba                                                          ; 5d60: a2 ba       ..  :bd60[1]
+    ldy #0                                                            ; 5d62: a0 00       ..  :bd62[1]
+    jsr tube_entry                                                    ; 5d64: 20 06 04     .. :bd64[1]
+    ldy #7                                                            ; 5d67: a0 07       ..  :bd67[1]
+    jsr cbe89                                                         ; 5d69: 20 89 be     .. :bd69[1]
+; $5d6c referenced 1 time by $bd7a
+loop_cbd6c
+    lda tube_host_r3_data                                             ; 5d6c: ad e5 fe    ... :bd6c[1]
+    sta (l00b8),y                                                     ; 5d6f: 91 b8       ..  :bd6f[1]
+    ldx #3                                                            ; 5d71: a2 03       ..  :bd71[1]
+    jsr cbe8d                                                         ; 5d73: 20 8d be     .. :bd73[1]
+    nop                                                               ; 5d76: ea          .   :bd76[1]
+    iny                                                               ; 5d77: c8          .   :bd77[1]
+    cpy l00be                                                         ; 5d78: c4 be       ..  :bd78[1]
+    bne loop_cbd6c                                                    ; 5d7a: d0 f0       ..  :bd7a[1]
+    beq cbda3                                                         ; 5d7c: f0 25       .%  :bd7c[1]
+; $5d7e referenced 1 time by $bd4f
+cbd7e
+    lda #0                                                            ; 5d7e: a9 00       ..  :bd7e[1]
+    sta l00be                                                         ; 5d80: 85 be       ..  :bd80[1]
+    lda #1                                                            ; 5d82: a9 01       ..  :bd82[1]
+    sta l00bf                                                         ; 5d84: 85 bf       ..  :bd84[1]
+    inc l00b9                                                         ; 5d86: e6 b9       ..  :bd86[1]
+    jsr cbe7b                                                         ; 5d88: 20 7b be     {. :bd88[1]
+    lda #6                                                            ; 5d8b: a9 06       ..  :bd8b[1]
+    ldx #$ba                                                          ; 5d8d: a2 ba       ..  :bd8d[1]
+    ldy #0                                                            ; 5d8f: a0 00       ..  :bd8f[1]
+    jsr tube_entry                                                    ; 5d91: 20 06 04     .. :bd91[1]
+    ldy #5                                                            ; 5d94: a0 05       ..  :bd94[1]
+    jsr cbe89                                                         ; 5d96: 20 89 be     .. :bd96[1]
+; $5d99 referenced 1 time by $bda1
+loop_cbd99
+    lda tube_host_r3_data                                             ; 5d99: ad e5 fe    ... :bd99[1]
+    sta (l00b8),y                                                     ; 5d9c: 91 b8       ..  :bd9c[1]
+    lda (l00b8),y                                                     ; 5d9e: b1 b8       ..  :bd9e[1]
+    iny                                                               ; 5da0: c8          .   :bda0[1]
+    bne loop_cbd99                                                    ; 5da1: d0 f6       ..  :bda1[1]
+; $5da3 referenced 1 time by $bd7c
+cbda3
+    jsr sub_cbe83                                                     ; 5da3: 20 83 be     .. :bda3[1]
+    ldx #$b8                                                          ; 5da6: a2 b8       ..  :bda6[1]
+    ldy #$b1                                                          ; 5da8: a0 b1       ..  :bda8[1]
+    jsr sub_cb580                                                     ; 5daa: 20 80 b5     .. :bdaa[1]
+    dec l00b9                                                         ; 5dad: c6 b9       ..  :bdad[1]
+    sec                                                               ; 5daf: 38          8   :bdaf[1]
+    jsr cb795                                                         ; 5db0: 20 95 b7     .. :bdb0[1]
+    jsr cbe47                                                         ; 5db3: 20 47 be     G. :bdb3[1]
+    jmp cbd46                                                         ; 5db6: 4c 46 bd    LF. :bdb6[1]
+
+; $5db9 referenced 2 times by $bd53, $bdcd
+cbdb9
+    rts                                                               ; 5db9: 60          `   :bdb9[1]
+
+; $5dba referenced 1 time by $bd3d
+cbdba
+    pla                                                               ; 5dba: 68          h   :bdba[1]
+    sta l00b2                                                         ; 5dbb: 85 b2       ..  :bdbb[1]
+    pla                                                               ; 5dbd: 68          h   :bdbd[1]
+    sta l00b1                                                         ; 5dbe: 85 b1       ..  :bdbe[1]
+; $5dc0 referenced 1 time by $be44
+cbdc0
+    ldx #$be                                                          ; 5dc0: a2 be       ..  :bdc0[1]
+    ldy #$f4                                                          ; 5dc2: a0 f4       ..  :bdc2[1]
+    jsr sub_cb841                                                     ; 5dc4: 20 41 b8     A. :bdc4[1]
+    lda l00bf                                                         ; 5dc7: a5 bf       ..  :bdc7[1]
+    bne cbdd3                                                         ; 5dc9: d0 08       ..  :bdc9[1]
+    ldx l00be                                                         ; 5dcb: a6 be       ..  :bdcb[1]
+    beq cbdb9                                                         ; 5dcd: f0 ea       ..  :bdcd[1]
+    lda #1                                                            ; 5dcf: a9 01       ..  :bdcf[1]
+    bne cbddd                                                         ; 5dd1: d0 0a       ..  :bdd1[1]
+; $5dd3 referenced 1 time by $bdc9
+cbdd3
+    lda #0                                                            ; 5dd3: a9 00       ..  :bdd3[1]
+    sta l00be                                                         ; 5dd5: 85 be       ..  :bdd5[1]
+    lda #1                                                            ; 5dd7: a9 01       ..  :bdd7[1]
+    sta l00bf                                                         ; 5dd9: 85 bf       ..  :bdd9[1]
+    lda #7                                                            ; 5ddb: a9 07       ..  :bddb[1]
+; $5ddd referenced 1 time by $bdd1
+cbddd
+    pha                                                               ; 5ddd: 48          H   :bddd[1]
+    inc l00b9                                                         ; 5dde: e6 b9       ..  :bdde[1]
+    ldx #$b8                                                          ; 5de0: a2 b8       ..  :bde0[1]
+    ldy #$b3                                                          ; 5de2: a0 b3       ..  :bde2[1]
+    jsr sub_cb580                                                     ; 5de4: 20 80 b5     .. :bde4[1]
+    lda l00be                                                         ; 5de7: a5 be       ..  :bde7[1]
+    pha                                                               ; 5de9: 48          H   :bde9[1]
+    dec l00b9                                                         ; 5dea: c6 b9       ..  :bdea[1]
+    clc                                                               ; 5dec: 18          .   :bdec[1]
+    jsr cb795                                                         ; 5ded: 20 95 b7     .. :bded[1]
+    pla                                                               ; 5df0: 68          h   :bdf0[1]
+    sta l00be                                                         ; 5df1: 85 be       ..  :bdf1[1]
+    pla                                                               ; 5df3: 68          h   :bdf3[1]
+    cmp #1                                                            ; 5df4: c9 01       ..  :bdf4[1]
+    bne cbe21                                                         ; 5df6: d0 29       .)  :bdf6[1]
+    lda #0                                                            ; 5df8: a9 00       ..  :bdf8[1]
+    ldy #$f4                                                          ; 5dfa: a0 f4       ..  :bdfa[1]
+    sta (l00b8),y                                                     ; 5dfc: 91 b8       ..  :bdfc[1]
+    inc l00b9                                                         ; 5dfe: e6 b9       ..  :bdfe[1]
+    jsr cbe7b                                                         ; 5e00: 20 7b be     {. :be00[1]
+    lda #1                                                            ; 5e03: a9 01       ..  :be03[1]
+    ldx #$ba                                                          ; 5e05: a2 ba       ..  :be05[1]
+    ldy #0                                                            ; 5e07: a0 00       ..  :be07[1]
+    jsr tube_entry                                                    ; 5e09: 20 06 04     .. :be09[1]
+    ldy #0                                                            ; 5e0c: a0 00       ..  :be0c[1]
+; $5e0e referenced 1 time by $be1d
+loop_cbe0e
+    lda (l00b8),y                                                     ; 5e0e: b1 b8       ..  :be0e[1]
+    sta tube_host_r3_data                                             ; 5e10: 8d e5 fe    ... :be10[1]
+    ldx #3                                                            ; 5e13: a2 03       ..  :be13[1]
+    jsr cbe8d                                                         ; 5e15: 20 8d be     .. :be15[1]
+    iny                                                               ; 5e18: c8          .   :be18[1]
+    cpy l00be                                                         ; 5e19: c4 be       ..  :be19[1]
+    cpy l00be                                                         ; 5e1b: c4 be       ..  :be1b[1]
+    bne loop_cbe0e                                                    ; 5e1d: d0 ef       ..  :be1d[1]
+    beq cbe3c                                                         ; 5e1f: f0 1b       ..  :be1f[1]
+; $5e21 referenced 1 time by $bdf6
+cbe21
+    inc l00b9                                                         ; 5e21: e6 b9       ..  :be21[1]
+    jsr cbe7b                                                         ; 5e23: 20 7b be     {. :be23[1]
+    lda #7                                                            ; 5e26: a9 07       ..  :be26[1]
+    ldx #$ba                                                          ; 5e28: a2 ba       ..  :be28[1]
+    ldy #0                                                            ; 5e2a: a0 00       ..  :be2a[1]
+    jsr tube_entry                                                    ; 5e2c: 20 06 04     .. :be2c[1]
+    ldy #0                                                            ; 5e2f: a0 00       ..  :be2f[1]
+; $5e31 referenced 1 time by $be3a
+loop_cbe31
+    lda (l00b8),y                                                     ; 5e31: b1 b8       ..  :be31[1]
+    sta tube_host_r3_data                                             ; 5e33: 8d e5 fe    ... :be33[1]
+    nop                                                               ; 5e36: ea          .   :be36[1]
+    nop                                                               ; 5e37: ea          .   :be37[1]
+    nop                                                               ; 5e38: ea          .   :be38[1]
+    iny                                                               ; 5e39: c8          .   :be39[1]
+    bne loop_cbe31                                                    ; 5e3a: d0 f5       ..  :be3a[1]
+; $5e3c referenced 1 time by $be1f
+cbe3c
+    jsr sub_cbe83                                                     ; 5e3c: 20 83 be     .. :be3c[1]
+    dec l00b9                                                         ; 5e3f: c6 b9       ..  :be3f[1]
+    jsr cbe47                                                         ; 5e41: 20 47 be     G. :be41[1]
+    jmp cbdc0                                                         ; 5e44: 4c c0 bd    L.. :be44[1]
+
+; $5e47 referenced 3 times by $bdb3, $be41, $be50
+cbe47
+    ldx #1                                                            ; 5e47: a2 01       ..  :be47[1]
+    inc l00ba,x                                                       ; 5e49: f6 ba       ..  :be49[1]
+    bne cbe52                                                         ; 5e4b: d0 05       ..  :be4b[1]
+    inx                                                               ; 5e4d: e8          .   :be4d[1]
+    cpx #4                                                            ; 5e4e: e0 04       ..  :be4e[1]
+    bcc cbe47                                                         ; 5e50: 90 f5       ..  :be50[1]
+; $5e52 referenced 1 time by $be4b
+cbe52
+    ldy #$f5                                                          ; 5e52: a0 f5       ..  :be52[1]
+    lda (l00b8),y                                                     ; 5e54: b1 b8       ..  :be54[1]
+    sec                                                               ; 5e56: 38          8   :be56[1]
+    sbc #1                                                            ; 5e57: e9 01       ..  :be57[1]
+    bcc cbe7a                                                         ; 5e59: 90 1f       ..  :be59[1]
+    sta (l00b8),y                                                     ; 5e5b: 91 b8       ..  :be5b[1]
+    jsr sub_cb616                                                     ; 5e5d: 20 16 b6     .. :be5d[1]
+    beq cbe7a                                                         ; 5e60: f0 18       ..  :be60[1]
+    ldx l00b7                                                         ; 5e62: a6 b7       ..  :be62[1]
+    jsr sub_cb85d                                                     ; 5e64: 20 5d b8     ]. :be64[1]
+    bvc cbe7a                                                         ; 5e67: 50 11       P.  :be67[1]
+    lda l00b1,x                                                       ; 5e69: b5 b1       ..  :be69[1]
+    cmp #$c0                                                          ; 5e6b: c9 c0       ..  :be6b[1]
+    bcc cbe7a                                                         ; 5e6d: 90 0b       ..  :be6d[1]
+    lda #$10                                                          ; 5e6f: a9 10       ..  :be6f[1]
+    sta l00b0,x                                                       ; 5e71: 95 b0       ..  :be71[1]
+    lda #$80                                                          ; 5e73: a9 80       ..  :be73[1]
+    sta l00b1,x                                                       ; 5e75: 95 b1       ..  :be75[1]
+    jsr sub_cb68f                                                     ; 5e77: 20 8f b6     .. :be77[1]
+; $5e7a referenced 4 times by $be59, $be60, $be67, $be6d
+cbe7a
+    rts                                                               ; 5e7a: 60          `   :be7a[1]
+
+; $5e7b referenced 5 times by $bd5b, $bd88, $be00, $be23, $be80
+cbe7b
+    lda #$c8                                                          ; 5e7b: a9 c8       ..  :be7b[1]
+    jsr tube_entry                                                    ; 5e7d: 20 06 04     .. :be7d[1]
+    bcc cbe7b                                                         ; 5e80: 90 f9       ..  :be80[1]
+    rts                                                               ; 5e82: 60          `   :be82[1]
+
+; $5e83 referenced 2 times by $bda3, $be3c
+sub_cbe83
+    lda #$88                                                          ; 5e83: a9 88       ..  :be83[1]
+    jsr tube_entry                                                    ; 5e85: 20 06 04     .. :be85[1]
+    rts                                                               ; 5e88: 60          `   :be88[1]
+
+; $5e89 referenced 3 times by $bd69, $bd96, $be8a
+cbe89
+    dey                                                               ; 5e89: 88          .   :be89[1]
+    bne cbe89                                                         ; 5e8a: d0 fd       ..  :be8a[1]
+    rts                                                               ; 5e8c: 60          `   :be8c[1]
+
+; $5e8d referenced 3 times by $bd73, $be15, $be8e
+cbe8d
+    dex                                                               ; 5e8d: ca          .   :be8d[1]
+    bne cbe8d                                                         ; 5e8e: d0 fd       ..  :be8e[1]
+    rts                                                               ; 5e90: 60          `   :be90[1]
+
+; $5e91 referenced 1 time by $bcf4
+sub_cbe91
+    lda #osbyte_read_tube_presence                                    ; 5e91: a9 ea       ..  :be91[1]
+    ldx #0                                                            ; 5e93: a2 00       ..  :be93[1]
+    ldy #$ff                                                          ; 5e95: a0 ff       ..  :be95[1]
+    jsr osbyte                                                        ; 5e97: 20 f4 ff     .. :be97[1]
+    cpx #$ff                                                          ; 5e9a: e0 ff       ..  :be9a[1]
+    rts                                                               ; 5e9c: 60          `   :be9c[1]
+
+; $5e9d referenced 2 times by $b338, $bcf1
+sub_cbe9d
+    jsr sub_cb85d                                                     ; 5e9d: 20 5d b8     ]. :be9d[1]
+    bpl cbec1                                                         ; 5ea0: 10 1f       ..  :bea0[1]
+    bvs cbec1                                                         ; 5ea2: 70 1d       p.  :bea2[1]
+    lda #0                                                            ; 5ea4: a9 00       ..  :bea4[1]
+    pha                                                               ; 5ea6: 48          H   :bea6[1]
+    ldy #$f1                                                          ; 5ea7: a0 f1       ..  :bea7[1]
+    lda (l00b8),y                                                     ; 5ea9: b1 b8       ..  :bea9[1]
+; $5eab referenced 1 time by $bec6
+loop_cbeab
+    pha                                                               ; 5eab: 48          H   :beab[1]
+    lda #osbyte_read_rom_info_table_low                               ; 5eac: a9 aa       ..  :beac[1]
+    ldx #0                                                            ; 5eae: a2 00       ..  :beae[1]
+    ldy #$ff                                                          ; 5eb0: a0 ff       ..  :beb0[1]
+    jsr osbyte                                                        ; 5eb2: 20 f4 ff     .. :beb2[1]
+    jsr cb82b                                                         ; 5eb5: 20 2b b8     +. :beb5[1]
+    stx l00ba                                                         ; 5eb8: 86 ba       ..  :beb8[1]
+    sty l00bb                                                         ; 5eba: 84 bb       ..  :beba[1]
+    pla                                                               ; 5ebc: 68          h   :bebc[1]
+    tay                                                               ; 5ebd: a8          .   :bebd[1]
+    pla                                                               ; 5ebe: 68          h   :bebe[1]
+    sta (l00ba),y                                                     ; 5ebf: 91 ba       ..  :bebf[1]
+; $5ec1 referenced 2 times by $bea0, $bea2
+cbec1
+    rts                                                               ; 5ec1: 60          `   :bec1[1]
+
+; $5ec2 referenced 2 times by $bc64, $bcae
+sub_cbec2
+    lda #2                                                            ; 5ec2: a9 02       ..  :bec2[1]
+    pha                                                               ; 5ec4: 48          H   :bec4[1]
+    tya                                                               ; 5ec5: 98          .   :bec5[1]
+    bpl loop_cbeab                                                    ; 5ec6: 10 e3       ..  :bec6[1]
+; $5ec8 referenced 1 time by $8003
+service_handler
+    cmp #service_claim_absolute_workspace                             ; 5ec8: c9 01       ..  :bec8[1]
+    bne cbee0                                                         ; 5eca: d0 14       ..  :beca[1]
+    pha                                                               ; 5ecc: 48          H   :becc[1]
+    tya                                                               ; 5ecd: 98          .   :becd[1]
+    pha                                                               ; 5ece: 48          H   :bece[1]
+    lda #osbyte_issue_service_request                                 ; 5ecf: a9 8f       ..  :becf[1]
+    ldx #service_check_swr_presence                                   ; 5ed1: a2 2b       .+  :bed1[1]
+    ldy romsel_copy                                                   ; 5ed3: a4 f4       ..  :bed3[1]
+    jsr osbyte                                                        ; 5ed5: 20 f4 ff     .. :bed5[1]
+    pla                                                               ; 5ed8: 68          h   :bed8[1]
+    tay                                                               ; 5ed9: a8          .   :bed9[1]
+    ldx romsel_copy                                                   ; 5eda: a6 f4       ..  :beda[1]
+    pla                                                               ; 5edc: 68          h   :bedc[1]
+; $5edd referenced 2 times by $bee2, $beec
+general_service_handler_indirect
+    jmp general_service_handler                                       ; 5edd: 4c b1 b1    L.. :bedd[1]
+
+; $5ee0 referenced 1 time by $beca
+cbee0
+    cmp #service_check_swr_presence                                   ; 5ee0: c9 2b       .+  :bee0[1]
+    bne general_service_handler_indirect                              ; 5ee2: d0 f9       ..  :bee2[1]
+    cpy romsel_copy                                                   ; 5ee4: c4 f4       ..  :bee4[1]
+    beq cbeee                                                         ; 5ee6: f0 06       ..  :bee6[1]
+; $5ee8 referenced 4 times by $bef8, $beff, $bf08, $bf4c
+cbee8
+    ldx romsel_copy                                                   ; 5ee8: a6 f4       ..  :bee8[1]
+    lda #0                                                            ; 5eea: a9 00       ..  :beea[1]
+    beq general_service_handler_indirect                              ; 5eec: f0 ef       ..  :beec[1]
+; $5eee referenced 1 time by $bee6
+cbeee
+    lda #$72 ; 'r'                                                    ; 5eee: a9 72       .r  :beee[1]
+    ldx #0                                                            ; 5ef0: a2 00       ..  :bef0[1]
+    jsr osbyte                                                        ; 5ef2: 20 f4 ff     .. :bef2[1]
+    jsr osbyte                                                        ; 5ef5: 20 f4 ff     .. :bef5[1]
+    bvs cbee8                                                         ; 5ef8: 70 ee       p.  :bef8[1]
+    lda #$ea                                                          ; 5efa: a9 ea       ..  :befa[1]
+    jsr sub_cbf82                                                     ; 5efc: 20 82 bf     .. :befc[1]
+    bne cbee8                                                         ; 5eff: d0 e7       ..  :beff[1]
+    lda #$d7                                                          ; 5f01: a9 d7       ..  :bf01[1]
+    ldy #$7f                                                          ; 5f03: a0 7f       ..  :bf03[1]
+    jsr sub_cbf84                                                     ; 5f05: 20 84 bf     .. :bf05[1]
+    bpl cbee8                                                         ; 5f08: 10 de       ..  :bf08[1]
+    jsr osnewl                                                        ; 5f0a: 20 e7 ff     .. :bf0a[1]
+    ldx #0                                                            ; 5f0d: a2 00       ..  :bf0d[1]
+    jsr sub_cbf7c                                                     ; 5f0f: 20 7c bf     |. :bf0f[1]
+    lda #$fd                                                          ; 5f12: a9 fd       ..  :bf12[1]
+    jsr sub_cbf82                                                     ; 5f14: 20 82 bf     .. :bf14[1]
+    beq cbf46                                                         ; 5f17: f0 2d       .-  :bf17[1]
+    tsx                                                               ; 5f19: ba          .   :bf19[1]
+    ldy #$30 ; '0'                                                    ; 5f1a: a0 30       .0  :bf1a[1]
+; $5f1c referenced 1 time by $bf21
+loop_cbf1c
+    lda cbf8a,y                                                       ; 5f1c: b9 8a bf    ... :bf1c[1]
+    pha                                                               ; 5f1f: 48          H   :bf1f[1]
+    dey                                                               ; 5f20: 88          .   :bf20[1]
+    bne loop_cbf1c                                                    ; 5f21: d0 f9       ..  :bf21[1]
+    txa                                                               ; 5f23: 8a          .   :bf23[1]
+    tay                                                               ; 5f24: a8          .   :bf24[1]
+    lda #1                                                            ; 5f25: a9 01       ..  :bf25[1]
+    pha                                                               ; 5f27: 48          H   :bf27[1]
+    tsx                                                               ; 5f28: ba          .   :bf28[1]
+    inx                                                               ; 5f29: e8          .   :bf29[1]
+    txa                                                               ; 5f2a: 8a          .   :bf2a[1]
+    pha                                                               ; 5f2b: 48          H   :bf2b[1]
+    ldx #$0f                                                          ; 5f2c: a2 0f       ..  :bf2c[1]
+    lda #0                                                            ; 5f2e: a9 00       ..  :bf2e[1]
+    sta l00b0                                                         ; 5f30: 85 b0       ..  :bf30[1]
+    rts                                                               ; 5f32: 60          `   :bf32[1]
+
+; $5f33 referenced 1 time by $bfb8
+cbf33
+    tya                                                               ; 5f33: 98          .   :bf33[1]
+    tax                                                               ; 5f34: aa          .   :bf34[1]
+    txs                                                               ; 5f35: 9a          .   :bf35[1]
+    lda l00b0                                                         ; 5f36: a5 b0       ..  :bf36[1]
+    asl                                                               ; 5f38: 0a          .   :bf38[1]
+    asl                                                               ; 5f39: 0a          .   :bf39[1]
+    clc                                                               ; 5f3a: 18          .   :bf3a[1]
+    adc #$0d                                                          ; 5f3b: 69 0d       i.  :bf3b[1]
+    tax                                                               ; 5f3d: aa          .   :bf3d[1]
+    jsr sub_cbf7c                                                     ; 5f3e: 20 7c bf     |. :bf3e[1]
+    ldx #$0a                                                          ; 5f41: a2 0a       ..  :bf41[1]
+    jsr sub_cbf7c                                                     ; 5f43: 20 7c bf     |. :bf43[1]
+; $5f46 referenced 1 time by $bf17
+cbf46
+    jsr osnewl                                                        ; 5f46: 20 e7 ff     .. :bf46[1]
+    jsr osnewl                                                        ; 5f49: 20 e7 ff     .. :bf49[1]
+    jmp cbee8                                                         ; 5f4c: 4c e8 be    L.. :bf4c[1]
+
+; $5f4f referenced 1 time by $bf7c
+lbf4f
+    !text "Acorn OS "                                                 ; 5f4f: 41 63 6f... Aco :bf4f[1]
+    !byte   0, $4b,   7,   0, $36, $34,   0,   0, $38, $30,   0,   0  ; 5f58: 00 4b 07... .K. :bf58[1]
+    !byte $39, $36,   0,   0                                          ; 5f64: 39 36 00... 96. :bf64[1]
+    !text "112"                                                       ; 5f68: 31 31 32    112 :bf68[1]
+    !byte 0                                                           ; 5f6b: 00          .   :bf6b[1]
+    !text "128"                                                       ; 5f6c: 31 32 38    128 :bf6c[1]
+    !byte 0                                                           ; 5f6f: 00          .   :bf6f[1]
+    !text "144"                                                       ; 5f70: 31 34 34    144 :bf70[1]
+    !byte 0                                                           ; 5f73: 00          .   :bf73[1]
+    !text "160"                                                       ; 5f74: 31 36 30    160 :bf74[1]
+    !byte 0                                                           ; 5f77: 00          .   :bf77[1]
+
+; $5f78 referenced 1 time by $bf7f
+loop_cbf78
+    jsr oswrch                                                        ; 5f78: 20 ee ff     .. :bf78[1]
+    inx                                                               ; 5f7b: e8          .   :bf7b[1]
+; $5f7c referenced 3 times by $bf0f, $bf3e, $bf43
+sub_cbf7c
+    lda lbf4f,x                                                       ; 5f7c: bd 4f bf    .O. :bf7c[1]
+    bne loop_cbf78                                                    ; 5f7f: d0 f7       ..  :bf7f[1]
+    rts                                                               ; 5f81: 60          `   :bf81[1]
+
+; $5f82 referenced 2 times by $befc, $bf14
+sub_cbf82
+    ldy #$ff                                                          ; 5f82: a0 ff       ..  :bf82[1]
+; $5f84 referenced 1 time by $bf05
+sub_cbf84
+    ldx #0                                                            ; 5f84: a2 00       ..  :bf84[1]
+    jsr osbyte                                                        ; 5f86: 20 f4 ff     .. :bf86[1]
+    txa                                                               ; 5f89: 8a          .   :bf89[1]
+; $5f8a referenced 1 time by $bf1c
+cbf8a
+    rts                                                               ; 5f8a: 60          `   :bf8a[1]
+
+    lda romsel_copy                                                   ; 5f8b: a5 f4       ..  :bf8b[1]
+    pha                                                               ; 5f8d: 48          H   :bf8d[1]
+; $5f8e referenced 2 times by $bfac, $bfb0
+cbf8e
+    stx romsel_copy                                                   ; 5f8e: 86 f4       ..  :bf8e[1]
+    stx romsel                                                        ; 5f90: 8e 30 fe    .0. :bf90[1]
+    lda lbfff                                                         ; 5f93: ad ff bf    ... :bf93[1]
+    pha                                                               ; 5f96: 48          H   :bf96[1]
+    eor #$a5                                                          ; 5f97: 49 a5       I.  :bf97[1]
+    sta lbfff                                                         ; 5f99: 8d ff bf    ... :bf99[1]
+    cmp lbfff                                                         ; 5f9c: cd ff bf    ... :bf9c[1]
+    bne cbfa3                                                         ; 5f9f: d0 02       ..  :bf9f[1]
+    inc l00b0                                                         ; 5fa1: e6 b0       ..  :bfa1[1]
+; $5fa3 referenced 1 time by $bf9f
+cbfa3
+    pla                                                               ; 5fa3: 68          h   :bfa3[1]
+    sta lbfff                                                         ; 5fa4: 8d ff bf    ... :bfa4[1]
+    dex                                                               ; 5fa7: ca          .   :bfa7[1]
+    bmi cbfb2                                                         ; 5fa8: 30 08       0.  :bfa8[1]
+    cpx #$0b                                                          ; 5faa: e0 0b       ..  :bfaa[1]
+    bne cbf8e                                                         ; 5fac: d0 e0       ..  :bfac[1]
+    ldx #1                                                            ; 5fae: a2 01       ..  :bfae[1]
+    bne cbf8e                                                         ; 5fb0: d0 dc       ..  :bfb0[1]
+; $5fb2 referenced 1 time by $bfa8
+cbfb2
+    pla                                                               ; 5fb2: 68          h   :bfb2[1]
+    sta romsel_copy                                                   ; 5fb3: 85 f4       ..  :bfb3[1]
+    sta romsel                                                        ; 5fb5: 8d 30 fe    .0. :bfb5[1]
+    jmp cbf33                                                         ; 5fb8: 4c 33 bf    L3. :bfb8[1]
+
+    !byte $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff  ; 5fbb: ff ff ff... ... :bfbb[1]
+    !byte $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff  ; 5fc7: ff ff ff... ... :bfc7[1]
+    !byte $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff  ; 5fd3: ff ff ff... ... :bfd3[1]
+    !byte $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff  ; 5fdf: ff ff ff... ... :bfdf[1]
+    !byte $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff  ; 5feb: ff ff ff... ... :bfeb[1]
+    !byte $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff                      ; 5ff7: ff ff ff... ... :bff7[1]
+; $5fff referenced 4 times by $bf93, $bf99, $bf9c, $bfa4
+lbfff
+    !byte $ff                                                         ; 5fff: ff          .   :bfff[1]
+}
+
+pydis_end
+
+; Label references by decreasing frequency:
+;     l00b8:                    125
+;     l00b0:                    105
+;     l00ba:                     44
+;     l00bf:                     42
+;     l00bc:                     41
+;     l00b6:                     35
+;     l00be:                     31
+;     l00cd:                     31
+;     sub_c2077:                 31
+;     l00c2:                     30
+;     l00b1:                     29
+;     sub_c23e3:                 29
+;     l00b9:                     28
+;     l00bb:                     28
+;     l00b5:                     26
+;     l00bd:                     26
+;     l00b4:                     25
+;     l00b3:                     23
+;     l00c1:                     23
+;     os_text_ptr:               23
+;     osbyte:                    22
+;     romsel_copy:               21
+;     l0f0e:                     21
+;     c4ea0:                     21
+;     l00c4:                     20
+;     c209f:                     20
+;     l00b2:                     19
+;     l10c2:                     19
+;     l0001:                     18
+;     l00a8:                     18
+;     l00aa:                     18
+;     l00c5:                     18
+;     l00c9:                     18
+;     l10de:                     18
+;     l0000:                     17
+;     l00b7:                     17
+;     l0e0f:                     17
+;     l0f06:                     17
+;     l1000:                     17
+;     l00a2:                     16
+;     l00ab:                     16
+;     l00ae:                     16
+;     c43dc:                     16
+;     c582b:                     16
+;     l00c0:                     15
+;     l00c3:                     15
+;     l00c7:                     15
+;     l0f05:                     15
+;     l00cc:                     14
+;     l1117:                     14
+;     c4e70:                     14
+;     c4f7f:                     14
+;     l00a1:                     13
+;     l00a5:                     13
+;     l00c8:                     13
+;     l0f07:                     13
+;     sub_c414a:                 13
+;     tube_host_r3_data:         13
+;     l00ac:                     12
+;     sub_c274c:                 12
+;     sub_c5841:                 12
+;     osasci:                    12
+;     l00c6:                     11
+;     osrdsc_ptr:                11
+;     l0e08:                     11
+;     sub_c2038:                 11
+;     sub_c2149:                 11
+;     c396e:                     11
+;     c4c0f:                     11
+;     lfe84:                     11
+;     tube_host_r2_data:         11
+;     l00a9:                     10
+;     l1111:                     10
+;     l1112:                     10
+;     sub_c20c3:                 10
+;     c33e6:                     10
+;     c5203:                     10
+;     lfe87:                     10
+;     tube_host_r2_status:       10
+;     l00ca:                      9
+;     l1074:                      9
+;     l108a:                      9
+;     l1097:                      9
+;     l10c0:                      9
+;     l1110:                      9
+;     c5bd0:                      9
+;     l00ce:                      8
+;     l00ff:                      8
+;     l0100:                      8
+;     l0df0:                      8
+;     l0f04:                      8
+;     l1060:                      8
+;     l1082:                      8
+;     l108b:                      8
+;     l1090:                      8
+;     l1096:                      8
+;     l10ca:                      8
+;     l10cf:                      8
+;     l10d1:                      8
+;     sub_c21b0:                  8
+;     sub_c21bf:                  8
+;     c2816:                      8
+;     sub_c2b7b:                  8
+;     sub_c3ae5:                  8
+;     c4e79:                      8
+;     sub_c585d:                  8
+;     tube_host_r1_status:        8
+;     osfind:                     8
+;     l00a7:                      7
+;     l00cf:                      7
+;     l0f08:                      7
+;     l1075:                      7
+;     l10c9:                      7
+;     l10d2:                      7
+;     l1114:                      7
+;     c204f:                      7
+;     sub_c2284:                  7
+;     sub_c2380:                  7
+;     c2b8b:                      7
+;     sub_c499c:                  7
+;     sub_c5580:                  7
+;     sub_c5ab9:                  7
+;     osrdsc:                     7
+;     l0015:                      6
+;     l00f3:                      6
+;     l00f7:                      6
+;     l0f0f:                      6
+;     l1100:                      6
+;     sub_c202e:                  6
+;     sub_c2280:                  6
+;     sub_c22fe:                  6
+;     l261c:                      6
+;     sub_c27da:                  6
+;     c340c:                      6
+;     sub_c39ac:                  6
+;     sub_c3d8e:                  6
+;     sub_c3e75:                  6
+;     c4f58:                      6
+;     sub_c55f2:                  6
+;     l5726:                      6
+;     c58fb:                      6
+;     oswrch:                     6
+;     l00a6:                      5
+;     l00af:                      5
+;     l00f0:                      5
+;     l1087:                      5
+;     l1088:                      5
+;     l1099:                      5
+;     l10c7:                      5
+;     l10dd:                      5
+;     l110c:                      5
+;     l1115:                      5
+;     l1116:                      5
+;     sub_c20bb:                  5
+;     sub_c20ed:                  5
+;     sub_c20f3:                  5
+;     c2125:                      5
+;     sub_c230a:                  5
+;     sub_c2335:                  5
+;     sub_c2386:                  5
+;     sub_c240c:                  5
+;     c2ba2:                      5
+;     sub_c2f3f:                  5
+;     c3257:                      5
+;     c39a3:                      5
+;     sub_c3a6e:                  5
+;     sub_c3ab8:                  5
+;     sub_c40de:                  5
+;     sub_c41b4:                  5
+;     c4e97:                      5
+;     sub_c56fe:                  5
+;     sub_c5745:                  5
+;     c5795:                      5
+;     sub_c5850:                  5
+;     sub_c5a67:                  5
+;     c5e7b:                      5
+;     osnewl:                     5
+;     l0002:                      4
+;     l0e00:                      4
+;     l0f0c:                      4
+;     l0f0d:                      4
+;     l1069:                      4
+;     l1076:                      4
+;     l1077:                      4
+;     l1081:                      4
+;     l1086:                      4
+;     l1095:                      4
+;     l10c4:                      4
+;     l10cb:                      4
+;     l10cc:                      4
+;     l10ce:                      4
+;     l10d9:                      4
+;     l10da:                      4
+;     l110d:                      4
+;     l1113:                      4
+;     l111a:                      4
+;     l111d:                      4
+;     sub_c2023:                  4
+;     sub_c2048:                  4
+;     sub_c20c8:                  4
+;     sub_c2174:                  4
+;     c21a7:                      4
+;     sub_c221d:                  4
+;     c2225:                      4
+;     sub_c22b2:                  4
+;     sub_c2327:                  4
+;     sub_c23dc:                  4
+;     c2d74:                      4
+;     c2d91:                      4
+;     c2e0e:                      4
+;     c2e12:                      4
+;     c2e64:                      4
+;     sub_c2f6b:                  4
+;     c340e:                      4
+;     c3436:                      4
+;     c393b:                      4
+;     sub_c3965:                  4
+;     sub_c3a8d:                  4
+;     c3adf:                      4
+;     c3ae9:                      4
+;     sub_c4379:                  4
+;     c45e5:                      4
+;     sub_c49ca:                  4
+;     sub_c4acf:                  4
+;     sub_c4c18:                  4
+;     sub_c4c62:                  4
+;     c4d79:                      4
+;     c5446:                      4
+;     l557f:                      4
+;     sub_c5616:                  4
+;     c568c:                      4
+;     sub_c568f:                  4
+;     sub_c583f:                  4
+;     sub_c5ac2:                  4
+;     sub_c5b00:                  4
+;     c5e7a:                      4
+;     c5ee8:                      4
+;     l5fff:                      4
+;     romsel:                     4
+;     lfe85:                      4
+;     lfe86:                      4
+;     osbput:                     4
+;     osbget:                     4
+;     osfile:                     4
+;     osrdch:                     4
+;     l00ef:                      3
+;     l0107:                      3
+;     l0109:                      3
+;     bytev:                      3
+;     bytev+1:                    3
+;     l0ef8:                      3
+;     l1092:                      3
+;     l1093:                      3
+;     l1094:                      3
+;     l1098:                      3
+;     l109d:                      3
+;     l109f:                      3
+;     l10c3:                      3
+;     l10c5:                      3
+;     l10c6:                      3
+;     l10d0:                      3
+;     l10d3:                      3
+;     l10d6:                      3
+;     l10d7:                      3
+;     l1119:                      3
+;     l111c:                      3
+;     c2103:                      3
+;     sub_c21be:                  3
+;     c2290:                      3
+;     c22e6:                      3
+;     sub_c233a:                  3
+;     sub_c236e:                  3
+;     c2454:                      3
+;     sub_c2456:                  3
+;     c29d7:                      3
+;     sub_c2b86:                  3
+;     c2d41:                      3
+;     c2e53:                      3
+;     c2ecc:                      3
+;     c2f2a:                      3
+;     sub_c2f7a:                  3
+;     c30fb:                      3
+;     c31af:                      3
+;     c3214:                      3
+;     sub_c33fd:                  3
+;     c3444:                      3
+;     c34bc:                      3
+;     sub_c3526:                  3
+;     c3738:                      3
+;     sub_c3940:                  3
+;     c39ed:                      3
+;     c3a8c:                      3
+;     sub_c3be5:                  3
+;     c3c82:                      3
+;     c3d5d:                      3
+;     sub_c3e30:                  3
+;     sub_c3f0f:                  3
+;     sub_c3f16:                  3
+;     sub_c3f1e:                  3
+;     c406b:                      3
+;     c414f:                      3
+;     c41c0:                      3
+;     sub_c4315:                  3
+;     sub_c4384:                  3
+;     sub_c4530:                  3
+;     c4660:                      3
+;     sub_c49c2:                  3
+;     c4a42:                      3
+;     c4a44:                      3
+;     sub_c4c0c:                  3
+;     c4cc4:                      3
+;     sub_c4d5d:                  3
+;     c4d77:                      3
+;     l4f76:                      3
+;     c51d5:                      3
+;     c5371:                      3
+;     sub_c558b:                  3
+;     c5684:                      3
+;     c56ca:                      3
+;     sub_c584e:                  3
+;     sub_c5986:                  3
+;     l5a30:                      3
+;     c5ab4:                      3
+;     sub_c5ac4:                  3
+;     c5e47:                      3
+;     c5e89:                      3
+;     c5e8d:                      3
+;     sub_c5f7c:                  3
+;     lfe80:                      3
+;     tube_host_r1_data:          3
+;     osword:                     3
+;     oscli:                      3
+;     l0003:                      2
+;     l0012:                      2
+;     l0014:                      2
+;     l00a0:                      2
+;     l00a3:                      2
+;     l00a4:                      2
+;     l00ad:                      2
+;     l00fd:                      2
+;     l0101:                      2
+;     l0102:                      2
+;     l0105:                      2
+;     l010b:                      2
+;     l0128:                      2
+;     fscv:                       2
+;     l0700:                      2
+;     l0e07:                      2
+;     l0f0a:                      2
+;     l0f0b:                      2
+;     l1045:                      2
+;     l1062:                      2
+;     l1065:                      2
+;     l1067:                      2
+;     l1078:                      2
+;     l107d:                      2
+;     l107e:                      2
+;     l107f:                      2
+;     l1089:                      2
+;     l108c:                      2
+;     l1091:                      2
+;     l109a:                      2
+;     l109b:                      2
+;     l109e:                      2
+;     l10c1:                      2
+;     l10cd:                      2
+;     l10d8:                      2
+;     l10db:                      2
+;     l10dc:                      2
+;     l10e2:                      2
+;     l10e3:                      2
+;     l10e4:                      2
+;     l1109:                      2
+;     l110b:                      2
+;     l110e:                      2
+;     l110f:                      2
+;     l111b:                      2
+;     sub_c209a:                  2
+;     sub_c20e3:                  2
+;     c215d:                      2
+;     sub_c21ae:                  2
+;     sub_c21c5:                  2
+;     c222a:                      2
+;     c225d:                      2
+;     sub_c2266:                  2
+;     sub_c226d:                  2
+;     sub_c22bb:                  2
+;     sub_c22e8:                  2
+;     c22fd:                      2
+;     sub_c241b:                  2
+;     sub_c2439:                  2
+;     c2543:                      2
+;     sub_c2555:                  2
+;     c2560:                      2
+;     c25bc:                      2
+;     c2703:                      2
+;     c2705:                      2
+;     c273b:                      2
+;     sub_c2745:                  2
+;     sub_c27db:                  2
+;     sub_c27e3:                  2
+;     c2808:                      2
+;     c283f:                      2
+;     sub_c2855:                  2
+;     sub_c2862:                  2
+;     c28a6:                      2
+;     c28f4:                      2
+;     sub_c2951:                  2
+;     c298a:                      2
+;     c29a5:                      2
+;     c29b4:                      2
+;     sub_c29da:                  2
+;     c2a00:                      2
+;     c2a6e:                      2
+;     sub_c2a77:                  2
+;     sub_c2ab3:                  2
+;     sub_c2b4d:                  2
+;     sub_c2b64:                  2
+;     c2be3:                      2
+;     c2c12:                      2
+;     c2cb2:                      2
+;     c2d0d:                      2
+;     c2d13:                      2
+;     c2e0d:                      2
+;     c2e32:                      2
+;     c2e9f:                      2
+;     c2ea5:                      2
+;     c2eb7:                      2
+;     c2eeb:                      2
+;     c2f3e:                      2
+;     c30c7:                      2
+;     c31df:                      2
+;     sub_c3279:                  2
+;     c3289:                      2
+;     sub_c328a:                  2
+;     c3367:                      2
+;     sub_c33c5:                  2
+;     sub_c33d3:                  2
+;     sub_c33f5:                  2
+;     sub_c3432:                  2
+;     sub_c3445:                  2
+;     c34a9:                      2
+;     c34c6:                      2
+;     sub_c3516:                  2
+;     sub_c352e:                  2
+;     c35fd:                      2
+;     c3628:                      2
+;     c365a:                      2
+;     c36b7:                      2
+;     c37b3:                      2
+;     sub_c392c:                  2
+;     sub_c394c:                  2
+;     sub_c395a:                  2
+;     sub_c39f3:                  2
+;     sub_c3a0f:                  2
+;     sub_c3a50:                  2
+;     sub_c3a60:                  2
+;     sub_c3a63:                  2
+;     sub_c3a78:                  2
+;     sub_c3a82:                  2
+;     sub_c3aa3:                  2
+;     sub_c3ac8:                  2
+;     sub_c3ad8:                  2
+;     c3b6e:                      2
+;     sub_c3b79:                  2
+;     c3bc5:                      2
+;     sub_c3bf2:                  2
+;     sub_c3d1e:                  2
+;     c3dcd:                      2
+;     c3dd5:                      2
+;     sub_c3df4:                  2
+;     sub_c3e1e:                  2
+;     c3e41:                      2
+;     sub_c3e54:                  2
+;     sub_c3ef4:                  2
+;     sub_c3f14:                  2
+;     sub_c3f26:                  2
+;     c401d:                      2
+;     c4021:                      2
+;     c406c:                      2
+;     c40f5:                      2
+;     c410b:                      2
+;     sub_c4168:                  2
+;     c419f:                      2
+;     sub_c41c6:                  2
+;     l41d3:                      2
+;     c42f2:                      2
+;     sub_c4324:                  2
+;     c438b:                      2
+;     sub_c43ec:                  2
+;     c4411:                      2
+;     c4414:                      2
+;     sub_c451f:                  2
+;     c45ab:                      2
+;     sub_c45b2:                  2
+;     c4637:                      2
+;     c4845:                      2
+;     c486b:                      2
+;     c487a:                      2
+;     sub_c490d:                  2
+;     c497d:                      2
+;     c49ff:                      2
+;     c4a1c:                      2
+;     c4a51:                      2
+;     sub_c4a53:                  2
+;     sub_c4ac2:                  2
+;     sub_c4af1:                  2
+;     c4b1a:                      2
+;     c4b41:                      2
+;     c4b54:                      2
+;     c4bbc:                      2
+;     sub_c4c4e:                  2
+;     l4cdb:                      2
+;     c4d15:                      2
+;     c4dd7:                      2
+;     c4e11:                      2
+;     c4ed3:                      2
+;     c4ee8:                      2
+;     c4f37:                      2
+;     l4f75:                      2
+;     l4f77:                      2
+;     l4f78:                      2
+;     c4fad:                      2
+;     c4ffb:                      2
+;     c500a:                      2
+;     c5035:                      2
+;     sub_c5047:                  2
+;     c5280:                      2
+;     c5297:                      2
+;     c52a0:                      2
+;     c5300:                      2
+;     c5406:                      2
+;     c545e:                      2
+;     sub_c5598:                  2
+;     sub_c55ce:                  2
+;     sub_c55ee:                  2
+;     sub_c5607:                  2
+;     sub_c561e:                  2
+;     c5655:                      2
+;     sub_c565f:                  2
+;     sub_c56b1:                  2
+;     c5718:                      2
+;     c57ed:                      2
+;     l5872:                      2
+;     c58e4:                      2
+;     c59e8:                      2
+;     sub_c59f5:                  2
+;     c5a10:                      2
+;     c5af8:                      2
+;     c5afd:                      2
+;     c5b28:                      2
+;     c5b2a:                      2
+;     c5c13:                      2
+;     c5c3a:                      2
+;     sub_c5c68:                  2
+;     c5cb9:                      2
+;     c5db9:                      2
+;     sub_c5e83:                  2
+;     sub_c5e9d:                  2
+;     c5ec1:                      2
+;     sub_c5ec2:                  2
+;     c5edd:                      2
+;     sub_c5f82:                  2
+;     c5f8e:                      2
+;     tube_host_r4_status:        2
+;     gsinit:                     2
+;     gsread:                     2
+;     osgbpb:                     2
+;     osargs:                     2
+;     l0013:                      1
+;     l00f1:                      1
+;     l0103:                      1
+;     l0104:                      1
+;     l010c:                      1
+;     l010d:                      1
+;     l010e:                      1
+;     brkv:                       1
+;     brkv+1:                     1
+;     filev:                      1
+;     evntv:                      1
+;     evntv+1:                    1
+;     l028d:                      1
+;     l0cff:                      1
+;     l0e0e:                      1
+;     l0e10:                      1
+;     l0f00:                      1
+;     l0f09:                      1
+;     l0f10:                      1
+;     l1001:                      1
+;     l1002:                      1
+;     l1003:                      1
+;     l1004:                      1
+;     l1005:                      1
+;     l1006:                      1
+;     l1007:                      1
+;     l100e:                      1
+;     l1047:                      1
+;     l104d:                      1
+;     l104e:                      1
+;     l1050:                      1
+;     l1058:                      1
+;     l105f:                      1
+;     l1061:                      1
+;     l1063:                      1
+;     l1064:                      1
+;     l1072:                      1
+;     l1079:                      1
+;     l107a:                      1
+;     l1083:                      1
+;     l108f:                      1
+;     pydis_start:                1
+;     l2001:                      1
+;     l2002:                      1
+;     c2003:                      1
+;     l2004:                      1
+;     l2006:                      1
+;     l2007:                      1
+;     sub_c2020:                  1
+;     c2040:                      1
+;     c2064:                      1
+;     c2086:                      1
+;     c2093:                      1
+;     c2096:                      1
+;     sub_c209d:                  1
+;     sub_c20b8:                  1
+;     c20d0:                      1
+;     sub_c20d3:                  1
+;     sub_c20db:                  1
+;     sub_c20e6:                  1
+;     sub_c20f6:                  1
+;     c2111:                      1
+;     c2115:                      1
+;     c212e:                      1
+;     c213a:                      1
+;     c215b:                      1
+;     c215f:                      1
+;     c2161:                      1
+;     c216b:                      1
+;     c2184:                      1
+;     c218a:                      1
+;     c218c:                      1
+;     c21a2:                      1
+;     sub_c21b7:                  1
+;     c21bd:                      1
+;     sub_c21c0:                  1
+;     sub_c21c4:                  1
+;     sub_c21ca:                  1
+;     c220c:                      1
+;     c220d:                      1
+;     c221c:                      1
+;     sub_c2222:                  1
+;     c2243:                      1
+;     c226f:                      1
+;     c2286:                      1
+;     c228b:                      1
+;     c22be:                      1
+;     c22c7:                      1
+;     c22d1:                      1
+;     c22d9:                      1
+;     c22e7:                      1
+;     c22fb:                      1
+;     c2306:                      1
+;     c230d:                      1
+;     c2326:                      1
+;     c2332:                      1
+;     c2333:                      1
+;     c2370:                      1
+;     c2390:                      1
+;     c2397:                      1
+;     c23ab:                      1
+;     sub_c23bf:                  1
+;     c23cd:                      1
+;     sub_c23d1:                  1
+;     sub_c23d4:                  1
+;     c23e2:                      1
+;     sub_c23ee:                  1
+;     c23f0:                      1
+;     c23fa:                      1
+;     c2406:                      1
+;     c2425:                      1
+;     c242b:                      1
+;     sub_c242c:                  1
+;     c2436:                      1
+;     c2438:                      1
+;     c2453:                      1
+;     c2463:                      1
+;     c2477:                      1
+;     c2481:                      1
+;     c2482:                      1
+;     c2493:                      1
+;     c249d:                      1
+;     c24e7:                      1
+;     c2527:                      1
+;     c253e:                      1
+;     c2552:                      1
+;     c255f:                      1
+;     c2564:                      1
+;     c2573:                      1
+;     c257b:                      1
+;     c259b:                      1
+;     c25b5:                      1
+;     c25c5:                      1
+;     l25d3:                      1
+;     sub_c25e3:                  1
+;     sub_c2602:                  1
+;     l261d:                      1
+;     c2717:                      1
+;     c2725:                      1
+;     c2734:                      1
+;     c2759:                      1
+;     c2779:                      1
+;     c277c:                      1
+;     c27a0:                      1
+;     c27ab:                      1
+;     c27b8:                      1
+;     c27be:                      1
+;     c27c6:                      1
+;     c2815:                      1
+;     sub_c2826:                  1
+;     c2837:                      1
+;     c2864:                      1
+;     c2867:                      1
+;     c28bc:                      1
+;     c292d:                      1
+;     sub_c2932:                  1
+;     c2945:                      1
+;     c295f:                      1
+;     c2968:                      1
+;     c296b:                      1
+;     sub_c2979:                  1
+;     c2990:                      1
+;     c29ad:                      1
+;     c29c4:                      1
+;     c29ca:                      1
+;     c29e2:                      1
+;     c29f6:                      1
+;     c2a17:                      1
+;     c2a19:                      1
+;     c2a49:                      1
+;     c2a50:                      1
+;     c2a54:                      1
+;     c2a82:                      1
+;     c2ac8:                      1
+;     c2ad0:                      1
+;     c2ad8:                      1
+;     c2aeb:                      1
+;     c2af0:                      1
+;     c2afb:                      1
+;     c2b18:                      1
+;     sub_c2b25:                  1
+;     c2b60:                      1
+;     c2b77:                      1
+;     c2b80:                      1
+;     c2bea:                      1
+;     sub_c2bf6:                  1
+;     sub_c2bf9:                  1
+;     c2bfb:                      1
+;     c2c2e:                      1
+;     c2c3a:                      1
+;     c2c4e:                      1
+;     sub_c2c56:                  1
+;     c2c58:                      1
+;     c2c61:                      1
+;     sub_c2c65:                  1
+;     c2c71:                      1
+;     c2c87:                      1
+;     c2cae:                      1
+;     c2cc1:                      1
+;     c2cd6:                      1
+;     c2ce7:                      1
+;     c2cfc:                      1
+;     c2d03:                      1
+;     c2d14:                      1
+;     c2d17:                      1
+;     sub_c2d1a:                  1
+;     c2d5d:                      1
+;     c2d92:                      1
+;     c2dac:                      1
+;     c2dba:                      1
+;     sub_c2dc6:                  1
+;     c2dd2:                      1
+;     c2de2:                      1
+;     c2de9:                      1
+;     c2df0:                      1
+;     c2e03:                      1
+;     c2e14:                      1
+;     c2e4d:                      1
+;     c2e6f:                      1
+;     c2e72:                      1
+;     c2e85:                      1
+;     c2e9e:                      1
+;     c2eaf:                      1
+;     c2ecb:                      1
+;     c2edf:                      1
+;     sub_c2eec:                  1
+;     c2ef8:                      1
+;     sub_c2efa:                  1
+;     sub_c2eff:                  1
+;     c2f12:                      1
+;     c2f17:                      1
+;     c2f21:                      1
+;     sub_c2f33:                  1
+;     sub_c2f37:                  1
+;     sub_c2f4f:                  1
+;     sub_c2f5e:                  1
+;     c2f6c:                      1
+;     sub_c2f75:                  1
+;     c2f81:                      1
+;     sub_c2f82:                  1
+;     sub_c2f94:                  1
+;     c2f96:                      1
+;     c2fac:                      1
+;     c2fb5:                      1
+;     c2fc7:                      1
+;     sub_c303e:                  1
+;     c3047:                      1
+;     c3060:                      1
+;     c3066:                      1
+;     c30db:                      1
+;     c30e7:                      1
+;     sub_c3104:                  1
+;     c3108:                      1
+;     c3113:                      1
+;     c3115:                      1
+;     l311d:                      1
+;     l3121:                      1
+;     l312d:                      1
+;     l3139:                      1
+;     l313f:                      1
+;     l3145:                      1
+;     l3146:                      1
+;     l3191:                      1
+;     l31a0:                      1
+;     c31ba:                      1
+;     c31cc:                      1
+;     c31e7:                      1
+;     c31eb:                      1
+;     c31f3:                      1
+;     c31f9:                      1
+;     c3201:                      1
+;     c320d:                      1
+;     c321f:                      1
+;     c322b:                      1
+;     c3238:                      1
+;     c323b:                      1
+;     c323f:                      1
+;     c3249:                      1
+;     c325a:                      1
+;     c326a:                      1
+;     c3276:                      1
+;     c329c:                      1
+;     sub_c329d:                  1
+;     c32bd:                      1
+;     c32c4:                      1
+;     c32c7:                      1
+;     c32d6:                      1
+;     c32e3:                      1
+;     c32ef:                      1
+;     c3302:                      1
+;     c3355:                      1
+;     c3357:                      1
+;     c336b:                      1
+;     c336f:                      1
+;     c3379:                      1
+;     c3382:                      1
+;     c338d:                      1
+;     c3390:                      1
+;     c33a8:                      1
+;     c33b1:                      1
+;     sub_c33b4:                  1
+;     c33bd:                      1
+;     c33c4:                      1
+;     sub_c33d8:                  1
+;     c33da:                      1
+;     c33e2:                      1
+;     c33e5:                      1
+;     sub_c33f1:                  1
+;     sub_c33f9:                  1
+;     c33ff:                      1
+;     c3450:                      1
+;     c345c:                      1
+;     c348d:                      1
+;     c34c1:                      1
+;     c34c2:                      1
+;     c34d4:                      1
+;     c3504:                      1
+;     c3535:                      1
+;     sub_c3536:                  1
+;     c353a:                      1
+;     c3556:                      1
+;     c356d:                      1
+;     c356f:                      1
+;     c357d:                      1
+;     c3593:                      1
+;     c35b6:                      1
+;     c35d9:                      1
+;     c35e4:                      1
+;     c35e7:                      1
+;     c35ec:                      1
+;     c3618:                      1
+;     c3649:                      1
+;     c364a:                      1
+;     c3658:                      1
+;     sub_c365d:                  1
+;     c367a:                      1
+;     c3682:                      1
+;     c3683:                      1
+;     c369e:                      1
+;     c36c1:                      1
+;     c36c2:                      1
+;     c36c3:                      1
+;     c36e4:                      1
+;     c36e9:                      1
+;     c36ec:                      1
+;     c36f2:                      1
+;     c36f5:                      1
+;     c3700:                      1
+;     c3714:                      1
+;     c3736:                      1
+;     c373c:                      1
+;     c373d:                      1
+;     c375b:                      1
+;     c376c:                      1
+;     c379d:                      1
+;     c37c8:                      1
+;     c37e6:                      1
+;     sub_c37e8:                  1
+;     c3803:                      1
+;     c381f:                      1
+;     c382e:                      1
+;     sub_c3832:                  1
+;     c3835:                      1
+;     c3837:                      1
+;     c384c:                      1
+;     c3851:                      1
+;     c3859:                      1
+;     c385e:                      1
+;     c386b:                      1
+;     c3873:                      1
+;     c3881:                      1
+;     c38a0:                      1
+;     c38b1:                      1
+;     c38ba:                      1
+;     c38c1:                      1
+;     c38cd:                      1
+;     c38e4:                      1
+;     c38ed:                      1
+;     c38f0:                      1
+;     c3942:                      1
+;     c394b:                      1
+;     c394e:                      1
+;     c3964:                      1
+;     c3978:                      1
+;     sub_c3988:                  1
+;     c3993:                      1
+;     c39a8:                      1
+;     c39ea:                      1
+;     c3a2a:                      1
+;     sub_c3a32:                  1
+;     c3a3f:                      1
+;     sub_c3a4b:                  1
+;     c3a55:                      1
+;     c3a73:                      1
+;     c3a77:                      1
+;     sub_c3ad3:                  1
+;     c3ad4:                      1
+;     l3aec:                      1
+;     l3b0f:                      1
+;     l3b18:                      1
+;     l3b21:                      1
+;     l3b29:                      1
+;     l3b31:                      1
+;     l3b3a:                      1
+;     l3b43:                      1
+;     c3b50:                      1
+;     sub_c3b51:                  1
+;     c3b5e:                      1
+;     sub_c3b61:                  1
+;     c3b63:                      1
+;     c3bc2:                      1
+;     sub_c3bca:                  1
+;     sub_c3bcd:                  1
+;     c3bcf:                      1
+;     c3be4:                      1
+;     c3c00:                      1
+;     c3c16:                      1
+;     c3c33:                      1
+;     c3c38:                      1
+;     c3c51:                      1
+;     c3c58:                      1
+;     c3c5d:                      1
+;     c3c6b:                      1
+;     c3c8b:                      1
+;     c3c90:                      1
+;     c3ca8:                      1
+;     c3cee:                      1
+;     c3d03:                      1
+;     c3d12:                      1
+;     sub_c3d19:                  1
+;     c3d2b:                      1
+;     c3d43:                      1
+;     c3d57:                      1
+;     c3d67:                      1
+;     c3d71:                      1
+;     c3d72:                      1
+;     sub_c3d75:                  1
+;     c3d86:                      1
+;     c3d89:                      1
+;     c3db4:                      1
+;     c3dce:                      1
+;     c3e07:                      1
+;     c3e13:                      1
+;     c3e16:                      1
+;     c3e28:                      1
+;     c3e2a:                      1
+;     c3e4d:                      1
+;     c3e5c:                      1
+;     c3e6f:                      1
+;     c3e71:                      1
+;     c3e74:                      1
+;     c3e8c:                      1
+;     sub_c3e94:                  1
+;     c3eb3:                      1
+;     c3ec2:                      1
+;     c3ef1:                      1
+;     c3f0d:                      1
+;     c3f19:                      1
+;     c3f5e:                      1
+;     c3f64:                      1
+;     c3f6a:                      1
+;     c3f6b:                      1
+;     c3f6e:                      1
+;     sub_c3f7c:                  1
+;     sub_c3f82:                  1
+;     c3f88:                      1
+;     c3fd9:                      1
+;     c3ff4:                      1
+;     c4005:                      1
+;     c4054:                      1
+;     c4061:                      1
+;     c4075:                      1
+;     c40a9:                      1
+;     sub_c40b8:                  1
+;     sub_c40f6:                  1
+;     c411d:                      1
+;     c4132:                      1
+;     c4143:                      1
+;     c416e:                      1
+;     c417a:                      1
+;     c4183:                      1
+;     sub_c4190:                  1
+;     c41aa:                      1
+;     c41c1:                      1
+;     c41cc:                      1
+;     c41d2:                      1
+;     c427a:                      1
+;     c42ab:                      1
+;     c430d:                      1
+;     c4321:                      1
+;     c434a:                      1
+;     c4378:                      1
+;     c438c:                      1
+;     c438e:                      1
+;     c43ae:                      1
+;     c43bd:                      1
+;     sub_c43e4:                  1
+;     c43fb:                      1
+;     c440c:                      1
+;     c445d:                      1
+;     c447b:                      1
+;     c4487:                      1
+;     sub_c44e1:                  1
+;     c44fa:                      1
+;     c4521:                      1
+;     c4538:                      1
+;     c4547:                      1
+;     c4574:                      1
+;     c4595:                      1
+;     c45a0:                      1
+;     c45c4:                      1
+;     c45e2:                      1
+;     c45fb:                      1
+;     c4605:                      1
+;     c463a:                      1
+;     c4647:                      1
+;     c4652:                      1
+;     c465d:                      1
+;     sub_c4663:                  1
+;     c4675:                      1
+;     c468a:                      1
+;     c46b3:                      1
+;     c46b6:                      1
+;     c46bb:                      1
+;     c46ce:                      1
+;     c46e2:                      1
+;     c470a:                      1
+;     c4712:                      1
+;     c4721:                      1
+;     c4728:                      1
+;     c473a:                      1
+;     sub_c473d:                  1
+;     sub_c476c:                  1
+;     c476f:                      1
+;     sub_c4779:                  1
+;     c4787:                      1
+;     sub_c4788:                  1
+;     c47a4:                      1
+;     c47a7:                      1
+;     sub_c47c4:                  1
+;     sub_c47c5:                  1
+;     c47c6:                      1
+;     sub_c47ce:                  1
+;     c47e0:                      1
+;     c47e1:                      1
+;     c47f2:                      1
+;     c47f7:                      1
+;     c4818:                      1
+;     c482f:                      1
+;     c4856:                      1
+;     c48bd:                      1
+;     sub_c48be:                  1
+;     sub_c48e2:                  1
+;     c48fa:                      1
+;     c4902:                      1
+;     c490c:                      1
+;     c4941:                      1
+;     c4947:                      1
+;     c4953:                      1
+;     c495d:                      1
+;     c496c:                      1
+;     c4970:                      1
+;     c4982:                      1
+;     c498d:                      1
+;     c49ab:                      1
+;     c49b8:                      1
+;     sub_c49bf:                  1
+;     c49e7:                      1
+;     c4a01:                      1
+;     c4a0a:                      1
+;     c4a0d:                      1
+;     sub_c4a12:                  1
+;     c4a78:                      1
+;     c4a7a:                      1
+;     c4a86:                      1
+;     sub_c4a9a:                  1
+;     c4ab7:                      1
+;     c4ab8:                      1
+;     c4abe:                      1
+;     c4ace:                      1
+;     sub_c4add:                  1
+;     sub_c4aea:                  1
+;     c4b09:                      1
+;     c4b17:                      1
+;     c4b2e:                      1
+;     c4b35:                      1
+;     c4b3d:                      1
+;     c4b6b:                      1
+;     c4b7d:                      1
+;     c4b80:                      1
+;     c4b93:                      1
+;     c4ba4:                      1
+;     sub_c4ba9:                  1
+;     c4bad:                      1
+;     c4bcf:                      1
+;     c4bf4:                      1
+;     c4bfb:                      1
+;     c4c28:                      1
+;     c4c45:                      1
+;     c4c46:                      1
+;     sub_c4c47:                  1
+;     sub_c4c6a:                  1
+;     sub_c4c72:                  1
+;     c4cc7:                      1
+;     l4cf3:                      1
+;     c4d2d:                      1
+;     c4d3f:                      1
+;     c4d52:                      1
+;     c4d61:                      1
+;     c4d6e:                      1
+;     c4d81:                      1
+;     c4d86:                      1
+;     c4da2:                      1
+;     c4dae:                      1
+;     c4dc1:                      1
+;     l4ddb:                      1
+;     c4ddf:                      1
+;     c4df8:                      1
+;     c4e06:                      1
+;     c4e20:                      1
+;     c4e27:                      1
+;     c4e32:                      1
+;     c4e35:                      1
+;     c4e40:                      1
+;     c4e45:                      1
+;     c4e5b:                      1
+;     c4e62:                      1
+;     c4e82:                      1
+;     sub_c4ea9:                  1
+;     c4ed7:                      1
+;     c4ef8:                      1
+;     c4f13:                      1
+;     c4f2d:                      1
+;     c4f35:                      1
+;     c4f38:                      1
+;     c4f4b:                      1
+;     c4f54:                      1
+;     c4f5d:                      1
+;     c4f63:                      1
+;     l4f73:                      1
+;     c4f79:                      1
+;     sub_c4f8d:                  1
+;     sub_c4f9a:                  1
+;     c4fa1:                      1
+;     c4fab:                      1
+;     c4fae:                      1
+;     c4fbf:                      1
+;     c4fdc:                      1
+;     c4fdf:                      1
+;     c4fea:                      1
+;     c4ff3:                      1
+;     c4ffd:                      1
+;     c5005:                      1
+;     c5014:                      1
+;     c501f:                      1
+;     sub_c5040:                  1
+;     c505a:                      1
+;     c5070:                      1
+;     l5075:                      1
+;     l5175:                      1
+;     c51b1:                      1
+;     c51dd:                      1
+;     c51e3:                      1
+;     c51ed:                      1
+;     c51fc:                      1
+;     c520f:                      1
+;     c5221:                      1
+;     sub_c5234:                  1
+;     c523d:                      1
+;     c5249:                      1
+;     c5260:                      1
+;     c5268:                      1
+;     c5275:                      1
+;     l5283:                      1
+;     c52b2:                      1
+;     c52b4:                      1
+;     c52bd:                      1
+;     sub_c52c8:                  1
+;     c52d1:                      1
+;     c52e1:                      1
+;     c52e7:                      1
+;     c5305:                      1
+;     c5314:                      1
+;     c5337:                      1
+;     c534f:                      1
+;     c5352:                      1
+;     c5375:                      1
+;     c537f:                      1
+;     c5382:                      1
+;     c5397:                      1
+;     c53ba:                      1
+;     c53de:                      1
+;     c540e:                      1
+;     c544b:                      1
+;     c544d:                      1
+;     c545a:                      1
+;     c5470:                      1
+;     c54a8:                      1
+;     c54af:                      1
+;     c54b4:                      1
+;     c54d8:                      1
+;     c54df:                      1
+;     c54e9:                      1
+;     c54ee:                      1
+;     c5502:                      1
+;     c5534:                      1
+;     c555e:                      1
+;     c5578:                      1
+;     c5597:                      1
+;     c55c6:                      1
+;     c55d0:                      1
+;     c55e6:                      1
+;     c55ed:                      1
+;     c565e:                      1
+;     c56a6:                      1
+;     c56b3:                      1
+;     c56c2:                      1
+;     l56c6:                      1
+;     l56ce:                      1
+;     c56d2:                      1
+;     sub_c56e6:                  1
+;     c56eb:                      1
+;     c56f5:                      1
+;     c5725:                      1
+;     c5736:                      1
+;     c575a:                      1
+;     sub_c5771:                  1
+;     l5774:                      1
+;     c57ae:                      1
+;     c57b2:                      1
+;     sub_c57b6:                  1
+;     c57be:                      1
+;     c57d7:                      1
+;     c57dd:                      1
+;     c57e8:                      1
+;     c57ec:                      1
+;     sub_c586f:                  1
+;     l587e:                      1
+;     sub_c5882:                  1
+;     c5898:                      1
+;     c58e6:                      1
+;     c58f5:                      1
+;     c5910:                      1
+;     l5924:                      1
+;     l5979:                      1
+;     l597a:                      1
+;     l5980:                      1
+;     c5999:                      1
+;     c59ae:                      1
+;     c59bd:                      1
+;     c59cc:                      1
+;     c59d1:                      1
+;     c59d2:                      1
+;     c59d9:                      1
+;     c59ee:                      1
+;     c59f7:                      1
+;     c59f9:                      1
+;     c5a15:                      1
+;     c5a19:                      1
+;     c5a1a:                      1
+;     c5a27:                      1
+;     c5a28:                      1
+;     c5a2e:                      1
+;     c5a2f:                      1
+;     l5a31:                      1
+;     c5a78:                      1
+;     c5a8c:                      1
+;     c5a94:                      1
+;     c5a9e:                      1
+;     c5ab0:                      1
+;     c5ab1:                      1
+;     c5ab8:                      1
+;     c5ad0:                      1
+;     sub_c5ad2:                  1
+;     c5aea:                      1
+;     c5b07:                      1
+;     c5b33:                      1
+;     c5b36:                      1
+;     l5b3a:                      1
+;     l5b3e:                      1
+;     l5b42:                      1
+;     c5b4c:                      1
+;     c5b6f:                      1
+;     c5b89:                      1
+;     c5b90:                      1
+;     c5ba1:                      1
+;     c5bbe:                      1
+;     c5bd9:                      1
+;     c5be4:                      1
+;     c5bf3:                      1
+;     c5bfe:                      1
+;     c5c2c:                      1
+;     c5c54:                      1
+;     c5c64:                      1
+;     c5c70:                      1
+;     c5c78:                      1
+;     c5c93:                      1
+;     c5cb2:                      1
+;     c5cd3:                      1
+;     c5cd6:                      1
+;     c5ce1:                      1
+;     c5cf9:                      1
+;     c5d08:                      1
+;     c5d0e:                      1
+;     c5d1b:                      1
+;     c5d2b:                      1
+;     c5d40:                      1
+;     c5d46:                      1
+;     c5d6c:                      1
+;     c5d7e:                      1
+;     c5d99:                      1
+;     c5da3:                      1
+;     c5dba:                      1
+;     c5dc0:                      1
+;     c5dd3:                      1
+;     c5ddd:                      1
+;     c5e0e:                      1
+;     c5e21:                      1
+;     c5e31:                      1
+;     c5e3c:                      1
+;     c5e52:                      1
+;     sub_c5e91:                  1
+;     c5eab:                      1
+;     c5ec8:                      1
+;     c5ee0:                      1
+;     c5eee:                      1
+;     c5f1c:                      1
+;     c5f33:                      1
+;     c5f46:                      1
+;     l5f4f:                      1
+;     c5f78:                      1
+;     sub_c5f84:                  1
+;     c5f8a:                      1
+;     c5fa3:                      1
+;     c5fb2:                      1
+;     nmi_handler_rom_start:      1
+;     nmi3_handler_rom_start-1:   1
+;     tube_host_code2:            1
+;     tube_host_code2+256:        1
+;     tube_host_code3:            1
+;     tube_host_code1:            1
+;     tube_host_r4_data:          1
+
+; Automatically generated labels:
+;     c0032
+;     c0036
+;     c0041
+;     c0400
+;     c0432
+;     c0434
+;     c0463
+;     c047a
+;     c0482
+;     c0484
+;     c048c
+;     c0491
+;     c049b
+;     c04bc
+;     c04f7
+;     c053a
+;     c0552
+;     c0593
+;     c059c
+;     c059e
+;     c05a6
+;     c05fc
+;     c0636
+;     c0645
+;     c0665
+;     c06a7
+;     c0d60
+;     c0d74
+;     c0d80
+;     c2003
+;     c2040
+;     c204f
+;     c2064
+;     c2086
+;     c2093
+;     c2096
+;     c209f
+;     c20d0
+;     c2103
+;     c2111
+;     c2115
+;     c2125
+;     c212e
+;     c213a
+;     c215b
+;     c215d
+;     c215f
+;     c2161
+;     c216b
+;     c2184
+;     c218a
+;     c218c
+;     c21a2
+;     c21a7
+;     c21bd
+;     c220c
+;     c220d
+;     c221c
+;     c2225
+;     c222a
+;     c2243
+;     c225d
+;     c226f
+;     c2286
+;     c228b
+;     c2290
+;     c22be
+;     c22c7
+;     c22d1
+;     c22d9
+;     c22e6
+;     c22e7
+;     c22fb
+;     c22fd
+;     c2306
+;     c230d
+;     c2326
+;     c2332
+;     c2333
+;     c2370
+;     c2390
+;     c2397
+;     c23ab
+;     c23cd
+;     c23e2
+;     c23f0
+;     c23fa
+;     c2406
+;     c2425
+;     c242b
+;     c2436
+;     c2438
+;     c2453
+;     c2454
+;     c2463
+;     c2477
+;     c2481
+;     c2482
+;     c2493
+;     c249d
+;     c24e7
+;     c2527
+;     c253e
+;     c2543
+;     c2552
+;     c255f
+;     c2560
+;     c2564
+;     c2573
+;     c257b
+;     c259b
+;     c25b5
+;     c25bc
+;     c25c5
+;     c2703
+;     c2705
+;     c2717
+;     c2725
+;     c2734
+;     c273b
+;     c2759
+;     c2779
+;     c277c
+;     c27a0
+;     c27ab
+;     c27b8
+;     c27be
+;     c27c6
+;     c2808
+;     c2815
+;     c2816
+;     c2837
+;     c283f
+;     c2864
+;     c2867
+;     c28a6
+;     c28bc
+;     c28f4
+;     c292d
+;     c2945
+;     c295f
+;     c2968
+;     c296b
+;     c298a
+;     c2990
+;     c29a5
+;     c29ad
+;     c29b4
+;     c29c4
+;     c29ca
+;     c29d7
+;     c29e2
+;     c29f6
+;     c2a00
+;     c2a17
+;     c2a19
+;     c2a49
+;     c2a50
+;     c2a54
+;     c2a6e
+;     c2a82
+;     c2ac8
+;     c2ad0
+;     c2ad8
+;     c2aeb
+;     c2af0
+;     c2afb
+;     c2b18
+;     c2b60
+;     c2b77
+;     c2b80
+;     c2b8b
+;     c2ba2
+;     c2be3
+;     c2bea
+;     c2bfb
+;     c2c12
+;     c2c2e
+;     c2c3a
+;     c2c4e
+;     c2c58
+;     c2c61
+;     c2c71
+;     c2c87
+;     c2cae
+;     c2cb2
+;     c2cc1
+;     c2cd6
+;     c2ce7
+;     c2cfc
+;     c2d03
+;     c2d0d
+;     c2d13
+;     c2d14
+;     c2d17
+;     c2d41
+;     c2d5d
+;     c2d74
+;     c2d91
+;     c2d92
+;     c2dac
+;     c2dba
+;     c2dd2
+;     c2de2
+;     c2de9
+;     c2df0
+;     c2e03
+;     c2e0d
+;     c2e0e
+;     c2e12
+;     c2e14
+;     c2e32
+;     c2e4d
+;     c2e53
+;     c2e64
+;     c2e6f
+;     c2e72
+;     c2e85
+;     c2e9e
+;     c2e9f
+;     c2ea5
+;     c2eaf
+;     c2eb7
+;     c2ecb
+;     c2ecc
+;     c2edf
+;     c2eeb
+;     c2ef8
+;     c2f12
+;     c2f17
+;     c2f21
+;     c2f2a
+;     c2f3e
+;     c2f6c
+;     c2f81
+;     c2f96
+;     c2fac
+;     c2fb5
+;     c2fc7
+;     c3047
+;     c3060
+;     c3066
+;     c30c7
+;     c30db
+;     c30e7
+;     c30fb
+;     c3108
+;     c3113
+;     c3115
+;     c31af
+;     c31ba
+;     c31cc
+;     c31df
+;     c31e7
+;     c31eb
+;     c31f3
+;     c31f9
+;     c3201
+;     c320d
+;     c3214
+;     c321f
+;     c322b
+;     c3238
+;     c323b
+;     c323f
+;     c3249
+;     c3257
+;     c325a
+;     c326a
+;     c3276
+;     c3289
+;     c329c
+;     c32bd
+;     c32c4
+;     c32c7
+;     c32d6
+;     c32e3
+;     c32ef
+;     c3302
+;     c3355
+;     c3357
+;     c3367
+;     c336b
+;     c336f
+;     c3379
+;     c3382
+;     c338d
+;     c3390
+;     c33a8
+;     c33b1
+;     c33bd
+;     c33c4
+;     c33da
+;     c33e2
+;     c33e5
+;     c33e6
+;     c33ff
+;     c340c
+;     c340e
+;     c3436
+;     c3444
+;     c3450
+;     c345c
+;     c348d
+;     c34a9
+;     c34bc
+;     c34c1
+;     c34c2
+;     c34c6
+;     c34d4
+;     c3504
+;     c3535
+;     c353a
+;     c3556
+;     c356d
+;     c356f
+;     c357d
+;     c3593
+;     c35b6
+;     c35d9
+;     c35e4
+;     c35e7
+;     c35ec
+;     c35fd
+;     c3618
+;     c3628
+;     c3649
+;     c364a
+;     c3658
+;     c365a
+;     c367a
+;     c3682
+;     c3683
+;     c369e
+;     c36b7
+;     c36c1
+;     c36c2
+;     c36c3
+;     c36e4
+;     c36e9
+;     c36ec
+;     c36f2
+;     c36f5
+;     c3700
+;     c3714
+;     c3736
+;     c3738
+;     c373c
+;     c373d
+;     c375b
+;     c376c
+;     c379d
+;     c37b3
+;     c37c8
+;     c37e6
+;     c3803
+;     c381f
+;     c382e
+;     c3835
+;     c3837
+;     c384c
+;     c3851
+;     c3859
+;     c385e
+;     c386b
+;     c3873
+;     c3881
+;     c38a0
+;     c38b1
+;     c38ba
+;     c38c1
+;     c38cd
+;     c38e4
+;     c38ed
+;     c38f0
+;     c393b
+;     c3942
+;     c394b
+;     c394e
+;     c3964
+;     c396e
+;     c3978
+;     c3993
+;     c39a3
+;     c39a8
+;     c39ea
+;     c39ed
+;     c3a2a
+;     c3a3f
+;     c3a55
+;     c3a73
+;     c3a77
+;     c3a8c
+;     c3ad4
+;     c3adf
+;     c3ae9
+;     c3b50
+;     c3b5e
+;     c3b63
+;     c3b6e
+;     c3bc2
+;     c3bc5
+;     c3bcf
+;     c3be4
+;     c3c00
+;     c3c16
+;     c3c33
+;     c3c38
+;     c3c51
+;     c3c58
+;     c3c5d
+;     c3c6b
+;     c3c82
+;     c3c8b
+;     c3c90
+;     c3ca8
+;     c3cee
+;     c3d03
+;     c3d12
+;     c3d2b
+;     c3d43
+;     c3d57
+;     c3d5d
+;     c3d67
+;     c3d71
+;     c3d72
+;     c3d86
+;     c3d89
+;     c3db4
+;     c3dcd
+;     c3dce
+;     c3dd5
+;     c3e07
+;     c3e13
+;     c3e16
+;     c3e28
+;     c3e2a
+;     c3e41
+;     c3e4d
+;     c3e5c
+;     c3e6f
+;     c3e71
+;     c3e74
+;     c3e8c
+;     c3eb3
+;     c3ec2
+;     c3ef1
+;     c3f0d
+;     c3f19
+;     c3f5e
+;     c3f64
+;     c3f6a
+;     c3f6b
+;     c3f6e
+;     c3f88
+;     c3fd9
+;     c3ff4
+;     c4005
+;     c401d
+;     c4021
+;     c4054
+;     c4061
+;     c406b
+;     c406c
+;     c4075
+;     c40a9
+;     c40f5
+;     c410b
+;     c411d
+;     c4132
+;     c4143
+;     c414f
+;     c416e
+;     c417a
+;     c4183
+;     c419f
+;     c41aa
+;     c41c0
+;     c41c1
+;     c41cc
+;     c41d2
+;     c427a
+;     c42ab
+;     c42f2
+;     c430d
+;     c4321
+;     c434a
+;     c4378
+;     c438b
+;     c438c
+;     c438e
+;     c43ae
+;     c43bd
+;     c43dc
+;     c43fb
+;     c440c
+;     c4411
+;     c4414
+;     c445d
+;     c447b
+;     c4487
+;     c44fa
+;     c4521
+;     c4538
+;     c4547
+;     c4574
+;     c4595
+;     c45a0
+;     c45ab
+;     c45c4
+;     c45e2
+;     c45e5
+;     c45fb
+;     c4605
+;     c4637
+;     c463a
+;     c4647
+;     c4652
+;     c465d
+;     c4660
+;     c4675
+;     c468a
+;     c46b3
+;     c46b6
+;     c46bb
+;     c46ce
+;     c46e2
+;     c470a
+;     c4712
+;     c4721
+;     c4728
+;     c473a
+;     c476f
+;     c4787
+;     c47a4
+;     c47a7
+;     c47c6
+;     c47e0
+;     c47e1
+;     c47f2
+;     c47f7
+;     c4818
+;     c482f
+;     c4845
+;     c4856
+;     c486b
+;     c487a
+;     c48bd
+;     c48fa
+;     c4902
+;     c490c
+;     c4941
+;     c4947
+;     c4953
+;     c495d
+;     c496c
+;     c4970
+;     c497d
+;     c4982
+;     c498d
+;     c49ab
+;     c49b8
+;     c49e7
+;     c49ff
+;     c4a01
+;     c4a0a
+;     c4a0d
+;     c4a1c
+;     c4a42
+;     c4a44
+;     c4a51
+;     c4a78
+;     c4a7a
+;     c4a86
+;     c4ab7
+;     c4ab8
+;     c4abe
+;     c4ace
+;     c4b09
+;     c4b17
+;     c4b1a
+;     c4b2e
+;     c4b35
+;     c4b3d
+;     c4b41
+;     c4b54
+;     c4b6b
+;     c4b7d
+;     c4b80
+;     c4b93
+;     c4ba4
+;     c4bad
+;     c4bbc
+;     c4bcf
+;     c4bf4
+;     c4bfb
+;     c4c0f
+;     c4c28
+;     c4c45
+;     c4c46
+;     c4cc4
+;     c4cc7
+;     c4d15
+;     c4d2d
+;     c4d3f
+;     c4d52
+;     c4d61
+;     c4d6e
+;     c4d77
+;     c4d79
+;     c4d81
+;     c4d86
+;     c4da2
+;     c4dae
+;     c4dc1
+;     c4dd7
+;     c4ddf
+;     c4df8
+;     c4e06
+;     c4e11
+;     c4e20
+;     c4e27
+;     c4e32
+;     c4e35
+;     c4e40
+;     c4e45
+;     c4e5b
+;     c4e62
+;     c4e70
+;     c4e79
+;     c4e82
+;     c4e97
+;     c4ea0
+;     c4ed3
+;     c4ed7
+;     c4ee8
+;     c4ef8
+;     c4f13
+;     c4f2d
+;     c4f35
+;     c4f37
+;     c4f38
+;     c4f4b
+;     c4f54
+;     c4f58
+;     c4f5d
+;     c4f63
+;     c4f79
+;     c4f7f
+;     c4fa1
+;     c4fab
+;     c4fad
+;     c4fae
+;     c4fbf
+;     c4fdc
+;     c4fdf
+;     c4fea
+;     c4ff3
+;     c4ffb
+;     c4ffd
+;     c5005
+;     c500a
+;     c5014
+;     c501f
+;     c5035
+;     c505a
+;     c5070
+;     c51b1
+;     c51d5
+;     c51dd
+;     c51e3
+;     c51ed
+;     c51fc
+;     c5203
+;     c520f
+;     c5221
+;     c523d
+;     c5249
+;     c5260
+;     c5268
+;     c5275
+;     c5280
+;     c5297
+;     c52a0
+;     c52b2
+;     c52b4
+;     c52bd
+;     c52d1
+;     c52e1
+;     c52e7
+;     c5300
+;     c5305
+;     c5314
+;     c5337
+;     c534f
+;     c5352
+;     c5371
+;     c5375
+;     c537f
+;     c5382
+;     c5397
+;     c53ba
+;     c53de
+;     c5406
+;     c540e
+;     c5446
+;     c544b
+;     c544d
+;     c545a
+;     c545e
+;     c5470
+;     c54a8
+;     c54af
+;     c54b4
+;     c54d8
+;     c54df
+;     c54e9
+;     c54ee
+;     c5502
+;     c5534
+;     c555e
+;     c5578
+;     c5597
+;     c55c6
+;     c55d0
+;     c55e6
+;     c55ed
+;     c5655
+;     c565e
+;     c5684
+;     c568c
+;     c56a6
+;     c56b3
+;     c56c2
+;     c56ca
+;     c56d2
+;     c56eb
+;     c56f5
+;     c5718
+;     c5725
+;     c5736
+;     c575a
+;     c5795
+;     c57ae
+;     c57b2
+;     c57be
+;     c57d7
+;     c57dd
+;     c57e8
+;     c57ec
+;     c57ed
+;     c582b
+;     c5898
+;     c58e4
+;     c58e6
+;     c58f5
+;     c58fb
+;     c5910
+;     c5999
+;     c59ae
+;     c59bd
+;     c59cc
+;     c59d1
+;     c59d2
+;     c59d9
+;     c59e8
+;     c59ee
+;     c59f7
+;     c59f9
+;     c5a10
+;     c5a15
+;     c5a19
+;     c5a1a
+;     c5a27
+;     c5a28
+;     c5a2e
+;     c5a2f
+;     c5a78
+;     c5a8c
+;     c5a94
+;     c5a9e
+;     c5ab0
+;     c5ab1
+;     c5ab4
+;     c5ab8
+;     c5ad0
+;     c5aea
+;     c5af8
+;     c5afd
+;     c5b07
+;     c5b28
+;     c5b2a
+;     c5b33
+;     c5b36
+;     c5b4c
+;     c5b6f
+;     c5b89
+;     c5b90
+;     c5ba1
+;     c5bbe
+;     c5bd0
+;     c5bd9
+;     c5be4
+;     c5bf3
+;     c5bfe
+;     c5c13
+;     c5c2c
+;     c5c3a
+;     c5c54
+;     c5c64
+;     c5c70
+;     c5c78
+;     c5c93
+;     c5cb2
+;     c5cb9
+;     c5cd3
+;     c5cd6
+;     c5ce1
+;     c5cf9
+;     c5d08
+;     c5d0e
+;     c5d1b
+;     c5d2b
+;     c5d40
+;     c5d46
+;     c5d6c
+;     c5d7e
+;     c5d99
+;     c5da3
+;     c5db9
+;     c5dba
+;     c5dc0
+;     c5dd3
+;     c5ddd
+;     c5e0e
+;     c5e21
+;     c5e31
+;     c5e3c
+;     c5e47
+;     c5e52
+;     c5e7a
+;     c5e7b
+;     c5e89
+;     c5e8d
+;     c5eab
+;     c5ec1
+;     c5ec8
+;     c5edd
+;     c5ee0
+;     c5ee8
+;     c5eee
+;     c5f1c
+;     c5f33
+;     c5f46
+;     c5f78
+;     c5f8a
+;     c5f8e
+;     c5fa3
+;     c5fb2
+;     c8040
+;     c8093
+;     c8096
+;     c809f
+;     c80d0
+;     c8103
+;     c8111
+;     c8115
+;     c8125
+;     c812e
+;     c815b
+;     c815d
+;     c815f
+;     c8184
+;     c818a
+;     c81a2
+;     c81a7
+;     c81bd
+;     c8225
+;     c822a
+;     c8243
+;     c825d
+;     c8286
+;     c828b
+;     c8290
+;     c82be
+;     c82d9
+;     c82e6
+;     c82e7
+;     c82fb
+;     c82fd
+;     c8306
+;     c8332
+;     c8333
+;     c83ab
+;     c83cd
+;     c83e2
+;     c842b
+;     c8436
+;     c8438
+;     c8453
+;     c8454
+;     c8477
+;     c8481
+;     c8482
+;     c849d
+;     c853e
+;     c8543
+;     c855f
+;     c8560
+;     c8573
+;     c859b
+;     c85bc
+;     c85c5
+;     c8703
+;     c8705
+;     c8734
+;     c873b
+;     c8759
+;     c8779
+;     c877c
+;     c87ab
+;     c87b8
+;     c87c6
+;     c8808
+;     c8815
+;     c8816
+;     c8837
+;     c883f
+;     c8864
+;     c8867
+;     c88a6
+;     c88f4
+;     c892d
+;     c8945
+;     c8968
+;     c896b
+;     c898a
+;     c89a5
+;     c89ad
+;     c89b4
+;     c89d7
+;     c89e2
+;     c89f6
+;     c8a00
+;     c8a19
+;     c8a49
+;     c8a50
+;     c8a54
+;     c8a6e
+;     c8a82
+;     c8ad0
+;     c8aeb
+;     c8b18
+;     c8b60
+;     c8b77
+;     c8b8b
+;     c8ba2
+;     c8be3
+;     c8bfb
+;     c8c12
+;     c8c2e
+;     c8c3a
+;     c8c4e
+;     c8c61
+;     c8c87
+;     c8cae
+;     c8cb2
+;     c8cc1
+;     c8cd6
+;     c8ce7
+;     c8cfc
+;     c8d03
+;     c8d0d
+;     c8d13
+;     c8d41
+;     c8d5d
+;     c8d74
+;     c8d91
+;     c8d92
+;     c8dd2
+;     c8de2
+;     c8e03
+;     c8e0d
+;     c8e0e
+;     c8e12
+;     c8e32
+;     c8e4d
+;     c8e53
+;     c8e64
+;     c8e6f
+;     c8e72
+;     c8e9e
+;     c8e9f
+;     c8ea5
+;     c8eaf
+;     c8eb7
+;     c8ecb
+;     c8ecc
+;     c8edf
+;     c8eeb
+;     c8ef8
+;     c8f12
+;     c8f21
+;     c8f2a
+;     c8f3e
+;     c8f81
+;     c8fb5
+;     c8fc7
+;     c9060
+;     c9115
+;     c91af
+;     c91cc
+;     c91df
+;     c91eb
+;     c91f3
+;     c91f9
+;     c9201
+;     c920d
+;     c9214
+;     c921f
+;     c922b
+;     c9238
+;     c923b
+;     c923f
+;     c9249
+;     c9257
+;     c925a
+;     c926a
+;     c9276
+;     c9289
+;     c929c
+;     c92bd
+;     c92c4
+;     c92c7
+;     c92d6
+;     c92e3
+;     c9302
+;     c9367
+;     c936b
+;     c9379
+;     c938d
+;     c9390
+;     c93a8
+;     c93b1
+;     c93c4
+;     c93e2
+;     c93e5
+;     c93e6
+;     c93ff
+;     c940c
+;     c940e
+;     c9436
+;     c9444
+;     c9450
+;     c945c
+;     c948d
+;     c94a9
+;     c94bc
+;     c94c1
+;     c94c2
+;     c94c6
+;     c94d4
+;     c9504
+;     c9535
+;     c9556
+;     c956d
+;     c956f
+;     c95e4
+;     c95e7
+;     c95fd
+;     c9628
+;     c9649
+;     c964a
+;     c9658
+;     c965a
+;     c967a
+;     c9682
+;     c9683
+;     c969e
+;     c96b7
+;     c96c3
+;     c96e4
+;     c96e9
+;     c96ec
+;     c96f5
+;     c9700
+;     c9714
+;     c9736
+;     c9738
+;     c973c
+;     c973d
+;     c975b
+;     c976c
+;     c97b3
+;     c97e6
+;     c981f
+;     c982e
+;     c9835
+;     c984c
+;     c9859
+;     c986b
+;     c9873
+;     c98b1
+;     c98ba
+;     c98cd
+;     c98ed
+;     c98f0
+;     c993b
+;     c994b
+;     c996e
+;     c9978
+;     c9993
+;     c99a3
+;     c99ea
+;     c99ed
+;     c9a2a
+;     c9a3f
+;     c9a73
+;     c9a77
+;     c9a8c
+;     c9ad4
+;     c9adf
+;     c9ae9
+;     c9b6e
+;     c9bc2
+;     c9bc5
+;     c9c16
+;     c9c33
+;     c9c51
+;     c9c58
+;     c9c6b
+;     c9c8b
+;     c9cee
+;     c9d12
+;     c9d2b
+;     c9d57
+;     c9d5d
+;     c9d67
+;     c9d71
+;     c9d72
+;     c9d86
+;     c9d89
+;     c9db4
+;     c9dcd
+;     c9dce
+;     c9dd5
+;     c9e13
+;     c9e16
+;     c9e28
+;     c9e2a
+;     c9e41
+;     c9e5c
+;     c9e6f
+;     c9e71
+;     c9eb3
+;     c9ec2
+;     c9ef1
+;     c9f0d
+;     c9f19
+;     c9f5e
+;     c9f64
+;     c9f6a
+;     c9f6b
+;     c9f88
+;     c9fd9
+;     c9ff4
+;     ca005
+;     ca01d
+;     ca021
+;     ca054
+;     ca06b
+;     ca06c
+;     ca075
+;     ca0a9
+;     ca0f5
+;     ca10b
+;     ca14f
+;     ca17a
+;     ca183
+;     ca19f
+;     ca1c0
+;     ca1c1
+;     ca1d2
+;     ca27a
+;     ca2ab
+;     ca2f2
+;     ca30d
+;     ca321
+;     ca34a
+;     ca378
+;     ca38b
+;     ca38c
+;     ca38e
+;     ca3ae
+;     ca3bd
+;     ca3dc
+;     ca3fb
+;     ca40c
+;     ca411
+;     ca414
+;     ca45d
+;     ca47b
+;     ca4fa
+;     ca538
+;     ca547
+;     ca574
+;     ca595
+;     ca5a0
+;     ca5ab
+;     ca5c4
+;     ca5e2
+;     ca5e5
+;     ca5fb
+;     ca605
+;     ca637
+;     ca63a
+;     ca647
+;     ca652
+;     ca65d
+;     ca660
+;     ca675
+;     ca68a
+;     ca6b3
+;     ca6b6
+;     ca6bb
+;     ca6ce
+;     ca6e2
+;     ca70a
+;     ca712
+;     ca721
+;     ca728
+;     ca73a
+;     ca787
+;     ca7a4
+;     ca7f2
+;     ca7f7
+;     ca818
+;     ca82f
+;     ca845
+;     ca856
+;     ca86b
+;     ca87a
+;     ca8bd
+;     ca8fa
+;     ca902
+;     ca90c
+;     ca95d
+;     ca96c
+;     ca970
+;     ca97d
+;     ca982
+;     ca98d
+;     ca9b8
+;     ca9ff
+;     caa0a
+;     caa0d
+;     caa1c
+;     caa42
+;     caa44
+;     caa51
+;     caa78
+;     caa7a
+;     caa86
+;     caab7
+;     caabe
+;     caace
+;     cab09
+;     cab17
+;     cab1a
+;     cab2e
+;     cab35
+;     cab3d
+;     cab41
+;     cab54
+;     cab7d
+;     cab93
+;     caba4
+;     cabbc
+;     cabcf
+;     cabfb
+;     cac0f
+;     cac28
+;     cac45
+;     cacc4
+;     cacc7
+;     caed3
+;     caed7
+;     cb1d5
+;     cb1dd
+;     cb1fc
+;     cb203
+;     cb20f
+;     cb221
+;     cb23d
+;     cb260
+;     cb268
+;     cb280
+;     cb297
+;     cb2a0
+;     cb2b2
+;     cb2e1
+;     cb2e7
+;     cb300
+;     cb305
+;     cb314
+;     cb337
+;     cb34f
+;     cb352
+;     cb371
+;     cb375
+;     cb37f
+;     cb382
+;     cb397
+;     cb3ba
+;     cb3de
+;     cb406
+;     cb40e
+;     cb446
+;     cb44b
+;     cb45a
+;     cb45e
+;     cb470
+;     cb4af
+;     cb4b4
+;     cb4d8
+;     cb4df
+;     cb4e9
+;     cb4ee
+;     cb502
+;     cb534
+;     cb597
+;     cb5d0
+;     cb5e6
+;     cb655
+;     cb65e
+;     cb684
+;     cb68c
+;     cb6a6
+;     cb6c2
+;     cb6ca
+;     cb6d2
+;     cb6eb
+;     cb6f5
+;     cb718
+;     cb725
+;     cb736
+;     cb795
+;     cb7ae
+;     cb7b2
+;     cb7e8
+;     cb7ec
+;     cb7ed
+;     cb82b
+;     cb898
+;     cb8e4
+;     cb8e6
+;     cb8f5
+;     cb8fb
+;     cb9ae
+;     cb9d2
+;     cb9d9
+;     cb9e8
+;     cb9ee
+;     cb9f7
+;     cba10
+;     cba15
+;     cba19
+;     cba27
+;     cba28
+;     cba2e
+;     cba2f
+;     cba78
+;     cba8c
+;     cba9e
+;     cbab0
+;     cbab1
+;     cbab4
+;     cbad0
+;     cbaf8
+;     cbafd
+;     cbb07
+;     cbb28
+;     cbb2a
+;     cbb33
+;     cbb36
+;     cbb4c
+;     cbb6f
+;     cbb89
+;     cbb90
+;     cbba1
+;     cbbbe
+;     cbbd0
+;     cbbd9
+;     cbbf3
+;     cbc13
+;     cbc2c
+;     cbc3a
+;     cbc54
+;     cbc64
+;     cbc78
+;     cbc93
+;     cbcb2
+;     cbcb9
+;     cbcd6
+;     cbce1
+;     cbcf9
+;     cbd0e
+;     cbd1b
+;     cbd40
+;     cbd46
+;     cbd7e
+;     cbda3
+;     cbdb9
+;     cbdba
+;     cbdc0
+;     cbdd3
+;     cbddd
+;     cbe21
+;     cbe3c
+;     cbe47
+;     cbe52
+;     cbe7a
+;     cbe7b
+;     cbe89
+;     cbe8d
+;     cbec1
+;     cbee0
+;     cbee8
+;     cbeee
+;     cbf33
+;     cbf46
+;     cbf8a
+;     cbf8e
+;     cbfa3
+;     cbfb2
+;     l0000
+;     l0001
+;     l0002
+;     l0003
+;     l0012
+;     l0013
+;     l0014
+;     l0015
+;     l0053
+;     l0054
+;     l0055
+;     l0056
+;     l00a0
+;     l00a1
+;     l00a2
+;     l00a3
+;     l00a4
+;     l00a5
+;     l00a6
+;     l00a7
+;     l00a8
+;     l00a9
+;     l00aa
+;     l00ab
+;     l00ac
+;     l00ad
+;     l00ae
+;     l00af
+;     l00b0
+;     l00b1
+;     l00b2
+;     l00b3
+;     l00b4
+;     l00b5
+;     l00b6
+;     l00b7
+;     l00b8
+;     l00b9
+;     l00ba
+;     l00bb
+;     l00bc
+;     l00bd
+;     l00be
+;     l00bf
+;     l00c0
+;     l00c1
+;     l00c2
+;     l00c3
+;     l00c4
+;     l00c5
+;     l00c6
+;     l00c7
+;     l00c8
+;     l00c9
+;     l00ca
+;     l00cc
+;     l00cd
+;     l00ce
+;     l00cf
+;     l00ef
+;     l00f0
+;     l00f1
+;     l00f3
+;     l00f7
+;     l00fd
+;     l00ff
+;     l0100
+;     l0101
+;     l0102
+;     l0103
+;     l0104
+;     l0105
+;     l0107
+;     l0109
+;     l010b
+;     l010c
+;     l010d
+;     l010e
+;     l0128
+;     l028d
+;     l0500
+;     l0600
+;     l0700
+;     l0cff
+;     l0d0f
+;     l0d12
+;     l0d1f
+;     l0d26
+;     l0d2a
+;     l0d30
+;     l0d3d
+;     l0d50
+;     l0df0
+;     l0e00
+;     l0e07
+;     l0e08
+;     l0e0e
+;     l0e0f
+;     l0e10
+;     l0ef8
+;     l0f00
+;     l0f04
+;     l0f05
+;     l0f06
+;     l0f07
+;     l0f08
+;     l0f09
+;     l0f0a
+;     l0f0b
+;     l0f0c
+;     l0f0d
+;     l0f0e
+;     l0f0f
+;     l0f10
+;     l1000
+;     l1001
+;     l1002
+;     l1003
+;     l1004
+;     l1005
+;     l1006
+;     l1007
+;     l100e
+;     l1045
+;     l1047
+;     l104d
+;     l104e
+;     l1050
+;     l1058
+;     l105f
+;     l1060
+;     l1061
+;     l1062
+;     l1063
+;     l1064
+;     l1065
+;     l1067
+;     l1069
+;     l1072
+;     l1074
+;     l1075
+;     l1076
+;     l1077
+;     l1078
+;     l1079
+;     l107a
+;     l107d
+;     l107e
+;     l107f
+;     l1081
+;     l1082
+;     l1083
+;     l1086
+;     l1087
+;     l1088
+;     l1089
+;     l108a
+;     l108b
+;     l108c
+;     l108f
+;     l1090
+;     l1091
+;     l1092
+;     l1093
+;     l1094
+;     l1095
+;     l1096
+;     l1097
+;     l1098
+;     l1099
+;     l109a
+;     l109b
+;     l109d
+;     l109e
+;     l109f
+;     l10c0
+;     l10c1
+;     l10c2
+;     l10c3
+;     l10c4
+;     l10c5
+;     l10c6
+;     l10c7
+;     l10c9
+;     l10ca
+;     l10cb
+;     l10cc
+;     l10cd
+;     l10ce
+;     l10cf
+;     l10d0
+;     l10d1
+;     l10d2
+;     l10d3
+;     l10d6
+;     l10d7
+;     l10d8
+;     l10d9
+;     l10da
+;     l10db
+;     l10dc
+;     l10dd
+;     l10de
+;     l10e2
+;     l10e3
+;     l10e4
+;     l1100
+;     l1109
+;     l110b
+;     l110c
+;     l110d
+;     l110e
+;     l110f
+;     l1110
+;     l1111
+;     l1112
+;     l1113
+;     l1114
+;     l1115
+;     l1116
+;     l1117
+;     l1119
+;     l111a
+;     l111b
+;     l111c
+;     l111d
+;     l2001
+;     l2002
+;     l2004
+;     l2006
+;     l2007
+;     l25d3
+;     l261c
+;     l261d
+;     l311d
+;     l3121
+;     l312d
+;     l3139
+;     l313f
+;     l3145
+;     l3146
+;     l3191
+;     l31a0
+;     l3aec
+;     l3b0f
+;     l3b18
+;     l3b21
+;     l3b29
+;     l3b31
+;     l3b3a
+;     l3b43
+;     l41d3
+;     l4cdb
+;     l4cf3
+;     l4ddb
+;     l4f73
+;     l4f75
+;     l4f76
+;     l4f77
+;     l4f78
+;     l5075
+;     l5175
+;     l5283
+;     l557f
+;     l56c6
+;     l56ce
+;     l5726
+;     l5774
+;     l5872
+;     l587e
+;     l5924
+;     l5979
+;     l597a
+;     l5980
+;     l5a30
+;     l5a31
+;     l5b3a
+;     l5b3e
+;     l5b42
+;     l5f4f
+;     l5fff
+;     l8001
+;     l8002
+;     l8004
+;     l911d
+;     l9121
+;     l9139
+;     l913f
+;     l9145
+;     l9146
+;     l9191
+;     l91a0
+;     l9aec
+;     l9b0f
+;     l9b18
+;     l9b21
+;     l9b29
+;     l9b31
+;     l9b3a
+;     l9b43
+;     la1d3
+;     lb075
+;     lb175
+;     lb283
+;     lb57f
+;     lb6c6
+;     lb6ce
+;     lb726
+;     lb774
+;     lb872
+;     lb87e
+;     lb924
+;     lb979
+;     lb97a
+;     lb980
+;     lbb3a
+;     lbb3e
+;     lbb42
+;     lbf4f
+;     lbfff
+;     lfe80
+;     lfe84
+;     lfe85
+;     lfe86
+;     lfe87
+;     loop_c0029
+;     loop_c003b
+;     loop_c0446
+;     loop_c0466
+;     loop_c0471
+;     loop_c04a6
+;     loop_c04e1
+;     loop_c0564
+;     loop_c0577
+;     loop_c0586
+;     loop_c05ab
+;     loop_c05c7
+;     loop_c05d3
+;     loop_c05e6
+;     loop_c0604
+;     loop_c061d
+;     loop_c062b
+;     loop_c064c
+;     loop_c0657
+;     loop_c065a
+;     loop_c8064
+;     loop_c8086
+;     loop_c813a
+;     loop_c8161
+;     loop_c816b
+;     loop_c818c
+;     loop_c820c
+;     loop_c820d
+;     loop_c821c
+;     loop_c826f
+;     loop_c82c7
+;     loop_c82d1
+;     loop_c830d
+;     loop_c8326
+;     loop_c8370
+;     loop_c8390
+;     loop_c8397
+;     loop_c83f0
+;     loop_c83fa
+;     loop_c8406
+;     loop_c8425
+;     loop_c8463
+;     loop_c8493
+;     loop_c84e7
+;     loop_c8527
+;     loop_c8552
+;     loop_c8564
+;     loop_c857b
+;     loop_c85b5
+;     loop_c8717
+;     loop_c8725
+;     loop_c87a0
+;     loop_c87be
+;     loop_c88bc
+;     loop_c895f
+;     loop_c8990
+;     loop_c89c4
+;     loop_c89ca
+;     loop_c8a17
+;     loop_c8ac8
+;     loop_c8ad8
+;     loop_c8af0
+;     loop_c8afb
+;     loop_c8b80
+;     loop_c8bea
+;     loop_c8c58
+;     loop_c8c71
+;     loop_c8d14
+;     loop_c8d17
+;     loop_c8dac
+;     loop_c8dba
+;     loop_c8de9
+;     loop_c8df0
+;     loop_c8e14
+;     loop_c8e85
+;     loop_c8f17
+;     loop_c8f6c
+;     loop_c8f96
+;     loop_c8fac
+;     loop_c9047
+;     loop_c9108
+;     loop_c9113
+;     loop_c91ba
+;     loop_c91e7
+;     loop_c92ef
+;     loop_c9355
+;     loop_c9357
+;     loop_c936f
+;     loop_c9382
+;     loop_c93bd
+;     loop_c93da
+;     loop_c953a
+;     loop_c957d
+;     loop_c9593
+;     loop_c95b6
+;     loop_c95d9
+;     loop_c95ec
+;     loop_c9618
+;     loop_c96c2
+;     loop_c96f2
+;     loop_c979d
+;     loop_c97c8
+;     loop_c9803
+;     loop_c9837
+;     loop_c9851
+;     loop_c985e
+;     loop_c9881
+;     loop_c98a0
+;     loop_c98c1
+;     loop_c98e4
+;     loop_c9942
+;     loop_c994e
+;     loop_c9964
+;     loop_c99a8
+;     loop_c9b50
+;     loop_c9b5e
+;     loop_c9b63
+;     loop_c9bcf
+;     loop_c9be4
+;     loop_c9c38
+;     loop_c9c5d
+;     loop_c9c90
+;     loop_c9ca8
+;     loop_c9d03
+;     loop_c9d43
+;     loop_c9e07
+;     loop_c9e74
+;     loop_c9e8c
+;     loop_c9f6e
+;     loop_ca061
+;     loop_ca11d
+;     loop_ca132
+;     loop_ca143
+;     loop_ca16e
+;     loop_ca1aa
+;     loop_ca1cc
+;     loop_ca487
+;     loop_ca521
+;     loop_ca76f
+;     loop_ca7a7
+;     loop_ca7c6
+;     loop_ca7e0
+;     loop_ca7e1
+;     loop_ca941
+;     loop_ca947
+;     loop_ca953
+;     loop_ca9ab
+;     loop_ca9e7
+;     loop_caa01
+;     loop_caab8
+;     loop_cab6b
+;     loop_cab80
+;     loop_cabad
+;     loop_cabf4
+;     loop_cac46
+;     loop_caf13
+;     loop_caf2d
+;     loop_cb1e3
+;     loop_cb1ed
+;     loop_cb249
+;     loop_cb275
+;     loop_cb2b4
+;     loop_cb2bd
+;     loop_cb2d1
+;     loop_cb44d
+;     loop_cb4a8
+;     loop_cb55e
+;     loop_cb578
+;     loop_cb5c6
+;     loop_cb5ed
+;     loop_cb6b3
+;     loop_cb75a
+;     loop_cb7be
+;     loop_cb7d7
+;     loop_cb7dd
+;     loop_cb910
+;     loop_cb999
+;     loop_cb9bd
+;     loop_cb9cc
+;     loop_cb9d1
+;     loop_cb9f9
+;     loop_cba1a
+;     loop_cba94
+;     loop_cbab8
+;     loop_cbaea
+;     loop_cbbe4
+;     loop_cbbfe
+;     loop_cbc70
+;     loop_cbcd3
+;     loop_cbd08
+;     loop_cbd2b
+;     loop_cbd6c
+;     loop_cbd99
+;     loop_cbe0e
+;     loop_cbe31
+;     loop_cbeab
+;     loop_cbf1c
+;     loop_cbf78
+;     sub_c0050
+;     sub_c0414
+;     sub_c0421
+;     sub_c04c7
+;     sub_c04ce
+;     sub_c0520
+;     sub_c052d
+;     sub_c0537
+;     sub_c0542
+;     sub_c055e
+;     sub_c0582
+;     sub_c0596
+;     sub_c05a9
+;     sub_c05d1
+;     sub_c05f2
+;     sub_c05ff
+;     sub_c0607
+;     sub_c0627
+;     sub_c2020
+;     sub_c2023
+;     sub_c202e
+;     sub_c2038
+;     sub_c2048
+;     sub_c2077
+;     sub_c209a
+;     sub_c209d
+;     sub_c20b8
+;     sub_c20bb
+;     sub_c20c3
+;     sub_c20c8
+;     sub_c20d3
+;     sub_c20db
+;     sub_c20e3
+;     sub_c20e6
+;     sub_c20ed
+;     sub_c20f3
+;     sub_c20f6
+;     sub_c2149
+;     sub_c2174
+;     sub_c21ae
+;     sub_c21b0
+;     sub_c21b7
+;     sub_c21be
+;     sub_c21bf
+;     sub_c21c0
+;     sub_c21c4
+;     sub_c21c5
+;     sub_c21ca
+;     sub_c221d
+;     sub_c2222
+;     sub_c2266
+;     sub_c226d
+;     sub_c2280
+;     sub_c2284
+;     sub_c22b2
+;     sub_c22bb
+;     sub_c22e8
+;     sub_c22fe
+;     sub_c230a
+;     sub_c2327
+;     sub_c2335
+;     sub_c233a
+;     sub_c236e
+;     sub_c2380
+;     sub_c2386
+;     sub_c23bf
+;     sub_c23d1
+;     sub_c23d4
+;     sub_c23dc
+;     sub_c23e3
+;     sub_c23ee
+;     sub_c240c
+;     sub_c241b
+;     sub_c242c
+;     sub_c2439
+;     sub_c2456
+;     sub_c2555
+;     sub_c25e3
+;     sub_c2602
+;     sub_c2745
+;     sub_c274c
+;     sub_c27da
+;     sub_c27db
+;     sub_c27e3
+;     sub_c2826
+;     sub_c2855
+;     sub_c2862
+;     sub_c2932
+;     sub_c2951
+;     sub_c2979
+;     sub_c29da
+;     sub_c2a77
+;     sub_c2ab3
+;     sub_c2b25
+;     sub_c2b4d
+;     sub_c2b64
+;     sub_c2b7b
+;     sub_c2b86
+;     sub_c2bf6
+;     sub_c2bf9
+;     sub_c2c56
+;     sub_c2c65
+;     sub_c2d1a
+;     sub_c2dc6
+;     sub_c2eec
+;     sub_c2efa
+;     sub_c2eff
+;     sub_c2f33
+;     sub_c2f37
+;     sub_c2f3f
+;     sub_c2f4f
+;     sub_c2f5e
+;     sub_c2f6b
+;     sub_c2f75
+;     sub_c2f7a
+;     sub_c2f82
+;     sub_c2f94
+;     sub_c303e
+;     sub_c3104
+;     sub_c3279
+;     sub_c328a
+;     sub_c329d
+;     sub_c33b4
+;     sub_c33c5
+;     sub_c33d3
+;     sub_c33d8
+;     sub_c33f1
+;     sub_c33f5
+;     sub_c33f9
+;     sub_c33fd
+;     sub_c3432
+;     sub_c3445
+;     sub_c3516
+;     sub_c3526
+;     sub_c352e
+;     sub_c3536
+;     sub_c365d
+;     sub_c37e8
+;     sub_c3832
+;     sub_c392c
+;     sub_c3940
+;     sub_c394c
+;     sub_c395a
+;     sub_c3965
+;     sub_c3988
+;     sub_c39ac
+;     sub_c39f3
+;     sub_c3a0f
+;     sub_c3a32
+;     sub_c3a4b
+;     sub_c3a50
+;     sub_c3a60
+;     sub_c3a63
+;     sub_c3a6e
+;     sub_c3a78
+;     sub_c3a82
+;     sub_c3a8d
+;     sub_c3aa3
+;     sub_c3ab8
+;     sub_c3ac8
+;     sub_c3ad3
+;     sub_c3ad8
+;     sub_c3ae5
+;     sub_c3b51
+;     sub_c3b61
+;     sub_c3b79
+;     sub_c3bca
+;     sub_c3bcd
+;     sub_c3be5
+;     sub_c3bf2
+;     sub_c3d19
+;     sub_c3d1e
+;     sub_c3d75
+;     sub_c3d8e
+;     sub_c3df4
+;     sub_c3e1e
+;     sub_c3e30
+;     sub_c3e54
+;     sub_c3e75
+;     sub_c3e94
+;     sub_c3ef4
+;     sub_c3f0f
+;     sub_c3f14
+;     sub_c3f16
+;     sub_c3f1e
+;     sub_c3f26
+;     sub_c3f7c
+;     sub_c3f82
+;     sub_c40b8
+;     sub_c40de
+;     sub_c40f6
+;     sub_c414a
+;     sub_c4168
+;     sub_c4190
+;     sub_c41b4
+;     sub_c41c6
+;     sub_c4315
+;     sub_c4324
+;     sub_c4379
+;     sub_c4384
+;     sub_c43e4
+;     sub_c43ec
+;     sub_c44e1
+;     sub_c451f
+;     sub_c4530
+;     sub_c45b2
+;     sub_c4663
+;     sub_c473d
+;     sub_c476c
+;     sub_c4779
+;     sub_c4788
+;     sub_c47c4
+;     sub_c47c5
+;     sub_c47ce
+;     sub_c48be
+;     sub_c48e2
+;     sub_c490d
+;     sub_c499c
+;     sub_c49bf
+;     sub_c49c2
+;     sub_c49ca
+;     sub_c4a12
+;     sub_c4a53
+;     sub_c4a9a
+;     sub_c4ac2
+;     sub_c4acf
+;     sub_c4add
+;     sub_c4aea
+;     sub_c4af1
+;     sub_c4ba9
+;     sub_c4c0c
+;     sub_c4c18
+;     sub_c4c47
+;     sub_c4c4e
+;     sub_c4c62
+;     sub_c4c6a
+;     sub_c4c72
+;     sub_c4d5d
+;     sub_c4ea9
+;     sub_c4f8d
+;     sub_c4f9a
+;     sub_c5040
+;     sub_c5047
+;     sub_c5234
+;     sub_c52c8
+;     sub_c5580
+;     sub_c558b
+;     sub_c5598
+;     sub_c55ce
+;     sub_c55ee
+;     sub_c55f2
+;     sub_c5607
+;     sub_c5616
+;     sub_c561e
+;     sub_c565f
+;     sub_c568f
+;     sub_c56b1
+;     sub_c56e6
+;     sub_c56fe
+;     sub_c5745
+;     sub_c5771
+;     sub_c57b6
+;     sub_c583f
+;     sub_c5841
+;     sub_c584e
+;     sub_c5850
+;     sub_c585d
+;     sub_c586f
+;     sub_c5882
+;     sub_c5986
+;     sub_c59f5
+;     sub_c5a67
+;     sub_c5ab9
+;     sub_c5ac2
+;     sub_c5ac4
+;     sub_c5ad2
+;     sub_c5b00
+;     sub_c5c68
+;     sub_c5e83
+;     sub_c5e91
+;     sub_c5e9d
+;     sub_c5ec2
+;     sub_c5f7c
+;     sub_c5f82
+;     sub_c5f84
+;     sub_c8020
+;     sub_c809a
+;     sub_c809d
+;     sub_c80b8
+;     sub_c80bb
+;     sub_c80c3
+;     sub_c80c8
+;     sub_c80d3
+;     sub_c80db
+;     sub_c80e3
+;     sub_c80e6
+;     sub_c80ed
+;     sub_c80f3
+;     sub_c80f6
+;     sub_c8149
+;     sub_c8174
+;     sub_c81ae
+;     sub_c81b0
+;     sub_c81b7
+;     sub_c81be
+;     sub_c81bf
+;     sub_c81c0
+;     sub_c81c4
+;     sub_c81c5
+;     sub_c81ca
+;     sub_c821d
+;     sub_c8222
+;     sub_c8238
+;     sub_c8254
+;     sub_c8266
+;     sub_c826d
+;     sub_c8280
+;     sub_c8284
+;     sub_c82b2
+;     sub_c82bb
+;     sub_c82e8
+;     sub_c82fe
+;     sub_c830a
+;     sub_c8327
+;     sub_c8335
+;     sub_c833a
+;     sub_c836e
+;     sub_c8380
+;     sub_c8386
+;     sub_c83bf
+;     sub_c83d1
+;     sub_c83d4
+;     sub_c83e3
+;     sub_c83ee
+;     sub_c840c
+;     sub_c841b
+;     sub_c842c
+;     sub_c8439
+;     sub_c8456
+;     sub_c8555
+;     sub_c85e3
+;     sub_c8602
+;     sub_c8745
+;     sub_c8750
+;     sub_c8782
+;     sub_c8794
+;     sub_c87da
+;     sub_c87db
+;     sub_c87e3
+;     sub_c87ee
+;     sub_c8826
+;     sub_c8855
+;     sub_c8862
+;     sub_c8932
+;     sub_c893f
+;     sub_c8943
+;     sub_c8951
+;     sub_c8979
+;     sub_c89b7
+;     sub_c89da
+;     sub_c89e6
+;     sub_c8a77
+;     sub_c8ab3
+;     sub_c8b25
+;     sub_c8b47
+;     sub_c8b4d
+;     sub_c8b64
+;     sub_c8b7b
+;     sub_c8b86
+;     sub_c8bac
+;     sub_c8bf6
+;     sub_c8bf9
+;     sub_c8c56
+;     sub_c8c65
+;     sub_c8d1a
+;     sub_c8dc6
+;     sub_c8eec
+;     sub_c8efa
+;     sub_c8eff
+;     sub_c8f33
+;     sub_c8f37
+;     sub_c8f3f
+;     sub_c8f4f
+;     sub_c8f5e
+;     sub_c8f6b
+;     sub_c8f75
+;     sub_c8f7a
+;     sub_c8f82
+;     sub_c8f94
+;     sub_c9279
+;     sub_c928a
+;     sub_c929d
+;     sub_c93b4
+;     sub_c93c5
+;     sub_c93d3
+;     sub_c93d8
+;     sub_c93f1
+;     sub_c93f5
+;     sub_c93f9
+;     sub_c93fd
+;     sub_c9432
+;     sub_c9445
+;     sub_c9516
+;     sub_c9526
+;     sub_c952e
+;     sub_c9536
+;     sub_c965d
+;     sub_c9785
+;     sub_c97b6
+;     sub_c97c9
+;     sub_c97e8
+;     sub_c9832
+;     sub_c992c
+;     sub_c9940
+;     sub_c995a
+;     sub_c9965
+;     sub_c9988
+;     sub_c99ac
+;     sub_c99f3
+;     sub_c9a0f
+;     sub_c9a32
+;     sub_c9a4b
+;     sub_c9a50
+;     sub_c9a60
+;     sub_c9a63
+;     sub_c9a6e
+;     sub_c9a78
+;     sub_c9a82
+;     sub_c9a8d
+;     sub_c9aa3
+;     sub_c9ab8
+;     sub_c9ac8
+;     sub_c9ad3
+;     sub_c9ad8
+;     sub_c9b51
+;     sub_c9b59
+;     sub_c9b61
+;     sub_c9b79
+;     sub_c9bca
+;     sub_c9bcd
+;     sub_c9be5
+;     sub_c9bf2
+;     sub_c9c0c
+;     sub_c9d19
+;     sub_c9d1e
+;     sub_c9d75
+;     sub_c9d9b
+;     sub_c9df4
+;     sub_c9e1e
+;     sub_c9e30
+;     sub_c9e54
+;     sub_c9e75
+;     sub_c9e94
+;     sub_c9ef4
+;     sub_c9f0f
+;     sub_c9f14
+;     sub_c9f16
+;     sub_c9f1e
+;     sub_c9f26
+;     sub_c9f7c
+;     sub_c9f82
+;     sub_ca0b8
+;     sub_ca0de
+;     sub_ca0f6
+;     sub_ca106
+;     sub_ca137
+;     sub_ca14a
+;     sub_ca168
+;     sub_ca190
+;     sub_ca1b4
+;     sub_ca1c6
+;     sub_ca244
+;     sub_ca315
+;     sub_ca324
+;     sub_ca379
+;     sub_ca384
+;     sub_ca3e4
+;     sub_ca3ec
+;     sub_ca417
+;     sub_ca463
+;     sub_ca4e1
+;     sub_ca51f
+;     sub_ca530
+;     sub_ca5b2
+;     sub_ca5bb
+;     sub_ca5bf
+;     sub_ca663
+;     sub_ca73d
+;     sub_ca76c
+;     sub_ca779
+;     sub_ca788
+;     sub_ca7c4
+;     sub_ca7c5
+;     sub_ca7ce
+;     sub_ca7f3
+;     sub_ca7f6
+;     sub_ca8be
+;     sub_ca8e2
+;     sub_ca90d
+;     sub_ca9bf
+;     sub_ca9c2
+;     sub_ca9ca
+;     sub_ca9d0
+;     sub_caa12
+;     sub_caa53
+;     sub_caa9a
+;     sub_caac2
+;     sub_caacf
+;     sub_caadd
+;     sub_caaea
+;     sub_caaf1
+;     sub_caafd
+;     sub_cab04
+;     sub_cab46
+;     sub_caba9
+;     sub_cabc5
+;     sub_cac0c
+;     sub_cac18
+;     sub_cac47
+;     sub_cac4e
+;     sub_cac62
+;     sub_cac6a
+;     sub_cac72
+;     sub_cb234
+;     sub_cb2c8
+;     sub_cb580
+;     sub_cb58b
+;     sub_cb598
+;     sub_cb5ce
+;     sub_cb5ee
+;     sub_cb5f2
+;     sub_cb607
+;     sub_cb616
+;     sub_cb61e
+;     sub_cb65f
+;     sub_cb68f
+;     sub_cb6b1
+;     sub_cb6c5
+;     sub_cb6cd
+;     sub_cb6e6
+;     sub_cb6fe
+;     sub_cb745
+;     sub_cb771
+;     sub_cb7b6
+;     sub_cb83f
+;     sub_cb841
+;     sub_cb84e
+;     sub_cb850
+;     sub_cb85d
+;     sub_cb86f
+;     sub_cb882
+;     sub_cb986
+;     sub_cb9f5
+;     sub_cba67
+;     sub_cbab9
+;     sub_cbac2
+;     sub_cbac4
+;     sub_cbad2
+;     sub_cbb00
+;     sub_cbb46
+;     sub_cbb4a
+;     sub_cbbd3
+;     sub_cbbd7
+;     sub_cbc37
+;     sub_cbc68
+;     sub_cbc81
+;     sub_cbe83
+;     sub_cbe91
+;     sub_cbe9d
+;     sub_cbec2
+;     sub_cbf7c
+;     sub_cbf82
+;     sub_cbf84
+!if (<(c956d-1)) != $6c {
+    !error "Assertion failed: <(c956d-1) == $6c"
+}
+!if (<(c956d-1)) != $6c {
+    !error "Assertion failed: <(c956d-1) == $6c"
+}
+!if (<(l0128)) != $28 {
+    !error "Assertion failed: <(l0128) == $28"
+}
+!if (<(l1000)) != $00 {
+    !error "Assertion failed: <(l1000) == $00"
+}
+!if (<(sub_c8238-1)) != $37 {
+    !error "Assertion failed: <(sub_c8238-1) == $37"
+}
+!if (<(sub_c8254-1)) != $53 {
+    !error "Assertion failed: <(sub_c8254-1) == $53"
+}
+!if (<(sub_c8750-1)) != $4f {
+    !error "Assertion failed: <(sub_c8750-1) == $4f"
+}
+!if (<(sub_c8782-1)) != $81 {
+    !error "Assertion failed: <(sub_c8782-1) == $81"
+}
+!if (<(sub_c8794-1)) != $93 {
+    !error "Assertion failed: <(sub_c8794-1) == $93"
+}
+!if (<(sub_c87ee-1)) != $ed {
+    !error "Assertion failed: <(sub_c87ee-1) == $ed"
+}
+!if (<(sub_c893f-1)) != $3e {
+    !error "Assertion failed: <(sub_c893f-1) == $3e"
+}
+!if (<(sub_c8943-1)) != $42 {
+    !error "Assertion failed: <(sub_c8943-1) == $42"
+}
+!if (<(sub_c89b7-1)) != $b6 {
+    !error "Assertion failed: <(sub_c89b7-1) == $b6"
+}
+!if (<(sub_c89e6-1)) != $e5 {
+    !error "Assertion failed: <(sub_c89e6-1) == $e5"
+}
+!if (<(sub_c8b47-1)) != $46 {
+    !error "Assertion failed: <(sub_c8b47-1) == $46"
+}
+!if (<(sub_c8bac-1)) != $ab {
+    !error "Assertion failed: <(sub_c8bac-1) == $ab"
+}
+!if (<(sub_c9b59-1)) != $58 {
+    !error "Assertion failed: <(sub_c9b59-1) == $58"
+}
+!if (<(sub_ca106-1)) != $05 {
+    !error "Assertion failed: <(sub_ca106-1) == $05"
+}
+!if (<(sub_ca137-1)) != $36 {
+    !error "Assertion failed: <(sub_ca137-1) == $36"
+}
+!if (<(sub_ca244-1)) != $43 {
+    !error "Assertion failed: <(sub_ca244-1) == $43"
+}
+!if (<(sub_ca417-1)) != $16 {
+    !error "Assertion failed: <(sub_ca417-1) == $16"
+}
+!if (<(sub_ca463-1)) != $62 {
+    !error "Assertion failed: <(sub_ca463-1) == $62"
+}
+!if (<(sub_ca5bb-1)) != $ba {
+    !error "Assertion failed: <(sub_ca5bb-1) == $ba"
+}
+!if (<(sub_ca5bf-1)) != $be {
+    !error "Assertion failed: <(sub_ca5bf-1) == $be"
+}
+!if (<(sub_ca7f3-1)) != $f2 {
+    !error "Assertion failed: <(sub_ca7f3-1) == $f2"
+}
+!if (<(sub_ca7f6-1)) != $f5 {
+    !error "Assertion failed: <(sub_ca7f6-1) == $f5"
+}
+!if (<(sub_ca9d0-1)) != $cf {
+    !error "Assertion failed: <(sub_ca9d0-1) == $cf"
+}
+!if (<(sub_caafd-1)) != $fc {
+    !error "Assertion failed: <(sub_caafd-1) == $fc"
+}
+!if (<(sub_cab04-1)) != $03 {
+    !error "Assertion failed: <(sub_cab04-1) == $03"
+}
+!if (<(sub_cab46-1)) != $45 {
+    !error "Assertion failed: <(sub_cab46-1) == $45"
+}
+!if (<(sub_cabc5-1)) != $c4 {
+    !error "Assertion failed: <(sub_cabc5-1) == $c4"
+}
+!if (<(sub_cbb46-1)) != $45 {
+    !error "Assertion failed: <(sub_cbb46-1) == $45"
+}
+!if (<(sub_cbb4a-1)) != $49 {
+    !error "Assertion failed: <(sub_cbb4a-1) == $49"
+}
+!if (<(sub_cbbd3-1)) != $d2 {
+    !error "Assertion failed: <(sub_cbbd3-1) == $d2"
+}
+!if (<(sub_cbbd7-1)) != $d6 {
+    !error "Assertion failed: <(sub_cbbd7-1) == $d6"
+}
+!if (<(sub_cbc37-1)) != $36 {
+    !error "Assertion failed: <(sub_cbc37-1) == $36"
+}
+!if (<(sub_cbc81-1)) != $80 {
+    !error "Assertion failed: <(sub_cbc81-1) == $80"
+}
+!if (<jump_address_low) != $51 {
+    !error "Assertion failed: <jump_address_low == $51"
+}
+!if (<tube_brkv_handler) != $16 {
+    !error "Assertion failed: <tube_brkv_handler == $16"
+}
+!if (<tube_evntv_handler) != $ad {
+    !error "Assertion failed: <tube_evntv_handler == $ad"
+}
+!if (>(c956d-1)) != $95 {
+    !error "Assertion failed: >(c956d-1) == $95"
+}
+!if (>(c956d-1)) != $95 {
+    !error "Assertion failed: >(c956d-1) == $95"
+}
+!if (>(l0128)) != $01 {
+    !error "Assertion failed: >(l0128) == $01"
+}
+!if (>(l1000)) != $10 {
+    !error "Assertion failed: >(l1000) == $10"
+}
+!if (>(sub_c8238-1)) != $82 {
+    !error "Assertion failed: >(sub_c8238-1) == $82"
+}
+!if (>(sub_c8254-1)) != $82 {
+    !error "Assertion failed: >(sub_c8254-1) == $82"
+}
+!if (>(sub_c8750-1)) != $87 {
+    !error "Assertion failed: >(sub_c8750-1) == $87"
+}
+!if (>(sub_c8782-1)) != $87 {
+    !error "Assertion failed: >(sub_c8782-1) == $87"
+}
+!if (>(sub_c8794-1)) != $87 {
+    !error "Assertion failed: >(sub_c8794-1) == $87"
+}
+!if (>(sub_c87ee-1)) != $87 {
+    !error "Assertion failed: >(sub_c87ee-1) == $87"
+}
+!if (>(sub_c893f-1)) != $89 {
+    !error "Assertion failed: >(sub_c893f-1) == $89"
+}
+!if (>(sub_c8943-1)) != $89 {
+    !error "Assertion failed: >(sub_c8943-1) == $89"
+}
+!if (>(sub_c89b7-1)) != $89 {
+    !error "Assertion failed: >(sub_c89b7-1) == $89"
+}
+!if (>(sub_c89e6-1)) != $89 {
+    !error "Assertion failed: >(sub_c89e6-1) == $89"
+}
+!if (>(sub_c8b47-1)) != $8b {
+    !error "Assertion failed: >(sub_c8b47-1) == $8b"
+}
+!if (>(sub_c8bac-1)) != $8b {
+    !error "Assertion failed: >(sub_c8bac-1) == $8b"
+}
+!if (>(sub_c9b59-1)) != $9b {
+    !error "Assertion failed: >(sub_c9b59-1) == $9b"
+}
+!if (>(sub_ca106-1)) != $a1 {
+    !error "Assertion failed: >(sub_ca106-1) == $a1"
+}
+!if (>(sub_ca137-1)) != $a1 {
+    !error "Assertion failed: >(sub_ca137-1) == $a1"
+}
+!if (>(sub_ca244-1)) != $a2 {
+    !error "Assertion failed: >(sub_ca244-1) == $a2"
+}
+!if (>(sub_ca417-1)) != $a4 {
+    !error "Assertion failed: >(sub_ca417-1) == $a4"
+}
+!if (>(sub_ca463-1)) != $a4 {
+    !error "Assertion failed: >(sub_ca463-1) == $a4"
+}
+!if (>(sub_ca5bb-1)) != $a5 {
+    !error "Assertion failed: >(sub_ca5bb-1) == $a5"
+}
+!if (>(sub_ca5bf-1)) != $a5 {
+    !error "Assertion failed: >(sub_ca5bf-1) == $a5"
+}
+!if (>(sub_ca7f3-1)) != $a7 {
+    !error "Assertion failed: >(sub_ca7f3-1) == $a7"
+}
+!if (>(sub_ca7f6-1)) != $a7 {
+    !error "Assertion failed: >(sub_ca7f6-1) == $a7"
+}
+!if (>(sub_ca9d0-1)) != $a9 {
+    !error "Assertion failed: >(sub_ca9d0-1) == $a9"
+}
+!if (>(sub_caafd-1)) != $aa {
+    !error "Assertion failed: >(sub_caafd-1) == $aa"
+}
+!if (>(sub_cab04-1)) != $ab {
+    !error "Assertion failed: >(sub_cab04-1) == $ab"
+}
+!if (>(sub_cab46-1)) != $ab {
+    !error "Assertion failed: >(sub_cab46-1) == $ab"
+}
+!if (>(sub_cabc5-1)) != $ab {
+    !error "Assertion failed: >(sub_cabc5-1) == $ab"
+}
+!if (>(sub_cbb46-1)) != $bb {
+    !error "Assertion failed: >(sub_cbb46-1) == $bb"
+}
+!if (>(sub_cbb4a-1)) != $bb {
+    !error "Assertion failed: >(sub_cbb4a-1) == $bb"
+}
+!if (>(sub_cbbd3-1)) != $bb {
+    !error "Assertion failed: >(sub_cbbd3-1) == $bb"
+}
+!if (>(sub_cbbd7-1)) != $bb {
+    !error "Assertion failed: >(sub_cbbd7-1) == $bb"
+}
+!if (>(sub_cbc37-1)) != $bc {
+    !error "Assertion failed: >(sub_cbc37-1) == $bc"
+}
+!if (>(sub_cbc81-1)) != $bc {
+    !error "Assertion failed: >(sub_cbc81-1) == $bc"
+}
+!if (>tube_brkv_handler) != $00 {
+    !error "Assertion failed: >tube_brkv_handler == $00"
+}
+!if (>tube_evntv_handler) != $06 {
+    !error "Assertion failed: >tube_evntv_handler == $06"
+}
+!if (copyright - rom_header) != $11 {
+    !error "Assertion failed: copyright - rom_header == $11"
+}
+!if (nmi3_handler_rom_end-nmi3_handler_rom_start) != $0e {
+    !error "Assertion failed: nmi3_handler_rom_end-nmi3_handler_rom_start == $0e"
+}
+!if (nmi_XXX1-(nmi_beq+2)) != $48 {
+    !error "Assertion failed: nmi_XXX1-(nmi_beq+2) == $48"
+}
+!if (nmi_XXX10-(nmi_bcs+2)) != $32 {
+    !error "Assertion failed: nmi_XXX10-(nmi_bcs+2) == $32"
+}
+!if (nmi_XXX11-(nmi_bcs+2)) != $3b {
+    !error "Assertion failed: nmi_XXX11-(nmi_bcs+2) == $3b"
+}
+!if (nmi_XXX12-(nmi_bcs+2)) != $3f {
+    !error "Assertion failed: nmi_XXX12-(nmi_bcs+2) == $3f"
+}
+!if (nmi_XXX13-(nmi_bcs+2)) != $49 {
+    !error "Assertion failed: nmi_XXX13-(nmi_bcs+2) == $49"
+}
+!if (nmi_XXX14-(nmi_bcs+2)) != $4d {
+    !error "Assertion failed: nmi_XXX14-(nmi_bcs+2) == $4d"
+}
+!if (nmi_XXX15-(nmi_bcs+2)) != $55 {
+    !error "Assertion failed: nmi_XXX15-(nmi_bcs+2) == $55"
+}
+!if (nmi_XXX16-(nmi_bcs+2)) != $5d {
+    !error "Assertion failed: nmi_XXX16-(nmi_bcs+2) == $5d"
+}
+!if (nmi_XXX17-(nmi_bcs+2)) != $06 {
+    !error "Assertion failed: nmi_XXX17-(nmi_bcs+2) == $06"
+}
+!if (nmi_XXX18-(nmi_bcs+2)) != $11 {
+    !error "Assertion failed: nmi_XXX18-(nmi_bcs+2) == $11"
+}
+!if (nmi_XXX19-(nmi_bcs+2)) != $7b {
+    !error "Assertion failed: nmi_XXX19-(nmi_bcs+2) == $7b"
+}
+!if (nmi_XXX2-(nmi_beq+2)) != $2f {
+    !error "Assertion failed: nmi_XXX2-(nmi_beq+2) == $2f"
+}
+!if (nmi_XXX2-1) != $0d38 {
+    !error "Assertion failed: nmi_XXX2-1 == $0d38"
+}
+!if (nmi_XXX20-(nmi_bcs+2)) != $7f {
+    !error "Assertion failed: nmi_XXX20-(nmi_bcs+2) == $7f"
+}
+!if (nmi_XXX21-(nmi_bcs+2)) != $26 {
+    !error "Assertion failed: nmi_XXX21-(nmi_bcs+2) == $26"
+}
+!if (nmi_XXX22-(nmi_bcs+2)) != $77 {
+    !error "Assertion failed: nmi_XXX22-(nmi_bcs+2) == $77"
+}
+!if (nmi_XXX23-(nmi_bcs+2)) != $24 {
+    !error "Assertion failed: nmi_XXX23-(nmi_bcs+2) == $24"
+}
+!if (nmi_XXX5-(nmi_cmp_imm_or_bcs+2)) != $06 {
+    !error "Assertion failed: nmi_XXX5-(nmi_cmp_imm_or_bcs+2) == $06"
+}
+!if (nmi_XXX7-(nmi_XXX6+2)) != $06 {
+    !error "Assertion failed: nmi_XXX7-(nmi_XXX6+2) == $06"
+}
+!if (nmi_XXX8-(nmi_beq+2)) != $4d {
+    !error "Assertion failed: nmi_XXX8-(nmi_beq+2) == $4d"
+}
+!if (nmi_handler2_rom_end-nmi_handler2_rom_start) != $94 {
+    !error "Assertion failed: nmi_handler2_rom_end-nmi_handler2_rom_start == $94"
+}
+!if (nmi_handler_rom_end-nmi_handler_rom_start-1) != $5d {
+    !error "Assertion failed: nmi_handler_rom_end-nmi_handler_rom_start-1 == $5d"
+}
+!if (opcode_bcs) != $b0 {
+    !error "Assertion failed: opcode_bcs == $b0"
+}
+!if (opcode_rti) != $40 {
+    !error "Assertion failed: opcode_rti == $40"
+}
+!if (osbyte_close_spool_exec) != $77 {
+    !error "Assertion failed: osbyte_close_spool_exec == $77"
+}
+!if (osbyte_explode_chars) != $14 {
+    !error "Assertion failed: osbyte_explode_chars == $14"
+}
+!if (osbyte_issue_service_request) != $8f {
+    !error "Assertion failed: osbyte_issue_service_request == $8f"
+}
+!if (osbyte_read_himem) != $84 {
+    !error "Assertion failed: osbyte_read_himem == $84"
+}
+!if (osbyte_read_oshwm) != $83 {
+    !error "Assertion failed: osbyte_read_oshwm == $83"
+}
+!if (osbyte_read_rom_info_table_low) != $aa {
+    !error "Assertion failed: osbyte_read_rom_info_table_low == $aa"
+}
+!if (osbyte_read_tube_presence) != $ea {
+    !error "Assertion failed: osbyte_read_tube_presence == $ea"
+}
+!if (osbyte_read_write_spool_file_handle) != $c7 {
+    !error "Assertion failed: osbyte_read_write_spool_file_handle == $c7"
+}
+!if (osbyte_read_write_startup_options) != $ff {
+    !error "Assertion failed: osbyte_read_write_startup_options == $ff"
+}
+!if (osbyte_rw_exec_handle) != $c6 {
+    !error "Assertion failed: osbyte_rw_exec_handle == $c6"
+}
+!if (osbyte_scan_keyboard_from_16) != $7a {
+    !error "Assertion failed: osbyte_scan_keyboard_from_16 == $7a"
+}
+!if (osbyte_write_keys_pressed) != $78 {
+    !error "Assertion failed: osbyte_write_keys_pressed == $78"
+}
+!if (osfile_load) != $ff {
+    !error "Assertion failed: osfile_load == $ff"
+}
+!if (osfile_read_catalogue_info) != $05 {
+    !error "Assertion failed: osfile_read_catalogue_info == $05"
+}
+!if (osfile_save) != $00 {
+    !error "Assertion failed: osfile_save == $00"
+}
+!if (service_absolute_workspace_claimed) != $0a {
+    !error "Assertion failed: service_absolute_workspace_claimed == $0a"
+}
+!if (service_boot) != $03 {
+    !error "Assertion failed: service_boot == $03"
+}
+!if (service_check_swr_presence) != $2b {
+    !error "Assertion failed: service_check_swr_presence == $2b"
+}
+!if (service_claim_absolute_workspace) != $01 {
+    !error "Assertion failed: service_claim_absolute_workspace == $01"
+}
+!if (service_claim_private_workspace) != $02 {
+    !error "Assertion failed: service_claim_private_workspace == $02"
+}
+!if (service_help) != $09 {
+    !error "Assertion failed: service_help == $09"
+}
+!if (service_select_filing_system) != $12 {
+    !error "Assertion failed: service_select_filing_system == $12"
+}
+!if (service_tube_post_init) != $fe {
+    !error "Assertion failed: service_tube_post_init == $fe"
+}
+!if (service_unrecognised_command) != $04 {
+    !error "Assertion failed: service_unrecognised_command == $04"
+}
+!if (service_unrecognised_osword) != $08 {
+    !error "Assertion failed: service_unrecognised_osword == $08"
+}
+!if (sub_c0520) != $0520 {
+    !error "Assertion failed: sub_c0520 == $0520"
+}
+!if (sub_c052d) != $052d {
+    !error "Assertion failed: sub_c052d == $052d"
+}
+!if (sub_c0537) != $0537 {
+    !error "Assertion failed: sub_c0537 == $0537"
+}
+!if (sub_c0542) != $0542 {
+    !error "Assertion failed: sub_c0542 == $0542"
+}
+!if (sub_c055e) != $055e {
+    !error "Assertion failed: sub_c055e == $055e"
+}
+!if (sub_c0596) != $0596 {
+    !error "Assertion failed: sub_c0596 == $0596"
+}
+!if (sub_c05a9) != $05a9 {
+    !error "Assertion failed: sub_c05a9 == $05a9"
+}
+!if (sub_c05d1) != $05d1 {
+    !error "Assertion failed: sub_c05d1 == $05d1"
+}
+!if (sub_c05f2) != $05f2 {
+    !error "Assertion failed: sub_c05f2 == $05f2"
+}
+!if (sub_c0607) != $0607 {
+    !error "Assertion failed: sub_c0607 == $0607"
+}
+!if (sub_c0627) != $0627 {
+    !error "Assertion failed: sub_c0627 == $0627"
+}
+!if (sub_c9785) != $9785 {
+    !error "Assertion failed: sub_c9785 == $9785"
+}
+!if (sub_c97b6) != $97b6 {
+    !error "Assertion failed: sub_c97b6 == $97b6"
+}
+!if (sub_c97c9) != $97c9 {
+    !error "Assertion failed: sub_c97c9 == $97c9"
+}
+!if (sub_c9c0c) != $9c0c {
+    !error "Assertion failed: sub_c9c0c == $9c0c"
+}
+!if (sub_c9d9b) != $9d9b {
+    !error "Assertion failed: sub_c9d9b == $9d9b"
+}
+!if (sub_c9e94) != $9e94 {
+    !error "Assertion failed: sub_c9e94 == $9e94"
+}
+!if (sub_c9f82) != $9f82 {
+    !error "Assertion failed: sub_c9f82 == $9f82"
+}
+!if (tube_brkv_handler_fwd) != $16 {
+    !error "Assertion failed: tube_brkv_handler_fwd == $16"
+}
+!if (tube_host_osword_0) != $0668 {
+    !error "Assertion failed: tube_host_osword_0 == $0668"
+}

--- a/examples/known_good/dfs226b_beebasm.asm
+++ b/examples/known_good/dfs226b_beebasm.asm
@@ -1,0 +1,14851 @@
+; Constants
+opcode_bcs                            = 176
+opcode_rti                            = 64
+osbyte_close_spool_exec               = 119
+osbyte_explode_chars                  = 20
+osbyte_issue_service_request          = 143
+osbyte_read_himem                     = 132
+osbyte_read_oshwm                     = 131
+osbyte_read_rom_info_table_low        = 170
+osbyte_read_tube_presence             = 234
+osbyte_read_write_spool_file_handle   = 199
+osbyte_read_write_startup_options     = 255
+osbyte_rw_exec_handle                 = 198
+osbyte_scan_keyboard_from_16          = 122
+osbyte_write_keys_pressed             = 120
+osfile_load                           = 255
+osfile_read_catalogue_info            = 5
+osfile_save                           = 0
+service_absolute_workspace_claimed    = 10
+service_boot                          = 3
+service_check_swr_presence            = 43
+service_claim_absolute_workspace      = 1
+service_claim_private_workspace       = 2
+service_help                          = 9
+service_select_filing_system          = 18
+service_tube_post_init                = 254
+service_unrecognised_command          = 4
+service_unrecognised_osword           = 8
+tube_brkv_handler_fwd                 = 22
+
+; Memory locations
+l0000                   = &0000
+l0001                   = &0001
+l0002                   = &0002
+l0003                   = &0003
+l0012                   = &0012
+l0013                   = &0013
+l0014                   = &0014
+l0015                   = &0015
+l0057                   = &0057
+l00a0                   = &00a0
+l00a1                   = &00a1
+l00a2                   = &00a2
+l00a3                   = &00a3
+l00a4                   = &00a4
+l00a5                   = &00a5
+l00a6                   = &00a6
+l00a7                   = &00a7
+l00a8                   = &00a8
+l00a9                   = &00a9
+l00aa                   = &00aa
+l00ab                   = &00ab
+l00ac                   = &00ac
+l00ad                   = &00ad
+l00ae                   = &00ae
+l00af                   = &00af
+l00b0                   = &00b0
+l00b1                   = &00b1
+l00b2                   = &00b2
+l00b3                   = &00b3
+l00b4                   = &00b4
+l00b5                   = &00b5
+l00b6                   = &00b6
+l00b7                   = &00b7
+l00b8                   = &00b8
+l00b9                   = &00b9
+l00ba                   = &00ba
+l00bb                   = &00bb
+l00bc                   = &00bc
+l00bd                   = &00bd
+l00be                   = &00be
+l00bf                   = &00bf
+l00c0                   = &00c0
+l00c1                   = &00c1
+l00c2                   = &00c2
+l00c3                   = &00c3
+l00c4                   = &00c4
+l00c5                   = &00c5
+l00c6                   = &00c6
+l00c7                   = &00c7
+l00c8                   = &00c8
+l00c9                   = &00c9
+l00ca                   = &00ca
+l00cc                   = &00cc
+l00cd                   = &00cd
+l00ce                   = &00ce
+l00cf                   = &00cf
+l00ef                   = &00ef
+l00f0                   = &00f0
+l00f1                   = &00f1
+os_text_ptr             = &00f2
+l00f3                   = &00f3
+romsel_copy             = &00f4
+osrdsc_ptr              = &00f6
+l00f7                   = &00f7
+l00fd                   = &00fd
+l00ff                   = &00ff
+l0100                   = &0100
+l0101                   = &0101
+l0102                   = &0102
+l0103                   = &0103
+l0104                   = &0104
+l0105                   = &0105
+l0107                   = &0107
+l0109                   = &0109
+l010b                   = &010b
+l010c                   = &010c
+l010d                   = &010d
+l010e                   = &010e
+l0128                   = &0128
+brkv                    = &0202
+bytev                   = &020a
+filev                   = &0212
+fscv                    = &021e
+evntv                   = &0220
+l028d                   = &028d
+l04fc                   = &04fc
+l06ce                   = &06ce
+l0700                   = &0700
+l0cff                   = &0cff
+l0d00                   = &0d00
+l0d47                   = &0d47
+sub_c0d5e               = &0d5e
+l0d94                   = &0d94
+l0df0                   = &0df0
+l0e00                   = &0e00
+l0e07                   = &0e07
+l0e08                   = &0e08
+l0e0e                   = &0e0e
+l0e0f                   = &0e0f
+l0e10                   = &0e10
+l0ef8                   = &0ef8
+l0f00                   = &0f00
+l0f04                   = &0f04
+l0f05                   = &0f05
+l0f06                   = &0f06
+l0f07                   = &0f07
+l0f08                   = &0f08
+l0f09                   = &0f09
+l0f0a                   = &0f0a
+l0f0b                   = &0f0b
+l0f0c                   = &0f0c
+l0f0d                   = &0f0d
+l0f0e                   = &0f0e
+l0f0f                   = &0f0f
+l0f10                   = &0f10
+l1000                   = &1000
+l1001                   = &1001
+l1002                   = &1002
+l1003                   = &1003
+l1004                   = &1004
+l1005                   = &1005
+l1006                   = &1006
+l1007                   = &1007
+l100e                   = &100e
+l1045                   = &1045
+l1047                   = &1047
+l104d                   = &104d
+l104e                   = &104e
+l1050                   = &1050
+l1058                   = &1058
+l105f                   = &105f
+l1060                   = &1060
+l1061                   = &1061
+l1062                   = &1062
+l1063                   = &1063
+l1064                   = &1064
+l1065                   = &1065
+l1067                   = &1067
+l1069                   = &1069
+l1072                   = &1072
+l1074                   = &1074
+l1075                   = &1075
+l1076                   = &1076
+l1077                   = &1077
+l1078                   = &1078
+l1079                   = &1079
+l107a                   = &107a
+l107d                   = &107d
+l107e                   = &107e
+l107f                   = &107f
+l1081                   = &1081
+l1082                   = &1082
+l1083                   = &1083
+l1086                   = &1086
+l1087                   = &1087
+l1088                   = &1088
+l1089                   = &1089
+l108a                   = &108a
+l108b                   = &108b
+l108c                   = &108c
+l108f                   = &108f
+l1090                   = &1090
+l1091                   = &1091
+l1092                   = &1092
+l1093                   = &1093
+l1094                   = &1094
+l1095                   = &1095
+l1096                   = &1096
+l1097                   = &1097
+l1098                   = &1098
+l1099                   = &1099
+l109a                   = &109a
+l109b                   = &109b
+l109d                   = &109d
+l109e                   = &109e
+l109f                   = &109f
+l10c0                   = &10c0
+l10c1                   = &10c1
+l10c2                   = &10c2
+l10c3                   = &10c3
+l10c4                   = &10c4
+l10c5                   = &10c5
+l10c6                   = &10c6
+l10c7                   = &10c7
+l10c9                   = &10c9
+l10ca                   = &10ca
+l10cb                   = &10cb
+l10cc                   = &10cc
+l10cd                   = &10cd
+l10ce                   = &10ce
+l10cf                   = &10cf
+l10d0                   = &10d0
+l10d1                   = &10d1
+l10d2                   = &10d2
+l10d3                   = &10d3
+l10d6                   = &10d6
+l10d7                   = &10d7
+l10d8                   = &10d8
+l10d9                   = &10d9
+l10da                   = &10da
+l10db                   = &10db
+l10dc                   = &10dc
+l10dd                   = &10dd
+l10de                   = &10de
+l10e2                   = &10e2
+l10e3                   = &10e3
+l10e4                   = &10e4
+l1100                   = &1100
+l1109                   = &1109
+l110b                   = &110b
+l110c                   = &110c
+l110d                   = &110d
+l110e                   = &110e
+l110f                   = &110f
+l1110                   = &1110
+l1111                   = &1111
+l1112                   = &1112
+l1113                   = &1113
+l1114                   = &1114
+l1115                   = &1115
+l1116                   = &1116
+l1117                   = &1117
+l1119                   = &1119
+l111a                   = &111a
+l111b                   = &111b
+l111c                   = &111c
+l111d                   = &111d
+sub_c2fd2               = &2fd2
+sub_c3030               = &3030
+sub_c303e               = &303e
+sub_c3067               = &3067
+c30fb                   = &30fb
+l4cdb                   = &4cdb
+sub_c4ea9               = &4ea9
+c4f38                   = &4f38
+c4f79                   = &4f79
+l5075                   = &5075
+nmi_handler_rom_end     = &9030
+nmi3_handler_rom_start  = &9030
+tube_host_code1         = &af79
+lc000                   = &c000
+romsel                  = &fe30
+lfe80                   = &fe80
+lfe84                   = &fe84
+lfe85                   = &fe85
+lfe86                   = &fe86
+lfe87                   = &fe87
+tube_host_r1_status     = &fee0
+tube_host_r1_data       = &fee1
+tube_host_r2_status     = &fee2
+tube_host_r2_data       = &fee3
+tube_host_r3_data       = &fee5
+tube_host_r4_status     = &fee6
+tube_host_r4_data       = &fee7
+osrdsc                  = &ffb9
+gsinit                  = &ffc2
+gsread                  = &ffc5
+osfind                  = &ffce
+osgbpb                  = &ffd1
+osbput                  = &ffd4
+osbget                  = &ffd7
+osargs                  = &ffda
+osfile                  = &ffdd
+osrdch                  = &ffe0
+osasci                  = &ffe3
+osnewl                  = &ffe7
+oswrch                  = &ffee
+osword                  = &fff1
+osbyte                  = &fff4
+oscli                   = &fff7
+
+    org &2000
+
+; Sideways ROM header
+; &2000 referenced 1 time by &04e2
+.pydis_start
+
+    org &8000
+; Sideways ROM header
+; &2000 referenced 1 time by &04e2
+.rom_header
+.language_entry
+l8001 = rom_header+1
+l8002 = rom_header+2
+    equb 0, 0, 0                                                      ; 2000: 00 00 00    ... :8000[1]
+; &2001 referenced 1 time by &04e7
+; &2002 referenced 1 time by &04ec
+
+; &2003 referenced 1 time by &04f1
+.service_entry
+l8004 = service_entry+1
+    jmp service_handler                                               ; 2003: 4c c8 be    L.. :8003[1]
+
+; &2004 referenced 1 time by &04f4
+; &2006 referenced 1 time by &04d6
+.rom_type
+    equb &82                                                          ; 2006: 82          .   :8006[1]
+; &2007 referenced 1 time by &04de
+.copyright_offset
+    equb copyright - rom_header                                       ; 2007: 11          .   :8007[1]
+.binary_version
+    equb &7b                                                          ; 2008: 7b          {   :8008[1]
+.title
+    equs "DFS"                                                        ; 2009: 44 46 53    DFS :8009[1]
+.version
+    equb 0                                                            ; 200c: 00          .   :800c[1]
+    equs "2.26"                                                       ; 200d: 32 2e 32... 2.2 :800d[1]
+.copyright
+    equb 0                                                            ; 2011: 00          .   :8011[1]
+    equs "(C)1985 Acorn", 0                                           ; 2012: 28 43 29... (C) :8012[1]
+
+; &2020 referenced 1 time by &9575
+.sub_c8020
+    jmp (fscv)                                                        ; 2020: 6c 1e 02    l.. :8020[1]
+
+; &2023 referenced 4 times by &8a6e, &94c6, &94d5, &9c00
+.generate_error_precheck_disc
+    jsr generate_error_precheck                                       ; 2023: 20 38 80     8. :8023[1]
+    equb 0                                                            ; 2026: 00          .   :8026[1]
+    equs "Disc "                                                      ; 2027: 44 69 73... Dis :8027[1]
+
+    bcc generate_error2                                               ; 202c: 90 21       .!  :802c[1]
+; &202e referenced 6 times by &8125, &889a, &89a5, &8a24, &8a3e, &8ba2
+.generate_error_precheck_bad
+    jsr generate_error_precheck                                       ; 202e: 20 38 80     8. :802e[1]
+    equb 0                                                            ; 2031: 00          .   :8031[1]
+    equs "Bad "                                                       ; 2032: 42 61 64... Bad :8032[1]
+
+    bcc generate_error2                                               ; 2036: 90 17       ..  :8036[1]
+; &2038 referenced 11 times by &8023, &802e, &8b18, &8bd8, &9a55, &9c70, &9c82, &9e80, &9e8c, &9f6e, &9fc8
+.generate_error_precheck
+    lda l10dd                                                         ; 2038: ad dd 10    ... :8038[1]
+    bne c8040                                                         ; 203b: d0 03       ..  :803b[1]
+    jsr sub_c9e30                                                     ; 203d: 20 30 9e     0. :803d[1]
+; &2040 referenced 1 time by &803b
+.c8040
+    lda #&ff                                                          ; 2040: a9 ff       ..  :8040[1]
+    sta l1082                                                         ; 2042: 8d 82 10    ... :8042[1]
+    sta l10dd                                                         ; 2045: 8d dd 10    ... :8045[1]
+; Generate an OS error using inline data. Called as either:
+;         jsr XXX:equb errnum, "error message", 0
+;     to actually generate an error now, or as:
+;         jsr XXX:equb errnum, "partial error message", instruction...
+;     to partially construct an error (on the stack) and continue
+; executing
+;     'instruction' afterwards; its opcode must have its top bit set.
+; Carry is
+;     always clear on exit.
+; &2048 referenced 4 times by &822a, &9439, &947c, &a14f
+.generate_error
+    ldx #2                                                            ; 2048: a2 02       ..  :8048[1]
+    lda #0                                                            ; 204a: a9 00       ..  :804a[1]
+    sta l0100                                                         ; 204c: 8d 00 01    ... :804c[1]
+; &204f referenced 7 times by &802c, &8036, &94da, &94e9, &94f7, &9507, &9511
+.generate_error2
+    sta l00b3                                                         ; 204f: 85 b3       ..  :804f[1]
+    pla                                                               ; 2051: 68          h   :8051[1]
+    sta l00ae                                                         ; 2052: 85 ae       ..  :8052[1]
+    pla                                                               ; 2054: 68          h   :8054[1]
+    sta l00af                                                         ; 2055: 85 af       ..  :8055[1]
+; XXX: Redundant lda l00b3? Is sta l00b3 above redundant too?
+    lda l00b3                                                         ; 2057: a5 b3       ..  :8057[1]
+    ldy #0                                                            ; 2059: a0 00       ..  :8059[1]
+    jsr inc16_ae                                                      ; 205b: 20 dc 83     .. :805b[1]
+    lda (l00ae),y                                                     ; 205e: b1 ae       ..  :805e[1]
+    sta l0101                                                         ; 2060: 8d 01 01    ... :8060[1]
+    dex                                                               ; 2063: ca          .   :8063[1]
+; &2064 referenced 1 time by &806f
+.loop_c8064
+    jsr inc16_ae                                                      ; 2064: 20 dc 83     .. :8064[1]
+    inx                                                               ; 2067: e8          .   :8067[1]
+    lda (l00ae),y                                                     ; 2068: b1 ae       ..  :8068[1]
+    sta l0100,x                                                       ; 206a: 9d 00 01    ... :806a[1]
+    bmi c8096                                                         ; 206d: 30 27       0'  :806d[1]
+    bne loop_c8064                                                    ; 206f: d0 f3       ..  :806f[1]
+    jsr sub_c8f75                                                     ; 2071: 20 75 8f     u. :8071[1]
+    jmp l0100                                                         ; 2074: 4c 00 01    L.. :8074[1]
+
+; Print (XXX: using l809f, which seems to be quite fancy) an inline
+; string
+;     terminated by a top-bit set instruction to execute after
+; printing the string.
+;     Carry is always clear on exit.
+; &2077 referenced 31 times by &84a5, &84b0, &84c8, &84dc, &84f1, &850d, &87ce, &9558, &a10c, &a247, &a298, &a34d, &a364, &a394, &a3a3, &a3ae, &a3bd, &a3e4, &a3ec, &a5f0, &a5fb, &a605, &a667, &a678, &a68a, &a699, &a70a, &a719, &aa5a, &aa65, &aebf
+.print_inline_l809f_top_bit_clear
+    sta l00b3                                                         ; 2077: 85 b3       ..  :8077[1]
+    pla                                                               ; 2079: 68          h   :8079[1]
+    sta l00ae                                                         ; 207a: 85 ae       ..  :807a[1]
+    pla                                                               ; 207c: 68          h   :807c[1]
+    sta l00af                                                         ; 207d: 85 af       ..  :807d[1]
+    lda l00b3                                                         ; 207f: a5 b3       ..  :807f[1]
+    pha                                                               ; 2081: 48          H   :8081[1]
+    tya                                                               ; 2082: 98          .   :8082[1]
+    pha                                                               ; 2083: 48          H   :8083[1]
+    ldy #0                                                            ; 2084: a0 00       ..  :8084[1]
+; &2086 referenced 1 time by &8090
+.loop_c8086
+    jsr inc16_ae                                                      ; 2086: 20 dc 83     .. :8086[1]
+    lda (l00ae),y                                                     ; 2089: b1 ae       ..  :8089[1]
+    bmi c8093                                                         ; 208b: 30 06       0.  :808b[1]
+    jsr c809f                                                         ; 208d: 20 9f 80     .. :808d[1]
+    jmp loop_c8086                                                    ; 2090: 4c 86 80    L.. :8090[1]
+
+; &2093 referenced 1 time by &808b
+.c8093
+    pla                                                               ; 2093: 68          h   :8093[1]
+    tay                                                               ; 2094: a8          .   :8094[1]
+    pla                                                               ; 2095: 68          h   :8095[1]
+; &2096 referenced 1 time by &806d
+.c8096
+    clc                                                               ; 2096: 18          .   :8096[1]
+    jmp (l00ae)                                                       ; 2097: 6c ae 00    l.. :8097[1]
+
+; &209a referenced 2 times by &84ff, &8519
+.sub_c809a
+    jsr sub_c80c3                                                     ; 209a: 20 c3 80     .. :809a[1]
+; &209d referenced 1 time by &8187
+.sub_c809d
+    lda #&2e ; '.'                                                    ; 209d: a9 2e       ..  :809d[1]
+; &209f referenced 20 times by &808d, &80c6, &8184, &8191, &81a2, &849d, &84ea, &8505, &851f, &a1c3, &a3df, &a40c, &a621, &a6bd, &a6c0, &aa6d, &aa7b, &aa87, &aa8c, &aabe
+.c809f
+    jsr sub_c83e3                                                     ; 209f: 20 e3 83     .. :809f[1]
+    pha                                                               ; 20a2: 48          H   :80a2[1]
+    lda #&ec                                                          ; 20a3: a9 ec       ..  :80a3[1]
+    jsr osbyte_read                                                   ; 20a5: 20 e5 9a     .. :80a5[1]
+    txa                                                               ; 20a8: 8a          .   :80a8[1]
+    pha                                                               ; 20a9: 48          H   :80a9[1]
+    ora #&10                                                          ; 20aa: 09 10       ..  :80aa[1]
+    jsr sub_c9ad3                                                     ; 20ac: 20 d3 9a     .. :80ac[1]
+    pla                                                               ; 20af: 68          h   :80af[1]
+    tax                                                               ; 20b0: aa          .   :80b0[1]
+    pla                                                               ; 20b1: 68          h   :80b1[1]
+    jsr osasci                                                        ; 20b2: 20 e3 ff     .. :80b2[1]
+    jmp c9ad4                                                         ; 20b5: 4c d4 9a    L.. :80b5[1]
+
+; &20b8 referenced 1 time by &aa62
+.sub_c80b8
+    jsr sub_c841b                                                     ; 20b8: 20 1b 84     .. :80b8[1]
+; &20bb referenced 5 times by &8368, &8373, &84ad, &a295, &a6c6
+.sub_c80bb
+    pha                                                               ; 20bb: 48          H   :80bb[1]
+    jsr sub_c81bf                                                     ; 20bc: 20 bf 81     .. :80bc[1]
+    jsr sub_c80c3                                                     ; 20bf: 20 c3 80     .. :80bf[1]
+    pla                                                               ; 20c2: 68          h   :80c2[1]
+; &20c3 referenced 10 times by &809a, &80bf, &8362, &84c0, &84d9, &a25c, &a291, &a361, &a36f, &a696
+.sub_c80c3
+    jsr sub_c80c8                                                     ; 20c3: 20 c8 80     .. :80c3[1]
+    bne c809f                                                         ; 20c6: d0 d7       ..  :80c6[1]
+; &20c8 referenced 4 times by &80c3, &952e, &a9ca, &ac6a
+.sub_c80c8
+    and #&0f                                                          ; 20c8: 29 0f       ).  :80c8[1]
+    cmp #&0a                                                          ; 20ca: c9 0a       ..  :80ca[1]
+    bcc c80d0                                                         ; 20cc: 90 02       ..  :80cc[1]
+    adc #6                                                            ; 20ce: 69 06       i.  :80ce[1]
+; &20d0 referenced 1 time by &80cc
+.c80d0
+    adc #&30 ; '0'                                                    ; 20d0: 69 30       i0  :80d0[1]
+    rts                                                               ; 20d2: 60          `   :80d2[1]
+
+; &20d3 referenced 1 time by &979d
+.sub_c80d3
+    jsr sub_c80e3                                                     ; 20d3: 20 e3 80     .. :80d3[1]
+    dex                                                               ; 20d6: ca          .   :80d6[1]
+    dex                                                               ; 20d7: ca          .   :80d7[1]
+    jsr sub_c80db                                                     ; 20d8: 20 db 80     .. :80d8[1]
+; &20db referenced 1 time by &80d8
+.sub_c80db
+    lda (l00b0),y                                                     ; 20db: b1 b0       ..  :80db[1]
+    sta l1072,x                                                       ; 20dd: 9d 72 10    .r. :80dd[1]
+    inx                                                               ; 20e0: e8          .   :80e0[1]
+    iny                                                               ; 20e1: c8          .   :80e1[1]
+    rts                                                               ; 20e2: 60          `   :80e2[1]
+
+; &20e3 referenced 2 times by &80d3, &979a
+.sub_c80e3
+    jsr sub_c80e6                                                     ; 20e3: 20 e6 80     .. :80e3[1]
+; &20e6 referenced 1 time by &80e3
+.sub_c80e6
+    lda (l00b0),y                                                     ; 20e6: b1 b0       ..  :80e6[1]
+    sta l00ba,x                                                       ; 20e8: 95 ba       ..  :80e8[1]
+    inx                                                               ; 20ea: e8          .   :80ea[1]
+    iny                                                               ; 20eb: c8          .   :80eb[1]
+    rts                                                               ; 20ec: 60          `   :80ec[1]
+
+; &20ed referenced 5 times by &821d, &89ec, &8bb2, &8bc7, &a46c
+.sub_c80ed
+    jsr sub_c8b7b                                                     ; 20ed: 20 7b 8b     {. :80ed[1]
+    jmp c8103                                                         ; 20f0: 4c 03 81    L.. :80f0[1]
+
+; &20f3 referenced 5 times by &8222, &8879, &8a77, &9a78, &9c22
+.sub_c80f3
+    jsr sub_c8b7b                                                     ; 20f3: 20 7b 8b     {. :80f3[1]
+; &20f6 referenced 1 time by &8892
+.sub_c80f6
+    lda l00ba                                                         ; 20f6: a5 ba       ..  :80f6[1]
+    sta os_text_ptr                                                   ; 20f8: 85 f2       ..  :80f8[1]
+    lda l00bb                                                         ; 20fa: a5 bb       ..  :80fa[1]
+    sta l00f3                                                         ; 20fc: 85 f3       ..  :80fc[1]
+    ldy #0                                                            ; 20fe: a0 00       ..  :80fe[1]
+    jsr clc_jmp_gsinit                                                ; 2100: 20 4c 87     L. :8100[1]
+; &2103 referenced 3 times by &80f0, &8113, &8123
+.c8103
+    ldx #&20 ; ' '                                                    ; 2103: a2 20       .   :8103[1]
+    jsr sub_c8149                                                     ; 2105: 20 49 81     I. :8105[1]
+    bcs c8125                                                         ; 2108: b0 1b       ..  :8108[1]
+    sta l1000                                                         ; 210a: 8d 00 10    ... :810a[1]
+    cmp #&2e ; '.'                                                    ; 210d: c9 2e       ..  :810d[1]
+    bne c8115                                                         ; 210f: d0 04       ..  :810f[1]
+; &2111 referenced 1 time by &8136
+.c8111
+    stx l00cc                                                         ; 2111: 86 cc       ..  :8111[1]
+    beq c8103                                                         ; 2113: f0 ee       ..  :8113[1]
+; &2115 referenced 1 time by &810f
+.c8115
+    cmp #&3a ; ':'                                                    ; 2115: c9 3a       .:  :8115[1]
+    bne c812e                                                         ; 2117: d0 15       ..  :8117[1]
+    jsr c8b8b                                                         ; 2119: 20 8b 8b     .. :8119[1]
+    jsr sub_c8149                                                     ; 211c: 20 49 81     I. :811c[1]
+    bcs c8125                                                         ; 211f: b0 04       ..  :811f[1]
+    cmp #&2e ; '.'                                                    ; 2121: c9 2e       ..  :8121[1]
+    beq c8103                                                         ; 2123: f0 de       ..  :8123[1]
+; &2125 referenced 5 times by &8108, &811f, &8147, &8155, &8159
+.c8125
+    jsr generate_error_precheck_bad                                   ; 2125: 20 2e 80     .. :8125[1]
+    equb &cc                                                          ; 2128: cc          .   :8128[1]
+    equs "name"                                                       ; 2129: 6e 61 6d... nam :8129[1]
+    equb 0                                                            ; 212d: 00          .   :812d[1]
+
+; &212e referenced 1 time by &8117
+.c812e
+    tax                                                               ; 212e: aa          .   :812e[1]
+    jsr sub_c8149                                                     ; 212f: 20 49 81     I. :812f[1]
+    bcs c815d                                                         ; 2132: b0 29       .)  :8132[1]
+    cmp #&2e ; '.'                                                    ; 2134: c9 2e       ..  :8134[1]
+    beq c8111                                                         ; 2136: f0 d9       ..  :8136[1]
+    ldx #1                                                            ; 2138: a2 01       ..  :8138[1]
+; &213a referenced 1 time by &8145
+.loop_c813a
+    sta l1000,x                                                       ; 213a: 9d 00 10    ... :813a[1]
+    inx                                                               ; 213d: e8          .   :813d[1]
+    jsr sub_c8149                                                     ; 213e: 20 49 81     I. :813e[1]
+    bcs c815f                                                         ; 2141: b0 1c       ..  :8141[1]
+    cpx #7                                                            ; 2143: e0 07       ..  :8143[1]
+    bne loop_c813a                                                    ; 2145: d0 f3       ..  :8145[1]
+    beq c8125                                                         ; 2147: f0 dc       ..  :8147[1]
+; &2149 referenced 11 times by &8105, &811c, &812f, &813e, &8990, &899c, &89af, &89cb, &8a19, &8b8b, &a143
+.sub_c8149
+    jsr gsread                                                        ; 2149: 20 c5 ff     .. :8149[1]
+    php                                                               ; 214c: 08          .   :814c[1]
+    and #&7f                                                          ; 214d: 29 7f       ).  :814d[1]
+    cmp #&0d                                                          ; 214f: c9 0d       ..  :814f[1]
+    beq c815b                                                         ; 2151: f0 08       ..  :8151[1]
+    cmp #&20 ; ' '                                                    ; 2153: c9 20       .   :8153[1]
+    bcc c8125                                                         ; 2155: 90 ce       ..  :8155[1]
+    cmp #&7f                                                          ; 2157: c9 7f       ..  :8157[1]
+    beq c8125                                                         ; 2159: f0 ca       ..  :8159[1]
+; &215b referenced 1 time by &8151
+.c815b
+    plp                                                               ; 215b: 28          (   :815b[1]
+    rts                                                               ; 215c: 60          `   :815c[1]
+
+; &215d referenced 2 times by &8132, &8248
+.c815d
+    ldx #1                                                            ; 215d: a2 01       ..  :815d[1]
+; &215f referenced 1 time by &8141
+.c815f
+    lda #&20 ; ' '                                                    ; 215f: a9 20       .   :815f[1]
+; &2161 referenced 1 time by &8167
+.loop_c8161
+    sta l1000,x                                                       ; 2161: 9d 00 10    ... :8161[1]
+    inx                                                               ; 2164: e8          .   :8164[1]
+    cpx #&40 ; '@'                                                    ; 2165: e0 40       .@  :8165[1]
+    bne loop_c8161                                                    ; 2167: d0 f8       ..  :8167[1]
+    ldx #6                                                            ; 2169: a2 06       ..  :8169[1]
+; &216b referenced 1 time by &8171
+.loop_c816b
+    lda l1000,x                                                       ; 216b: bd 00 10    ... :816b[1]
+    sta l00c5,x                                                       ; 216e: 95 c5       ..  :816e[1]
+    dex                                                               ; 2170: ca          .   :8170[1]
+    bpl loop_c816b                                                    ; 2171: 10 f8       ..  :8171[1]
+    rts                                                               ; 2173: 60          `   :8173[1]
+
+; &2174 referenced 4 times by &833d, &85cd, &875e, &87a5
+.sub_c8174
+    jsr sub_c83e3                                                     ; 2174: 20 e3 83     .. :8174[1]
+    lda l0e0f,y                                                       ; 2177: b9 0f 0e    ... :8177[1]
+    php                                                               ; 217a: 08          .   :817a[1]
+    and #&7f                                                          ; 217b: 29 7f       ).  :817b[1]
+    bne c8184                                                         ; 217d: d0 05       ..  :817d[1]
+    jsr sub_cac0c                                                     ; 217f: 20 0c ac     .. :817f[1]
+    beq c818a                                                         ; 2182: f0 06       ..  :8182[1]
+; &2184 referenced 1 time by &817d
+.c8184
+    jsr c809f                                                         ; 2184: 20 9f 80     .. :8184[1]
+    jsr sub_c809d                                                     ; 2187: 20 9d 80     .. :8187[1]
+; &218a referenced 1 time by &8182
+.c818a
+    ldx #6                                                            ; 218a: a2 06       ..  :818a[1]
+; &218c referenced 1 time by &8196
+.loop_c818c
+    lda l0e08,y                                                       ; 218c: b9 08 0e    ... :818c[1]
+    and #&7f                                                          ; 218f: 29 7f       ).  :818f[1]
+    jsr c809f                                                         ; 2191: 20 9f 80     .. :8191[1]
+    iny                                                               ; 2194: c8          .   :8194[1]
+    dex                                                               ; 2195: ca          .   :8195[1]
+    bpl loop_c818c                                                    ; 2196: 10 f4       ..  :8196[1]
+    jsr sub_cac0c                                                     ; 2198: 20 0c ac     .. :8198[1]
+    lda #&20 ; ' '                                                    ; 219b: a9 20       .   :819b[1]
+    plp                                                               ; 219d: 28          (   :819d[1]
+    bpl c81a2                                                         ; 219e: 10 02       ..  :819e[1]
+    lda #&4c ; 'L'                                                    ; 21a0: a9 4c       .L  :81a0[1]
+; &21a2 referenced 1 time by &819e
+.c81a2
+    jsr c809f                                                         ; 21a2: 20 9f 80     .. :81a2[1]
+    ldy #1                                                            ; 21a5: a0 01       ..  :81a5[1]
+; &21a7 referenced 4 times by &81ab, &84c5, &850a, &85c2
+.c81a7
+    jsr cac0f                                                         ; 21a7: 20 0f ac     .. :81a7[1]
+    dey                                                               ; 21aa: 88          .   :81aa[1]
+    bne c81a7                                                         ; 21ab: d0 fa       ..  :81ab[1]
+    rts                                                               ; 21ad: 60          `   :81ad[1]
+
+; &21ae referenced 2 times by &88a9, &8b6b
+.sub_c81ae
+    lsr a                                                             ; 21ae: 4a          J   :81ae[1]
+    lsr a                                                             ; 21af: 4a          J   :81af[1]
+; &21b0 referenced 8 times by &81f5, &85e6, &9cdb, &9cfd, &a2c6, &a49f, &a505, &a8e6
+.sub_c81b0
+    lsr a                                                             ; 21b0: 4a          J   :81b0[1]
+    lsr a                                                             ; 21b1: 4a          J   :81b1[1]
+    lsr a                                                             ; 21b2: 4a          J   :81b2[1]
+    lsr a                                                             ; 21b3: 4a          J   :81b3[1]
+    and #3                                                            ; 21b4: 29 03       ).  :81b4[1]
+    rts                                                               ; 21b6: 60          `   :81b6[1]
+
+; &21b7 referenced 1 time by &8b54
+.sub_c81b7
+    and #8                                                            ; 21b7: 29 08       ).  :81b7[1]
+    beq c81bd                                                         ; 21b9: f0 02       ..  :81b9[1]
+    lda #3                                                            ; 21bb: a9 03       ..  :81bb[1]
+; &21bd referenced 1 time by &81b9
+.c81bd
+    rts                                                               ; 21bd: 60          `   :81bd[1]
+
+; &21be referenced 3 times by &9cb3, &9d0c, &9e00
+.sub_c81be
+    lsr a                                                             ; 21be: 4a          J   :81be[1]
+; &21bf referenced 8 times by &80bc, &84d5, &9527, &9644, &98fb, &a18d, &a9c3, &ac63
+.sub_c81bf
+    lsr a                                                             ; 21bf: 4a          J   :81bf[1]
+; &21c0 referenced 1 time by &a90d
+.sub_c81c0
+    lsr a                                                             ; 21c0: 4a          J   :81c0[1]
+    lsr a                                                             ; 21c1: 4a          J   :81c1[1]
+    lsr a                                                             ; 21c2: 4a          J   :81c2[1]
+    rts                                                               ; 21c3: 60          `   :81c3[1]
+
+; &21c4 referenced 1 time by &9e2a
+.sub_c81c4
+    asl a                                                             ; 21c4: 0a          .   :81c4[1]
+; &21c5 referenced 2 times by &8a5d, &9bae
+.sub_c81c5
+    asl a                                                             ; 21c5: 0a          .   :81c5[1]
+    asl a                                                             ; 21c6: 0a          .   :81c6[1]
+    asl a                                                             ; 21c7: 0a          .   :81c7[1]
+    asl a                                                             ; 21c8: 0a          .   :81c8[1]
+    rts                                                               ; 21c9: 60          `   :81c9[1]
+
+; &21ca referenced 1 time by &8867
+.sub_c81ca
+    lda #5                                                            ; 21ca: a9 05       ..  :81ca[1]
+    sta l1095                                                         ; 21cc: 8d 95 10    ... :81cc[1]
+    lda l00cd                                                         ; 21cf: a5 cd       ..  :81cf[1]
+    sta l1090                                                         ; 21d1: 8d 90 10    ... :81d1[1]
+    lda #&0a                                                          ; 21d4: a9 0a       ..  :81d4[1]
+    sta l00b0                                                         ; 21d6: 85 b0       ..  :81d6[1]
+    lda l00bc                                                         ; 21d8: a5 bc       ..  :81d8[1]
+    sta l1091                                                         ; 21da: 8d 91 10    ... :81da[1]
+    lda l00bd                                                         ; 21dd: a5 bd       ..  :81dd[1]
+    sta l1092                                                         ; 21df: 8d 92 10    ... :81df[1]
+    lda l1074                                                         ; 21e2: ad 74 10    .t. :81e2[1]
+    sta l1093                                                         ; 21e5: 8d 93 10    ... :81e5[1]
+    lda l1075                                                         ; 21e8: ad 75 10    .u. :81e8[1]
+    sta l1094                                                         ; 21eb: 8d 94 10    ... :81eb[1]
+    lda #&ff                                                          ; 21ee: a9 ff       ..  :81ee[1]
+    sta l1097                                                         ; 21f0: 8d 97 10    ... :81f0[1]
+    lda l00c2                                                         ; 21f3: a5 c2       ..  :81f3[1]
+    jsr sub_c81b0                                                     ; 21f5: 20 b0 81     .. :81f5[1]
+    sta l109a                                                         ; 21f8: 8d 9a 10    ... :81f8[1]
+    lda l00c0                                                         ; 21fb: a5 c0       ..  :81fb[1]
+    sta l109b                                                         ; 21fd: 8d 9b 10    ... :81fd[1]
+    lda l00c1                                                         ; 2200: a5 c1       ..  :8200[1]
+    sta l1099                                                         ; 2202: 8d 99 10    ... :8202[1]
+    lda l00c2                                                         ; 2205: a5 c2       ..  :8205[1]
+    and #3                                                            ; 2207: 29 03       ).  :8207[1]
+    tax                                                               ; 2209: aa          .   :8209[1]
+    lda l00c3                                                         ; 220a: a5 c3       ..  :820a[1]
+; &220c referenced 1 time by &8215
+.loop_c820c
+    sec                                                               ; 220c: 38          8   :820c[1]
+; &220d referenced 1 time by &8212
+.loop_c820d
+    inc l1097                                                         ; 220d: ee 97 10    ... :820d[1]
+    sbc l00b0                                                         ; 2210: e5 b0       ..  :8210[1]
+    bcs loop_c820d                                                    ; 2212: b0 f9       ..  :8212[1]
+    dex                                                               ; 2214: ca          .   :8214[1]
+    bpl loop_c820c                                                    ; 2215: 10 f5       ..  :8215[1]
+    adc l00b0                                                         ; 2217: 65 b0       e.  :8217[1]
+    sta l1098                                                         ; 2219: 8d 98 10    ... :8219[1]
+; &221c referenced 1 time by &8228
+.loop_c821c
+    rts                                                               ; 221c: 60          `   :821c[1]
+
+; &221d referenced 4 times by &825a, &8756, &8788, &879d
+.sub_c821d
+    jsr sub_c80ed                                                     ; 221d: 20 ed 80     .. :821d[1]
+    bmi c8225                                                         ; 2220: 30 03       0.  :8220[1]
+; &2222 referenced 1 time by &881b
+.sub_c8222
+    jsr sub_c80f3                                                     ; 2222: 20 f3 80     .. :8222[1]
+; &2225 referenced 4 times by &8220, &824e, &8bb7, &a478
+.c8225
+    jsr sub_c8284                                                     ; 2225: 20 84 82     .. :8225[1]
+    bcs loop_c821c                                                    ; 2228: b0 f2       ..  :8228[1]
+; &222a referenced 2 times by &89fd, &ab17
+.c822a
+    jsr generate_error                                                ; 222a: 20 48 80     H. :822a[1]
+    equb &d6                                                          ; 222d: d6          .   :822d[1]
+    equs "Not found"                                                  ; 222e: 4e 6f 74... Not :822e[1]
+    equb 0                                                            ; 2237: 00          .   :8237[1]
+
+.sub_c8238
+    jsr sub_c8b7b                                                     ; 2238: 20 7b 8b     {. :8238[1]
+    jsr clc_jmp_gsinit                                                ; 223b: 20 4c 87     L. :823b[1]
+    beq c8243                                                         ; 223e: f0 03       ..  :823e[1]
+    jsr c898a                                                         ; 2240: 20 8a 89     .. :8240[1]
+; &2243 referenced 1 time by &823e
+.c8243
+    lda #&2a ; '*'                                                    ; 2243: a9 2a       .*  :8243[1]
+    sta l1000                                                         ; 2245: 8d 00 10    ... :8245[1]
+    jsr c815d                                                         ; 2248: 20 5d 81     ]. :8248[1]
+    jsr sub_c99ac                                                     ; 224b: 20 ac 99     .. :824b[1]
+    jsr c8225                                                         ; 224e: 20 25 82     %. :824e[1]
+    jmp c825d                                                         ; 2251: 4c 5d 82    L]. :8251[1]
+
+.sub_c8254
+    jsr sub_c99ac                                                     ; 2254: 20 ac 99     .. :8254[1]
+    jsr sub_ca14a                                                     ; 2257: 20 4a a1     J. :8257[1]
+    jsr sub_c821d                                                     ; 225a: 20 1d 82     .. :825a[1]
+; &225d referenced 2 times by &8251, &8263
+.c825d
+    jsr sub_c833a                                                     ; 225d: 20 3a 83     :. :825d[1]
+    jsr sub_c8280                                                     ; 2260: 20 80 82     .. :8260[1]
+    bcs c825d                                                         ; 2263: b0 f8       ..  :8263[1]
+    rts                                                               ; 2265: 60          `   :8265[1]
+
+; &2266 referenced 2 times by &887f, &8895
+.sub_c8266
+    jsr sub_c93f9                                                     ; 2266: 20 f9 93     .. :8266[1]
+    lda #0                                                            ; 2269: a9 00       ..  :8269[1]
+    beq c828b                                                         ; 226b: f0 1e       ..  :826b[1]
+; &226d referenced 2 times by &9bd9, &a4f2
+.sub_c826d
+    ldx #6                                                            ; 226d: a2 06       ..  :826d[1]
+; &226f referenced 1 time by &8275
+.loop_c826f
+    lda l00c5,x                                                       ; 226f: b5 c5       ..  :826f[1]
+    sta l1058,x                                                       ; 2271: 9d 58 10    .X. :8271[1]
+    dex                                                               ; 2274: ca          .   :8274[1]
+    bpl loop_c826f                                                    ; 2275: 10 f8       ..  :8275[1]
+    lda #&20 ; ' '                                                    ; 2277: a9 20       .   :8277[1]
+    sta l105f                                                         ; 2279: 8d 5f 10    ._. :8279[1]
+    lda #&58 ; 'X'                                                    ; 227c: a9 58       .X  :827c[1]
+    bne c8286                                                         ; 227e: d0 06       ..  :827e[1]
+; &2280 referenced 6 times by &8260, &877c, &87ab, &87c6, &8a10, &a4db
+.sub_c8280
+    ldx #0                                                            ; 2280: a2 00       ..  :8280[1]
+    beq c8290                                                         ; 2282: f0 0c       ..  :8282[1]
+; &2284 referenced 7 times by &8225, &87bb, &89f8, &8a7a, &8bcf, &9a7b, &9c28
+.sub_c8284
+    lda #0                                                            ; 2284: a9 00       ..  :8284[1]
+; &2286 referenced 1 time by &827e
+.c8286
+    pha                                                               ; 2286: 48          H   :8286[1]
+    jsr sub_c93fd                                                     ; 2287: 20 fd 93     .. :8287[1]
+    pla                                                               ; 228a: 68          h   :828a[1]
+; &228b referenced 1 time by &826b
+.c828b
+    tax                                                               ; 228b: aa          .   :828b[1]
+    lda #0                                                            ; 228c: a9 00       ..  :828c[1]
+    sta l00b6                                                         ; 228e: 85 b6       ..  :828e[1]
+; &2290 referenced 3 times by &8282, &82a4, &82ad
+.c8290
+    ldy #0                                                            ; 2290: a0 00       ..  :8290[1]
+    lda #&0e                                                          ; 2292: a9 0e       ..  :8292[1]
+    sta l00b7                                                         ; 2294: 85 b7       ..  :8294[1]
+    lda l00b6                                                         ; 2296: a5 b6       ..  :8296[1]
+    cmp l0f05                                                         ; 2298: cd 05 0f    ... :8298[1]
+    bcs c82e6                                                         ; 229b: b0 49       .I  :829b[1]
+    adc #8                                                            ; 229d: 69 08       i.  :829d[1]
+    sta l00b6                                                         ; 229f: 85 b6       ..  :829f[1]
+    jsr sub_c82bb                                                     ; 22a1: 20 bb 82     .. :82a1[1]
+    bcc c8290                                                         ; 22a4: 90 ea       ..  :82a4[1]
+    lda l00cc                                                         ; 22a6: a5 cc       ..  :82a6[1]
+    ldy #7                                                            ; 22a8: a0 07       ..  :82a8[1]
+    jsr sub_c82e8                                                     ; 22aa: 20 e8 82     .. :82aa[1]
+    bne c8290                                                         ; 22ad: d0 e1       ..  :82ad[1]
+    ldy l00b6                                                         ; 22af: a4 b6       ..  :82af[1]
+    sec                                                               ; 22b1: 38          8   :82b1[1]
+; &22b2 referenced 4 times by &87e8, &8aca, &a27c, &a848
+.sub_c82b2
+    dey                                                               ; 22b2: 88          .   :82b2[1]
+    dey                                                               ; 22b3: 88          .   :82b3[1]
+    dey                                                               ; 22b4: 88          .   :82b4[1]
+    dey                                                               ; 22b5: 88          .   :82b5[1]
+    dey                                                               ; 22b6: 88          .   :82b6[1]
+    dey                                                               ; 22b7: 88          .   :82b7[1]
+    dey                                                               ; 22b8: 88          .   :82b8[1]
+    dey                                                               ; 22b9: 88          .   :82b9[1]
+    rts                                                               ; 22ba: 60          `   :82ba[1]
+
+; &22bb referenced 2 times by &82a1, &82c7
+.sub_c82bb
+    jsr sub_c83e3                                                     ; 22bb: 20 e3 83     .. :82bb[1]
+; &22be referenced 1 time by &82e4
+.c82be
+    lda l1000,x                                                       ; 22be: bd 00 10    ... :82be[1]
+    cmp l10ce                                                         ; 22c1: cd ce 10    ... :82c1[1]
+    bne c82d9                                                         ; 22c4: d0 13       ..  :82c4[1]
+    inx                                                               ; 22c6: e8          .   :82c6[1]
+; &22c7 referenced 1 time by &82cf
+.loop_c82c7
+    jsr sub_c82bb                                                     ; 22c7: 20 bb 82     .. :82c7[1]
+    bcs c82e7                                                         ; 22ca: b0 1b       ..  :82ca[1]
+    iny                                                               ; 22cc: c8          .   :82cc[1]
+    cpy #7                                                            ; 22cd: c0 07       ..  :82cd[1]
+    bcc loop_c82c7                                                    ; 22cf: 90 f6       ..  :82cf[1]
+; &22d1 referenced 1 time by &82db
+.loop_c82d1
+    lda l1000,x                                                       ; 22d1: bd 00 10    ... :82d1[1]
+    cmp #&20 ; ' '                                                    ; 22d4: c9 20       .   :82d4[1]
+    bne c82e6                                                         ; 22d6: d0 0e       ..  :82d6[1]
+    rts                                                               ; 22d8: 60          `   :82d8[1]
+
+; &22d9 referenced 1 time by &82c4
+.c82d9
+    cpy #7                                                            ; 22d9: c0 07       ..  :82d9[1]
+    bcs loop_c82d1                                                    ; 22db: b0 f4       ..  :82db[1]
+    jsr sub_c82e8                                                     ; 22dd: 20 e8 82     .. :82dd[1]
+    bne c82e6                                                         ; 22e0: d0 04       ..  :82e0[1]
+    inx                                                               ; 22e2: e8          .   :82e2[1]
+    iny                                                               ; 22e3: c8          .   :82e3[1]
+    bne c82be                                                         ; 22e4: d0 d8       ..  :82e4[1]
+; &22e6 referenced 3 times by &829b, &82d6, &82e0
+.c82e6
+    clc                                                               ; 22e6: 18          .   :82e6[1]
+; &22e7 referenced 1 time by &82ca
+.c82e7
+    rts                                                               ; 22e7: 60          `   :82e7[1]
+
+; &22e8 referenced 2 times by &82aa, &82dd
+.sub_c82e8
+    cmp l10ce                                                         ; 22e8: cd ce 10    ... :82e8[1]
+    beq c82fd                                                         ; 22eb: f0 10       ..  :82eb[1]
+    cmp l10cd                                                         ; 22ed: cd cd 10    ... :82ed[1]
+    beq c82fd                                                         ; 22f0: f0 0b       ..  :82f0[1]
+    jsr sub_c8327                                                     ; 22f2: 20 27 83     '. :82f2[1]
+    eor (l00b6),y                                                     ; 22f5: 51 b6       Q.  :82f5[1]
+    bcs c82fb                                                         ; 22f7: b0 02       ..  :82f7[1]
+    and #&5f ; '_'                                                    ; 22f9: 29 5f       )_  :82f9[1]
+; &22fb referenced 1 time by &82f7
+.c82fb
+    and #&7f                                                          ; 22fb: 29 7f       ).  :82fb[1]
+; &22fd referenced 2 times by &82eb, &82f0
+.c82fd
+    rts                                                               ; 22fd: 60          `   :82fd[1]
+
+; &22fe referenced 6 times by &8441, &8567, &857e, &858e, &aa2b, &aa3b
+.sub_c82fe
+    php                                                               ; 22fe: 08          .   :82fe[1]
+    jsr sub_c8327                                                     ; 22ff: 20 27 83     '. :82ff[1]
+    bcs c8306                                                         ; 2302: b0 02       ..  :8302[1]
+    and #&5f ; '_'                                                    ; 2304: 29 5f       )_  :8304[1]
+; &2306 referenced 1 time by &8302
+.c8306
+    and #&7f                                                          ; 2306: 29 7f       ).  :8306[1]
+    plp                                                               ; 2308: 28          (   :8308[1]
+    rts                                                               ; 2309: 60          `   :8309[1]
+
+; &230a referenced 5 times by &878e, &87e3, &8a7f, &99c4, &a4f7
+.sub_c830a
+    jsr sub_c9a60                                                     ; 230a: 20 60 9a     `. :830a[1]
+; &230d referenced 1 time by &831d
+.loop_c830d
+    lda l0e10,y                                                       ; 230d: b9 10 0e    ... :830d[1]
+    sta l0e08,y                                                       ; 2310: 99 08 0e    ... :8310[1]
+    lda l0f10,y                                                       ; 2313: b9 10 0f    ... :8313[1]
+    sta l0f08,y                                                       ; 2316: 99 08 0f    ... :8316[1]
+    iny                                                               ; 2319: c8          .   :8319[1]
+    cpy l0f05                                                         ; 231a: cc 05 0f    ... :831a[1]
+    bcc loop_c830d                                                    ; 231d: 90 ee       ..  :831d[1]
+    tya                                                               ; 231f: 98          .   :831f[1]
+    sbc #8                                                            ; 2320: e9 08       ..  :8320[1]
+    sta l0f05                                                         ; 2322: 8d 05 0f    ... :8322[1]
+    clc                                                               ; 2325: 18          .   :8325[1]
+; &2326 referenced 1 time by &8338
+.loop_c8326
+    rts                                                               ; 2326: 60          `   :8326[1]
+
+; &2327 referenced 4 times by &82f2, &82ff, &8736, &98a8
+.sub_c8327
+    pha                                                               ; 2327: 48          H   :8327[1]
+    and #&5f ; '_'                                                    ; 2328: 29 5f       )_  :8328[1]
+    cmp #&41 ; 'A'                                                    ; 232a: c9 41       .A  :832a[1]
+    bcc c8332                                                         ; 232c: 90 04       ..  :832c[1]
+    cmp #&5b ; '['                                                    ; 232e: c9 5b       .[  :832e[1]
+    bcc c8333                                                         ; 2330: 90 01       ..  :8330[1]
+; &2332 referenced 1 time by &832c
+.c8332
+    sec                                                               ; 2332: 38          8   :8332[1]
+; &2333 referenced 1 time by &8330
+.c8333
+    pla                                                               ; 2333: 68          h   :8333[1]
+    rts                                                               ; 2334: 60          `   :8334[1]
+
+; &2335 referenced 5 times by &878b, &884f, &8a0d, &8b04, &a2ad
+.sub_c8335
+    bit l10c6                                                         ; 2335: 2c c6 10    ,.. :8335[1]
+    bmi loop_c8326                                                    ; 2338: 30 ec       0.  :8338[1]
+; &233a referenced 3 times by &825d, &a30f, &a482
+.sub_c833a
+    jsr sub_c83e3                                                     ; 233a: 20 e3 83     .. :833a[1]
+    jsr sub_c8174                                                     ; 233d: 20 74 81     t. :833d[1]
+    tya                                                               ; 2340: 98          .   :8340[1]
+    pha                                                               ; 2341: 48          H   :8341[1]
+    lda #&60 ; '`'                                                    ; 2342: a9 60       .`  :8342[1]
+    sta l00b0                                                         ; 2344: 85 b0       ..  :8344[1]
+    lda #&10                                                          ; 2346: a9 10       ..  :8346[1]
+    sta l00b1                                                         ; 2348: 85 b1       ..  :8348[1]
+    jsr sub_c8386                                                     ; 234a: 20 86 83     .. :834a[1]
+    ldy #2                                                            ; 234d: a0 02       ..  :834d[1]
+    jsr cac0f                                                         ; 234f: 20 0f ac     .. :834f[1]
+    jsr sub_c836e                                                     ; 2352: 20 6e 83     n. :8352[1]
+    jsr sub_c836e                                                     ; 2355: 20 6e 83     n. :8355[1]
+    jsr sub_c836e                                                     ; 2358: 20 6e 83     n. :8358[1]
+    pla                                                               ; 235b: 68          h   :835b[1]
+    tay                                                               ; 235c: a8          .   :835c[1]
+    lda l0f0e,y                                                       ; 235d: b9 0e 0f    ... :835d[1]
+    and #3                                                            ; 2360: 29 03       ).  :8360[1]
+    jsr sub_c80c3                                                     ; 2362: 20 c3 80     .. :8362[1]
+    lda l0f0f,y                                                       ; 2365: b9 0f 0f    ... :8365[1]
+    jsr sub_c80bb                                                     ; 2368: 20 bb 80     .. :8368[1]
+    jmp ca3dc                                                         ; 236b: 4c dc a3    L.. :836b[1]
+
+; &236e referenced 3 times by &8352, &8355, &8358
+.sub_c836e
+    ldx #3                                                            ; 236e: a2 03       ..  :836e[1]
+; &2370 referenced 1 time by &8378
+.loop_c8370
+    lda l1062,y                                                       ; 2370: b9 62 10    .b. :8370[1]
+    jsr sub_c80bb                                                     ; 2373: 20 bb 80     .. :8373[1]
+    dey                                                               ; 2376: 88          .   :8376[1]
+    dex                                                               ; 2377: ca          .   :8377[1]
+    bne loop_c8370                                                    ; 2378: d0 f6       ..  :8378[1]
+    jsr sub_c87db                                                     ; 237a: 20 db 87     .. :837a[1]
+    jmp cac0f                                                         ; 237d: 4c 0f ac    L.. :837d[1]
+
+; &2380 referenced 7 times by &89bd, &975e, &9bf8, &a26a, &a4d1, &a4ef, &a7fc
+.sub_c8380
+    jsr sub_c83e3                                                     ; 2380: 20 e3 83     .. :8380[1]
+    jmp c940c                                                         ; 2383: 4c 0c 94    L.. :8383[1]
+
+; &2386 referenced 5 times by &834a, &8821, &885f, &99b8, &99c1
+.sub_c8386
+    jsr sub_c83e3                                                     ; 2386: 20 e3 83     .. :8386[1]
+    tya                                                               ; 2389: 98          .   :8389[1]
+    pha                                                               ; 238a: 48          H   :838a[1]
+    tax                                                               ; 238b: aa          .   :838b[1]
+    ldy #&12                                                          ; 238c: a0 12       ..  :838c[1]
+    lda #0                                                            ; 238e: a9 00       ..  :838e[1]
+; &2390 referenced 1 time by &8395
+.loop_c8390
+    dey                                                               ; 2390: 88          .   :8390[1]
+    sta (l00b0),y                                                     ; 2391: 91 b0       ..  :8391[1]
+    cpy #2                                                            ; 2393: c0 02       ..  :8393[1]
+    bne loop_c8390                                                    ; 2395: d0 f9       ..  :8395[1]
+; &2397 referenced 1 time by &839e
+.loop_c8397
+    jsr sub_c83d1                                                     ; 2397: 20 d1 83     .. :8397[1]
+    iny                                                               ; 239a: c8          .   :839a[1]
+    iny                                                               ; 239b: c8          .   :839b[1]
+    cpy #&0e                                                          ; 239c: c0 0e       ..  :839c[1]
+    bne loop_c8397                                                    ; 239e: d0 f7       ..  :839e[1]
+    pla                                                               ; 23a0: 68          h   :83a0[1]
+    tax                                                               ; 23a1: aa          .   :83a1[1]
+    lda l0e0f,x                                                       ; 23a2: bd 0f 0e    ... :83a2[1]
+    bpl c83ab                                                         ; 23a5: 10 04       ..  :83a5[1]
+    lda #8                                                            ; 23a7: a9 08       ..  :83a7[1]
+    sta (l00b0),y                                                     ; 23a9: 91 b0       ..  :83a9[1]
+; &23ab referenced 1 time by &83a5
+.c83ab
+    lda l0f0e,x                                                       ; 23ab: bd 0e 0f    ... :83ab[1]
+    ldy #4                                                            ; 23ae: a0 04       ..  :83ae[1]
+    jsr sub_c83bf                                                     ; 23b0: 20 bf 83     .. :83b0[1]
+    ldy #&0c                                                          ; 23b3: a0 0c       ..  :83b3[1]
+    lsr a                                                             ; 23b5: 4a          J   :83b5[1]
+    lsr a                                                             ; 23b6: 4a          J   :83b6[1]
+    pha                                                               ; 23b7: 48          H   :83b7[1]
+    and #3                                                            ; 23b8: 29 03       ).  :83b8[1]
+    sta (l00b0),y                                                     ; 23ba: 91 b0       ..  :83ba[1]
+    pla                                                               ; 23bc: 68          h   :83bc[1]
+    ldy #8                                                            ; 23bd: a0 08       ..  :83bd[1]
+; &23bf referenced 1 time by &83b0
+.sub_c83bf
+    lsr a                                                             ; 23bf: 4a          J   :83bf[1]
+    lsr a                                                             ; 23c0: 4a          J   :83c0[1]
+    pha                                                               ; 23c1: 48          H   :83c1[1]
+    and #3                                                            ; 23c2: 29 03       ).  :83c2[1]
+    cmp #3                                                            ; 23c4: c9 03       ..  :83c4[1]
+    bne c83cd                                                         ; 23c6: d0 05       ..  :83c6[1]
+    lda #&ff                                                          ; 23c8: a9 ff       ..  :83c8[1]
+    sta (l00b0),y                                                     ; 23ca: 91 b0       ..  :83ca[1]
+    iny                                                               ; 23cc: c8          .   :83cc[1]
+; &23cd referenced 1 time by &83c6
+.c83cd
+    sta (l00b0),y                                                     ; 23cd: 91 b0       ..  :83cd[1]
+    pla                                                               ; 23cf: 68          h   :83cf[1]
+    rts                                                               ; 23d0: 60          `   :83d0[1]
+
+; &23d1 referenced 1 time by &8397
+.sub_c83d1
+    jsr sub_c83d4                                                     ; 23d1: 20 d4 83     .. :83d1[1]
+; &23d4 referenced 1 time by &83d1
+.sub_c83d4
+    lda l0f08,x                                                       ; 23d4: bd 08 0f    ... :83d4[1]
+    sta (l00b0),y                                                     ; 23d7: 91 b0       ..  :83d7[1]
+    inx                                                               ; 23d9: e8          .   :83d9[1]
+    iny                                                               ; 23da: c8          .   :83da[1]
+    rts                                                               ; 23db: 60          `   :83db[1]
+
+; &23dc referenced 4 times by &805b, &8064, &8086, &a9ab
+.inc16_ae
+    inc l00ae                                                         ; 23dc: e6 ae       ..  :83dc[1]
+    bne c83e2                                                         ; 23de: d0 02       ..  :83de[1]
+    inc l00af                                                         ; 23e0: e6 af       ..  :83e0[1]
+; &23e2 referenced 1 time by &83de
+.c83e2
+    rts                                                               ; 23e2: 60          `   :83e2[1]
+
+; &23e3 referenced 29 times by &809f, &8174, &82bb, &833a, &8380, &8386, &8951, &8a32, &96c3, &97cd, &993b, &99f3, &9a0f, &9a32, &9a63, &9ac8, &9ad8, &9b51, &9bf2, &9c10, &9d9b, &9f7c, &9f82, &a06c, &a190, &a1b4, &a379, &a384, &ac72
+.sub_c83e3
+    pha                                                               ; 23e3: 48          H   :83e3[1]
+    txa                                                               ; 23e4: 8a          .   :83e4[1]
+    pha                                                               ; 23e5: 48          H   :83e5[1]
+    tya                                                               ; 23e6: 98          .   :83e6[1]
+    pha                                                               ; 23e7: 48          H   :83e7[1]
+    lda #&84                                                          ; 23e8: a9 84       ..  :83e8[1]
+    pha                                                               ; 23ea: 48          H   :83ea[1]
+    lda #5                                                            ; 23eb: a9 05       ..  :83eb[1]
+    pha                                                               ; 23ed: 48          H   :83ed[1]
+; &23ee referenced 1 time by &8411
+.sub_c83ee
+    ldy #5                                                            ; 23ee: a0 05       ..  :83ee[1]
+; &23f0 referenced 1 time by &83f6
+.loop_c83f0
+    tsx                                                               ; 23f0: ba          .   :83f0[1]
+    lda l0107,x                                                       ; 23f1: bd 07 01    ... :83f1[1]
+    pha                                                               ; 23f4: 48          H   :83f4[1]
+    dey                                                               ; 23f5: 88          .   :83f5[1]
+    bne loop_c83f0                                                    ; 23f6: d0 f8       ..  :83f6[1]
+    ldy #&0a                                                          ; 23f8: a0 0a       ..  :83f8[1]
+; &23fa referenced 1 time by &8402
+.loop_c83fa
+    lda l0109,x                                                       ; 23fa: bd 09 01    ... :83fa[1]
+    sta l010b,x                                                       ; 23fd: 9d 0b 01    ... :83fd[1]
+    dex                                                               ; 2400: ca          .   :8400[1]
+    dey                                                               ; 2401: 88          .   :8401[1]
+    bne loop_c83fa                                                    ; 2402: d0 f6       ..  :8402[1]
+    pla                                                               ; 2404: 68          h   :8404[1]
+    pla                                                               ; 2405: 68          h   :8405[1]
+; &2406 referenced 1 time by &8418
+.loop_c8406
+    pla                                                               ; 2406: 68          h   :8406[1]
+    tay                                                               ; 2407: a8          .   :8407[1]
+    pla                                                               ; 2408: 68          h   :8408[1]
+    tax                                                               ; 2409: aa          .   :8409[1]
+    pla                                                               ; 240a: 68          h   :840a[1]
+    rts                                                               ; 240b: 60          `   :840b[1]
+
+; &240c referenced 5 times by &841b, &9785, &9c16, &9e94, &aadd
+.sub_c840c
+    pha                                                               ; 240c: 48          H   :840c[1]
+    txa                                                               ; 240d: 8a          .   :840d[1]
+    pha                                                               ; 240e: 48          H   :840e[1]
+    tya                                                               ; 240f: 98          .   :840f[1]
+    pha                                                               ; 2410: 48          H   :8410[1]
+    jsr sub_c83ee                                                     ; 2411: 20 ee 83     .. :8411[1]
+    tsx                                                               ; 2414: ba          .   :8414[1]
+    sta l0103,x                                                       ; 2415: 9d 03 01    ... :8415[1]
+    jmp loop_c8406                                                    ; 2418: 4c 06 84    L.. :8418[1]
+
+; &241b referenced 2 times by &80b8, &a9bf
+.sub_c841b
+    jsr sub_c840c                                                     ; 241b: 20 0c 84     .. :841b[1]
+    tay                                                               ; 241e: a8          .   :841e[1]
+    beq c842b                                                         ; 241f: f0 0a       ..  :841f[1]
+    clc                                                               ; 2421: 18          .   :8421[1]
+    sed                                                               ; 2422: f8          .   :8422[1]
+    lda #0                                                            ; 2423: a9 00       ..  :8423[1]
+; &2425 referenced 1 time by &8428
+.loop_c8425
+    adc #1                                                            ; 2425: 69 01       i.  :8425[1]
+    dey                                                               ; 2427: 88          .   :8427[1]
+    bne loop_c8425                                                    ; 2428: d0 fb       ..  :8428[1]
+    cld                                                               ; 242a: d8          .   :842a[1]
+; &242b referenced 1 time by &841f
+.c842b
+    rts                                                               ; 242b: 60          `   :842b[1]
+
+; &242c referenced 1 time by &abb1
+.sub_c842c
+    and #&7f                                                          ; 242c: 29 7f       ).  :842c[1]
+    cmp #&7f                                                          ; 242e: c9 7f       ..  :842e[1]
+    beq c8436                                                         ; 2430: f0 04       ..  :8430[1]
+    cmp #&20 ; ' '                                                    ; 2432: c9 20       .   :8432[1]
+    bcs c8438                                                         ; 2434: b0 02       ..  :8434[1]
+; &2436 referenced 1 time by &8430
+.c8436
+    lda #&2e ; '.'                                                    ; 2436: a9 2e       ..  :8436[1]
+; &2438 referenced 1 time by &8434
+.c8438
+    rts                                                               ; 2438: 60          `   :8438[1]
+
+; &2439 referenced 2 times by &8444, &8463
+.sub_c8439
+    sec                                                               ; 2439: 38          8   :8439[1]
+    sbc #&30 ; '0'                                                    ; 243a: e9 30       .0  :843a[1]
+    bcc c8454                                                         ; 243c: 90 16       ..  :843c[1]
+    cmp #&0a                                                          ; 243e: c9 0a       ..  :843e[1]
+    rts                                                               ; 2440: 60          `   :8440[1]
+
+    jsr sub_c82fe                                                     ; 2441: 20 fe 82     .. :8441[1]
+    jsr sub_c8439                                                     ; 2444: 20 39 84     9. :8444[1]
+    bcc c8453                                                         ; 2447: 90 0a       ..  :8447[1]
+    sbc #7                                                            ; 2449: e9 07       ..  :8449[1]
+    bcc c8454                                                         ; 244b: 90 07       ..  :844b[1]
+    cmp #&0a                                                          ; 244d: c9 0a       ..  :844d[1]
+    bcc c8454                                                         ; 244f: 90 03       ..  :844f[1]
+    cmp #&10                                                          ; 2451: c9 10       ..  :8451[1]
+; &2453 referenced 1 time by &8447
+.c8453
+    rts                                                               ; 2453: 60          `   :8453[1]
+
+; &2454 referenced 3 times by &843c, &844b, &844f
+.c8454
+    sec                                                               ; 2454: 38          8   :8454[1]
+    rts                                                               ; 2455: 60          `   :8455[1]
+
+; &2456 referenced 3 times by &87f7, &a5ce, &a9e7
+.sub_c8456
+    jsr clc_jmp_gsinit                                                ; 2456: 20 4c 87     L. :8456[1]
+    sec                                                               ; 2459: 38          8   :8459[1]
+    beq c8482                                                         ; 245a: f0 26       .&  :845a[1]
+    php                                                               ; 245c: 08          .   :845c[1]
+    lda #0                                                            ; 245d: a9 00       ..  :845d[1]
+    sta l00b9                                                         ; 245f: 85 b9       ..  :845f[1]
+    beq c8477                                                         ; 2461: f0 14       ..  :8461[1]
+; &2463 referenced 1 time by &847a
+.loop_c8463
+    jsr sub_c8439                                                     ; 2463: 20 39 84     9. :8463[1]
+    bcs c8481                                                         ; 2466: b0 19       ..  :8466[1]
+    sta l00b8                                                         ; 2468: 85 b8       ..  :8468[1]
+    lda l00b9                                                         ; 246a: a5 b9       ..  :846a[1]
+    asl a                                                             ; 246c: 0a          .   :846c[1]
+    sta l00b9                                                         ; 246d: 85 b9       ..  :846d[1]
+    asl a                                                             ; 246f: 0a          .   :846f[1]
+    asl a                                                             ; 2470: 0a          .   :8470[1]
+    adc l00b9                                                         ; 2471: 65 b9       e.  :8471[1]
+    adc l00b8                                                         ; 2473: 65 b8       e.  :8473[1]
+    sta l00b9                                                         ; 2475: 85 b9       ..  :8475[1]
+; &2477 referenced 1 time by &8461
+.c8477
+    jsr gsread                                                        ; 2477: 20 c5 ff     .. :8477[1]
+    bcc loop_c8463                                                    ; 247a: 90 e7       ..  :847a[1]
+    lda l00b9                                                         ; 247c: a5 b9       ..  :847c[1]
+    plp                                                               ; 247e: 28          (   :847e[1]
+    clc                                                               ; 247f: 18          .   :847f[1]
+    rts                                                               ; 2480: 60          `   :8480[1]
+
+; &2481 referenced 1 time by &8466
+.c8481
+    plp                                                               ; 2481: 28          (   :8481[1]
+; &2482 referenced 1 time by &845a
+.c8482
+    rts                                                               ; 2482: 60          `   :8482[1]
+
+    jsr sub_c8745                                                     ; 2483: 20 45 87     E. :8483[1]
+    jsr sub_c8b86                                                     ; 2486: 20 86 8b     .. :8486[1]
+    jsr c940c                                                         ; 2489: 20 0c 94     .. :8489[1]
+    ldy #&ff                                                          ; 248c: a0 ff       ..  :848c[1]
+    sty l00a8                                                         ; 248e: 84 a8       ..  :848e[1]
+    iny                                                               ; 2490: c8          .   :8490[1]
+    sty l00aa                                                         ; 2491: 84 aa       ..  :8491[1]
+; &2493 referenced 1 time by &84a3
+.loop_c8493
+    lda l0e00,y                                                       ; 2493: b9 00 0e    ... :8493[1]
+    cpy #8                                                            ; 2496: c0 08       ..  :8496[1]
+    bcc c849d                                                         ; 2498: 90 03       ..  :8498[1]
+    lda l0ef8,y                                                       ; 249a: b9 f8 0e    ... :849a[1]
+; &249d referenced 1 time by &8498
+.c849d
+    jsr c809f                                                         ; 249d: 20 9f 80     .. :849d[1]
+    iny                                                               ; 24a0: c8          .   :84a0[1]
+    cpy #&0c                                                          ; 24a1: c0 0c       ..  :84a1[1]
+    bne loop_c8493                                                    ; 24a3: d0 ee       ..  :84a3[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 24a5: 20 77 80     w. :84a5[1]
+    equs " ("                                                         ; 24a8: 20 28        (  :84a8[1]
+
+    lda l0f04                                                         ; 24aa: ad 04 0f    ... :84aa[1]
+    jsr sub_c80bb                                                     ; 24ad: 20 bb 80     .. :84ad[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 24b0: 20 77 80     w. :84b0[1]
+    equs ") FM", &0d, "Drive "                                        ; 24b3: 29 20 46... ) F :84b3[1]
+
+    lda l00cd                                                         ; 24be: a5 cd       ..  :84be[1]
+    jsr sub_c80c3                                                     ; 24c0: 20 c3 80     .. :84c0[1]
+    ldy #&0d                                                          ; 24c3: a0 0d       ..  :84c3[1]
+    jsr c81a7                                                         ; 24c5: 20 a7 81     .. :84c5[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 24c8: 20 77 80     w. :84c8[1]
+    equs "Option "                                                    ; 24cb: 4f 70 74... Opt :84cb[1]
+
+    lda l0f06                                                         ; 24d2: ad 06 0f    ... :84d2[1]
+    jsr sub_c81bf                                                     ; 24d5: 20 bf 81     .. :84d5[1]
+    pha                                                               ; 24d8: 48          H   :84d8[1]
+    jsr sub_c80c3                                                     ; 24d9: 20 c3 80     .. :84d9[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 24dc: 20 77 80     w. :84dc[1]
+    equs " ("                                                         ; 24df: 20 28        (  :84df[1]
+
+    ldy #3                                                            ; 24e1: a0 03       ..  :84e1[1]
+    pla                                                               ; 24e3: 68          h   :84e3[1]
+    asl a                                                             ; 24e4: 0a          .   :84e4[1]
+    asl a                                                             ; 24e5: 0a          .   :84e5[1]
+    tax                                                               ; 24e6: aa          .   :84e6[1]
+; &24e7 referenced 1 time by &84ef
+.loop_c84e7
+    lda opt4_table,x                                                  ; 24e7: bd d3 85    ... :84e7[1]
+    jsr c809f                                                         ; 24ea: 20 9f 80     .. :84ea[1]
+    inx                                                               ; 24ed: e8          .   :84ed[1]
+    dey                                                               ; 24ee: 88          .   :84ee[1]
+    bpl loop_c84e7                                                    ; 24ef: 10 f6       ..  :84ef[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 24f1: 20 77 80     w. :84f1[1]
+    equs ")", &0d, "Dir. :"                                           ; 24f4: 29 0d 44... ).D :84f4[1]
+
+    lda l10ca                                                         ; 24fc: ad ca 10    ... :84fc[1]
+    jsr sub_c809a                                                     ; 24ff: 20 9a 80     .. :84ff[1]
+    lda l10c9                                                         ; 2502: ad c9 10    ... :8502[1]
+    jsr c809f                                                         ; 2505: 20 9f 80     .. :8505[1]
+    ldy #&0b                                                          ; 2508: a0 0b       ..  :8508[1]
+    jsr c81a7                                                         ; 250a: 20 a7 81     .. :850a[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 250d: 20 77 80     w. :850d[1]
+    equs "Lib. :"                                                     ; 2510: 4c 69 62... Lib :8510[1]
+
+    lda l10cc                                                         ; 2516: ad cc 10    ... :8516[1]
+    jsr sub_c809a                                                     ; 2519: 20 9a 80     .. :8519[1]
+    lda l10cb                                                         ; 251c: ad cb 10    ... :851c[1]
+    jsr c809f                                                         ; 251f: 20 9f 80     .. :851f[1]
+    jsr ca3dc                                                         ; 2522: 20 dc a3     .. :8522[1]
+    ldy #0                                                            ; 2525: a0 00       ..  :8525[1]
+; &2527 referenced 1 time by &8541
+.loop_c8527
+    cpy l0f05                                                         ; 2527: cc 05 0f    ... :8527[1]
+    bcs c8543                                                         ; 252a: b0 17       ..  :852a[1]
+    lda l0e0f,y                                                       ; 252c: b9 0f 0e    ... :852c[1]
+    eor l10c9                                                         ; 252f: 4d c9 10    M.. :852f[1]
+    and #&5f ; '_'                                                    ; 2532: 29 5f       )_  :8532[1]
+    bne c853e                                                         ; 2534: d0 08       ..  :8534[1]
+    lda l0e0f,y                                                       ; 2536: b9 0f 0e    ... :8536[1]
+    and #&80                                                          ; 2539: 29 80       ).  :8539[1]
+    sta l0e0f,y                                                       ; 253b: 99 0f 0e    ... :853b[1]
+; &253e referenced 1 time by &8534
+.c853e
+    jsr sub_c87da                                                     ; 253e: 20 da 87     .. :853e[1]
+    bcc loop_c8527                                                    ; 2541: 90 e4       ..  :8541[1]
+; &2543 referenced 2 times by &852a, &85d0
+.c8543
+    ldy #0                                                            ; 2543: a0 00       ..  :8543[1]
+    jsr sub_c8555                                                     ; 2545: 20 55 85     U. :8545[1]
+    bcc c8560                                                         ; 2548: 90 16       ..  :8548[1]
+    lda #&ff                                                          ; 254a: a9 ff       ..  :854a[1]
+    sta l1082                                                         ; 254c: 8d 82 10    ... :854c[1]
+    jmp ca3dc                                                         ; 254f: 4c dc a3    L.. :854f[1]
+
+; &2552 referenced 1 time by &855d
+.loop_c8552
+    jsr sub_c87da                                                     ; 2552: 20 da 87     .. :8552[1]
+; &2555 referenced 2 times by &8545, &8573
+.sub_c8555
+    cpy l0f05                                                         ; 2555: cc 05 0f    ... :8555[1]
+    bcs c855f                                                         ; 2558: b0 05       ..  :8558[1]
+    lda l0e08,y                                                       ; 255a: b9 08 0e    ... :855a[1]
+    bmi loop_c8552                                                    ; 255d: 30 f3       0.  :855d[1]
+; &255f referenced 1 time by &8558
+.c855f
+    rts                                                               ; 255f: 60          `   :855f[1]
+
+; &2560 referenced 2 times by &8548, &8594
+.c8560
+    sty l00ab                                                         ; 2560: 84 ab       ..  :8560[1]
+    ldx #0                                                            ; 2562: a2 00       ..  :8562[1]
+; &2564 referenced 1 time by &8571
+.loop_c8564
+    lda l0e08,y                                                       ; 2564: b9 08 0e    ... :8564[1]
+    jsr sub_c82fe                                                     ; 2567: 20 fe 82     .. :8567[1]
+    sta l1060,x                                                       ; 256a: 9d 60 10    .`. :856a[1]
+    iny                                                               ; 256d: c8          .   :856d[1]
+    inx                                                               ; 256e: e8          .   :856e[1]
+    cpx #8                                                            ; 256f: e0 08       ..  :856f[1]
+    bne loop_c8564                                                    ; 2571: d0 f1       ..  :8571[1]
+; &2573 referenced 1 time by &8599
+.c8573
+    jsr sub_c8555                                                     ; 2573: 20 55 85     U. :8573[1]
+    bcs c859b                                                         ; 2576: b0 23       .#  :8576[1]
+    sec                                                               ; 2578: 38          8   :8578[1]
+    ldx #6                                                            ; 2579: a2 06       ..  :8579[1]
+; &257b referenced 1 time by &8586
+.loop_c857b
+    lda l0e0e,y                                                       ; 257b: b9 0e 0e    ... :857b[1]
+    jsr sub_c82fe                                                     ; 257e: 20 fe 82     .. :857e[1]
+    sbc l1060,x                                                       ; 2581: fd 60 10    .`. :8581[1]
+    dey                                                               ; 2584: 88          .   :8584[1]
+    dex                                                               ; 2585: ca          .   :8585[1]
+    bpl loop_c857b                                                    ; 2586: 10 f3       ..  :8586[1]
+    jsr sub_c87db                                                     ; 2588: 20 db 87     .. :8588[1]
+    lda l0e0f,y                                                       ; 258b: b9 0f 0e    ... :858b[1]
+    jsr sub_c82fe                                                     ; 258e: 20 fe 82     .. :858e[1]
+    sbc l1067                                                         ; 2591: ed 67 10    .g. :8591[1]
+    bcc c8560                                                         ; 2594: 90 ca       ..  :8594[1]
+    jsr sub_c87da                                                     ; 2596: 20 da 87     .. :8596[1]
+    bcs c8573                                                         ; 2599: b0 d8       ..  :8599[1]
+; &259b referenced 1 time by &8576
+.c859b
+    ldy l00ab                                                         ; 259b: a4 ab       ..  :859b[1]
+    lda l0e08,y                                                       ; 259d: b9 08 0e    ... :859d[1]
+    ora #&80                                                          ; 25a0: 09 80       ..  :85a0[1]
+    sta l0e08,y                                                       ; 25a2: 99 08 0e    ... :85a2[1]
+    lda l1067                                                         ; 25a5: ad 67 10    .g. :85a5[1]
+    cmp l00aa                                                         ; 25a8: c5 aa       ..  :85a8[1]
+    beq c85bc                                                         ; 25aa: f0 10       ..  :85aa[1]
+    ldx l00aa                                                         ; 25ac: a6 aa       ..  :85ac[1]
+    sta l00aa                                                         ; 25ae: 85 aa       ..  :85ae[1]
+    bne c85bc                                                         ; 25b0: d0 0a       ..  :85b0[1]
+    jsr ca3dc                                                         ; 25b2: 20 dc a3     .. :85b2[1]
+; &25b5 referenced 1 time by &85be
+.loop_c85b5
+    jsr ca3dc                                                         ; 25b5: 20 dc a3     .. :85b5[1]
+    ldy #&ff                                                          ; 25b8: a0 ff       ..  :85b8[1]
+    bne c85c5                                                         ; 25ba: d0 09       ..  :85ba[1]
+; &25bc referenced 2 times by &85aa, &85b0
+.c85bc
+    ldy l00a8                                                         ; 25bc: a4 a8       ..  :85bc[1]
+    bne loop_c85b5                                                    ; 25be: d0 f5       ..  :85be[1]
+    ldy #5                                                            ; 25c0: a0 05       ..  :85c0[1]
+    jsr c81a7                                                         ; 25c2: 20 a7 81     .. :85c2[1]
+; &25c5 referenced 1 time by &85ba
+.c85c5
+    iny                                                               ; 25c5: c8          .   :85c5[1]
+    sty l00a8                                                         ; 25c6: 84 a8       ..  :85c6[1]
+    ldy l00ab                                                         ; 25c8: a4 ab       ..  :85c8[1]
+    jsr sub_cac0c                                                     ; 25ca: 20 0c ac     .. :85ca[1]
+    jsr sub_c8174                                                     ; 25cd: 20 74 81     t. :85cd[1]
+    jmp c8543                                                         ; 25d0: 4c 43 85    LC. :85d0[1]
+
+; &25d3 referenced 1 time by &84e7
+.opt4_table
+    equs "off", 0                                                     ; 25d3: 6f 66 66... off :85d3[1]
+    equs "LOAD"                                                       ; 25d7: 4c 4f 41... LOA :85d7[1]
+    equs "RUN", 0                                                     ; 25db: 52 55 4e... RUN :85db[1]
+    equs "EXEC"                                                       ; 25df: 45 58 45... EXE :85df[1]
+
+; &25e3 referenced 1 time by &8acd
+.sub_c85e3
+    lda l0f0e,y                                                       ; 25e3: b9 0e 0f    ... :85e3[1]
+    jsr sub_c81b0                                                     ; 25e6: 20 b0 81     .. :85e6[1]
+    sta l00c2                                                         ; 25e9: 85 c2       ..  :85e9[1]
+    clc                                                               ; 25eb: 18          .   :85eb[1]
+    lda #&ff                                                          ; 25ec: a9 ff       ..  :85ec[1]
+    adc l0f0c,y                                                       ; 25ee: 79 0c 0f    y.. :85ee[1]
+    lda l0f0f,y                                                       ; 25f1: b9 0f 0f    ... :85f1[1]
+    adc l0f0d,y                                                       ; 25f4: 79 0d 0f    y.. :85f4[1]
+    sta l00c3                                                         ; 25f7: 85 c3       ..  :85f7[1]
+    lda l0f0e,y                                                       ; 25f9: b9 0e 0f    ... :85f9[1]
+    and #3                                                            ; 25fc: 29 03       ).  :85fc[1]
+    adc l00c2                                                         ; 25fe: 65 c2       e.  :85fe[1]
+    sta l00c2                                                         ; 2600: 85 c2       ..  :8600[1]
+; &2602 referenced 1 time by &8ac2
+.sub_c8602
+    sec                                                               ; 2602: 38          8   :8602[1]
+    lda l0f07,y                                                       ; 2603: b9 07 0f    ... :8603[1]
+    sbc l00c3                                                         ; 2606: e5 c3       ..  :8606[1]
+    pha                                                               ; 2608: 48          H   :8608[1]
+    lda l0f06,y                                                       ; 2609: b9 06 0f    ... :8609[1]
+    and #3                                                            ; 260c: 29 03       ).  :860c[1]
+    sbc l00c2                                                         ; 260e: e5 c2       ..  :860e[1]
+    tax                                                               ; 2610: aa          .   :8610[1]
+    lda #0                                                            ; 2611: a9 00       ..  :8611[1]
+    cmp l00c0                                                         ; 2613: c5 c0       ..  :8613[1]
+    pla                                                               ; 2615: 68          h   :8615[1]
+    sbc l00c1                                                         ; 2616: e5 c1       ..  :8616[1]
+    txa                                                               ; 2618: 8a          .   :8618[1]
+    sbc l00c4                                                         ; 2619: e5 c4       ..  :8619[1]
+    rts                                                               ; 261b: 60          `   :861b[1]
+
+; &261c referenced 6 times by &870e, &8719, &8726, &873c, &a16f, &a187
+.command_table
+    equs "ACCESS"                                                     ; 261c: 41 43 43... ACC :861c[1]
+; &261d referenced 1 time by &8740
+    equb >(sub_c89e6-1)                                               ; 2622: 89          .   :8622[1]
+    equb <(sub_c89e6-1)                                               ; 2623: e5          .   :8623[1]
+    equb &32                                                          ; 2624: 32          2   :8624[1]
+    equs "BACKUP"                                                     ; 2625: 42 41 43... BAC :8625[1]
+    equb >(sub_ca417-1)                                               ; 262b: a4          .   :862b[1]
+    equb <(sub_ca417-1)                                               ; 262c: 16          .   :862c[1]
+    equb 4                                                            ; 262d: 04          .   :862d[1]
+    equs "CLOSE"                                                      ; 262e: 43 4c 4f... CLO :862e[1]
+    equb >(sub_c9b59-1)                                               ; 2633: 9b          .   :8633[1]
+    equb <(sub_c9b59-1)                                               ; 2634: 58          X   :8634[1]
+    equb 0                                                            ; 2635: 00          .   :8635[1]
+    equs "COMPACT"                                                    ; 2636: 43 4f 4d... COM :8636[1]
+    equb >(sub_ca244-1)                                               ; 263d: a2          .   :863d[1]
+    equb <(sub_ca244-1)                                               ; 263e: 43          C   :863e[1]
+    equb 7                                                            ; 263f: 07          .   :863f[1]
+    equs "COPY"                                                       ; 2640: 43 4f 50... COP :8640[1]
+    equb >(sub_ca463-1)                                               ; 2644: a4          .   :8644[1]
+    equb <(sub_ca463-1)                                               ; 2645: 62          b   :8645[1]
+    equb &24                                                          ; 2646: 24          $   :8646[1]
+    equs "DELETE"                                                     ; 2647: 44 45 4c... DEL :8647[1]
+    equb >(sub_c8782-1)                                               ; 264d: 87          .   :864d[1]
+    equb <(sub_c8782-1)                                               ; 264e: 81          .   :864e[1]
+    equb 1                                                            ; 264f: 01          .   :864f[1]
+    equs "DESTROY"                                                    ; 2650: 44 45 53... DES :8650[1]
+    equb >(sub_c8794-1)                                               ; 2657: 87          .   :8657[1]
+    equb <(sub_c8794-1)                                               ; 2658: 93          .   :8658[1]
+    equb 2                                                            ; 2659: 02          .   :8659[1]
+    equs "DIR"                                                        ; 265a: 44 49 52    DIR :865a[1]
+    equb >(sub_c893f-1)                                               ; 265d: 89          .   :865d[1]
+    equb <(sub_c893f-1)                                               ; 265e: 3e          >   :865e[1]
+    equb 6                                                            ; 265f: 06          .   :865f[1]
+    equs "DRIVE"                                                      ; 2660: 44 52 49... DRI :8660[1]
+    equb >(sub_c87ee-1)                                               ; 2665: 87          .   :8665[1]
+    equb <(sub_c87ee-1)                                               ; 2666: ed          .   :8666[1]
+    equb 9                                                            ; 2667: 09          .   :8667[1]
+    equs "ENABLE"                                                     ; 2668: 45 4e 41... ENA :8668[1]
+    equb >(sub_c8b47-1)                                               ; 266e: 8b          .   :866e[1]
+    equb <(sub_c8b47-1)                                               ; 266f: 46          F   :866f[1]
+    equb 0                                                            ; 2670: 00          .   :8670[1]
+    equs "EX"                                                         ; 2671: 45 58       EX  :8671[1]
+    equb >(sub_c8238-1)                                               ; 2673: 82          .   :8673[1]
+    equb <(sub_c8238-1)                                               ; 2674: 37          7   :8674[1]
+    equb 6                                                            ; 2675: 06          .   :8675[1]
+    equs "FORM"                                                       ; 2676: 46 4f 52... FOR :8676[1]
+    equb >(sub_ca5bf-1)                                               ; 267a: a5          .   :867a[1]
+    equb <(sub_ca5bf-1)                                               ; 267b: be          .   :867b[1]
+    equb &ba                                                          ; 267c: ba          .   :867c[1]
+    equs "FREE"                                                       ; 267d: 46 52 45... FRE :867d[1]
+    equb >(sub_ca7f3-1)                                               ; 2681: a7          .   :8681[1]
+    equb <(sub_ca7f3-1)                                               ; 2682: f2          .   :8682[1]
+    equb 7                                                            ; 2683: 07          .   :8683[1]
+    equs "INFO"                                                       ; 2684: 49 4e 46... INF :8684[1]
+    equb >(sub_c8254-1)                                               ; 2688: 82          .   :8688[1]
+    equb <(sub_c8254-1)                                               ; 2689: 53          S   :8689[1]
+    equb 2                                                            ; 268a: 02          .   :868a[1]
+    equs "LIB"                                                        ; 268b: 4c 49 42    LIB :868b[1]
+    equb >(sub_c8943-1)                                               ; 268e: 89          .   :868e[1]
+    equb <(sub_c8943-1)                                               ; 268f: 42          B   :868f[1]
+    equb 6                                                            ; 2690: 06          .   :8690[1]
+    equs "MAP"                                                        ; 2691: 4d 41 50    MAP :8691[1]
+    equb >(sub_ca7f6-1)                                               ; 2694: a7          .   :8694[1]
+    equb <(sub_ca7f6-1)                                               ; 2695: f5          .   :8695[1]
+    equb 7                                                            ; 2696: 07          .   :8696[1]
+    equs "RENAME"                                                     ; 2697: 52 45 4e... REN :8697[1]
+    equb >(sub_c8bac-1)                                               ; 269d: 8b          .   :869d[1]
+    equb <(sub_c8bac-1)                                               ; 269e: ab          .   :869e[1]
+    equb 5                                                            ; 269f: 05          .   :869f[1]
+    equs "TITLE"                                                      ; 26a0: 54 49 54... TIT :86a0[1]
+    equb >(sub_c89b7-1)                                               ; 26a5: 89          .   :86a5[1]
+    equb <(sub_c89b7-1)                                               ; 26a6: b6          .   :86a6[1]
+    equb 8                                                            ; 26a7: 08          .   :86a7[1]
+    equs "VERIFY"                                                     ; 26a8: 56 45 52... VER :86a8[1]
+    equb >(sub_ca5bb-1)                                               ; 26ae: a5          .   :86ae[1]
+    equb <(sub_ca5bb-1)                                               ; 26af: ba          .   :86af[1]
+    equb &0b                                                          ; 26b0: 0b          .   :86b0[1]
+    equs "WIPE"                                                       ; 26b1: 57 49 50... WIP :86b1[1]
+    equb >(sub_c8750-1)                                               ; 26b5: 87          .   :86b5[1]
+    equb <(sub_c8750-1)                                               ; 26b6: 4f          O   :86b6[1]
+    equb   2, &88, &72                                                ; 26b7: 02 88 72    ..r :86b7[1]
+    equs "BUILD"                                                      ; 26ba: 42 55 49... BUI :86ba[1]
+    equb >(sub_cabc5-1)                                               ; 26bf: ab          .   :86bf[1]
+    equb <(sub_cabc5-1)                                               ; 26c0: c4          .   :86c0[1]
+    equb 1                                                            ; 26c1: 01          .   :86c1[1]
+    equs "DISC"                                                       ; 26c2: 44 49 53... DIS :86c2[1]
+    equb >(c956d-1)                                                   ; 26c6: 95          .   :86c6[1]
+    equb <(c956d-1)                                                   ; 26c7: 6c          l   :86c7[1]
+    equb 0                                                            ; 26c8: 00          .   :86c8[1]
+    equs "DUMP"                                                       ; 26c9: 44 55 4d... DUM :86c9[1]
+    equb >(sub_cab46-1)                                               ; 26cd: ab          .   :86cd[1]
+    equb <(sub_cab46-1)                                               ; 26ce: 45          E   :86ce[1]
+    equb 1                                                            ; 26cf: 01          .   :86cf[1]
+    equs "LIST"                                                       ; 26d0: 4c 49 53... LIS :86d0[1]
+    equb >(sub_cab04-1)                                               ; 26d4: ab          .   :86d4[1]
+    equb <(sub_cab04-1)                                               ; 26d5: 03          .   :86d5[1]
+    equb 1                                                            ; 26d6: 01          .   :86d6[1]
+    equs "ROMS"                                                       ; 26d7: 52 4f 4d... ROM :86d7[1]
+    equb >(sub_ca9d0-1)                                               ; 26db: a9          .   :86db[1]
+    equb <(sub_ca9d0-1)                                               ; 26dc: cf          .   :86dc[1]
+    equb &0c                                                          ; 26dd: 0c          .   :86dd[1]
+    equs "TYPE"                                                       ; 26de: 54 59 50... TYP :86de[1]
+    equb >(sub_caafd-1)                                               ; 26e2: aa          .   :86e2[1]
+    equb <(sub_caafd-1)                                               ; 26e3: fc          .   :86e3[1]
+    equb 1                                                            ; 26e4: 01          .   :86e4[1]
+    equs "DISK"                                                       ; 26e5: 44 49 53... DIS :86e5[1]
+    equb >(c956d-1)                                                   ; 26e9: 95          .   :86e9[1]
+    equb <(c956d-1)                                                   ; 26ea: 6c          l   :86ea[1]
+    equb   0, &86, &1a                                                ; 26eb: 00 86 1a    ... :86eb[1]
+    equs "DFS"                                                        ; 26ee: 44 46 53    DFS :86ee[1]
+    equb >(sub_ca106-1)                                               ; 26f1: a1          .   :86f1[1]
+    equb <(sub_ca106-1)                                               ; 26f2: 05          .   :86f2[1]
+    equb 0                                                            ; 26f3: 00          .   :86f3[1]
+    equs "UTILS"                                                      ; 26f4: 55 54 49... UTI :86f4[1]
+    equb >(sub_ca137-1)                                               ; 26f9: a1          .   :86f9[1]
+    equb <(sub_ca137-1)                                               ; 26fa: 36          6   :86fa[1]
+    equb   0, &a1                                                     ; 26fb: 00 a1       ..  :86fb[1]
+    equs "= E"                                                        ; 26fd: 3d 20 45    = E :86fd[1]
+    equb &87, &a2, &fd                                                ; 2700: 87 a2 fd    ... :8700[1]
+
+; &2703 referenced 2 times by &96f2, &a134
+.c8703
+    tya                                                               ; 2703: 98          .   :8703[1]
+    pha                                                               ; 2704: 48          H   :8704[1]
+; &2705 referenced 2 times by &872f, &8739
+.c8705
+    inx                                                               ; 2705: e8          .   :8705[1]
+    inx                                                               ; 2706: e8          .   :8706[1]
+    pla                                                               ; 2707: 68          h   :8707[1]
+    pha                                                               ; 2708: 48          H   :8708[1]
+    tay                                                               ; 2709: a8          .   :8709[1]
+    jsr clc_jmp_gsinit                                                ; 270a: 20 4c 87     L. :870a[1]
+    inx                                                               ; 270d: e8          .   :870d[1]
+    lda command_table,x                                               ; 270e: bd 1c 86    ... :870e[1]
+    bmi c873b                                                         ; 2711: 30 28       0(  :8711[1]
+    dex                                                               ; 2713: ca          .   :8713[1]
+    dey                                                               ; 2714: 88          .   :8714[1]
+    stx l00bf                                                         ; 2715: 86 bf       ..  :8715[1]
+; &2717 referenced 1 time by &8722
+.loop_c8717
+    inx                                                               ; 2717: e8          .   :8717[1]
+    iny                                                               ; 2718: c8          .   :8718[1]
+    lda command_table,x                                               ; 2719: bd 1c 86    ... :8719[1]
+    bmi c8734                                                         ; 271c: 30 16       0.  :871c[1]
+    eor (os_text_ptr),y                                               ; 271e: 51 f2       Q.  :871e[1]
+    and #&5f ; '_'                                                    ; 2720: 29 5f       )_  :8720[1]
+    beq loop_c8717                                                    ; 2722: f0 f3       ..  :8722[1]
+    dex                                                               ; 2724: ca          .   :8724[1]
+; &2725 referenced 1 time by &8729
+.loop_c8725
+    inx                                                               ; 2725: e8          .   :8725[1]
+    lda command_table,x                                               ; 2726: bd 1c 86    ... :8726[1]
+    bpl loop_c8725                                                    ; 2729: 10 fa       ..  :8729[1]
+    lda (os_text_ptr),y                                               ; 272b: b1 f2       ..  :872b[1]
+    cmp #&2e ; '.'                                                    ; 272d: c9 2e       ..  :872d[1]
+    bne c8705                                                         ; 272f: d0 d4       ..  :872f[1]
+    iny                                                               ; 2731: c8          .   :8731[1]
+    bcs c873b                                                         ; 2732: b0 07       ..  :8732[1]
+; &2734 referenced 1 time by &871c
+.c8734
+    lda (os_text_ptr),y                                               ; 2734: b1 f2       ..  :8734[1]
+    jsr sub_c8327                                                     ; 2736: 20 27 83     '. :8736[1]
+    bcc c8705                                                         ; 2739: 90 ca       ..  :8739[1]
+; &273b referenced 2 times by &8711, &8732
+.c873b
+    pla                                                               ; 273b: 68          h   :873b[1]
+    lda command_table,x                                               ; 273c: bd 1c 86    ... :873c[1]
+    pha                                                               ; 273f: 48          H   :873f[1]
+    lda command_table+1,x                                             ; 2740: bd 1d 86    ... :8740[1]
+    pha                                                               ; 2743: 48          H   :8743[1]
+    rts                                                               ; 2744: 60          `   :8744[1]
+
+; &2745 referenced 2 times by &8483, &8870
+.sub_c8745
+    stx os_text_ptr                                                   ; 2745: 86 f2       ..  :8745[1]
+    sty l00f3                                                         ; 2747: 84 f3       ..  :8747[1]
+    ldy #0                                                            ; 2749: a0 00       ..  :8749[1]
+    rts                                                               ; 274b: 60          `   :874b[1]
+
+; &274c referenced 12 times by &8100, &823b, &8456, &870a, &897e, &89f1, &8b86, &a13e, &a14a, &a5e5, &a657, &a9f7
+.clc_jmp_gsinit
+    clc                                                               ; 274c: 18          .   :874c[1]
+    jmp gsinit                                                        ; 274d: 4c c2 ff    L.. :874d[1]
+
+.sub_c8750
+    jsr sub_c99ac                                                     ; 2750: 20 ac 99     .. :8750[1]
+    jsr sub_ca14a                                                     ; 2753: 20 4a a1     J. :8753[1]
+    jsr sub_c821d                                                     ; 2756: 20 1d 82     .. :8756[1]
+; &2759 referenced 1 time by &877f
+.c8759
+    lda l0e0f,y                                                       ; 2759: b9 0f 0e    ... :8759[1]
+    bmi c877c                                                         ; 275c: 30 1e       0.  :875c[1]
+    jsr sub_c8174                                                     ; 275e: 20 74 81     t. :875e[1]
+    jsr sub_ca3e4                                                     ; 2761: 20 e4 a3     .. :8761[1]
+    bne c8779                                                         ; 2764: d0 13       ..  :8764[1]
+    ldx l00b6                                                         ; 2766: a6 b6       ..  :8766[1]
+    jsr sub_c9bf2                                                     ; 2768: 20 f2 9b     .. :8768[1]
+    stx l00b6                                                         ; 276b: 86 b6       ..  :876b[1]
+    jsr sub_c87e3                                                     ; 276d: 20 e3 87     .. :876d[1]
+    sty l00ab                                                         ; 2770: 84 ab       ..  :8770[1]
+    jsr c93e6                                                         ; 2772: 20 e6 93     .. :8772[1]
+    lda l00ab                                                         ; 2775: a5 ab       ..  :8775[1]
+    sta l00b6                                                         ; 2777: 85 b6       ..  :8777[1]
+; &2779 referenced 1 time by &8764
+.c8779
+    jsr ca3dc                                                         ; 2779: 20 dc a3     .. :8779[1]
+; &277c referenced 1 time by &875c
+.c877c
+    jsr sub_c8280                                                     ; 277c: 20 80 82     .. :877c[1]
+    bcs c8759                                                         ; 277f: b0 d8       ..  :877f[1]
+    rts                                                               ; 2781: 60          `   :8781[1]
+
+.sub_c8782
+    jsr c99a3                                                         ; 2782: 20 a3 99     .. :8782[1]
+    jsr sub_ca14a                                                     ; 2785: 20 4a a1     J. :8785[1]
+    jsr sub_c821d                                                     ; 2788: 20 1d 82     .. :8788[1]
+    jsr sub_c8335                                                     ; 278b: 20 35 83     5. :878b[1]
+    jsr sub_c830a                                                     ; 278e: 20 0a 83     .. :878e[1]
+    jmp c93e6                                                         ; 2791: 4c e6 93    L.. :8791[1]
+
+.sub_c8794
+    jsr sub_ca315                                                     ; 2794: 20 15 a3     .. :8794[1]
+    jsr sub_c99ac                                                     ; 2797: 20 ac 99     .. :8797[1]
+    jsr sub_ca14a                                                     ; 279a: 20 4a a1     J. :879a[1]
+    jsr sub_c821d                                                     ; 279d: 20 1d 82     .. :879d[1]
+; &27a0 referenced 1 time by &87ae
+.loop_c87a0
+    lda l0e0f,y                                                       ; 27a0: b9 0f 0e    ... :87a0[1]
+    bmi c87ab                                                         ; 27a3: 30 06       0.  :87a3[1]
+    jsr sub_c8174                                                     ; 27a5: 20 74 81     t. :87a5[1]
+    jsr ca3dc                                                         ; 27a8: 20 dc a3     .. :87a8[1]
+; &27ab referenced 1 time by &87a3
+.c87ab
+    jsr sub_c8280                                                     ; 27ab: 20 80 82     .. :87ab[1]
+    bcs loop_c87a0                                                    ; 27ae: b0 f0       ..  :87ae[1]
+    jsr sub_ca3ec                                                     ; 27b0: 20 ec a3     .. :87b0[1]
+    beq c87b8                                                         ; 27b3: f0 03       ..  :87b3[1]
+    jmp ca3dc                                                         ; 27b5: 4c dc a3    L.. :87b5[1]
+
+; &27b8 referenced 1 time by &87b3
+.c87b8
+    jsr sub_c9bf2                                                     ; 27b8: 20 f2 9b     .. :87b8[1]
+    jsr sub_c8284                                                     ; 27bb: 20 84 82     .. :87bb[1]
+; &27be referenced 1 time by &87c9
+.loop_c87be
+    lda l0e0f,y                                                       ; 27be: b9 0f 0e    ... :87be[1]
+    bmi c87c6                                                         ; 27c1: 30 03       0.  :87c1[1]
+    jsr sub_c87e3                                                     ; 27c3: 20 e3 87     .. :87c3[1]
+; &27c6 referenced 1 time by &87c1
+.c87c6
+    jsr sub_c8280                                                     ; 27c6: 20 80 82     .. :87c6[1]
+    bcs loop_c87be                                                    ; 27c9: b0 f3       ..  :87c9[1]
+    jsr c93e6                                                         ; 27cb: 20 e6 93     .. :87cb[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 27ce: 20 77 80     w. :87ce[1]
+    equs &0d, "Deleted", &0d                                          ; 27d1: 0d 44 65... .De :87d1[1]
+
+; &27da referenced 6 times by &853e, &8552, &8596, &8b0c, &8be5, &98b5
+.sub_c87da
+    iny                                                               ; 27da: c8          .   :87da[1]
+; &27db referenced 2 times by &837a, &8588
+.sub_c87db
+    iny                                                               ; 27db: c8          .   :87db[1]
+    iny                                                               ; 27dc: c8          .   :87dc[1]
+    iny                                                               ; 27dd: c8          .   :87dd[1]
+    iny                                                               ; 27de: c8          .   :87de[1]
+    iny                                                               ; 27df: c8          .   :87df[1]
+    iny                                                               ; 27e0: c8          .   :87e0[1]
+    iny                                                               ; 27e1: c8          .   :87e1[1]
+    rts                                                               ; 27e2: 60          `   :87e2[1]
+
+; &27e3 referenced 2 times by &876d, &87c3
+.sub_c87e3
+    jsr sub_c830a                                                     ; 27e3: 20 0a 83     .. :87e3[1]
+    ldy l00b6                                                         ; 27e6: a4 b6       ..  :87e6[1]
+    jsr sub_c82b2                                                     ; 27e8: 20 b2 82     .. :87e8[1]
+    sty l00b6                                                         ; 27eb: 84 b6       ..  :87eb[1]
+    rts                                                               ; 27ed: 60          `   :87ed[1]
+
+.sub_c87ee
+    jsr sub_ca14a                                                     ; 27ee: 20 4a a1     J. :87ee[1]
+    jsr c8b8b                                                         ; 27f1: 20 8b 8b     .. :87f1[1]
+    sta l10ca                                                         ; 27f4: 8d ca 10    ... :87f4[1]
+    jsr sub_c8456                                                     ; 27f7: 20 56 84     V. :87f7[1]
+    beq c8815                                                         ; 27fa: f0 19       ..  :87fa[1]
+    cmp #&28 ; '('                                                    ; 27fc: c9 28       .(  :87fc[1]
+    beq c8808                                                         ; 27fe: f0 08       ..  :87fe[1]
+    cmp #&50 ; 'P'                                                    ; 2800: c9 50       .P  :8800[1]
+    clc                                                               ; 2802: 18          .   :8802[1]
+    beq c8808                                                         ; 2803: f0 03       ..  :8803[1]
+    jmp ca14f                                                         ; 2805: 4c 4f a1    LO. :8805[1]
+
+; &2808 referenced 2 times by &87fe, &8803
+.c8808
+    php                                                               ; 2808: 08          .   :8808[1]
+    ldx l10ca                                                         ; 2809: ae ca 10    ... :8809[1]
+    lda l10de,x                                                       ; 280c: bd de 10    ... :880c[1]
+    rol a                                                             ; 280f: 2a          *   :880f[1]
+    plp                                                               ; 2810: 28          (   :8810[1]
+    ror a                                                             ; 2811: 6a          j   :8811[1]
+    sta l10de,x                                                       ; 2812: 9d de 10    ... :8812[1]
+; &2815 referenced 1 time by &87fa
+.c8815
+    rts                                                               ; 2815: 60          `   :8815[1]
+
+; &2816 referenced 8 times by &888f, &8985, &898d, &8b83, &8b9d, &9bef, &a475, &a4ce
+.c8816
+    and #3                                                            ; 2816: 29 03       ).  :8816[1]
+    sta l00cd                                                         ; 2818: 85 cd       ..  :8818[1]
+    rts                                                               ; 281a: 60          `   :881a[1]
+
+    jsr sub_c8222                                                     ; 281b: 20 22 82     ". :881b[1]
+    jsr sub_c9a82                                                     ; 281e: 20 82 9a     .. :881e[1]
+    jsr sub_c8386                                                     ; 2821: 20 86 83     .. :8821[1]
+    lda #&80                                                          ; 2824: a9 80       ..  :8824[1]
+; &2826 referenced 1 time by &88f6
+.sub_c8826
+    sta l1096                                                         ; 2826: 8d 96 10    ... :8826[1]
+    sty l00ba                                                         ; 2829: 84 ba       ..  :8829[1]
+    ldx #0                                                            ; 282b: a2 00       ..  :882b[1]
+    lda l00be                                                         ; 282d: a5 be       ..  :882d[1]
+    bne c8837                                                         ; 282f: d0 06       ..  :882f[1]
+    iny                                                               ; 2831: c8          .   :8831[1]
+    iny                                                               ; 2832: c8          .   :8832[1]
+    ldx #2                                                            ; 2833: a2 02       ..  :8833[1]
+    bne c883f                                                         ; 2835: d0 08       ..  :8835[1]
+; &2837 referenced 1 time by &882f
+.c8837
+    lda l0f0e,y                                                       ; 2837: b9 0e 0f    ... :8837[1]
+    sta l00c2                                                         ; 283a: 85 c2       ..  :883a[1]
+    jsr sub_c8b4d                                                     ; 283c: 20 4d 8b     M. :883c[1]
+; &283f referenced 2 times by &8835, &8848
+.c883f
+    lda l0f08,y                                                       ; 283f: b9 08 0f    ... :883f[1]
+    sta l00bc,x                                                       ; 2842: 95 bc       ..  :8842[1]
+    iny                                                               ; 2844: c8          .   :8844[1]
+    inx                                                               ; 2845: e8          .   :8845[1]
+    cpx #8                                                            ; 2846: e0 08       ..  :8846[1]
+    bne c883f                                                         ; 2848: d0 f5       ..  :8848[1]
+    jsr sub_c8b64                                                     ; 284a: 20 64 8b     d. :884a[1]
+    ldy l00ba                                                         ; 284d: a4 ba       ..  :884d[1]
+    jsr sub_c8335                                                     ; 284f: 20 35 83     5. :884f[1]
+    jmp c8867                                                         ; 2852: 4c 67 88    Lg. :8852[1]
+
+; &2855 referenced 2 times by &9f61, &a561
+.sub_c8855
+    lda #&80                                                          ; 2855: a9 80       ..  :8855[1]
+    bne c8864                                                         ; 2857: d0 0b       ..  :8857[1]
+    jsr sub_c8a77                                                     ; 2859: 20 77 8a     w. :8859[1]
+    jsr sub_c9a82                                                     ; 285c: 20 82 9a     .. :885c[1]
+    jsr sub_c8386                                                     ; 285f: 20 86 83     .. :885f[1]
+; &2862 referenced 2 times by &9f51, &a587
+.sub_c8862
+    lda #&a0                                                          ; 2862: a9 a0       ..  :8862[1]
+; &2864 referenced 1 time by &8857
+.c8864
+    sta l1096                                                         ; 2864: 8d 96 10    ... :8864[1]
+; &2867 referenced 1 time by &8852
+.c8867
+    jsr sub_c81ca                                                     ; 2867: 20 ca 81     .. :8867[1]
+    jsr sub_c9445                                                     ; 286a: 20 45 94     E. :886a[1]
+    lda #1                                                            ; 286d: a9 01       ..  :886d[1]
+    rts                                                               ; 286f: 60          `   :886f[1]
+
+    jsr sub_c8745                                                     ; 2870: 20 45 87     E. :8870[1]
+    jsr sub_c8932                                                     ; 2873: 20 32 89     2. :8873[1]
+    sty l10da                                                         ; 2876: 8c da 10    ... :8876[1]
+    jsr sub_c80f3                                                     ; 2879: 20 f3 80     .. :8879[1]
+    sty l10d9                                                         ; 287c: 8c d9 10    ... :887c[1]
+    jsr sub_c8266                                                     ; 287f: 20 66 82     f. :887f[1]
+    bcs c88a6                                                         ; 2882: b0 22       ."  :8882[1]
+    ldy l10da                                                         ; 2884: ac da 10    ... :8884[1]
+    lda l10cb                                                         ; 2887: ad cb 10    ... :8887[1]
+    sta l00cc                                                         ; 288a: 85 cc       ..  :888a[1]
+    lda l10cc                                                         ; 288c: ad cc 10    ... :888c[1]
+    jsr c8816                                                         ; 288f: 20 16 88     .. :888f[1]
+    jsr sub_c80f6                                                     ; 2892: 20 f6 80     .. :8892[1]
+    jsr sub_c8266                                                     ; 2895: 20 66 82     f. :8895[1]
+    bcs c88a6                                                         ; 2898: b0 0c       ..  :8898[1]
+    jsr generate_error_precheck_bad                                   ; 289a: 20 2e 80     .. :889a[1]
+    equb &fe                                                          ; 289d: fe          .   :889d[1]
+    equs "command"                                                    ; 289e: 63 6f 6d... com :889e[1]
+    equb 0                                                            ; 28a5: 00          .   :88a5[1]
+
+; &28a6 referenced 2 times by &8882, &8898
+.c88a6
+    lda l0f0e,y                                                       ; 28a6: b9 0e 0f    ... :88a6[1]
+    jsr sub_c81ae                                                     ; 28a9: 20 ae 81     .. :88a9[1]
+    cmp #3                                                            ; 28ac: c9 03       ..  :88ac[1]
+    bne c88f4                                                         ; 28ae: d0 44       .D  :88ae[1]
+    lda l0f0a,y                                                       ; 28b0: b9 0a 0f    ... :88b0[1]
+    and l0f0b,y                                                       ; 28b3: 39 0b 0f    9.. :88b3[1]
+    cmp #&ff                                                          ; 28b6: c9 ff       ..  :88b6[1]
+    bne c88f4                                                         ; 28b8: d0 3a       .:  :88b8[1]
+    ldx #6                                                            ; 28ba: a2 06       ..  :88ba[1]
+; &28bc referenced 1 time by &88c3
+.loop_c88bc
+    lda l1000,x                                                       ; 28bc: bd 00 10    ... :88bc[1]
+    sta l1007,x                                                       ; 28bf: 9d 07 10    ... :88bf[1]
+    dex                                                               ; 28c2: ca          .   :88c2[1]
+    bpl loop_c88bc                                                    ; 28c3: 10 f7       ..  :88c3[1]
+    lda #&0d                                                          ; 28c5: a9 0d       ..  :88c5[1]
+    sta l100e                                                         ; 28c7: 8d 0e 10    ... :88c7[1]
+    lda #&45 ; 'E'                                                    ; 28ca: a9 45       .E  :88ca[1]
+    sta l1000                                                         ; 28cc: 8d 00 10    ... :88cc[1]
+    lda #&2e ; '.'                                                    ; 28cf: a9 2e       ..  :88cf[1]
+    sta l1001                                                         ; 28d1: 8d 01 10    ... :88d1[1]
+    lda #&3a ; ':'                                                    ; 28d4: a9 3a       .:  :88d4[1]
+    sta l1002                                                         ; 28d6: 8d 02 10    ... :88d6[1]
+    lda l00cd                                                         ; 28d9: a5 cd       ..  :88d9[1]
+    ora #&30 ; '0'                                                    ; 28db: 09 30       .0  :88db[1]
+    sta l1003                                                         ; 28dd: 8d 03 10    ... :88dd[1]
+    lda #&2e ; '.'                                                    ; 28e0: a9 2e       ..  :88e0[1]
+    sta l1004                                                         ; 28e2: 8d 04 10    ... :88e2[1]
+    sta l1006                                                         ; 28e5: 8d 06 10    ... :88e5[1]
+    lda l00cc                                                         ; 28e8: a5 cc       ..  :88e8[1]
+    sta l1005                                                         ; 28ea: 8d 05 10    ... :88ea[1]
+    ldx #<(l1000)                                                     ; 28ed: a2 00       ..  :88ed[1]
+    ldy #>(l1000)                                                     ; 28ef: a0 10       ..  :88ef[1]
+    jmp oscli                                                         ; 28f1: 4c f7 ff    L.. :88f1[1]
+
+; &28f4 referenced 2 times by &88ae, &88b8
+.c88f4
+    lda #&81                                                          ; 28f4: a9 81       ..  :88f4[1]
+    jsr sub_c8826                                                     ; 28f6: 20 26 88     &. :88f6[1]
+    clc                                                               ; 28f9: 18          .   :88f9[1]
+    lda l10d9                                                         ; 28fa: ad d9 10    ... :88fa[1]
+    tay                                                               ; 28fd: a8          .   :88fd[1]
+    adc os_text_ptr                                                   ; 28fe: 65 f2       e.  :88fe[1]
+    sta l10d9                                                         ; 2900: 8d d9 10    ... :8900[1]
+    lda l00f3                                                         ; 2903: a5 f3       ..  :8903[1]
+    adc #0                                                            ; 2905: 69 00       i.  :8905[1]
+    sta l10da                                                         ; 2907: 8d da 10    ... :8907[1]
+    lda l1076                                                         ; 290a: ad 76 10    .v. :890a[1]
+    and l1077                                                         ; 290d: 2d 77 10    -w. :890d[1]
+    ora l10d6                                                         ; 2910: 0d d6 10    ... :8910[1]
+    cmp #&ff                                                          ; 2913: c9 ff       ..  :8913[1]
+    beq c892d                                                         ; 2915: f0 16       ..  :8915[1]
+    lda l00be                                                         ; 2917: a5 be       ..  :8917[1]
+    sta l1074                                                         ; 2919: 8d 74 10    .t. :8919[1]
+    lda l00bf                                                         ; 291c: a5 bf       ..  :891c[1]
+    sta l1075                                                         ; 291e: 8d 75 10    .u. :891e[1]
+    jsr sub_c8f6b                                                     ; 2921: 20 6b 8f     k. :8921[1]
+    ldx #&74 ; 't'                                                    ; 2924: a2 74       .t  :8924[1]
+    ldy #&10                                                          ; 2926: a0 10       ..  :8926[1]
+    lda #4                                                            ; 2928: a9 04       ..  :8928[1]
+    jmp tube_entry                                                    ; 292a: 4c 06 04    L.. :892a[1]
+
+; &292d referenced 1 time by &8915
+.c892d
+    lda #1                                                            ; 292d: a9 01       ..  :892d[1]
+    jmp (l00be)                                                       ; 292f: 6c be 00    l.. :892f[1]
+
+; &2932 referenced 1 time by &8873
+.sub_c8932
+    lda #&ff                                                          ; 2932: a9 ff       ..  :8932[1]
+    sta l00be                                                         ; 2934: 85 be       ..  :8934[1]
+    lda os_text_ptr                                                   ; 2936: a5 f2       ..  :8936[1]
+    sta l00ba                                                         ; 2938: 85 ba       ..  :8938[1]
+    lda l00f3                                                         ; 293a: a5 f3       ..  :893a[1]
+    sta l00bb                                                         ; 293c: 85 bb       ..  :893c[1]
+    rts                                                               ; 293e: 60          `   :893e[1]
+
+.sub_c893f
+    ldx #0                                                            ; 293f: a2 00       ..  :893f[1]
+    beq c8945                                                         ; 2941: f0 02       ..  :8941[1]
+.sub_c8943
+    ldx #2                                                            ; 2943: a2 02       ..  :8943[1]
+; &2945 referenced 1 time by &8941
+.c8945
+    jsr sub_c8979                                                     ; 2945: 20 79 89     y. :8945[1]
+    sta l10ca,x                                                       ; 2948: 9d ca 10    ... :8948[1]
+    lda l00cc                                                         ; 294b: a5 cc       ..  :894b[1]
+    sta l10c9,x                                                       ; 294d: 9d c9 10    ... :894d[1]
+    rts                                                               ; 2950: 60          `   :8950[1]
+
+; &2951 referenced 2 times by &96b4, &9729
+.sub_c8951
+    jsr sub_c83e3                                                     ; 2951: 20 e3 83     .. :8951[1]
+    lda l00b0                                                         ; 2954: a5 b0       ..  :8954[1]
+    pha                                                               ; 2956: 48          H   :8956[1]
+    lda l00b1                                                         ; 2957: a5 b1       ..  :8957[1]
+    pha                                                               ; 2959: 48          H   :8959[1]
+    jsr sub_c9ab8                                                     ; 295a: 20 b8 9a     .. :895a[1]
+    ldy #0                                                            ; 295d: a0 00       ..  :895d[1]
+; &295f referenced 1 time by &8970
+.loop_c895f
+    cpy #&c0                                                          ; 295f: c0 c0       ..  :895f[1]
+    bcc c8968                                                         ; 2961: 90 05       ..  :8961[1]
+    lda l1000,y                                                       ; 2963: b9 00 10    ... :8963[1]
+    bcs c896b                                                         ; 2966: b0 03       ..  :8966[1]
+; &2968 referenced 1 time by &8961
+.c8968
+    lda l1100,y                                                       ; 2968: b9 00 11    ... :8968[1]
+; &296b referenced 1 time by &8966
+.c896b
+    sta (l00b0),y                                                     ; 296b: 91 b0       ..  :896b[1]
+    iny                                                               ; 296d: c8          .   :896d[1]
+    cpy #&ee                                                          ; 296e: c0 ee       ..  :896e[1]
+    bne loop_c895f                                                    ; 2970: d0 ed       ..  :8970[1]
+    pla                                                               ; 2972: 68          h   :8972[1]
+    sta l00b1                                                         ; 2973: 85 b1       ..  :8973[1]
+    pla                                                               ; 2975: 68          h   :8975[1]
+    sta l00b0                                                         ; 2976: 85 b0       ..  :8976[1]
+    rts                                                               ; 2978: 60          `   :8978[1]
+
+; &2979 referenced 1 time by &8945
+.sub_c8979
+    lda l10c9                                                         ; 2979: ad c9 10    ... :8979[1]
+    sta l00cc                                                         ; 297c: 85 cc       ..  :897c[1]
+    jsr clc_jmp_gsinit                                                ; 297e: 20 4c 87     L. :897e[1]
+    bne c898a                                                         ; 2981: d0 07       ..  :8981[1]
+    lda #0                                                            ; 2983: a9 00       ..  :8983[1]
+    jsr c8816                                                         ; 2985: 20 16 88     .. :8985[1]
+    beq c89b4                                                         ; 2988: f0 2a       .*  :8988[1]
+; &298a referenced 2 times by &8240, &8981
+.c898a
+    lda l10ca                                                         ; 298a: ad ca 10    ... :898a[1]
+    jsr c8816                                                         ; 298d: 20 16 88     .. :898d[1]
+; &2990 referenced 1 time by &89a3
+.loop_c8990
+    jsr sub_c8149                                                     ; 2990: 20 49 81     I. :8990[1]
+    bcs c89a5                                                         ; 2993: b0 10       ..  :8993[1]
+    cmp #&3a ; ':'                                                    ; 2995: c9 3a       .:  :8995[1]
+    bne c89ad                                                         ; 2997: d0 14       ..  :8997[1]
+    jsr c8b8b                                                         ; 2999: 20 8b 8b     .. :8999[1]
+    jsr sub_c8149                                                     ; 299c: 20 49 81     I. :899c[1]
+    bcs c89b4                                                         ; 299f: b0 13       ..  :899f[1]
+    cmp #&2e ; '.'                                                    ; 29a1: c9 2e       ..  :89a1[1]
+    beq loop_c8990                                                    ; 29a3: f0 eb       ..  :89a3[1]
+; &29a5 referenced 2 times by &8993, &89b2
+.c89a5
+    jsr generate_error_precheck_bad                                   ; 29a5: 20 2e 80     .. :89a5[1]
+    equb &ce                                                          ; 29a8: ce          .   :89a8[1]
+    equs "dir"                                                        ; 29a9: 64 69 72    dir :89a9[1]
+    equb 0                                                            ; 29ac: 00          .   :89ac[1]
+
+; &29ad referenced 1 time by &8997
+.c89ad
+    sta l00cc                                                         ; 29ad: 85 cc       ..  :89ad[1]
+    jsr sub_c8149                                                     ; 29af: 20 49 81     I. :89af[1]
+    bcc c89a5                                                         ; 29b2: 90 f1       ..  :89b2[1]
+; &29b4 referenced 2 times by &8988, &899f
+.c89b4
+    lda l00cd                                                         ; 29b4: a5 cd       ..  :89b4[1]
+    rts                                                               ; 29b6: 60          `   :89b6[1]
+
+.sub_c89b7
+    jsr sub_ca14a                                                     ; 29b7: 20 4a a1     J. :89b7[1]
+    jsr sub_c8b7b                                                     ; 29ba: 20 7b 8b     {. :89ba[1]
+    jsr sub_c8380                                                     ; 29bd: 20 80 83     .. :89bd[1]
+    ldx #&0b                                                          ; 29c0: a2 0b       ..  :89c0[1]
+    lda #0                                                            ; 29c2: a9 00       ..  :89c2[1]
+; &29c4 referenced 1 time by &89c8
+.loop_c89c4
+    jsr sub_c89da                                                     ; 29c4: 20 da 89     .. :89c4[1]
+    dex                                                               ; 29c7: ca          .   :89c7[1]
+    bpl loop_c89c4                                                    ; 29c8: 10 fa       ..  :89c8[1]
+; &29ca referenced 1 time by &89d5
+.loop_c89ca
+    inx                                                               ; 29ca: e8          .   :89ca[1]
+    jsr sub_c8149                                                     ; 29cb: 20 49 81     I. :89cb[1]
+    bcs c89d7                                                         ; 29ce: b0 07       ..  :89ce[1]
+    jsr sub_c89da                                                     ; 29d0: 20 da 89     .. :89d0[1]
+    cpx #&0b                                                          ; 29d3: e0 0b       ..  :89d3[1]
+    bcc loop_c89ca                                                    ; 29d5: 90 f3       ..  :89d5[1]
+; &29d7 referenced 3 times by &89ce, &8a15, &99ed
+.c89d7
+    jmp c93e6                                                         ; 29d7: 4c e6 93    L.. :89d7[1]
+
+; &29da referenced 2 times by &89c4, &89d0
+.sub_c89da
+    cpx #8                                                            ; 29da: e0 08       ..  :89da[1]
+    bcc c89e2                                                         ; 29dc: 90 04       ..  :89dc[1]
+    sta l0ef8,x                                                       ; 29de: 9d f8 0e    ... :89de[1]
+    rts                                                               ; 29e1: 60          `   :89e1[1]
+
+; &29e2 referenced 1 time by &89dc
+.c89e2
+    sta l0e00,x                                                       ; 29e2: 9d 00 0e    ... :89e2[1]
+    rts                                                               ; 29e5: 60          `   :89e5[1]
+
+.sub_c89e6
+    jsr sub_c99ac                                                     ; 29e6: 20 ac 99     .. :89e6[1]
+    jsr sub_ca14a                                                     ; 29e9: 20 4a a1     J. :89e9[1]
+    jsr sub_c80ed                                                     ; 29ec: 20 ed 80     .. :89ec[1]
+    ldx #0                                                            ; 29ef: a2 00       ..  :89ef[1]
+    jsr clc_jmp_gsinit                                                ; 29f1: 20 4c 87     L. :89f1[1]
+    bne c8a19                                                         ; 29f4: d0 23       .#  :89f4[1]
+; &29f6 referenced 1 time by &8a1c
+.c89f6
+    stx l00aa                                                         ; 29f6: 86 aa       ..  :89f6[1]
+    jsr sub_c8284                                                     ; 29f8: 20 84 82     .. :89f8[1]
+    bcs c8a00                                                         ; 29fb: b0 03       ..  :89fb[1]
+    jmp c822a                                                         ; 29fd: 4c 2a 82    L*. :89fd[1]
+
+; &2a00 referenced 2 times by &89fb, &8a13
+.c8a00
+    jsr sub_c9a63                                                     ; 2a00: 20 63 9a     c. :8a00[1]
+    lda l0e0f,y                                                       ; 2a03: b9 0f 0e    ... :8a03[1]
+    and #&7f                                                          ; 2a06: 29 7f       ).  :8a06[1]
+    ora l00aa                                                         ; 2a08: 05 aa       ..  :8a08[1]
+    sta l0e0f,y                                                       ; 2a0a: 99 0f 0e    ... :8a0a[1]
+    jsr sub_c8335                                                     ; 2a0d: 20 35 83     5. :8a0d[1]
+    jsr sub_c8280                                                     ; 2a10: 20 80 82     .. :8a10[1]
+    bcs c8a00                                                         ; 2a13: b0 eb       ..  :8a13[1]
+    bcc c89d7                                                         ; 2a15: 90 c0       ..  :8a15[1]
+; &2a17 referenced 1 time by &8a22
+.loop_c8a17
+    ldx #&80                                                          ; 2a17: a2 80       ..  :8a17[1]
+; &2a19 referenced 1 time by &89f4
+.c8a19
+    jsr sub_c8149                                                     ; 2a19: 20 49 81     I. :8a19[1]
+    bcs c89f6                                                         ; 2a1c: b0 d8       ..  :8a1c[1]
+    and #&5f ; '_'                                                    ; 2a1e: 29 5f       )_  :8a1e[1]
+    cmp #&4c ; 'L'                                                    ; 2a20: c9 4c       .L  :8a20[1]
+    beq loop_c8a17                                                    ; 2a22: f0 f3       ..  :8a22[1]
+    jsr generate_error_precheck_bad                                   ; 2a24: 20 2e 80     .. :8a24[1]
+    equb &cf                                                          ; 2a27: cf          .   :8a27[1]
+    equs "attribute"                                                  ; 2a28: 61 74 74... att :8a28[1]
+    equb 0                                                            ; 2a31: 00          .   :8a31[1]
+
+    jsr sub_c83e3                                                     ; 2a32: 20 e3 83     .. :8a32[1]
+    txa                                                               ; 2a35: 8a          .   :8a35[1]
+    cmp #4                                                            ; 2a36: c9 04       ..  :8a36[1]
+    beq c8a54                                                         ; 2a38: f0 1a       ..  :8a38[1]
+    cmp #2                                                            ; 2a3a: c9 02       ..  :8a3a[1]
+    bcc c8a49                                                         ; 2a3c: 90 0b       ..  :8a3c[1]
+    jsr generate_error_precheck_bad                                   ; 2a3e: 20 2e 80     .. :8a3e[1]
+    equb &cb                                                          ; 2a41: cb          .   :8a41[1]
+    equs "option"                                                     ; 2a42: 6f 70 74... opt :8a42[1]
+    equb 0                                                            ; 2a48: 00          .   :8a48[1]
+
+; &2a49 referenced 1 time by &8a3c
+.c8a49
+    ldx #&ff                                                          ; 2a49: a2 ff       ..  :8a49[1]
+    tya                                                               ; 2a4b: 98          .   :8a4b[1]
+    beq c8a50                                                         ; 2a4c: f0 02       ..  :8a4c[1]
+    ldx #0                                                            ; 2a4e: a2 00       ..  :8a4e[1]
+; &2a50 referenced 1 time by &8a4c
+.c8a50
+    stx l10c6                                                         ; 2a50: 8e c6 10    ... :8a50[1]
+    rts                                                               ; 2a53: 60          `   :8a53[1]
+
+; &2a54 referenced 1 time by &8a38
+.c8a54
+    tya                                                               ; 2a54: 98          .   :8a54[1]
+    pha                                                               ; 2a55: 48          H   :8a55[1]
+    jsr sub_c8b7b                                                     ; 2a56: 20 7b 8b     {. :8a56[1]
+    jsr c940c                                                         ; 2a59: 20 0c 94     .. :8a59[1]
+    pla                                                               ; 2a5c: 68          h   :8a5c[1]
+    jsr sub_c81c5                                                     ; 2a5d: 20 c5 81     .. :8a5d[1]
+    eor l0f06                                                         ; 2a60: 4d 06 0f    M.. :8a60[1]
+    and #&30 ; '0'                                                    ; 2a63: 29 30       )0  :8a63[1]
+    eor l0f06                                                         ; 2a65: 4d 06 0f    M.. :8a65[1]
+    sta l0f06                                                         ; 2a68: 8d 06 0f    ... :8a68[1]
+    jmp c93e6                                                         ; 2a6b: 4c e6 93    L.. :8a6b[1]
+
+; &2a6e referenced 2 times by &8ac8, &a414
+.c8a6e
+    jsr generate_error_precheck_disc                                  ; 2a6e: 20 23 80     #. :8a6e[1]
+    equb &c6                                                          ; 2a71: c6          .   :8a71[1]
+    equs "full"                                                       ; 2a72: 66 75 6c... ful :8a72[1]
+    equb 0                                                            ; 2a76: 00          .   :8a76[1]
+
+; &2a77 referenced 2 times by &8859, &9c4e
+.sub_c8a77
+    jsr sub_c80f3                                                     ; 2a77: 20 f3 80     .. :8a77[1]
+    jsr sub_c8284                                                     ; 2a7a: 20 84 82     .. :8a7a[1]
+    bcc c8a82                                                         ; 2a7d: 90 03       ..  :8a7d[1]
+    jsr sub_c830a                                                     ; 2a7f: 20 0a 83     .. :8a7f[1]
+; &2a82 referenced 1 time by &8a7d
+.c8a82
+    lda l00c0                                                         ; 2a82: a5 c0       ..  :8a82[1]
+    pha                                                               ; 2a84: 48          H   :8a84[1]
+    lda l00c1                                                         ; 2a85: a5 c1       ..  :8a85[1]
+    pha                                                               ; 2a87: 48          H   :8a87[1]
+    sec                                                               ; 2a88: 38          8   :8a88[1]
+    lda l00c2                                                         ; 2a89: a5 c2       ..  :8a89[1]
+    sbc l00c0                                                         ; 2a8b: e5 c0       ..  :8a8b[1]
+    sta l00c0                                                         ; 2a8d: 85 c0       ..  :8a8d[1]
+    lda l00c3                                                         ; 2a8f: a5 c3       ..  :8a8f[1]
+    sbc l00c1                                                         ; 2a91: e5 c1       ..  :8a91[1]
+    sta l00c1                                                         ; 2a93: 85 c1       ..  :8a93[1]
+    lda l107a                                                         ; 2a95: ad 7a 10    .z. :8a95[1]
+    sbc l1078                                                         ; 2a98: ed 78 10    .x. :8a98[1]
+    sta l00c4                                                         ; 2a9b: 85 c4       ..  :8a9b[1]
+    jsr sub_c8ab3                                                     ; 2a9d: 20 b3 8a     .. :8a9d[1]
+    lda l1079                                                         ; 2aa0: ad 79 10    .y. :8aa0[1]
+    sta l1075                                                         ; 2aa3: 8d 75 10    .u. :8aa3[1]
+    lda l1078                                                         ; 2aa6: ad 78 10    .x. :8aa6[1]
+    sta l1074                                                         ; 2aa9: 8d 74 10    .t. :8aa9[1]
+    pla                                                               ; 2aac: 68          h   :8aac[1]
+    sta l00bd                                                         ; 2aad: 85 bd       ..  :8aad[1]
+    pla                                                               ; 2aaf: 68          h   :8aaf[1]
+    sta l00bc                                                         ; 2ab0: 85 bc       ..  :8ab0[1]
+    rts                                                               ; 2ab2: 60          `   :8ab2[1]
+
+; &2ab3 referenced 2 times by &8a9d, &a50a
+.sub_c8ab3
+    lda #0                                                            ; 2ab3: a9 00       ..  :8ab3[1]
+    sta l00c2                                                         ; 2ab5: 85 c2       ..  :8ab5[1]
+    lda #2                                                            ; 2ab7: a9 02       ..  :8ab7[1]
+    sta l00c3                                                         ; 2ab9: 85 c3       ..  :8ab9[1]
+    ldy l0f05                                                         ; 2abb: ac 05 0f    ... :8abb[1]
+    cpy #&f8                                                          ; 2abe: c0 f8       ..  :8abe[1]
+    bcs c8b18                                                         ; 2ac0: b0 56       .V  :8ac0[1]
+    jsr sub_c8602                                                     ; 2ac2: 20 02 86     .. :8ac2[1]
+    jmp c8ad0                                                         ; 2ac5: 4c d0 8a    L.. :8ac5[1]
+
+; &2ac8 referenced 1 time by &8ad1
+.loop_c8ac8
+    beq c8a6e                                                         ; 2ac8: f0 a4       ..  :8ac8[1]
+    jsr sub_c82b2                                                     ; 2aca: 20 b2 82     .. :8aca[1]
+    jsr sub_c85e3                                                     ; 2acd: 20 e3 85     .. :8acd[1]
+; &2ad0 referenced 1 time by &8ac5
+.c8ad0
+    tya                                                               ; 2ad0: 98          .   :8ad0[1]
+    bcc loop_c8ac8                                                    ; 2ad1: 90 f5       ..  :8ad1[1]
+    sty l00b0                                                         ; 2ad3: 84 b0       ..  :8ad3[1]
+    ldy l0f05                                                         ; 2ad5: ac 05 0f    ... :8ad5[1]
+; &2ad8 referenced 1 time by &8ae9
+.loop_c8ad8
+    cpy l00b0                                                         ; 2ad8: c4 b0       ..  :8ad8[1]
+    beq c8aeb                                                         ; 2ada: f0 0f       ..  :8ada[1]
+    lda l0e07,y                                                       ; 2adc: b9 07 0e    ... :8adc[1]
+    sta l0e0f,y                                                       ; 2adf: 99 0f 0e    ... :8adf[1]
+    lda l0f07,y                                                       ; 2ae2: b9 07 0f    ... :8ae2[1]
+    sta l0f0f,y                                                       ; 2ae5: 99 0f 0f    ... :8ae5[1]
+    dey                                                               ; 2ae8: 88          .   :8ae8[1]
+    bcs loop_c8ad8                                                    ; 2ae9: b0 ed       ..  :8ae9[1]
+; &2aeb referenced 1 time by &8ada
+.c8aeb
+    ldx #0                                                            ; 2aeb: a2 00       ..  :8aeb[1]
+    jsr sub_c8b25                                                     ; 2aed: 20 25 8b     %. :8aed[1]
+; &2af0 referenced 1 time by &8af9
+.loop_c8af0
+    lda l00c5,x                                                       ; 2af0: b5 c5       ..  :8af0[1]
+    sta l0e08,y                                                       ; 2af2: 99 08 0e    ... :8af2[1]
+    iny                                                               ; 2af5: c8          .   :8af5[1]
+    inx                                                               ; 2af6: e8          .   :8af6[1]
+    cpx #8                                                            ; 2af7: e0 08       ..  :8af7[1]
+    bne loop_c8af0                                                    ; 2af9: d0 f5       ..  :8af9[1]
+; &2afb referenced 1 time by &8b02
+.loop_c8afb
+    lda l00bb,x                                                       ; 2afb: b5 bb       ..  :8afb[1]
+    dey                                                               ; 2afd: 88          .   :8afd[1]
+    sta l0f08,y                                                       ; 2afe: 99 08 0f    ... :8afe[1]
+    dex                                                               ; 2b01: ca          .   :8b01[1]
+    bne loop_c8afb                                                    ; 2b02: d0 f7       ..  :8b02[1]
+    jsr sub_c8335                                                     ; 2b04: 20 35 83     5. :8b04[1]
+    tya                                                               ; 2b07: 98          .   :8b07[1]
+    pha                                                               ; 2b08: 48          H   :8b08[1]
+    ldy l0f05                                                         ; 2b09: ac 05 0f    ... :8b09[1]
+    jsr sub_c87da                                                     ; 2b0c: 20 da 87     .. :8b0c[1]
+    sty l0f05                                                         ; 2b0f: 8c 05 0f    ... :8b0f[1]
+    jsr c93e6                                                         ; 2b12: 20 e6 93     .. :8b12[1]
+    pla                                                               ; 2b15: 68          h   :8b15[1]
+    tay                                                               ; 2b16: a8          .   :8b16[1]
+    rts                                                               ; 2b17: 60          `   :8b17[1]
+
+; &2b18 referenced 1 time by &8ac0
+.c8b18
+    jsr generate_error_precheck                                       ; 2b18: 20 38 80     8. :8b18[1]
+    equb &be                                                          ; 2b1b: be          .   :8b1b[1]
+    equs "Cat full"                                                   ; 2b1c: 43 61 74... Cat :8b1c[1]
+    equb 0                                                            ; 2b24: 00          .   :8b24[1]
+
+; &2b25 referenced 1 time by &8aed
+.sub_c8b25
+    lda l1076                                                         ; 2b25: ad 76 10    .v. :8b25[1]
+    and #3                                                            ; 2b28: 29 03       ).  :8b28[1]
+    asl a                                                             ; 2b2a: 0a          .   :8b2a[1]
+    asl a                                                             ; 2b2b: 0a          .   :8b2b[1]
+    eor l00c4                                                         ; 2b2c: 45 c4       E.  :8b2c[1]
+    and #&fc                                                          ; 2b2e: 29 fc       ).  :8b2e[1]
+    eor l00c4                                                         ; 2b30: 45 c4       E.  :8b30[1]
+    asl a                                                             ; 2b32: 0a          .   :8b32[1]
+    asl a                                                             ; 2b33: 0a          .   :8b33[1]
+    eor l1074                                                         ; 2b34: 4d 74 10    Mt. :8b34[1]
+    and #&fc                                                          ; 2b37: 29 fc       ).  :8b37[1]
+    eor l1074                                                         ; 2b39: 4d 74 10    Mt. :8b39[1]
+    asl a                                                             ; 2b3c: 0a          .   :8b3c[1]
+    asl a                                                             ; 2b3d: 0a          .   :8b3d[1]
+    eor l00c2                                                         ; 2b3e: 45 c2       E.  :8b3e[1]
+    and #&fc                                                          ; 2b40: 29 fc       ).  :8b40[1]
+    eor l00c2                                                         ; 2b42: 45 c2       E.  :8b42[1]
+    sta l00c2                                                         ; 2b44: 85 c2       ..  :8b44[1]
+    rts                                                               ; 2b46: 60          `   :8b46[1]
+
+.sub_c8b47
+    lda #1                                                            ; 2b47: a9 01       ..  :8b47[1]
+    sta l10c7                                                         ; 2b49: 8d c7 10    ... :8b49[1]
+    rts                                                               ; 2b4c: 60          `   :8b4c[1]
+
+; &2b4d referenced 2 times by &883c, &a4fd
+.sub_c8b4d
+    lda #0                                                            ; 2b4d: a9 00       ..  :8b4d[1]
+    sta l1075                                                         ; 2b4f: 8d 75 10    .u. :8b4f[1]
+    lda l00c2                                                         ; 2b52: a5 c2       ..  :8b52[1]
+    jsr sub_c81b7                                                     ; 2b54: 20 b7 81     .. :8b54[1]
+    cmp #3                                                            ; 2b57: c9 03       ..  :8b57[1]
+    bne c8b60                                                         ; 2b59: d0 05       ..  :8b59[1]
+    lda #&ff                                                          ; 2b5b: a9 ff       ..  :8b5b[1]
+    sta l1075                                                         ; 2b5d: 8d 75 10    .u. :8b5d[1]
+; &2b60 referenced 1 time by &8b59
+.c8b60
+    sta l1074                                                         ; 2b60: 8d 74 10    .t. :8b60[1]
+    rts                                                               ; 2b63: 60          `   :8b63[1]
+
+; &2b64 referenced 2 times by &884a, &a500
+.sub_c8b64
+    lda #0                                                            ; 2b64: a9 00       ..  :8b64[1]
+    sta l1077                                                         ; 2b66: 8d 77 10    .w. :8b66[1]
+    lda l00c2                                                         ; 2b69: a5 c2       ..  :8b69[1]
+    jsr sub_c81ae                                                     ; 2b6b: 20 ae 81     .. :8b6b[1]
+    cmp #3                                                            ; 2b6e: c9 03       ..  :8b6e[1]
+    bne c8b77                                                         ; 2b70: d0 05       ..  :8b70[1]
+    lda #&ff                                                          ; 2b72: a9 ff       ..  :8b72[1]
+    sta l1077                                                         ; 2b74: 8d 77 10    .w. :8b74[1]
+; &2b77 referenced 1 time by &8b70
+.c8b77
+    sta l1076                                                         ; 2b77: 8d 76 10    .v. :8b77[1]
+    rts                                                               ; 2b7a: 60          `   :8b7a[1]
+
+; &2b7b referenced 8 times by &80ed, &80f3, &8238, &89ba, &8a56, &975b, &988b, &98d7
+.sub_c8b7b
+    lda l10c9                                                         ; 2b7b: ad c9 10    ... :8b7b[1]
+    sta l00cc                                                         ; 2b7e: 85 cc       ..  :8b7e[1]
+; &2b80 referenced 1 time by &8b89
+.loop_c8b80
+    lda l10ca                                                         ; 2b80: ad ca 10    ... :8b80[1]
+    jmp c8816                                                         ; 2b83: 4c 16 88    L.. :8b83[1]
+
+; &2b86 referenced 3 times by &8486, &a244, &a7f9
+.sub_c8b86
+    jsr clc_jmp_gsinit                                                ; 2b86: 20 4c 87     L. :8b86[1]
+    beq loop_c8b80                                                    ; 2b89: f0 f5       ..  :8b89[1]
+; &2b8b referenced 7 times by &8119, &87f1, &8999, &8b92, &a327, &a330, &a637
+.c8b8b
+    jsr sub_c8149                                                     ; 2b8b: 20 49 81     I. :8b8b[1]
+    bcs c8ba2                                                         ; 2b8e: b0 12       ..  :8b8e[1]
+    cmp #&3a ; ':'                                                    ; 2b90: c9 3a       .:  :8b90[1]
+    beq c8b8b                                                         ; 2b92: f0 f7       ..  :8b92[1]
+    sec                                                               ; 2b94: 38          8   :8b94[1]
+    sbc #&30 ; '0'                                                    ; 2b95: e9 30       .0  :8b95[1]
+    bcc c8ba2                                                         ; 2b97: 90 09       ..  :8b97[1]
+    cmp #4                                                            ; 2b99: c9 04       ..  :8b99[1]
+    bcs c8ba2                                                         ; 2b9b: b0 05       ..  :8b9b[1]
+    jsr c8816                                                         ; 2b9d: 20 16 88     .. :8b9d[1]
+    clc                                                               ; 2ba0: 18          .   :8ba0[1]
+    rts                                                               ; 2ba1: 60          `   :8ba1[1]
+
+; &2ba2 referenced 5 times by &8b8e, &8b97, &8b9b, &8bcd, &a660
+.c8ba2
+    jsr generate_error_precheck_bad                                   ; 2ba2: 20 2e 80     .. :8ba2[1]
+    equb &cd                                                          ; 2ba5: cd          .   :8ba5[1]
+    equs "drive"                                                      ; 2ba6: 64 72 69... dri :8ba6[1]
+    equb 0                                                            ; 2bab: 00          .   :8bab[1]
+
+.sub_c8bac
+    jsr c99a3                                                         ; 2bac: 20 a3 99     .. :8bac[1]
+    jsr sub_ca14a                                                     ; 2baf: 20 4a a1     J. :8baf[1]
+    jsr sub_c80ed                                                     ; 2bb2: 20 ed 80     .. :8bb2[1]
+    tya                                                               ; 2bb5: 98          .   :8bb5[1]
+    pha                                                               ; 2bb6: 48          H   :8bb6[1]
+    jsr c8225                                                         ; 2bb7: 20 25 82     %. :8bb7[1]
+    jsr sub_c9a60                                                     ; 2bba: 20 60 9a     `. :8bba[1]
+    sty l00c4                                                         ; 2bbd: 84 c4       ..  :8bbd[1]
+    pla                                                               ; 2bbf: 68          h   :8bbf[1]
+    tay                                                               ; 2bc0: a8          .   :8bc0[1]
+    jsr sub_ca14a                                                     ; 2bc1: 20 4a a1     J. :8bc1[1]
+    lda l00cd                                                         ; 2bc4: a5 cd       ..  :8bc4[1]
+    pha                                                               ; 2bc6: 48          H   :8bc6[1]
+    jsr sub_c80ed                                                     ; 2bc7: 20 ed 80     .. :8bc7[1]
+    pla                                                               ; 2bca: 68          h   :8bca[1]
+    cmp l00cd                                                         ; 2bcb: c5 cd       ..  :8bcb[1]
+    bne c8ba2                                                         ; 2bcd: d0 d3       ..  :8bcd[1]
+    jsr sub_c8284                                                     ; 2bcf: 20 84 82     .. :8bcf[1]
+    bcc c8be3                                                         ; 2bd2: 90 0f       ..  :8bd2[1]
+    cpy l00c4                                                         ; 2bd4: c4 c4       ..  :8bd4[1]
+    beq c8be3                                                         ; 2bd6: f0 0b       ..  :8bd6[1]
+    jsr generate_error_precheck                                       ; 2bd8: 20 38 80     8. :8bd8[1]
+    equb &c4                                                          ; 2bdb: c4          .   :8bdb[1]
+    equs "Exists"                                                     ; 2bdc: 45 78 69... Exi :8bdc[1]
+    equb 0                                                            ; 2be2: 00          .   :8be2[1]
+
+; &2be3 referenced 2 times by &8bd2, &8bd6
+.c8be3
+    ldy l00c4                                                         ; 2be3: a4 c4       ..  :8be3[1]
+    jsr sub_c87da                                                     ; 2be5: 20 da 87     .. :8be5[1]
+    ldx #7                                                            ; 2be8: a2 07       ..  :8be8[1]
+; &2bea referenced 1 time by &8bf1
+.loop_c8bea
+    lda l00c5,x                                                       ; 2bea: b5 c5       ..  :8bea[1]
+    sta l0e07,y                                                       ; 2bec: 99 07 0e    ... :8bec[1]
+    dey                                                               ; 2bef: 88          .   :8bef[1]
+    dex                                                               ; 2bf0: ca          .   :8bf0[1]
+    bpl loop_c8bea                                                    ; 2bf1: 10 f7       ..  :8bf1[1]
+    jmp c93e6                                                         ; 2bf3: 4c e6 93    L.. :8bf3[1]
+
+; &2bf6 referenced 1 time by &9466
+.sub_c8bf6
+    clc                                                               ; 2bf6: 18          .   :8bf6[1]
+    bcc c8bfb                                                         ; 2bf7: 90 02       ..  :8bf7[1]
+; &2bf9 referenced 1 time by &9211
+.sub_c8bf9
+    cli                                                               ; 2bf9: 58          X   :8bf9[1]
+    sec                                                               ; 2bfa: 38          8   :8bfa[1]
+; &2bfb referenced 1 time by &8bf7
+.c8bfb
+    ror l00b2                                                         ; 2bfb: 66 b2       f.  :8bfb[1]
+    stx l00b0                                                         ; 2bfd: 86 b0       ..  :8bfd[1]
+    sty l00b1                                                         ; 2bff: 84 b1       ..  :8bff[1]
+    cld                                                               ; 2c01: d8          .   :8c01[1]
+    jsr sub_c8c65                                                     ; 2c02: 20 65 8c     e. :8c02[1]
+    lda l00a2                                                         ; 2c05: a5 a2       ..  :8c05[1]
+    bne c8c12                                                         ; 2c07: d0 09       ..  :8c07[1]
+    ldy #5                                                            ; 2c09: a0 05       ..  :8c09[1]
+    lda (l00b0),y                                                     ; 2c0b: b1 b0       ..  :8c0b[1]
+    beq c8c12                                                         ; 2c0d: f0 03       ..  :8c0d[1]
+    jsr sub_c8d1a                                                     ; 2c0f: 20 1a 8d     .. :8c0f[1]
+; &2c12 referenced 2 times by &8c07, &8c0d
+.c8c12
+    ldy #5                                                            ; 2c12: a0 05       ..  :8c12[1]
+    lda (l00b0),y                                                     ; 2c14: b1 b0       ..  :8c14[1]
+    clc                                                               ; 2c16: 18          .   :8c16[1]
+    adc #7                                                            ; 2c17: 69 07       i.  :8c17[1]
+    tay                                                               ; 2c19: a8          .   :8c19[1]
+    lda l00a2                                                         ; 2c1a: a5 a2       ..  :8c1a[1]
+    jsr sub_c8c56                                                     ; 2c1c: 20 56 8c     V. :8c1c[1]
+    sta (l00b0),y                                                     ; 2c1f: 91 b0       ..  :8c1f[1]
+    ldx l00a7                                                         ; 2c21: a6 a7       ..  :8c21[1]
+    cpx #&80                                                          ; 2c23: e0 80       ..  :8c23[1]
+    bne c8c2e                                                         ; 2c25: d0 07       ..  :8c25[1]
+    lda lfe84                                                         ; 2c27: ad 84 fe    ... :8c27[1]
+    and #&20 ; ' '                                                    ; 2c2a: 29 20       )   :8c2a[1]
+    ora (l00b0),y                                                     ; 2c2c: 11 b0       ..  :8c2c[1]
+; &2c2e referenced 1 time by &8c25
+.c8c2e
+    pha                                                               ; 2c2e: 48          H   :8c2e[1]
+    and #&df                                                          ; 2c2f: 29 df       ).  :8c2f[1]
+    cmp #&18                                                          ; 2c31: c9 18       ..  :8c31[1]
+    bne c8c3a                                                         ; 2c33: d0 05       ..  :8c33[1]
+    lda #&ff                                                          ; 2c35: a9 ff       ..  :8c35[1]
+    sta l1087                                                         ; 2c37: 8d 87 10    ... :8c37[1]
+; &2c3a referenced 1 time by &8c33
+.c8c3a
+    lda l00cd                                                         ; 2c3a: a5 cd       ..  :8c3a[1]
+    and #1                                                            ; 2c3c: 29 01       ).  :8c3c[1]
+    tay                                                               ; 2c3e: a8          .   :8c3e[1]
+    lda l00ce                                                         ; 2c3f: a5 ce       ..  :8c3f[1]
+    sta l1088,y                                                       ; 2c41: 99 88 10    ... :8c41[1]
+    jsr c8f2a                                                         ; 2c44: 20 2a 8f     *. :8c44[1]
+    bit l00a1                                                         ; 2c47: 24 a1       $.  :8c47[1]
+    bpl c8c4e                                                         ; 2c49: 10 03       ..  :8c49[1]
+    jsr sub_c8f7a                                                     ; 2c4b: 20 7a 8f     z. :8c4b[1]
+; &2c4e referenced 1 time by &8c49
+.c8c4e
+    jsr sub_c8f5e                                                     ; 2c4e: 20 5e 8f     ^. :8c4e[1]
+    lda lfe87                                                         ; 2c51: ad 87 fe    ... :8c51[1]
+    pla                                                               ; 2c54: 68          h   :8c54[1]
+    rts                                                               ; 2c55: 60          `   :8c55[1]
+
+; &2c56 referenced 1 time by &8c1c
+.sub_c8c56
+    ldx #5                                                            ; 2c56: a2 05       ..  :8c56[1]
+; &2c58 referenced 1 time by &8c5e
+.loop_c8c58
+    cmp l9139,x                                                       ; 2c58: dd 39 91    .9. :8c58[1]
+    beq c8c61                                                         ; 2c5b: f0 04       ..  :8c5b[1]
+    dex                                                               ; 2c5d: ca          .   :8c5d[1]
+    bpl loop_c8c58                                                    ; 2c5e: 10 f8       ..  :8c5e[1]
+    rts                                                               ; 2c60: 60          `   :8c60[1]
+
+; &2c61 referenced 1 time by &8c5b
+.c8c61
+    lda l913f,x                                                       ; 2c61: bd 3f 91    .?. :8c61[1]
+    rts                                                               ; 2c64: 60          `   :8c64[1]
+
+; &2c65 referenced 1 time by &8c02
+.sub_c8c65
+    jsr sub_c8f4f                                                     ; 2c65: 20 4f 8f     O. :8c65[1]
+    jsr sub_c8f82                                                     ; 2c68: 20 82 8f     .. :8c68[1]
+    lda #0                                                            ; 2c6b: a9 00       ..  :8c6b[1]
+    sta l00a1                                                         ; 2c6d: 85 a1       ..  :8c6d[1]
+    ldy #9                                                            ; 2c6f: a0 09       ..  :8c6f[1]
+; &2c71 referenced 1 time by &8c79
+.loop_c8c71
+    lda (l00b0),y                                                     ; 2c71: b1 b0       ..  :8c71[1]
+    sta l00aa,y                                                       ; 2c73: 99 aa 00    ... :8c73[1]
+    iny                                                               ; 2c76: c8          .   :8c76[1]
+    cpy #&0c                                                          ; 2c77: c0 0c       ..  :8c77[1]
+    bne loop_c8c71                                                    ; 2c79: d0 f6       ..  :8c79[1]
+    ldy #6                                                            ; 2c7b: a0 06       ..  :8c7b[1]
+    lda (l00b0),y                                                     ; 2c7d: b1 b0       ..  :8c7d[1]
+    and #&f0                                                          ; 2c7f: 29 f0       ).  :8c7f[1]
+    cmp #&a0                                                          ; 2c81: c9 a0       ..  :8c81[1]
+    beq c8c87                                                         ; 2c83: f0 02       ..  :8c83[1]
+    cmp #&f0                                                          ; 2c85: c9 f0       ..  :8c85[1]
+; &2c87 referenced 1 time by &8c83
+.c8c87
+    ror l00a1                                                         ; 2c87: 66 a1       f.  :8c87[1]
+    ldy #3                                                            ; 2c89: a0 03       ..  :8c89[1]
+    lda (l00b0),y                                                     ; 2c8b: b1 b0       ..  :8c8b[1]
+    iny                                                               ; 2c8d: c8          .   :8c8d[1]
+    and (l00b0),y                                                     ; 2c8e: 31 b0       1.  :8c8e[1]
+    cmp #&ff                                                          ; 2c90: c9 ff       ..  :8c90[1]
+    clc                                                               ; 2c92: 18          .   :8c92[1]
+    beq c8cb2                                                         ; 2c93: f0 1d       ..  :8c93[1]
+    jsr sub_c8f3f                                                     ; 2c95: 20 3f 8f     ?. :8c95[1]
+    clc                                                               ; 2c98: 18          .   :8c98[1]
+    bmi c8cb2                                                         ; 2c99: 30 17       0.  :8c99[1]
+    jsr sub_c8f6b                                                     ; 2c9b: 20 6b 8f     k. :8c9b[1]
+    lda l00a1                                                         ; 2c9e: a5 a1       ..  :8c9e[1]
+    rol a                                                             ; 2ca0: 2a          *   :8ca0[1]
+    rol a                                                             ; 2ca1: 2a          *   :8ca1[1]
+    and #1                                                            ; 2ca2: 29 01       ).  :8ca2[1]
+    eor #1                                                            ; 2ca4: 49 01       I.  :8ca4[1]
+    ldx l00b0                                                         ; 2ca6: a6 b0       ..  :8ca6[1]
+    ldy l00b1                                                         ; 2ca8: a4 b1       ..  :8ca8[1]
+    inx                                                               ; 2caa: e8          .   :8caa[1]
+    bne c8cae                                                         ; 2cab: d0 01       ..  :8cab[1]
+    iny                                                               ; 2cad: c8          .   :8cad[1]
+; &2cae referenced 1 time by &8cab
+.c8cae
+    jsr tube_entry                                                    ; 2cae: 20 06 04     .. :8cae[1]
+    sec                                                               ; 2cb1: 38          8   :8cb1[1]
+; &2cb2 referenced 2 times by &8c93, &8c99
+.c8cb2
+    ror l00a1                                                         ; 2cb2: 66 a1       f.  :8cb2[1]
+    jsr sub_c8f94                                                     ; 2cb4: 20 94 8f     .. :8cb4[1]
+    ldy #0                                                            ; 2cb7: a0 00       ..  :8cb7[1]
+    lda (l00b0),y                                                     ; 2cb9: b1 b0       ..  :8cb9[1]
+    bmi c8cc1                                                         ; 2cbb: 30 04       0.  :8cbb[1]
+    and #&0f                                                          ; 2cbd: 29 0f       ).  :8cbd[1]
+    sta l00cd                                                         ; 2cbf: 85 cd       ..  :8cbf[1]
+; &2cc1 referenced 1 time by &8cbb
+.c8cc1
+    lda l00cd                                                         ; 2cc1: a5 cd       ..  :8cc1[1]
+    and #3                                                            ; 2cc3: 29 03       ).  :8cc3[1]
+    tax                                                               ; 2cc5: aa          .   :8cc5[1]
+    lda l10de,x                                                       ; 2cc6: bd de 10    ... :8cc6[1]
+    sta l108a                                                         ; 2cc9: 8d 8a 10    ... :8cc9[1]
+    lda l00cd                                                         ; 2ccc: a5 cd       ..  :8ccc[1]
+    ldy #&0a                                                          ; 2cce: a0 0a       ..  :8cce[1]
+    and #8                                                            ; 2cd0: 29 08       ).  :8cd0[1]
+    beq c8cd6                                                         ; 2cd2: f0 02       ..  :8cd2[1]
+    ldy #&10                                                          ; 2cd4: a0 10       ..  :8cd4[1]
+; &2cd6 referenced 1 time by &8cd2
+.c8cd6
+    sty l00a3                                                         ; 2cd6: 84 a3       ..  :8cd6[1]
+    eor l911d,x                                                       ; 2cd8: 5d 1d 91    ].. :8cd8[1]
+    sta lfe80                                                         ; 2cdb: 8d 80 fe    ... :8cdb[1]
+    lsr a                                                             ; 2cde: 4a          J   :8cde[1]
+    ldx l1088                                                         ; 2cdf: ae 88 10    ... :8cdf[1]
+    bcs c8ce7                                                         ; 2ce2: b0 03       ..  :8ce2[1]
+    ldx l1089                                                         ; 2ce4: ae 89 10    ... :8ce4[1]
+; &2ce7 referenced 1 time by &8ce2
+.c8ce7
+    ldy #0                                                            ; 2ce7: a0 00       ..  :8ce7[1]
+    sty l00a2                                                         ; 2ce9: 84 a2       ..  :8ce9[1]
+    lda l1087                                                         ; 2ceb: ad 87 10    ... :8ceb[1]
+    bit l1087                                                         ; 2cee: 2c 87 10    ,.. :8cee[1]
+    bcc c8cfc                                                         ; 2cf1: 90 09       ..  :8cf1[1]
+    bpl c8d0d                                                         ; 2cf3: 10 18       ..  :8cf3[1]
+    sty l1088                                                         ; 2cf5: 8c 88 10    ... :8cf5[1]
+    and #&7f                                                          ; 2cf8: 29 7f       ).  :8cf8[1]
+    bpl c8d03                                                         ; 2cfa: 10 07       ..  :8cfa[1]
+; &2cfc referenced 1 time by &8cf1
+.c8cfc
+    bvc c8d0d                                                         ; 2cfc: 50 0f       P.  :8cfc[1]
+    sty l1089                                                         ; 2cfe: 8c 89 10    ... :8cfe[1]
+    and #&bf                                                          ; 2d01: 29 bf       ).  :8d01[1]
+; &2d03 referenced 1 time by &8cfa
+.c8d03
+    sta l1087                                                         ; 2d03: 8d 87 10    ... :8d03[1]
+    lda #0                                                            ; 2d06: a9 00       ..  :8d06[1]
+    jsr c8e12                                                         ; 2d08: 20 12 8e     .. :8d08[1]
+    ldx #0                                                            ; 2d0b: a2 00       ..  :8d0b[1]
+; &2d0d referenced 2 times by &8cf3, &8cfc
+.c8d0d
+    txa                                                               ; 2d0d: 8a          .   :8d0d[1]
+    sta l00ce                                                         ; 2d0e: 85 ce       ..  :8d0e[1]
+    jsr c8f2a                                                         ; 2d10: 20 2a 8f     *. :8d10[1]
+; &2d13 referenced 2 times by &8d1d, &8d25
+.c8d13
+    rts                                                               ; 2d13: 60          `   :8d13[1]
+
+; &2d14 referenced 1 time by &8d29
+.loop_c8d14
+    jmp c8eaf                                                         ; 2d14: 4c af 8e    L.. :8d14[1]
+
+; &2d17 referenced 1 time by &8d2d
+.loop_c8d17
+    jmp c8e12                                                         ; 2d17: 4c 12 8e    L.. :8d17[1]
+
+; &2d1a referenced 1 time by &8c0f
+.sub_c8d1a
+    jsr sub_c8eff                                                     ; 2d1a: 20 ff 8e     .. :8d1a[1]
+    bne c8d13                                                         ; 2d1d: d0 f4       ..  :8d1d[1]
+    ldy #6                                                            ; 2d1f: a0 06       ..  :8d1f[1]
+    lda (l00b0),y                                                     ; 2d21: b1 b0       ..  :8d21[1]
+    cmp #&10                                                          ; 2d23: c9 10       ..  :8d23[1]
+    beq c8d13                                                         ; 2d25: f0 ec       ..  :8d25[1]
+    cmp #&c0                                                          ; 2d27: c9 c0       ..  :8d27[1]
+    beq loop_c8d14                                                    ; 2d29: f0 e9       ..  :8d29[1]
+    cmp #&e0                                                          ; 2d2b: c9 e0       ..  :8d2b[1]
+    bcs loop_c8d17                                                    ; 2d2d: b0 e8       ..  :8d2d[1]
+    ldy #8                                                            ; 2d2f: a0 08       ..  :8d2f[1]
+    lda (l00b0),y                                                     ; 2d31: b1 b0       ..  :8d31[1]
+    bit l00b2                                                         ; 2d33: 24 b2       $.  :8d33[1]
+    bmi c8d92                                                         ; 2d35: 30 5b       0[  :8d35[1]
+    ldx l00b5                                                         ; 2d37: a6 b5       ..  :8d37[1]
+    beq c8d41                                                         ; 2d39: f0 06       ..  :8d39[1]
+    inc l00b3                                                         ; 2d3b: e6 b3       ..  :8d3b[1]
+    bne c8d41                                                         ; 2d3d: d0 02       ..  :8d3d[1]
+    inc l00b4                                                         ; 2d3f: e6 b4       ..  :8d3f[1]
+; &2d41 referenced 3 times by &8d39, &8d3d, &8d8f
+.c8d41
+    jsr nmi_handler2_rom_end                                          ; 2d41: 20 fb 90     .. :8d41[1]
+    sta l00cf                                                         ; 2d44: 85 cf       ..  :8d44[1]
+    sbc l00a3                                                         ; 2d46: e5 a3       ..  :8d46[1]
+    eor #&ff                                                          ; 2d48: 49 ff       I.  :8d48[1]
+    clc                                                               ; 2d4a: 18          .   :8d4a[1]
+    adc #1                                                            ; 2d4b: 69 01       i.  :8d4b[1]
+    sta l00a5                                                         ; 2d4d: 85 a5       ..  :8d4d[1]
+    lda l00b4                                                         ; 2d4f: a5 b4       ..  :8d4f[1]
+    bne c8d74                                                         ; 2d51: d0 21       .!  :8d51[1]
+    lda l00b3                                                         ; 2d53: a5 b3       ..  :8d53[1]
+    beq c8d91                                                         ; 2d55: f0 3a       .:  :8d55[1]
+    cmp l00a5                                                         ; 2d57: c5 a5       ..  :8d57[1]
+    beq c8d5d                                                         ; 2d59: f0 02       ..  :8d59[1]
+    bcs c8d74                                                         ; 2d5b: b0 17       ..  :8d5b[1]
+; &2d5d referenced 1 time by &8d59
+.c8d5d
+    sta l00a5                                                         ; 2d5d: 85 a5       ..  :8d5d[1]
+    ldx l00b5                                                         ; 2d5f: a6 b5       ..  :8d5f[1]
+    beq c8d74                                                         ; 2d61: f0 11       ..  :8d61[1]
+    stx l00a6                                                         ; 2d63: 86 a6       ..  :8d63[1]
+    ror l00a1                                                         ; 2d65: 66 a1       f.  :8d65[1]
+    sec                                                               ; 2d67: 38          8   :8d67[1]
+    rol l00a1                                                         ; 2d68: 26 a1       &.  :8d68[1]
+    cmp #1                                                            ; 2d6a: c9 01       ..  :8d6a[1]
+    bne c8d74                                                         ; 2d6c: d0 06       ..  :8d6c[1]
+    lda nmi_lda_immXXX4+1                                             ; 2d6e: ad 22 0d    .". :8d6e[1]
+    sta nmi_lda_immXXX3+1                                             ; 2d71: 8d 4c 0d    .L. :8d71[1]
+; &2d74 referenced 4 times by &8d51, &8d5b, &8d61, &8d6c
+.c8d74
+    lda l00b3                                                         ; 2d74: a5 b3       ..  :8d74[1]
+    sec                                                               ; 2d76: 38          8   :8d76[1]
+    sbc l00a5                                                         ; 2d77: e5 a5       ..  :8d77[1]
+    sta l00b3                                                         ; 2d79: 85 b3       ..  :8d79[1]
+    lda l00b4                                                         ; 2d7b: a5 b4       ..  :8d7b[1]
+    sbc #0                                                            ; 2d7d: e9 00       ..  :8d7d[1]
+    sta l00b4                                                         ; 2d7f: 85 b4       ..  :8d7f[1]
+    jsr c8e0e                                                         ; 2d81: 20 0e 8e     .. :8d81[1]
+    bne c8d91                                                         ; 2d84: d0 0b       ..  :8d84[1]
+    lda l00b3                                                         ; 2d86: a5 b3       ..  :8d86[1]
+    ora l00b4                                                         ; 2d88: 05 b4       ..  :8d88[1]
+    beq c8d91                                                         ; 2d8a: f0 05       ..  :8d8a[1]
+    jsr c8ecc                                                         ; 2d8c: 20 cc 8e     .. :8d8c[1]
+    beq c8d41                                                         ; 2d8f: f0 b0       ..  :8d8f[1]
+; &2d91 referenced 4 times by &8d55, &8d84, &8d8a, &8d9d
+.c8d91
+    rts                                                               ; 2d91: 60          `   :8d91[1]
+
+; &2d92 referenced 1 time by &8d35
+.c8d92
+    jsr nmi_handler2_rom_end                                          ; 2d92: 20 fb 90     .. :8d92[1]
+    sta l00cf                                                         ; 2d95: 85 cf       ..  :8d95[1]
+    ldy #9                                                            ; 2d97: a0 09       ..  :8d97[1]
+    lda (l00b0),y                                                     ; 2d99: b1 b0       ..  :8d99[1]
+    and #&1f                                                          ; 2d9b: 29 1f       ).  :8d9b[1]
+    beq c8d91                                                         ; 2d9d: f0 f2       ..  :8d9d[1]
+    sta l00a5                                                         ; 2d9f: 85 a5       ..  :8d9f[1]
+    bit l00a1                                                         ; 2da1: 24 a1       $.  :8da1[1]
+    bvs c8e0e                                                         ; 2da3: 70 69       pi  :8da3[1]
+    bit l108a                                                         ; 2da5: 2c 8a 10    ,.. :8da5[1]
+    bvc c8e0e                                                         ; 2da8: 50 64       Pd  :8da8[1]
+    ldx #&33 ; '3'                                                    ; 2daa: a2 33       .3  :8daa[1]
+; &2dac referenced 1 time by &8db3
+.loop_c8dac
+    lda c0d60,x                                                       ; 2dac: bd 60 0d    .`. :8dac[1]
+    sta l1000,x                                                       ; 2daf: 9d 00 10    ... :8daf[1]
+    dex                                                               ; 2db2: ca          .   :8db2[1]
+    bpl loop_c8dac                                                    ; 2db3: 10 f7       ..  :8db3[1]
+    jsr sub_c8dc6                                                     ; 2db5: 20 c6 8d     .. :8db5[1]
+    ldx #&33 ; '3'                                                    ; 2db8: a2 33       .3  :8db8[1]
+; &2dba referenced 1 time by &8dc1
+.loop_c8dba
+    lda l1000,x                                                       ; 2dba: bd 00 10    ... :8dba[1]
+    sta c0d60,x                                                       ; 2dbd: 9d 60 0d    .`. :8dbd[1]
+    dex                                                               ; 2dc0: ca          .   :8dc0[1]
+    bpl loop_c8dba                                                    ; 2dc1: 10 f7       ..  :8dc1[1]
+    lda l00a2                                                         ; 2dc3: a5 a2       ..  :8dc3[1]
+    rts                                                               ; 2dc5: 60          `   :8dc5[1]
+
+; &2dc6 referenced 1 time by &8db5
+.sub_c8dc6
+    lda #0                                                            ; 2dc6: a9 00       ..  :8dc6[1]
+    sta l00b4                                                         ; 2dc8: 85 b4       ..  :8dc8[1]
+    lda (l00b0),y                                                     ; 2dca: b1 b0       ..  :8dca[1]
+    and #&e0                                                          ; 2dcc: 29 e0       ).  :8dcc[1]
+    bne c8dd2                                                         ; 2dce: d0 02       ..  :8dce[1]
+    lda #&10                                                          ; 2dd0: a9 10       ..  :8dd0[1]
+; &2dd2 referenced 1 time by &8dce
+.c8dd2
+    asl a                                                             ; 2dd2: 0a          .   :8dd2[1]
+    rol l00b4                                                         ; 2dd3: 26 b4       &.  :8dd3[1]
+    asl a                                                             ; 2dd5: 0a          .   :8dd5[1]
+    rol l00b4                                                         ; 2dd6: 26 b4       &.  :8dd6[1]
+    asl a                                                             ; 2dd8: 0a          .   :8dd8[1]
+    rol l00b4                                                         ; 2dd9: 26 b4       &.  :8dd9[1]
+    sta l00b3                                                         ; 2ddb: 85 b3       ..  :8ddb[1]
+    tax                                                               ; 2ddd: aa          .   :8ddd[1]
+    beq c8de2                                                         ; 2dde: f0 02       ..  :8dde[1]
+    inc l00b4                                                         ; 2de0: e6 b4       ..  :8de0[1]
+; &2de2 referenced 1 time by &8dde
+.c8de2
+    jsr nmi3_handler_rom_end                                          ; 2de2: 20 3e 90     >. :8de2[1]
+    lda #&14                                                          ; 2de5: a9 14       ..  :8de5[1]
+    sta l00b7                                                         ; 2de7: 85 b7       ..  :8de7[1]
+; &2de9 referenced 1 time by &8dfc
+.loop_c8de9
+    lda #&e0                                                          ; 2de9: a9 e0       ..  :8de9[1]
+    sta l00a2                                                         ; 2deb: 85 a2       ..  :8deb[1]
+    sta lfe84                                                         ; 2ded: 8d 84 fe    ... :8ded[1]
+; &2df0 referenced 1 time by &8df2
+.loop_c8df0
+    lda l00a2                                                         ; 2df0: a5 a2       ..  :8df0[1]
+    bmi loop_c8df0                                                    ; 2df2: 30 fc       0.  :8df2[1]
+    bne c8e0d                                                         ; 2df4: d0 17       ..  :8df4[1]
+    lda l00a5                                                         ; 2df6: a5 a5       ..  :8df6[1]
+    beq c8e03                                                         ; 2df8: f0 09       ..  :8df8[1]
+    dec l00b7                                                         ; 2dfa: c6 b7       ..  :8dfa[1]
+    bne loop_c8de9                                                    ; 2dfc: d0 eb       ..  :8dfc[1]
+    lda #&10                                                          ; 2dfe: a9 10       ..  :8dfe[1]
+    sta l00a2                                                         ; 2e00: 85 a2       ..  :8e00[1]
+    rts                                                               ; 2e02: 60          `   :8e02[1]
+
+; &2e03 referenced 1 time by &8df8
+.c8e03
+    lda l00b6                                                         ; 2e03: a5 b6       ..  :8e03[1]
+    eor #&fb                                                          ; 2e05: 49 fb       I.  :8e05[1]
+    beq c8e0d                                                         ; 2e07: f0 04       ..  :8e07[1]
+    lda #&20 ; ' '                                                    ; 2e09: a9 20       .   :8e09[1]
+    sta l00a2                                                         ; 2e0b: 85 a2       ..  :8e0b[1]
+; &2e0d referenced 2 times by &8df4, &8e07
+.c8e0d
+    rts                                                               ; 2e0d: 60          `   :8e0d[1]
+
+; &2e0e referenced 4 times by &8d81, &8da3, &8da8, &8ec2
+.c8e0e
+    ldy #6                                                            ; 2e0e: a0 06       ..  :8e0e[1]
+    lda (l00b0),y                                                     ; 2e10: b1 b0       ..  :8e10[1]
+; &2e12 referenced 4 times by &8d08, &8d17, &8efc, &8f21
+.c8e12
+    ldy #&ff                                                          ; 2e12: a0 ff       ..  :8e12[1]
+; &2e14 referenced 1 time by &8e18
+.loop_c8e14
+    iny                                                               ; 2e14: c8          .   :8e14[1]
+    cmp l9121,y                                                       ; 2e15: d9 21 91    .!. :8e15[1]
+    bne loop_c8e14                                                    ; 2e18: d0 fa       ..  :8e18[1]
+    pha                                                               ; 2e1a: 48          H   :8e1a[1]
+    lda nmi_and_table,y                                               ; 2e1b: b9 2d 91    .-. :8e1b[1]
+    sta nmi_and_imm+1                                                 ; 2e1e: 8d 05 0d    ... :8e1e[1]
+    ror l00a2                                                         ; 2e21: 66 a2       f.  :8e21[1]
+    pla                                                               ; 2e23: 68          h   :8e23[1]
+    bpl c8e72                                                         ; 2e24: 10 4c       .L  :8e24[1]
+    bit l00a1                                                         ; 2e26: 24 a1       $.  :8e26[1]
+    bvc c8e32                                                         ; 2e28: 50 08       P.  :8e28[1]
+    ldy l00ce                                                         ; 2e2a: a4 ce       ..  :8e2a[1]
+    cpy #&14                                                          ; 2e2c: c0 14       ..  :8e2c[1]
+    bcc c8e32                                                         ; 2e2e: 90 02       ..  :8e2e[1]
+    ora #2                                                            ; 2e30: 09 02       ..  :8e30[1]
+; &2e32 referenced 2 times by &8e28, &8e2e
+.c8e32
+    sta l00a7                                                         ; 2e32: 85 a7       ..  :8e32[1]
+    ldy #1                                                            ; 2e34: a0 01       ..  :8e34[1]
+    cmp #&c0                                                          ; 2e36: c9 c0       ..  :8e36[1]
+    beq c8e53                                                         ; 2e38: f0 19       ..  :8e38[1]
+    ora #4                                                            ; 2e3a: 09 04       ..  :8e3a[1]
+    bcs c8e53                                                         ; 2e3c: b0 15       ..  :8e3c[1]
+    ldy l00a5                                                         ; 2e3e: a4 a5       ..  :8e3e[1]
+    cmp #&85                                                          ; 2e40: c9 85       ..  :8e40[1]
+    beq c8e4d                                                         ; 2e42: f0 09       ..  :8e42[1]
+    cmp #&87                                                          ; 2e44: c9 87       ..  :8e44[1]
+    bne c8e53                                                         ; 2e46: d0 0b       ..  :8e46[1]
+    lda #nmi_XXX1-(nmi_beq+2)                                         ; 2e48: a9 48       .H  :8e48[1]
+    sta nmi_beq+1                                                     ; 2e4a: 8d 09 0d    ... :8e4a[1]
+; &2e4d referenced 1 time by &8e42
+.c8e4d
+    lda #&80                                                          ; 2e4d: a9 80       ..  :8e4d[1]
+    sta l00a7                                                         ; 2e4f: 85 a7       ..  :8e4f[1]
+    lda #&84                                                          ; 2e51: a9 84       ..  :8e51[1]
+; &2e53 referenced 3 times by &8e38, &8e3c, &8e46
+.c8e53
+    sty l00a5                                                         ; 2e53: 84 a5       ..  :8e53[1]
+    sta lfe84                                                         ; 2e55: 8d 84 fe    ... :8e55[1]
+    cmp #&f0                                                          ; 2e58: c9 f0       ..  :8e58[1]
+    bcc c8e64                                                         ; 2e5a: 90 08       ..  :8e5a[1]
+    jsr c8e9f                                                         ; 2e5c: 20 9f 8e     .. :8e5c[1]
+    and #&5c ; '\'                                                    ; 2e5f: 29 5c       )\  :8e5f[1]
+    sta l00a2                                                         ; 2e61: 85 a2       ..  :8e61[1]
+    rts                                                               ; 2e63: 60          `   :8e63[1]
+
+; &2e64 referenced 4 times by &8e5a, &8e66, &8e7f, &8e83
+.c8e64
+    lda l00a2                                                         ; 2e64: a5 a2       ..  :8e64[1]
+    bmi c8e64                                                         ; 2e66: 30 fc       0.  :8e66[1]
+    cmp #&20 ; ' '                                                    ; 2e68: c9 20       .   :8e68[1]
+    bne c8e6f                                                         ; 2e6a: d0 03       ..  :8e6a[1]
+    jsr c8ea5                                                         ; 2e6c: 20 a5 8e     .. :8e6c[1]
+; &2e6f referenced 1 time by &8e6a
+.c8e6f
+    lda l00a2                                                         ; 2e6f: a5 a2       ..  :8e6f[1]
+    rts                                                               ; 2e71: 60          `   :8e71[1]
+
+; &2e72 referenced 1 time by &8e24
+.c8e72
+    ldy #1                                                            ; 2e72: a0 01       ..  :8e72[1]
+    sty l00a5                                                         ; 2e74: 84 a5       ..  :8e74[1]
+    ora l00a4                                                         ; 2e76: 05 a4       ..  :8e76[1]
+    sta l00a7                                                         ; 2e78: 85 a7       ..  :8e78[1]
+    sta lfe84                                                         ; 2e7a: 8d 84 fe    ... :8e7a[1]
+    bit l00b2                                                         ; 2e7d: 24 b2       $.  :8e7d[1]
+    bmi c8e64                                                         ; 2e7f: 30 e3       0.  :8e7f[1]
+    cmp #&20 ; ' '                                                    ; 2e81: c9 20       .   :8e81[1]
+    bcs c8e64                                                         ; 2e83: b0 df       ..  :8e83[1]
+; &2e85 referenced 1 time by &8e8b
+.loop_c8e85
+    lda l00a2                                                         ; 2e85: a5 a2       ..  :8e85[1]
+    bpl c8e9e                                                         ; 2e87: 10 15       ..  :8e87[1]
+    lda l00ff                                                         ; 2e89: a5 ff       ..  :8e89[1]
+    bpl loop_c8e85                                                    ; 2e8b: 10 f8       ..  :8e8b[1]
+    lda #opcode_rti                                                   ; 2e8d: a9 40       .@  :8e8d[1]
+    sta nmi_handler_ram                                               ; 2e8f: 8d 00 0d    ... :8e8f[1]
+    lda #0                                                            ; 2e92: a9 00       ..  :8e92[1]
+    sta lfe80                                                         ; 2e94: 8d 80 fe    ... :8e94[1]
+    lda l00ff                                                         ; 2e97: a5 ff       ..  :8e97[1]
+    sta l1082                                                         ; 2e99: 8d 82 10    ... :8e99[1]
+    sta l00a2                                                         ; 2e9c: 85 a2       ..  :8e9c[1]
+; &2e9e referenced 1 time by &8e87
+.c8e9e
+    rts                                                               ; 2e9e: 60          `   :8e9e[1]
+
+; &2e9f referenced 2 times by &8e5c, &8ea3
+.c8e9f
+    lda lfe84                                                         ; 2e9f: ad 84 fe    ... :8e9f[1]
+    ror a                                                             ; 2ea2: 6a          j   :8ea2[1]
+    bcc c8e9f                                                         ; 2ea3: 90 fa       ..  :8ea3[1]
+; &2ea5 referenced 2 times by &8e6c, &8ea9
+.c8ea5
+    lda lfe84                                                         ; 2ea5: ad 84 fe    ... :8ea5[1]
+    ror a                                                             ; 2ea8: 6a          j   :8ea8[1]
+    bcs c8ea5                                                         ; 2ea9: b0 fa       ..  :8ea9[1]
+    lda lfe84                                                         ; 2eab: ad 84 fe    ... :8eab[1]
+    rts                                                               ; 2eae: 60          `   :8eae[1]
+
+; &2eaf referenced 1 time by &8d14
+.c8eaf
+    lda #nmi_XXX1-(nmi_beq+2)                                         ; 2eaf: a9 48       .H  :8eaf[1]
+    sta nmi_lda_immXXX3+1                                             ; 2eb1: 8d 4c 0d    .L. :8eb1[1]
+    ldx nmi_beq+1                                                     ; 2eb4: ae 09 0d    ... :8eb4[1]
+; &2eb7 referenced 2 times by &8eb9, &8ec9
+.c8eb7
+    sbc #1                                                            ; 2eb7: e9 01       ..  :8eb7[1]
+    bne c8eb7                                                         ; 2eb9: d0 fc       ..  :8eb9[1]
+    stx nmi_beq+1                                                     ; 2ebb: 8e 09 0d    ... :8ebb[1]
+    lda #4                                                            ; 2ebe: a9 04       ..  :8ebe[1]
+    sta l00a6                                                         ; 2ec0: 85 a6       ..  :8ec0[1]
+    jsr c8e0e                                                         ; 2ec2: 20 0e 8e     .. :8ec2[1]
+    bne c8ecb                                                         ; 2ec5: d0 04       ..  :8ec5[1]
+    dec l00b3                                                         ; 2ec7: c6 b3       ..  :8ec7[1]
+    bne c8eb7                                                         ; 2ec9: d0 ec       ..  :8ec9[1]
+; &2ecb referenced 1 time by &8ec5
+.c8ecb
+    rts                                                               ; 2ecb: 60          `   :8ecb[1]
+
+; &2ecc referenced 3 times by &8d8c, &8ee2, &8ee7
+.c8ecc
+    jsr sub_c8eec                                                     ; 2ecc: 20 ec 8e     .. :8ecc[1]
+    bne c8eeb                                                         ; 2ecf: d0 1a       ..  :8ecf[1]
+    lda l00cd                                                         ; 2ed1: a5 cd       ..  :8ed1[1]
+    and #1                                                            ; 2ed3: 29 01       ).  :8ed3[1]
+    asl a                                                             ; 2ed5: 0a          .   :8ed5[1]
+    tay                                                               ; 2ed6: a8          .   :8ed6[1]
+    lda l00ce                                                         ; 2ed7: a5 ce       ..  :8ed7[1]
+    bit l108a                                                         ; 2ed9: 2c 8a 10    ,.. :8ed9[1]
+    bpl c8edf                                                         ; 2edc: 10 01       ..  :8edc[1]
+    lsr a                                                             ; 2ede: 4a          J   :8ede[1]
+; &2edf referenced 1 time by &8edc
+.c8edf
+    cmp l108b,y                                                       ; 2edf: d9 8b 10    ... :8edf[1]
+    beq c8ecc                                                         ; 2ee2: f0 e8       ..  :8ee2[1]
+    cmp l108c,y                                                       ; 2ee4: d9 8c 10    ... :8ee4[1]
+    beq c8ecc                                                         ; 2ee7: f0 e3       ..  :8ee7[1]
+    lda #0                                                            ; 2ee9: a9 00       ..  :8ee9[1]
+; &2eeb referenced 2 times by &8ecf, &8ef6
+.c8eeb
+    rts                                                               ; 2eeb: 60          `   :8eeb[1]
+
+; &2eec referenced 1 time by &8ecc
+.sub_c8eec
+    bit l108a                                                         ; 2eec: 2c 8a 10    ,.. :8eec[1]
+    bpl c8ef8                                                         ; 2eef: 10 07       ..  :8eef[1]
+    lda #&40 ; '@'                                                    ; 2ef1: a9 40       .@  :8ef1[1]
+    jsr sub_c8efa                                                     ; 2ef3: 20 fa 8e     .. :8ef3[1]
+    bne c8eeb                                                         ; 2ef6: d0 f3       ..  :8ef6[1]
+; &2ef8 referenced 1 time by &8eef
+.c8ef8
+    lda #&50 ; 'P'                                                    ; 2ef8: a9 50       .P  :8ef8[1]
+; &2efa referenced 1 time by &8ef3
+.sub_c8efa
+    inc l00ce                                                         ; 2efa: e6 ce       ..  :8efa[1]
+    jmp c8e12                                                         ; 2efc: 4c 12 8e    L.. :8efc[1]
+
+; &2eff referenced 1 time by &8d1a
+.sub_c8eff
+    lda l00cd                                                         ; 2eff: a5 cd       ..  :8eff[1]
+    and #1                                                            ; 2f01: 29 01       ).  :8f01[1]
+    asl a                                                             ; 2f03: 0a          .   :8f03[1]
+    tax                                                               ; 2f04: aa          .   :8f04[1]
+    ldy #7                                                            ; 2f05: a0 07       ..  :8f05[1]
+    lda (l00b0),y                                                     ; 2f07: b1 b0       ..  :8f07[1]
+    jsr sub_c8f33                                                     ; 2f09: 20 33 8f     3. :8f09[1]
+    bit l108a                                                         ; 2f0c: 2c 8a 10    ,.. :8f0c[1]
+    bpl c8f12                                                         ; 2f0f: 10 01       ..  :8f0f[1]
+    asl a                                                             ; 2f11: 0a          .   :8f11[1]
+; &2f12 referenced 1 time by &8f0f
+.c8f12
+    sta l00ce                                                         ; 2f12: 85 ce       ..  :8f12[1]
+    tay                                                               ; 2f14: a8          .   :8f14[1]
+    beq c8f21                                                         ; 2f15: f0 0a       ..  :8f15[1]
+; &2f17 referenced 1 time by &8f1d
+.loop_c8f17
+    sta lfe87                                                         ; 2f17: 8d 87 fe    ... :8f17[1]
+    cmp lfe87                                                         ; 2f1a: cd 87 fe    ... :8f1a[1]
+    bne loop_c8f17                                                    ; 2f1d: d0 f8       ..  :8f1d[1]
+    lda #&10                                                          ; 2f1f: a9 10       ..  :8f1f[1]
+; &2f21 referenced 1 time by &8f15
+.c8f21
+    jsr c8e12                                                         ; 2f21: 20 12 8e     .. :8f21[1]
+    bne c8f3e                                                         ; 2f24: d0 18       ..  :8f24[1]
+    ldy #7                                                            ; 2f26: a0 07       ..  :8f26[1]
+    lda (l00b0),y                                                     ; 2f28: b1 b0       ..  :8f28[1]
+; &2f2a referenced 3 times by &8c44, &8d10, &8f30
+.c8f2a
+    sta lfe85                                                         ; 2f2a: 8d 85 fe    ... :8f2a[1]
+    cmp lfe85                                                         ; 2f2d: cd 85 fe    ... :8f2d[1]
+    bne c8f2a                                                         ; 2f30: d0 f8       ..  :8f30[1]
+    rts                                                               ; 2f32: 60          `   :8f32[1]
+
+; &2f33 referenced 1 time by &8f09
+.sub_c8f33
+    jsr sub_c8f37                                                     ; 2f33: 20 37 8f     7. :8f33[1]
+    inx                                                               ; 2f36: e8          .   :8f36[1]
+; &2f37 referenced 1 time by &8f33
+.sub_c8f37
+    cmp l108b,x                                                       ; 2f37: dd 8b 10    ... :8f37[1]
+    bcc c8f3e                                                         ; 2f3a: 90 02       ..  :8f3a[1]
+    adc #0                                                            ; 2f3c: 69 00       i.  :8f3c[1]
+; &2f3e referenced 2 times by &8f24, &8f3a
+.c8f3e
+    rts                                                               ; 2f3e: 60          `   :8f3e[1]
+
+; &2f3f referenced 5 times by &8c95, &8f75, &92b0, &932b, &9628
+.sub_c8f3f
+    lda #osbyte_read_tube_presence                                    ; 2f3f: a9 ea       ..  :8f3f[1]
+    ldx #0                                                            ; 2f41: a2 00       ..  :8f41[1]
+    ldy #&ff                                                          ; 2f43: a0 ff       ..  :8f43[1]
+    jsr osbyte                                                        ; 2f45: 20 f4 ff     .. :8f45[1]
+    txa                                                               ; 2f48: 8a          .   :8f48[1]
+    eor #&ff                                                          ; 2f49: 49 ff       I.  :8f49[1]
+    sta l10d6                                                         ; 2f4b: 8d d6 10    ... :8f4b[1]
+    rts                                                               ; 2f4e: 60          `   :8f4e[1]
+
+; &2f4f referenced 1 time by &8c65
+.sub_c8f4f
+    lda #osbyte_issue_service_request                                 ; 2f4f: a9 8f       ..  :8f4f[1]
+    ldx #&0c                                                          ; 2f51: a2 0c       ..  :8f51[1]
+    ldy #&ff                                                          ; 2f53: a0 ff       ..  :8f53[1]
+    jsr osbyte                                                        ; 2f55: 20 f4 ff     .. :8f55[1]
+    sty l00a0                                                         ; 2f58: 84 a0       ..  :8f58[1]
+    inc l10d3                                                         ; 2f5a: ee d3 10    ... :8f5a[1]
+    rts                                                               ; 2f5d: 60          `   :8f5d[1]
+
+; &2f5e referenced 1 time by &8c4e
+.sub_c8f5e
+    ldy l00a0                                                         ; 2f5e: a4 a0       ..  :8f5e[1]
+    lda #osbyte_issue_service_request                                 ; 2f60: a9 8f       ..  :8f60[1]
+    ldx #&0b                                                          ; 2f62: a2 0b       ..  :8f62[1]
+    jsr osbyte                                                        ; 2f64: 20 f4 ff     .. :8f64[1]
+    dec l10d3                                                         ; 2f67: ce d3 10    ... :8f67[1]
+    rts                                                               ; 2f6a: 60          `   :8f6a[1]
+
+; &2f6b referenced 4 times by &8921, &8c9b, &933e, &9819
+.sub_c8f6b
+    pha                                                               ; 2f6b: 48          H   :8f6b[1]
+; &2f6c referenced 1 time by &8f71
+.loop_c8f6c
+    lda #&c1                                                          ; 2f6c: a9 c1       ..  :8f6c[1]
+    jsr tube_entry                                                    ; 2f6e: 20 06 04     .. :8f6e[1]
+    bcc loop_c8f6c                                                    ; 2f71: 90 f9       ..  :8f71[1]
+    pla                                                               ; 2f73: 68          h   :8f73[1]
+    rts                                                               ; 2f74: 60          `   :8f74[1]
+
+; &2f75 referenced 1 time by &8071
+.sub_c8f75
+    jsr sub_c8f3f                                                     ; 2f75: 20 3f 8f     ?. :8f75[1]
+    bmi c8f81                                                         ; 2f78: 30 07       0.  :8f78[1]
+; &2f7a referenced 3 times by &8c4b, &9364, &97e3
+.sub_c8f7a
+    pha                                                               ; 2f7a: 48          H   :8f7a[1]
+    lda #&81                                                          ; 2f7b: a9 81       ..  :8f7b[1]
+    jsr tube_entry                                                    ; 2f7d: 20 06 04     .. :8f7d[1]
+    pla                                                               ; 2f80: 68          h   :8f80[1]
+; &2f81 referenced 1 time by &8f78
+.c8f81
+    rts                                                               ; 2f81: 60          `   :8f81[1]
+
+; &2f82 referenced 1 time by &8c68
+.sub_c8f82
+    lda #osbyte_read_write_startup_options                            ; 2f82: a9 ff       ..  :8f82[1]
+    ldx #0                                                            ; 2f84: a2 00       ..  :8f84[1]
+    tay                                                               ; 2f86: a8          .   :8f86[1]
+    jsr osbyte                                                        ; 2f87: 20 f4 ff     .. :8f87[1]
+    txa                                                               ; 2f8a: 8a          .   :8f8a[1]
+    lsr a                                                             ; 2f8b: 4a          J   :8f8b[1]
+    lsr a                                                             ; 2f8c: 4a          J   :8f8c[1]
+    lsr a                                                             ; 2f8d: 4a          J   :8f8d[1]
+    lsr a                                                             ; 2f8e: 4a          J   :8f8e[1]
+    and #3                                                            ; 2f8f: 29 03       ).  :8f8f[1]
+    sta l00a4                                                         ; 2f91: 85 a4       ..  :8f91[1]
+    rts                                                               ; 2f93: 60          `   :8f93[1]
+
+; &2f94 referenced 1 time by &8cb4
+.sub_c8f94
+    ldx #nmi_handler_rom_end-nmi_handler_rom_start-1                  ; 2f94: a2 5d       .]  :8f94[1]
+; &2f96 referenced 1 time by &8f9d
+.loop_c8f96
+    lda nmi_handler_rom_start,x                                       ; 2f96: bd d2 8f    ... :8f96[1]
+    sta nmi_handler_ram,x                                             ; 2f99: 9d 00 0d    ... :8f99[1]
+    dex                                                               ; 2f9c: ca          .   :8f9c[1]
+    bpl loop_c8f96                                                    ; 2f9d: 10 f7       ..  :8f9d[1]
+    ldx #3                                                            ; 2f9f: a2 03       ..  :8f9f[1]
+    bit l00a1                                                         ; 2fa1: 24 a1       $.  :8fa1[1]
+    bvc c8fb5                                                         ; 2fa3: 50 10       P.  :8fa3[1]
+    lda #nmi_XXX8-(nmi_beq+2)                                         ; 2fa5: a9 4d       .M  :8fa5[1]
+    sta nmi_lda_immXXX4+1                                             ; 2fa7: 8d 22 0d    .". :8fa7[1]
+    ldx #nmi3_handler_rom_end-nmi3_handler_rom_start                  ; 2faa: a2 0e       ..  :8faa[1]
+; &2fac referenced 1 time by &8fb3
+.loop_c8fac
+    lda nmi3_handler_rom_start-1,x                                    ; 2fac: bd 2f 90    ./. :8fac[1]
+    sta nmi_XXX2-1,x                                                  ; 2faf: 9d 38 0d    .8. :8faf[1]
+    dex                                                               ; 2fb2: ca          .   :8fb2[1]
+    bne loop_c8fac                                                    ; 2fb3: d0 f7       ..  :8fb3[1]
+; &2fb5 referenced 1 time by &8fa3
+.c8fb5
+    bit l00a1                                                         ; 2fb5: 24 a1       $.  :8fb5[1]
+    bmi c8fc7                                                         ; 2fb7: 30 0e       0.  :8fb7[1]
+    ldy #1                                                            ; 2fb9: a0 01       ..  :8fb9[1]
+    lda (l00b0),y                                                     ; 2fbb: b1 b0       ..  :8fbb[1]
+    sta nmi_lda_abs+1,x                                               ; 2fbd: 9d 3a 0d    .:. :8fbd[1]
+    iny                                                               ; 2fc0: c8          .   :8fc0[1]
+    lda (l00b0),y                                                     ; 2fc1: b1 b0       ..  :8fc1[1]
+    sta nmi_lda_abs+2,x                                               ; 2fc3: 9d 3b 0d    .;. :8fc3[1]
+    rts                                                               ; 2fc6: 60          `   :8fc6[1]
+
+; &2fc7 referenced 1 time by &8fb7
+.c8fc7
+    lda #opcode_bcs                                                   ; 2fc7: a9 b0       ..  :8fc7[1]
+    sta nmi_XXX6                                                      ; 2fc9: 8d 3f 0d    .?. :8fc9[1]
+    lda #nmi_XXX7-(nmi_XXX6+2)                                        ; 2fcc: a9 06       ..  :8fcc[1]
+    sta nmi_XXX6+1                                                    ; 2fce: 8d 40 0d    .@. :8fce[1]
+    rts                                                               ; 2fd1: 60          `   :8fd1[1]
+
+.nmi_handler_rom_start
+    org pydis_start + (nmi_handler_rom_start - rom_header)
+    copyblock rom_header, nmi_handler_rom_start, pydis_start
+    clear rom_header, nmi_handler_rom_start
+
+
+    org &0d00
+.nmi_handler_ram
+    pha                                                               ; 2fd2: 48          H   :0d00[5]
+    lda lfe84                                                         ; 2fd3: ad 84 fe    ... :0d01[5]
+; The operand of this and is modified at runtime.
+.nmi_and_imm
+    and #&18                                                          ; 2fd6: 29 18       ).  :0d04[5]
+    cmp #3                                                            ; 2fd8: c9 03       ..  :0d06[5]
+; The operand of this "beq" is modified at runtime.
+.nmi_beq
+    beq nmi_XXX2                                                      ; 2fda: f0 2f       ./  :0d08[5]
+    and #&fc                                                          ; 2fdc: 29 fc       ).  :0d0a[5]
+    bne l0d12                                                         ; 2fde: d0 04       ..  :0d0c[5]
+    dec l00a5                                                         ; 2fe0: c6 a5       ..  :0d0e[5]
+    bne nmi_lda_zp                                                    ; 2fe2: d0 04       ..  :0d10[5]
+.l0d12
+    sta l00a2                                                         ; 2fe4: 85 a2       ..  :0d12[5]
+    pla                                                               ; 2fe6: 68          h   :0d14[5]
+    rti                                                               ; 2fe7: 40          @   :0d15[5]
+
+; The operand of this lda is modified at runtime.
+.nmi_lda_zp
+    lda l00a5                                                         ; 2fe8: a5 a5       ..  :0d16[5]
+; This instruction is patched at runtime to toggle between cmp #/bcs.
+.nmi_cmp_imm_or_bcs
+    cmp #1                                                            ; 2fea: c9 01       ..  :0d18[5]
+    bne l0d26                                                         ; 2fec: d0 0a       ..  :0d1a[5]
+    lda l00a1                                                         ; 2fee: a5 a1       ..  :0d1c[5]
+    ror a                                                             ; 2ff0: 6a          j   :0d1e[5]
+.l0d1f
+nmi_XXX5 = l0d1f+1
+    bcc l0d26                                                         ; 2ff1: 90 05       ..  :0d1f[5]
+; One patched variant of the code transfers control to nmi_XXX5, which
+; is the
+;     second byte of the following bcc instruction. That is always
+; &05, which is
+;     ORA #. XXX: correct?
+; The operand of this lda is modified at runtime.
+.nmi_lda_immXXX4
+    lda #nmi_XXX1-(nmi_beq+2)                                         ; 2ff3: a9 48       .H  :0d21[5]
+    sta nmi_lda_immXXX3+1                                             ; 2ff5: 8d 4c 0d    .L. :0d23[5]
+.l0d26
+    inc l00cf                                                         ; 2ff8: e6 cf       ..  :0d26[5]
+    lda l00cf                                                         ; 2ffa: a5 cf       ..  :0d28[5]
+.l0d2a
+    sta lfe86                                                         ; 2ffc: 8d 86 fe    ... :0d2a[5]
+    cmp lfe86                                                         ; 2fff: cd 86 fe    ... :0d2d[5]
+    bne l0d2a                                                         ; 3002: d0 f8       ..  :0d30[5]
+    lda l00a7                                                         ; 3004: a5 a7       ..  :0d32[5]
+    sta lfe84                                                         ; 3006: 8d 84 fe    ... :0d34[5]
+    pla                                                               ; 3009: 68          h   :0d37[5]
+    rti                                                               ; 300a: 40          @   :0d38[5]
+
+.nmi_XXX2
+    lda lfe87                                                         ; 300b: ad 87 fe    ... :0d39[5]
+; The operand of this sta is modified at runtime.
+.nmi_sta_abs
+    sta tube_host_r3_data                                             ; 300e: 8d e5 fe    ... :0d3c[5]
+; The first two bytes of the following instruction may be patched at
+; runtime.
+.nmi_XXX6
+    inc nmi_sta_abs+1                                                 ; 3011: ee 3d 0d    .=. :0d3f[5]
+    bne nmi_XXX7                                                      ; 3014: d0 03       ..  :0d42[5]
+    inc nmi_sta_abs+2                                                 ; 3016: ee 3e 0d    .>. :0d44[5]
+.nmi_XXX7
+    dec l00a6                                                         ; 3019: c6 a6       ..  :0d47[5]
+    bne l0d50                                                         ; 301b: d0 05       ..  :0d49[5]
+; The operand of this lda is modified at runtime.
+.nmi_lda_immXXX3
+    lda #nmi_XXX2-(nmi_beq+2)                                         ; 301d: a9 2f       ./  :0d4b[5]
+    sta nmi_beq+1                                                     ; 301f: 8d 09 0d    ... :0d4d[5]
+.l0d50
+    pla                                                               ; 3022: 68          h   :0d50[5]
+    rti                                                               ; 3023: 40          @   :0d51[5]
+
+.nmi_XXX1
+    lda lfe87                                                         ; 3024: ad 87 fe    ... :0d52[5]
+    pla                                                               ; 3027: 68          h   :0d55[5]
+    rti                                                               ; 3028: 40          @   :0d56[5]
+
+.nmi_XXX8
+    lda #0                                                            ; 3029: a9 00       ..  :0d57[5]
+    sta lfe87                                                         ; 302b: 8d 87 fe    ... :0d59[5]
+    pla                                                               ; 302e: 68          h   :0d5c[5]
+    rti                                                               ; 302f: 40          @   :0d5d[5]
+
+; The operand of this lda is modified at runtime.
+    org sub_c2fd2 + (sub_c0d5e - nmi_handler_ram)
+    copyblock nmi_handler_ram, sub_c0d5e, sub_c2fd2
+    clear nmi_handler_ram, sub_c0d5e
+
+; The operand of this lda is modified at runtime.
+; The operand of this lda is modified at runtime.
+
+    org &0d39
+; The operand of this lda is modified at runtime.
+.nmi_lda_abs
+    lda tube_host_r3_data                                             ; 3030: ad e5 fe    ... :0d39[6]
+    sta lfe87                                                         ; 3033: 8d 87 fe    ... :0d3c[6]
+    inc nmi_lda_abs+1                                                 ; 3036: ee 3a 0d    .:. :0d3f[6]
+    bne nmi_XXX7                                                      ; 3039: d0 03       ..  :0d42[6]
+    inc nmi_lda_abs+2                                                 ; 303b: ee 3b 0d    .;. :0d44[6]
+; &303e referenced 1 time by &8de2
+    org sub_c3030 + (l0d47 - nmi_lda_abs)
+    copyblock nmi_lda_abs, l0d47, sub_c3030
+    clear nmi_lda_abs, l0d47
+
+; &303e referenced 1 time by &8de2
+; &303e referenced 1 time by &8de2
+
+    org &903e
+; &303e referenced 1 time by &8de2
+.nmi3_handler_rom_end
+    ldx nmi_sta_abs+1                                                 ; 303e: ae 3d 0d    .=. :903e[1]
+    lda nmi_sta_abs+2                                                 ; 3041: ad 3e 0d    .>. :9041[1]
+    pha                                                               ; 3044: 48          H   :9044[1]
+    ldy #nmi_handler2_rom_end-nmi_handler2_rom_start                  ; 3045: a0 94       ..  :9045[1]
+; &3047 referenced 1 time by &904e
+.loop_c9047
+    lda nmi_handler2_rom_start-1,y                                    ; 3047: b9 66 90    .f. :9047[1]
+    sta l0cff,y                                                       ; 304a: 99 ff 0c    ... :904a[1]
+    dey                                                               ; 304d: 88          .   :904d[1]
+    bne loop_c9047                                                    ; 304e: d0 f7       ..  :904e[1]
+    pla                                                               ; 3050: 68          h   :9050[1]
+    bit l00a1                                                         ; 3051: 24 a1       $.  :9051[1]
+    bpl c9060                                                         ; 3053: 10 0b       ..  :9053[1]
+    lda #opcode_bcs                                                   ; 3055: a9 b0       ..  :9055[1]
+    sta nmi_cmp_imm_or_bcs                                            ; 3057: 8d 18 0d    ... :9057[1]
+    lda #nmi_XXX5-(nmi_cmp_imm_or_bcs+2)                              ; 305a: a9 06       ..  :905a[1]
+    sta nmi_cmp_imm_or_bcs+1                                          ; 305c: 8d 19 0d    ... :905c[1]
+    rts                                                               ; 305f: 60          `   :905f[1]
+
+; &3060 referenced 1 time by &9053
+.c9060
+    stx nmi_lda_zp                                                    ; 3060: 8e 16 0d    ... :9060[1]
+    sta nmi_lda_zp+1                                                  ; 3063: 8d 17 0d    ... :9063[1]
+; &3066 referenced 1 time by &9047
+    rts                                                               ; 3066: 60          `   :9066[1]
+
+.nmi_handler2_rom_start
+    org sub_c303e + (nmi_handler2_rom_start - nmi3_handler_rom_end)
+    copyblock nmi3_handler_rom_end, nmi_handler2_rom_start, sub_c303e
+    clear nmi3_handler_rom_end, nmi_handler2_rom_start
+
+
+    org &0d00
+    pha                                                               ; 3067: 48          H   :0d00[7]
+    lda lfe84                                                         ; 3068: ad 84 fe    ... :0d01[7]
+    and #&1b                                                          ; 306b: 29 1b       ).  :0d04[7]
+    cmp #3                                                            ; 306d: c9 03       ..  :0d06[7]
+    bne l0d0f                                                         ; 306f: d0 05       ..  :0d08[7]
+    lda lfe87                                                         ; 3071: ad 87 fe    ... :0d0a[7]
+; The operand of this bcs is modified at runtime
+.nmi_bcs
+    bcs nmi_XXX21                                                     ; 3074: b0 26       .&  :0d0d[7]
+.l0d0f
+    and #&fc                                                          ; 3076: 29 fc       ).  :0d0f[7]
+    sta l00a2                                                         ; 3078: 85 a2       ..  :0d11[7]
+    pla                                                               ; 307a: 68          h   :0d13[7]
+    rti                                                               ; 307b: 40          @   :0d14[7]
+
+; The operand of this sta is modified at runtime.
+.nmi_XXX17
+.nmi_sta_abs2
+    sta tube_host_r3_data                                             ; 307c: 8d e5 fe    ... :0d15[7]
+    inc nmi_sta_abs2+1                                                ; 307f: ee 16 0d    ... :0d18[7]
+    bne nmi_XXX18                                                     ; 3082: d0 03       ..  :0d1b[7]
+    inc nmi_sta_abs2+2                                                ; 3084: ee 17 0d    ... :0d1d[7]
+.nmi_XXX18
+    dec l00a6                                                         ; 3087: c6 a6       ..  :0d20[7]
+    bne nmi_XXX23                                                     ; 3089: d0 0f       ..  :0d22[7]
+    dec l00a7                                                         ; 308b: c6 a7       ..  :0d24[7]
+    bne nmi_XXX23                                                     ; 308d: d0 0b       ..  :0d26[7]
+    lda #nmi_XXX22-(nmi_bcs+2)                                        ; 308f: a9 77       .w  :0d28[7]
+    dec l00a5                                                         ; 3091: c6 a5       ..  :0d2a[7]
+    bne l0d30                                                         ; 3093: d0 02       ..  :0d2c[7]
+    lda #nmi_XXX23-(nmi_bcs+2)                                        ; 3095: a9 24       .$  :0d2e[7]
+.l0d30
+    sta nmi_bcs+1                                                     ; 3097: 8d 0e 0d    ... :0d30[7]
+.nmi_XXX23
+    pla                                                               ; 309a: 68          h   :0d33[7]
+    rti                                                               ; 309b: 40          @   :0d34[7]
+
+.nmi_XXX21
+    cmp #&fe                                                          ; 309c: c9 fe       ..  :0d35[7]
+    beq l0d3d                                                         ; 309e: f0 04       ..  :0d37[7]
+    cmp #&ce                                                          ; 30a0: c9 ce       ..  :0d39[7]
+    bne nmi_XXX23                                                     ; 30a2: d0 f6       ..  :0d3b[7]
+.l0d3d
+    lda #nmi_XXX10-(nmi_bcs+2)                                        ; 30a4: a9 32       .2  :0d3d[7]
+    bne l0d30                                                         ; 30a6: d0 ef       ..  :0d3f[7]
+.nmi_XXX10
+    sbc lfe87                                                         ; 30a8: ed 87 fe    ... :0d41[7]
+    sta l00b5                                                         ; 30ab: 85 b5       ..  :0d44[7]
+    lda #nmi_XXX11-(nmi_bcs+2)                                        ; 30ad: a9 3b       .;  :0d46[7]
+    bne l0d30                                                         ; 30af: d0 e6       ..  :0d48[7]
+.nmi_XXX11
+    lda #nmi_XXX12-(nmi_bcs+2)                                        ; 30b1: a9 3f       .?  :0d4a[7]
+    bne l0d30                                                         ; 30b3: d0 e2       ..  :0d4c[7]
+.nmi_XXX12
+    sbc l00cf                                                         ; 30b5: e5 cf       ..  :0d4e[7]
+    ora l00b5                                                         ; 30b7: 05 b5       ..  :0d50[7]
+    sta l00b5                                                         ; 30b9: 85 b5       ..  :0d52[7]
+    lda #nmi_XXX13-(nmi_bcs+2)                                        ; 30bb: a9 49       .I  :0d54[7]
+    bne l0d30                                                         ; 30bd: d0 d8       ..  :0d56[7]
+.nmi_XXX13
+    lda #nmi_XXX14-(nmi_bcs+2)                                        ; 30bf: a9 4d       .M  :0d58[7]
+    bne l0d30                                                         ; 30c1: d0 d4       ..  :0d5a[7]
+.nmi_XXX14
+    lda l00b3                                                         ; 30c3: a5 b3       ..  :0d5c[7]
+    sta l00a6                                                         ; 30c5: 85 a6       ..  :0d5e[7]
+; &30c7 referenced 2 times by &8dac, &8dbd
+.c0d60
+    lda #nmi_XXX15-(nmi_bcs+2)                                        ; 30c7: a9 55       .U  :0d60[7]
+    bne l0d30                                                         ; 30c9: d0 cc       ..  :0d62[7]
+.nmi_XXX15
+    lda l00b4                                                         ; 30cb: a5 b4       ..  :0d64[7]
+    sta l00a7                                                         ; 30cd: 85 a7       ..  :0d66[7]
+    lda #nmi_XXX16-(nmi_bcs+2)                                        ; 30cf: a9 5d       .]  :0d68[7]
+    bne l0d30                                                         ; 30d1: d0 c4       ..  :0d6a[7]
+.nmi_XXX16
+    cmp #&fb                                                          ; 30d3: c9 fb       ..  :0d6c[7]
+    beq c0d74                                                         ; 30d5: f0 04       ..  :0d6e[7]
+    cmp #&f8                                                          ; 30d7: c9 f8       ..  :0d70[7]
+    bne nmi_XXX23                                                     ; 30d9: d0 bf       ..  :0d72[7]
+; &30db referenced 1 time by &0d6e
+.c0d74
+    sta l00b6                                                         ; 30db: 85 b6       ..  :0d74[7]
+    lda l00b5                                                         ; 30dd: a5 b5       ..  :0d76[7]
+    bne c0d80                                                         ; 30df: d0 06       ..  :0d78[7]
+    inc l00cf                                                         ; 30e1: e6 cf       ..  :0d7a[7]
+    lda #nmi_XXX17-(nmi_bcs+2)                                        ; 30e3: a9 06       ..  :0d7c[7]
+    bne l0d30                                                         ; 30e5: d0 b0       ..  :0d7e[7]
+; &30e7 referenced 1 time by &0d78
+.c0d80
+    inc l00a5                                                         ; 30e7: e6 a5       ..  :0d80[7]
+    lda #nmi_XXX18-(nmi_bcs+2)                                        ; 30e9: a9 11       ..  :0d82[7]
+    bne l0d30                                                         ; 30eb: d0 aa       ..  :0d84[7]
+.nmi_XXX22
+    lda #nmi_XXX19-(nmi_bcs+2)                                        ; 30ed: a9 7b       .{  :0d86[7]
+    bne l0d30                                                         ; 30ef: d0 a6       ..  :0d88[7]
+.nmi_XXX19
+    lda #nmi_XXX20-(nmi_bcs+2)                                        ; 30f1: a9 7f       ..  :0d8a[7]
+    bne l0d30                                                         ; 30f3: d0 a2       ..  :0d8c[7]
+.nmi_XXX20
+    bne nmi_XXX23                                                     ; 30f5: d0 a3       ..  :0d8e[7]
+    lda #nmi_XXX21-(nmi_bcs+2)                                        ; 30f7: a9 26       .&  :0d90[7]
+    bne l0d30                                                         ; 30f9: d0 9c       ..  :0d92[7]
+; &30fb referenced 3 times by &8d41, &8d92, &9101
+    org sub_c3067 + (l0d94 - l0d00)
+    copyblock l0d00, l0d94, sub_c3067
+    clear l0d00, l0d94
+
+; &30fb referenced 3 times by &8d41, &8d92, &9101
+; &30fb referenced 3 times by &8d41, &8d92, &9101
+
+    org &90fb
+; &30fb referenced 3 times by &8d41, &8d92, &9101
+.nmi_handler2_rom_end
+    sta lfe86                                                         ; 30fb: 8d 86 fe    ... :90fb[1]
+    cmp lfe86                                                         ; 30fe: cd 86 fe    ... :90fe[1]
+    bne nmi_handler2_rom_end                                          ; 3101: d0 f8       ..  :9101[1]
+    rts                                                               ; 3103: 60          `   :9103[1]
+
+; &3104 referenced 1 time by &966b
+.set_c_iff_have_fdc
+    ldx #0                                                            ; 3104: a2 00       ..  :9104[1]
+    lda #&5a ; 'Z'                                                    ; 3106: a9 5a       .Z  :9106[1]
+; &3108 referenced 1 time by &9111
+.loop_c9108
+    sta lfe85                                                         ; 3108: 8d 85 fe    ... :9108[1]
+    cmp lfe85                                                         ; 310b: cd 85 fe    ... :910b[1]
+    beq c9115                                                         ; 310e: f0 05       ..  :910e[1]
+    dex                                                               ; 3110: ca          .   :9110[1]
+    bne loop_c9108                                                    ; 3111: d0 f5       ..  :9111[1]
+; &3113 referenced 1 time by &911a
+.loop_c9113
+    clc                                                               ; 3113: 18          .   :9113[1]
+    rts                                                               ; 3114: 60          `   :9114[1]
+
+; &3115 referenced 1 time by &910e
+.c9115
+    lda lfe80                                                         ; 3115: ad 80 fe    ... :9115[1]
+    and #3                                                            ; 3118: 29 03       ).  :9118[1]
+    beq loop_c9113                                                    ; 311a: f0 f7       ..  :911a[1]
+    rts                                                               ; 311c: 60          `   :911c[1]
+
+; &311d referenced 1 time by &8cd8
+.l911d
+    equs ")*-."                                                       ; 311d: 29 2a 2d... )*- :911d[1]
+; &3121 referenced 1 time by &8e15
+.l9121
+    equb   0, &10, &40, &50, &80, &81, &83, &a0, &a1, &c0, &e0, &f0   ; 3121: 00 10 40... ..@ :9121[1]
+; &312d referenced 1 time by &8e1b
+.nmi_and_table
+    equb &18, &18, &18, &18, &3f, &1f, &1f, &5f, &5f, &17, &1b, &5f   ; 312d: 18 18 18... ... :912d[1]
+; &3139 referenced 1 time by &8c58
+.l9139
+    equb   8, &10, &18, &20, &40,   0                                 ; 3139: 08 10 18... ... :9139[1]
+; &313f referenced 1 time by &8c61
+.l913f
+    equb &0e, &18, &0c, &20, &12,   0                                 ; 313f: 0e 18 0c... ... :913f[1]
+; &3145 referenced 1 time by &92e3
+.l9145
+    equb &6d                                                          ; 3145: 6d          m   :9145[1]
+; &3146 referenced 1 time by &92e8
+.l9146
+    equb &91, &49, &91, &3c, &0c,   3,   1,   1,   1,   1,   1,   1   ; 3146: 91 49 91... .I. :9146[1]
+    equb &16, &0c,   3,   1, &ff,   1,   1, &18,   4, &4e,   0, &f5   ; 3152: 16 0c 03... ... :9152[1]
+    equb &fe,   0,   0,   0,   0, &f7, &4e,   0, &f5, &fb, &5a, &5a   ; 315e: fe 00 00... ... :915e[1]
+    equb &f7, &4e, &4e, &10,   6,   0,   1,   1,   1,   1,   1,   1   ; 316a: f7 4e 4e... .NN :916a[1]
+    equb &0b,   6,   0,   1, &ff,   1,   1, &13,   3, &ff,   0,   0   ; 3176: 0b 06 00... ... :9176[1]
+    equb &fe,   0,   0,   0,   0, &f7, &ff,   0,   0, &fb, &e5, &e5   ; 3182: fe 00 00... ... :9182[1]
+    equb &f7, &ff, &ff                                                ; 318e: f7 ff ff    ... :918e[1]
+; &3191 referenced 1 time by &91df
+.l9191
+    equb &0a, &0b, &0e, &0f, &12, &13, &16, &17, &1b, &1e, &1f        ; 3191: 0a 0b 0e... ... :9191[1]
+    equs "#) 0"                                                       ; 319c: 23 29 20... #)  :919c[1]
+; &31a0 referenced 1 time by &9201
+.l91a0
+    equb &a0, &a0, &a1, &a1, &80, &80, &81, &81, &c0, &83, &83, &f0   ; 31a0: a0 a0 a1... ... :91a0[1]
+    equb &10, &e0, &f0                                                ; 31ac: 10 e0 f0    ... :91ac[1]
+
+; &31af referenced 3 times by &9758, &a6dc, &a700
+.c91af
+    lda #&ff                                                          ; 31af: a9 ff       ..  :91af[1]
+    sta l1082                                                         ; 31b1: 8d 82 10    ... :91b1[1]
+    stx l00c7                                                         ; 31b4: 86 c7       ..  :91b4[1]
+    sty l00c8                                                         ; 31b6: 84 c8       ..  :91b6[1]
+    ldy #&0c                                                          ; 31b8: a0 0c       ..  :91b8[1]
+; &31ba referenced 1 time by &91c0
+.loop_c91ba
+    lda (l00c7),y                                                     ; 31ba: b1 c7       ..  :91ba[1]
+    sta l00ba,y                                                       ; 31bc: 99 ba 00    ... :91bc[1]
+    dey                                                               ; 31bf: 88          .   :91bf[1]
+    bpl loop_c91ba                                                    ; 31c0: 10 f8       ..  :91c0[1]
+    ldx #&0c                                                          ; 31c2: a2 0c       ..  :91c2[1]
+    lda l00bf                                                         ; 31c4: a5 bf       ..  :91c4[1]
+    cmp #&0a                                                          ; 31c6: c9 0a       ..  :91c6[1]
+    bne c91cc                                                         ; 31c8: d0 02       ..  :91c8[1]
+    ldx #&0e                                                          ; 31ca: a2 0e       ..  :91ca[1]
+; &31cc referenced 1 time by &91c8
+.c91cc
+    lda l00c0                                                         ; 31cc: a5 c0       ..  :91cc[1]
+    and #&3f ; '?'                                                    ; 31ce: 29 3f       )?  :91ce[1]
+    cmp #&3a ; ':'                                                    ; 31d0: c9 3a       .:  :91d0[1]
+    beq c921f                                                         ; 31d2: f0 4b       .K  :91d2[1]
+    cmp #&3d ; '='                                                    ; 31d4: c9 3d       .=  :91d4[1]
+    beq c923f                                                         ; 31d6: f0 67       .g  :91d6[1]
+    cmp #&35 ; '5'                                                    ; 31d8: c9 35       .5  :91d8[1]
+    bne c91df                                                         ; 31da: d0 03       ..  :91da[1]
+    jmp c925a                                                         ; 31dc: 4c 5a 92    LZ. :91dc[1]
+
+; &31df referenced 2 times by &91da, &91e5
+.c91df
+    cmp l9191,x                                                       ; 31df: dd 91 91    ... :91df[1]
+    beq c91eb                                                         ; 31e2: f0 07       ..  :91e2[1]
+    dex                                                               ; 31e4: ca          .   :91e4[1]
+    bpl c91df                                                         ; 31e5: 10 f8       ..  :91e5[1]
+; &31e7 referenced 1 time by &91ff
+.loop_c91e7
+    lda #&fe                                                          ; 31e7: a9 fe       ..  :91e7[1]
+    bmi c9214                                                         ; 31e9: 30 29       0)  :91e9[1]
+; &31eb referenced 1 time by &91e2
+.c91eb
+    cmp #&23 ; '#'                                                    ; 31eb: c9 23       .#  :91eb[1]
+    beq c91f3                                                         ; 31ed: f0 04       ..  :91ed[1]
+    cpx #4                                                            ; 31ef: e0 04       ..  :91ef[1]
+    bcs c9201                                                         ; 31f1: b0 0e       ..  :91f1[1]
+; &31f3 referenced 1 time by &91ed
+.c91f3
+    lda l00ba                                                         ; 31f3: a5 ba       ..  :91f3[1]
+    bpl c91f9                                                         ; 31f5: 10 02       ..  :91f5[1]
+    lda l00cd                                                         ; 31f7: a5 cd       ..  :91f7[1]
+; &31f9 referenced 1 time by &91f5
+.c91f9
+    and #3                                                            ; 31f9: 29 03       ).  :91f9[1]
+    tay                                                               ; 31fb: a8          .   :91fb[1]
+    lda l10de,y                                                       ; 31fc: b9 de 10    ... :91fc[1]
+    bmi loop_c91e7                                                    ; 31ff: 30 e6       0.  :91ff[1]
+; &3201 referenced 1 time by &91f1
+.c9201
+    ldy l91a0,x                                                       ; 3201: bc a0 91    ... :9201[1]
+    sty l00c0                                                         ; 3204: 84 c0       ..  :9204[1]
+    cpy #&f0                                                          ; 3206: c0 f0       ..  :9206[1]
+    bne c920d                                                         ; 3208: d0 03       ..  :9208[1]
+    jsr sub_c929d                                                     ; 320a: 20 9d 92     .. :920a[1]
+; &320d referenced 1 time by &9208
+.c920d
+    ldx #&ba                                                          ; 320d: a2 ba       ..  :920d[1]
+    ldy #0                                                            ; 320f: a0 00       ..  :920f[1]
+    jsr sub_c8bf9                                                     ; 3211: 20 f9 8b     .. :9211[1]
+; &3214 referenced 3 times by &91e9, &9257, &9276
+.c9214
+    pha                                                               ; 3214: 48          H   :9214[1]
+    lda l00bf                                                         ; 3215: a5 bf       ..  :9215[1]
+    clc                                                               ; 3217: 18          .   :9217[1]
+    adc #7                                                            ; 3218: 69 07       i.  :9218[1]
+    tay                                                               ; 321a: a8          .   :921a[1]
+    pla                                                               ; 321b: 68          h   :921b[1]
+    sta (l00c7),y                                                     ; 321c: 91 c7       ..  :921c[1]
+    rts                                                               ; 321e: 60          `   :921e[1]
+
+; &321f referenced 1 time by &91d2
+.c921f
+    jsr sub_c928a                                                     ; 321f: 20 8a 92     .. :921f[1]
+    bcs c922b                                                         ; 3222: b0 07       ..  :9222[1]
+    lda l00c2                                                         ; 3224: a5 c2       ..  :9224[1]
+    sta l108b,x                                                       ; 3226: 9d 8b 10    ... :9226[1]
+    bcc c923b                                                         ; 3229: 90 10       ..  :9229[1]
+; &322b referenced 1 time by &9222
+.c922b
+    jsr sub_c9279                                                     ; 322b: 20 79 92     y. :922b[1]
+    bcc c9257                                                         ; 322e: 90 27       .'  :922e[1]
+    lda l00c2                                                         ; 3230: a5 c2       ..  :9230[1]
+    ldy l10de,x                                                       ; 3232: bc de 10    ... :9232[1]
+    bpl c9238                                                         ; 3235: 10 01       ..  :9235[1]
+    asl a                                                             ; 3237: 0a          .   :9237[1]
+; &3238 referenced 1 time by &9235
+.c9238
+    sta l1088,x                                                       ; 3238: 9d 88 10    ... :9238[1]
+; &323b referenced 1 time by &9229
+.c923b
+    lda #0                                                            ; 323b: a9 00       ..  :923b[1]
+    beq c9257                                                         ; 323d: f0 18       ..  :923d[1]
+; &323f referenced 1 time by &91d6
+.c923f
+    jsr sub_c928a                                                     ; 323f: 20 8a 92     .. :923f[1]
+    bcs c9249                                                         ; 3242: b0 05       ..  :9242[1]
+    lda l108b,x                                                       ; 3244: bd 8b 10    ... :9244[1]
+    bcc c9257                                                         ; 3247: 90 0e       ..  :9247[1]
+; &3249 referenced 1 time by &9242
+.c9249
+    jsr sub_c9279                                                     ; 3249: 20 79 92     y. :9249[1]
+    bcc c9257                                                         ; 324c: 90 09       ..  :924c[1]
+    lda l1088,x                                                       ; 324e: bd 88 10    ... :924e[1]
+    ldy l10de,x                                                       ; 3251: bc de 10    ... :9251[1]
+    bpl c9257                                                         ; 3254: 10 01       ..  :9254[1]
+    lsr a                                                             ; 3256: 4a          J   :9256[1]
+; &3257 referenced 5 times by &922e, &923d, &9247, &924c, &9254
+.c9257
+    jmp c9214                                                         ; 3257: 4c 14 92    L.. :9257[1]
+
+; &325a referenced 1 time by &91dc
+.c925a
+    lda #&ff                                                          ; 325a: a9 ff       ..  :925a[1]
+    ldx #0                                                            ; 325c: a2 00       ..  :925c[1]
+    ldy l00c1                                                         ; 325e: a4 c1       ..  :925e[1]
+    cpy #&10                                                          ; 3260: c0 10       ..  :9260[1]
+    beq c926a                                                         ; 3262: f0 06       ..  :9262[1]
+    cpy #&18                                                          ; 3264: c0 18       ..  :9264[1]
+    bne c9276                                                         ; 3266: d0 0e       ..  :9266[1]
+    inx                                                               ; 3268: e8          .   :9268[1]
+    inx                                                               ; 3269: e8          .   :9269[1]
+; &326a referenced 1 time by &9262
+.c926a
+    lda l00c2                                                         ; 326a: a5 c2       ..  :926a[1]
+    sta l108b,x                                                       ; 326c: 9d 8b 10    ... :926c[1]
+    lda l00c3                                                         ; 326f: a5 c3       ..  :926f[1]
+    sta l108c,x                                                       ; 3271: 9d 8c 10    ... :9271[1]
+    lda #0                                                            ; 3274: a9 00       ..  :9274[1]
+; &3276 referenced 1 time by &9266
+.c9276
+    jmp c9214                                                         ; 3276: 4c 14 92    L.. :9276[1]
+
+; &3279 referenced 2 times by &922b, &9249
+.sub_c9279
+    ldx #0                                                            ; 3279: a2 00       ..  :9279[1]
+    lda l00c1                                                         ; 327b: a5 c1       ..  :927b[1]
+    cmp #&12                                                          ; 327d: c9 12       ..  :927d[1]
+    beq c9289                                                         ; 327f: f0 08       ..  :927f[1]
+    inx                                                               ; 3281: e8          .   :9281[1]
+    cmp #&1a                                                          ; 3282: c9 1a       ..  :9282[1]
+    beq c9289                                                         ; 3284: f0 03       ..  :9284[1]
+    lda #&fe                                                          ; 3286: a9 fe       ..  :9286[1]
+    clc                                                               ; 3288: 18          .   :9288[1]
+; &3289 referenced 2 times by &927f, &9284
+.c9289
+    rts                                                               ; 3289: 60          `   :9289[1]
+
+; &328a referenced 2 times by &921f, &923f
+.sub_c928a
+    lda l00c1                                                         ; 328a: a5 c1       ..  :928a[1]
+    and #&f6                                                          ; 328c: 29 f6       ).  :928c[1]
+    cmp #&10                                                          ; 328e: c9 10       ..  :928e[1]
+    sec                                                               ; 3290: 38          8   :9290[1]
+    bne c929c                                                         ; 3291: d0 09       ..  :9291[1]
+    lda l00c1                                                         ; 3293: a5 c1       ..  :9293[1]
+    lsr a                                                             ; 3295: 4a          J   :9295[1]
+    lsr a                                                             ; 3296: 4a          J   :9296[1]
+    ora l00c1                                                         ; 3297: 05 c1       ..  :9297[1]
+    and #3                                                            ; 3299: 29 03       ).  :9299[1]
+    tax                                                               ; 329b: aa          .   :929b[1]
+; &329c referenced 1 time by &9291
+.c929c
+    rts                                                               ; 329c: 60          `   :929c[1]
+
+; &329d referenced 1 time by &920a
+.sub_c929d
+    jsr sub_c9a8d                                                     ; 329d: 20 8d 9a     .. :929d[1]
+    lda l00bb                                                         ; 32a0: a5 bb       ..  :92a0[1]
+    sta l00b0                                                         ; 32a2: 85 b0       ..  :92a2[1]
+    sta l00b4                                                         ; 32a4: 85 b4       ..  :92a4[1]
+    clc                                                               ; 32a6: 18          .   :92a6[1]
+    adc #&80                                                          ; 32a7: 69 80       i.  :92a7[1]
+    sta l00b2                                                         ; 32a9: 85 b2       ..  :92a9[1]
+    lda l00bc                                                         ; 32ab: a5 bc       ..  :92ab[1]
+    sta l00b1                                                         ; 32ad: 85 b1       ..  :92ad[1]
+    php                                                               ; 32af: 08          .   :92af[1]
+    jsr sub_c8f3f                                                     ; 32b0: 20 3f 8f     ?. :92b0[1]
+    bmi c92bd                                                         ; 32b3: 30 08       0.  :92b3[1]
+    lda l00bd                                                         ; 32b5: a5 bd       ..  :92b5[1]
+    ora l00be                                                         ; 32b7: 05 be       ..  :92b7[1]
+    cmp #&ff                                                          ; 32b9: c9 ff       ..  :92b9[1]
+    bne c92c4                                                         ; 32bb: d0 07       ..  :92bb[1]
+; &32bd referenced 1 time by &92b3
+.c92bd
+    lda l00b1                                                         ; 32bd: a5 b1       ..  :92bd[1]
+    cmp l10cf                                                         ; 32bf: cd cf 10    ... :92bf[1]
+    bcs c92c7                                                         ; 32c2: b0 03       ..  :92c2[1]
+; &32c4 referenced 1 time by &92bb
+.c92c4
+    lda l10cf                                                         ; 32c4: ad cf 10    ... :92c4[1]
+; &32c7 referenced 1 time by &92c2
+.c92c7
+    plp                                                               ; 32c7: 28          (   :92c7[1]
+    sta l00b5                                                         ; 32c8: 85 b5       ..  :92c8[1]
+    adc #0                                                            ; 32ca: 69 00       i.  :92ca[1]
+    sta l00b3                                                         ; 32cc: 85 b3       ..  :92cc[1]
+    inc l00b5                                                         ; 32ce: e6 b5       ..  :92ce[1]
+    lda l00ba                                                         ; 32d0: a5 ba       ..  :92d0[1]
+    bpl c92d6                                                         ; 32d2: 10 02       ..  :92d2[1]
+    lda #0                                                            ; 32d4: a9 00       ..  :92d4[1]
+; &32d6 referenced 1 time by &92d2
+.c92d6
+    rol a                                                             ; 32d6: 2a          *   :92d6[1]
+    rol a                                                             ; 32d7: 2a          *   :92d7[1]
+    rol a                                                             ; 32d8: 2a          *   :92d8[1]
+    sta l108a                                                         ; 32d9: 8d 8a 10    ... :92d9[1]
+    ldx #2                                                            ; 32dc: a2 02       ..  :92dc[1]
+    rol a                                                             ; 32de: 2a          *   :92de[1]
+    bmi c92e3                                                         ; 32df: 30 02       0.  :92df[1]
+    ldx #0                                                            ; 32e1: a2 00       ..  :92e1[1]
+; &32e3 referenced 1 time by &92df
+.c92e3
+    lda l9145,x                                                       ; 32e3: bd 45 91    .E. :92e3[1]
+    sta l00b6                                                         ; 32e6: 85 b6       ..  :92e6[1]
+    lda l9146,x                                                       ; 32e8: bd 46 91    .F. :92e8[1]
+    sta l00b7                                                         ; 32eb: 85 b7       ..  :92eb[1]
+    ldy #&23 ; '#'                                                    ; 32ed: a0 23       .#  :92ed[1]
+; &32ef referenced 1 time by &92f4
+.loop_c92ef
+    lda (l00b6),y                                                     ; 32ef: b1 b6       ..  :92ef[1]
+    sta (l00b2),y                                                     ; 32f1: 91 b2       ..  :92f1[1]
+    dey                                                               ; 32f3: 88          .   :92f3[1]
+    bpl loop_c92ef                                                    ; 32f4: 10 f9       ..  :92f4[1]
+    iny                                                               ; 32f6: c8          .   :92f6[1]
+    sty l00b6                                                         ; 32f7: 84 b6       ..  :92f7[1]
+    lda l00c3                                                         ; 32f9: a5 c3       ..  :92f9[1]
+    pha                                                               ; 32fb: 48          H   :92fb[1]
+    and #&e0                                                          ; 32fc: 29 e0       ).  :92fc[1]
+    bne c9302                                                         ; 32fe: d0 02       ..  :92fe[1]
+    lda #&10                                                          ; 3300: a9 10       ..  :9300[1]
+; &3302 referenced 1 time by &92fe
+.c9302
+    asl a                                                             ; 3302: 0a          .   :9302[1]
+    rol l00b6                                                         ; 3303: 26 b6       &.  :9303[1]
+    asl a                                                             ; 3305: 0a          .   :9305[1]
+    rol l00b6                                                         ; 3306: 26 b6       &.  :9306[1]
+    asl a                                                             ; 3308: 0a          .   :9308[1]
+    rol l00b6                                                         ; 3309: 26 b6       &.  :9309[1]
+    ldy #&0d                                                          ; 330b: a0 0d       ..  :930b[1]
+    sta (l00b2),y                                                     ; 330d: 91 b2       ..  :930d[1]
+    lda l00b6                                                         ; 330f: a5 b6       ..  :930f[1]
+    iny                                                               ; 3311: c8          .   :9311[1]
+    sta (l00b2),y                                                     ; 3312: 91 b2       ..  :9312[1]
+    pla                                                               ; 3314: 68          h   :9314[1]
+    and #&1f                                                          ; 3315: 29 1f       ).  :9315[1]
+    sta l00b9                                                         ; 3317: 85 b9       ..  :9317[1]
+    lda l00c2                                                         ; 3319: a5 c2       ..  :9319[1]
+    ldy #&10                                                          ; 331b: a0 10       ..  :931b[1]
+    sta (l00b2),y                                                     ; 331d: 91 b2       ..  :931d[1]
+    lda l00c5                                                         ; 331f: a5 c5       ..  :931f[1]
+    ldy #0                                                            ; 3321: a0 00       ..  :9321[1]
+    sta (l00b2),y                                                     ; 3323: 91 b2       ..  :9323[1]
+    tya                                                               ; 3325: 98          .   :9325[1]
+    sta l00b8                                                         ; 3326: 85 b8       ..  :9326[1]
+    jsr sub_c93d3                                                     ; 3328: 20 d3 93     .. :9328[1]
+    jsr sub_c8f3f                                                     ; 332b: 20 3f 8f     ?. :932b[1]
+    bmi c9367                                                         ; 332e: 30 37       07  :932e[1]
+    lda l00bd                                                         ; 3330: a5 bd       ..  :9330[1]
+    and l00be                                                         ; 3332: 25 be       %.  :9332[1]
+    cmp #&ff                                                          ; 3334: c9 ff       ..  :9334[1]
+    beq c9367                                                         ; 3336: f0 2f       ./  :9336[1]
+    lda #&ff                                                          ; 3338: a9 ff       ..  :9338[1]
+    sta l00bd                                                         ; 333a: 85 bd       ..  :933a[1]
+    sta l00be                                                         ; 333c: 85 be       ..  :933c[1]
+    jsr sub_c8f6b                                                     ; 333e: 20 6b 8f     k. :933e[1]
+    ldx #&bb                                                          ; 3341: a2 bb       ..  :9341[1]
+    ldy #0                                                            ; 3343: a0 00       ..  :9343[1]
+    tya                                                               ; 3345: 98          .   :9345[1]
+    jsr tube_entry                                                    ; 3346: 20 06 04     .. :9346[1]
+    ldx l00b5                                                         ; 3349: a6 b5       ..  :9349[1]
+    dex                                                               ; 334b: ca          .   :934b[1]
+    stx l00b1                                                         ; 334c: 86 b1       ..  :934c[1]
+    lda l00b9                                                         ; 334e: a5 b9       ..  :934e[1]
+    asl a                                                             ; 3350: 0a          .   :9350[1]
+    asl a                                                             ; 3351: 0a          .   :9351[1]
+    tax                                                               ; 3352: aa          .   :9352[1]
+    ldy #0                                                            ; 3353: a0 00       ..  :9353[1]
+; &3355 referenced 1 time by &9362
+.loop_c9355
+    lda #7                                                            ; 3355: a9 07       ..  :9355[1]
+; &3357 referenced 1 time by &9359
+.loop_c9357
+    sbc #1                                                            ; 3357: e9 01       ..  :9357[1]
+    bne loop_c9357                                                    ; 3359: d0 fc       ..  :9359[1]
+    lda tube_host_r3_data                                             ; 335b: ad e5 fe    ... :935b[1]
+    sta (l00b0),y                                                     ; 335e: 91 b0       ..  :935e[1]
+    iny                                                               ; 3360: c8          .   :9360[1]
+    dex                                                               ; 3361: ca          .   :9361[1]
+    bpl loop_c9355                                                    ; 3362: 10 f1       ..  :9362[1]
+    jsr sub_c8f7a                                                     ; 3364: 20 7a 8f     z. :9364[1]
+; &3367 referenced 2 times by &932e, &9336
+.c9367
+    lda l00b5                                                         ; 3367: a5 b5       ..  :9367[1]
+    sta l00bc                                                         ; 3369: 85 bc       ..  :9369[1]
+; &336b referenced 1 time by &939c
+.c936b
+    ldy #&16                                                          ; 336b: a0 16       ..  :936b[1]
+    ldx #0                                                            ; 336d: a2 00       ..  :936d[1]
+; &336f referenced 1 time by &937c
+.loop_c936f
+    lda (l00b0,x)                                                     ; 336f: a1 b0       ..  :936f[1]
+    sta (l00b2),y                                                     ; 3371: 91 b2       ..  :9371[1]
+    inc l00b0                                                         ; 3373: e6 b0       ..  :9373[1]
+    bne c9379                                                         ; 3375: d0 02       ..  :9375[1]
+    inc l00b1                                                         ; 3377: e6 b1       ..  :9377[1]
+; &3379 referenced 1 time by &9375
+.c9379
+    iny                                                               ; 3379: c8          .   :9379[1]
+    cpy #&1a                                                          ; 337a: c0 1a       ..  :937a[1]
+    bne loop_c936f                                                    ; 337c: d0 f1       ..  :937c[1]
+    lda #1                                                            ; 337e: a9 01       ..  :937e[1]
+    sta l00b6                                                         ; 3380: 85 b6       ..  :9380[1]
+; &3382 referenced 1 time by &9396
+.loop_c9382
+    lda l00b6                                                         ; 3382: a5 b6       ..  :9382[1]
+    cmp #&0e                                                          ; 3384: c9 0e       ..  :9384[1]
+    bne c938d                                                         ; 3386: d0 05       ..  :9386[1]
+    jsr sub_c93b4                                                     ; 3388: 20 b4 93     .. :9388[1]
+    beq c9390                                                         ; 338b: f0 03       ..  :938b[1]
+; &338d referenced 1 time by &9386
+.c938d
+    jsr sub_c93d3                                                     ; 338d: 20 d3 93     .. :938d[1]
+; &3390 referenced 1 time by &938b
+.c9390
+    inc l00b6                                                         ; 3390: e6 b6       ..  :9390[1]
+    lda l00b6                                                         ; 3392: a5 b6       ..  :9392[1]
+    cmp #&11                                                          ; 3394: c9 11       ..  :9394[1]
+    bne loop_c9382                                                    ; 3396: d0 ea       ..  :9396[1]
+    inc l00b8                                                         ; 3398: e6 b8       ..  :9398[1]
+    dec l00b9                                                         ; 339a: c6 b9       ..  :939a[1]
+    bne c936b                                                         ; 339c: d0 cd       ..  :939c[1]
+    tay                                                               ; 339e: a8          .   :939e[1]
+    lda #&0e                                                          ; 339f: a9 0e       ..  :939f[1]
+    bit l108a                                                         ; 33a1: 2c 8a 10    ,.. :93a1[1]
+    bvc c93a8                                                         ; 33a4: 50 02       P.  :93a4[1]
+    lda #&1a                                                          ; 33a6: a9 1a       ..  :93a6[1]
+; &33a8 referenced 1 time by &93a4
+.c93a8
+    clc                                                               ; 33a8: 18          .   :93a8[1]
+    adc l00bc                                                         ; 33a9: 65 bc       e.  :93a9[1]
+    sbc l00b5                                                         ; 33ab: e5 b5       ..  :93ab[1]
+    bcs c93b1                                                         ; 33ad: b0 02       ..  :93ad[1]
+    lda #1                                                            ; 33af: a9 01       ..  :93af[1]
+; &33b1 referenced 1 time by &93ad
+.c93b1
+    sta (l00b2),y                                                     ; 33b1: 91 b2       ..  :93b1[1]
+    tya                                                               ; 33b3: 98          .   :93b3[1]
+; &33b4 referenced 1 time by &9388
+.sub_c93b4
+    jsr sub_c93c5                                                     ; 33b4: 20 c5 93     .. :93b4[1]
+    beq c93c4                                                         ; 33b7: f0 0b       ..  :93b7[1]
+    stx l00b7                                                         ; 33b9: 86 b7       ..  :93b9[1]
+    ldx #0                                                            ; 33bb: a2 00       ..  :93bb[1]
+; &33bd referenced 1 time by &93c2
+.loop_c93bd
+    jsr sub_c93d8                                                     ; 33bd: 20 d8 93     .. :93bd[1]
+    dec l00b7                                                         ; 33c0: c6 b7       ..  :93c0[1]
+    bne loop_c93bd                                                    ; 33c2: d0 f9       ..  :93c2[1]
+; &33c4 referenced 1 time by &93b7
+.c93c4
+    rts                                                               ; 33c4: 60          `   :93c4[1]
+
+; &33c5 referenced 2 times by &93b4, &93d3
+.sub_c93c5
+    tay                                                               ; 33c5: a8          .   :93c5[1]
+    lda (l00b2),y                                                     ; 33c6: b1 b2       ..  :93c6[1]
+    tax                                                               ; 33c8: aa          .   :93c8[1]
+    tya                                                               ; 33c9: 98          .   :93c9[1]
+    clc                                                               ; 33ca: 18          .   :93ca[1]
+    adc #&12                                                          ; 33cb: 69 12       i.  :93cb[1]
+    tay                                                               ; 33cd: a8          .   :93cd[1]
+    lda (l00b2),y                                                     ; 33ce: b1 b2       ..  :93ce[1]
+    cpx #0                                                            ; 33d0: e0 00       ..  :93d0[1]
+    rts                                                               ; 33d2: 60          `   :93d2[1]
+
+; &33d3 referenced 2 times by &9328, &938d
+.sub_c93d3
+    jsr sub_c93c5                                                     ; 33d3: 20 c5 93     .. :93d3[1]
+    beq c93e5                                                         ; 33d6: f0 0d       ..  :93d6[1]
+; &33d8 referenced 1 time by &93bd
+.sub_c93d8
+    ldy #0                                                            ; 33d8: a0 00       ..  :93d8[1]
+; &33da referenced 1 time by &93e3
+.loop_c93da
+    sta (l00b4),y                                                     ; 33da: 91 b4       ..  :93da[1]
+    inc l00b4                                                         ; 33dc: e6 b4       ..  :93dc[1]
+    bne c93e2                                                         ; 33de: d0 02       ..  :93de[1]
+    inc l00b5                                                         ; 33e0: e6 b5       ..  :93e0[1]
+; &33e2 referenced 1 time by &93de
+.c93e2
+    dex                                                               ; 33e2: ca          .   :93e2[1]
+    bne loop_c93da                                                    ; 33e3: d0 f5       ..  :93e3[1]
+; &33e5 referenced 1 time by &93d6
+.c93e5
+    rts                                                               ; 33e5: 60          `   :93e5[1]
+
+; &33e6 referenced 10 times by &8772, &8791, &87cb, &89d7, &8a6b, &8b12, &8bf3, &9bbc, &9fff, &a30a
+.c93e6
+    lda l0f04                                                         ; 33e6: ad 04 0f    ... :93e6[1]
+    clc                                                               ; 33e9: 18          .   :93e9[1]
+    sed                                                               ; 33ea: f8          .   :93ea[1]
+    adc #1                                                            ; 33eb: 69 01       i.  :93eb[1]
+    sta l0f04                                                         ; 33ed: 8d 04 0f    ... :93ed[1]
+    cld                                                               ; 33f0: d8          .   :93f0[1]
+; &33f1 referenced 1 time by &a737
+.sub_c93f1
+    ldy #&a0                                                          ; 33f1: a0 a0       ..  :93f1[1]
+    bne c940e                                                         ; 33f3: d0 19       ..  :93f3[1]
+; &33f5 referenced 2 times by &9636, &a7ce
+.sub_c93f5
+    ldy #&81                                                          ; 33f5: a0 81       ..  :93f5[1]
+    bne c940e                                                         ; 33f7: d0 15       ..  :93f7[1]
+; &33f9 referenced 1 time by &8266
+.sub_c93f9
+    ldy #&81                                                          ; 33f9: a0 81       ..  :93f9[1]
+    bne c93ff                                                         ; 33fb: d0 02       ..  :93fb[1]
+; &33fd referenced 3 times by &8287, &988e, &98da
+.sub_c93fd
+    ldy #&80                                                          ; 33fd: a0 80       ..  :93fd[1]
+; &33ff referenced 1 time by &93fb
+.c93ff
+    bit lfe84                                                         ; 33ff: 2c 84 fe    ,.. :93ff[1]
+    bpl c940e                                                         ; 3402: 10 0a       ..  :9402[1]
+    lda l1082                                                         ; 3404: ad 82 10    ... :9404[1]
+    cmp l00cd                                                         ; 3407: c5 cd       ..  :9407[1]
+    bne c940e                                                         ; 3409: d0 03       ..  :9409[1]
+    rts                                                               ; 340b: 60          `   :940b[1]
+
+; &340c referenced 6 times by &8383, &8489, &8a59, &a431, &a448, &a460
+.c940c
+    ldy #&80                                                          ; 340c: a0 80       ..  :940c[1]
+; &340e referenced 4 times by &93f3, &93f7, &9402, &9409
+.c940e
+    jsr sub_c9536                                                     ; 340e: 20 36 95     6. :940e[1]
+    sty l1096                                                         ; 3411: 8c 96 10    ... :9411[1]
+    lda l00cd                                                         ; 3414: a5 cd       ..  :9414[1]
+    sta l1090                                                         ; 3416: 8d 90 10    ... :9416[1]
+    lda #2                                                            ; 3419: a9 02       ..  :9419[1]
+    sta l1099                                                         ; 341b: 8d 99 10    ... :941b[1]
+    lda #&0e                                                          ; 341e: a9 0e       ..  :941e[1]
+    sta l1092                                                         ; 3420: 8d 92 10    ... :9420[1]
+    dec l1093                                                         ; 3423: ce 93 10    ... :9423[1]
+    dec l1094                                                         ; 3426: ce 94 10    ... :9426[1]
+    jsr sub_c9445                                                     ; 3429: 20 45 94     E. :9429[1]
+    lda l00cd                                                         ; 342c: a5 cd       ..  :942c[1]
+    sta l1082                                                         ; 342e: 8d 82 10    ... :942e[1]
+    rts                                                               ; 3431: 60          `   :9431[1]
+
+; &3432 referenced 2 times by &944d, &a6f9
+.sub_c9432
+    bit l00ff                                                         ; 3432: 24 ff       $.  :9432[1]
+    bpl c9444                                                         ; 3434: 10 0e       ..  :9434[1]
+; &3436 referenced 4 times by &946c, &a411, &a65d, &abc2
+.c9436
+    jsr sub_c9ad8                                                     ; 3436: 20 d8 9a     .. :9436[1]
+    jsr generate_error                                                ; 3439: 20 48 80     H. :9439[1]
+    equb &11                                                          ; 343c: 11          .   :943c[1]
+    equs "Escape"                                                     ; 343d: 45 73 63... Esc :943d[1]
+    equb 0                                                            ; 3443: 00          .   :9443[1]
+
+; &3444 referenced 3 times by &9434, &946a, &947a
+.c9444
+    rts                                                               ; 3444: 60          `   :9444[1]
+
+; &3445 referenced 2 times by &886a, &9429
+.sub_c9445
+    jsr sub_c9516                                                     ; 3445: 20 16 95     .. :9445[1]
+    lda #6                                                            ; 3448: a9 06       ..  :9448[1]
+    sta l109e                                                         ; 344a: 8d 9e 10    ... :944a[1]
+    jsr sub_c9432                                                     ; 344d: 20 32 94     2. :944d[1]
+; &3450 referenced 1 time by &94bf
+.c9450
+    lda l1097                                                         ; 3450: ad 97 10    ... :9450[1]
+    ldx l1090                                                         ; 3453: ae 90 10    ... :9453[1]
+    ldy l10de,x                                                       ; 3456: bc de 10    ... :9456[1]
+    bpl c945c                                                         ; 3459: 10 01       ..  :9459[1]
+    asl a                                                             ; 345b: 0a          .   :945b[1]
+; &345c referenced 1 time by &9459
+.c945c
+    ldy #&18                                                          ; 345c: a0 18       ..  :945c[1]
+    cmp #&50 ; 'P'                                                    ; 345e: c9 50       .P  :945e[1]
+    bcs c94c1                                                         ; 3460: b0 5f       ._  :9460[1]
+    ldx #&90                                                          ; 3462: a2 90       ..  :9462[1]
+    ldy #&10                                                          ; 3464: a0 10       ..  :9464[1]
+    jsr sub_c8bf6                                                     ; 3466: 20 f6 8b     .. :9466[1]
+    tay                                                               ; 3469: a8          .   :9469[1]
+    beq c9444                                                         ; 346a: f0 d8       ..  :946a[1]
+    bmi c9436                                                         ; 346c: 30 c8       0.  :946c[1]
+    cmp #&12                                                          ; 346e: c9 12       ..  :946e[1]
+    beq c94c6                                                         ; 3470: f0 54       .T  :9470[1]
+    cmp #&20 ; ' '                                                    ; 3472: c9 20       .   :9472[1]
+    bne c948d                                                         ; 3474: d0 17       ..  :9474[1]
+    lda l1096                                                         ; 3476: ad 96 10    ... :9476[1]
+    ror a                                                             ; 3479: 6a          j   :9479[1]
+    bcs c9444                                                         ; 347a: b0 c8       ..  :947a[1]
+    jsr generate_error                                                ; 347c: 20 48 80     H. :947c[1]
+    equb &bc                                                          ; 347f: bc          .   :947f[1]
+    equs "Execute only"                                               ; 3480: 45 78 65... Exe :9480[1]
+    equb 0                                                            ; 348c: 00          .   :948c[1]
+
+; &348d referenced 1 time by &9474
+.c948d
+    cmp #&18                                                          ; 348d: c9 18       ..  :948d[1]
+    bne c94bc                                                         ; 348f: d0 2b       .+  :948f[1]
+    lda l108a                                                         ; 3491: ad 8a 10    ... :9491[1]
+    cmp #4                                                            ; 3494: c9 04       ..  :9494[1]
+    bne c94a9                                                         ; 3496: d0 11       ..  :9496[1]
+    ldx l1096                                                         ; 3498: ae 96 10    ... :9498[1]
+    cpx #&81                                                          ; 349b: e0 81       ..  :949b[1]
+    bne c94a9                                                         ; 349d: d0 0a       ..  :949d[1]
+    lda #&ff                                                          ; 349f: a9 ff       ..  :949f[1]
+    eor l108b                                                         ; 34a1: 4d 8b 10    M.. :94a1[1]
+    sta l108b                                                         ; 34a4: 8d 8b 10    ... :94a4[1]
+    bcs c94bc                                                         ; 34a7: b0 13       ..  :94a7[1]
+; &34a9 referenced 2 times by &9496, &949d
+.c94a9
+    ldx l00ce                                                         ; 34a9: a6 ce       ..  :94a9[1]
+    beq c94bc                                                         ; 34ab: f0 0f       ..  :94ab[1]
+    rol a                                                             ; 34ad: 2a          *   :94ad[1]
+    and #&80                                                          ; 34ae: 29 80       ).  :94ae[1]
+    ldx l1090                                                         ; 34b0: ae 90 10    ... :94b0[1]
+    eor l10de,x                                                       ; 34b3: 5d de 10    ].. :94b3[1]
+    sta l10de,x                                                       ; 34b6: 9d de 10    ... :94b6[1]
+    jsr sub_c9516                                                     ; 34b9: 20 16 95     .. :94b9[1]
+; &34bc referenced 3 times by &948f, &94a7, &94ab
+.c94bc
+    dec l109e                                                         ; 34bc: ce 9e 10    ... :94bc[1]
+    bne c9450                                                         ; 34bf: d0 8f       ..  :94bf[1]
+; &34c1 referenced 1 time by &9460
+.c94c1
+    tya                                                               ; 34c1: 98          .   :94c1[1]
+; &34c2 referenced 1 time by &a70f
+.c94c2
+    cmp #&12                                                          ; 34c2: c9 12       ..  :94c2[1]
+    bne c94d4                                                         ; 34c4: d0 0e       ..  :94c4[1]
+; &34c6 referenced 2 times by &9470, &9523
+.c94c6
+    jsr generate_error_precheck_disc                                  ; 34c6: 20 23 80     #. :94c6[1]
+    equb &c9                                                          ; 34c9: c9          .   :94c9[1]
+    equs "read only"                                                  ; 34ca: 72 65 61... rea :94ca[1]
+    equb 0                                                            ; 34d3: 00          .   :94d3[1]
+
+; &34d4 referenced 1 time by &94c4
+.c94d4
+    pha                                                               ; 34d4: 48          H   :94d4[1]
+    jsr generate_error_precheck_disc                                  ; 34d5: 20 23 80     #. :94d5[1]
+    equb 0                                                            ; 34d8: 00          .   :94d8[1]
+
+    nop                                                               ; 34d9: ea          .   :94d9[1]
+    jsr generate_error2                                               ; 34da: 20 4f 80     O. :94da[1]
+    equb &c7                                                          ; 34dd: c7          .   :94dd[1]
+    equs "fault "                                                     ; 34de: 66 61 75... fau :94de[1]
+
+    nop                                                               ; 34e4: ea          .   :94e4[1]
+    pla                                                               ; 34e5: 68          h   :94e5[1]
+    jsr sub_c9526                                                     ; 34e6: 20 26 95     &. :94e6[1]
+    jsr generate_error2                                               ; 34e9: 20 4f 80     O. :94e9[1]
+    equb 0                                                            ; 34ec: 00          .   :94ec[1]
+    equs " at :"                                                      ; 34ed: 20 61 74...  at :94ed[1]
+
+    lda l00cd                                                         ; 34f2: a5 cd       ..  :94f2[1]
+    jsr sub_c952e                                                     ; 34f4: 20 2e 95     .. :94f4[1]
+    jsr generate_error2                                               ; 34f7: 20 4f 80     O. :94f7[1]
+    equb 0                                                            ; 34fa: 00          .   :94fa[1]
+    equs " "                                                          ; 34fb: 20              :94fb[1]
+
+    lda l00ce                                                         ; 34fc: a5 ce       ..  :94fc[1]
+    bit l108a                                                         ; 34fe: 2c 8a 10    ,.. :94fe[1]
+    bpl c9504                                                         ; 3501: 10 01       ..  :9501[1]
+    lsr a                                                             ; 3503: 4a          J   :9503[1]
+; &3504 referenced 1 time by &9501
+.c9504
+    jsr sub_c9526                                                     ; 3504: 20 26 95     &. :9504[1]
+    jsr generate_error2                                               ; 3507: 20 4f 80     O. :9507[1]
+    equb 0                                                            ; 350a: 00          .   :950a[1]
+    equs "/"                                                          ; 350b: 2f          /   :950b[1]
+
+    lda l00cf                                                         ; 350c: a5 cf       ..  :950c[1]
+    jsr sub_c9526                                                     ; 350e: 20 26 95     &. :950e[1]
+    jsr generate_error2                                               ; 3511: 20 4f 80     O. :9511[1]
+    equb &c7,   0                                                     ; 3514: c7 00       ..  :9514[1]
+
+; &3516 referenced 2 times by &9445, &94b9
+.sub_c9516
+    lda l1096                                                         ; 3516: ad 96 10    ... :9516[1]
+    cmp #&a0                                                          ; 3519: c9 a0       ..  :9519[1]
+    bcc c9535                                                         ; 351b: 90 18       ..  :951b[1]
+    ldx l1090                                                         ; 351d: ae 90 10    ... :951d[1]
+    lda l10de,x                                                       ; 3520: bd de 10    ... :9520[1]
+    bmi c94c6                                                         ; 3523: 30 a1       0.  :9523[1]
+    rts                                                               ; 3525: 60          `   :9525[1]
+
+; &3526 referenced 3 times by &94e6, &9504, &950e
+.sub_c9526
+    pha                                                               ; 3526: 48          H   :9526[1]
+    jsr sub_c81bf                                                     ; 3527: 20 bf 81     .. :9527[1]
+    jsr sub_c952e                                                     ; 352a: 20 2e 95     .. :952a[1]
+    pla                                                               ; 352d: 68          h   :952d[1]
+; &352e referenced 2 times by &94f4, &952a
+.sub_c952e
+    jsr sub_c80c8                                                     ; 352e: 20 c8 80     .. :952e[1]
+    sta l0100,x                                                       ; 3531: 9d 00 01    ... :9531[1]
+    inx                                                               ; 3534: e8          .   :9534[1]
+; &3535 referenced 1 time by &951b
+.c9535
+    rts                                                               ; 3535: 60          `   :9535[1]
+
+; &3536 referenced 1 time by &940e
+.sub_c9536
+    ldx #&0d                                                          ; 3536: a2 0d       ..  :9536[1]
+    lda #0                                                            ; 3538: a9 00       ..  :9538[1]
+; &353a referenced 1 time by &953e
+.loop_c953a
+    sta l108f,x                                                       ; 353a: 9d 8f 10    ... :953a[1]
+    dex                                                               ; 353d: ca          .   :953d[1]
+    bne loop_c953a                                                    ; 353e: d0 fa       ..  :953e[1]
+    lda #5                                                            ; 3540: a9 05       ..  :9540[1]
+    sta l1095                                                         ; 3542: 8d 95 10    ... :9542[1]
+    rts                                                               ; 3545: 60          `   :9545[1]
+
+    equs "L.!BOOT", &0d                                               ; 3546: 4c 2e 21... L.! :9546[1]
+    equs "E.!BOOT", &0d                                               ; 354e: 45 2e 21... E.! :954e[1]
+
+; &3556 referenced 1 time by &96e9
+.c9556
+    lda l00b3                                                         ; 3556: a5 b3       ..  :9556[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 3558: 20 77 80     w. :9558[1]
+    equs "Acorn 1770 DFS", &0d, &0d                                   ; 355b: 41 63 6f... Aco :955b[1]
+
+    bcc c956f                                                         ; 356b: 90 02       ..  :956b[1]
+; &356d referenced 1 time by &96fd
+.c956d
+    lda #&ff                                                          ; 356d: a9 ff       ..  :956d[1]
+; &356f referenced 1 time by &956b
+.c956f
+    jsr zero_stacked_XXX                                              ; 356f: 20 8e 9d     .. :956f[1]
+    pha                                                               ; 3572: 48          H   :9572[1]
+    lda #6                                                            ; 3573: a9 06       ..  :9573[1]
+    jsr sub_c8020                                                     ; 3575: 20 20 80      . :9575[1]
+    lda lfe87                                                         ; 3578: ad 87 fe    ... :9578[1]
+    ldx #&0d                                                          ; 357b: a2 0d       ..  :957b[1]
+; &357d referenced 1 time by &9584
+.loop_c957d
+    lda l9aec,x                                                       ; 357d: bd ec 9a    ... :957d[1]
+    sta filev,x                                                       ; 3580: 9d 12 02    ... :9580[1]
+    dex                                                               ; 3583: ca          .   :9583[1]
+    bpl loop_c957d                                                    ; 3584: 10 f7       ..  :9584[1]
+    lda #&a8                                                          ; 3586: a9 a8       ..  :9586[1]
+    jsr osbyte_read                                                   ; 3588: 20 e5 9a     .. :9588[1]
+    sty l00b1                                                         ; 358b: 84 b1       ..  :958b[1]
+    stx l00b0                                                         ; 358d: 86 b0       ..  :958d[1]
+    ldx #7                                                            ; 358f: a2 07       ..  :958f[1]
+    ldy #&1b                                                          ; 3591: a0 1b       ..  :9591[1]
+; &3593 referenced 1 time by &95a5
+.loop_c9593
+    lda c9adf,y                                                       ; 3593: b9 df 9a    ... :9593[1]
+    sta (l00b0),y                                                     ; 3596: 91 b0       ..  :9596[1]
+    iny                                                               ; 3598: c8          .   :9598[1]
+    lda c9adf,y                                                       ; 3599: b9 df 9a    ... :9599[1]
+    sta (l00b0),y                                                     ; 359c: 91 b0       ..  :959c[1]
+    iny                                                               ; 359e: c8          .   :959e[1]
+    lda romsel_copy                                                   ; 359f: a5 f4       ..  :959f[1]
+    sta (l00b0),y                                                     ; 35a1: 91 b0       ..  :95a1[1]
+    iny                                                               ; 35a3: c8          .   :95a3[1]
+    dex                                                               ; 35a4: ca          .   :95a4[1]
+    bne loop_c9593                                                    ; 35a5: d0 ec       ..  :95a5[1]
+    sty l1082                                                         ; 35a7: 8c 82 10    ... :95a7[1]
+    sty l1083                                                         ; 35aa: 8c 83 10    ... :95aa[1]
+    stx l00cd                                                         ; 35ad: 86 cd       ..  :95ad[1]
+    lda #&ff                                                          ; 35af: a9 ff       ..  :95af[1]
+    sta l1087                                                         ; 35b1: 8d 87 10    ... :95b1[1]
+    ldy #3                                                            ; 35b4: a0 03       ..  :95b4[1]
+; &35b6 referenced 1 time by &95ba
+.loop_c95b6
+    sta l108b,y                                                       ; 35b6: 99 8b 10    ... :95b6[1]
+    dey                                                               ; 35b9: 88          .   :95b9[1]
+    bpl loop_c95b6                                                    ; 35ba: 10 fa       ..  :95ba[1]
+    ldx #&0f                                                          ; 35bc: a2 0f       ..  :95bc[1]
+    jsr c9adf                                                         ; 35be: 20 df 9a     .. :95be[1]
+    jsr sub_c9ab8                                                     ; 35c1: 20 b8 9a     .. :95c1[1]
+    ldy #&d3                                                          ; 35c4: a0 d3       ..  :95c4[1]
+    lda (l00b0),y                                                     ; 35c6: b1 b0       ..  :95c6[1]
+    bpl c95fd                                                         ; 35c8: 10 33       .3  :95c8[1]
+    pla                                                               ; 35ca: 68          h   :95ca[1]
+    pha                                                               ; 35cb: 48          H   :95cb[1]
+    beq c95fd                                                         ; 35cc: f0 2f       ./  :95cc[1]
+    ldy #&d4                                                          ; 35ce: a0 d4       ..  :95ce[1]
+    lda (l00b0),y                                                     ; 35d0: b1 b0       ..  :95d0[1]
+    bmi c9628                                                         ; 35d2: 30 54       0T  :95d2[1]
+    jsr sub_c9aa3                                                     ; 35d4: 20 a3 9a     .. :95d4[1]
+    ldy #0                                                            ; 35d7: a0 00       ..  :95d7[1]
+; &35d9 referenced 1 time by &95e8
+.loop_c95d9
+    lda (l00b0),y                                                     ; 35d9: b1 b0       ..  :95d9[1]
+    cpy #&c0                                                          ; 35db: c0 c0       ..  :95db[1]
+    bcc c95e4                                                         ; 35dd: 90 05       ..  :95dd[1]
+    sta l1000,y                                                       ; 35df: 99 00 10    ... :95df[1]
+    bcs c95e7                                                         ; 35e2: b0 03       ..  :95e2[1]
+; &35e4 referenced 1 time by &95dd
+.c95e4
+    sta l1100,y                                                       ; 35e4: 99 00 11    ... :95e4[1]
+; &35e7 referenced 1 time by &95e2
+.c95e7
+    dey                                                               ; 35e7: 88          .   :95e7[1]
+    bne loop_c95d9                                                    ; 35e8: d0 ef       ..  :95e8[1]
+    lda #&a0                                                          ; 35ea: a9 a0       ..  :95ea[1]
+; &35ec referenced 1 time by &95f9
+.loop_c95ec
+    tay                                                               ; 35ec: a8          .   :95ec[1]
+    pha                                                               ; 35ed: 48          H   :95ed[1]
+    lda #&3f ; '?'                                                    ; 35ee: a9 3f       .?  :95ee[1]
+    jsr sub_c9f16                                                     ; 35f0: 20 16 9f     .. :95f0[1]
+    pla                                                               ; 35f3: 68          h   :95f3[1]
+    sta l111d,y                                                       ; 35f4: 99 1d 11    ... :95f4[1]
+    sbc #&1f                                                          ; 35f7: e9 1f       ..  :95f7[1]
+    bne loop_c95ec                                                    ; 35f9: d0 f1       ..  :95f9[1]
+    beq c9628                                                         ; 35fb: f0 2b       .+  :95fb[1]
+; &35fd referenced 2 times by &95c8, &95cc
+.c95fd
+    jsr sub_c9aa3                                                     ; 35fd: 20 a3 9a     .. :95fd[1]
+    lda #&24 ; '$'                                                    ; 3600: a9 24       .$  :9600[1]
+    sta l10c9                                                         ; 3602: 8d c9 10    ... :9602[1]
+    sta l10cb                                                         ; 3605: 8d cb 10    ... :9605[1]
+    ldy #0                                                            ; 3608: a0 00       ..  :9608[1]
+    sty l10ca                                                         ; 360a: 8c ca 10    ... :960a[1]
+    sty l10cc                                                         ; 360d: 8c cc 10    ... :960d[1]
+    ldy #0                                                            ; 3610: a0 00       ..  :9610[1]
+    sty l10c0                                                         ; 3612: 8c c0 10    ... :9612[1]
+    ldx #3                                                            ; 3615: a2 03       ..  :9615[1]
+    tya                                                               ; 3617: 98          .   :9617[1]
+; &3618 referenced 1 time by &961c
+.loop_c9618
+    sta l10de,x                                                       ; 3618: 9d de 10    ... :9618[1]
+    dex                                                               ; 361b: ca          .   :961b[1]
+    bne loop_c9618                                                    ; 361c: d0 fa       ..  :961c[1]
+    dey                                                               ; 361e: 88          .   :961e[1]
+    sty l10c7                                                         ; 361f: 8c c7 10    ... :961f[1]
+    sty l10c6                                                         ; 3622: 8c c6 10    ... :9622[1]
+    sty l10dd                                                         ; 3625: 8c dd 10    ... :9625[1]
+; &3628 referenced 2 times by &95d2, &95fb
+.c9628
+    jsr sub_c8f3f                                                     ; 3628: 20 3f 8f     ?. :9628[1]
+    pla                                                               ; 362b: 68          h   :962b[1]
+    bne c9649                                                         ; 362c: d0 1b       ..  :962c[1]
+    lda #4                                                            ; 362e: a9 04       ..  :962e[1]
+    ora l10de                                                         ; 3630: 0d de 10    ... :9630[1]
+    sta l10de                                                         ; 3633: 8d de 10    ... :9633[1]
+    jsr sub_c93f5                                                     ; 3636: 20 f5 93     .. :9636[1]
+    lda #&fb                                                          ; 3639: a9 fb       ..  :9639[1]
+    and l10de                                                         ; 363b: 2d de 10    -.. :963b[1]
+    sta l10de                                                         ; 363e: 8d de 10    ... :963e[1]
+    lda l0f06                                                         ; 3641: ad 06 0f    ... :9641[1]
+    jsr sub_c81bf                                                     ; 3644: 20 bf 81     .. :9644[1]
+    bne c964a                                                         ; 3647: d0 01       ..  :9647[1]
+; &3649 referenced 1 time by &962c
+.c9649
+    rts                                                               ; 3649: 60          `   :9649[1]
+
+; &364a referenced 1 time by &9647
+.c964a
+    ldy #&95                                                          ; 364a: a0 95       ..  :964a[1]
+    ldx #&46 ; 'F'                                                    ; 364c: a2 46       .F  :964c[1]
+    cmp #2                                                            ; 364e: c9 02       ..  :964e[1]
+    bcc c965a                                                         ; 3650: 90 08       ..  :9650[1]
+    beq c9658                                                         ; 3652: f0 04       ..  :9652[1]
+    ldx #&4e ; 'N'                                                    ; 3654: a2 4e       .N  :9654[1]
+    bne c965a                                                         ; 3656: d0 02       ..  :9656[1]
+; &3658 referenced 1 time by &9652
+.c9658
+    ldx #&50 ; 'P'                                                    ; 3658: a2 50       .P  :9658[1]
+; &365a referenced 2 times by &9650, &9656
+.c965a
+    jmp oscli                                                         ; 365a: 4c f7 ff    L.. :965a[1]
+
+; &365d referenced 1 time by &b1b1
+.sub_c965d
+    jsr service_handler_help_and_tube                                 ; 365d: 20 a9 ae     .. :965d[1]
+    pha                                                               ; 3660: 48          H   :9660[1]
+    lda l0df0,x                                                       ; 3661: bd f0 0d    ... :9661[1]
+    bmi pla_rts                                                       ; 3664: 30 5b       0[  :9664[1]
+    pla                                                               ; 3666: 68          h   :9666[1]
+    cmp #service_claim_absolute_workspace                             ; 3667: c9 01       ..  :9667[1]
+    bne c9683                                                         ; 3669: d0 18       ..  :9669[1]
+    jsr set_c_iff_have_fdc                                            ; 366b: 20 04 91     .. :966b[1]
+    ldx romsel_copy                                                   ; 366e: a6 f4       ..  :966e[1]
+    bcs c967a                                                         ; 3670: b0 08       ..  :9670[1]
+    lda #&80                                                          ; 3672: a9 80       ..  :9672[1]
+    sta l0df0,x                                                       ; 3674: 9d f0 0d    ... :9674[1]
+    lda #1                                                            ; 3677: a9 01       ..  :9677[1]
+    rts                                                               ; 3679: 60          `   :9679[1]
+
+; &367a referenced 1 time by &9670
+.c967a
+    lda #service_claim_absolute_workspace                             ; 367a: a9 01       ..  :967a[1]
+    cpy #&17                                                          ; 367c: c0 17       ..  :967c[1]
+    bcs c9682                                                         ; 367e: b0 02       ..  :967e[1]
+    ldy #&17                                                          ; 3680: a0 17       ..  :9680[1]
+; &3682 referenced 1 time by &967e
+.c9682
+    rts                                                               ; 3682: 60          `   :9682[1]
+
+; &3683 referenced 1 time by &9669
+.c9683
+    cmp #service_claim_private_workspace                              ; 3683: c9 02       ..  :9683[1]
+    bne c96c3                                                         ; 3685: d0 3c       .<  :9685[1]
+    pha                                                               ; 3687: 48          H   :9687[1]
+    tya                                                               ; 3688: 98          .   :9688[1]
+    pha                                                               ; 3689: 48          H   :9689[1]
+    sta l00b1                                                         ; 368a: 85 b1       ..  :968a[1]
+    ldy l0df0,x                                                       ; 368c: bc f0 0d    ... :968c[1]
+    sta l0df0,x                                                       ; 368f: 9d f0 0d    ... :968f[1]
+    lda #0                                                            ; 3692: a9 00       ..  :9692[1]
+    sta l00b0                                                         ; 3694: 85 b0       ..  :9694[1]
+    cpy l00b1                                                         ; 3696: c4 b1       ..  :9696[1]
+    beq c969e                                                         ; 3698: f0 04       ..  :9698[1]
+    ldy #&d3                                                          ; 369a: a0 d3       ..  :969a[1]
+    sta (l00b0),y                                                     ; 369c: 91 b0       ..  :969c[1]
+; &369e referenced 1 time by &9698
+.c969e
+    lda #&fd                                                          ; 369e: a9 fd       ..  :969e[1]
+    jsr osbyte_read                                                   ; 36a0: 20 e5 9a     .. :96a0[1]
+    dex                                                               ; 36a3: ca          .   :96a3[1]
+    txa                                                               ; 36a4: 8a          .   :96a4[1]
+    ldy #&d3                                                          ; 36a5: a0 d3       ..  :96a5[1]
+    and (l00b0),y                                                     ; 36a7: 31 b0       1.  :96a7[1]
+    sta (l00b0),y                                                     ; 36a9: 91 b0       ..  :96a9[1]
+    php                                                               ; 36ab: 08          .   :96ab[1]
+    iny                                                               ; 36ac: c8          .   :96ac[1]
+    plp                                                               ; 36ad: 28          (   :96ad[1]
+    bpl c96b7                                                         ; 36ae: 10 07       ..  :96ae[1]
+    lda (l00b0),y                                                     ; 36b0: b1 b0       ..  :96b0[1]
+    bpl c96b7                                                         ; 36b2: 10 03       ..  :96b2[1]
+    jsr sub_c8951                                                     ; 36b4: 20 51 89     Q. :96b4[1]
+; &36b7 referenced 2 times by &96ae, &96b2
+.c96b7
+    lda #0                                                            ; 36b7: a9 00       ..  :96b7[1]
+    sta (l00b0),y                                                     ; 36b9: 91 b0       ..  :96b9[1]
+    ldx romsel_copy                                                   ; 36bb: a6 f4       ..  :96bb[1]
+    pla                                                               ; 36bd: 68          h   :96bd[1]
+    tay                                                               ; 36be: a8          .   :96be[1]
+    iny                                                               ; 36bf: c8          .   :96bf[1]
+    iny                                                               ; 36c0: c8          .   :96c0[1]
+; &36c1 referenced 1 time by &9664
+.pla_rts
+    pla                                                               ; 36c1: 68          h   :96c1[1]
+; &36c2 referenced 1 time by &96df
+.loop_c96c2
+    rts                                                               ; 36c2: 60          `   :96c2[1]
+
+; &36c3 referenced 1 time by &9685
+.c96c3
+    jsr sub_c83e3                                                     ; 36c3: 20 e3 83     .. :96c3[1]
+    cmp #service_boot                                                 ; 36c6: c9 03       ..  :96c6[1]
+    bne c96ec                                                         ; 36c8: d0 22       ."  :96c8[1]
+    sty l00b3                                                         ; 36ca: 84 b3       ..  :96ca[1]
+    lda #0                                                            ; 36cc: a9 00       ..  :96cc[1]
+    sta l10de                                                         ; 36ce: 8d de 10    ... :96ce[1]
+    lda #osbyte_scan_keyboard_from_16                                 ; 36d1: a9 7a       .z  :96d1[1]
+    jsr osbyte                                                        ; 36d3: 20 f4 ff     .. :96d3[1]
+    txa                                                               ; 36d6: 8a          .   :96d6[1]
+    bmi c96e9                                                         ; 36d7: 30 10       0.  :96d7[1]
+    cmp #&32 ; '2'                                                    ; 36d9: c9 32       .2  :96d9[1]
+    beq c96e4                                                         ; 36db: f0 07       ..  :96db[1]
+    cmp #&61 ; 'a'                                                    ; 36dd: c9 61       .a  :96dd[1]
+    bne loop_c96c2                                                    ; 36df: d0 e1       ..  :96df[1]
+    jsr sub_cac72                                                     ; 36e1: 20 72 ac     r. :96e1[1]
+; &36e4 referenced 1 time by &96db
+.c96e4
+    lda #osbyte_write_keys_pressed                                    ; 36e4: a9 78       .x  :96e4[1]
+    jsr osbyte                                                        ; 36e6: 20 f4 ff     .. :96e6[1]
+; &36e9 referenced 1 time by &96d7
+.c96e9
+    jmp c9556                                                         ; 36e9: 4c 56 95    LV. :96e9[1]
+
+; &36ec referenced 1 time by &96c8
+.c96ec
+    cmp #service_unrecognised_command                                 ; 36ec: c9 04       ..  :96ec[1]
+    bne c96f5                                                         ; 36ee: d0 05       ..  :96ee[1]
+    ldx #&9b                                                          ; 36f0: a2 9b       ..  :96f0[1]
+; &36f2 referenced 1 time by &970a
+.loop_c96f2
+    jmp c8703                                                         ; 36f2: 4c 03 87    L.. :96f2[1]
+
+; &36f5 referenced 1 time by &96ee
+.c96f5
+    cmp #service_select_filing_system                                 ; 36f5: c9 12       ..  :96f5[1]
+    bne c9700                                                         ; 36f7: d0 07       ..  :96f7[1]
+    cpy #4                                                            ; 36f9: c0 04       ..  :96f9[1]
+    bne c973c                                                         ; 36fb: d0 3f       .?  :96fb[1]
+    jmp c956d                                                         ; 36fd: 4c 6d 95    Lm. :96fd[1]
+
+; &3700 referenced 1 time by &96f7
+.c9700
+    cmp #service_help                                                 ; 3700: c9 09       ..  :9700[1]
+    bne c9714                                                         ; 3702: d0 10       ..  :9702[1]
+    lda (os_text_ptr),y                                               ; 3704: b1 f2       ..  :9704[1]
+    ldx #&cf                                                          ; 3706: a2 cf       ..  :9706[1]
+    cmp #&0d                                                          ; 3708: c9 0d       ..  :9708[1]
+    bne loop_c96f2                                                    ; 370a: d0 e6       ..  :970a[1]
+    tya                                                               ; 370c: 98          .   :970c[1]
+    inx                                                               ; 370d: e8          .   :970d[1]
+    inx                                                               ; 370e: e8          .   :970e[1]
+    ldy #2                                                            ; 370f: a0 02       ..  :970f[1]
+    jmp ca10b                                                         ; 3711: 4c 0b a1    L.. :9711[1]
+
+; &3714 referenced 1 time by &9702
+.c9714
+    jsr zero_stacked_XXX                                              ; 3714: 20 8e 9d     .. :9714[1]
+    cmp #service_absolute_workspace_claimed                           ; 3717: c9 0a       ..  :9717[1]
+    bne c973d                                                         ; 3719: d0 22       ."  :9719[1]
+    jsr sub_c9ab8                                                     ; 371b: 20 b8 9a     .. :971b[1]
+    ldy #&d4                                                          ; 371e: a0 d4       ..  :971e[1]
+    lda (l00b0),y                                                     ; 3720: b1 b0       ..  :9720[1]
+    bpl c9736                                                         ; 3722: 10 12       ..  :9722[1]
+    ldy #0                                                            ; 3724: a0 00       ..  :9724[1]
+    jsr sub_c9d75                                                     ; 3726: 20 75 9d     u. :9726[1]
+    jsr sub_c8951                                                     ; 3729: 20 51 89     Q. :9729[1]
+    jsr sub_c9ab8                                                     ; 372c: 20 b8 9a     .. :972c[1]
+    ldy #&d4                                                          ; 372f: a0 d4       ..  :972f[1]
+    lda #0                                                            ; 3731: a9 00       ..  :9731[1]
+    sta (l00b0),y                                                     ; 3733: 91 b0       ..  :9733[1]
+    rts                                                               ; 3735: 60          `   :9735[1]
+
+; &3736 referenced 1 time by &9722
+.c9736
+    lda #&0a                                                          ; 3736: a9 0a       ..  :9736[1]
+; &3738 referenced 3 times by &973f, &9743, &9747
+.c9738
+    tsx                                                               ; 3738: ba          .   :9738[1]
+    sta l0105,x                                                       ; 3739: 9d 05 01    ... :9739[1]
+; &373c referenced 1 time by &96fb
+.c973c
+    rts                                                               ; 373c: 60          `   :973c[1]
+
+; &373d referenced 1 time by &9719
+.c973d
+    cmp #service_unrecognised_osword                                  ; 373d: c9 08       ..  :973d[1]
+    bne c9738                                                         ; 373f: d0 f7       ..  :973f[1]
+    ldy l00ef                                                         ; 3741: a4 ef       ..  :9741[1]
+    bmi c9738                                                         ; 3743: 30 f3       0.  :9743[1]
+    cpy #&7d ; '}'                                                    ; 3745: c0 7d       .}  :9745[1]
+    bcc c9738                                                         ; 3747: 90 ef       ..  :9747[1]
+    ldx l00f0                                                         ; 3749: a6 f0       ..  :9749[1]
+    stx l00c7                                                         ; 374b: 86 c7       ..  :974b[1]
+    ldx l00f1                                                         ; 374d: a6 f1       ..  :974d[1]
+    stx l00c8                                                         ; 374f: 86 c8       ..  :974f[1]
+    iny                                                               ; 3751: c8          .   :9751[1]
+    bpl c975b                                                         ; 3752: 10 07       ..  :9752[1]
+    ldx l00c7                                                         ; 3754: a6 c7       ..  :9754[1]
+    ldy l00c8                                                         ; 3756: a4 c8       ..  :9756[1]
+    jmp c91af                                                         ; 3758: 4c af 91    L.. :9758[1]
+
+; &375b referenced 1 time by &9752
+.c975b
+    jsr sub_c8b7b                                                     ; 375b: 20 7b 8b     {. :975b[1]
+    jsr sub_c8380                                                     ; 375e: 20 80 83     .. :975e[1]
+    iny                                                               ; 3761: c8          .   :9761[1]
+    bmi c976c                                                         ; 3762: 30 08       0.  :9762[1]
+    ldy #0                                                            ; 3764: a0 00       ..  :9764[1]
+    lda l0f04                                                         ; 3766: ad 04 0f    ... :9766[1]
+    sta (l00c7),y                                                     ; 3769: 91 c7       ..  :9769[1]
+    rts                                                               ; 376b: 60          `   :976b[1]
+
+; &376c referenced 1 time by &9762
+.c976c
+    lda #0                                                            ; 376c: a9 00       ..  :976c[1]
+    tay                                                               ; 376e: a8          .   :976e[1]
+    sta (l00c7),y                                                     ; 376f: 91 c7       ..  :976f[1]
+    iny                                                               ; 3771: c8          .   :9771[1]
+    lda l0f07                                                         ; 3772: ad 07 0f    ... :9772[1]
+    sta (l00c7),y                                                     ; 3775: 91 c7       ..  :9775[1]
+    iny                                                               ; 3777: c8          .   :9777[1]
+    lda l0f06                                                         ; 3778: ad 06 0f    ... :9778[1]
+    and #3                                                            ; 377b: 29 03       ).  :977b[1]
+    sta (l00c7),y                                                     ; 377d: 91 c7       ..  :977d[1]
+    iny                                                               ; 377f: c8          .   :977f[1]
+    lda #0                                                            ; 3780: a9 00       ..  :9780[1]
+    sta (l00c7),y                                                     ; 3782: 91 c7       ..  :9782[1]
+    rts                                                               ; 3784: 60          `   :9784[1]
+
+.sub_c9785
+    jsr sub_c840c                                                     ; 3785: 20 0c 84     .. :9785[1]
+    pha                                                               ; 3788: 48          H   :9788[1]
+    jsr c99a3                                                         ; 3789: 20 a3 99     .. :9789[1]
+    stx l00b0                                                         ; 378c: 86 b0       ..  :978c[1]
+    stx l10db                                                         ; 378e: 8e db 10    ... :978e[1]
+    sty l00b1                                                         ; 3791: 84 b1       ..  :9791[1]
+    sty l10dc                                                         ; 3793: 8c dc 10    ... :9793[1]
+    ldx #0                                                            ; 3796: a2 00       ..  :9796[1]
+    ldy #0                                                            ; 3798: a0 00       ..  :9798[1]
+    jsr sub_c80e3                                                     ; 379a: 20 e3 80     .. :979a[1]
+; &379d referenced 1 time by &97a2
+.loop_c979d
+    jsr sub_c80d3                                                     ; 379d: 20 d3 80     .. :979d[1]
+    cpy #&12                                                          ; 37a0: c0 12       ..  :97a0[1]
+    bne loop_c979d                                                    ; 37a2: d0 f9       ..  :97a2[1]
+    pla                                                               ; 37a4: 68          h   :97a4[1]
+    tax                                                               ; 37a5: aa          .   :97a5[1]
+    inx                                                               ; 37a6: e8          .   :97a6[1]
+    cpx #8                                                            ; 37a7: e0 08       ..  :97a7[1]
+    bcs c97b3                                                         ; 37a9: b0 08       ..  :97a9[1]
+    lda l9b29,x                                                       ; 37ab: bd 29 9b    .). :97ab[1]
+    pha                                                               ; 37ae: 48          H   :97ae[1]
+    lda l9b21,x                                                       ; 37af: bd 21 9b    .!. :97af[1]
+    pha                                                               ; 37b2: 48          H   :97b2[1]
+; &37b3 referenced 2 times by &97a9, &97b8
+.c97b3
+    lda #0                                                            ; 37b3: a9 00       ..  :97b3[1]
+    rts                                                               ; 37b5: 60          `   :97b5[1]
+
+.sub_c97b6
+    cmp #9                                                            ; 37b6: c9 09       ..  :97b6[1]
+    bcs c97b3                                                         ; 37b8: b0 f9       ..  :97b8[1]
+    stx l00b5                                                         ; 37ba: 86 b5       ..  :97ba[1]
+    tax                                                               ; 37bc: aa          .   :97bc[1]
+    lda l9b18,x                                                       ; 37bd: bd 18 9b    ... :97bd[1]
+    pha                                                               ; 37c0: 48          H   :97c0[1]
+    lda l9b0f,x                                                       ; 37c1: bd 0f 9b    ... :97c1[1]
+    pha                                                               ; 37c4: 48          H   :97c4[1]
+    txa                                                               ; 37c5: 8a          .   :97c5[1]
+    ldx l00b5                                                         ; 37c6: a6 b5       ..  :97c6[1]
+; &37c8 referenced 1 time by &97cb
+.loop_c97c8
+    rts                                                               ; 37c8: 60          `   :97c8[1]
+
+.sub_c97c9
+    cmp #9                                                            ; 37c9: c9 09       ..  :97c9[1]
+    bcs loop_c97c8                                                    ; 37cb: b0 fb       ..  :97cb[1]
+    jsr sub_c83e3                                                     ; 37cd: 20 e3 83     .. :97cd[1]
+    jsr zero_stacked_XXX                                              ; 37d0: 20 8e 9d     .. :97d0[1]
+    stx l107d                                                         ; 37d3: 8e 7d 10    .}. :97d3[1]
+    sty l107e                                                         ; 37d6: 8c 7e 10    .~. :97d6[1]
+    tay                                                               ; 37d9: a8          .   :97d9[1]
+    jsr sub_c97e8                                                     ; 37da: 20 e8 97     .. :97da[1]
+    php                                                               ; 37dd: 08          .   :97dd[1]
+    bit l1081                                                         ; 37de: 2c 81 10    ,.. :97de[1]
+    bpl c97e6                                                         ; 37e1: 10 03       ..  :97e1[1]
+    jsr sub_c8f7a                                                     ; 37e3: 20 7a 8f     z. :97e3[1]
+; &37e6 referenced 1 time by &97e1
+.c97e6
+    plp                                                               ; 37e6: 28          (   :97e6[1]
+    rts                                                               ; 37e7: 60          `   :97e7[1]
+
+; &37e8 referenced 1 time by &97da
+.sub_c97e8
+    lda l9b31,y                                                       ; 37e8: b9 31 9b    .1. :97e8[1]
+    sta l10d7                                                         ; 37eb: 8d d7 10    ... :97eb[1]
+    lda l9b3a,y                                                       ; 37ee: b9 3a 9b    .:. :97ee[1]
+    sta l10d8                                                         ; 37f1: 8d d8 10    ... :97f1[1]
+    lda l9b43,y                                                       ; 37f4: b9 43 9b    .C. :97f4[1]
+    lsr a                                                             ; 37f7: 4a          J   :97f7[1]
+    php                                                               ; 37f8: 08          .   :97f8[1]
+    lsr a                                                             ; 37f9: 4a          J   :97f9[1]
+    php                                                               ; 37fa: 08          .   :97fa[1]
+    sta l107f                                                         ; 37fb: 8d 7f 10    ... :97fb[1]
+    jsr sub_c995a                                                     ; 37fe: 20 5a 99     Z. :97fe[1]
+    ldy #&0c                                                          ; 3801: a0 0c       ..  :9801[1]
+; &3803 referenced 1 time by &9809
+.loop_c9803
+    lda (l00b4),y                                                     ; 3803: b1 b4       ..  :9803[1]
+    sta l1060,y                                                       ; 3805: 99 60 10    .`. :9805[1]
+    dey                                                               ; 3808: 88          .   :9808[1]
+    bpl loop_c9803                                                    ; 3809: 10 f8       ..  :9809[1]
+    lda l1063                                                         ; 380b: ad 63 10    .c. :980b[1]
+    and l1064                                                         ; 380e: 2d 64 10    -d. :980e[1]
+    ora l10d6                                                         ; 3811: 0d d6 10    ... :9811[1]
+    clc                                                               ; 3814: 18          .   :9814[1]
+    adc #1                                                            ; 3815: 69 01       i.  :9815[1]
+    beq c981f                                                         ; 3817: f0 06       ..  :9817[1]
+    jsr sub_c8f6b                                                     ; 3819: 20 6b 8f     k. :9819[1]
+    clc                                                               ; 381c: 18          .   :981c[1]
+    lda #&ff                                                          ; 381d: a9 ff       ..  :981d[1]
+; &381f referenced 1 time by &9817
+.c981f
+    sta l1081                                                         ; 381f: 8d 81 10    ... :981f[1]
+    lda l107f                                                         ; 3822: ad 7f 10    ... :9822[1]
+    bcs c982e                                                         ; 3825: b0 07       ..  :9825[1]
+    ldx #&61 ; 'a'                                                    ; 3827: a2 61       .a  :9827[1]
+    ldy #&10                                                          ; 3829: a0 10       ..  :9829[1]
+    jsr tube_entry                                                    ; 382b: 20 06 04     .. :982b[1]
+; &382e referenced 1 time by &9825
+.c982e
+    plp                                                               ; 382e: 28          (   :982e[1]
+    bcs c9835                                                         ; 382f: b0 04       ..  :982f[1]
+    plp                                                               ; 3831: 28          (   :9831[1]
+; &3832 referenced 1 time by &9861
+.sub_c9832
+    jmp (l10d7)                                                       ; 3832: 6c d7 10    l.. :9832[1]
+
+; &3835 referenced 1 time by &982f
+.c9835
+    ldx #3                                                            ; 3835: a2 03       ..  :9835[1]
+; &3837 referenced 1 time by &983d
+.loop_c9837
+    lda l1069,x                                                       ; 3837: bd 69 10    .i. :9837[1]
+    sta l00b6,x                                                       ; 383a: 95 b6       ..  :983a[1]
+    dex                                                               ; 383c: ca          .   :983c[1]
+    bpl loop_c9837                                                    ; 383d: 10 f8       ..  :983d[1]
+    ldx #&b6                                                          ; 383f: a2 b6       ..  :983f[1]
+    ldy l1060                                                         ; 3841: ac 60 10    .`. :9841[1]
+    lda #0                                                            ; 3844: a9 00       ..  :9844[1]
+    plp                                                               ; 3846: 28          (   :9846[1]
+    bcs c984c                                                         ; 3847: b0 03       ..  :9847[1]
+    jsr ca06c                                                         ; 3849: 20 6c a0     l. :9849[1]
+; &384c referenced 1 time by &9847
+.c984c
+    jsr c9dd5                                                         ; 384c: 20 d5 9d     .. :984c[1]
+    ldx #3                                                            ; 384f: a2 03       ..  :984f[1]
+; &3851 referenced 1 time by &9857
+.loop_c9851
+    lda l00b6,x                                                       ; 3851: b5 b6       ..  :9851[1]
+    sta l1069,x                                                       ; 3853: 9d 69 10    .i. :9853[1]
+    dex                                                               ; 3856: ca          .   :9856[1]
+    bpl loop_c9851                                                    ; 3857: 10 f8       ..  :9857[1]
+; &3859 referenced 1 time by &989b
+.c9859
+    jsr invert_l1065                                                  ; 3859: 20 4c 99     L. :9859[1]
+    bmi c986b                                                         ; 385c: 30 0d       0.  :985c[1]
+; &385e referenced 1 time by &9870
+.loop_c985e
+    ldy l1060                                                         ; 385e: ac 60 10    .`. :985e[1]
+    jsr sub_c9832                                                     ; 3861: 20 32 98     2. :9861[1]
+    bcs c9873                                                         ; 3864: b0 0d       ..  :9864[1]
+    ldx #9                                                            ; 3866: a2 09       ..  :9866[1]
+    jsr sub_c9940                                                     ; 3868: 20 40 99     @. :9868[1]
+; &386b referenced 1 time by &985c
+.c986b
+    ldx #5                                                            ; 386b: a2 05       ..  :986b[1]
+    jsr sub_c9940                                                     ; 386d: 20 40 99     @. :986d[1]
+    bne loop_c985e                                                    ; 3870: d0 ec       ..  :9870[1]
+    clc                                                               ; 3872: 18          .   :9872[1]
+; &3873 referenced 1 time by &9864
+.c9873
+    php                                                               ; 3873: 08          .   :9873[1]
+    jsr invert_l1065                                                  ; 3874: 20 4c 99     L. :9874[1]
+    ldx #5                                                            ; 3877: a2 05       ..  :9877[1]
+    jsr sub_c9940                                                     ; 3879: 20 40 99     @. :9879[1]
+    ldy #&0c                                                          ; 387c: a0 0c       ..  :987c[1]
+    jsr sub_c995a                                                     ; 387e: 20 5a 99     Z. :987e[1]
+; &3881 referenced 1 time by &9887
+.loop_c9881
+    lda l1060,y                                                       ; 3881: b9 60 10    .`. :9881[1]
+    sta (l00b4),y                                                     ; 3884: 91 b4       ..  :9884[1]
+    dey                                                               ; 3886: 88          .   :9886[1]
+    bpl loop_c9881                                                    ; 3887: 10 f8       ..  :9887[1]
+    plp                                                               ; 3889: 28          (   :9889[1]
+    rts                                                               ; 388a: 60          `   :988a[1]
+
+    jsr sub_c8b7b                                                     ; 388b: 20 7b 8b     {. :988b[1]
+    jsr sub_c93fd                                                     ; 388e: 20 fd 93     .. :988e[1]
+    lda #&9d                                                          ; 3891: a9 9d       ..  :9891[1]
+    sta l10d7                                                         ; 3893: 8d d7 10    ... :9893[1]
+    lda #&98                                                          ; 3896: a9 98       ..  :9896[1]
+    sta l10d8                                                         ; 3898: 8d d8 10    ... :9898[1]
+    bne c9859                                                         ; 389b: d0 bc       ..  :989b[1]
+    ldy l1069                                                         ; 389d: ac 69 10    .i. :989d[1]
+; &38a0 referenced 1 time by &98b8
+.loop_c98a0
+    cpy l0f05                                                         ; 38a0: cc 05 0f    ... :98a0[1]
+    bcs c98cd                                                         ; 38a3: b0 28       .(  :98a3[1]
+    lda l0e0f,y                                                       ; 38a5: b9 0f 0e    ... :98a5[1]
+    jsr sub_c8327                                                     ; 38a8: 20 27 83     '. :98a8[1]
+    eor l00cc                                                         ; 38ab: 45 cc       E.  :98ab[1]
+    bcs c98b1                                                         ; 38ad: b0 02       ..  :98ad[1]
+    and #&df                                                          ; 38af: 29 df       ).  :98af[1]
+; &38b1 referenced 1 time by &98ad
+.c98b1
+    and #&7f                                                          ; 38b1: 29 7f       ).  :98b1[1]
+    beq c98ba                                                         ; 38b3: f0 05       ..  :98b3[1]
+    jsr sub_c87da                                                     ; 38b5: 20 da 87     .. :98b5[1]
+    bne loop_c98a0                                                    ; 38b8: d0 e6       ..  :98b8[1]
+; &38ba referenced 1 time by &98b3
+.c98ba
+    lda #7                                                            ; 38ba: a9 07       ..  :98ba[1]
+    jsr c996e                                                         ; 38bc: 20 6e 99     n. :98bc[1]
+    sta l00b0                                                         ; 38bf: 85 b0       ..  :98bf[1]
+; &38c1 referenced 1 time by &98ca
+.loop_c98c1
+    lda l0e08,y                                                       ; 38c1: b9 08 0e    ... :98c1[1]
+    jsr c996e                                                         ; 38c4: 20 6e 99     n. :98c4[1]
+    iny                                                               ; 38c7: c8          .   :98c7[1]
+    dec l00b0                                                         ; 38c8: c6 b0       ..  :98c8[1]
+    bne loop_c98c1                                                    ; 38ca: d0 f5       ..  :98ca[1]
+    clc                                                               ; 38cc: 18          .   :98cc[1]
+; &38cd referenced 1 time by &98a3
+.c98cd
+    sty l1069                                                         ; 38cd: 8c 69 10    .i. :98cd[1]
+    lda l0f04                                                         ; 38d0: ad 04 0f    ... :98d0[1]
+    sta l1060                                                         ; 38d3: 8d 60 10    .`. :98d3[1]
+    rts                                                               ; 38d6: 60          `   :98d6[1]
+
+    jsr sub_c8b7b                                                     ; 38d7: 20 7b 8b     {. :98d7[1]
+    jsr sub_c93fd                                                     ; 38da: 20 fd 93     .. :98da[1]
+    lda #&0c                                                          ; 38dd: a9 0c       ..  :98dd[1]
+    jsr c996e                                                         ; 38df: 20 6e 99     n. :98df[1]
+    ldy #0                                                            ; 38e2: a0 00       ..  :98e2[1]
+; &38e4 referenced 1 time by &98f6
+.loop_c98e4
+    cpy #8                                                            ; 38e4: c0 08       ..  :98e4[1]
+    bcs c98ed                                                         ; 38e6: b0 05       ..  :98e6[1]
+    lda l0e00,y                                                       ; 38e8: b9 00 0e    ... :98e8[1]
+    bcc c98f0                                                         ; 38eb: 90 03       ..  :98eb[1]
+; &38ed referenced 1 time by &98e6
+.c98ed
+    lda l0ef8,y                                                       ; 38ed: b9 f8 0e    ... :98ed[1]
+; &38f0 referenced 1 time by &98eb
+.c98f0
+    jsr c996e                                                         ; 38f0: 20 6e 99     n. :98f0[1]
+    iny                                                               ; 38f3: c8          .   :98f3[1]
+    cpy #&0c                                                          ; 38f4: c0 0c       ..  :98f4[1]
+    bne loop_c98e4                                                    ; 38f6: d0 ec       ..  :98f6[1]
+    lda l0f06                                                         ; 38f8: ad 06 0f    ... :98f8[1]
+    jsr sub_c81bf                                                     ; 38fb: 20 bf 81     .. :98fb[1]
+    jsr c996e                                                         ; 38fe: 20 6e 99     n. :98fe[1]
+    lda l00cd                                                         ; 3901: a5 cd       ..  :9901[1]
+    jmp c996e                                                         ; 3903: 4c 6e 99    Ln. :9903[1]
+
+    jsr sub_c9965                                                     ; 3906: 20 65 99     e. :9906[1]
+    lda l10ca                                                         ; 3909: ad ca 10    ... :9909[1]
+    ora #&30 ; '0'                                                    ; 390c: 09 30       .0  :990c[1]
+    jsr c996e                                                         ; 390e: 20 6e 99     n. :990e[1]
+    jsr sub_c9965                                                     ; 3911: 20 65 99     e. :9911[1]
+    lda l10c9                                                         ; 3914: ad c9 10    ... :9914[1]
+    bne c996e                                                         ; 3917: d0 55       .U  :9917[1]
+    jsr sub_c9965                                                     ; 3919: 20 65 99     e. :9919[1]
+    lda l10cc                                                         ; 391c: ad cc 10    ... :991c[1]
+    ora #&30 ; '0'                                                    ; 391f: 09 30       .0  :991f[1]
+    jsr c996e                                                         ; 3921: 20 6e 99     n. :9921[1]
+    jsr sub_c9965                                                     ; 3924: 20 65 99     e. :9924[1]
+    lda l10cb                                                         ; 3927: ad cb 10    ... :9927[1]
+    bne c996e                                                         ; 392a: d0 42       .B  :992a[1]
+; &392c referenced 2 times by &9978, &9993
+.sub_c992c
+    pha                                                               ; 392c: 48          H   :992c[1]
+    lda l1061                                                         ; 392d: ad 61 10    .a. :992d[1]
+    sta l00b8                                                         ; 3930: 85 b8       ..  :9930[1]
+    lda l1062                                                         ; 3932: ad 62 10    .b. :9932[1]
+    sta l00b9                                                         ; 3935: 85 b9       ..  :9935[1]
+    ldx #0                                                            ; 3937: a2 00       ..  :9937[1]
+    pla                                                               ; 3939: 68          h   :9939[1]
+    rts                                                               ; 393a: 60          `   :993a[1]
+
+; &393b referenced 4 times by &9976, &997d, &9990, &9998
+.c993b
+    jsr sub_c83e3                                                     ; 393b: 20 e3 83     .. :993b[1]
+    ldx #1                                                            ; 393e: a2 01       ..  :993e[1]
+; &3940 referenced 3 times by &9868, &986d, &9879
+.sub_c9940
+    ldy #4                                                            ; 3940: a0 04       ..  :9940[1]
+; &3942 referenced 1 time by &9949
+.loop_c9942
+    inc l1060,x                                                       ; 3942: fe 60 10    .`. :9942[1]
+    bne c994b                                                         ; 3945: d0 04       ..  :9945[1]
+    inx                                                               ; 3947: e8          .   :9947[1]
+    dey                                                               ; 3948: 88          .   :9948[1]
+    bne loop_c9942                                                    ; 3949: d0 f7       ..  :9949[1]
+; &394b referenced 1 time by &9945
+.c994b
+    rts                                                               ; 394b: 60          `   :994b[1]
+
+; Invert the 32-bit value at l1065
+; &394c referenced 2 times by &9859, &9874
+.invert_l1065
+    ldx #3                                                            ; 394c: a2 03       ..  :994c[1]
+; &394e referenced 1 time by &9957
+.loop_c994e
+    lda #&ff                                                          ; 394e: a9 ff       ..  :994e[1]
+    eor l1065,x                                                       ; 3950: 5d 65 10    ]e. :9950[1]
+    sta l1065,x                                                       ; 3953: 9d 65 10    .e. :9953[1]
+    dex                                                               ; 3956: ca          .   :9956[1]
+    bpl loop_c994e                                                    ; 3957: 10 f5       ..  :9957[1]
+    rts                                                               ; 3959: 60          `   :9959[1]
+
+; &395a referenced 2 times by &97fe, &987e
+.sub_c995a
+    lda l107d                                                         ; 395a: ad 7d 10    .}. :995a[1]
+    sta l00b4                                                         ; 395d: 85 b4       ..  :995d[1]
+    lda l107e                                                         ; 395f: ad 7e 10    .~. :995f[1]
+    sta l00b5                                                         ; 3962: 85 b5       ..  :9962[1]
+; &3964 referenced 1 time by &996c
+.loop_c9964
+    rts                                                               ; 3964: 60          `   :9964[1]
+
+; &3965 referenced 4 times by &9906, &9911, &9919, &9924
+.sub_c9965
+    lda #1                                                            ; 3965: a9 01       ..  :9965[1]
+    bne c996e                                                         ; 3967: d0 05       ..  :9967[1]
+    jsr sub_c9e94                                                     ; 3969: 20 94 9e     .. :9969[1]
+    bcs loop_c9964                                                    ; 396c: b0 f6       ..  :996c[1]
+; &396e referenced 11 times by &98bc, &98c4, &98df, &98f0, &98fe, &9903, &990e, &9917, &9921, &992a, &9967
+.c996e
+    bit l1081                                                         ; 396e: 2c 81 10    ,.. :996e[1]
+    bpl c9978                                                         ; 3971: 10 05       ..  :9971[1]
+    sta tube_host_r3_data                                             ; 3973: 8d e5 fe    ... :9973[1]
+    bmi c993b                                                         ; 3976: 30 c3       0.  :9976[1]
+; &3978 referenced 1 time by &9971
+.c9978
+    jsr sub_c992c                                                     ; 3978: 20 2c 99     ,. :9978[1]
+    sta (l00b8,x)                                                     ; 397b: 81 b8       ..  :997b[1]
+    jmp c993b                                                         ; 397d: 4c 3b 99    L;. :997d[1]
+
+    jsr sub_c9988                                                     ; 3980: 20 88 99     .. :9980[1]
+    jsr sub_c9f82                                                     ; 3983: 20 82 9f     .. :9983[1]
+    clc                                                               ; 3986: 18          .   :9986[1]
+    rts                                                               ; 3987: 60          `   :9987[1]
+
+; &3988 referenced 1 time by &9980
+.sub_c9988
+    bit l1081                                                         ; 3988: 2c 81 10    ,.. :9988[1]
+    bpl c9993                                                         ; 398b: 10 06       ..  :998b[1]
+    lda tube_host_r3_data                                             ; 398d: ad e5 fe    ... :998d[1]
+    jmp c993b                                                         ; 3990: 4c 3b 99    L;. :9990[1]
+
+; &3993 referenced 1 time by &998b
+.c9993
+    jsr sub_c992c                                                     ; 3993: 20 2c 99     ,. :9993[1]
+    lda (l00b8,x)                                                     ; 3996: a1 b8       ..  :9996[1]
+    jmp c993b                                                         ; 3998: 4c 3b 99    L;. :9998[1]
+
+    bit l10c7                                                         ; 399b: 2c c7 10    ,.. :999b[1]
+    bmi c99a3                                                         ; 399e: 30 03       0.  :999e[1]
+    dec l10c7                                                         ; 39a0: ce c7 10    ... :99a0[1]
+; &39a3 referenced 5 times by &8782, &8bac, &9789, &999e, &9c25
+.c99a3
+    lda #&ff                                                          ; 39a3: a9 ff       ..  :99a3[1]
+    sta l10ce                                                         ; 39a5: 8d ce 10    ... :99a5[1]
+; &39a8 referenced 1 time by &99b3
+.loop_c99a8
+    sta l10cd                                                         ; 39a8: 8d cd 10    ... :99a8[1]
+    rts                                                               ; 39ab: 60          `   :99ab[1]
+
+; &39ac referenced 6 times by &824b, &8254, &8750, &8797, &89e6, &a463
+.sub_c99ac
+    lda #&2a ; '*'                                                    ; 39ac: a9 2a       .*  :99ac[1]
+    sta l10ce                                                         ; 39ae: 8d ce 10    ... :99ae[1]
+    lda #&23 ; '#'                                                    ; 39b1: a9 23       .#  :99b1[1]
+    bne loop_c99a8                                                    ; 39b3: d0 f3       ..  :99b3[1]
+    jsr sub_c9a6e                                                     ; 39b5: 20 6e 9a     n. :99b5[1]
+    jsr sub_c8386                                                     ; 39b8: 20 86 83     .. :99b8[1]
+    lda #1                                                            ; 39bb: a9 01       ..  :99bb[1]
+    rts                                                               ; 39bd: 60          `   :99bd[1]
+
+    jsr sub_c9a4b                                                     ; 39be: 20 4b 9a     K. :99be[1]
+    jsr sub_c8386                                                     ; 39c1: 20 86 83     .. :99c1[1]
+    jsr sub_c830a                                                     ; 39c4: 20 0a 83     .. :99c4[1]
+    bcc c99ed                                                         ; 39c7: 90 24       .$  :99c7[1]
+    jsr sub_c9a6e                                                     ; 39c9: 20 6e 9a     n. :99c9[1]
+    jsr sub_c99f3                                                     ; 39cc: 20 f3 99     .. :99cc[1]
+    jsr sub_c9a0f                                                     ; 39cf: 20 0f 9a     .. :99cf[1]
+    bvc c99ea                                                         ; 39d2: 50 16       P.  :99d2[1]
+    jsr sub_c9a6e                                                     ; 39d4: 20 6e 9a     n. :99d4[1]
+    jsr sub_c9a0f                                                     ; 39d7: 20 0f 9a     .. :99d7[1]
+    bvc c99ed                                                         ; 39da: 50 11       P.  :99da[1]
+    jsr sub_c9a6e                                                     ; 39dc: 20 6e 9a     n. :99dc[1]
+    jsr sub_c99f3                                                     ; 39df: 20 f3 99     .. :99df[1]
+    bvc c99ed                                                         ; 39e2: 50 09       P.  :99e2[1]
+    jsr sub_c9a6e                                                     ; 39e4: 20 6e 9a     n. :99e4[1]
+    jsr sub_c9a63                                                     ; 39e7: 20 63 9a     c. :99e7[1]
+; &39ea referenced 1 time by &99d2
+.c99ea
+    jsr sub_c9a32                                                     ; 39ea: 20 32 9a     2. :99ea[1]
+; &39ed referenced 3 times by &99c7, &99da, &99e2
+.c99ed
+    jsr c89d7                                                         ; 39ed: 20 d7 89     .. :99ed[1]
+    lda #1                                                            ; 39f0: a9 01       ..  :99f0[1]
+    rts                                                               ; 39f2: 60          `   :99f2[1]
+
+; &39f3 referenced 2 times by &99cc, &99df
+.sub_c99f3
+    jsr sub_c83e3                                                     ; 39f3: 20 e3 83     .. :99f3[1]
+    ldy #2                                                            ; 39f6: a0 02       ..  :99f6[1]
+    lda (l00b0),y                                                     ; 39f8: b1 b0       ..  :99f8[1]
+    sta l0f08,x                                                       ; 39fa: 9d 08 0f    ... :99fa[1]
+    iny                                                               ; 39fd: c8          .   :99fd[1]
+    lda (l00b0),y                                                     ; 39fe: b1 b0       ..  :99fe[1]
+    sta l0f09,x                                                       ; 3a00: 9d 09 0f    ... :9a00[1]
+    iny                                                               ; 3a03: c8          .   :9a03[1]
+    lda (l00b0),y                                                     ; 3a04: b1 b0       ..  :9a04[1]
+    asl a                                                             ; 3a06: 0a          .   :9a06[1]
+    asl a                                                             ; 3a07: 0a          .   :9a07[1]
+    eor l0f0e,x                                                       ; 3a08: 5d 0e 0f    ].. :9a08[1]
+    and #&0c                                                          ; 3a0b: 29 0c       ).  :9a0b[1]
+    bpl c9a2a                                                         ; 3a0d: 10 1b       ..  :9a0d[1]
+; &3a0f referenced 2 times by &99cf, &99d7
+.sub_c9a0f
+    jsr sub_c83e3                                                     ; 3a0f: 20 e3 83     .. :9a0f[1]
+    ldy #6                                                            ; 3a12: a0 06       ..  :9a12[1]
+    lda (l00b0),y                                                     ; 3a14: b1 b0       ..  :9a14[1]
+    sta l0f0a,x                                                       ; 3a16: 9d 0a 0f    ... :9a16[1]
+    iny                                                               ; 3a19: c8          .   :9a19[1]
+    lda (l00b0),y                                                     ; 3a1a: b1 b0       ..  :9a1a[1]
+    sta l0f0b,x                                                       ; 3a1c: 9d 0b 0f    ... :9a1c[1]
+    iny                                                               ; 3a1f: c8          .   :9a1f[1]
+    lda (l00b0),y                                                     ; 3a20: b1 b0       ..  :9a20[1]
+    ror a                                                             ; 3a22: 6a          j   :9a22[1]
+    ror a                                                             ; 3a23: 6a          j   :9a23[1]
+    ror a                                                             ; 3a24: 6a          j   :9a24[1]
+    eor l0f0e,x                                                       ; 3a25: 5d 0e 0f    ].. :9a25[1]
+    and #&c0                                                          ; 3a28: 29 c0       ).  :9a28[1]
+; &3a2a referenced 1 time by &9a0d
+.c9a2a
+    eor l0f0e,x                                                       ; 3a2a: 5d 0e 0f    ].. :9a2a[1]
+    sta l0f0e,x                                                       ; 3a2d: 9d 0e 0f    ... :9a2d[1]
+    clv                                                               ; 3a30: b8          .   :9a30[1]
+    rts                                                               ; 3a31: 60          `   :9a31[1]
+
+; &3a32 referenced 1 time by &99ea
+.sub_c9a32
+    jsr sub_c83e3                                                     ; 3a32: 20 e3 83     .. :9a32[1]
+    ldy #&0e                                                          ; 3a35: a0 0e       ..  :9a35[1]
+    lda (l00b0),y                                                     ; 3a37: b1 b0       ..  :9a37[1]
+    and #&0a                                                          ; 3a39: 29 0a       ).  :9a39[1]
+    beq c9a3f                                                         ; 3a3b: f0 02       ..  :9a3b[1]
+    lda #&80                                                          ; 3a3d: a9 80       ..  :9a3d[1]
+; &3a3f referenced 1 time by &9a3b
+.c9a3f
+    eor l0e0f,x                                                       ; 3a3f: 5d 0f 0e    ].. :9a3f[1]
+    and #&80                                                          ; 3a42: 29 80       ).  :9a42[1]
+    eor l0e0f,x                                                       ; 3a44: 5d 0f 0e    ].. :9a44[1]
+    sta l0e0f,x                                                       ; 3a47: 9d 0f 0e    ... :9a47[1]
+    rts                                                               ; 3a4a: 60          `   :9a4a[1]
+
+; &3a4b referenced 1 time by &99be
+.sub_c9a4b
+    jsr sub_c9a78                                                     ; 3a4b: 20 78 9a     x. :9a4b[1]
+    bcc c9a73                                                         ; 3a4e: 90 23       .#  :9a4e[1]
+; &3a50 referenced 2 times by &9a60, &9c55
+.sub_c9a50
+    lda l0e0f,y                                                       ; 3a50: b9 0f 0e    ... :9a50[1]
+    bpl c9a77                                                         ; 3a53: 10 22       ."  :9a53[1]
+; &3a55 referenced 1 time by &9f6b
+.generate_error_precheck_locked
+    jsr generate_error_precheck                                       ; 3a55: 20 38 80     8. :9a55[1]
+    equb &c3                                                          ; 3a58: c3          .   :9a58[1]
+    equs "Locked"                                                     ; 3a59: 4c 6f 63... Loc :9a59[1]
+    equb 0                                                            ; 3a5f: 00          .   :9a5f[1]
+
+; &3a60 referenced 2 times by &830a, &8bba
+.sub_c9a60
+    jsr sub_c9a50                                                     ; 3a60: 20 50 9a     P. :9a60[1]
+; &3a63 referenced 2 times by &8a00, &99e7
+.sub_c9a63
+    jsr sub_c83e3                                                     ; 3a63: 20 e3 83     .. :9a63[1]
+    jsr sub_c9d1e                                                     ; 3a66: 20 1e 9d     .. :9a66[1]
+    bcc c9a8c                                                         ; 3a69: 90 21       .!  :9a69[1]
+    jmp generate_error_precheck_open                                  ; 3a6b: 4c 82 9c    L.. :9a6b[1]
+
+; &3a6e referenced 5 times by &99b5, &99c9, &99d4, &99dc, &99e4
+.sub_c9a6e
+    jsr sub_c9a78                                                     ; 3a6e: 20 78 9a     x. :9a6e[1]
+    bcs c9a8c                                                         ; 3a71: b0 19       ..  :9a71[1]
+; &3a73 referenced 1 time by &9a4e
+.c9a73
+    pla                                                               ; 3a73: 68          h   :9a73[1]
+    pla                                                               ; 3a74: 68          h   :9a74[1]
+    lda #0                                                            ; 3a75: a9 00       ..  :9a75[1]
+; &3a77 referenced 1 time by &9a53
+.c9a77
+    rts                                                               ; 3a77: 60          `   :9a77[1]
+
+; &3a78 referenced 2 times by &9a4b, &9a6e
+.sub_c9a78
+    jsr sub_c80f3                                                     ; 3a78: 20 f3 80     .. :9a78[1]
+    jsr sub_c8284                                                     ; 3a7b: 20 84 82     .. :9a7b[1]
+    bcc c9a8c                                                         ; 3a7e: 90 0c       ..  :9a7e[1]
+    tya                                                               ; 3a80: 98          .   :9a80[1]
+    tax                                                               ; 3a81: aa          .   :9a81[1]
+; &3a82 referenced 2 times by &881e, &885c
+.sub_c9a82
+    lda l10db                                                         ; 3a82: ad db 10    ... :9a82[1]
+    sta l00b0                                                         ; 3a85: 85 b0       ..  :9a85[1]
+    lda l10dc                                                         ; 3a87: ad dc 10    ... :9a87[1]
+    sta l00b1                                                         ; 3a8a: 85 b1       ..  :9a8a[1]
+; &3a8c referenced 3 times by &9a69, &9a71, &9a7e
+.c9a8c
+    rts                                                               ; 3a8c: 60          `   :9a8c[1]
+
+; &3a8d referenced 4 times by &929d, &a267, &a34a, &a64f
+.sub_c9a8d
+    lda #osbyte_read_oshwm                                            ; 3a8d: a9 83       ..  :9a8d[1]
+    jsr osbyte                                                        ; 3a8f: 20 f4 ff     .. :9a8f[1]
+    sty l10cf                                                         ; 3a92: 8c cf 10    ... :9a92[1]
+    lda #osbyte_read_himem                                            ; 3a95: a9 84       ..  :9a95[1]
+    jsr osbyte                                                        ; 3a97: 20 f4 ff     .. :9a97[1]
+    tya                                                               ; 3a9a: 98          .   :9a9a[1]
+    sec                                                               ; 3a9b: 38          8   :9a9b[1]
+    sbc l10cf                                                         ; 3a9c: ed cf 10    ... :9a9c[1]
+    sta l10d0                                                         ; 3a9f: 8d d0 10    ... :9a9f[1]
+    rts                                                               ; 3aa2: 60          `   :9aa2[1]
+
+; &3aa3 referenced 2 times by &95d4, &95fd
+.sub_c9aa3
+    ldx #&0a                                                          ; 3aa3: a2 0a       ..  :9aa3[1]
+    jsr c9adf                                                         ; 3aa5: 20 df 9a     .. :9aa5[1]
+    jsr sub_c9ab8                                                     ; 3aa8: 20 b8 9a     .. :9aa8[1]
+    ldy #&d3                                                          ; 3aab: a0 d3       ..  :9aab[1]
+    lda #&ff                                                          ; 3aad: a9 ff       ..  :9aad[1]
+    sta (l00b0),y                                                     ; 3aaf: 91 b0       ..  :9aaf[1]
+    sta l10d3                                                         ; 3ab1: 8d d3 10    ... :9ab1[1]
+    iny                                                               ; 3ab4: c8          .   :9ab4[1]
+    sta (l00b0),y                                                     ; 3ab5: 91 b0       ..  :9ab5[1]
+    rts                                                               ; 3ab7: 60          `   :9ab7[1]
+
+; &3ab8 referenced 5 times by &895a, &95c1, &971b, &972c, &9aa8
+.sub_c9ab8
+    pha                                                               ; 3ab8: 48          H   :9ab8[1]
+    ldx romsel_copy                                                   ; 3ab9: a6 f4       ..  :9ab9[1]
+    lda #0                                                            ; 3abb: a9 00       ..  :9abb[1]
+    sta l00b0                                                         ; 3abd: 85 b0       ..  :9abd[1]
+    lda l0df0,x                                                       ; 3abf: bd f0 0d    ... :9abf[1]
+    and #&3f ; '?'                                                    ; 3ac2: 29 3f       )?  :9ac2[1]
+    sta l00b1                                                         ; 3ac4: 85 b1       ..  :9ac4[1]
+    pla                                                               ; 3ac6: 68          h   :9ac6[1]
+    rts                                                               ; 3ac7: 60          `   :9ac7[1]
+
+; &3ac8 referenced 2 times by &a3d4, &a3fb
+.sub_c9ac8
+    jsr sub_c83e3                                                     ; 3ac8: 20 e3 83     .. :9ac8[1]
+    lda #&0f                                                          ; 3acb: a9 0f       ..  :9acb[1]
+    ldx #1                                                            ; 3acd: a2 01       ..  :9acd[1]
+    ldy #0                                                            ; 3acf: a0 00       ..  :9acf[1]
+    beq c9ae9                                                         ; 3ad1: f0 16       ..  :9ad1[1]
+; &3ad3 referenced 1 time by &80ac
+.sub_c9ad3
+    tax                                                               ; 3ad3: aa          .   :9ad3[1]
+; &3ad4 referenced 1 time by &80b5
+.c9ad4
+    lda #3                                                            ; 3ad4: a9 03       ..  :9ad4[1]
+    bne c9ae9                                                         ; 3ad6: d0 11       ..  :9ad6[1]
+; &3ad8 referenced 2 times by &9436, &abbc
+.sub_c9ad8
+    jsr sub_c83e3                                                     ; 3ad8: 20 e3 83     .. :9ad8[1]
+    lda #&7e ; '~'                                                    ; 3adb: a9 7e       .~  :9adb[1]
+    bne c9ae9                                                         ; 3add: d0 0a       ..  :9add[1]
+; &3adf referenced 4 times by &9593, &9599, &95be, &9aa5
+.c9adf
+    lda #&8f                                                          ; 3adf: a9 8f       ..  :9adf[1]
+    bne c9ae9                                                         ; 3ae1: d0 06       ..  :9ae1[1]
+    lda #osbyte_read_write_startup_options                            ; 3ae3: a9 ff       ..  :9ae3[1]
+; &3ae5 referenced 8 times by &80a5, &9588, &96a0, &9e32, &9e43, &aae2, &ac7c, &aeb7
+.osbyte_read
+    ldx #0                                                            ; 3ae5: a2 00       ..  :9ae5[1]
+    ldy #&ff                                                          ; 3ae7: a0 ff       ..  :9ae7[1]
+; &3ae9 referenced 4 times by &9ad1, &9ad6, &9add, &9ae1
+.c9ae9
+    jmp osbyte                                                        ; 3ae9: 4c f4 ff    L.. :9ae9[1]
+
+; &3aec referenced 1 time by &957d
+.l9aec
+    equb &1b, &ff, &1e, &ff, &21, &ff, &24, &ff, &27, &ff, &2a, &ff   ; 3aec: 1b ff 1e... ... :9aec[1]
+    equb &2d, &ff                                                     ; 3af8: 2d ff       -.  :9af8[1]
+    equw sub_c9785                                                    ; 3afa: 85 97       ..  :9afa[1]
+    equb 0                                                            ; 3afc: 00          .   :9afc[1]
+    equw sub_c9d9b                                                    ; 3afd: 9b 9d       ..  :9afd[1]
+    equb 0                                                            ; 3aff: 00          .   :9aff[1]
+    equw sub_c9e94                                                    ; 3b00: 94 9e       ..  :9b00[1]
+    equb 0                                                            ; 3b02: 00          .   :9b02[1]
+    equw sub_c9f82                                                    ; 3b03: 82 9f       ..  :9b03[1]
+    equb 0                                                            ; 3b05: 00          .   :9b05[1]
+    equw sub_c97c9                                                    ; 3b06: c9 97       ..  :9b06[1]
+    equb 0                                                            ; 3b08: 00          .   :9b08[1]
+    equw sub_c9c0c                                                    ; 3b09: 0c 9c       ..  :9b09[1]
+    equb 0                                                            ; 3b0b: 00          .   :9b0b[1]
+    equw sub_c97b6                                                    ; 3b0c: b6 97       ..  :9b0c[1]
+    equb 0                                                            ; 3b0e: 00          .   :9b0e[1]
+; &3b0f referenced 1 time by &97c1
+.l9b0f
+    equs "1\o"                                                        ; 3b0f: 31 5c 6f    1\o :9b0f[1]
+    equb &fd, &6f, &82, &50, &4b, &9a                                 ; 3b12: fd 6f 82... .o. :9b12[1]
+; &3b18 referenced 1 time by &97bd
+.l9b18
+    equb &8a, &9e, &88, &86, &88, &84, &9b, &9b, &99                  ; 3b18: 8a 9e 88... ... :9b18[1]
+; &3b21 referenced 1 time by &97af
+.l9b21
+    equb &1a, &58, &c8, &db, &d3, &e3, &b4, &bd                       ; 3b21: 1a 58 c8... .X. :9b21[1]
+; &3b29 referenced 1 time by &97ab
+.l9b29
+    equb &88, &88, &99, &99, &99, &99, &99, &99                       ; 3b29: 88 88 99... ... :9b29[1]
+; &3b31 referenced 1 time by &97e8
+.l9b31
+    equb &1b, &80, &80, &69, &69, &d7,   6, &19, &8b                  ; 3b31: 1b 80 80... ... :9b31[1]
+; &3b3a referenced 1 time by &97ee
+.l9b3a
+    equb &86, &99, &99, &99, &99, &98, &99, &99, &98                  ; 3b3a: 86 99 99... ... :9b3a[1]
+; &3b43 referenced 1 time by &97f4
+.l9b43
+    equb   4,   2,   3,   6,   7,   4,   4,   4,   4, &a2, &11, &a0   ; 3b43: 04 02 03... ... :9b43[1]
+    equb &15                                                          ; 3b4f: 15          .   :9b4f[1]
+
+; &3b50 referenced 1 time by &9b66
+.loop_c9b50
+    rts                                                               ; 3b50: 60          `   :9b50[1]
+
+; &3b51 referenced 1 time by &9b5e
+.sub_c9b51
+    jsr sub_c83e3                                                     ; 3b51: 20 e3 83     .. :9b51[1]
+    lda #osbyte_close_spool_exec                                      ; 3b54: a9 77       .w  :9b54[1]
+    jmp osbyte                                                        ; 3b56: 4c f4 ff    L.. :9b56[1]
+
+.sub_c9b59
+    lda #&20 ; ' '                                                    ; 3b59: a9 20       .   :9b59[1]
+    sta l1086                                                         ; 3b5b: 8d 86 10    ... :9b5b[1]
+; &3b5e referenced 1 time by &9b74
+.loop_c9b5e
+    jsr sub_c9b51                                                     ; 3b5e: 20 51 9b     Q. :9b5e[1]
+; &3b61 referenced 1 time by &9d81
+.sub_c9b61
+    lda #0                                                            ; 3b61: a9 00       ..  :9b61[1]
+; &3b63 referenced 1 time by &9b6c
+.loop_c9b63
+    clc                                                               ; 3b63: 18          .   :9b63[1]
+    adc #&20 ; ' '                                                    ; 3b64: 69 20       i   :9b64[1]
+    beq loop_c9b50                                                    ; 3b66: f0 e8       ..  :9b66[1]
+    tay                                                               ; 3b68: a8          .   :9b68[1]
+    jsr sub_c9b79                                                     ; 3b69: 20 79 9b     y. :9b69[1]
+    bne loop_c9b63                                                    ; 3b6c: d0 f5       ..  :9b6c[1]
+; &3b6e referenced 2 times by &9c13, &9d86
+.c9b6e
+    lda #&20 ; ' '                                                    ; 3b6e: a9 20       .   :9b6e[1]
+    sta l1086                                                         ; 3b70: 8d 86 10    ... :9b70[1]
+    tya                                                               ; 3b73: 98          .   :9b73[1]
+    beq loop_c9b5e                                                    ; 3b74: f0 e8       ..  :9b74[1]
+    jsr sub_c9e75                                                     ; 3b76: 20 75 9e     u. :9b76[1]
+; &3b79 referenced 2 times by &9b69, &a264
+.sub_c9b79
+    pha                                                               ; 3b79: 48          H   :9b79[1]
+    jsr sub_c9df4                                                     ; 3b7a: 20 f4 9d     .. :9b7a[1]
+    bcs c9bc5                                                         ; 3b7d: b0 46       .F  :9b7d[1]
+    lda l111b,y                                                       ; 3b7f: b9 1b 11    ... :9b7f[1]
+    eor #&ff                                                          ; 3b82: 49 ff       I.  :9b82[1]
+    and l10c0                                                         ; 3b84: 2d c0 10    -.. :9b84[1]
+    sta l10c0                                                         ; 3b87: 8d c0 10    ... :9b87[1]
+    lda l1117,y                                                       ; 3b8a: b9 17 11    ... :9b8a[1]
+    and #&60 ; '`'                                                    ; 3b8d: 29 60       )`  :9b8d[1]
+    beq c9bc5                                                         ; 3b8f: f0 34       .4  :9b8f[1]
+    jsr sub_c9bca                                                     ; 3b91: 20 ca 9b     .. :9b91[1]
+    lda l1117,y                                                       ; 3b94: b9 17 11    ... :9b94[1]
+    and l1086                                                         ; 3b97: 2d 86 10    -.. :9b97[1]
+    beq c9bc2                                                         ; 3b9a: f0 26       .&  :9b9a[1]
+    ldx l10c3                                                         ; 3b9c: ae c3 10    ... :9b9c[1]
+    lda l1114,y                                                       ; 3b9f: b9 14 11    ... :9b9f[1]
+    sta l0f0c,x                                                       ; 3ba2: 9d 0c 0f    ... :9ba2[1]
+    lda l1115,y                                                       ; 3ba5: b9 15 11    ... :9ba5[1]
+    sta l0f0d,x                                                       ; 3ba8: 9d 0d 0f    ... :9ba8[1]
+    lda l1116,y                                                       ; 3bab: b9 16 11    ... :9bab[1]
+    jsr sub_c81c5                                                     ; 3bae: 20 c5 81     .. :9bae[1]
+    eor l0f0e,x                                                       ; 3bb1: 5d 0e 0f    ].. :9bb1[1]
+    and #&30 ; '0'                                                    ; 3bb4: 29 30       )0  :9bb4[1]
+    eor l0f0e,x                                                       ; 3bb6: 5d 0e 0f    ].. :9bb6[1]
+    sta l0f0e,x                                                       ; 3bb9: 9d 0e 0f    ... :9bb9[1]
+    jsr c93e6                                                         ; 3bbc: 20 e6 93     .. :9bbc[1]
+    ldy l10c2                                                         ; 3bbf: ac c2 10    ... :9bbf[1]
+; &3bc2 referenced 1 time by &9b9a
+.c9bc2
+    jsr sub_c9f1e                                                     ; 3bc2: 20 1e 9f     .. :9bc2[1]
+; &3bc5 referenced 2 times by &9b7d, &9b8f
+.c9bc5
+    ldx l10c5                                                         ; 3bc5: ae c5 10    ... :9bc5[1]
+    pla                                                               ; 3bc8: 68          h   :9bc8[1]
+    rts                                                               ; 3bc9: 60          `   :9bc9[1]
+
+; &3bca referenced 1 time by &9b91
+.sub_c9bca
+    jsr sub_c9be5                                                     ; 3bca: 20 e5 9b     .. :9bca[1]
+; &3bcd referenced 1 time by &9f9f
+.sub_c9bcd
+    ldx #6                                                            ; 3bcd: a2 06       ..  :9bcd[1]
+; &3bcf referenced 1 time by &9bd7
+.loop_c9bcf
+    lda l110c,y                                                       ; 3bcf: b9 0c 11    ... :9bcf[1]
+    sta l00c5,x                                                       ; 3bd2: 95 c5       ..  :9bd2[1]
+    dey                                                               ; 3bd4: 88          .   :9bd4[1]
+    dey                                                               ; 3bd5: 88          .   :9bd5[1]
+    dex                                                               ; 3bd6: ca          .   :9bd6[1]
+    bpl loop_c9bcf                                                    ; 3bd7: 10 f6       ..  :9bd7[1]
+    jsr sub_c826d                                                     ; 3bd9: 20 6d 82     m. :9bd9[1]
+    bcc generate_error_precheck_disc_changed                          ; 3bdc: 90 22       ."  :9bdc[1]
+    sty l10c3                                                         ; 3bde: 8c c3 10    ... :9bde[1]
+    ldy l10c2                                                         ; 3be1: ac c2 10    ... :9be1[1]
+; &3be4 referenced 1 time by &9bfe
+.loop_c9be4
+    rts                                                               ; 3be4: 60          `   :9be4[1]
+
+; &3be5 referenced 3 times by &9bca, &9eb8, &9f93
+.sub_c9be5
+    lda l110e,y                                                       ; 3be5: b9 0e 11    ... :9be5[1]
+    and #&7f                                                          ; 3be8: 29 7f       ).  :9be8[1]
+    sta l00cc                                                         ; 3bea: 85 cc       ..  :9bea[1]
+    lda l1117,y                                                       ; 3bec: b9 17 11    ... :9bec[1]
+    jmp c8816                                                         ; 3bef: 4c 16 88    L.. :9bef[1]
+
+; &3bf2 referenced 2 times by &8768, &87b8
+.sub_c9bf2
+    jsr sub_c83e3                                                     ; 3bf2: 20 e3 83     .. :9bf2[1]
+    lda l0f04                                                         ; 3bf5: ad 04 0f    ... :9bf5[1]
+    jsr sub_c8380                                                     ; 3bf8: 20 80 83     .. :9bf8[1]
+    cmp l0f04                                                         ; 3bfb: cd 04 0f    ... :9bfb[1]
+    beq loop_c9be4                                                    ; 3bfe: f0 e4       ..  :9bfe[1]
+; &3c00 referenced 1 time by &9bdc
+.generate_error_precheck_disc_changed
+    jsr generate_error_precheck_disc                                  ; 3c00: 20 23 80     #. :9c00[1]
+    equb &c8                                                          ; 3c03: c8          .   :9c03[1]
+    equs "changed"                                                    ; 3c04: 63 68 61... cha :9c04[1]
+    equb 0                                                            ; 3c0b: 00          .   :9c0b[1]
+
+.sub_c9c0c
+    and #&c0                                                          ; 3c0c: 29 c0       ).  :9c0c[1]
+    bne c9c16                                                         ; 3c0e: d0 06       ..  :9c0e[1]
+    jsr sub_c83e3                                                     ; 3c10: 20 e3 83     .. :9c10[1]
+    jmp c9b6e                                                         ; 3c13: 4c 6e 9b    Ln. :9c13[1]
+
+; &3c16 referenced 1 time by &9c0e
+.c9c16
+    jsr sub_c840c                                                     ; 3c16: 20 0c 84     .. :9c16[1]
+    stx l00ba                                                         ; 3c19: 86 ba       ..  :9c19[1]
+    sty l00bb                                                         ; 3c1b: 84 bb       ..  :9c1b[1]
+    sta l00b4                                                         ; 3c1d: 85 b4       ..  :9c1d[1]
+    bit l00b4                                                         ; 3c1f: 24 b4       $.  :9c1f[1]
+    php                                                               ; 3c21: 08          .   :9c21[1]
+    jsr sub_c80f3                                                     ; 3c22: 20 f3 80     .. :9c22[1]
+    jsr c99a3                                                         ; 3c25: 20 a3 99     .. :9c25[1]
+    jsr sub_c8284                                                     ; 3c28: 20 84 82     .. :9c28[1]
+    bcs c9c51                                                         ; 3c2b: b0 24       .$  :9c2b[1]
+    plp                                                               ; 3c2d: 28          (   :9c2d[1]
+    bvc c9c33                                                         ; 3c2e: 50 03       P.  :9c2e[1]
+    lda #0                                                            ; 3c30: a9 00       ..  :9c30[1]
+    rts                                                               ; 3c32: 60          `   :9c32[1]
+
+; &3c33 referenced 1 time by &9c2e
+.c9c33
+    php                                                               ; 3c33: 08          .   :9c33[1]
+    lda #0                                                            ; 3c34: a9 00       ..  :9c34[1]
+    ldx #7                                                            ; 3c36: a2 07       ..  :9c36[1]
+; &3c38 referenced 1 time by &9c3e
+.loop_c9c38
+    sta l00bc,x                                                       ; 3c38: 95 bc       ..  :9c38[1]
+    sta l1074,x                                                       ; 3c3a: 9d 74 10    .t. :9c3a[1]
+    dex                                                               ; 3c3d: ca          .   :9c3d[1]
+    bpl loop_c9c38                                                    ; 3c3e: 10 f8       ..  :9c3e[1]
+    dec l00be                                                         ; 3c40: c6 be       ..  :9c40[1]
+    dec l00bf                                                         ; 3c42: c6 bf       ..  :9c42[1]
+    dec l1076                                                         ; 3c44: ce 76 10    .v. :9c44[1]
+    dec l1077                                                         ; 3c47: ce 77 10    .w. :9c47[1]
+    lda #&40 ; '@'                                                    ; 3c4a: a9 40       .@  :9c4a[1]
+    sta l00c3                                                         ; 3c4c: 85 c3       ..  :9c4c[1]
+    jsr sub_c8a77                                                     ; 3c4e: 20 77 8a     w. :9c4e[1]
+; &3c51 referenced 1 time by &9c2b
+.c9c51
+    plp                                                               ; 3c51: 28          (   :9c51[1]
+    php                                                               ; 3c52: 08          .   :9c52[1]
+    bvs c9c58                                                         ; 3c53: 70 03       p.  :9c53[1]
+    jsr sub_c9a50                                                     ; 3c55: 20 50 9a     P. :9c55[1]
+; &3c58 referenced 1 time by &9c53
+.c9c58
+    jsr sub_c9d1e                                                     ; 3c58: 20 1e 9d     .. :9c58[1]
+    bcc c9c6b                                                         ; 3c5b: 90 0e       ..  :9c5b[1]
+; &3c5d referenced 1 time by &9c69
+.loop_c9c5d
+    lda l110c,y                                                       ; 3c5d: b9 0c 11    ... :9c5d[1]
+    bpl generate_error_precheck_open                                  ; 3c60: 10 20       .   :9c60[1]
+    plp                                                               ; 3c62: 28          (   :9c62[1]
+    php                                                               ; 3c63: 08          .   :9c63[1]
+    bmi generate_error_precheck_open                                  ; 3c64: 30 1c       0.  :9c64[1]
+    jsr sub_c9d19                                                     ; 3c66: 20 19 9d     .. :9c66[1]
+    bcs loop_c9c5d                                                    ; 3c69: b0 f2       ..  :9c69[1]
+; &3c6b referenced 1 time by &9c5b
+.c9c6b
+    ldy l10c2                                                         ; 3c6b: ac c2 10    ... :9c6b[1]
+    bne c9c8b                                                         ; 3c6e: d0 1b       ..  :9c6e[1]
+    jsr generate_error_precheck                                       ; 3c70: 20 38 80     8. :9c70[1]
+    equb &c0                                                          ; 3c73: c0          .   :9c73[1]
+    equs "Too many open"                                              ; 3c74: 54 6f 6f... Too :9c74[1]
+    equb 0                                                            ; 3c81: 00          .   :9c81[1]
+
+; &3c82 referenced 3 times by &9a6b, &9c60, &9c64
+.generate_error_precheck_open
+    jsr generate_error_precheck                                       ; 3c82: 20 38 80     8. :9c82[1]
+    equb &c2                                                          ; 3c85: c2          .   :9c85[1]
+    equs "Open"                                                       ; 3c86: 4f 70 65... Ope :9c86[1]
+    equb 0                                                            ; 3c8a: 00          .   :9c8a[1]
+
+; &3c8b referenced 1 time by &9c6e
+.c9c8b
+    lda #8                                                            ; 3c8b: a9 08       ..  :9c8b[1]
+    sta l10c4                                                         ; 3c8d: 8d c4 10    ... :9c8d[1]
+; &3c90 referenced 1 time by &9ca2
+.loop_c9c90
+    lda l0e08,x                                                       ; 3c90: bd 08 0e    ... :9c90[1]
+    sta l1100,y                                                       ; 3c93: 99 00 11    ... :9c93[1]
+    iny                                                               ; 3c96: c8          .   :9c96[1]
+    lda l0f08,x                                                       ; 3c97: bd 08 0f    ... :9c97[1]
+    sta l1100,y                                                       ; 3c9a: 99 00 11    ... :9c9a[1]
+    iny                                                               ; 3c9d: c8          .   :9c9d[1]
+    inx                                                               ; 3c9e: e8          .   :9c9e[1]
+    dec l10c4                                                         ; 3c9f: ce c4 10    ... :9c9f[1]
+    bne loop_c9c90                                                    ; 3ca2: d0 ec       ..  :9ca2[1]
+    ldx #&10                                                          ; 3ca4: a2 10       ..  :9ca4[1]
+    lda #0                                                            ; 3ca6: a9 00       ..  :9ca6[1]
+; &3ca8 referenced 1 time by &9cad
+.loop_c9ca8
+    sta l1100,y                                                       ; 3ca8: 99 00 11    ... :9ca8[1]
+    iny                                                               ; 3cab: c8          .   :9cab[1]
+    dex                                                               ; 3cac: ca          .   :9cac[1]
+    bne loop_c9ca8                                                    ; 3cad: d0 f9       ..  :9cad[1]
+    lda l10c2                                                         ; 3caf: ad c2 10    ... :9caf[1]
+    tay                                                               ; 3cb2: a8          .   :9cb2[1]
+    jsr sub_c81be                                                     ; 3cb3: 20 be 81     .. :9cb3[1]
+    adc #&11                                                          ; 3cb6: 69 11       i.  :9cb6[1]
+    sta l1113,y                                                       ; 3cb8: 99 13 11    ... :9cb8[1]
+    lda l10c1                                                         ; 3cbb: ad c1 10    ... :9cbb[1]
+    sta l111b,y                                                       ; 3cbe: 99 1b 11    ... :9cbe[1]
+    ora l10c0                                                         ; 3cc1: 0d c0 10    ... :9cc1[1]
+    sta l10c0                                                         ; 3cc4: 8d c0 10    ... :9cc4[1]
+    lda l1109,y                                                       ; 3cc7: b9 09 11    ... :9cc7[1]
+    adc #&ff                                                          ; 3cca: 69 ff       i.  :9cca[1]
+    lda l110b,y                                                       ; 3ccc: b9 0b 11    ... :9ccc[1]
+    adc #0                                                            ; 3ccf: 69 00       i.  :9ccf[1]
+    sta l1119,y                                                       ; 3cd1: 99 19 11    ... :9cd1[1]
+    lda l110d,y                                                       ; 3cd4: b9 0d 11    ... :9cd4[1]
+    ora #&0f                                                          ; 3cd7: 09 0f       ..  :9cd7[1]
+    adc #0                                                            ; 3cd9: 69 00       i.  :9cd9[1]
+    jsr sub_c81b0                                                     ; 3cdb: 20 b0 81     .. :9cdb[1]
+    sta l111a,y                                                       ; 3cde: 99 1a 11    ... :9cde[1]
+    plp                                                               ; 3ce1: 28          (   :9ce1[1]
+    bvc c9d12                                                         ; 3ce2: 50 2e       P.  :9ce2[1]
+    bmi c9cee                                                         ; 3ce4: 30 08       0.  :9ce4[1]
+    lda #&80                                                          ; 3ce6: a9 80       ..  :9ce6[1]
+    ora l110c,y                                                       ; 3ce8: 19 0c 11    ... :9ce8[1]
+    sta l110c,y                                                       ; 3ceb: 99 0c 11    ... :9ceb[1]
+; &3cee referenced 1 time by &9ce4
+.c9cee
+    lda l1109,y                                                       ; 3cee: b9 09 11    ... :9cee[1]
+    sta l1114,y                                                       ; 3cf1: 99 14 11    ... :9cf1[1]
+    lda l110b,y                                                       ; 3cf4: b9 0b 11    ... :9cf4[1]
+    sta l1115,y                                                       ; 3cf7: 99 15 11    ... :9cf7[1]
+    lda l110d,y                                                       ; 3cfa: b9 0d 11    ... :9cfa[1]
+    jsr sub_c81b0                                                     ; 3cfd: 20 b0 81     .. :9cfd[1]
+    sta l1116,y                                                       ; 3d00: 99 16 11    ... :9d00[1]
+; &3d03 referenced 1 time by &9d17
+.loop_c9d03
+    lda l00cd                                                         ; 3d03: a5 cd       ..  :9d03[1]
+    ora l1117,y                                                       ; 3d05: 19 17 11    ... :9d05[1]
+    sta l1117,y                                                       ; 3d08: 99 17 11    ... :9d08[1]
+    tya                                                               ; 3d0b: 98          .   :9d0b[1]
+    jsr sub_c81be                                                     ; 3d0c: 20 be 81     .. :9d0c[1]
+    ora #&10                                                          ; 3d0f: 09 10       ..  :9d0f[1]
+    rts                                                               ; 3d11: 60          `   :9d11[1]
+
+; &3d12 referenced 1 time by &9ce2
+.c9d12
+    lda #&20 ; ' '                                                    ; 3d12: a9 20       .   :9d12[1]
+    sta l1117,y                                                       ; 3d14: 99 17 11    ... :9d14[1]
+    bne loop_c9d03                                                    ; 3d17: d0 ea       ..  :9d17[1]
+; &3d19 referenced 1 time by &9c66
+.sub_c9d19
+    txa                                                               ; 3d19: 8a          .   :9d19[1]
+    pha                                                               ; 3d1a: 48          H   :9d1a[1]
+    jmp c9d5d                                                         ; 3d1b: 4c 5d 9d    L]. :9d1b[1]
+
+; &3d1e referenced 2 times by &9a66, &9c58
+.sub_c9d1e
+    lda #0                                                            ; 3d1e: a9 00       ..  :9d1e[1]
+    sta l10c2                                                         ; 3d20: 8d c2 10    ... :9d20[1]
+    lda #8                                                            ; 3d23: a9 08       ..  :9d23[1]
+    sta l00b5                                                         ; 3d25: 85 b5       ..  :9d25[1]
+    tya                                                               ; 3d27: 98          .   :9d27[1]
+    tax                                                               ; 3d28: aa          .   :9d28[1]
+    ldy #&a0                                                          ; 3d29: a0 a0       ..  :9d29[1]
+; &3d2b referenced 1 time by &9d6f
+.c9d2b
+    sty l00b3                                                         ; 3d2b: 84 b3       ..  :9d2b[1]
+    txa                                                               ; 3d2d: 8a          .   :9d2d[1]
+    pha                                                               ; 3d2e: 48          H   :9d2e[1]
+    lda #8                                                            ; 3d2f: a9 08       ..  :9d2f[1]
+    sta l00b2                                                         ; 3d31: 85 b2       ..  :9d31[1]
+    lda l00b5                                                         ; 3d33: a5 b5       ..  :9d33[1]
+    bit l10c0                                                         ; 3d35: 2c c0 10    ,.. :9d35[1]
+    beq c9d57                                                         ; 3d38: f0 1d       ..  :9d38[1]
+    lda l1117,y                                                       ; 3d3a: b9 17 11    ... :9d3a[1]
+    eor l00cd                                                         ; 3d3d: 45 cd       E.  :9d3d[1]
+    and #3                                                            ; 3d3f: 29 03       ).  :9d3f[1]
+    bne c9d5d                                                         ; 3d41: d0 1a       ..  :9d41[1]
+; &3d43 referenced 1 time by &9d52
+.loop_c9d43
+    lda l0e08,x                                                       ; 3d43: bd 08 0e    ... :9d43[1]
+    eor l1100,y                                                       ; 3d46: 59 00 11    Y.. :9d46[1]
+    and #&7f                                                          ; 3d49: 29 7f       ).  :9d49[1]
+    bne c9d5d                                                         ; 3d4b: d0 10       ..  :9d4b[1]
+    inx                                                               ; 3d4d: e8          .   :9d4d[1]
+    iny                                                               ; 3d4e: c8          .   :9d4e[1]
+    iny                                                               ; 3d4f: c8          .   :9d4f[1]
+    dec l00b2                                                         ; 3d50: c6 b2       ..  :9d50[1]
+    bne loop_c9d43                                                    ; 3d52: d0 ef       ..  :9d52[1]
+    sec                                                               ; 3d54: 38          8   :9d54[1]
+    bcs c9d67                                                         ; 3d55: b0 10       ..  :9d55[1]
+; &3d57 referenced 1 time by &9d38
+.c9d57
+    sty l10c2                                                         ; 3d57: 8c c2 10    ... :9d57[1]
+    sta l10c1                                                         ; 3d5a: 8d c1 10    ... :9d5a[1]
+; &3d5d referenced 3 times by &9d1b, &9d41, &9d4b
+.c9d5d
+    sec                                                               ; 3d5d: 38          8   :9d5d[1]
+    lda l00b3                                                         ; 3d5e: a5 b3       ..  :9d5e[1]
+    sbc #&20 ; ' '                                                    ; 3d60: e9 20       .   :9d60[1]
+    sta l00b3                                                         ; 3d62: 85 b3       ..  :9d62[1]
+    asl l00b5                                                         ; 3d64: 06 b5       ..  :9d64[1]
+    clc                                                               ; 3d66: 18          .   :9d66[1]
+; &3d67 referenced 1 time by &9d55
+.c9d67
+    pla                                                               ; 3d67: 68          h   :9d67[1]
+    tax                                                               ; 3d68: aa          .   :9d68[1]
+    ldy l00b3                                                         ; 3d69: a4 b3       ..  :9d69[1]
+    lda l00b5                                                         ; 3d6b: a5 b5       ..  :9d6b[1]
+    bcs c9d71                                                         ; 3d6d: b0 02       ..  :9d6d[1]
+    bne c9d2b                                                         ; 3d6f: d0 ba       ..  :9d6f[1]
+; &3d71 referenced 1 time by &9d6d
+.c9d71
+    rts                                                               ; 3d71: 60          `   :9d71[1]
+
+; &3d72 referenced 1 time by &9da0
+.c9d72
+    jsr zero_stacked_XXX                                              ; 3d72: 20 8e 9d     .. :9d72[1]
+; &3d75 referenced 1 time by &9726
+.sub_c9d75
+    lda l10c0                                                         ; 3d75: ad c0 10    ... :9d75[1]
+    pha                                                               ; 3d78: 48          H   :9d78[1]
+    lda #0                                                            ; 3d79: a9 00       ..  :9d79[1]
+    sta l1086                                                         ; 3d7b: 8d 86 10    ... :9d7b[1]
+    tya                                                               ; 3d7e: 98          .   :9d7e[1]
+    bne c9d86                                                         ; 3d7f: d0 05       ..  :9d7f[1]
+    jsr sub_c9b61                                                     ; 3d81: 20 61 9b     a. :9d81[1]
+    beq c9d89                                                         ; 3d84: f0 03       ..  :9d84[1]
+; &3d86 referenced 1 time by &9d7f
+.c9d86
+    jsr c9b6e                                                         ; 3d86: 20 6e 9b     n. :9d86[1]
+; &3d89 referenced 1 time by &9d84
+.c9d89
+    pla                                                               ; 3d89: 68          h   :9d89[1]
+    sta l10c0                                                         ; 3d8a: 8d c0 10    ... :9d8a[1]
+    rts                                                               ; 3d8d: 60          `   :9d8d[1]
+
+; &3d8e referenced 6 times by &956f, &9714, &97d0, &9d72, &9daa, &9db8
+.zero_stacked_XXX
+    pha                                                               ; 3d8e: 48          H   :9d8e[1]
+    txa                                                               ; 3d8f: 8a          .   :9d8f[1]
+    pha                                                               ; 3d90: 48          H   :9d90[1]
+    lda #0                                                            ; 3d91: a9 00       ..  :9d91[1]
+    tsx                                                               ; 3d93: ba          .   :9d93[1]
+    sta l0109,x                                                       ; 3d94: 9d 09 01    ... :9d94[1]
+    pla                                                               ; 3d97: 68          h   :9d97[1]
+    tax                                                               ; 3d98: aa          .   :9d98[1]
+    pla                                                               ; 3d99: 68          h   :9d99[1]
+    rts                                                               ; 3d9a: 60          `   :9d9a[1]
+
+.sub_c9d9b
+    jsr sub_c83e3                                                     ; 3d9b: 20 e3 83     .. :9d9b[1]
+    cmp #&ff                                                          ; 3d9e: c9 ff       ..  :9d9e[1]
+    beq c9d72                                                         ; 3da0: f0 d0       ..  :9da0[1]
+    cpy #0                                                            ; 3da2: c0 00       ..  :9da2[1]
+    beq c9db4                                                         ; 3da4: f0 0e       ..  :9da4[1]
+    cmp #3                                                            ; 3da6: c9 03       ..  :9da6[1]
+    bcs c9dcd                                                         ; 3da8: b0 23       .#  :9da8[1]
+    jsr zero_stacked_XXX                                              ; 3daa: 20 8e 9d     .. :9daa[1]
+    cmp #1                                                            ; 3dad: c9 01       ..  :9dad[1]
+    bne c9dd5                                                         ; 3daf: d0 24       .$  :9daf[1]
+    jmp ca06c                                                         ; 3db1: 4c 6c a0    Ll. :9db1[1]
+
+; &3db4 referenced 1 time by &9da4
+.c9db4
+    cmp #2                                                            ; 3db4: c9 02       ..  :9db4[1]
+    bcs c9dcd                                                         ; 3db6: b0 15       ..  :9db6[1]
+    jsr zero_stacked_XXX                                              ; 3db8: 20 8e 9d     .. :9db8[1]
+    beq c9dce                                                         ; 3dbb: f0 11       ..  :9dbb[1]
+    lda #&ff                                                          ; 3dbd: a9 ff       ..  :9dbd[1]
+    sta l0002,x                                                       ; 3dbf: 95 02       ..  :9dbf[1]
+    sta l0003,x                                                       ; 3dc1: 95 03       ..  :9dc1[1]
+    lda l10d9                                                         ; 3dc3: ad d9 10    ... :9dc3[1]
+    sta l0000,x                                                       ; 3dc6: 95 00       ..  :9dc6[1]
+    lda l10da                                                         ; 3dc8: ad da 10    ... :9dc8[1]
+    sta l0001,x                                                       ; 3dcb: 95 01       ..  :9dcb[1]
+; &3dcd referenced 2 times by &9da8, &9db6
+.c9dcd
+    rts                                                               ; 3dcd: 60          `   :9dcd[1]
+
+; &3dce referenced 1 time by &9dbb
+.c9dce
+    lda #4                                                            ; 3dce: a9 04       ..  :9dce[1]
+    tsx                                                               ; 3dd0: ba          .   :9dd0[1]
+    sta l0105,x                                                       ; 3dd1: 9d 05 01    ... :9dd1[1]
+    rts                                                               ; 3dd4: 60          `   :9dd4[1]
+
+; &3dd5 referenced 2 times by &984c, &9daf
+.c9dd5
+    jsr sub_c9e75                                                     ; 3dd5: 20 75 9e     u. :9dd5[1]
+    sty l10c2                                                         ; 3dd8: 8c c2 10    ... :9dd8[1]
+    asl a                                                             ; 3ddb: 0a          .   :9ddb[1]
+    adc l10c2                                                         ; 3ddc: 6d c2 10    m.. :9ddc[1]
+    tay                                                               ; 3ddf: a8          .   :9ddf[1]
+    lda l1110,y                                                       ; 3de0: b9 10 11    ... :9de0[1]
+    sta l0000,x                                                       ; 3de3: 95 00       ..  :9de3[1]
+    lda l1111,y                                                       ; 3de5: b9 11 11    ... :9de5[1]
+    sta l0001,x                                                       ; 3de8: 95 01       ..  :9de8[1]
+    lda l1112,y                                                       ; 3dea: b9 12 11    ... :9dea[1]
+    sta l0002,x                                                       ; 3ded: 95 02       ..  :9ded[1]
+    lda #0                                                            ; 3def: a9 00       ..  :9def[1]
+    sta l0003,x                                                       ; 3df1: 95 03       ..  :9df1[1]
+    rts                                                               ; 3df3: 60          `   :9df3[1]
+
+; &3df4 referenced 2 times by &9b7a, &9e78
+.sub_c9df4
+    pha                                                               ; 3df4: 48          H   :9df4[1]
+    stx l10c5                                                         ; 3df5: 8e c5 10    ... :9df5[1]
+    tya                                                               ; 3df8: 98          .   :9df8[1]
+    and #&e0                                                          ; 3df9: 29 e0       ).  :9df9[1]
+    sta l10c2                                                         ; 3dfb: 8d c2 10    ... :9dfb[1]
+    beq c9e13                                                         ; 3dfe: f0 13       ..  :9dfe[1]
+    jsr sub_c81be                                                     ; 3e00: 20 be 81     .. :9e00[1]
+    tay                                                               ; 3e03: a8          .   :9e03[1]
+    lda #0                                                            ; 3e04: a9 00       ..  :9e04[1]
+    sec                                                               ; 3e06: 38          8   :9e06[1]
+; &3e07 referenced 1 time by &9e09
+.loop_c9e07
+    ror a                                                             ; 3e07: 6a          j   :9e07[1]
+    dey                                                               ; 3e08: 88          .   :9e08[1]
+    bne loop_c9e07                                                    ; 3e09: d0 fc       ..  :9e09[1]
+    ldy l10c2                                                         ; 3e0b: ac c2 10    ... :9e0b[1]
+    bit l10c0                                                         ; 3e0e: 2c c0 10    ,.. :9e0e[1]
+    bne c9e16                                                         ; 3e11: d0 03       ..  :9e11[1]
+; &3e13 referenced 1 time by &9dfe
+.c9e13
+    pla                                                               ; 3e13: 68          h   :9e13[1]
+    sec                                                               ; 3e14: 38          8   :9e14[1]
+    rts                                                               ; 3e15: 60          `   :9e15[1]
+
+; &3e16 referenced 1 time by &9e11
+.c9e16
+    pla                                                               ; 3e16: 68          h   :9e16[1]
+    clc                                                               ; 3e17: 18          .   :9e17[1]
+    rts                                                               ; 3e18: 60          `   :9e18[1]
+
+    equb &48, &8a, &4c, &20, &9e                                      ; 3e19: 48 8a 4c... H.L :9e19[1]
+
+; &3e1e referenced 2 times by &9e56, &9e75
+.sub_c9e1e
+    pha                                                               ; 3e1e: 48          H   :9e1e[1]
+    tya                                                               ; 3e1f: 98          .   :9e1f[1]
+    cmp #&10                                                          ; 3e20: c9 10       ..  :9e20[1]
+    bcc c9e28                                                         ; 3e22: 90 04       ..  :9e22[1]
+    cmp #&18                                                          ; 3e24: c9 18       ..  :9e24[1]
+    bcc c9e2a                                                         ; 3e26: 90 02       ..  :9e26[1]
+; &3e28 referenced 1 time by &9e22
+.c9e28
+    lda #8                                                            ; 3e28: a9 08       ..  :9e28[1]
+; &3e2a referenced 1 time by &9e26
+.c9e2a
+    jsr sub_c81c4                                                     ; 3e2a: 20 c4 81     .. :9e2a[1]
+    tay                                                               ; 3e2d: a8          .   :9e2d[1]
+    pla                                                               ; 3e2e: 68          h   :9e2e[1]
+    rts                                                               ; 3e2f: 60          `   :9e2f[1]
+
+; &3e30 referenced 3 times by &803d, &9e7d, &9fc5
+.sub_c9e30
+    lda #osbyte_rw_exec_handle                                        ; 3e30: a9 c6       ..  :9e30[1]
+    jsr osbyte_read                                                   ; 3e32: 20 e5 9a     .. :9e32[1]
+    txa                                                               ; 3e35: 8a          .   :9e35[1]
+    beq c9e41                                                         ; 3e36: f0 09       ..  :9e36[1]
+    jsr sub_c9e54                                                     ; 3e38: 20 54 9e     T. :9e38[1]
+    bne c9e41                                                         ; 3e3b: d0 04       ..  :9e3b[1]
+    lda #osbyte_rw_exec_handle                                        ; 3e3d: a9 c6       ..  :9e3d[1]
+    bne osbyte_write_0                                                ; 3e3f: d0 0c       ..  :9e3f[1]
+; &3e41 referenced 2 times by &9e36, &9e3b
+.c9e41
+    lda #osbyte_read_write_spool_file_handle                          ; 3e41: a9 c7       ..  :9e41[1]
+    jsr osbyte_read                                                   ; 3e43: 20 e5 9a     .. :9e43[1]
+    jsr sub_c9e54                                                     ; 3e46: 20 54 9e     T. :9e46[1]
+    bne c9e5c                                                         ; 3e49: d0 11       ..  :9e49[1]
+    lda #osbyte_read_write_spool_file_handle                          ; 3e4b: a9 c7       ..  :9e4b[1]
+; &3e4d referenced 1 time by &9e3f
+.osbyte_write_0
+    ldx #0                                                            ; 3e4d: a2 00       ..  :9e4d[1]
+    ldy #0                                                            ; 3e4f: a0 00       ..  :9e4f[1]
+    jmp osbyte                                                        ; 3e51: 4c f4 ff    L.. :9e51[1]
+
+; &3e54 referenced 2 times by &9e38, &9e46
+.sub_c9e54
+    txa                                                               ; 3e54: 8a          .   :9e54[1]
+    tay                                                               ; 3e55: a8          .   :9e55[1]
+    jsr sub_c9e1e                                                     ; 3e56: 20 1e 9e     .. :9e56[1]
+    cpy l10c2                                                         ; 3e59: cc c2 10    ... :9e59[1]
+; &3e5c referenced 1 time by &9e49
+.c9e5c
+    rts                                                               ; 3e5c: 60          `   :9e5c[1]
+
+    pha                                                               ; 3e5d: 48          H   :9e5d[1]
+    tya                                                               ; 3e5e: 98          .   :9e5e[1]
+    pha                                                               ; 3e5f: 48          H   :9e5f[1]
+    txa                                                               ; 3e60: 8a          .   :9e60[1]
+    tay                                                               ; 3e61: a8          .   :9e61[1]
+    jsr sub_c9e75                                                     ; 3e62: 20 75 9e     u. :9e62[1]
+    tya                                                               ; 3e65: 98          .   :9e65[1]
+    jsr sub_ca0de                                                     ; 3e66: 20 de a0     .. :9e66[1]
+    bne c9e6f                                                         ; 3e69: d0 04       ..  :9e69[1]
+    ldx #&ff                                                          ; 3e6b: a2 ff       ..  :9e6b[1]
+    bne c9e71                                                         ; 3e6d: d0 02       ..  :9e6d[1]
+; &3e6f referenced 1 time by &9e69
+.c9e6f
+    ldx #0                                                            ; 3e6f: a2 00       ..  :9e6f[1]
+; &3e71 referenced 1 time by &9e6d
+.c9e71
+    pla                                                               ; 3e71: 68          h   :9e71[1]
+    tay                                                               ; 3e72: a8          .   :9e72[1]
+    pla                                                               ; 3e73: 68          h   :9e73[1]
+; &3e74 referenced 1 time by &9e7b
+.loop_c9e74
+    rts                                                               ; 3e74: 60          `   :9e74[1]
+
+; &3e75 referenced 6 times by &9b76, &9dd5, &9e62, &9e97, &9f85, &a06f
+.sub_c9e75
+    jsr sub_c9e1e                                                     ; 3e75: 20 1e 9e     .. :9e75[1]
+    jsr sub_c9df4                                                     ; 3e78: 20 f4 9d     .. :9e78[1]
+    bcc loop_c9e74                                                    ; 3e7b: 90 f7       ..  :9e7b[1]
+    jsr sub_c9e30                                                     ; 3e7d: 20 30 9e     0. :9e7d[1]
+    jsr generate_error_precheck                                       ; 3e80: 20 38 80     8. :9e80[1]
+    equb &de                                                          ; 3e83: de          .   :9e83[1]
+    equs "Channel"                                                    ; 3e84: 43 68 61... Cha :9e84[1]
+    equb 0                                                            ; 3e8b: 00          .   :9e8b[1]
+
+; &3e8c referenced 1 time by &9ea5
+.loop_c9e8c
+    jsr generate_error_precheck                                       ; 3e8c: 20 38 80     8. :9e8c[1]
+    equb &df                                                          ; 3e8f: df          .   :9e8f[1]
+    equs "EOF"                                                        ; 3e90: 45 4f 46    EOF :9e90[1]
+    equb 0                                                            ; 3e93: 00          .   :9e93[1]
+
+; &3e94 referenced 1 time by &9969
+.sub_c9e94
+    jsr sub_c840c                                                     ; 3e94: 20 0c 84     .. :9e94[1]
+    jsr sub_c9e75                                                     ; 3e97: 20 75 9e     u. :9e97[1]
+    tya                                                               ; 3e9a: 98          .   :9e9a[1]
+    jsr sub_ca0de                                                     ; 3e9b: 20 de a0     .. :9e9b[1]
+    bne c9eb3                                                         ; 3e9e: d0 13       ..  :9e9e[1]
+    lda l1117,y                                                       ; 3ea0: b9 17 11    ... :9ea0[1]
+    and #&10                                                          ; 3ea3: 29 10       ).  :9ea3[1]
+    bne loop_c9e8c                                                    ; 3ea5: d0 e5       ..  :9ea5[1]
+    lda #&10                                                          ; 3ea7: a9 10       ..  :9ea7[1]
+    jsr sub_c9f0f                                                     ; 3ea9: 20 0f 9f     .. :9ea9[1]
+    ldx l10c5                                                         ; 3eac: ae c5 10    ... :9eac[1]
+    lda #&fe                                                          ; 3eaf: a9 fe       ..  :9eaf[1]
+    sec                                                               ; 3eb1: 38          8   :9eb1[1]
+    rts                                                               ; 3eb2: 60          `   :9eb2[1]
+
+; &3eb3 referenced 1 time by &9e9e
+.c9eb3
+    lda l1117,y                                                       ; 3eb3: b9 17 11    ... :9eb3[1]
+    bmi c9ec2                                                         ; 3eb6: 30 0a       0.  :9eb6[1]
+    jsr sub_c9be5                                                     ; 3eb8: 20 e5 9b     .. :9eb8[1]
+    jsr sub_c9f1e                                                     ; 3ebb: 20 1e 9f     .. :9ebb[1]
+    sec                                                               ; 3ebe: 38          8   :9ebe[1]
+    jsr sub_c9f26                                                     ; 3ebf: 20 26 9f     &. :9ebf[1]
+; &3ec2 referenced 1 time by &9eb6
+.c9ec2
+    lda l1110,y                                                       ; 3ec2: b9 10 11    ... :9ec2[1]
+    sta l00ba                                                         ; 3ec5: 85 ba       ..  :9ec5[1]
+    lda l1113,y                                                       ; 3ec7: b9 13 11    ... :9ec7[1]
+    sta l00bb                                                         ; 3eca: 85 bb       ..  :9eca[1]
+    ldy #0                                                            ; 3ecc: a0 00       ..  :9ecc[1]
+    lda (l00ba),y                                                     ; 3ece: b1 ba       ..  :9ece[1]
+    pha                                                               ; 3ed0: 48          H   :9ed0[1]
+    ldy l10c2                                                         ; 3ed1: ac c2 10    ... :9ed1[1]
+    ldx l00ba                                                         ; 3ed4: a6 ba       ..  :9ed4[1]
+    inx                                                               ; 3ed6: e8          .   :9ed6[1]
+    txa                                                               ; 3ed7: 8a          .   :9ed7[1]
+    sta l1110,y                                                       ; 3ed8: 99 10 11    ... :9ed8[1]
+    bne c9ef1                                                         ; 3edb: d0 14       ..  :9edb[1]
+    clc                                                               ; 3edd: 18          .   :9edd[1]
+    lda l1111,y                                                       ; 3ede: b9 11 11    ... :9ede[1]
+    adc #1                                                            ; 3ee1: 69 01       i.  :9ee1[1]
+    sta l1111,y                                                       ; 3ee3: 99 11 11    ... :9ee3[1]
+    lda l1112,y                                                       ; 3ee6: b9 12 11    ... :9ee6[1]
+    adc #0                                                            ; 3ee9: 69 00       i.  :9ee9[1]
+    sta l1112,y                                                       ; 3eeb: 99 12 11    ... :9eeb[1]
+    jsr sub_c9f14                                                     ; 3eee: 20 14 9f     .. :9eee[1]
+; &3ef1 referenced 1 time by &9edb
+.c9ef1
+    clc                                                               ; 3ef1: 18          .   :9ef1[1]
+    pla                                                               ; 3ef2: 68          h   :9ef2[1]
+    rts                                                               ; 3ef3: 60          `   :9ef3[1]
+
+; &3ef4 referenced 2 times by &9f5e, &a018
+.sub_c9ef4
+    clc                                                               ; 3ef4: 18          .   :9ef4[1]
+    lda l110f,y                                                       ; 3ef5: b9 0f 11    ... :9ef5[1]
+    adc l1111,y                                                       ; 3ef8: 79 11 11    y.. :9ef8[1]
+    sta l00c3                                                         ; 3efb: 85 c3       ..  :9efb[1]
+    sta l111c,y                                                       ; 3efd: 99 1c 11    ... :9efd[1]
+    lda l110d,y                                                       ; 3f00: b9 0d 11    ... :9f00[1]
+    and #3                                                            ; 3f03: 29 03       ).  :9f03[1]
+    adc l1112,y                                                       ; 3f05: 79 12 11    y.. :9f05[1]
+    sta l00c2                                                         ; 3f08: 85 c2       ..  :9f08[1]
+    sta l111d,y                                                       ; 3f0a: 99 1d 11    ... :9f0a[1]
+; &3f0d referenced 1 time by &a0db
+.c9f0d
+    lda #&80                                                          ; 3f0d: a9 80       ..  :9f0d[1]
+; &3f0f referenced 3 times by &9ea9, &a035, &a05c
+.sub_c9f0f
+    ora l1117,y                                                       ; 3f0f: 19 17 11    ... :9f0f[1]
+    bne c9f19                                                         ; 3f12: d0 05       ..  :9f12[1]
+; &3f14 referenced 2 times by &9eee, &a041
+.sub_c9f14
+    lda #&7f                                                          ; 3f14: a9 7f       ..  :9f14[1]
+; &3f16 referenced 3 times by &95f0, &9f59, &a0ba
+.sub_c9f16
+    and l1117,y                                                       ; 3f16: 39 17 11    9.. :9f16[1]
+; &3f19 referenced 1 time by &9f12
+.c9f19
+    sta l1117,y                                                       ; 3f19: 99 17 11    ... :9f19[1]
+    clc                                                               ; 3f1c: 18          .   :9f1c[1]
+    rts                                                               ; 3f1d: 60          `   :9f1d[1]
+
+; &3f1e referenced 3 times by &9bc2, &9ebb, &a00a
+.sub_c9f1e
+    lda l1117,y                                                       ; 3f1e: b9 17 11    ... :9f1e[1]
+    and #&40 ; '@'                                                    ; 3f21: 29 40       )@  :9f21[1]
+    beq c9f6a                                                         ; 3f23: f0 45       .E  :9f23[1]
+    clc                                                               ; 3f25: 18          .   :9f25[1]
+; &3f26 referenced 2 times by &9ebf, &a01e
+.sub_c9f26
+    php                                                               ; 3f26: 08          .   :9f26[1]
+    inc l10dd                                                         ; 3f27: ee dd 10    ... :9f27[1]
+    ldy l10c2                                                         ; 3f2a: ac c2 10    ... :9f2a[1]
+    lda l1113,y                                                       ; 3f2d: b9 13 11    ... :9f2d[1]
+    sta l00bd                                                         ; 3f30: 85 bd       ..  :9f30[1]
+    lda #&ff                                                          ; 3f32: a9 ff       ..  :9f32[1]
+    sta l1074                                                         ; 3f34: 8d 74 10    .t. :9f34[1]
+    sta l1075                                                         ; 3f37: 8d 75 10    .u. :9f37[1]
+    lda #0                                                            ; 3f3a: a9 00       ..  :9f3a[1]
+    sta l00bc                                                         ; 3f3c: 85 bc       ..  :9f3c[1]
+    sta l00c0                                                         ; 3f3e: 85 c0       ..  :9f3e[1]
+    lda #1                                                            ; 3f40: a9 01       ..  :9f40[1]
+    sta l00c1                                                         ; 3f42: 85 c1       ..  :9f42[1]
+    plp                                                               ; 3f44: 28          (   :9f44[1]
+    bcs c9f5e                                                         ; 3f45: b0 17       ..  :9f45[1]
+    lda l111c,y                                                       ; 3f47: b9 1c 11    ... :9f47[1]
+    sta l00c3                                                         ; 3f4a: 85 c3       ..  :9f4a[1]
+    lda l111d,y                                                       ; 3f4c: b9 1d 11    ... :9f4c[1]
+    sta l00c2                                                         ; 3f4f: 85 c2       ..  :9f4f[1]
+    jsr sub_c8862                                                     ; 3f51: 20 62 88     b. :9f51[1]
+    ldy l10c2                                                         ; 3f54: ac c2 10    ... :9f54[1]
+    lda #&bf                                                          ; 3f57: a9 bf       ..  :9f57[1]
+    jsr sub_c9f16                                                     ; 3f59: 20 16 9f     .. :9f59[1]
+    bcc c9f64                                                         ; 3f5c: 90 06       ..  :9f5c[1]
+; &3f5e referenced 1 time by &9f45
+.c9f5e
+    jsr sub_c9ef4                                                     ; 3f5e: 20 f4 9e     .. :9f5e[1]
+    jsr sub_c8855                                                     ; 3f61: 20 55 88     U. :9f61[1]
+; &3f64 referenced 1 time by &9f5c
+.c9f64
+    dec l10dd                                                         ; 3f64: ce dd 10    ... :9f64[1]
+    ldy l10c2                                                         ; 3f67: ac c2 10    ... :9f67[1]
+; &3f6a referenced 1 time by &9f23
+.c9f6a
+    rts                                                               ; 3f6a: 60          `   :9f6a[1]
+
+; &3f6b referenced 1 time by &9f91
+.c9f6b
+    jmp generate_error_precheck_locked                                ; 3f6b: 4c 55 9a    LU. :9f6b[1]
+
+; &3f6e referenced 1 time by &9f8c
+.loop_c9f6e
+    jsr generate_error_precheck                                       ; 3f6e: 20 38 80     8. :9f6e[1]
+    equb &c1                                                          ; 3f71: c1          .   :9f71[1]
+    equs "Read only"                                                  ; 3f72: 52 65 61... Rea :9f72[1]
+    equb 0                                                            ; 3f7b: 00          .   :9f7b[1]
+
+; &3f7c referenced 1 time by &a09a
+.sub_c9f7c
+    jsr sub_c83e3                                                     ; 3f7c: 20 e3 83     .. :9f7c[1]
+    jmp c9f88                                                         ; 3f7f: 4c 88 9f    L.. :9f7f[1]
+
+; &3f82 referenced 1 time by &9983
+.sub_c9f82
+    jsr sub_c83e3                                                     ; 3f82: 20 e3 83     .. :9f82[1]
+    jsr sub_c9e75                                                     ; 3f85: 20 75 9e     u. :9f85[1]
+; &3f88 referenced 1 time by &9f7f
+.c9f88
+    pha                                                               ; 3f88: 48          H   :9f88[1]
+    lda l110c,y                                                       ; 3f89: b9 0c 11    ... :9f89[1]
+    bmi loop_c9f6e                                                    ; 3f8c: 30 e0       0.  :9f8c[1]
+    lda l110e,y                                                       ; 3f8e: b9 0e 11    ... :9f8e[1]
+    bmi c9f6b                                                         ; 3f91: 30 d8       0.  :9f91[1]
+    jsr sub_c9be5                                                     ; 3f93: 20 e5 9b     .. :9f93[1]
+    tya                                                               ; 3f96: 98          .   :9f96[1]
+    clc                                                               ; 3f97: 18          .   :9f97[1]
+    adc #4                                                            ; 3f98: 69 04       i.  :9f98[1]
+    jsr sub_ca0de                                                     ; 3f9a: 20 de a0     .. :9f9a[1]
+    bne ca005                                                         ; 3f9d: d0 66       .f  :9f9d[1]
+    jsr sub_c9bcd                                                     ; 3f9f: 20 cd 9b     .. :9f9f[1]
+    ldx l10c3                                                         ; 3fa2: ae c3 10    ... :9fa2[1]
+    sec                                                               ; 3fa5: 38          8   :9fa5[1]
+    lda l0f07,x                                                       ; 3fa6: bd 07 0f    ... :9fa6[1]
+    sbc l0f0f,x                                                       ; 3fa9: fd 0f 0f    ... :9fa9[1]
+    pha                                                               ; 3fac: 48          H   :9fac[1]
+    lda l0f06,x                                                       ; 3fad: bd 06 0f    ... :9fad[1]
+    sbc l0f0e,x                                                       ; 3fb0: fd 0e 0f    ... :9fb0[1]
+    and #3                                                            ; 3fb3: 29 03       ).  :9fb3[1]
+    cmp l111a,y                                                       ; 3fb5: d9 1a 11    ... :9fb5[1]
+    bne c9fd9                                                         ; 3fb8: d0 1f       ..  :9fb8[1]
+    pla                                                               ; 3fba: 68          h   :9fba[1]
+    cmp l1119,y                                                       ; 3fbb: d9 19 11    ... :9fbb[1]
+    bne c9ff4                                                         ; 3fbe: d0 34       .4  :9fbe[1]
+    sty l00b4                                                         ; 3fc0: 84 b4       ..  :9fc0[1]
+    sty l10c2                                                         ; 3fc2: 8c c2 10    ... :9fc2[1]
+    jsr sub_c9e30                                                     ; 3fc5: 20 30 9e     0. :9fc5[1]
+    jsr generate_error_precheck                                       ; 3fc8: 20 38 80     8. :9fc8[1]
+    equb &bf                                                          ; 3fcb: bf          .   :9fcb[1]
+    equs "Can't extend"                                               ; 3fcc: 43 61 6e... Can :9fcc[1]
+    equb 0                                                            ; 3fd8: 00          .   :9fd8[1]
+
+; &3fd9 referenced 1 time by &9fb8
+.c9fd9
+    lda l111a,y                                                       ; 3fd9: b9 1a 11    ... :9fd9[1]
+    clc                                                               ; 3fdc: 18          .   :9fdc[1]
+    adc #1                                                            ; 3fdd: 69 01       i.  :9fdd[1]
+    sta l111a,y                                                       ; 3fdf: 99 1a 11    ... :9fdf[1]
+    asl a                                                             ; 3fe2: 0a          .   :9fe2[1]
+    asl a                                                             ; 3fe3: 0a          .   :9fe3[1]
+    asl a                                                             ; 3fe4: 0a          .   :9fe4[1]
+    asl a                                                             ; 3fe5: 0a          .   :9fe5[1]
+    eor l0f0e,x                                                       ; 3fe6: 5d 0e 0f    ].. :9fe6[1]
+    and #&30 ; '0'                                                    ; 3fe9: 29 30       )0  :9fe9[1]
+    eor l0f0e,x                                                       ; 3feb: 5d 0e 0f    ].. :9feb[1]
+    sta l0f0e,x                                                       ; 3fee: 9d 0e 0f    ... :9fee[1]
+    pla                                                               ; 3ff1: 68          h   :9ff1[1]
+    lda #0                                                            ; 3ff2: a9 00       ..  :9ff2[1]
+; &3ff4 referenced 1 time by &9fbe
+.c9ff4
+    sta l0f0d,x                                                       ; 3ff4: 9d 0d 0f    ... :9ff4[1]
+    sta l1119,y                                                       ; 3ff7: 99 19 11    ... :9ff7[1]
+    lda #0                                                            ; 3ffa: a9 00       ..  :9ffa[1]
+    sta l0f0c,x                                                       ; 3ffc: 9d 0c 0f    ... :9ffc[1]
+    jsr c93e6                                                         ; 3fff: 20 e6 93     .. :9fff[1]
+    ldy l10c2                                                         ; 4002: ac c2 10    ... :a002[1]
+; &4005 referenced 1 time by &9f9d
+.ca005
+    lda l1117,y                                                       ; 4005: b9 17 11    ... :a005[1]
+    bmi ca021                                                         ; 4008: 30 17       0.  :a008[1]
+    jsr sub_c9f1e                                                     ; 400a: 20 1e 9f     .. :a00a[1]
+    lda l1114,y                                                       ; 400d: b9 14 11    ... :a00d[1]
+    bne ca01d                                                         ; 4010: d0 0b       ..  :a010[1]
+    tya                                                               ; 4012: 98          .   :a012[1]
+    jsr sub_ca0de                                                     ; 4013: 20 de a0     .. :a013[1]
+    bne ca01d                                                         ; 4016: d0 05       ..  :a016[1]
+    jsr sub_c9ef4                                                     ; 4018: 20 f4 9e     .. :a018[1]
+    bne ca021                                                         ; 401b: d0 04       ..  :a01b[1]
+; &401d referenced 2 times by &a010, &a016
+.ca01d
+    sec                                                               ; 401d: 38          8   :a01d[1]
+    jsr sub_c9f26                                                     ; 401e: 20 26 9f     &. :a01e[1]
+; &4021 referenced 2 times by &a008, &a01b
+.ca021
+    lda l1110,y                                                       ; 4021: b9 10 11    ... :a021[1]
+    sta l00ba                                                         ; 4024: 85 ba       ..  :a024[1]
+    lda l1113,y                                                       ; 4026: b9 13 11    ... :a026[1]
+    sta l00bb                                                         ; 4029: 85 bb       ..  :a029[1]
+    pla                                                               ; 402b: 68          h   :a02b[1]
+    ldy #0                                                            ; 402c: a0 00       ..  :a02c[1]
+    sta (l00ba),y                                                     ; 402e: 91 ba       ..  :a02e[1]
+    ldy l10c2                                                         ; 4030: ac c2 10    ... :a030[1]
+    lda #&40 ; '@'                                                    ; 4033: a9 40       .@  :a033[1]
+    jsr sub_c9f0f                                                     ; 4035: 20 0f 9f     .. :a035[1]
+    inc l00ba                                                         ; 4038: e6 ba       ..  :a038[1]
+    lda l00ba                                                         ; 403a: a5 ba       ..  :a03a[1]
+    sta l1110,y                                                       ; 403c: 99 10 11    ... :a03c[1]
+    bne ca054                                                         ; 403f: d0 13       ..  :a03f[1]
+    jsr sub_c9f14                                                     ; 4041: 20 14 9f     .. :a041[1]
+    lda l1111,y                                                       ; 4044: b9 11 11    ... :a044[1]
+    adc #1                                                            ; 4047: 69 01       i.  :a047[1]
+    sta l1111,y                                                       ; 4049: 99 11 11    ... :a049[1]
+    lda l1112,y                                                       ; 404c: b9 12 11    ... :a04c[1]
+    adc #0                                                            ; 404f: 69 00       i.  :a04f[1]
+    sta l1112,y                                                       ; 4051: 99 12 11    ... :a051[1]
+; &4054 referenced 1 time by &a03f
+.ca054
+    tya                                                               ; 4054: 98          .   :a054[1]
+    jsr sub_ca0de                                                     ; 4055: 20 de a0     .. :a055[1]
+    bcc ca06b                                                         ; 4058: 90 11       ..  :a058[1]
+    lda #&20 ; ' '                                                    ; 405a: a9 20       .   :a05a[1]
+    jsr sub_c9f0f                                                     ; 405c: 20 0f 9f     .. :a05c[1]
+    ldx #2                                                            ; 405f: a2 02       ..  :a05f[1]
+; &4061 referenced 1 time by &a069
+.loop_ca061
+    lda l1110,y                                                       ; 4061: b9 10 11    ... :a061[1]
+    sta l1114,y                                                       ; 4064: 99 14 11    ... :a064[1]
+    iny                                                               ; 4067: c8          .   :a067[1]
+    dex                                                               ; 4068: ca          .   :a068[1]
+    bpl loop_ca061                                                    ; 4069: 10 f6       ..  :a069[1]
+; &406b referenced 3 times by &a058, &a0d1, &a0d9
+.ca06b
+    rts                                                               ; 406b: 60          `   :a06b[1]
+
+; &406c referenced 2 times by &9849, &9db1
+.ca06c
+    jsr sub_c83e3                                                     ; 406c: 20 e3 83     .. :a06c[1]
+    jsr sub_c9e75                                                     ; 406f: 20 75 9e     u. :a06f[1]
+    ldy l10c2                                                         ; 4072: ac c2 10    ... :a072[1]
+; &4075 referenced 1 time by &a0a6
+.ca075
+    jsr sub_ca0f6                                                     ; 4075: 20 f6 a0     .. :a075[1]
+    bcs ca0a9                                                         ; 4078: b0 2f       ./  :a078[1]
+    lda l1114,y                                                       ; 407a: b9 14 11    ... :a07a[1]
+    sta l1110,y                                                       ; 407d: 99 10 11    ... :a07d[1]
+    lda l1115,y                                                       ; 4080: b9 15 11    ... :a080[1]
+    sta l1111,y                                                       ; 4083: 99 11 11    ... :a083[1]
+    lda l1116,y                                                       ; 4086: b9 16 11    ... :a086[1]
+    sta l1112,y                                                       ; 4089: 99 12 11    ... :a089[1]
+    jsr sub_ca0b8                                                     ; 408c: 20 b8 a0     .. :a08c[1]
+    lda l00b6                                                         ; 408f: a5 b6       ..  :a08f[1]
+    pha                                                               ; 4091: 48          H   :a091[1]
+    lda l00b7                                                         ; 4092: a5 b7       ..  :a092[1]
+    pha                                                               ; 4094: 48          H   :a094[1]
+    lda l00b8                                                         ; 4095: a5 b8       ..  :a095[1]
+    pha                                                               ; 4097: 48          H   :a097[1]
+    lda #0                                                            ; 4098: a9 00       ..  :a098[1]
+    jsr sub_c9f7c                                                     ; 409a: 20 7c 9f     |. :a09a[1]
+    pla                                                               ; 409d: 68          h   :a09d[1]
+    sta l00b8                                                         ; 409e: 85 b8       ..  :a09e[1]
+    pla                                                               ; 40a0: 68          h   :a0a0[1]
+    sta l00b7                                                         ; 40a1: 85 b7       ..  :a0a1[1]
+    pla                                                               ; 40a3: 68          h   :a0a3[1]
+    sta l00b6                                                         ; 40a4: 85 b6       ..  :a0a4[1]
+    jmp ca075                                                         ; 40a6: 4c 75 a0    Lu. :a0a6[1]
+
+; &40a9 referenced 1 time by &a078
+.ca0a9
+    lda l0000,x                                                       ; 40a9: b5 00       ..  :a0a9[1]
+    sta l1110,y                                                       ; 40ab: 99 10 11    ... :a0ab[1]
+    lda l0001,x                                                       ; 40ae: b5 01       ..  :a0ae[1]
+    sta l1111,y                                                       ; 40b0: 99 11 11    ... :a0b0[1]
+    lda l0002,x                                                       ; 40b3: b5 02       ..  :a0b3[1]
+    sta l1112,y                                                       ; 40b5: 99 12 11    ... :a0b5[1]
+; &40b8 referenced 1 time by &a08c
+.sub_ca0b8
+    lda #&6f ; 'o'                                                    ; 40b8: a9 6f       .o  :a0b8[1]
+    jsr sub_c9f16                                                     ; 40ba: 20 16 9f     .. :a0ba[1]
+    lda l110f,y                                                       ; 40bd: b9 0f 11    ... :a0bd[1]
+    adc l1111,y                                                       ; 40c0: 79 11 11    y.. :a0c0[1]
+    sta l10c4                                                         ; 40c3: 8d c4 10    ... :a0c3[1]
+    lda l110d,y                                                       ; 40c6: b9 0d 11    ... :a0c6[1]
+    and #3                                                            ; 40c9: 29 03       ).  :a0c9[1]
+    adc l1112,y                                                       ; 40cb: 79 12 11    y.. :a0cb[1]
+    cmp l111d,y                                                       ; 40ce: d9 1d 11    ... :a0ce[1]
+    bne ca06b                                                         ; 40d1: d0 98       ..  :a0d1[1]
+    lda l10c4                                                         ; 40d3: ad c4 10    ... :a0d3[1]
+    cmp l111c,y                                                       ; 40d6: d9 1c 11    ... :a0d6[1]
+    bne ca06b                                                         ; 40d9: d0 90       ..  :a0d9[1]
+    jmp c9f0d                                                         ; 40db: 4c 0d 9f    L.. :a0db[1]
+
+; &40de referenced 5 times by &9e66, &9e9b, &9f9a, &a013, &a055
+.sub_ca0de
+    tax                                                               ; 40de: aa          .   :a0de[1]
+    lda l1112,y                                                       ; 40df: b9 12 11    ... :a0df[1]
+    cmp l1116,x                                                       ; 40e2: dd 16 11    ... :a0e2[1]
+    bne ca0f5                                                         ; 40e5: d0 0e       ..  :a0e5[1]
+    lda l1111,y                                                       ; 40e7: b9 11 11    ... :a0e7[1]
+    cmp l1115,x                                                       ; 40ea: dd 15 11    ... :a0ea[1]
+    bne ca0f5                                                         ; 40ed: d0 06       ..  :a0ed[1]
+    lda l1110,y                                                       ; 40ef: b9 10 11    ... :a0ef[1]
+    cmp l1114,x                                                       ; 40f2: dd 14 11    ... :a0f2[1]
+; &40f5 referenced 2 times by &a0e5, &a0ed
+.ca0f5
+    rts                                                               ; 40f5: 60          `   :a0f5[1]
+
+; &40f6 referenced 1 time by &a075
+.sub_ca0f6
+    lda l1114,y                                                       ; 40f6: b9 14 11    ... :a0f6[1]
+    cmp l0000,x                                                       ; 40f9: d5 00       ..  :a0f9[1]
+    lda l1115,y                                                       ; 40fb: b9 15 11    ... :a0fb[1]
+    sbc l0001,x                                                       ; 40fe: f5 01       ..  :a0fe[1]
+    lda l1116,y                                                       ; 4100: b9 16 11    ... :a100[1]
+    sbc l0002,x                                                       ; 4103: f5 02       ..  :a103[1]
+    rts                                                               ; 4105: 60          `   :a105[1]
+
+.sub_ca106
+    tya                                                               ; 4106: 98          .   :a106[1]
+    ldx #&ff                                                          ; 4107: a2 ff       ..  :a107[1]
+    ldy #&14                                                          ; 4109: a0 14       ..  :a109[1]
+; &410b referenced 2 times by &9711, &a13c
+.ca10b
+    pha                                                               ; 410b: 48          H   :a10b[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 410c: 20 77 80     w. :a10c[1]
+    equs &0d, "DFS 2.26", &0d                                         ; 410f: 0d 44 46... .DF :a10f[1]
+
+    stx l00bf                                                         ; 4119: 86 bf       ..  :a119[1]
+    sty l00b7                                                         ; 411b: 84 b7       ..  :a11b[1]
+; &411d referenced 1 time by &a12e
+.loop_ca11d
+    lda #0                                                            ; 411d: a9 00       ..  :a11d[1]
+    sta l00b9                                                         ; 411f: 85 b9       ..  :a11f[1]
+    ldy #2                                                            ; 4121: a0 02       ..  :a121[1]
+    jsr sub_ca1c6                                                     ; 4123: 20 c6 a1     .. :a123[1]
+    jsr sub_ca168                                                     ; 4126: 20 68 a1     h. :a126[1]
+    jsr ca3dc                                                         ; 4129: 20 dc a3     .. :a129[1]
+    dec l00b7                                                         ; 412c: c6 b7       ..  :a12c[1]
+    bne loop_ca11d                                                    ; 412e: d0 ed       ..  :a12e[1]
+    pla                                                               ; 4130: 68          h   :a130[1]
+    tay                                                               ; 4131: a8          .   :a131[1]
+; &4132 referenced 1 time by &a148
+.loop_ca132
+    ldx #&cf                                                          ; 4132: a2 cf       ..  :a132[1]
+    jmp c8703                                                         ; 4134: 4c 03 87    L.. :a134[1]
+
+.sub_ca137
+    tya                                                               ; 4137: 98          .   :a137[1]
+    ldx #&9d                                                          ; 4138: a2 9d       ..  :a138[1]
+    ldy #6                                                            ; 413a: a0 06       ..  :a13a[1]
+    bne ca10b                                                         ; 413c: d0 cd       ..  :a13c[1]
+    jsr clc_jmp_gsinit                                                ; 413e: 20 4c 87     L. :a13e[1]
+    beq ca1c0                                                         ; 4141: f0 7d       .}  :a141[1]
+; &4143 referenced 1 time by &a146
+.loop_ca143
+    jsr sub_c8149                                                     ; 4143: 20 49 81     I. :a143[1]
+    bcc loop_ca143                                                    ; 4146: 90 fb       ..  :a146[1]
+    bcs loop_ca132                                                    ; 4148: b0 e8       ..  :a148[1]
+; &414a referenced 13 times by &8257, &8753, &8785, &879a, &87ee, &89b7, &89e9, &8baf, &8bc1, &a324, &a32d, &a469, &a5cb
+.sub_ca14a
+    jsr clc_jmp_gsinit                                                ; 414a: 20 4c 87     L. :a14a[1]
+    bne ca1c0                                                         ; 414d: d0 71       .q  :a14d[1]
+; &414f referenced 3 times by &8805, &a5e2, &ac25
+.ca14f
+    jsr generate_error                                                ; 414f: 20 48 80     H. :a14f[1]
+    equb &dc                                                          ; 4152: dc          .   :a152[1]
+    equs "Syntax: "                                                   ; 4153: 53 79 6e... Syn :a153[1]
+
+    stx l00b9                                                         ; 415b: 86 b9       ..  :a15b[1]
+    jsr sub_ca168                                                     ; 415d: 20 68 a1     h. :a15d[1]
+    lda #0                                                            ; 4160: a9 00       ..  :a160[1]
+    jsr sub_ca1b4                                                     ; 4162: 20 b4 a1     .. :a162[1]
+    jmp l0100                                                         ; 4165: 4c 00 01    L.. :a165[1]
+
+; &4168 referenced 2 times by &a126, &a15d
+.sub_ca168
+    ldx l00bf                                                         ; 4168: a6 bf       ..  :a168[1]
+    lda #9                                                            ; 416a: a9 09       ..  :a16a[1]
+    sta l00b8                                                         ; 416c: 85 b8       ..  :a16c[1]
+; &416e referenced 1 time by &a177
+.loop_ca16e
+    inx                                                               ; 416e: e8          .   :a16e[1]
+    lda command_table,x                                               ; 416f: bd 1c 86    ... :a16f[1]
+    bmi ca17a                                                         ; 4172: 30 06       0.  :a172[1]
+    jsr sub_ca1b4                                                     ; 4174: 20 b4 a1     .. :a174[1]
+    jmp loop_ca16e                                                    ; 4177: 4c 6e a1    Ln. :a177[1]
+
+; &417a referenced 1 time by &a172
+.ca17a
+    ldy l00b8                                                         ; 417a: a4 b8       ..  :a17a[1]
+    cpy #&0c                                                          ; 417c: c0 0c       ..  :a17c[1]
+    beq ca183                                                         ; 417e: f0 03       ..  :a17e[1]
+    jsr sub_ca1c6                                                     ; 4180: 20 c6 a1     .. :a180[1]
+; &4183 referenced 1 time by &a17e
+.ca183
+    inx                                                               ; 4183: e8          .   :a183[1]
+    inx                                                               ; 4184: e8          .   :a184[1]
+    stx l00bf                                                         ; 4185: 86 bf       ..  :a185[1]
+    lda command_table,x                                               ; 4187: bd 1c 86    ... :a187[1]
+    jsr sub_ca190                                                     ; 418a: 20 90 a1     .. :a18a[1]
+    jsr sub_c81bf                                                     ; 418d: 20 bf 81     .. :a18d[1]
+; &4190 referenced 1 time by &a18a
+.sub_ca190
+    jsr sub_c83e3                                                     ; 4190: 20 e3 83     .. :a190[1]
+    and #&0f                                                          ; 4193: 29 0f       ).  :a193[1]
+    beq ca1c0                                                         ; 4195: f0 29       .)  :a195[1]
+    tay                                                               ; 4197: a8          .   :a197[1]
+    lda #&20 ; ' '                                                    ; 4198: a9 20       .   :a198[1]
+    jsr sub_ca1b4                                                     ; 419a: 20 b4 a1     .. :a19a[1]
+    ldx #&ff                                                          ; 419d: a2 ff       ..  :a19d[1]
+; &419f referenced 2 times by &a1a3, &a1a6
+.ca19f
+    inx                                                               ; 419f: e8          .   :a19f[1]
+    lda la1d3,x                                                       ; 41a0: bd d3 a1    ... :a1a0[1]
+    bpl ca19f                                                         ; 41a3: 10 fa       ..  :a1a3[1]
+    dey                                                               ; 41a5: 88          .   :a1a5[1]
+    bne ca19f                                                         ; 41a6: d0 f7       ..  :a1a6[1]
+    and #&7f                                                          ; 41a8: 29 7f       ).  :a1a8[1]
+; &41aa referenced 1 time by &a1b1
+.loop_ca1aa
+    jsr sub_ca1b4                                                     ; 41aa: 20 b4 a1     .. :a1aa[1]
+    inx                                                               ; 41ad: e8          .   :a1ad[1]
+    lda la1d3,x                                                       ; 41ae: bd d3 a1    ... :a1ae[1]
+    bpl loop_ca1aa                                                    ; 41b1: 10 f7       ..  :a1b1[1]
+    rts                                                               ; 41b3: 60          `   :a1b3[1]
+
+; &41b4 referenced 5 times by &a162, &a174, &a19a, &a1aa, &a1cc
+.sub_ca1b4
+    jsr sub_c83e3                                                     ; 41b4: 20 e3 83     .. :a1b4[1]
+    ldx l00b9                                                         ; 41b7: a6 b9       ..  :a1b7[1]
+    beq ca1c1                                                         ; 41b9: f0 06       ..  :a1b9[1]
+    inc l00b9                                                         ; 41bb: e6 b9       ..  :a1bb[1]
+    sta l0100,x                                                       ; 41bd: 9d 00 01    ... :a1bd[1]
+; &41c0 referenced 3 times by &a141, &a14d, &a195
+.ca1c0
+    rts                                                               ; 41c0: 60          `   :a1c0[1]
+
+; &41c1 referenced 1 time by &a1b9
+.ca1c1
+    dec l00b8                                                         ; 41c1: c6 b8       ..  :a1c1[1]
+    jmp c809f                                                         ; 41c3: 4c 9f 80    L.. :a1c3[1]
+
+; &41c6 referenced 2 times by &a123, &a180
+.sub_ca1c6
+    lda l00b9                                                         ; 41c6: a5 b9       ..  :a1c6[1]
+    bne ca1d2                                                         ; 41c8: d0 08       ..  :a1c8[1]
+    lda #&20 ; ' '                                                    ; 41ca: a9 20       .   :a1ca[1]
+; &41cc referenced 1 time by &a1d0
+.loop_ca1cc
+    jsr sub_ca1b4                                                     ; 41cc: 20 b4 a1     .. :a1cc[1]
+    dey                                                               ; 41cf: 88          .   :a1cf[1]
+    bne loop_ca1cc                                                    ; 41d0: d0 fa       ..  :a1d0[1]
+; &41d2 referenced 1 time by &a1c8
+.ca1d2
+    rts                                                               ; 41d2: 60          `   :a1d2[1]
+
+; &41d3 referenced 2 times by &a1a0, &a1ae
+.la1d3
+    equb &bc                                                          ; 41d3: bc          .   :a1d3[1]
+    equs "fsp>"                                                       ; 41d4: 66 73 70... fsp :a1d4[1]
+    equb &bc                                                          ; 41d8: bc          .   :a1d8[1]
+    equs "afsp>"                                                      ; 41d9: 61 66 73... afs :a1d9[1]
+    equb &a8, &4c, &29, &bc                                           ; 41de: a8 4c 29... .L) :a1de[1]
+    equs "source> <dest.>"                                            ; 41e2: 73 6f 75... sou :a1e2[1]
+    equb &bc                                                          ; 41f1: bc          .   :a1f1[1]
+    equs "old fsp> <new fsp>"                                         ; 41f2: 6f 6c 64... old :a1f2[1]
+    equb &a8                                                          ; 4204: a8          .   :a204[1]
+    equs "<dir>)"                                                     ; 4205: 3c 64 69... <di :a205[1]
+    equb &a8                                                          ; 420b: a8          .   :a20b[1]
+    equs "<drive>)"                                                   ; 420c: 3c 64 72... <dr :a20c[1]
+    equb &bc                                                          ; 4214: bc          .   :a214[1]
+    equs "title>"                                                     ; 4215: 74 69 74... tit :a215[1]
+    equb &bc                                                          ; 421b: bc          .   :a21b[1]
+    equs "drive> (40)(80)"                                            ; 421c: 64 72 69... dri :a21c[1]
+    equb &b4                                                          ; 422b: b4          .   :a22b[1]
+    equs "0/80"                                                       ; 422c: 30 2f 38... 0/8 :a22c[1]
+    equb &a8                                                          ; 4230: a8          .   :a230[1]
+    equs "<drive>)..."                                                ; 4231: 3c 64 72... <dr :a231[1]
+    equb &a8                                                          ; 423c: a8          .   :a23c[1]
+    equs "<rom>)"                                                     ; 423d: 3c 72 6f... <ro :a23d[1]
+    equb &ff                                                          ; 4243: ff          .   :a243[1]
+
+.sub_ca244
+    jsr sub_c8b86                                                     ; 4244: 20 86 8b     .. :a244[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4247: 20 77 80     w. :a247[1]
+    equs "Compacting :"                                               ; 424a: 43 6f 6d... Com :a24a[1]
+
+    sta l10d1                                                         ; 4256: 8d d1 10    ... :a256[1]
+    sta l10d2                                                         ; 4259: 8d d2 10    ... :a259[1]
+    jsr sub_c80c3                                                     ; 425c: 20 c3 80     .. :a25c[1]
+    jsr ca3dc                                                         ; 425f: 20 dc a3     .. :a25f[1]
+    ldy #0                                                            ; 4262: a0 00       ..  :a262[1]
+    jsr sub_c9b79                                                     ; 4264: 20 79 9b     y. :a264[1]
+    jsr sub_c9a8d                                                     ; 4267: 20 8d 9a     .. :a267[1]
+    jsr sub_c8380                                                     ; 426a: 20 80 83     .. :a26a[1]
+    ldy l0f05                                                         ; 426d: ac 05 0f    ... :a26d[1]
+    sty l00ca                                                         ; 4270: 84 ca       ..  :a270[1]
+    lda #2                                                            ; 4272: a9 02       ..  :a272[1]
+    sta l00c8                                                         ; 4274: 85 c8       ..  :a274[1]
+    lda #0                                                            ; 4276: a9 00       ..  :a276[1]
+    sta l00c9                                                         ; 4278: 85 c9       ..  :a278[1]
+; &427a referenced 1 time by &a312
+.ca27a
+    ldy l00ca                                                         ; 427a: a4 ca       ..  :a27a[1]
+    jsr sub_c82b2                                                     ; 427c: 20 b2 82     .. :a27c[1]
+    cpy #&f8                                                          ; 427f: c0 f8       ..  :a27f[1]
+    bne ca2ab                                                         ; 4281: d0 28       .(  :a281[1]
+    lda l0f07                                                         ; 4283: ad 07 0f    ... :a283[1]
+    sec                                                               ; 4286: 38          8   :a286[1]
+    sbc l00c8                                                         ; 4287: e5 c8       ..  :a287[1]
+    pha                                                               ; 4289: 48          H   :a289[1]
+    lda l0f06                                                         ; 428a: ad 06 0f    ... :a28a[1]
+    and #3                                                            ; 428d: 29 03       ).  :a28d[1]
+    sbc l00c9                                                         ; 428f: e5 c9       ..  :a28f[1]
+    jsr sub_c80c3                                                     ; 4291: 20 c3 80     .. :a291[1]
+    pla                                                               ; 4294: 68          h   :a294[1]
+    jsr sub_c80bb                                                     ; 4295: 20 bb 80     .. :a295[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4298: 20 77 80     w. :a298[1]
+    equs " free sectors", &0d                                         ; 429b: 20 66 72...  fr :a29b[1]
+
+    nop                                                               ; 42a9: ea          .   :a2a9[1]
+    rts                                                               ; 42aa: 60          `   :a2aa[1]
+
+; &42ab referenced 1 time by &a281
+.ca2ab
+    sty l00ca                                                         ; 42ab: 84 ca       ..  :a2ab[1]
+    jsr sub_c8335                                                     ; 42ad: 20 35 83     5. :a2ad[1]
+    ldy l00ca                                                         ; 42b0: a4 ca       ..  :a2b0[1]
+    lda l0f0c,y                                                       ; 42b2: b9 0c 0f    ... :a2b2[1]
+    cmp #1                                                            ; 42b5: c9 01       ..  :a2b5[1]
+    lda #0                                                            ; 42b7: a9 00       ..  :a2b7[1]
+    sta l00bc                                                         ; 42b9: 85 bc       ..  :a2b9[1]
+    sta l00c0                                                         ; 42bb: 85 c0       ..  :a2bb[1]
+    adc l0f0d,y                                                       ; 42bd: 79 0d 0f    y.. :a2bd[1]
+    sta l00c4                                                         ; 42c0: 85 c4       ..  :a2c0[1]
+    lda l0f0e,y                                                       ; 42c2: b9 0e 0f    ... :a2c2[1]
+    php                                                               ; 42c5: 08          .   :a2c5[1]
+    jsr sub_c81b0                                                     ; 42c6: 20 b0 81     .. :a2c6[1]
+    plp                                                               ; 42c9: 28          (   :a2c9[1]
+    adc #0                                                            ; 42ca: 69 00       i.  :a2ca[1]
+    sta l00c5                                                         ; 42cc: 85 c5       ..  :a2cc[1]
+    lda l0f0f,y                                                       ; 42ce: b9 0f 0f    ... :a2ce[1]
+    sta l00c6                                                         ; 42d1: 85 c6       ..  :a2d1[1]
+    lda l0f0e,y                                                       ; 42d3: b9 0e 0f    ... :a2d3[1]
+    and #3                                                            ; 42d6: 29 03       ).  :a2d6[1]
+    sta l00c7                                                         ; 42d8: 85 c7       ..  :a2d8[1]
+    cmp l00c9                                                         ; 42da: c5 c9       ..  :a2da[1]
+    bne ca2f2                                                         ; 42dc: d0 14       ..  :a2dc[1]
+    lda l00c6                                                         ; 42de: a5 c6       ..  :a2de[1]
+    cmp l00c8                                                         ; 42e0: c5 c8       ..  :a2e0[1]
+    bne ca2f2                                                         ; 42e2: d0 0e       ..  :a2e2[1]
+    clc                                                               ; 42e4: 18          .   :a2e4[1]
+    adc l00c4                                                         ; 42e5: 65 c4       e.  :a2e5[1]
+    sta l00c8                                                         ; 42e7: 85 c8       ..  :a2e7[1]
+    lda l00c9                                                         ; 42e9: a5 c9       ..  :a2e9[1]
+    adc l00c5                                                         ; 42eb: 65 c5       e.  :a2eb[1]
+    sta l00c9                                                         ; 42ed: 85 c9       ..  :a2ed[1]
+    jmp ca30d                                                         ; 42ef: 4c 0d a3    L.. :a2ef[1]
+
+; &42f2 referenced 2 times by &a2dc, &a2e2
+.ca2f2
+    lda l00c8                                                         ; 42f2: a5 c8       ..  :a2f2[1]
+    sta l0f0f,y                                                       ; 42f4: 99 0f 0f    ... :a2f4[1]
+    lda l0f0e,y                                                       ; 42f7: b9 0e 0f    ... :a2f7[1]
+    and #&fc                                                          ; 42fa: 29 fc       ).  :a2fa[1]
+    ora l00c9                                                         ; 42fc: 05 c9       ..  :a2fc[1]
+    sta l0f0e,y                                                       ; 42fe: 99 0e 0f    ... :a2fe[1]
+    lda #0                                                            ; 4301: a9 00       ..  :a301[1]
+    sta l00a8                                                         ; 4303: 85 a8       ..  :a303[1]
+    sta l00a9                                                         ; 4305: 85 a9       ..  :a305[1]
+    jsr sub_ca530                                                     ; 4307: 20 30 a5     0. :a307[1]
+    jsr c93e6                                                         ; 430a: 20 e6 93     .. :a30a[1]
+; &430d referenced 1 time by &a2ef
+.ca30d
+    ldy l00ca                                                         ; 430d: a4 ca       ..  :a30d[1]
+    jsr sub_c833a                                                     ; 430f: 20 3a 83     :. :a30f[1]
+    jmp ca27a                                                         ; 4312: 4c 7a a2    Lz. :a312[1]
+
+; &4315 referenced 3 times by &8794, &a41a, &a64c
+.sub_ca315
+    bit l10c7                                                         ; 4315: 2c c7 10    ,.. :a315[1]
+    bpl ca378                                                         ; 4318: 10 5e       .^  :a318[1]
+    jsr sub_ca3ec                                                     ; 431a: 20 ec a3     .. :a31a[1]
+    beq ca321                                                         ; 431d: f0 02       ..  :a31d[1]
+    pla                                                               ; 431f: 68          h   :a31f[1]
+    pla                                                               ; 4320: 68          h   :a320[1]
+; &4321 referenced 1 time by &a31d
+.ca321
+    jmp ca3dc                                                         ; 4321: 4c dc a3    L.. :a321[1]
+
+; &4324 referenced 2 times by &a417, &a466
+.sub_ca324
+    jsr sub_ca14a                                                     ; 4324: 20 4a a1     J. :a324[1]
+    jsr c8b8b                                                         ; 4327: 20 8b 8b     .. :a327[1]
+    sta l10d1                                                         ; 432a: 8d d1 10    ... :a32a[1]
+    jsr sub_ca14a                                                     ; 432d: 20 4a a1     J. :a32d[1]
+    jsr c8b8b                                                         ; 4330: 20 8b 8b     .. :a330[1]
+    sta l10d2                                                         ; 4333: 8d d2 10    ... :a333[1]
+    tya                                                               ; 4336: 98          .   :a336[1]
+    pha                                                               ; 4337: 48          H   :a337[1]
+    lda #0                                                            ; 4338: a9 00       ..  :a338[1]
+    sta l00a9                                                         ; 433a: 85 a9       ..  :a33a[1]
+    lda l10d2                                                         ; 433c: ad d2 10    ... :a33c[1]
+    cmp l10d1                                                         ; 433f: cd d1 10    ... :a33f[1]
+    bne ca34a                                                         ; 4342: d0 06       ..  :a342[1]
+    lda #&ff                                                          ; 4344: a9 ff       ..  :a344[1]
+    sta l00a9                                                         ; 4346: 85 a9       ..  :a346[1]
+    sta l00aa                                                         ; 4348: 85 aa       ..  :a348[1]
+; &434a referenced 1 time by &a342
+.ca34a
+    jsr sub_c9a8d                                                     ; 434a: 20 8d 9a     .. :a34a[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 434d: 20 77 80     w. :a34d[1]
+    equs "Copying from :"                                             ; 4350: 43 6f 70... Cop :a350[1]
+
+    lda l10d1                                                         ; 435e: ad d1 10    ... :a35e[1]
+    jsr sub_c80c3                                                     ; 4361: 20 c3 80     .. :a361[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4364: 20 77 80     w. :a364[1]
+    equs " to :"                                                      ; 4367: 20 74 6f...  to :a367[1]
+
+    lda l10d2                                                         ; 436c: ad d2 10    ... :a36c[1]
+    jsr sub_c80c3                                                     ; 436f: 20 c3 80     .. :a36f[1]
+    jsr ca3dc                                                         ; 4372: 20 dc a3     .. :a372[1]
+    pla                                                               ; 4375: 68          h   :a375[1]
+    tay                                                               ; 4376: a8          .   :a376[1]
+    clc                                                               ; 4377: 18          .   :a377[1]
+; &4378 referenced 1 time by &a318
+.ca378
+    rts                                                               ; 4378: 60          `   :a378[1]
+
+; &4379 referenced 4 times by &a429, &a46f, &a4c8, &a55b
+.sub_ca379
+    jsr sub_c83e3                                                     ; 4379: 20 e3 83     .. :a379[1]
+    bit l00a9                                                         ; 437c: 24 a9       $.  :a37c[1]
+    bpl ca38b                                                         ; 437e: 10 0b       ..  :a37e[1]
+    lda #0                                                            ; 4380: a9 00       ..  :a380[1]
+    beq ca38e                                                         ; 4382: f0 0a       ..  :a382[1]
+; &4384 referenced 3 times by &a440, &a4e4, &a581
+.sub_ca384
+    jsr sub_c83e3                                                     ; 4384: 20 e3 83     .. :a384[1]
+    bit l00a9                                                         ; 4387: 24 a9       $.  :a387[1]
+    bmi ca38c                                                         ; 4389: 30 01       0.  :a389[1]
+; &438b referenced 2 times by &a37e, &a390
+.ca38b
+    rts                                                               ; 438b: 60          `   :a38b[1]
+
+; &438c referenced 1 time by &a389
+.ca38c
+    lda #&80                                                          ; 438c: a9 80       ..  :a38c[1]
+; &438e referenced 1 time by &a382
+.ca38e
+    cmp l00aa                                                         ; 438e: c5 aa       ..  :a38e[1]
+    beq ca38b                                                         ; 4390: f0 f9       ..  :a390[1]
+    sta l00aa                                                         ; 4392: 85 aa       ..  :a392[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4394: 20 77 80     w. :a394[1]
+    equs "Insert "                                                    ; 4397: 49 6e 73... Ins :a397[1]
+
+    nop                                                               ; 439e: ea          .   :a39e[1]
+    bit l00aa                                                         ; 439f: 24 aa       $.  :a39f[1]
+    bmi ca3ae                                                         ; 43a1: 30 0b       0.  :a3a1[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 43a3: 20 77 80     w. :a3a3[1]
+    equs "source"                                                     ; 43a6: 73 6f 75... sou :a3a6[1]
+
+    bcc ca3bd                                                         ; 43ac: 90 0f       ..  :a3ac[1]
+; &43ae referenced 1 time by &a3a1
+.ca3ae
+    jsr print_inline_l809f_top_bit_clear                              ; 43ae: 20 77 80     w. :a3ae[1]
+    equs "destination"                                                ; 43b1: 64 65 73... des :a3b1[1]
+
+    nop                                                               ; 43bc: ea          .   :a3bc[1]
+; &43bd referenced 1 time by &a3ac
+.ca3bd
+    jsr print_inline_l809f_top_bit_clear                              ; 43bd: 20 77 80     w. :a3bd[1]
+    equs " disc and hit a key"                                        ; 43c0: 20 64 69...  di :a3c0[1]
+
+    nop                                                               ; 43d3: ea          .   :a3d3[1]
+    jsr sub_c9ac8                                                     ; 43d4: 20 c8 9a     .. :a3d4[1]
+    jsr osrdch                                                        ; 43d7: 20 e0 ff     .. :a3d7[1]
+    bcs ca411                                                         ; 43da: b0 35       .5  :a3da[1]
+; &43dc referenced 16 times by &836b, &8522, &854f, &85b2, &85b5, &8779, &87a8, &87b5, &a129, &a25f, &a321, &a372, &a62f, &a6b0, &a73a, &aa95
+.ca3dc
+    pha                                                               ; 43dc: 48          H   :a3dc[1]
+    lda #&0d                                                          ; 43dd: a9 0d       ..  :a3dd[1]
+    jsr c809f                                                         ; 43df: 20 9f 80     .. :a3df[1]
+    pla                                                               ; 43e2: 68          h   :a3e2[1]
+    rts                                                               ; 43e3: 60          `   :a3e3[1]
+
+; &43e4 referenced 1 time by &8761
+.sub_ca3e4
+    jsr print_inline_l809f_top_bit_clear                              ; 43e4: 20 77 80     w. :a3e4[1]
+    equs " : "                                                        ; 43e7: 20 3a 20     :  :a3e7[1]
+
+    bcc ca3fb                                                         ; 43ea: 90 0f       ..  :a3ea[1]
+; &43ec referenced 2 times by &87b0, &a31a
+.sub_ca3ec
+    jsr print_inline_l809f_top_bit_clear                              ; 43ec: 20 77 80     w. :a3ec[1]
+    equs "Go (Y/N) ? "                                                ; 43ef: 47 6f 20... Go  :a3ef[1]
+
+    nop                                                               ; 43fa: ea          .   :a3fa[1]
+; &43fb referenced 1 time by &a3ea
+.ca3fb
+    jsr sub_c9ac8                                                     ; 43fb: 20 c8 9a     .. :a3fb[1]
+    jsr osrdch                                                        ; 43fe: 20 e0 ff     .. :a3fe[1]
+    bcs ca411                                                         ; 4401: b0 0e       ..  :a401[1]
+    and #&5f ; '_'                                                    ; 4403: 29 5f       )_  :a403[1]
+    cmp #&59 ; 'Y'                                                    ; 4405: c9 59       .Y  :a405[1]
+    php                                                               ; 4407: 08          .   :a407[1]
+    beq ca40c                                                         ; 4408: f0 02       ..  :a408[1]
+    lda #&4e ; 'N'                                                    ; 440a: a9 4e       .N  :a40a[1]
+; &440c referenced 1 time by &a408
+.ca40c
+    jsr c809f                                                         ; 440c: 20 9f 80     .. :a40c[1]
+    plp                                                               ; 440f: 28          (   :a40f[1]
+    rts                                                               ; 4410: 60          `   :a410[1]
+
+; &4411 referenced 2 times by &a3da, &a401
+.ca411
+    jmp c9436                                                         ; 4411: 4c 36 94    L6. :a411[1]
+
+; &4414 referenced 2 times by &a452, &a45b
+.ca414
+    jmp c8a6e                                                         ; 4414: 4c 6e 8a    Ln. :a414[1]
+
+.sub_ca417
+    jsr sub_ca324                                                     ; 4417: 20 24 a3     $. :a417[1]
+    jsr sub_ca315                                                     ; 441a: 20 15 a3     .. :a41a[1]
+    lda #0                                                            ; 441d: a9 00       ..  :a41d[1]
+    sta l00c7                                                         ; 441f: 85 c7       ..  :a41f[1]
+    sta l00c9                                                         ; 4421: 85 c9       ..  :a421[1]
+    sta l00c8                                                         ; 4423: 85 c8       ..  :a423[1]
+    sta l00c6                                                         ; 4425: 85 c6       ..  :a425[1]
+    sta l00a8                                                         ; 4427: 85 a8       ..  :a427[1]
+    jsr sub_ca379                                                     ; 4429: 20 79 a3     y. :a429[1]
+    lda l10d1                                                         ; 442c: ad d1 10    ... :a42c[1]
+    sta l00cd                                                         ; 442f: 85 cd       ..  :a42f[1]
+    jsr c940c                                                         ; 4431: 20 0c 94     .. :a431[1]
+    lda l0f07                                                         ; 4434: ad 07 0f    ... :a434[1]
+    sta l00c4                                                         ; 4437: 85 c4       ..  :a437[1]
+    lda l0f06                                                         ; 4439: ad 06 0f    ... :a439[1]
+    and #3                                                            ; 443c: 29 03       ).  :a43c[1]
+    sta l00c5                                                         ; 443e: 85 c5       ..  :a43e[1]
+    jsr sub_ca384                                                     ; 4440: 20 84 a3     .. :a440[1]
+    lda l10d2                                                         ; 4443: ad d2 10    ... :a443[1]
+    sta l00cd                                                         ; 4446: 85 cd       ..  :a446[1]
+    jsr c940c                                                         ; 4448: 20 0c 94     .. :a448[1]
+    lda l0f06                                                         ; 444b: ad 06 0f    ... :a44b[1]
+    and #3                                                            ; 444e: 29 03       ).  :a44e[1]
+    cmp l00c5                                                         ; 4450: c5 c5       ..  :a450[1]
+    bcc ca414                                                         ; 4452: 90 c0       ..  :a452[1]
+    bne ca45d                                                         ; 4454: d0 07       ..  :a454[1]
+    lda l0f07                                                         ; 4456: ad 07 0f    ... :a456[1]
+    cmp l00c4                                                         ; 4459: c5 c4       ..  :a459[1]
+    bcc ca414                                                         ; 445b: 90 b7       ..  :a45b[1]
+; &445d referenced 1 time by &a454
+.ca45d
+    jsr sub_ca530                                                     ; 445d: 20 30 a5     0. :a45d[1]
+    jmp c940c                                                         ; 4460: 4c 0c 94    L.. :a460[1]
+
+.sub_ca463
+    jsr sub_c99ac                                                     ; 4463: 20 ac 99     .. :a463[1]
+    jsr sub_ca324                                                     ; 4466: 20 24 a3     $. :a466[1]
+    jsr sub_ca14a                                                     ; 4469: 20 4a a1     J. :a469[1]
+    jsr sub_c80ed                                                     ; 446c: 20 ed 80     .. :a46c[1]
+    jsr sub_ca379                                                     ; 446f: 20 79 a3     y. :a46f[1]
+    lda l10d1                                                         ; 4472: ad d1 10    ... :a472[1]
+    jsr c8816                                                         ; 4475: 20 16 88     .. :a475[1]
+    jsr c8225                                                         ; 4478: 20 25 82     %. :a478[1]
+; &447b referenced 1 time by &a4de
+.ca47b
+    lda l00cc                                                         ; 447b: a5 cc       ..  :a47b[1]
+    pha                                                               ; 447d: 48          H   :a47d[1]
+    lda l00b6                                                         ; 447e: a5 b6       ..  :a47e[1]
+    sta l00ab                                                         ; 4480: 85 ab       ..  :a480[1]
+    jsr sub_c833a                                                     ; 4482: 20 3a 83     :. :a482[1]
+    ldx #0                                                            ; 4485: a2 00       ..  :a485[1]
+; &4487 referenced 1 time by &a49b
+.loop_ca487
+    lda l0e08,y                                                       ; 4487: b9 08 0e    ... :a487[1]
+    sta l00c5,x                                                       ; 448a: 95 c5       ..  :a48a[1]
+    sta l1050,x                                                       ; 448c: 9d 50 10    .P. :a48c[1]
+    lda l0f08,y                                                       ; 448f: b9 08 0f    ... :a48f[1]
+    sta l00bb,x                                                       ; 4492: 95 bb       ..  :a492[1]
+    sta l1047,x                                                       ; 4494: 9d 47 10    .G. :a494[1]
+    inx                                                               ; 4497: e8          .   :a497[1]
+    iny                                                               ; 4498: c8          .   :a498[1]
+    cpx #8                                                            ; 4499: e0 08       ..  :a499[1]
+    bne loop_ca487                                                    ; 449b: d0 ea       ..  :a49b[1]
+    lda l00c1                                                         ; 449d: a5 c1       ..  :a49d[1]
+    jsr sub_c81b0                                                     ; 449f: 20 b0 81     .. :a49f[1]
+    sta l00c3                                                         ; 44a2: 85 c3       ..  :a4a2[1]
+    lda l00bf                                                         ; 44a4: a5 bf       ..  :a4a4[1]
+    clc                                                               ; 44a6: 18          .   :a4a6[1]
+    adc #&ff                                                          ; 44a7: 69 ff       i.  :a4a7[1]
+    lda l00c0                                                         ; 44a9: a5 c0       ..  :a4a9[1]
+    adc #0                                                            ; 44ab: 69 00       i.  :a4ab[1]
+    sta l00c4                                                         ; 44ad: 85 c4       ..  :a4ad[1]
+    lda l00c3                                                         ; 44af: a5 c3       ..  :a4af[1]
+    adc #0                                                            ; 44b1: 69 00       i.  :a4b1[1]
+    sta l00c5                                                         ; 44b3: 85 c5       ..  :a4b3[1]
+    lda l104e                                                         ; 44b5: ad 4e 10    .N. :a4b5[1]
+    sta l00c6                                                         ; 44b8: 85 c6       ..  :a4b8[1]
+    lda l104d                                                         ; 44ba: ad 4d 10    .M. :a4ba[1]
+    and #3                                                            ; 44bd: 29 03       ).  :a4bd[1]
+    sta l00c7                                                         ; 44bf: 85 c7       ..  :a4bf[1]
+    lda #&ff                                                          ; 44c1: a9 ff       ..  :a4c1[1]
+    sta l00a8                                                         ; 44c3: 85 a8       ..  :a4c3[1]
+    jsr sub_ca530                                                     ; 44c5: 20 30 a5     0. :a4c5[1]
+    jsr sub_ca379                                                     ; 44c8: 20 79 a3     y. :a4c8[1]
+    lda l10d1                                                         ; 44cb: ad d1 10    ... :a4cb[1]
+    jsr c8816                                                         ; 44ce: 20 16 88     .. :a4ce[1]
+    jsr sub_c8380                                                     ; 44d1: 20 80 83     .. :a4d1[1]
+    lda l00ab                                                         ; 44d4: a5 ab       ..  :a4d4[1]
+    sta l00b6                                                         ; 44d6: 85 b6       ..  :a4d6[1]
+    pla                                                               ; 44d8: 68          h   :a4d8[1]
+    sta l00cc                                                         ; 44d9: 85 cc       ..  :a4d9[1]
+    jsr sub_c8280                                                     ; 44db: 20 80 82     .. :a4db[1]
+    bcs ca47b                                                         ; 44de: b0 9b       ..  :a4de[1]
+    rts                                                               ; 44e0: 60          `   :a4e0[1]
+
+; &44e1 referenced 1 time by &a56d
+.sub_ca4e1
+    jsr sub_ca51f                                                     ; 44e1: 20 1f a5     .. :a4e1[1]
+    jsr sub_ca384                                                     ; 44e4: 20 84 a3     .. :a4e4[1]
+    lda l10d2                                                         ; 44e7: ad d2 10    ... :a4e7[1]
+    sta l00cd                                                         ; 44ea: 85 cd       ..  :a4ea[1]
+    lda l00cc                                                         ; 44ec: a5 cc       ..  :a4ec[1]
+    pha                                                               ; 44ee: 48          H   :a4ee[1]
+    jsr sub_c8380                                                     ; 44ef: 20 80 83     .. :a4ef[1]
+    jsr sub_c826d                                                     ; 44f2: 20 6d 82     m. :a4f2[1]
+    bcc ca4fa                                                         ; 44f5: 90 03       ..  :a4f5[1]
+    jsr sub_c830a                                                     ; 44f7: 20 0a 83     .. :a4f7[1]
+; &44fa referenced 1 time by &a4f5
+.ca4fa
+    pla                                                               ; 44fa: 68          h   :a4fa[1]
+    sta l00cc                                                         ; 44fb: 85 cc       ..  :a4fb[1]
+    jsr sub_c8b4d                                                     ; 44fd: 20 4d 8b     M. :a4fd[1]
+    jsr sub_c8b64                                                     ; 4500: 20 64 8b     d. :a500[1]
+    lda l00c2                                                         ; 4503: a5 c2       ..  :a503[1]
+    jsr sub_c81b0                                                     ; 4505: 20 b0 81     .. :a505[1]
+    sta l00c4                                                         ; 4508: 85 c4       ..  :a508[1]
+    jsr sub_c8ab3                                                     ; 450a: 20 b3 8a     .. :a50a[1]
+    lda l00c2                                                         ; 450d: a5 c2       ..  :a50d[1]
+    and #3                                                            ; 450f: 29 03       ).  :a50f[1]
+    pha                                                               ; 4511: 48          H   :a511[1]
+    lda l00c3                                                         ; 4512: a5 c3       ..  :a512[1]
+    pha                                                               ; 4514: 48          H   :a514[1]
+    jsr sub_ca51f                                                     ; 4515: 20 1f a5     .. :a515[1]
+    pla                                                               ; 4518: 68          h   :a518[1]
+    sta l00c8                                                         ; 4519: 85 c8       ..  :a519[1]
+    pla                                                               ; 451b: 68          h   :a51b[1]
+    sta l00c9                                                         ; 451c: 85 c9       ..  :a51c[1]
+    rts                                                               ; 451e: 60          `   :a51e[1]
+
+; &451f referenced 2 times by &a4e1, &a515
+.sub_ca51f
+    ldx #&11                                                          ; 451f: a2 11       ..  :a51f[1]
+; &4521 referenced 1 time by &a52d
+.loop_ca521
+    lda l1045,x                                                       ; 4521: bd 45 10    .E. :a521[1]
+    ldy l00ba,x                                                       ; 4524: b4 ba       ..  :a524[1]
+    sta l00ba,x                                                       ; 4526: 95 ba       ..  :a526[1]
+    tya                                                               ; 4528: 98          .   :a528[1]
+    sta l1045,x                                                       ; 4529: 9d 45 10    .E. :a529[1]
+    dex                                                               ; 452c: ca          .   :a52c[1]
+    bpl loop_ca521                                                    ; 452d: 10 f2       ..  :a52d[1]
+    rts                                                               ; 452f: 60          `   :a52f[1]
+
+; &4530 referenced 3 times by &a307, &a45d, &a4c5
+.sub_ca530
+    lda #0                                                            ; 4530: a9 00       ..  :a530[1]
+    sta l00bc                                                         ; 4532: 85 bc       ..  :a532[1]
+    sta l00c0                                                         ; 4534: 85 c0       ..  :a534[1]
+    beq ca5ab                                                         ; 4536: f0 73       .s  :a536[1]
+; &4538 referenced 1 time by &a5af
+.ca538
+    lda l00c4                                                         ; 4538: a5 c4       ..  :a538[1]
+    tay                                                               ; 453a: a8          .   :a53a[1]
+    cmp l10d0                                                         ; 453b: cd d0 10    ... :a53b[1]
+    lda l00c5                                                         ; 453e: a5 c5       ..  :a53e[1]
+    sbc #0                                                            ; 4540: e9 00       ..  :a540[1]
+    bcc ca547                                                         ; 4542: 90 03       ..  :a542[1]
+    ldy l10d0                                                         ; 4544: ac d0 10    ... :a544[1]
+; &4547 referenced 1 time by &a542
+.ca547
+    sty l00c1                                                         ; 4547: 84 c1       ..  :a547[1]
+    lda l00c6                                                         ; 4549: a5 c6       ..  :a549[1]
+    sta l00c3                                                         ; 454b: 85 c3       ..  :a54b[1]
+    lda l00c7                                                         ; 454d: a5 c7       ..  :a54d[1]
+    sta l00c2                                                         ; 454f: 85 c2       ..  :a54f[1]
+    lda l10cf                                                         ; 4551: ad cf 10    ... :a551[1]
+    sta l00bd                                                         ; 4554: 85 bd       ..  :a554[1]
+    lda l10d1                                                         ; 4556: ad d1 10    ... :a556[1]
+    sta l00cd                                                         ; 4559: 85 cd       ..  :a559[1]
+    jsr sub_ca379                                                     ; 455b: 20 79 a3     y. :a55b[1]
+    jsr sub_ca5b2                                                     ; 455e: 20 b2 a5     .. :a55e[1]
+    jsr sub_c8855                                                     ; 4561: 20 55 88     U. :a561[1]
+    lda l10d2                                                         ; 4564: ad d2 10    ... :a564[1]
+    sta l00cd                                                         ; 4567: 85 cd       ..  :a567[1]
+    bit l00a8                                                         ; 4569: 24 a8       $.  :a569[1]
+    bpl ca574                                                         ; 456b: 10 07       ..  :a56b[1]
+    jsr sub_ca4e1                                                     ; 456d: 20 e1 a4     .. :a56d[1]
+    lda #0                                                            ; 4570: a9 00       ..  :a570[1]
+    sta l00a8                                                         ; 4572: 85 a8       ..  :a572[1]
+; &4574 referenced 1 time by &a56b
+.ca574
+    lda l00c8                                                         ; 4574: a5 c8       ..  :a574[1]
+    sta l00c3                                                         ; 4576: 85 c3       ..  :a576[1]
+    lda l00c9                                                         ; 4578: a5 c9       ..  :a578[1]
+    sta l00c2                                                         ; 457a: 85 c2       ..  :a57a[1]
+    lda l10cf                                                         ; 457c: ad cf 10    ... :a57c[1]
+    sta l00bd                                                         ; 457f: 85 bd       ..  :a57f[1]
+    jsr sub_ca384                                                     ; 4581: 20 84 a3     .. :a581[1]
+    jsr sub_ca5b2                                                     ; 4584: 20 b2 a5     .. :a584[1]
+    jsr sub_c8862                                                     ; 4587: 20 62 88     b. :a587[1]
+    lda l00c1                                                         ; 458a: a5 c1       ..  :a58a[1]
+    clc                                                               ; 458c: 18          .   :a58c[1]
+    adc l00c8                                                         ; 458d: 65 c8       e.  :a58d[1]
+    sta l00c8                                                         ; 458f: 85 c8       ..  :a58f[1]
+    bcc ca595                                                         ; 4591: 90 02       ..  :a591[1]
+    inc l00c9                                                         ; 4593: e6 c9       ..  :a593[1]
+; &4595 referenced 1 time by &a591
+.ca595
+    lda l00c1                                                         ; 4595: a5 c1       ..  :a595[1]
+    clc                                                               ; 4597: 18          .   :a597[1]
+    adc l00c6                                                         ; 4598: 65 c6       e.  :a598[1]
+    sta l00c6                                                         ; 459a: 85 c6       ..  :a59a[1]
+    bcc ca5a0                                                         ; 459c: 90 02       ..  :a59c[1]
+    inc l00c7                                                         ; 459e: e6 c7       ..  :a59e[1]
+; &45a0 referenced 1 time by &a59c
+.ca5a0
+    sec                                                               ; 45a0: 38          8   :a5a0[1]
+    lda l00c4                                                         ; 45a1: a5 c4       ..  :a5a1[1]
+    sbc l00c1                                                         ; 45a3: e5 c1       ..  :a5a3[1]
+    sta l00c4                                                         ; 45a5: 85 c4       ..  :a5a5[1]
+    bcs ca5ab                                                         ; 45a7: b0 02       ..  :a5a7[1]
+    dec l00c5                                                         ; 45a9: c6 c5       ..  :a5a9[1]
+; &45ab referenced 2 times by &a536, &a5a7
+.ca5ab
+    lda l00c4                                                         ; 45ab: a5 c4       ..  :a5ab[1]
+    ora l00c5                                                         ; 45ad: 05 c5       ..  :a5ad[1]
+    bne ca538                                                         ; 45af: d0 87       ..  :a5af[1]
+    rts                                                               ; 45b1: 60          `   :a5b1[1]
+
+; &45b2 referenced 2 times by &a55e, &a584
+.sub_ca5b2
+    lda #&ff                                                          ; 45b2: a9 ff       ..  :a5b2[1]
+    sta l1074                                                         ; 45b4: 8d 74 10    .t. :a5b4[1]
+    sta l1075                                                         ; 45b7: 8d 75 10    .u. :a5b7[1]
+    rts                                                               ; 45ba: 60          `   :a5ba[1]
+
+.sub_ca5bb
+    lda #0                                                            ; 45bb: a9 00       ..  :a5bb[1]
+    beq ca5c4                                                         ; 45bd: f0 05       ..  :a5bd[1]
+.sub_ca5bf
+    lda #&ff                                                          ; 45bf: a9 ff       ..  :a5bf[1]
+    sta l1082                                                         ; 45c1: 8d 82 10    ... :a5c1[1]
+; &45c4 referenced 1 time by &a5bd
+.ca5c4
+    sta l00c9                                                         ; 45c4: 85 c9       ..  :a5c4[1]
+    sta l1090                                                         ; 45c6: 8d 90 10    ... :a5c6[1]
+    bpl ca5e5                                                         ; 45c9: 10 1a       ..  :a5c9[1]
+    jsr sub_ca14a                                                     ; 45cb: 20 4a a1     J. :a5cb[1]
+    jsr sub_c8456                                                     ; 45ce: 20 56 84     V. :a5ce[1]
+    sta l109f                                                         ; 45d1: 8d 9f 10    ... :a5d1[1]
+    bcs ca5e2                                                         ; 45d4: b0 0c       ..  :a5d4[1]
+    cmp #&23 ; '#'                                                    ; 45d6: c9 23       .#  :a5d6[1]
+    beq ca5e5                                                         ; 45d8: f0 0b       ..  :a5d8[1]
+    cmp #&28 ; '('                                                    ; 45da: c9 28       .(  :a5da[1]
+    beq ca5e5                                                         ; 45dc: f0 07       ..  :a5dc[1]
+    cmp #&50 ; 'P'                                                    ; 45de: c9 50       .P  :a5de[1]
+    beq ca5e5                                                         ; 45e0: f0 03       ..  :a5e0[1]
+; &45e2 referenced 1 time by &a5d4
+.ca5e2
+    jmp ca14f                                                         ; 45e2: 4c 4f a1    LO. :a5e2[1]
+
+; &45e5 referenced 4 times by &a5c9, &a5d8, &a5dc, &a5e0
+.ca5e5
+    jsr clc_jmp_gsinit                                                ; 45e5: 20 4c 87     L. :a5e5[1]
+    sty l00ca                                                         ; 45e8: 84 ca       ..  :a5e8[1]
+    bne ca637                                                         ; 45ea: d0 4b       .K  :a5ea[1]
+    bit l00c9                                                         ; 45ec: 24 c9       $.  :a5ec[1]
+    bmi ca5fb                                                         ; 45ee: 30 0b       0.  :a5ee[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 45f0: 20 77 80     w. :a5f0[1]
+    equs "Verify"                                                     ; 45f3: 56 65 72... Ver :a5f3[1]
+
+    bcc ca605                                                         ; 45f9: 90 0a       ..  :a5f9[1]
+; &45fb referenced 1 time by &a5ee
+.ca5fb
+    jsr print_inline_l809f_top_bit_clear                              ; 45fb: 20 77 80     w. :a5fb[1]
+    equs "Format"                                                     ; 45fe: 46 6f 72... For :a5fe[1]
+
+    nop                                                               ; 4604: ea          .   :a604[1]
+; &4605 referenced 1 time by &a5f9
+.ca605
+    jsr print_inline_l809f_top_bit_clear                              ; 4605: 20 77 80     w. :a605[1]
+    equs " which drive ? "                                            ; 4608: 20 77 68...  wh :a608[1]
+
+    nop                                                               ; 4617: ea          .   :a617[1]
+    jsr osrdch                                                        ; 4618: 20 e0 ff     .. :a618[1]
+    bcs ca65d                                                         ; 461b: b0 40       .@  :a61b[1]
+    cmp #&20 ; ' '                                                    ; 461d: c9 20       .   :a61d[1]
+    bcc ca660                                                         ; 461f: 90 3f       .?  :a61f[1]
+    jsr c809f                                                         ; 4621: 20 9f 80     .. :a621[1]
+    sec                                                               ; 4624: 38          8   :a624[1]
+    sbc #&30 ; '0'                                                    ; 4625: e9 30       .0  :a625[1]
+    bcc ca660                                                         ; 4627: 90 37       .7  :a627[1]
+    cmp #4                                                            ; 4629: c9 04       ..  :a629[1]
+    bcs ca660                                                         ; 462b: b0 33       .3  :a62b[1]
+    sta l00cd                                                         ; 462d: 85 cd       ..  :a62d[1]
+    jsr ca3dc                                                         ; 462f: 20 dc a3     .. :a62f[1]
+    ldy l00ca                                                         ; 4632: a4 ca       ..  :a632[1]
+    jmp ca63a                                                         ; 4634: 4c 3a a6    L:. :a634[1]
+
+; &4637 referenced 2 times by &a5ea, &a65a
+.ca637
+    jsr c8b8b                                                         ; 4637: 20 8b 8b     .. :a637[1]
+; &463a referenced 1 time by &a634
+.ca63a
+    sty l00ca                                                         ; 463a: 84 ca       ..  :a63a[1]
+    bit l00c9                                                         ; 463c: 24 c9       $.  :a63c[1]
+    bpl ca647                                                         ; 463e: 10 07       ..  :a63e[1]
+    ldx l00cd                                                         ; 4640: a6 cd       ..  :a640[1]
+    lda #0                                                            ; 4642: a9 00       ..  :a642[1]
+    sta l10de,x                                                       ; 4644: 9d de 10    ... :a644[1]
+; &4647 referenced 1 time by &a63e
+.ca647
+    bit l1090                                                         ; 4647: 2c 90 10    ,.. :a647[1]
+    bpl ca652                                                         ; 464a: 10 06       ..  :a64a[1]
+    jsr sub_ca315                                                     ; 464c: 20 15 a3     .. :a64c[1]
+    jsr sub_c9a8d                                                     ; 464f: 20 8d 9a     .. :a64f[1]
+; &4652 referenced 1 time by &a64a
+.ca652
+    jsr sub_ca663                                                     ; 4652: 20 63 a6     c. :a652[1]
+    ldy l00ca                                                         ; 4655: a4 ca       ..  :a655[1]
+    jsr clc_jmp_gsinit                                                ; 4657: 20 4c 87     L. :a657[1]
+    bne ca637                                                         ; 465a: d0 db       ..  :a65a[1]
+    rts                                                               ; 465c: 60          `   :a65c[1]
+
+; &465d referenced 1 time by &a61b
+.ca65d
+    jmp c9436                                                         ; 465d: 4c 36 94    L6. :a65d[1]
+
+; &4660 referenced 3 times by &a61f, &a627, &a62b
+.ca660
+    jmp c8ba2                                                         ; 4660: 4c a2 8b    L.. :a660[1]
+
+; &4663 referenced 1 time by &a652
+.sub_ca663
+    bit l00c9                                                         ; 4663: 24 c9       $.  :a663[1]
+    bmi ca675                                                         ; 4665: 30 0e       0.  :a665[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4667: 20 77 80     w. :a667[1]
+    equs "Verifying"                                                  ; 466a: 56 65 72... Ver :a66a[1]
+
+    bcc ca68a                                                         ; 4673: 90 15       ..  :a673[1]
+; &4675 referenced 1 time by &a665
+.ca675
+    jsr sub_ca76c                                                     ; 4675: 20 6c a7     l. :a675[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4678: 20 77 80     w. :a678[1]
+    equs "Formatting"                                                 ; 467b: 46 6f 72... For :a67b[1]
+
+    ldx l00cd                                                         ; 4685: a6 cd       ..  :a685[1]
+    stx l1090                                                         ; 4687: 8e 90 10    ... :a687[1]
+; &468a referenced 1 time by &a673
+.ca68a
+    jsr print_inline_l809f_top_bit_clear                              ; 468a: 20 77 80     w. :a68a[1]
+    equs " drive "                                                    ; 468d: 20 64 72...  dr :a68d[1]
+
+    lda l00cd                                                         ; 4694: a5 cd       ..  :a694[1]
+    jsr sub_c80c3                                                     ; 4696: 20 c3 80     .. :a696[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4699: 20 77 80     w. :a699[1]
+    equs " track   "                                                  ; 469c: 20 74 72...  tr :a69c[1]
+
+    nop                                                               ; 46a5: ea          .   :a6a5[1]
+    bit l00c9                                                         ; 46a6: 24 c9       $.  :a6a6[1]
+    bmi ca6b6                                                         ; 46a8: 30 0c       0.  :a6a8[1]
+    jsr sub_ca7ce                                                     ; 46aa: 20 ce a7     .. :a6aa[1]
+    txa                                                               ; 46ad: 8a          .   :a6ad[1]
+    bne ca6b3                                                         ; 46ae: d0 03       ..  :a6ae[1]
+    jmp ca3dc                                                         ; 46b0: 4c dc a3    L.. :a6b0[1]
+
+; &46b3 referenced 1 time by &a6ae
+.ca6b3
+    sta l109f                                                         ; 46b3: 8d 9f 10    ... :a6b3[1]
+; &46b6 referenced 1 time by &a6a8
+.ca6b6
+    lda #0                                                            ; 46b6: a9 00       ..  :a6b6[1]
+    sta l1097                                                         ; 46b8: 8d 97 10    ... :a6b8[1]
+; &46bb referenced 1 time by &a731
+.ca6bb
+    lda #8                                                            ; 46bb: a9 08       ..  :a6bb[1]
+    jsr c809f                                                         ; 46bd: 20 9f 80     .. :a6bd[1]
+    jsr c809f                                                         ; 46c0: 20 9f 80     .. :a6c0[1]
+    lda l1097                                                         ; 46c3: ad 97 10    ... :a6c3[1]
+    jsr sub_c80bb                                                     ; 46c6: 20 bb 80     .. :a6c6[1]
+    lda #6                                                            ; 46c9: a9 06       ..  :a6c9[1]
+    sta l109d                                                         ; 46cb: 8d 9d 10    ... :a6cb[1]
+; &46ce referenced 1 time by &a708
+.ca6ce
+    jsr sub_ca73d                                                     ; 46ce: 20 3d a7     =. :a6ce[1]
+    bit l00c9                                                         ; 46d1: 24 c9       $.  :a6d1[1]
+    bpl ca6e2                                                         ; 46d3: 10 0d       ..  :a6d3[1]
+    jsr sub_ca788                                                     ; 46d5: 20 88 a7     .. :a6d5[1]
+    ldx #&90                                                          ; 46d8: a2 90       ..  :a6d8[1]
+    ldy #&10                                                          ; 46da: a0 10       ..  :a6da[1]
+    jsr c91af                                                         ; 46dc: 20 af 91     .. :a6dc[1]
+    tax                                                               ; 46df: aa          .   :a6df[1]
+    bne ca70a                                                         ; 46e0: d0 28       .(  :a6e0[1]
+; &46e2 referenced 1 time by &a6d3
+.ca6e2
+    lda #0                                                            ; 46e2: a9 00       ..  :a6e2[1]
+    sta l1098                                                         ; 46e4: 8d 98 10    ... :a6e4[1]
+    lda l1099                                                         ; 46e7: ad 99 10    ... :a6e7[1]
+    and #&1f                                                          ; 46ea: 29 1f       ).  :a6ea[1]
+    sta l1099                                                         ; 46ec: 8d 99 10    ... :a6ec[1]
+    lda #3                                                            ; 46ef: a9 03       ..  :a6ef[1]
+    sta l1095                                                         ; 46f1: 8d 95 10    ... :a6f1[1]
+    lda #&5f ; '_'                                                    ; 46f4: a9 5f       ._  :a6f4[1]
+    sta l1096                                                         ; 46f6: 8d 96 10    ... :a6f6[1]
+    jsr sub_c9432                                                     ; 46f9: 20 32 94     2. :a6f9[1]
+    ldx #&90                                                          ; 46fc: a2 90       ..  :a6fc[1]
+    ldy #&10                                                          ; 46fe: a0 10       ..  :a6fe[1]
+    jsr c91af                                                         ; 4700: 20 af 91     .. :a700[1]
+    beq ca712                                                         ; 4703: f0 0d       ..  :a703[1]
+    dec l109d                                                         ; 4705: ce 9d 10    ... :a705[1]
+    bne ca6ce                                                         ; 4708: d0 c4       ..  :a708[1]
+; &470a referenced 1 time by &a6e0
+.ca70a
+    jsr print_inline_l809f_top_bit_clear                              ; 470a: 20 77 80     w. :a70a[1]
+    equs "?"                                                          ; 470d: 3f          ?   :a70d[1]
+
+    nop                                                               ; 470e: ea          .   :a70e[1]
+    jmp c94c2                                                         ; 470f: 4c c2 94    L.. :a70f[1]
+
+; &4712 referenced 1 time by &a703
+.ca712
+    lda l109d                                                         ; 4712: ad 9d 10    ... :a712[1]
+    cmp #6                                                            ; 4715: c9 06       ..  :a715[1]
+    beq ca721                                                         ; 4717: f0 08       ..  :a717[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4719: 20 77 80     w. :a719[1]
+    equs "?   "                                                       ; 471c: 3f 20 20... ?   :a71c[1]
+
+    nop                                                               ; 4720: ea          .   :a720[1]
+; &4721 referenced 1 time by &a717
+.ca721
+    bit l00c9                                                         ; 4721: 24 c9       $.  :a721[1]
+    bpl ca728                                                         ; 4723: 10 03       ..  :a723[1]
+    jsr sub_ca779                                                     ; 4725: 20 79 a7     y. :a725[1]
+; &4728 referenced 1 time by &a723
+.ca728
+    inc l1097                                                         ; 4728: ee 97 10    ... :a728[1]
+    lda l1097                                                         ; 472b: ad 97 10    ... :a72b[1]
+    cmp l109f                                                         ; 472e: cd 9f 10    ... :a72e[1]
+    bne ca6bb                                                         ; 4731: d0 88       ..  :a731[1]
+    bit l00c9                                                         ; 4733: 24 c9       $.  :a733[1]
+    bpl ca73a                                                         ; 4735: 10 03       ..  :a735[1]
+    jsr sub_c93f1                                                     ; 4737: 20 f1 93     .. :a737[1]
+; &473a referenced 1 time by &a735
+.ca73a
+    jmp ca3dc                                                         ; 473a: 4c dc a3    L.. :a73a[1]
+
+; &473d referenced 1 time by &a6ce
+.sub_ca73d
+    ldx #0                                                            ; 473d: a2 00       ..  :a73d[1]
+    stx l1091                                                         ; 473f: 8e 91 10    ... :a73f[1]
+    stx l109a                                                         ; 4742: 8e 9a 10    ... :a742[1]
+    dex                                                               ; 4745: ca          .   :a745[1]
+    stx l1093                                                         ; 4746: 8e 93 10    ... :a746[1]
+    stx l1094                                                         ; 4749: 8e 94 10    ... :a749[1]
+    lda l10cf                                                         ; 474c: ad cf 10    ... :a74c[1]
+    sta l1092                                                         ; 474f: 8d 92 10    ... :a74f[1]
+    lda #5                                                            ; 4752: a9 05       ..  :a752[1]
+    sta l1095                                                         ; 4754: 8d 95 10    ... :a754[1]
+    lda #&63 ; 'c'                                                    ; 4757: a9 63       .c  :a757[1]
+    sta l1096                                                         ; 4759: 8d 96 10    ... :a759[1]
+    lda #&2a ; '*'                                                    ; 475c: a9 2a       .*  :a75c[1]
+    sta l1099                                                         ; 475e: 8d 99 10    ... :a75e[1]
+    ldx #&10                                                          ; 4761: a2 10       ..  :a761[1]
+    ldy #&13                                                          ; 4763: a0 13       ..  :a763[1]
+    stx l109b                                                         ; 4765: 8e 9b 10    ... :a765[1]
+    sty l1098                                                         ; 4768: 8c 98 10    ... :a768[1]
+    rts                                                               ; 476b: 60          `   :a76b[1]
+
+; &476c referenced 1 time by &a675
+.sub_ca76c
+    lda #0                                                            ; 476c: a9 00       ..  :a76c[1]
+    tay                                                               ; 476e: a8          .   :a76e[1]
+; &476f referenced 1 time by &a776
+.loop_ca76f
+    sta l0e00,y                                                       ; 476f: 99 00 0e    ... :a76f[1]
+    sta l0f00,y                                                       ; 4772: 99 00 0f    ... :a772[1]
+    iny                                                               ; 4775: c8          .   :a775[1]
+    bne loop_ca76f                                                    ; 4776: d0 f7       ..  :a776[1]
+    rts                                                               ; 4778: 60          `   :a778[1]
+
+; &4779 referenced 1 time by &a725
+.sub_ca779
+    lda #&0a                                                          ; 4779: a9 0a       ..  :a779[1]
+    clc                                                               ; 477b: 18          .   :a77b[1]
+    adc l0f07                                                         ; 477c: 6d 07 0f    m.. :a77c[1]
+    sta l0f07                                                         ; 477f: 8d 07 0f    ... :a77f[1]
+    bcc ca787                                                         ; 4782: 90 03       ..  :a782[1]
+    inc l0f06                                                         ; 4784: ee 06 0f    ... :a784[1]
+; &4787 referenced 1 time by &a782
+.ca787
+    rts                                                               ; 4787: 60          `   :a787[1]
+
+; &4788 referenced 1 time by &a6d5
+.sub_ca788
+    lda #0                                                            ; 4788: a9 00       ..  :a788[1]
+    sta l00b0                                                         ; 478a: 85 b0       ..  :a78a[1]
+    lda l10cf                                                         ; 478c: ad cf 10    ... :a78c[1]
+    sta l00b1                                                         ; 478f: 85 b1       ..  :a78f[1]
+    lda #&0a                                                          ; 4791: a9 0a       ..  :a791[1]
+    sta l00b2                                                         ; 4793: 85 b2       ..  :a793[1]
+    lda l1097                                                         ; 4795: ad 97 10    ... :a795[1]
+    beq ca7a4                                                         ; 4798: f0 0a       ..  :a798[1]
+    ldy #2                                                            ; 479a: a0 02       ..  :a79a[1]
+    lda (l00b0),y                                                     ; 479c: b1 b0       ..  :a79c[1]
+    clc                                                               ; 479e: 18          .   :a79e[1]
+    adc #7                                                            ; 479f: 69 07       i.  :a79f[1]
+    jsr sub_ca7c5                                                     ; 47a1: 20 c5 a7     .. :a7a1[1]
+; &47a4 referenced 1 time by &a798
+.ca7a4
+    tax                                                               ; 47a4: aa          .   :a7a4[1]
+    ldy #0                                                            ; 47a5: a0 00       ..  :a7a5[1]
+; &47a7 referenced 1 time by &a7c1
+.loop_ca7a7
+    lda l1097                                                         ; 47a7: ad 97 10    ... :a7a7[1]
+    sta (l00b0),y                                                     ; 47aa: 91 b0       ..  :a7aa[1]
+    iny                                                               ; 47ac: c8          .   :a7ac[1]
+    lda #0                                                            ; 47ad: a9 00       ..  :a7ad[1]
+    sta (l00b0),y                                                     ; 47af: 91 b0       ..  :a7af[1]
+    iny                                                               ; 47b1: c8          .   :a7b1[1]
+    txa                                                               ; 47b2: 8a          .   :a7b2[1]
+    sta (l00b0),y                                                     ; 47b3: 91 b0       ..  :a7b3[1]
+    iny                                                               ; 47b5: c8          .   :a7b5[1]
+    lda #1                                                            ; 47b6: a9 01       ..  :a7b6[1]
+    sta (l00b0),y                                                     ; 47b8: 91 b0       ..  :a7b8[1]
+    iny                                                               ; 47ba: c8          .   :a7ba[1]
+    inx                                                               ; 47bb: e8          .   :a7bb[1]
+    jsr sub_ca7c4                                                     ; 47bc: 20 c4 a7     .. :a7bc[1]
+    dec l00b2                                                         ; 47bf: c6 b2       ..  :a7bf[1]
+    bne loop_ca7a7                                                    ; 47c1: d0 e4       ..  :a7c1[1]
+    rts                                                               ; 47c3: 60          `   :a7c3[1]
+
+; &47c4 referenced 1 time by &a7bc
+.sub_ca7c4
+    txa                                                               ; 47c4: 8a          .   :a7c4[1]
+; &47c5 referenced 1 time by &a7a1
+.sub_ca7c5
+    sec                                                               ; 47c5: 38          8   :a7c5[1]
+; &47c6 referenced 1 time by &a7c8
+.loop_ca7c6
+    sbc #&0a                                                          ; 47c6: e9 0a       ..  :a7c6[1]
+    bcs loop_ca7c6                                                    ; 47c8: b0 fc       ..  :a7c8[1]
+    adc #&0a                                                          ; 47ca: 69 0a       i.  :a7ca[1]
+    tax                                                               ; 47cc: aa          .   :a7cc[1]
+    rts                                                               ; 47cd: 60          `   :a7cd[1]
+
+; &47ce referenced 1 time by &a6aa
+.sub_ca7ce
+    jsr sub_c93f5                                                     ; 47ce: 20 f5 93     .. :a7ce[1]
+    lda l0f06                                                         ; 47d1: ad 06 0f    ... :a7d1[1]
+    and #3                                                            ; 47d4: 29 03       ).  :a7d4[1]
+    tax                                                               ; 47d6: aa          .   :a7d6[1]
+    lda l0f07                                                         ; 47d7: ad 07 0f    ... :a7d7[1]
+    ldy #&0a                                                          ; 47da: a0 0a       ..  :a7da[1]
+    sty l00b0                                                         ; 47dc: 84 b0       ..  :a7dc[1]
+    ldy #&ff                                                          ; 47de: a0 ff       ..  :a7de[1]
+; &47e0 referenced 1 time by &a7e7
+.loop_ca7e0
+    sec                                                               ; 47e0: 38          8   :a7e0[1]
+; &47e1 referenced 1 time by &a7e4
+.loop_ca7e1
+    iny                                                               ; 47e1: c8          .   :a7e1[1]
+    sbc l00b0                                                         ; 47e2: e5 b0       ..  :a7e2[1]
+    bcs loop_ca7e1                                                    ; 47e4: b0 fb       ..  :a7e4[1]
+    dex                                                               ; 47e6: ca          .   :a7e6[1]
+    bpl loop_ca7e0                                                    ; 47e7: 10 f7       ..  :a7e7[1]
+    adc l00b0                                                         ; 47e9: 65 b0       e.  :a7e9[1]
+    pha                                                               ; 47eb: 48          H   :a7eb[1]
+    tya                                                               ; 47ec: 98          .   :a7ec[1]
+    tax                                                               ; 47ed: aa          .   :a7ed[1]
+    pla                                                               ; 47ee: 68          h   :a7ee[1]
+    beq ca7f2                                                         ; 47ef: f0 01       ..  :a7ef[1]
+    inx                                                               ; 47f1: e8          .   :a7f1[1]
+; &47f2 referenced 1 time by &a7ef
+.ca7f2
+    rts                                                               ; 47f2: 60          `   :a7f2[1]
+
+.sub_ca7f3
+    sec                                                               ; 47f3: 38          8   :a7f3[1]
+    bcs ca7f7                                                         ; 47f4: b0 01       ..  :a7f4[1]
+.sub_ca7f6
+    clc                                                               ; 47f6: 18          .   :a7f6[1]
+; &47f7 referenced 1 time by &a7f4
+.ca7f7
+    ror l00c6                                                         ; 47f7: 66 c6       f.  :a7f7[1]
+    jsr sub_c8b86                                                     ; 47f9: 20 86 8b     .. :a7f9[1]
+    jsr sub_c8380                                                     ; 47fc: 20 80 83     .. :a7fc[1]
+    bit l00c6                                                         ; 47ff: 24 c6       $.  :a7ff[1]
+    bmi ca818                                                         ; 4801: 30 15       0.  :a801[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 4803: 20 9c a9     .. :a803[1]
+    equs "Address :  Length", &0d                                     ; 4806: 41 64 64... Add :a806[1]
+
+; &4818 referenced 1 time by &a801
+.ca818
+    lda l0f06                                                         ; 4818: ad 06 0f    ... :a818[1]
+    and #3                                                            ; 481b: 29 03       ).  :a81b[1]
+    sta l00c5                                                         ; 481d: 85 c5       ..  :a81d[1]
+    sta l00c2                                                         ; 481f: 85 c2       ..  :a81f[1]
+    lda l0f07                                                         ; 4821: ad 07 0f    ... :a821[1]
+    sta l00c4                                                         ; 4824: 85 c4       ..  :a824[1]
+    sec                                                               ; 4826: 38          8   :a826[1]
+    sbc #2                                                            ; 4827: e9 02       ..  :a827[1]
+    sta l00c1                                                         ; 4829: 85 c1       ..  :a829[1]
+    bcs ca82f                                                         ; 482b: b0 02       ..  :a82b[1]
+    dec l00c2                                                         ; 482d: c6 c2       ..  :a82d[1]
+; &482f referenced 1 time by &a82b
+.ca82f
+    lda #2                                                            ; 482f: a9 02       ..  :a82f[1]
+    sta l00bb                                                         ; 4831: 85 bb       ..  :a831[1]
+    lda #0                                                            ; 4833: a9 00       ..  :a833[1]
+    sta l00bc                                                         ; 4835: 85 bc       ..  :a835[1]
+    sta l00bf                                                         ; 4837: 85 bf       ..  :a837[1]
+    sta l00c0                                                         ; 4839: 85 c0       ..  :a839[1]
+    lda l0f05                                                         ; 483b: ad 05 0f    ... :a83b[1]
+    and #&f8                                                          ; 483e: 29 f8       ).  :a83e[1]
+    tay                                                               ; 4840: a8          .   :a840[1]
+    beq ca86b                                                         ; 4841: f0 28       .(  :a841[1]
+    bne ca856                                                         ; 4843: d0 11       ..  :a843[1]
+; &4845 referenced 2 times by &a869, &a889
+.ca845
+    jsr sub_ca8e2                                                     ; 4845: 20 e2 a8     .. :a845[1]
+    jsr sub_c82b2                                                     ; 4848: 20 b2 82     .. :a848[1]
+    lda l00c4                                                         ; 484b: a5 c4       ..  :a84b[1]
+    sec                                                               ; 484d: 38          8   :a84d[1]
+    sbc l00bb                                                         ; 484e: e5 bb       ..  :a84e[1]
+    lda l00c5                                                         ; 4850: a5 c5       ..  :a850[1]
+    sbc l00bc                                                         ; 4852: e5 bc       ..  :a852[1]
+    bcc ca86b                                                         ; 4854: 90 15       ..  :a854[1]
+; &4856 referenced 1 time by &a843
+.ca856
+    lda l0f07,y                                                       ; 4856: b9 07 0f    ... :a856[1]
+    sec                                                               ; 4859: 38          8   :a859[1]
+    sbc l00bb                                                         ; 485a: e5 bb       ..  :a85a[1]
+    sta l00c1                                                         ; 485c: 85 c1       ..  :a85c[1]
+    php                                                               ; 485e: 08          .   :a85e[1]
+    lda l0f06,y                                                       ; 485f: b9 06 0f    ... :a85f[1]
+    and #3                                                            ; 4862: 29 03       ).  :a862[1]
+    plp                                                               ; 4864: 28          (   :a864[1]
+    sbc l00bc                                                         ; 4865: e5 bc       ..  :a865[1]
+    sta l00c2                                                         ; 4867: 85 c2       ..  :a867[1]
+    bcc ca845                                                         ; 4869: 90 da       ..  :a869[1]
+; &486b referenced 2 times by &a841, &a854
+.ca86b
+    sty l00bd                                                         ; 486b: 84 bd       ..  :a86b[1]
+    bit l00c6                                                         ; 486d: 24 c6       $.  :a86d[1]
+    bmi ca87a                                                         ; 486f: 30 09       0.  :a86f[1]
+    lda l00c1                                                         ; 4871: a5 c1       ..  :a871[1]
+    ora l00c2                                                         ; 4873: 05 c2       ..  :a873[1]
+    beq ca87a                                                         ; 4875: f0 03       ..  :a875[1]
+    jsr sub_ca8be                                                     ; 4877: 20 be a8     .. :a877[1]
+; &487a referenced 2 times by &a86f, &a875
+.ca87a
+    lda l00c1                                                         ; 487a: a5 c1       ..  :a87a[1]
+    clc                                                               ; 487c: 18          .   :a87c[1]
+    adc l00bf                                                         ; 487d: 65 bf       e.  :a87d[1]
+    sta l00bf                                                         ; 487f: 85 bf       ..  :a87f[1]
+    lda l00c2                                                         ; 4881: a5 c2       ..  :a881[1]
+    adc l00c0                                                         ; 4883: 65 c0       e.  :a883[1]
+    sta l00c0                                                         ; 4885: 85 c0       ..  :a885[1]
+    ldy l00bd                                                         ; 4887: a4 bd       ..  :a887[1]
+    bne ca845                                                         ; 4889: d0 ba       ..  :a889[1]
+    bit l00c6                                                         ; 488b: 24 c6       $.  :a88b[1]
+    bpl ca8bd                                                         ; 488d: 10 2e       ..  :a88d[1]
+    tay                                                               ; 488f: a8          .   :a88f[1]
+    ldx l00bf                                                         ; 4890: a6 bf       ..  :a890[1]
+    lda #&f8                                                          ; 4892: a9 f8       ..  :a892[1]
+    sec                                                               ; 4894: 38          8   :a894[1]
+    sbc l0f05                                                         ; 4895: ed 05 0f    ... :a895[1]
+    jsr sub_ca90d                                                     ; 4898: 20 0d a9     .. :a898[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 489b: 20 9c a9     .. :a89b[1]
+    equs "Free", &0d                                                  ; 489e: 46 72 65... Fre :a89e[1]
+
+    lda l00c4                                                         ; 48a3: a5 c4       ..  :a8a3[1]
+    sec                                                               ; 48a5: 38          8   :a8a5[1]
+    sbc l00bf                                                         ; 48a6: e5 bf       ..  :a8a6[1]
+    tax                                                               ; 48a8: aa          .   :a8a8[1]
+    lda l00c5                                                         ; 48a9: a5 c5       ..  :a8a9[1]
+    sbc l00c0                                                         ; 48ab: e5 c0       ..  :a8ab[1]
+    tay                                                               ; 48ad: a8          .   :a8ad[1]
+    lda l0f05                                                         ; 48ae: ad 05 0f    ... :a8ae[1]
+    jsr sub_ca90d                                                     ; 48b1: 20 0d a9     .. :a8b1[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 48b4: 20 9c a9     .. :a8b4[1]
+    equs "Used", &0d                                                  ; 48b7: 55 73 65... Use :a8b7[1]
+
+    nop                                                               ; 48bc: ea          .   :a8bc[1]
+; &48bd referenced 1 time by &a88d
+.ca8bd
+    rts                                                               ; 48bd: 60          `   :a8bd[1]
+
+; &48be referenced 1 time by &a877
+.sub_ca8be
+    lda l00bc                                                         ; 48be: a5 bc       ..  :a8be[1]
+    jsr sub_ca9ca                                                     ; 48c0: 20 ca a9     .. :a8c0[1]
+    lda l00bb                                                         ; 48c3: a5 bb       ..  :a8c3[1]
+    jsr sub_ca9c2                                                     ; 48c5: 20 c2 a9     .. :a8c5[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 48c8: 20 9c a9     .. :a8c8[1]
+    equs "     :  "                                                   ; 48cb: 20 20 20...     :a8cb[1]
+
+    lda l00c2                                                         ; 48d3: a5 c2       ..  :a8d3[1]
+    jsr sub_ca9ca                                                     ; 48d5: 20 ca a9     .. :a8d5[1]
+    lda l00c1                                                         ; 48d8: a5 c1       ..  :a8d8[1]
+    jsr sub_ca9c2                                                     ; 48da: 20 c2 a9     .. :a8da[1]
+    lda #&0d                                                          ; 48dd: a9 0d       ..  :a8dd[1]
+    jsr osasci                                                        ; 48df: 20 e3 ff     .. :a8df[1]
+; &48e2 referenced 1 time by &a845
+.sub_ca8e2
+    lda l0f06,y                                                       ; 48e2: b9 06 0f    ... :a8e2[1]
+    pha                                                               ; 48e5: 48          H   :a8e5[1]
+    jsr sub_c81b0                                                     ; 48e6: 20 b0 81     .. :a8e6[1]
+    sta l00bc                                                         ; 48e9: 85 bc       ..  :a8e9[1]
+    pla                                                               ; 48eb: 68          h   :a8eb[1]
+    and #3                                                            ; 48ec: 29 03       ).  :a8ec[1]
+    clc                                                               ; 48ee: 18          .   :a8ee[1]
+    adc l00bc                                                         ; 48ef: 65 bc       e.  :a8ef[1]
+    sta l00bc                                                         ; 48f1: 85 bc       ..  :a8f1[1]
+    lda l0f04,y                                                       ; 48f3: b9 04 0f    ... :a8f3[1]
+    beq ca8fa                                                         ; 48f6: f0 02       ..  :a8f6[1]
+    lda #1                                                            ; 48f8: a9 01       ..  :a8f8[1]
+; &48fa referenced 1 time by &a8f6
+.ca8fa
+    clc                                                               ; 48fa: 18          .   :a8fa[1]
+    adc l0f05,y                                                       ; 48fb: 79 05 0f    y.. :a8fb[1]
+    bcc ca902                                                         ; 48fe: 90 02       ..  :a8fe[1]
+    inc l00bc                                                         ; 4900: e6 bc       ..  :a900[1]
+; &4902 referenced 1 time by &a8fe
+.ca902
+    clc                                                               ; 4902: 18          .   :a902[1]
+    adc l0f07,y                                                       ; 4903: 79 07 0f    y.. :a903[1]
+    sta l00bb                                                         ; 4906: 85 bb       ..  :a906[1]
+    bcc ca90c                                                         ; 4908: 90 02       ..  :a908[1]
+    inc l00bc                                                         ; 490a: e6 bc       ..  :a90a[1]
+; &490c referenced 1 time by &a908
+.ca90c
+    rts                                                               ; 490c: 60          `   :a90c[1]
+
+; &490d referenced 2 times by &a898, &a8b1
+.sub_ca90d
+    jsr sub_c81c0                                                     ; 490d: 20 c0 81     .. :a90d[1]
+    jsr sub_ca9bf                                                     ; 4910: 20 bf a9     .. :a910[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 4913: 20 9c a9     .. :a913[1]
+    equs " Files "                                                    ; 4916: 20 46 69...  Fi :a916[1]
+
+    stx l00bc                                                         ; 491d: 86 bc       ..  :a91d[1]
+    sty l00bd                                                         ; 491f: 84 bd       ..  :a91f[1]
+    tya                                                               ; 4921: 98          .   :a921[1]
+    jsr sub_ca9ca                                                     ; 4922: 20 ca a9     .. :a922[1]
+    txa                                                               ; 4925: 8a          .   :a925[1]
+    jsr sub_ca9c2                                                     ; 4926: 20 c2 a9     .. :a926[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 4929: 20 9c a9     .. :a929[1]
+    equs " Sectors "                                                  ; 492c: 20 53 65...  Se :a92c[1]
+
+    lda #0                                                            ; 4935: a9 00       ..  :a935[1]
+    sta l00bb                                                         ; 4937: 85 bb       ..  :a937[1]
+    sta l00be                                                         ; 4939: 85 be       ..  :a939[1]
+    ldx #&1f                                                          ; 493b: a2 1f       ..  :a93b[1]
+    stx l00c1                                                         ; 493d: 86 c1       ..  :a93d[1]
+    ldx #9                                                            ; 493f: a2 09       ..  :a93f[1]
+; &4941 referenced 1 time by &a945
+.loop_ca941
+    sta l1000,x                                                       ; 4941: 9d 00 10    ... :a941[1]
+    dex                                                               ; 4944: ca          .   :a944[1]
+    bpl loop_ca941                                                    ; 4945: 10 fa       ..  :a945[1]
+; &4947 referenced 1 time by &a966
+.loop_ca947
+    asl l00bb                                                         ; 4947: 06 bb       ..  :a947[1]
+    rol l00bc                                                         ; 4949: 26 bc       &.  :a949[1]
+    rol l00bd                                                         ; 494b: 26 bd       &.  :a94b[1]
+    rol l00be                                                         ; 494d: 26 be       &.  :a94d[1]
+    ldx #0                                                            ; 494f: a2 00       ..  :a94f[1]
+    ldy #9                                                            ; 4951: a0 09       ..  :a951[1]
+; &4953 referenced 1 time by &a962
+.loop_ca953
+    lda l1000,x                                                       ; 4953: bd 00 10    ... :a953[1]
+    rol a                                                             ; 4956: 2a          *   :a956[1]
+    cmp #&0a                                                          ; 4957: c9 0a       ..  :a957[1]
+    bcc ca95d                                                         ; 4959: 90 02       ..  :a959[1]
+    sbc #&0a                                                          ; 495b: e9 0a       ..  :a95b[1]
+; &495d referenced 1 time by &a959
+.ca95d
+    sta l1000,x                                                       ; 495d: 9d 00 10    ... :a95d[1]
+    inx                                                               ; 4960: e8          .   :a960[1]
+    dey                                                               ; 4961: 88          .   :a961[1]
+    bpl loop_ca953                                                    ; 4962: 10 ef       ..  :a962[1]
+    dec l00c1                                                         ; 4964: c6 c1       ..  :a964[1]
+    bpl loop_ca947                                                    ; 4966: 10 df       ..  :a966[1]
+    ldy #&20 ; ' '                                                    ; 4968: a0 20       .   :a968[1]
+    ldx #5                                                            ; 496a: a2 05       ..  :a96a[1]
+; &496c referenced 1 time by &a98e
+.ca96c
+    bne ca970                                                         ; 496c: d0 02       ..  :a96c[1]
+    ldy #&2c ; ','                                                    ; 496e: a0 2c       .,  :a96e[1]
+; &4970 referenced 1 time by &a96c
+.ca970
+    lda l1000,x                                                       ; 4970: bd 00 10    ... :a970[1]
+    bne ca97d                                                         ; 4973: d0 08       ..  :a973[1]
+    cpy #&2c ; ','                                                    ; 4975: c0 2c       .,  :a975[1]
+    beq ca97d                                                         ; 4977: f0 04       ..  :a977[1]
+    lda #&20 ; ' '                                                    ; 4979: a9 20       .   :a979[1]
+    bne ca982                                                         ; 497b: d0 05       ..  :a97b[1]
+; &497d referenced 2 times by &a973, &a977
+.ca97d
+    ldy #&2c ; ','                                                    ; 497d: a0 2c       .,  :a97d[1]
+    clc                                                               ; 497f: 18          .   :a97f[1]
+    adc #&30 ; '0'                                                    ; 4980: 69 30       i0  :a980[1]
+; &4982 referenced 1 time by &a97b
+.ca982
+    jsr osasci                                                        ; 4982: 20 e3 ff     .. :a982[1]
+    cpx #3                                                            ; 4985: e0 03       ..  :a985[1]
+    bne ca98d                                                         ; 4987: d0 04       ..  :a987[1]
+    tya                                                               ; 4989: 98          .   :a989[1]
+    jsr osasci                                                        ; 498a: 20 e3 ff     .. :a98a[1]
+; &498d referenced 1 time by &a987
+.ca98d
+    dex                                                               ; 498d: ca          .   :a98d[1]
+    bpl ca96c                                                         ; 498e: 10 dc       ..  :a98e[1]
+    jsr print_inline_osasci_top_bit_clear                             ; 4990: 20 9c a9     .. :a990[1]
+    equs " Bytes "                                                    ; 4993: 20 42 79...  By :a993[1]
+
+    nop                                                               ; 499a: ea          .   :a99a[1]
+    rts                                                               ; 499b: 60          `   :a99b[1]
+
+; &499c referenced 7 times by &a803, &a89b, &a8b4, &a8c8, &a913, &a929, &a990
+.print_inline_osasci_top_bit_clear
+    sta l00b3                                                         ; 499c: 85 b3       ..  :a99c[1]
+    pla                                                               ; 499e: 68          h   :a99e[1]
+    sta l00ae                                                         ; 499f: 85 ae       ..  :a99f[1]
+    pla                                                               ; 49a1: 68          h   :a9a1[1]
+    sta l00af                                                         ; 49a2: 85 af       ..  :a9a2[1]
+    lda l00b3                                                         ; 49a4: a5 b3       ..  :a9a4[1]
+    pha                                                               ; 49a6: 48          H   :a9a6[1]
+    tya                                                               ; 49a7: 98          .   :a9a7[1]
+    pha                                                               ; 49a8: 48          H   :a9a8[1]
+    ldy #0                                                            ; 49a9: a0 00       ..  :a9a9[1]
+; &49ab referenced 1 time by &a9b5
+.loop_ca9ab
+    jsr inc16_ae                                                      ; 49ab: 20 dc 83     .. :a9ab[1]
+    lda (l00ae),y                                                     ; 49ae: b1 ae       ..  :a9ae[1]
+    bmi ca9b8                                                         ; 49b0: 30 06       0.  :a9b0[1]
+    jsr osasci                                                        ; 49b2: 20 e3 ff     .. :a9b2[1]
+    jmp loop_ca9ab                                                    ; 49b5: 4c ab a9    L.. :a9b5[1]
+
+; &49b8 referenced 1 time by &a9b0
+.ca9b8
+    pla                                                               ; 49b8: 68          h   :a9b8[1]
+    tay                                                               ; 49b9: a8          .   :a9b9[1]
+    pla                                                               ; 49ba: 68          h   :a9ba[1]
+    clc                                                               ; 49bb: 18          .   :a9bb[1]
+    jmp (l00ae)                                                       ; 49bc: 6c ae 00    l.. :a9bc[1]
+
+; &49bf referenced 1 time by &a910
+.sub_ca9bf
+    jsr sub_c841b                                                     ; 49bf: 20 1b 84     .. :a9bf[1]
+; &49c2 referenced 3 times by &a8c5, &a8da, &a926
+.sub_ca9c2
+    pha                                                               ; 49c2: 48          H   :a9c2[1]
+    jsr sub_c81bf                                                     ; 49c3: 20 bf 81     .. :a9c3[1]
+    jsr sub_ca9ca                                                     ; 49c6: 20 ca a9     .. :a9c6[1]
+    pla                                                               ; 49c9: 68          h   :a9c9[1]
+; &49ca referenced 4 times by &a8c0, &a8d5, &a922, &a9c6
+.sub_ca9ca
+    jsr sub_c80c8                                                     ; 49ca: 20 c8 80     .. :a9ca[1]
+    jmp osasci                                                        ; 49cd: 4c e3 ff    L.. :a9cd[1]
+
+.sub_ca9d0
+    lda #0                                                            ; 49d0: a9 00       ..  :a9d0[1]
+    sta l00a8                                                         ; 49d2: 85 a8       ..  :a9d2[1]
+    jsr sub_caaea                                                     ; 49d4: 20 ea aa     .. :a9d4[1]
+    lda #&0f                                                          ; 49d7: a9 0f       ..  :a9d7[1]
+    sta l00aa                                                         ; 49d9: 85 aa       ..  :a9d9[1]
+    jsr sub_caadd                                                     ; 49db: 20 dd aa     .. :a9db[1]
+    sec                                                               ; 49de: 38          8   :a9de[1]
+    jsr gsinit                                                        ; 49df: 20 c2 ff     .. :a9df[1]
+    sty l00ab                                                         ; 49e2: 84 ab       ..  :a9e2[1]
+    clc                                                               ; 49e4: 18          .   :a9e4[1]
+    beq ca9ff                                                         ; 49e5: f0 18       ..  :a9e5[1]
+; &49e7 referenced 1 time by &a9fc
+.loop_ca9e7
+    jsr sub_c8456                                                     ; 49e7: 20 56 84     V. :a9e7[1]
+    bcs ca9ff                                                         ; 49ea: b0 13       ..  :a9ea[1]
+    sty l00ab                                                         ; 49ec: 84 ab       ..  :a9ec[1]
+    and #&0f                                                          ; 49ee: 29 0f       ).  :a9ee[1]
+    sta l00aa                                                         ; 49f0: 85 aa       ..  :a9f0[1]
+    jsr sub_caa53                                                     ; 49f2: 20 53 aa     S. :a9f2[1]
+    ldy l00ab                                                         ; 49f5: a4 ab       ..  :a9f5[1]
+    jsr clc_jmp_gsinit                                                ; 49f7: 20 4c 87     L. :a9f7[1]
+    sty l00ab                                                         ; 49fa: 84 ab       ..  :a9fa[1]
+    bne loop_ca9e7                                                    ; 49fc: d0 e9       ..  :a9fc[1]
+    rts                                                               ; 49fe: 60          `   :a9fe[1]
+
+; &49ff referenced 2 times by &a9e5, &a9ea
+.ca9ff
+    ror l00a8                                                         ; 49ff: 66 a8       f.  :a9ff[1]
+; &4a01 referenced 1 time by &aa0f
+.loop_caa01
+    bit l00a8                                                         ; 4a01: 24 a8       $.  :aa01[1]
+    bpl caa0a                                                         ; 4a03: 10 05       ..  :aa03[1]
+    jsr sub_caa12                                                     ; 4a05: 20 12 aa     .. :aa05[1]
+    bcc caa0d                                                         ; 4a08: 90 03       ..  :aa08[1]
+; &4a0a referenced 1 time by &aa03
+.caa0a
+    jsr sub_caa53                                                     ; 4a0a: 20 53 aa     S. :aa0a[1]
+; &4a0d referenced 1 time by &aa08
+.caa0d
+    dec l00aa                                                         ; 4a0d: c6 aa       ..  :aa0d[1]
+    bpl loop_caa01                                                    ; 4a0f: 10 f0       ..  :aa0f[1]
+    rts                                                               ; 4a11: 60          `   :aa11[1]
+
+; &4a12 referenced 1 time by &aa05
+.sub_caa12
+    lda #9                                                            ; 4a12: a9 09       ..  :aa12[1]
+    sta osrdsc_ptr                                                    ; 4a14: 85 f6       ..  :aa14[1]
+    lda #&80                                                          ; 4a16: a9 80       ..  :aa16[1]
+    sta l00f7                                                         ; 4a18: 85 f7       ..  :aa18[1]
+    ldy l00ab                                                         ; 4a1a: a4 ab       ..  :aa1a[1]
+; &4a1c referenced 2 times by &aa39, &aa40
+.caa1c
+    lda (os_text_ptr),y                                               ; 4a1c: b1 f2       ..  :aa1c[1]
+    cmp #&0d                                                          ; 4a1e: c9 0d       ..  :aa1e[1]
+    beq caa44                                                         ; 4a20: f0 22       ."  :aa20[1]
+    cmp #&22 ; '"'                                                    ; 4a22: c9 22       ."  :aa22[1]
+    beq caa44                                                         ; 4a24: f0 1e       ..  :aa24[1]
+    iny                                                               ; 4a26: c8          .   :aa26[1]
+    cmp #&2a ; '*'                                                    ; 4a27: c9 2a       .*  :aa27[1]
+    beq caa51                                                         ; 4a29: f0 26       .&  :aa29[1]
+    jsr sub_c82fe                                                     ; 4a2b: 20 fe 82     .. :aa2b[1]
+    sta l00ae                                                         ; 4a2e: 85 ae       ..  :aa2e[1]
+    jsr sub_caacf                                                     ; 4a30: 20 cf aa     .. :aa30[1]
+    beq caa42                                                         ; 4a33: f0 0d       ..  :aa33[1]
+    ldx l00ae                                                         ; 4a35: a6 ae       ..  :aa35[1]
+    cpx #&23 ; '#'                                                    ; 4a37: e0 23       .#  :aa37[1]
+    beq caa1c                                                         ; 4a39: f0 e1       ..  :aa39[1]
+    jsr sub_c82fe                                                     ; 4a3b: 20 fe 82     .. :aa3b[1]
+    cmp l00ae                                                         ; 4a3e: c5 ae       ..  :aa3e[1]
+    beq caa1c                                                         ; 4a40: f0 da       ..  :aa40[1]
+; &4a42 referenced 3 times by &aa33, &aa4f, &aa57
+.caa42
+    clc                                                               ; 4a42: 18          .   :aa42[1]
+    rts                                                               ; 4a43: 60          `   :aa43[1]
+
+; &4a44 referenced 3 times by &aa20, &aa24, &aa4b
+.caa44
+    jsr sub_caacf                                                     ; 4a44: 20 cf aa     .. :aa44[1]
+    beq caa51                                                         ; 4a47: f0 08       ..  :aa47[1]
+    cmp #&20 ; ' '                                                    ; 4a49: c9 20       .   :aa49[1]
+    beq caa44                                                         ; 4a4b: f0 f7       ..  :aa4b[1]
+    cmp #&0d                                                          ; 4a4d: c9 0d       ..  :aa4d[1]
+    bne caa42                                                         ; 4a4f: d0 f1       ..  :aa4f[1]
+; &4a51 referenced 2 times by &aa29, &aa47
+.caa51
+    sec                                                               ; 4a51: 38          8   :aa51[1]
+    rts                                                               ; 4a52: 60          `   :aa52[1]
+
+; &4a53 referenced 2 times by &a9f2, &aa0a
+.sub_caa53
+    ldy l00aa                                                         ; 4a53: a4 aa       ..  :aa53[1]
+    lda (l00b4),y                                                     ; 4a55: b1 b4       ..  :aa55[1]
+    beq caa42                                                         ; 4a57: f0 e9       ..  :aa57[1]
+    pha                                                               ; 4a59: 48          H   :aa59[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4a5a: 20 77 80     w. :aa5a[1]
+    equs "Rom "                                                       ; 4a5d: 52 6f 6d... Rom :aa5d[1]
+
+    tya                                                               ; 4a61: 98          .   :aa61[1]
+    jsr sub_c80b8                                                     ; 4a62: 20 b8 80     .. :aa62[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4a65: 20 77 80     w. :aa65[1]
+    equs " : "                                                        ; 4a68: 20 3a 20     :  :aa68[1]
+
+    lda #&28 ; '('                                                    ; 4a6b: a9 28       .(  :aa6b[1]
+    jsr c809f                                                         ; 4a6d: 20 9f 80     .. :aa6d[1]
+    pla                                                               ; 4a70: 68          h   :aa70[1]
+    pha                                                               ; 4a71: 48          H   :aa71[1]
+    bmi caa78                                                         ; 4a72: 30 04       0.  :aa72[1]
+    ldy #&20 ; ' '                                                    ; 4a74: a0 20       .   :aa74[1]
+    bne caa7a                                                         ; 4a76: d0 02       ..  :aa76[1]
+; &4a78 referenced 1 time by &aa72
+.caa78
+    ldy #&53 ; 'S'                                                    ; 4a78: a0 53       .S  :aa78[1]
+; &4a7a referenced 1 time by &aa76
+.caa7a
+    tya                                                               ; 4a7a: 98          .   :aa7a[1]
+    jsr c809f                                                         ; 4a7b: 20 9f 80     .. :aa7b[1]
+    pla                                                               ; 4a7e: 68          h   :aa7e[1]
+    ldy #&20 ; ' '                                                    ; 4a7f: a0 20       .   :aa7f[1]
+    asl a                                                             ; 4a81: 0a          .   :aa81[1]
+    bpl caa86                                                         ; 4a82: 10 02       ..  :aa82[1]
+    ldy #&4c ; 'L'                                                    ; 4a84: a0 4c       .L  :aa84[1]
+; &4a86 referenced 1 time by &aa82
+.caa86
+    tya                                                               ; 4a86: 98          .   :aa86[1]
+    jsr c809f                                                         ; 4a87: 20 9f 80     .. :aa87[1]
+    lda #&29 ; ')'                                                    ; 4a8a: a9 29       .)  :aa8a[1]
+    jsr c809f                                                         ; 4a8c: 20 9f 80     .. :aa8c[1]
+    jsr cac0f                                                         ; 4a8f: 20 0f ac     .. :aa8f[1]
+    jsr sub_caa9a                                                     ; 4a92: 20 9a aa     .. :aa92[1]
+    jsr ca3dc                                                         ; 4a95: 20 dc a3     .. :aa95[1]
+    sec                                                               ; 4a98: 38          8   :aa98[1]
+    rts                                                               ; 4a99: 60          `   :aa99[1]
+
+; &4a9a referenced 1 time by &aa92
+.sub_caa9a
+    lda #7                                                            ; 4a9a: a9 07       ..  :aa9a[1]
+    sta osrdsc_ptr                                                    ; 4a9c: 85 f6       ..  :aa9c[1]
+    lda #&80                                                          ; 4a9e: a9 80       ..  :aa9e[1]
+    sta l00f7                                                         ; 4aa0: 85 f7       ..  :aaa0[1]
+    jsr sub_caacf                                                     ; 4aa2: 20 cf aa     .. :aaa2[1]
+    sta l00ae                                                         ; 4aa5: 85 ae       ..  :aaa5[1]
+    inc osrdsc_ptr                                                    ; 4aa7: e6 f6       ..  :aaa7[1]
+    ldy #&1e                                                          ; 4aa9: a0 1e       ..  :aaa9[1]
+    jsr sub_caac2                                                     ; 4aab: 20 c2 aa     .. :aaab[1]
+    bcs caab7                                                         ; 4aae: b0 07       ..  :aaae[1]
+    jsr cac0f                                                         ; 4ab0: 20 0f ac     .. :aab0[1]
+    dey                                                               ; 4ab3: 88          .   :aab3[1]
+    jsr sub_caac2                                                     ; 4ab4: 20 c2 aa     .. :aab4[1]
+; &4ab7 referenced 1 time by &aaae
+.caab7
+    rts                                                               ; 4ab7: 60          `   :aab7[1]
+
+; &4ab8 referenced 1 time by &aacb
+.loop_caab8
+    cmp #&20 ; ' '                                                    ; 4ab8: c9 20       .   :aab8[1]
+    bcs caabe                                                         ; 4aba: b0 02       ..  :aaba[1]
+    lda #&20 ; ' '                                                    ; 4abc: a9 20       .   :aabc[1]
+; &4abe referenced 1 time by &aaba
+.caabe
+    jsr c809f                                                         ; 4abe: 20 9f 80     .. :aabe[1]
+    dey                                                               ; 4ac1: 88          .   :aac1[1]
+; &4ac2 referenced 2 times by &aaab, &aab4
+.sub_caac2
+    lda osrdsc_ptr                                                    ; 4ac2: a5 f6       ..  :aac2[1]
+    cmp l00ae                                                         ; 4ac4: c5 ae       ..  :aac4[1]
+    bcs caace                                                         ; 4ac6: b0 06       ..  :aac6[1]
+    jsr sub_caacf                                                     ; 4ac8: 20 cf aa     .. :aac8[1]
+    bne loop_caab8                                                    ; 4acb: d0 eb       ..  :aacb[1]
+    clc                                                               ; 4acd: 18          .   :aacd[1]
+; &4ace referenced 1 time by &aac6
+.caace
+    rts                                                               ; 4ace: 60          `   :aace[1]
+
+; &4acf referenced 4 times by &aa30, &aa44, &aaa2, &aac8
+.sub_caacf
+    tya                                                               ; 4acf: 98          .   :aacf[1]
+    pha                                                               ; 4ad0: 48          H   :aad0[1]
+    ldy l00aa                                                         ; 4ad1: a4 aa       ..  :aad1[1]
+    jsr osrdsc                                                        ; 4ad3: 20 b9 ff     .. :aad3[1]
+    inc osrdsc_ptr                                                    ; 4ad6: e6 f6       ..  :aad6[1]
+    tax                                                               ; 4ad8: aa          .   :aad8[1]
+    pla                                                               ; 4ad9: 68          h   :aad9[1]
+    tay                                                               ; 4ada: a8          .   :aada[1]
+    txa                                                               ; 4adb: 8a          .   :aadb[1]
+    rts                                                               ; 4adc: 60          `   :aadc[1]
+
+; &4add referenced 1 time by &a9db
+.sub_caadd
+    jsr sub_c840c                                                     ; 4add: 20 0c 84     .. :aadd[1]
+    lda #&aa                                                          ; 4ae0: a9 aa       ..  :aae0[1]
+    jsr osbyte_read                                                   ; 4ae2: 20 e5 9a     .. :aae2[1]
+    stx l00b4                                                         ; 4ae5: 86 b4       ..  :aae5[1]
+    sty l00b5                                                         ; 4ae7: 84 b5       ..  :aae7[1]
+    rts                                                               ; 4ae9: 60          `   :aae9[1]
+
+; &4aea referenced 1 time by &a9d4
+.sub_caaea
+    tsx                                                               ; 4aea: ba          .   :aaea[1]
+    lda #0                                                            ; 4aeb: a9 00       ..  :aaeb[1]
+    sta l0107,x                                                       ; 4aed: 9d 07 01    ... :aaed[1]
+    rts                                                               ; 4af0: 60          `   :aaf0[1]
+
+; &4af1 referenced 2 times by &ab51, &abd5
+.sub_caaf1
+    ldx romsel_copy                                                   ; 4af1: a6 f4       ..  :aaf1[1]
+    lda l0df0,x                                                       ; 4af3: bd f0 0d    ... :aaf3[1]
+    and #&3f ; '?'                                                    ; 4af6: 29 3f       )?  :aaf6[1]
+    sta l00ad                                                         ; 4af8: 85 ad       ..  :aaf8[1]
+    inc l00ad                                                         ; 4afa: e6 ad       ..  :aafa[1]
+    rts                                                               ; 4afc: 60          `   :aafc[1]
+
+.sub_caafd
+    jsr sub_cac18                                                     ; 4afd: 20 18 ac     .. :aafd[1]
+    lda #0                                                            ; 4b00: a9 00       ..  :ab00[1]
+    beq cab09                                                         ; 4b02: f0 05       ..  :ab02[1]
+.sub_cab04
+    jsr sub_cac18                                                     ; 4b04: 20 18 ac     .. :ab04[1]
+    lda #&ff                                                          ; 4b07: a9 ff       ..  :ab07[1]
+; &4b09 referenced 1 time by &ab02
+.cab09
+    sta l00ab                                                         ; 4b09: 85 ab       ..  :ab09[1]
+    lda #&40 ; '@'                                                    ; 4b0b: a9 40       .@  :ab0b[1]
+    jsr osfind                                                        ; 4b0d: 20 ce ff     .. :ab0d[1]
+    tay                                                               ; 4b10: a8          .   :ab10[1]
+    lda #&0d                                                          ; 4b11: a9 0d       ..  :ab11[1]
+    cpy #0                                                            ; 4b13: c0 00       ..  :ab13[1]
+    bne cab35                                                         ; 4b15: d0 1e       ..  :ab15[1]
+; &4b17 referenced 1 time by &ab4f
+.cab17
+    jmp c822a                                                         ; 4b17: 4c 2a 82    L*. :ab17[1]
+
+; &4b1a referenced 2 times by &ab21, &ab3a
+.cab1a
+    jsr osbget                                                        ; 4b1a: 20 d7 ff     .. :ab1a[1]
+    bcs cab3d                                                         ; 4b1d: b0 1e       ..  :ab1d[1]
+    cmp #&0a                                                          ; 4b1f: c9 0a       ..  :ab1f[1]
+    beq cab1a                                                         ; 4b21: f0 f7       ..  :ab21[1]
+    plp                                                               ; 4b23: 28          (   :ab23[1]
+    bne cab2e                                                         ; 4b24: d0 08       ..  :ab24[1]
+    pha                                                               ; 4b26: 48          H   :ab26[1]
+    jsr sub_cac4e                                                     ; 4b27: 20 4e ac     N. :ab27[1]
+    jsr cac0f                                                         ; 4b2a: 20 0f ac     .. :ab2a[1]
+    pla                                                               ; 4b2d: 68          h   :ab2d[1]
+; &4b2e referenced 1 time by &ab24
+.cab2e
+    jsr osasci                                                        ; 4b2e: 20 e3 ff     .. :ab2e[1]
+    bit l00ff                                                         ; 4b31: 24 ff       $.  :ab31[1]
+    bmi cab54                                                         ; 4b33: 30 1f       0.  :ab33[1]
+; &4b35 referenced 1 time by &ab15
+.cab35
+    and l00ab                                                         ; 4b35: 25 ab       %.  :ab35[1]
+    cmp #&0d                                                          ; 4b37: c9 0d       ..  :ab37[1]
+    php                                                               ; 4b39: 08          .   :ab39[1]
+    jmp cab1a                                                         ; 4b3a: 4c 1a ab    L.. :ab3a[1]
+
+; &4b3d referenced 1 time by &ab1d
+.cab3d
+    plp                                                               ; 4b3d: 28          (   :ab3d[1]
+    jsr osnewl                                                        ; 4b3e: 20 e7 ff     .. :ab3e[1]
+; &4b41 referenced 2 times by &aba5, &abbf
+.cab41
+    lda #0                                                            ; 4b41: a9 00       ..  :ab41[1]
+    jmp osfind                                                        ; 4b43: 4c ce ff    L.. :ab43[1]
+
+.sub_cab46
+    jsr sub_cac18                                                     ; 4b46: 20 18 ac     .. :ab46[1]
+    lda #&40 ; '@'                                                    ; 4b49: a9 40       .@  :ab49[1]
+    jsr osfind                                                        ; 4b4b: 20 ce ff     .. :ab4b[1]
+    tay                                                               ; 4b4e: a8          .   :ab4e[1]
+    beq cab17                                                         ; 4b4f: f0 c6       ..  :ab4f[1]
+    jsr sub_caaf1                                                     ; 4b51: 20 f1 aa     .. :ab51[1]
+; &4b54 referenced 2 times by &ab33, &aba7
+.cab54
+    bit l00ff                                                         ; 4b54: 24 ff       $.  :ab54[1]
+    bmi cabbc                                                         ; 4b56: 30 64       0d  :ab56[1]
+    lda l00a9                                                         ; 4b58: a5 a9       ..  :ab58[1]
+    jsr sub_cac62                                                     ; 4b5a: 20 62 ac     b. :ab5a[1]
+    lda l00a8                                                         ; 4b5d: a5 a8       ..  :ab5d[1]
+    jsr sub_cac62                                                     ; 4b5f: 20 62 ac     b. :ab5f[1]
+    jsr cac0f                                                         ; 4b62: 20 0f ac     .. :ab62[1]
+    lda #8                                                            ; 4b65: a9 08       ..  :ab65[1]
+    sta l00ac                                                         ; 4b67: 85 ac       ..  :ab67[1]
+    ldx #0                                                            ; 4b69: a2 00       ..  :ab69[1]
+; &4b6b referenced 1 time by &ab7a
+.loop_cab6b
+    jsr osbget                                                        ; 4b6b: 20 d7 ff     .. :ab6b[1]
+    bcs cab7d                                                         ; 4b6e: b0 0d       ..  :ab6e[1]
+    sta (l00ac,x)                                                     ; 4b70: 81 ac       ..  :ab70[1]
+    jsr sub_cac62                                                     ; 4b72: 20 62 ac     b. :ab72[1]
+    jsr cac0f                                                         ; 4b75: 20 0f ac     .. :ab75[1]
+    dec l00ac                                                         ; 4b78: c6 ac       ..  :ab78[1]
+    bne loop_cab6b                                                    ; 4b7a: d0 ef       ..  :ab7a[1]
+    clc                                                               ; 4b7c: 18          .   :ab7c[1]
+; &4b7d referenced 1 time by &ab6e
+.cab7d
+    php                                                               ; 4b7d: 08          .   :ab7d[1]
+    bcc cab93                                                         ; 4b7e: 90 13       ..  :ab7e[1]
+; &4b80 referenced 1 time by &ab91
+.loop_cab80
+    lda #&2a ; '*'                                                    ; 4b80: a9 2a       .*  :ab80[1]
+    jsr osasci                                                        ; 4b82: 20 e3 ff     .. :ab82[1]
+    jsr osasci                                                        ; 4b85: 20 e3 ff     .. :ab85[1]
+    jsr cac0f                                                         ; 4b88: 20 0f ac     .. :ab88[1]
+    lda #0                                                            ; 4b8b: a9 00       ..  :ab8b[1]
+    sta (l00ac,x)                                                     ; 4b8d: 81 ac       ..  :ab8d[1]
+    dec l00ac                                                         ; 4b8f: c6 ac       ..  :ab8f[1]
+    bne loop_cab80                                                    ; 4b91: d0 ed       ..  :ab91[1]
+; &4b93 referenced 1 time by &ab7e
+.cab93
+    jsr sub_caba9                                                     ; 4b93: 20 a9 ab     .. :ab93[1]
+    jsr osnewl                                                        ; 4b96: 20 e7 ff     .. :ab96[1]
+    lda #8                                                            ; 4b99: a9 08       ..  :ab99[1]
+    clc                                                               ; 4b9b: 18          .   :ab9b[1]
+    adc l00a8                                                         ; 4b9c: 65 a8       e.  :ab9c[1]
+    sta l00a8                                                         ; 4b9e: 85 a8       ..  :ab9e[1]
+    bcc caba4                                                         ; 4ba0: 90 02       ..  :aba0[1]
+    inc l00a9                                                         ; 4ba2: e6 a9       ..  :aba2[1]
+; &4ba4 referenced 1 time by &aba0
+.caba4
+    plp                                                               ; 4ba4: 28          (   :aba4[1]
+    bcs cab41                                                         ; 4ba5: b0 9a       ..  :aba5[1]
+    bcc cab54                                                         ; 4ba7: 90 ab       ..  :aba7[1]
+; &4ba9 referenced 1 time by &ab93
+.sub_caba9
+    lda #8                                                            ; 4ba9: a9 08       ..  :aba9[1]
+    sta l00ac                                                         ; 4bab: 85 ac       ..  :abab[1]
+; &4bad referenced 1 time by &abb9
+.loop_cabad
+    ldx #0                                                            ; 4bad: a2 00       ..  :abad[1]
+    lda (l00ac,x)                                                     ; 4baf: a1 ac       ..  :abaf[1]
+    jsr sub_c842c                                                     ; 4bb1: 20 2c 84     ,. :abb1[1]
+    jsr osasci                                                        ; 4bb4: 20 e3 ff     .. :abb4[1]
+    dec l00ac                                                         ; 4bb7: c6 ac       ..  :abb7[1]
+    bne loop_cabad                                                    ; 4bb9: d0 f2       ..  :abb9[1]
+    rts                                                               ; 4bbb: 60          `   :abbb[1]
+
+; &4bbc referenced 2 times by &ab56, &ac02
+.cabbc
+    jsr sub_c9ad8                                                     ; 4bbc: 20 d8 9a     .. :abbc[1]
+    jsr cab41                                                         ; 4bbf: 20 41 ab     A. :abbf[1]
+    jmp c9436                                                         ; 4bc2: 4c 36 94    L6. :abc2[1]
+
+.sub_cabc5
+    jsr sub_cac18                                                     ; 4bc5: 20 18 ac     .. :abc5[1]
+    lda #&80                                                          ; 4bc8: a9 80       ..  :abc8[1]
+    jsr osfind                                                        ; 4bca: 20 ce ff     .. :abca[1]
+    sta l00ab                                                         ; 4bcd: 85 ab       ..  :abcd[1]
+; &4bcf referenced 1 time by &ac09
+.cabcf
+    jsr sub_cac4e                                                     ; 4bcf: 20 4e ac     N. :abcf[1]
+    jsr cac0f                                                         ; 4bd2: 20 0f ac     .. :abd2[1]
+    jsr sub_caaf1                                                     ; 4bd5: 20 f1 aa     .. :abd5[1]
+    ldx #&ac                                                          ; 4bd8: a2 ac       ..  :abd8[1]
+    ldy #&ff                                                          ; 4bda: a0 ff       ..  :abda[1]
+    sty l00ae                                                         ; 4bdc: 84 ae       ..  :abdc[1]
+    sty l00b0                                                         ; 4bde: 84 b0       ..  :abde[1]
+    iny                                                               ; 4be0: c8          .   :abe0[1]
+    sty l00ac                                                         ; 4be1: 84 ac       ..  :abe1[1]
+    lda #&20 ; ' '                                                    ; 4be3: a9 20       .   :abe3[1]
+    sta l00af                                                         ; 4be5: 85 af       ..  :abe5[1]
+    tya                                                               ; 4be7: 98          .   :abe7[1]
+    jsr osword                                                        ; 4be8: 20 f1 ff     .. :abe8[1]
+    php                                                               ; 4beb: 08          .   :abeb[1]
+    sty l00aa                                                         ; 4bec: 84 aa       ..  :abec[1]
+    ldy l00ab                                                         ; 4bee: a4 ab       ..  :abee[1]
+    ldx #0                                                            ; 4bf0: a2 00       ..  :abf0[1]
+    beq cabfb                                                         ; 4bf2: f0 07       ..  :abf2[1]
+; &4bf4 referenced 1 time by &abff
+.loop_cabf4
+    lda (l00ac,x)                                                     ; 4bf4: a1 ac       ..  :abf4[1]
+    jsr osbput                                                        ; 4bf6: 20 d4 ff     .. :abf6[1]
+    inc l00ac                                                         ; 4bf9: e6 ac       ..  :abf9[1]
+; &4bfb referenced 1 time by &abf2
+.cabfb
+    lda l00ac                                                         ; 4bfb: a5 ac       ..  :abfb[1]
+    cmp l00aa                                                         ; 4bfd: c5 aa       ..  :abfd[1]
+    bne loop_cabf4                                                    ; 4bff: d0 f3       ..  :abff[1]
+    plp                                                               ; 4c01: 28          (   :ac01[1]
+    bcs cabbc                                                         ; 4c02: b0 b8       ..  :ac02[1]
+    lda #&0d                                                          ; 4c04: a9 0d       ..  :ac04[1]
+    jsr osbput                                                        ; 4c06: 20 d4 ff     .. :ac06[1]
+    jmp cabcf                                                         ; 4c09: 4c cf ab    L.. :ac09[1]
+
+; &4c0c referenced 3 times by &817f, &8198, &85ca
+.sub_cac0c
+    jsr cac0f                                                         ; 4c0c: 20 0f ac     .. :ac0c[1]
+; &4c0f referenced 11 times by &81a7, &834f, &837d, &aa8f, &aab0, &ab2a, &ab62, &ab75, &ab88, &abd2, &ac0c
+.cac0f
+    pha                                                               ; 4c0f: 48          H   :ac0f[1]
+    lda #&20 ; ' '                                                    ; 4c10: a9 20       .   :ac10[1]
+    jsr osasci                                                        ; 4c12: 20 e3 ff     .. :ac12[1]
+    pla                                                               ; 4c15: 68          h   :ac15[1]
+    clc                                                               ; 4c16: 18          .   :ac16[1]
+    rts                                                               ; 4c17: 60          `   :ac17[1]
+
+; &4c18 referenced 4 times by &aafd, &ab04, &ab46, &abc5
+.sub_cac18
+    tsx                                                               ; 4c18: ba          .   :ac18[1]
+    lda #0                                                            ; 4c19: a9 00       ..  :ac19[1]
+    sta l0107,x                                                       ; 4c1b: 9d 07 01    ... :ac1b[1]
+    jsr sub_cac47                                                     ; 4c1e: 20 47 ac     G. :ac1e[1]
+    cmp #&0d                                                          ; 4c21: c9 0d       ..  :ac21[1]
+    bne cac28                                                         ; 4c23: d0 03       ..  :ac23[1]
+    jmp ca14f                                                         ; 4c25: 4c 4f a1    LO. :ac25[1]
+
+; &4c28 referenced 1 time by &ac23
+.cac28
+    lda #0                                                            ; 4c28: a9 00       ..  :ac28[1]
+    sta l00a8                                                         ; 4c2a: 85 a8       ..  :ac2a[1]
+    sta l00a9                                                         ; 4c2c: 85 a9       ..  :ac2c[1]
+    pha                                                               ; 4c2e: 48          H   :ac2e[1]
+    tya                                                               ; 4c2f: 98          .   :ac2f[1]
+    clc                                                               ; 4c30: 18          .   :ac30[1]
+    adc os_text_ptr                                                   ; 4c31: 65 f2       e.  :ac31[1]
+    tax                                                               ; 4c33: aa          .   :ac33[1]
+    lda l00f3                                                         ; 4c34: a5 f3       ..  :ac34[1]
+    adc #0                                                            ; 4c36: 69 00       i.  :ac36[1]
+    tay                                                               ; 4c38: a8          .   :ac38[1]
+    pla                                                               ; 4c39: 68          h   :ac39[1]
+    rts                                                               ; 4c3a: 60          `   :ac3a[1]
+
+    tya                                                               ; 4c3b: 98          .   :ac3b[1]
+    clc                                                               ; 4c3c: 18          .   :ac3c[1]
+    adc os_text_ptr                                                   ; 4c3d: 65 f2       e.  :ac3d[1]
+    sta os_text_ptr                                                   ; 4c3f: 85 f2       ..  :ac3f[1]
+    bcc cac45                                                         ; 4c41: 90 02       ..  :ac41[1]
+    inc os_text_ptr                                                   ; 4c43: e6 f2       ..  :ac43[1]
+; &4c45 referenced 1 time by &ac41
+.cac45
+    rts                                                               ; 4c45: 60          `   :ac45[1]
+
+; &4c46 referenced 1 time by &ac4b
+.loop_cac46
+    iny                                                               ; 4c46: c8          .   :ac46[1]
+; &4c47 referenced 1 time by &ac1e
+.sub_cac47
+    lda (os_text_ptr),y                                               ; 4c47: b1 f2       ..  :ac47[1]
+    cmp #&20 ; ' '                                                    ; 4c49: c9 20       .   :ac49[1]
+    beq loop_cac46                                                    ; 4c4b: f0 f9       ..  :ac4b[1]
+    rts                                                               ; 4c4d: 60          `   :ac4d[1]
+
+; &4c4e referenced 2 times by &ab27, &abcf
+.sub_cac4e
+    sed                                                               ; 4c4e: f8          .   :ac4e[1]
+    clc                                                               ; 4c4f: 18          .   :ac4f[1]
+    lda l00a8                                                         ; 4c50: a5 a8       ..  :ac50[1]
+    adc #1                                                            ; 4c52: 69 01       i.  :ac52[1]
+    sta l00a8                                                         ; 4c54: 85 a8       ..  :ac54[1]
+    lda l00a9                                                         ; 4c56: a5 a9       ..  :ac56[1]
+    adc #0                                                            ; 4c58: 69 00       i.  :ac58[1]
+    sta l00a9                                                         ; 4c5a: 85 a9       ..  :ac5a[1]
+    cld                                                               ; 4c5c: d8          .   :ac5c[1]
+    jsr sub_cac62                                                     ; 4c5d: 20 62 ac     b. :ac5d[1]
+    lda l00a8                                                         ; 4c60: a5 a8       ..  :ac60[1]
+; &4c62 referenced 4 times by &ab5a, &ab5f, &ab72, &ac5d
+.sub_cac62
+    pha                                                               ; 4c62: 48          H   :ac62[1]
+    jsr sub_c81bf                                                     ; 4c63: 20 bf 81     .. :ac63[1]
+    jsr sub_cac6a                                                     ; 4c66: 20 6a ac     j. :ac66[1]
+    pla                                                               ; 4c69: 68          h   :ac69[1]
+; &4c6a referenced 1 time by &ac66
+.sub_cac6a
+    jsr sub_c80c8                                                     ; 4c6a: 20 c8 80     .. :ac6a[1]
+    jsr osasci                                                        ; 4c6d: 20 e3 ff     .. :ac6d[1]
+    sec                                                               ; 4c70: 38          8   :ac70[1]
+    rts                                                               ; 4c71: 60          `   :ac71[1]
+
+; &4c72 referenced 1 time by &96e1
+.sub_cac72
+    jsr sub_c83e3                                                     ; 4c72: 20 e3 83     .. :ac72[1]
+    lda #&40 ; '@'                                                    ; 4c75: a9 40       .@  :ac75[1]
+    sta l10de                                                         ; 4c77: 8d de 10    ... :ac77[1]
+    lda #&a8                                                          ; 4c7a: a9 a8       ..  :ac7a[1]
+    jsr osbyte_read                                                   ; 4c7c: 20 e5 9a     .. :ac7c[1]
+    stx l00b0                                                         ; 4c7f: 86 b0       ..  :ac7f[1]
+    sty l00b1                                                         ; 4c81: 84 b1       ..  :ac81[1]
+    ldy #&0f                                                          ; 4c83: a0 0f       ..  :ac83[1]
+    lda #&4c ; 'L'                                                    ; 4c85: a9 4c       .L  :ac85[1]
+    sta l10e2                                                         ; 4c87: 8d e2 10    ... :ac87[1]
+    lda bytev                                                         ; 4c8a: ad 0a 02    ... :ac8a[1]
+    sta l10e3                                                         ; 4c8d: 8d e3 10    ... :ac8d[1]
+    lda bytev+1                                                       ; 4c90: ad 0b 02    ... :ac90[1]
+    sta l10e4                                                         ; 4c93: 8d e4 10    ... :ac93[1]
+    php                                                               ; 4c96: 08          .   :ac96[1]
+    sei                                                               ; 4c97: 78          x   :ac97[1]
+    lda #&0f                                                          ; 4c98: a9 0f       ..  :ac98[1]
+    sta bytev                                                         ; 4c9a: 8d 0a 02    ... :ac9a[1]
+    lda #&ff                                                          ; 4c9d: a9 ff       ..  :ac9d[1]
+    sta bytev+1                                                       ; 4c9f: 8d 0b 02    ... :ac9f[1]
+    lda #&b2                                                          ; 4ca2: a9 b2       ..  :aca2[1]
+    sta (l00b0),y                                                     ; 4ca4: 91 b0       ..  :aca4[1]
+    iny                                                               ; 4ca6: c8          .   :aca6[1]
+    lda #&ac                                                          ; 4ca7: a9 ac       ..  :aca7[1]
+    sta (l00b0),y                                                     ; 4ca9: 91 b0       ..  :aca9[1]
+    iny                                                               ; 4cab: c8          .   :acab[1]
+    lda romsel_copy                                                   ; 4cac: a5 f4       ..  :acac[1]
+    sta (l00b0),y                                                     ; 4cae: 91 b0       ..  :acae[1]
+    plp                                                               ; 4cb0: 28          (   :acb0[1]
+    rts                                                               ; 4cb1: 60          `   :acb1[1]
+
+    cmp #0                                                            ; 4cb2: c9 00       ..  :acb2[1]
+    beq cacc7                                                         ; 4cb4: f0 11       ..  :acb4[1]
+    cmp #&81                                                          ; 4cb6: c9 81       ..  :acb6[1]
+    bne cacc4                                                         ; 4cb8: d0 0a       ..  :acb8[1]
+    cpy #&ff                                                          ; 4cba: c0 ff       ..  :acba[1]
+    bne cacc4                                                         ; 4cbc: d0 06       ..  :acbc[1]
+    cpx #0                                                            ; 4cbe: e0 00       ..  :acbe[1]
+    bne cacc4                                                         ; 4cc0: d0 02       ..  :acc0[1]
+    dex                                                               ; 4cc2: ca          .   :acc2[1]
+    rts                                                               ; 4cc3: 60          `   :acc3[1]
+
+; &4cc4 referenced 3 times by &acb8, &acbc, &acc0
+.cacc4
+    jmp l10e2                                                         ; 4cc4: 4c e2 10    L.. :acc4[1]
+
+; &4cc7 referenced 1 time by &acb4
+.cacc7
+    php                                                               ; 4cc7: 08          .   :acc7[1]
+    sei                                                               ; 4cc8: 78          x   :acc8[1]
+    lda l10e3                                                         ; 4cc9: ad e3 10    ... :acc9[1]
+    sta bytev                                                         ; 4ccc: 8d 0a 02    ... :accc[1]
+    lda l10e4                                                         ; 4ccf: ad e4 10    ... :accf[1]
+    sta bytev+1                                                       ; 4cd2: 8d 0b 02    ... :acd2[1]
+    lda #0                                                            ; 4cd5: a9 00       ..  :acd5[1]
+    ldx #1                                                            ; 4cd7: a2 01       ..  :acd7[1]
+    plp                                                               ; 4cd9: 28          (   :acd9[1]
+    rts                                                               ; 4cda: 60          `   :acda[1]
+
+; &4cdb referenced 2 times by &0050, &af1c
+.tube_host_code2
+    org c30fb + (tube_host_code2 - nmi_handler2_rom_end)
+    copyblock nmi_handler2_rom_end, tube_host_code2, c30fb
+    clear nmi_handler2_rom_end, tube_host_code2
+
+; &4cdb referenced 2 times by &0050, &af1c
+; &4cdb referenced 2 times by &0050, &af1c
+
+    org &0500
+; &4cdb referenced 2 times by &0050, &af1c
+.l0500
+    equw          sub_c0537,          sub_c0596,          sub_c05f2   ; 4cdb: 37 05 96... 7.. :0500[3]
+    equw          sub_c0607,          sub_c0627, tube_host_osword_0   ; 4ce1: 07 06 27... ..' :0506[3]
+    equw          sub_c055e,          sub_c052d,          sub_c0520   ; 4ce7: 5e 05 2d... ^.- :050c[3]
+    equw          sub_c0542,          sub_c05a9,          sub_c05d1   ; 4ced: 42 05 a9... B.. :0512[3]
+; Table of flags used by tube_entry_small_a to set up registers 1/4
+; for the
+; selected operation.
+; &4cf3 referenced 1 time by &0453
+.tube_entry_flags
+    equb &86, &88, &96, &98, &18, &18, &82, &18                       ; 4cf3: 86 88 96... ... :0518[3]
+
+.sub_c0520
+    jsr read_tube_r2_data                                             ; 4cfb: 20 c5 06     .. :0520[3]
+    tay                                                               ; 4cfe: a8          .   :0523[3]
+    jsr read_tube_r2_data                                             ; 4cff: 20 c5 06     .. :0524[3]
+    jsr osbput                                                        ; 4d02: 20 d4 ff     .. :0527[3]
+    jmp c059c                                                         ; 4d05: 4c 9c 05    L.. :052a[3]
+
+.sub_c052d
+    jsr read_tube_r2_data                                             ; 4d08: 20 c5 06     .. :052d[3]
+    tay                                                               ; 4d0b: a8          .   :0530[3]
+    jsr osbget                                                        ; 4d0c: 20 d7 ff     .. :0531[3]
+    jmp c053a                                                         ; 4d0f: 4c 3a 05    L:. :0534[3]
+
+.sub_c0537
+    jsr osrdch                                                        ; 4d12: 20 e0 ff     .. :0537[3]
+; &4d15 referenced 2 times by &0534, &05ef
+.c053a
+    ror a                                                             ; 4d15: 6a          j   :053a[3]
+    jsr write_tube_r2_data                                            ; 4d16: 20 95 06     .. :053b[3]
+    rol a                                                             ; 4d19: 2a          *   :053e[3]
+    jmp c059e                                                         ; 4d1a: 4c 9e 05    L.. :053f[3]
+
+.sub_c0542
+    jsr read_tube_r2_data                                             ; 4d1d: 20 c5 06     .. :0542[3]
+    beq c0552                                                         ; 4d20: f0 0b       ..  :0545[3]
+    pha                                                               ; 4d22: 48          H   :0547[3]
+    jsr sub_c0582                                                     ; 4d23: 20 82 05     .. :0548[3]
+    pla                                                               ; 4d26: 68          h   :054b[3]
+    jsr osfind                                                        ; 4d27: 20 ce ff     .. :054c[3]
+    jmp c059e                                                         ; 4d2a: 4c 9e 05    L.. :054f[3]
+
+; &4d2d referenced 1 time by &0545
+.c0552
+    jsr read_tube_r2_data                                             ; 4d2d: 20 c5 06     .. :0552[3]
+    tay                                                               ; 4d30: a8          .   :0555[3]
+    lda #0                                                            ; 4d31: a9 00       ..  :0556[3]
+    jsr osfind                                                        ; 4d33: 20 ce ff     .. :0558[3]
+    jmp c059c                                                         ; 4d36: 4c 9c 05    L.. :055b[3]
+
+.sub_c055e
+    jsr read_tube_r2_data                                             ; 4d39: 20 c5 06     .. :055e[3]
+    tay                                                               ; 4d3c: a8          .   :0561[3]
+    ldx #4                                                            ; 4d3d: a2 04       ..  :0562[3]
+; &4d3f referenced 1 time by &056a
+.loop_c0564
+    jsr read_tube_r2_data                                             ; 4d3f: 20 c5 06     .. :0564[3]
+    sta l00ff,x                                                       ; 4d42: 95 ff       ..  :0567[3]
+    dex                                                               ; 4d44: ca          .   :0569[3]
+    bne loop_c0564                                                    ; 4d45: d0 f8       ..  :056a[3]
+    jsr read_tube_r2_data                                             ; 4d47: 20 c5 06     .. :056c[3]
+    jsr osargs                                                        ; 4d4a: 20 da ff     .. :056f[3]
+    jsr write_tube_r2_data                                            ; 4d4d: 20 95 06     .. :0572[3]
+    ldx #3                                                            ; 4d50: a2 03       ..  :0575[3]
+; &4d52 referenced 1 time by &057d
+.loop_c0577
+    lda l0000,x                                                       ; 4d52: b5 00       ..  :0577[3]
+    jsr write_tube_r2_data                                            ; 4d54: 20 95 06     .. :0579[3]
+    dex                                                               ; 4d57: ca          .   :057c[3]
+    bpl loop_c0577                                                    ; 4d58: 10 f8       ..  :057d[3]
+    jmp c0036                                                         ; 4d5a: 4c 36 00    L6. :057f[3]
+
+; &4d5d referenced 3 times by &0548, &0596, &05b3
+.sub_c0582
+    ldx #0                                                            ; 4d5d: a2 00       ..  :0582[3]
+    ldy #0                                                            ; 4d5f: a0 00       ..  :0584[3]
+; &4d61 referenced 1 time by &0591
+.loop_c0586
+    jsr read_tube_r2_data                                             ; 4d61: 20 c5 06     .. :0586[3]
+    sta l0700,y                                                       ; 4d64: 99 00 07    ... :0589[3]
+    iny                                                               ; 4d67: c8          .   :058c[3]
+    beq c0593                                                         ; 4d68: f0 04       ..  :058d[3]
+    cmp #&0d                                                          ; 4d6a: c9 0d       ..  :058f[3]
+    bne loop_c0586                                                    ; 4d6c: d0 f3       ..  :0591[3]
+; &4d6e referenced 1 time by &058d
+.c0593
+    ldy #7                                                            ; 4d6e: a0 07       ..  :0593[3]
+    rts                                                               ; 4d70: 60          `   :0595[3]
+
+.sub_c0596
+    jsr sub_c0582                                                     ; 4d71: 20 82 05     .. :0596[3]
+    jsr oscli                                                         ; 4d74: 20 f7 ff     .. :0599[3]
+; &4d77 referenced 3 times by &0489, &052a, &055b
+.c059c
+    lda #&7f                                                          ; 4d77: a9 7f       ..  :059c[3]
+; &4d79 referenced 4 times by &053f, &054f, &05a1, &067d
+.c059e
+    bit tube_host_r2_status                                           ; 4d79: 2c e2 fe    ,.. :059e[3]
+    bvc c059e                                                         ; 4d7c: 50 fb       P.  :05a1[3]
+    sta tube_host_r2_data                                             ; 4d7e: 8d e3 fe    ... :05a3[3]
+; &4d81 referenced 1 time by &05cf
+.c05a6
+    jmp c0036                                                         ; 4d81: 4c 36 00    L6. :05a6[3]
+
+.sub_c05a9
+    ldx #&10                                                          ; 4d84: a2 10       ..  :05a9[3]
+; &4d86 referenced 1 time by &05b1
+.loop_c05ab
+    jsr read_tube_r2_data                                             ; 4d86: 20 c5 06     .. :05ab[3]
+    sta l0001,x                                                       ; 4d89: 95 01       ..  :05ae[3]
+    dex                                                               ; 4d8b: ca          .   :05b0[3]
+    bne loop_c05ab                                                    ; 4d8c: d0 f8       ..  :05b1[3]
+    jsr sub_c0582                                                     ; 4d8e: 20 82 05     .. :05b3[3]
+    stx l0000                                                         ; 4d91: 86 00       ..  :05b6[3]
+    sty l0001                                                         ; 4d93: 84 01       ..  :05b8[3]
+    ldy #0                                                            ; 4d95: a0 00       ..  :05ba[3]
+    jsr read_tube_r2_data                                             ; 4d97: 20 c5 06     .. :05bc[3]
+    jsr osfile                                                        ; 4d9a: 20 dd ff     .. :05bf[3]
+    jsr write_tube_r2_data                                            ; 4d9d: 20 95 06     .. :05c2[3]
+    ldx #&10                                                          ; 4da0: a2 10       ..  :05c5[3]
+; &4da2 referenced 1 time by &05cd
+.loop_c05c7
+    lda l0001,x                                                       ; 4da2: b5 01       ..  :05c7[3]
+    jsr write_tube_r2_data                                            ; 4da4: 20 95 06     .. :05c9[3]
+    dex                                                               ; 4da7: ca          .   :05cc[3]
+    bne loop_c05c7                                                    ; 4da8: d0 f8       ..  :05cd[3]
+    beq c05a6                                                         ; 4daa: f0 d5       ..  :05cf[3]
+.sub_c05d1
+    ldx #&0d                                                          ; 4dac: a2 0d       ..  :05d1[3]
+; &4dae referenced 1 time by &05d9
+.loop_c05d3
+    jsr read_tube_r2_data                                             ; 4dae: 20 c5 06     .. :05d3[3]
+    sta l00ff,x                                                       ; 4db1: 95 ff       ..  :05d6[3]
+    dex                                                               ; 4db3: ca          .   :05d8[3]
+    bne loop_c05d3                                                    ; 4db4: d0 f8       ..  :05d9[3]
+    jsr read_tube_r2_data                                             ; 4db6: 20 c5 06     .. :05db[3]
+    ldy #0                                                            ; 4db9: a0 00       ..  :05de[3]
+    jsr osgbpb                                                        ; 4dbb: 20 d1 ff     .. :05e0[3]
+    pha                                                               ; 4dbe: 48          H   :05e3[3]
+    ldx #&0c                                                          ; 4dbf: a2 0c       ..  :05e4[3]
+; &4dc1 referenced 1 time by &05ec
+.loop_c05e6
+    lda l0000,x                                                       ; 4dc1: b5 00       ..  :05e6[3]
+    jsr write_tube_r2_data                                            ; 4dc3: 20 95 06     .. :05e8[3]
+    dex                                                               ; 4dc6: ca          .   :05eb[3]
+    bpl loop_c05e6                                                    ; 4dc7: 10 f8       ..  :05ec[3]
+    pla                                                               ; 4dc9: 68          h   :05ee[3]
+    jmp c053a                                                         ; 4dca: 4c 3a 05    L:. :05ef[3]
+
+.sub_c05f2
+    jsr read_tube_r2_data                                             ; 4dcd: 20 c5 06     .. :05f2[3]
+    tax                                                               ; 4dd0: aa          .   :05f5[3]
+    jsr read_tube_r2_data                                             ; 4dd1: 20 c5 06     .. :05f6[3]
+    jsr osbyte                                                        ; 4dd4: 20 f4 ff     .. :05f9[3]
+; &4dd7 referenced 2 times by &05ff, &0625
+.c05fc
+    bit tube_host_r2_status                                           ; 4dd7: 2c e2 fe    ,.. :05fc[3]
+.sub_c05ff
+l0600 = sub_c05ff+1
+    bvc c05fc                                                         ; 4dda: 50 fb       P.  :05ff[3]
+; &4ddb referenced 1 time by &af22
+    stx tube_host_r2_data                                             ; 4ddc: 8e e3 fe    ... :0601[3]
+; &4ddf referenced 1 time by &0617
+.loop_c0604
+    jmp c0036                                                         ; 4ddf: 4c 36 00    L6. :0604[3]
+
+.sub_c0607
+    jsr read_tube_r2_data                                             ; 4de2: 20 c5 06     .. :0607[3]
+    tax                                                               ; 4de5: aa          .   :060a[3]
+    jsr read_tube_r2_data                                             ; 4de6: 20 c5 06     .. :060b[3]
+    tay                                                               ; 4de9: a8          .   :060e[3]
+    jsr read_tube_r2_data                                             ; 4dea: 20 c5 06     .. :060f[3]
+    jsr osbyte                                                        ; 4ded: 20 f4 ff     .. :0612[3]
+    eor #&9d                                                          ; 4df0: 49 9d       I.  :0615[3]
+    beq loop_c0604                                                    ; 4df2: f0 eb       ..  :0617[3]
+    ror a                                                             ; 4df4: 6a          j   :0619[3]
+    jsr write_tube_r2_data                                            ; 4df5: 20 95 06     .. :061a[3]
+; &4df8 referenced 1 time by &0620
+.loop_c061d
+    bit tube_host_r2_status                                           ; 4df8: 2c e2 fe    ,.. :061d[3]
+    bvc loop_c061d                                                    ; 4dfb: 50 fb       P.  :0620[3]
+    sty tube_host_r2_data                                             ; 4dfd: 8c e3 fe    ... :0622[3]
+    bvs c05fc                                                         ; 4e00: 70 d5       p.  :0625[3]
+.sub_c0627
+    jsr read_tube_r2_data                                             ; 4e02: 20 c5 06     .. :0627[3]
+    tay                                                               ; 4e05: a8          .   :062a[3]
+; &4e06 referenced 1 time by &062e
+.loop_c062b
+    bit tube_host_r2_status                                           ; 4e06: 2c e2 fe    ,.. :062b[3]
+    bpl loop_c062b                                                    ; 4e09: 10 fb       ..  :062e[3]
+    ldx tube_host_r2_data                                             ; 4e0b: ae e3 fe    ... :0630[3]
+    dex                                                               ; 4e0e: ca          .   :0633[3]
+    bmi c0645                                                         ; 4e0f: 30 0f       0.  :0634[3]
+; &4e11 referenced 2 times by &0639, &0642
+.c0636
+    bit tube_host_r2_status                                           ; 4e11: 2c e2 fe    ,.. :0636[3]
+    bpl c0636                                                         ; 4e14: 10 fb       ..  :0639[3]
+    lda tube_host_r2_data                                             ; 4e16: ad e3 fe    ... :063b[3]
+    sta l0128,x                                                       ; 4e19: 9d 28 01    .(. :063e[3]
+    dex                                                               ; 4e1c: ca          .   :0641[3]
+    bpl c0636                                                         ; 4e1d: 10 f2       ..  :0642[3]
+    tya                                                               ; 4e1f: 98          .   :0644[3]
+; &4e20 referenced 1 time by &0634
+.c0645
+    ldx #<(l0128)                                                     ; 4e20: a2 28       .(  :0645[3]
+    ldy #>(l0128)                                                     ; 4e22: a0 01       ..  :0647[3]
+    jsr osword                                                        ; 4e24: 20 f1 ff     .. :0649[3]
+; &4e27 referenced 1 time by &064f
+.loop_c064c
+    bit tube_host_r2_status                                           ; 4e27: 2c e2 fe    ,.. :064c[3]
+    bpl loop_c064c                                                    ; 4e2a: 10 fb       ..  :064f[3]
+    ldx tube_host_r2_data                                             ; 4e2c: ae e3 fe    ... :0651[3]
+    dex                                                               ; 4e2f: ca          .   :0654[3]
+    bmi c0665                                                         ; 4e30: 30 0e       0.  :0655[3]
+; &4e32 referenced 1 time by &0663
+.loop_c0657
+    ldy l0128,x                                                       ; 4e32: bc 28 01    .(. :0657[3]
+; &4e35 referenced 1 time by &065d
+.loop_c065a
+    bit tube_host_r2_status                                           ; 4e35: 2c e2 fe    ,.. :065a[3]
+    bvc loop_c065a                                                    ; 4e38: 50 fb       P.  :065d[3]
+    sty tube_host_r2_data                                             ; 4e3a: 8c e3 fe    ... :065f[3]
+    dex                                                               ; 4e3d: ca          .   :0662[3]
+    bpl loop_c0657                                                    ; 4e3e: 10 f2       ..  :0663[3]
+; &4e40 referenced 1 time by &0655
+.c0665
+    jmp c0036                                                         ; 4e40: 4c 36 00    L6. :0665[3]
+
+.tube_host_osword_0
+    ldx #4                                                            ; 4e43: a2 04       ..  :0668[3]
+; &4e45 referenced 1 time by &0670
+.tube_host_osword_0_loop
+    jsr read_tube_r2_data                                             ; 4e45: 20 c5 06     .. :066a[3]
+    sta l0000,x                                                       ; 4e48: 95 00       ..  :066d[3]
+    dex                                                               ; 4e4a: ca          .   :066f[3]
+    bpl tube_host_osword_0_loop                                       ; 4e4b: 10 f8       ..  :0670[3]
+    inx                                                               ; 4e4d: e8          .   :0672[3]
+    ldy #0                                                            ; 4e4e: a0 00       ..  :0673[3]
+    txa                                                               ; 4e50: 8a          .   :0675[3]
+    jsr osword                                                        ; 4e51: 20 f1 ff     .. :0676[3]
+    bcc tube_host_osword_0_no_escape                                  ; 4e54: 90 05       ..  :0679[3]
+    lda #&ff                                                          ; 4e56: a9 ff       ..  :067b[3]
+    jmp c059e                                                         ; 4e58: 4c 9e 05    L.. :067d[3]
+
+; &4e5b referenced 1 time by &0679
+.tube_host_osword_0_no_escape
+    ldx #0                                                            ; 4e5b: a2 00       ..  :0680[3]
+    lda #&7f                                                          ; 4e5d: a9 7f       ..  :0682[3]
+    jsr write_tube_r2_data                                            ; 4e5f: 20 95 06     .. :0684[3]
+; &4e62 referenced 1 time by &0690
+.tube_host_osword_0_no_escape_loop
+    lda l0700,x                                                       ; 4e62: bd 00 07    ... :0687[3]
+    jsr write_tube_r2_data                                            ; 4e65: 20 95 06     .. :068a[3]
+    inx                                                               ; 4e68: e8          .   :068d[3]
+    cmp #&0d                                                          ; 4e69: c9 0d       ..  :068e[3]
+    bne tube_host_osword_0_no_escape_loop                             ; 4e6b: d0 f5       ..  :0690[3]
+    jmp c0036                                                         ; 4e6d: 4c 36 00    L6. :0692[3]
+
+; Wait for register 2 to have space and write A to it.
+; &4e70 referenced 14 times by &0020, &0026, &002c, &0474, &053b, &0572, &0579, &05c2, &05c9, &05e8, &061a, &0684, &068a, &0698
+.write_tube_r2_data
+    bit tube_host_r2_status                                           ; 4e70: 2c e2 fe    ,.. :0695[3]
+    bvc write_tube_r2_data                                            ; 4e73: 50 fb       P.  :0698[3]
+    sta tube_host_r2_data                                             ; 4e75: 8d e3 fe    ... :069a[3]
+    rts                                                               ; 4e78: 60          `   :069d[3]
+
+; Wait for register 4 to have space and write A to it.
+; &4e79 referenced 8 times by &0018, &0418, &041d, &043b, &0443, &0448, &0463, &06a1
+.write_tube_r4_data
+    bit tube_host_r4_status                                           ; 4e79: 2c e6 fe    ,.. :069e[3]
+    bvc write_tube_r4_data                                            ; 4e7c: 50 fb       P.  :06a1[3]
+    sta tube_host_r4_data                                             ; 4e7e: 8d e7 fe    ... :06a3[3]
+    rts                                                               ; 4e81: 60          `   :06a6[3]
+
+; &4e82 referenced 1 time by &0403
+.c06a7
+    lda l00ff                                                         ; 4e82: a5 ff       ..  :06a7[3]
+    sec                                                               ; 4e84: 38          8   :06a9[3]
+    ror a                                                             ; 4e85: 6a          j   :06aa[3]
+    bmi write_tube_r1_data                                            ; 4e86: 30 0f       0.  :06ab[3]
+.tube_evntv_handler
+    pha                                                               ; 4e88: 48          H   :06ad[3]
+    lda #0                                                            ; 4e89: a9 00       ..  :06ae[3]
+    jsr write_tube_r1_data                                            ; 4e8b: 20 bc 06     .. :06b0[3]
+    tya                                                               ; 4e8e: 98          .   :06b3[3]
+    jsr write_tube_r1_data                                            ; 4e8f: 20 bc 06     .. :06b4[3]
+    txa                                                               ; 4e92: 8a          .   :06b7[3]
+    jsr write_tube_r1_data                                            ; 4e93: 20 bc 06     .. :06b8[3]
+    pla                                                               ; 4e96: 68          h   :06bb[3]
+; Wait for register 1 to have space and write A to it.
+; &4e97 referenced 5 times by &06ab, &06b0, &06b4, &06b8, &06bf
+.write_tube_r1_data
+    bit tube_host_r1_status                                           ; 4e97: 2c e0 fe    ,.. :06bc[3]
+    bvc write_tube_r1_data                                            ; 4e9a: 50 fb       P.  :06bf[3]
+    sta tube_host_r1_data                                             ; 4e9c: 8d e1 fe    ... :06c1[3]
+    rts                                                               ; 4e9f: 60          `   :06c4[3]
+
+; Wait for register 2 to have data and read A from it.
+; &4ea0 referenced 21 times by &0520, &0524, &052d, &0542, &0552, &055e, &0564, &056c, &0586, &05ab, &05bc, &05d3, &05db, &05f2, &05f6, &0607, &060b, &060f, &0627, &066a, &06c8
+.read_tube_r2_data
+    bit tube_host_r2_status                                           ; 4ea0: 2c e2 fe    ,.. :06c5[3]
+    bpl read_tube_r2_data                                             ; 4ea3: 10 fb       ..  :06c8[3]
+    lda tube_host_r2_data                                             ; 4ea5: ad e3 fe    ... :06ca[3]
+    rts                                                               ; 4ea8: 60          `   :06cd[3]
+
+; &4ea9 referenced 1 time by &965d
+    org l4cdb + (l06ce - l0500)
+    copyblock l0500, l06ce, l4cdb
+    clear l0500, l06ce
+
+; &4ea9 referenced 1 time by &965d
+; &4ea9 referenced 1 time by &965d
+
+    org &aea9
+; &4ea9 referenced 1 time by &965d
+.service_handler_help_and_tube
+    cmp #service_help                                                 ; 4ea9: c9 09       ..  :aea9[1]
+    bne caed7                                                         ; 4eab: d0 2a       .*  :aeab[1]
+    tya                                                               ; 4ead: 98          .   :aead[1]
+    pha                                                               ; 4eae: 48          H   :aeae[1]
+    lda (os_text_ptr),y                                               ; 4eaf: b1 f2       ..  :aeaf[1]
+    cmp #&0d                                                          ; 4eb1: c9 0d       ..  :aeb1[1]
+    bne caed3                                                         ; 4eb3: d0 1e       ..  :aeb3[1]
+    lda #&e9                                                          ; 4eb5: a9 e9       ..  :aeb5[1]
+    jsr osbyte_read                                                   ; 4eb7: 20 e5 9a     .. :aeb7[1]
+    ldx romsel_copy                                                   ; 4eba: a6 f4       ..  :aeba[1]
+    tya                                                               ; 4ebc: 98          .   :aebc[1]
+    beq caed3                                                         ; 4ebd: f0 14       ..  :aebd[1]
+    jsr print_inline_l809f_top_bit_clear                              ; 4ebf: 20 77 80     w. :aebf[1]
+    equs &0d, "TUBE HOST 2.30", &0d                                   ; 4ec2: 0d 54 55... .TU :aec2[1]
+
+    nop                                                               ; 4ed2: ea          .   :aed2[1]
+; &4ed3 referenced 2 times by &aeb3, &aebd
+.caed3
+    pla                                                               ; 4ed3: 68          h   :aed3[1]
+    tay                                                               ; 4ed4: a8          .   :aed4[1]
+    lda #9                                                            ; 4ed5: a9 09       ..  :aed5[1]
+; &4ed7 referenced 1 time by &aeab
+.caed7
+    cmp #service_tube_post_init                                       ; 4ed7: c9 fe       ..  :aed7[1]
+    bcc just_rts                                                      ; 4ed9: 90 5c       .\  :aed9[1]
+    bne service_handler_tube_main_init                                ; 4edb: d0 1b       ..  :aedb[1]
+    cpy #0                                                            ; 4edd: c0 00       ..  :aedd[1]
+    beq just_rts                                                      ; 4edf: f0 56       .V  :aedf[1]
+    ldx #6                                                            ; 4ee1: a2 06       ..  :aee1[1]
+    lda #osbyte_explode_chars                                         ; 4ee3: a9 14       ..  :aee3[1]
+    jsr osbyte                                                        ; 4ee5: 20 f4 ff     .. :aee5[1]
+; &4ee8 referenced 2 times by &aeeb, &aef5
+.tube_banner_loop
+    bit tube_host_r1_status                                           ; 4ee8: 2c e0 fe    ,.. :aee8[1]
+    bpl tube_banner_loop                                              ; 4eeb: 10 fb       ..  :aeeb[1]
+    lda tube_host_r1_data                                             ; 4eed: ad e1 fe    ... :aeed[1]
+    beq lda_0_rts                                                     ; 4ef0: f0 43       .C  :aef0[1]
+    jsr oswrch                                                        ; 4ef2: 20 ee ff     .. :aef2[1]
+    jmp tube_banner_loop                                              ; 4ef5: 4c e8 ae    L.. :aef5[1]
+
+; &4ef8 referenced 1 time by &aedb
+.service_handler_tube_main_init
+    lda #<tube_evntv_handler                                          ; 4ef8: a9 ad       ..  :aef8[1]
+    sta evntv                                                         ; 4efa: 8d 20 02    . . :aefa[1]
+    lda #>tube_evntv_handler                                          ; 4efd: a9 06       ..  :aefd[1]
+    sta evntv+1                                                       ; 4eff: 8d 21 02    .!. :aeff[1]
+    lda #<tube_brkv_handler                                           ; 4f02: a9 16       ..  :af02[1]
+    sta brkv                                                          ; 4f04: 8d 02 02    ... :af04[1]
+    lda #>tube_brkv_handler                                           ; 4f07: a9 00       ..  :af07[1]
+    sta brkv+1                                                        ; 4f09: 8d 03 02    ... :af09[1]
+    lda #&8e                                                          ; 4f0c: a9 8e       ..  :af0c[1]
+    sta tube_host_r1_status                                           ; 4f0e: 8d e0 fe    ... :af0e[1]
+    ldy #0                                                            ; 4f11: a0 00       ..  :af11[1]
+; &4f13 referenced 1 time by &af26
+.loop_caf13
+    lda tube_host_code1,y                                             ; 4f13: b9 79 af    .y. :af13[1]
+    sta c0400,y                                                       ; 4f16: 99 00 04    ... :af16[1]
+    lda tube_host_code2,y                                             ; 4f19: b9 db ac    ... :af19[1]
+    sta l0500,y                                                       ; 4f1c: 99 00 05    ... :af1c[1]
+    lda tube_host_code2+256,y                                         ; 4f1f: b9 db ad    ... :af1f[1]
+    sta l0600,y                                                       ; 4f22: 99 00 06    ... :af22[1]
+    dey                                                               ; 4f25: 88          .   :af25[1]
+    bne loop_caf13                                                    ; 4f26: d0 eb       ..  :af26[1]
+    jsr sub_c0421                                                     ; 4f28: 20 21 04     !. :af28[1]
+    ldx #&41 ; 'A'                                                    ; 4f2b: a2 41       .A  :af2b[1]
+; &4f2d referenced 1 time by &af33
+.loop_caf2d
+    lda tube_host_code3,x                                             ; 4f2d: bd 38 af    .8. :af2d[1]
+    sta tube_brkv_handler_fwd,x                                       ; 4f30: 95 16       ..  :af30[1]
+    dex                                                               ; 4f32: ca          .   :af32[1]
+    bpl loop_caf2d                                                    ; 4f33: 10 f8       ..  :af33[1]
+; &4f35 referenced 1 time by &aef0
+.lda_0_rts
+    lda #0                                                            ; 4f35: a9 00       ..  :af35[1]
+; &4f37 referenced 2 times by &aed9, &aedf
+.just_rts
+    rts                                                               ; 4f37: 60          `   :af37[1]
+
+; &4f38 referenced 1 time by &af30
+.tube_host_code3
+    org sub_c4ea9 + (tube_host_code3 - service_handler_help_and_tube)
+    copyblock service_handler_help_and_tube, tube_host_code3, sub_c4ea9
+    clear service_handler_help_and_tube, tube_host_code3
+
+; &4f38 referenced 1 time by &af30
+; &4f38 referenced 1 time by &af30
+
+    org &16
+; &4f38 referenced 1 time by &af30
+.tube_brkv_handler
+    lda #&ff                                                          ; 4f38: a9 ff       ..  :0016[4]
+    jsr write_tube_r4_data                                            ; 4f3a: 20 9e 06     .. :0018[4]
+    lda tube_host_r2_data                                             ; 4f3d: ad e3 fe    ... :001b[4]
+    lda #0                                                            ; 4f40: a9 00       ..  :001e[4]
+    jsr write_tube_r2_data                                            ; 4f42: 20 95 06     .. :0020[4]
+    tay                                                               ; 4f45: a8          .   :0023[4]
+    lda (l00fd),y                                                     ; 4f46: b1 fd       ..  :0024[4]
+    jsr write_tube_r2_data                                            ; 4f48: 20 95 06     .. :0026[4]
+; &4f4b referenced 1 time by &0030
+.loop_c0029
+    iny                                                               ; 4f4b: c8          .   :0029[4]
+    lda (l00fd),y                                                     ; 4f4c: b1 fd       ..  :002a[4]
+    jsr write_tube_r2_data                                            ; 4f4e: 20 95 06     .. :002c[4]
+    tax                                                               ; 4f51: aa          .   :002f[4]
+    bne loop_c0029                                                    ; 4f52: d0 f7       ..  :0030[4]
+; &4f54 referenced 1 time by &0477
+.c0032
+    ldx #&ff                                                          ; 4f54: a2 ff       ..  :0032[4]
+    txs                                                               ; 4f56: 9a          .   :0034[4]
+    cli                                                               ; 4f57: 58          X   :0035[4]
+; &4f58 referenced 6 times by &0044, &057f, &05a6, &0604, &0665, &0692
+.c0036
+    bit tube_host_r1_status                                           ; 4f58: 2c e0 fe    ,.. :0036[4]
+    bpl c0041                                                         ; 4f5b: 10 06       ..  :0039[4]
+; &4f5d referenced 1 time by &0049
+.loop_c003b
+    lda tube_host_r1_data                                             ; 4f5d: ad e1 fe    ... :003b[4]
+    jsr oswrch                                                        ; 4f60: 20 ee ff     .. :003e[4]
+; &4f63 referenced 1 time by &0039
+.c0041
+    bit tube_host_r2_status                                           ; 4f63: 2c e2 fe    ,.. :0041[4]
+    bpl c0036                                                         ; 4f66: 10 f0       ..  :0044[4]
+    bit tube_host_r1_status                                           ; 4f68: 2c e0 fe    ,.. :0046[4]
+    bmi loop_c003b                                                    ; 4f6b: 30 f0       0.  :0049[4]
+    ldx tube_host_r2_data                                             ; 4f6d: ae e3 fe    ... :004b[4]
+; Patch the following JMP so we effectively do JMP (&500,X)
+    stx jump_address_low                                              ; 4f70: 86 51       .Q  :004e[4]
+.sub_c0050
+jump_address_low = sub_c0050+1
+    jmp (l0500)                                                       ; 4f72: 6c 00 05    l.. :0050[4]
+
+; &4f73 referenced 1 time by &004e
+; &4f75 referenced 2 times by &04da, &04ea
+.l0053
+    equb 0                                                            ; 4f75: 00          .   :0053[4]
+; &4f76 referenced 3 times by &04b2, &04d0, &04ef
+.l0054
+    equb &80                                                          ; 4f76: 80          .   :0054[4]
+; &4f77 referenced 2 times by &04b6, &04f9
+.l0055
+    equb 0                                                            ; 4f77: 00          .   :0055[4]
+; &4f78 referenced 2 times by &04ba, &04f7
+.l0056
+    equb 0                                                            ; 4f78: 00          .   :0056[4]
+; &4f79 referenced 1 time by &af16
+    org c4f38 + (l0057 - tube_brkv_handler)
+    copyblock tube_brkv_handler, l0057, c4f38
+    clear tube_brkv_handler, l0057
+
+; &4f79 referenced 1 time by &af16
+; &4f79 referenced 1 time by &af16
+
+    org &0400
+; &4f79 referenced 1 time by &af16
+.c0400
+    jmp c0484                                                         ; 4f79: 4c 84 04    L.. :0400[2]
+
+    jmp c06a7                                                         ; 4f7c: 4c a7 06    L.. :0403[2]
+
+; &4f7f referenced 14 times by &0493, &04cb, &892a, &8cae, &8f6e, &8f7d, &9346, &982b, &bd64, &bd91, &be09, &be2c, &be7d, &be85
+.tube_entry
+    cmp #&80                                                          ; 4f7f: c9 80       ..  :0406[2]
+    bcc tube_entry_small_a                                            ; 4f81: 90 2b       .+  :0408[2]
+    cmp #&c0                                                          ; 4f83: c9 c0       ..  :040a[2]
+    bcs tube_entry_claim_tube                                         ; 4f85: b0 1a       ..  :040c[2]
+; This is a call to release the tube.
+    ora #&40 ; '@'                                                    ; 4f87: 09 40       .@  :040e[2]
+    cmp l0015                                                         ; 4f89: c5 15       ..  :0410[2]
+    bne c0434                                                         ; 4f8b: d0 20       .   :0412[2]
+; &4f8d referenced 1 time by &0471
+.sub_c0414
+    php                                                               ; 4f8d: 08          .   :0414[2]
+    sei                                                               ; 4f8e: 78          x   :0415[2]
+    lda #5                                                            ; 4f8f: a9 05       ..  :0416[2]
+    jsr write_tube_r4_data                                            ; 4f91: 20 9e 06     .. :0418[2]
+    lda l0015                                                         ; 4f94: a5 15       ..  :041b[2]
+    jsr write_tube_r4_data                                            ; 4f96: 20 9e 06     .. :041d[2]
+    plp                                                               ; 4f99: 28          (   :0420[2]
+; &4f9a referenced 1 time by &af28
+.sub_c0421
+    lda #&80                                                          ; 4f9a: a9 80       ..  :0421[2]
+    sta l0015                                                         ; 4f9c: 85 15       ..  :0423[2]
+    sta l0014                                                         ; 4f9e: 85 14       ..  :0425[2]
+    rts                                                               ; 4fa0: 60          `   :0427[2]
+
+; &4fa1 referenced 1 time by &040c
+.tube_entry_claim_tube
+    asl l0014                                                         ; 4fa1: 06 14       ..  :0428[2]
+    bcs c0432                                                         ; 4fa3: b0 06       ..  :042a[2]
+    cmp l0015                                                         ; 4fa5: c5 15       ..  :042c[2]
+    beq c0434                                                         ; 4fa7: f0 04       ..  :042e[2]
+    clc                                                               ; 4fa9: 18          .   :0430[2]
+    rts                                                               ; 4faa: 60          `   :0431[2]
+
+; &4fab referenced 1 time by &042a
+.c0432
+    sta l0015                                                         ; 4fab: 85 15       ..  :0432[2]
+; &4fad referenced 2 times by &0412, &042e
+.c0434
+    rts                                                               ; 4fad: 60          `   :0434[2]
+
+; &4fae referenced 1 time by &0408
+.tube_entry_small_a
+    php                                                               ; 4fae: 08          .   :0435[2]
+    sei                                                               ; 4faf: 78          x   :0436[2]
+    sty l0013                                                         ; 4fb0: 84 13       ..  :0437[2]
+    stx l0012                                                         ; 4fb2: 86 12       ..  :0439[2]
+    jsr write_tube_r4_data                                            ; 4fb4: 20 9e 06     .. :043b[2]
+    tax                                                               ; 4fb7: aa          .   :043e[2]
+    ldy #3                                                            ; 4fb8: a0 03       ..  :043f[2]
+    lda l0015                                                         ; 4fba: a5 15       ..  :0441[2]
+    jsr write_tube_r4_data                                            ; 4fbc: 20 9e 06     .. :0443[2]
+; &4fbf referenced 1 time by &044c
+.loop_c0446
+    lda (l0012),y                                                     ; 4fbf: b1 12       ..  :0446[2]
+    jsr write_tube_r4_data                                            ; 4fc1: 20 9e 06     .. :0448[2]
+    dey                                                               ; 4fc4: 88          .   :044b[2]
+    bpl loop_c0446                                                    ; 4fc5: 10 f8       ..  :044c[2]
+    ldy #&18                                                          ; 4fc7: a0 18       ..  :044e[2]
+    sty tube_host_r1_status                                           ; 4fc9: 8c e0 fe    ... :0450[2]
+    lda tube_entry_flags,x                                            ; 4fcc: bd 18 05    ... :0453[2]
+    sta tube_host_r1_status                                           ; 4fcf: 8d e0 fe    ... :0456[2]
+    lsr a                                                             ; 4fd2: 4a          J   :0459[2]
+    lsr a                                                             ; 4fd3: 4a          J   :045a[2]
+    bcc c0463                                                         ; 4fd4: 90 06       ..  :045b[2]
+    bit tube_host_r3_data                                             ; 4fd6: 2c e5 fe    ,.. :045d[2]
+    bit tube_host_r3_data                                             ; 4fd9: 2c e5 fe    ,.. :0460[2]
+; &4fdc referenced 1 time by &045b
+.c0463
+    jsr write_tube_r4_data                                            ; 4fdc: 20 9e 06     .. :0463[2]
+; &4fdf referenced 1 time by &0469
+.loop_c0466
+    bit tube_host_r4_status                                           ; 4fdf: 2c e6 fe    ,.. :0466[2]
+    bvc loop_c0466                                                    ; 4fe2: 50 fb       P.  :0469[2]
+    bcs c047a                                                         ; 4fe4: b0 0d       ..  :046b[2]
+    cpx #4                                                            ; 4fe6: e0 04       ..  :046d[2]
+    bne c0482                                                         ; 4fe8: d0 11       ..  :046f[2]
+; &4fea referenced 1 time by &048f
+.loop_c0471
+    jsr sub_c0414                                                     ; 4fea: 20 14 04     .. :0471[2]
+    jsr write_tube_r2_data                                            ; 4fed: 20 95 06     .. :0474[2]
+    jmp c0032                                                         ; 4ff0: 4c 32 00    L2. :0477[2]
+
+; &4ff3 referenced 1 time by &046b
+.c047a
+    lsr a                                                             ; 4ff3: 4a          J   :047a[2]
+    bcc c0482                                                         ; 4ff4: 90 05       ..  :047b[2]
+    ldy #&88                                                          ; 4ff6: a0 88       ..  :047d[2]
+    sty tube_host_r1_status                                           ; 4ff8: 8c e0 fe    ... :047f[2]
+; &4ffb referenced 2 times by &046f, &047b
+.c0482
+    plp                                                               ; 4ffb: 28          (   :0482[2]
+    rts                                                               ; 4ffc: 60          `   :0483[2]
+
+; &4ffd referenced 1 time by &0400
+.c0484
+    cli                                                               ; 4ffd: 58          X   :0484[2]
+    bcs c0491                                                         ; 4ffe: b0 0a       ..  :0485[2]
+    bne c048c                                                         ; 5000: d0 03       ..  :0487[2]
+    jmp c059c                                                         ; 5002: 4c 9c 05    L.. :0489[2]
+
+; &5005 referenced 1 time by &0487
+.c048c
+    ldx l028d                                                         ; 5005: ae 8d 02    ... :048c[2]
+    beq loop_c0471                                                    ; 5008: f0 e0       ..  :048f[2]
+; &500a referenced 2 times by &0485, &0496
+.c0491
+    lda #&ff                                                          ; 500a: a9 ff       ..  :0491[2]
+    jsr tube_entry                                                    ; 500c: 20 06 04     .. :0493[2]
+    bcc c0491                                                         ; 500f: 90 f9       ..  :0496[2]
+    jsr sub_c04ce                                                     ; 5011: 20 ce 04     .. :0498[2]
+; &5014 referenced 1 time by &04c0
+.c049b
+    php                                                               ; 5014: 08          .   :049b[2]
+    sei                                                               ; 5015: 78          x   :049c[2]
+    lda #7                                                            ; 5016: a9 07       ..  :049d[2]
+    jsr sub_c04c7                                                     ; 5018: 20 c7 04     .. :049f[2]
+    ldy #0                                                            ; 501b: a0 00       ..  :04a2[2]
+    sty l0000                                                         ; 501d: 84 00       ..  :04a4[2]
+; &501f referenced 1 time by &04af
+.loop_c04a6
+    lda (l0000),y                                                     ; 501f: b1 00       ..  :04a6[2]
+    sta tube_host_r3_data                                             ; 5021: 8d e5 fe    ... :04a8[2]
+    nop                                                               ; 5024: ea          .   :04ab[2]
+    nop                                                               ; 5025: ea          .   :04ac[2]
+    nop                                                               ; 5026: ea          .   :04ad[2]
+    iny                                                               ; 5027: c8          .   :04ae[2]
+    bne loop_c04a6                                                    ; 5028: d0 f5       ..  :04af[2]
+    plp                                                               ; 502a: 28          (   :04b1[2]
+    inc l0054                                                         ; 502b: e6 54       .T  :04b2[2]
+    bne c04bc                                                         ; 502d: d0 06       ..  :04b4[2]
+    inc l0055                                                         ; 502f: e6 55       .U  :04b6[2]
+    bne c04bc                                                         ; 5031: d0 02       ..  :04b8[2]
+    inc l0056                                                         ; 5033: e6 56       .V  :04ba[2]
+; &5035 referenced 2 times by &04b4, &04b8
+.c04bc
+    inc l0001                                                         ; 5035: e6 01       ..  :04bc[2]
+    bit l0001                                                         ; 5037: 24 01       $.  :04be[2]
+    bvc c049b                                                         ; 5039: 50 d9       P.  :04c0[2]
+    jsr sub_c04ce                                                     ; 503b: 20 ce 04     .. :04c2[2]
+    lda #4                                                            ; 503e: a9 04       ..  :04c5[2]
+; &5040 referenced 1 time by &049f
+.sub_c04c7
+    ldy #0                                                            ; 5040: a0 00       ..  :04c7[2]
+    ldx #&53 ; 'S'                                                    ; 5042: a2 53       .S  :04c9[2]
+    jmp tube_entry                                                    ; 5044: 4c 06 04    L.. :04cb[2]
+
+; &5047 referenced 2 times by &0498, &04c2
+.sub_c04ce
+    lda #&80                                                          ; 5047: a9 80       ..  :04ce[2]
+    sta l0054                                                         ; 5049: 85 54       .T  :04d0[2]
+    sta l0001                                                         ; 504b: 85 01       ..  :04d2[2]
+    lda #&20 ; ' '                                                    ; 504d: a9 20       .   :04d4[2]
+    and rom_type                                                      ; 504f: 2d 06 80    -.. :04d6[2]
+    tay                                                               ; 5052: a8          .   :04d9[2]
+    sty l0053                                                         ; 5053: 84 53       .S  :04da[2]
+    beq c04f7                                                         ; 5055: f0 19       ..  :04dc[2]
+    ldx copyright_offset                                              ; 5057: ae 07 80    ... :04de[2]
+; &505a referenced 1 time by &04e5
+.loop_c04e1
+    inx                                                               ; 505a: e8          .   :04e1[2]
+    lda rom_header,x                                                  ; 505b: bd 00 80    ... :04e2[2]
+    bne loop_c04e1                                                    ; 505e: d0 fa       ..  :04e5[2]
+    lda l8001,x                                                       ; 5060: bd 01 80    ... :04e7[2]
+    sta l0053                                                         ; 5063: 85 53       .S  :04ea[2]
+    lda l8002,x                                                       ; 5065: bd 02 80    ... :04ec[2]
+    sta l0054                                                         ; 5068: 85 54       .T  :04ef[2]
+    ldy service_entry,x                                               ; 506a: bc 03 80    ... :04f1[2]
+    lda l8004,x                                                       ; 506d: bd 04 80    ... :04f4[2]
+; &5070 referenced 1 time by &04dc
+.c04f7
+    sta l0056                                                         ; 5070: 85 56       .V  :04f7[2]
+    sty l0055                                                         ; 5072: 84 55       .U  :04f9[2]
+    rts                                                               ; 5074: 60          `   :04fb[2]
+
+; &5075 referenced 1 time by &b2b4
+    org c4f79 + (l04fc - c0400)
+    copyblock c0400, l04fc, c4f79
+    clear c0400, l04fc
+
+; &5075 referenced 1 time by &b2b4
+; &5075 referenced 1 time by &b2b4
+
+    org &b075
+; &5075 referenced 1 time by &b2b4
+.lb075
+    equb &0a                                                          ; 5075: 0a          .   :b075[1]
+    equs "SRAM 1.05"                                                  ; 5076: 53 52 41... SRA :b076[1]
+    equb &0d, &0a                                                     ; 507f: 0d 0a       ..  :b07f[1]
+    equs "  SRDATA  <id.>"                                            ; 5081: 20 20 53...   S :b081[1]
+    equb &0d, &0a                                                     ; 5090: 0d 0a       ..  :b090[1]
+    equs "  SRLOAD  <filename> <sram address> (<id.>) (Q)"            ; 5092: 20 20 53...   S :b092[1]
+    equb &0d, &0a                                                     ; 50c1: 0d 0a       ..  :b0c1[1]
+    equs "  SRREAD  <dest. start> <dest. end> <sram start> (<id.>)"   ; 50c3: 20 20 53...   S :b0c3[1]
+    equb &0d, &0a                                                     ; 50fb: 0d 0a       ..  :b0fb[1]
+    equs "  SRROM   <id.>"                                            ; 50fd: 20 20 53...   S :b0fd[1]
+    equb &0d, &0a                                                     ; 510c: 0d 0a       ..  :b10c[1]
+    equs "  SRSAVE  <filename> <sram start> <sram end> (<id.>) (Q)"   ; 510e: 20 20 53...   S :b10e[1]
+    equb &0d, &0a                                                     ; 5146: 0d 0a       ..  :b146[1]
+    equs "  SRWRITE <source start> <source end> <sram s"              ; 5148: 20 20 53...   S :b148[1]
+; &5175 referenced 1 time by &b2bd
+.lb175
+    equs "tart> (<id.>)"                                              ; 5175: 74 61 72... tar :b175[1]
+    equb &0d, &0a                                                     ; 5182: 0d 0a       ..  :b182[1]
+    equs "End addresses may be replaced by +<length>"                 ; 5184: 45 6e 64... End :b184[1]
+    equb &0d, &0a,   0                                                ; 51ae: 0d 0a 00    ... :b1ae[1]
+
+; &51b1 referenced 1 time by &bedd
+.general_service_handler
+    jsr sub_c965d                                                     ; 51b1: 20 5d 96     ]. :b1b1[1]
+    pha                                                               ; 51b4: 48          H   :b1b4[1]
+    tax                                                               ; 51b5: aa          .   :b1b5[1]
+    lda l00b8                                                         ; 51b6: a5 b8       ..  :b1b6[1]
+    pha                                                               ; 51b8: 48          H   :b1b8[1]
+    lda l00b9                                                         ; 51b9: a5 b9       ..  :b1b9[1]
+    pha                                                               ; 51bb: 48          H   :b1bb[1]
+    tya                                                               ; 51bc: 98          .   :b1bc[1]
+    pha                                                               ; 51bd: 48          H   :b1bd[1]
+    txa                                                               ; 51be: 8a          .   :b1be[1]
+    ldx romsel_copy                                                   ; 51bf: a6 f4       ..  :b1bf[1]
+    jsr cb82b                                                         ; 51c1: 20 2b b8     +. :b1c1[1]
+    bit l00b9                                                         ; 51c4: 24 b9       $.  :b1c4[1]
+    bmi cb203                                                         ; 51c6: 30 3b       0;  :b1c6[1]
+    cmp #8                                                            ; 51c8: c9 08       ..  :b1c8[1]
+    bne cb1fc                                                         ; 51ca: d0 30       .0  :b1ca[1]
+    lda l00ef                                                         ; 51cc: a5 ef       ..  :b1cc[1]
+    cmp #&43 ; 'C'                                                    ; 51ce: c9 43       .C  :b1ce[1]
+    bne cb1dd                                                         ; 51d0: d0 0b       ..  :b1d0[1]
+    jsr sub_cb2c8                                                     ; 51d2: 20 c8 b2     .. :b1d2[1]
+; &51d5 referenced 3 times by &b1f9, &b231, &b25d
+.cb1d5
+    tsx                                                               ; 51d5: ba          .   :b1d5[1]
+    lda #0                                                            ; 51d6: a9 00       ..  :b1d6[1]
+    sta l0104,x                                                       ; 51d8: 9d 04 01    ... :b1d8[1]
+    beq cb203                                                         ; 51db: f0 26       .&  :b1db[1]
+; &51dd referenced 1 time by &b1d0
+.cb1dd
+    cmp #&42 ; 'B'                                                    ; 51dd: c9 42       .B  :b1dd[1]
+    bne cb203                                                         ; 51df: d0 22       ."  :b1df[1]
+    ldy #9                                                            ; 51e1: a0 09       ..  :b1e1[1]
+; &51e3 referenced 1 time by &b1eb
+.loop_cb1e3
+    lda (l00f0),y                                                     ; 51e3: b1 f0       ..  :b1e3[1]
+    sta l00b4,y                                                       ; 51e5: 99 b4 00    ... :b1e5[1]
+    dey                                                               ; 51e8: 88          .   :b1e8[1]
+    cpy #8                                                            ; 51e9: c0 08       ..  :b1e9[1]
+    bcs loop_cb1e3                                                    ; 51eb: b0 f6       ..  :b1eb[1]
+; &51ed referenced 1 time by &b1f3
+.loop_cb1ed
+    lda (l00f0),y                                                     ; 51ed: b1 f0       ..  :b1ed[1]
+    sta l00b0,y                                                       ; 51ef: 99 b0 00    ... :b1ef[1]
+    dey                                                               ; 51f2: 88          .   :b1f2[1]
+    bpl loop_cb1ed                                                    ; 51f3: 10 f8       ..  :b1f3[1]
+    cli                                                               ; 51f5: 58          X   :b1f5[1]
+    jsr cbcb9                                                         ; 51f6: 20 b9 bc     .. :b1f6[1]
+    jmp cb1d5                                                         ; 51f9: 4c d5 b1    L.. :b1f9[1]
+
+; &51fc referenced 1 time by &b1ca
+.cb1fc
+    cmp #2                                                            ; 51fc: c9 02       ..  :b1fc[1]
+    bne cb20f                                                         ; 51fe: d0 0f       ..  :b1fe[1]
+    jsr sub_cb882                                                     ; 5200: 20 82 b8     .. :b200[1]
+; &5203 referenced 10 times by &b1c6, &b1db, &b1df, &b219, &b21e, &b228, &b22c, &b262, &b26a, &b280
+.cb203
+    pla                                                               ; 5203: 68          h   :b203[1]
+    tay                                                               ; 5204: a8          .   :b204[1]
+    pla                                                               ; 5205: 68          h   :b205[1]
+    sta l00b9                                                         ; 5206: 85 b9       ..  :b206[1]
+    pla                                                               ; 5208: 68          h   :b208[1]
+    sta l00b8                                                         ; 5209: 85 b8       ..  :b209[1]
+    pla                                                               ; 520b: 68          h   :b20b[1]
+    ldx romsel_copy                                                   ; 520c: a6 f4       ..  :b20c[1]
+    rts                                                               ; 520e: 60          `   :b20e[1]
+
+; &520f referenced 1 time by &b1fe
+.cb20f
+    cmp #6                                                            ; 520f: c9 06       ..  :b20f[1]
+    bne cb221                                                         ; 5211: d0 0e       ..  :b211[1]
+    ldy #&ff                                                          ; 5213: a0 ff       ..  :b213[1]
+    lda (l00b8),y                                                     ; 5215: b1 b8       ..  :b215[1]
+    cmp #&4e ; 'N'                                                    ; 5217: c9 4e       .N  :b217[1]
+    bne cb203                                                         ; 5219: d0 e8       ..  :b219[1]
+    jsr sub_cb5f2                                                     ; 521b: 20 f2 b5     .. :b21b[1]
+    jmp cb203                                                         ; 521e: 4c 03 b2    L.. :b21e[1]
+
+; &5221 referenced 1 time by &b211
+.cb221
+    cmp #4                                                            ; 5221: c9 04       ..  :b221[1]
+    bne cb23d                                                         ; 5223: d0 18       ..  :b223[1]
+    jsr sub_cb9f5                                                     ; 5225: 20 f5 b9     .. :b225[1]
+    bcs cb203                                                         ; 5228: b0 d9       ..  :b228[1]
+    cpx #4                                                            ; 522a: e0 04       ..  :b22a[1]
+    beq cb203                                                         ; 522c: f0 d5       ..  :b22c[1]
+    jsr sub_cb234                                                     ; 522e: 20 34 b2     4. :b22e[1]
+    jmp cb1d5                                                         ; 5231: 4c d5 b1    L.. :b231[1]
+
+; &5234 referenced 1 time by &b22e
+.sub_cb234
+    lda sram_table,x                                                  ; 5234: bd 30 ba    .0. :b234[1]
+    pha                                                               ; 5237: 48          H   :b237[1]
+    lda sram_table+1,x                                                ; 5238: bd 31 ba    .1. :b238[1]
+    pha                                                               ; 523b: 48          H   :b23b[1]
+    rts                                                               ; 523c: 60          `   :b23c[1]
+
+; &523d referenced 1 time by &b223
+.cb23d
+    cmp #7                                                            ; 523d: c9 07       ..  :b23d[1]
+    bne cb268                                                         ; 523f: d0 27       .'  :b23f[1]
+    lda l00ef                                                         ; 5241: a5 ef       ..  :b241[1]
+    cmp #&44 ; 'D'                                                    ; 5243: c9 44       .D  :b243[1]
+    bne cb260                                                         ; 5245: d0 19       ..  :b245[1]
+    ldy #&ee                                                          ; 5247: a0 ee       ..  :b247[1]
+; &5249 referenced 1 time by &b266
+.loop_cb249
+    lda (l00b8),y                                                     ; 5249: b1 b8       ..  :b249[1]
+    and #&3f ; '?'                                                    ; 524b: 29 3f       )?  :b24b[1]
+    sta l00b0                                                         ; 524d: 85 b0       ..  :b24d[1]
+    ldy #&fe                                                          ; 524f: a0 fe       ..  :b24f[1]
+    lda (l00b8),y                                                     ; 5251: b1 b8       ..  :b251[1]
+    and #8                                                            ; 5253: 29 08       ).  :b253[1]
+    asl a                                                             ; 5255: 0a          .   :b255[1]
+    asl a                                                             ; 5256: 0a          .   :b256[1]
+    asl a                                                             ; 5257: 0a          .   :b257[1]
+    asl a                                                             ; 5258: 0a          .   :b258[1]
+    ora l00b0                                                         ; 5259: 05 b0       ..  :b259[1]
+    sta l00f0                                                         ; 525b: 85 f0       ..  :b25b[1]
+    jmp cb1d5                                                         ; 525d: 4c d5 b1    L.. :b25d[1]
+
+; &5260 referenced 1 time by &b245
+.cb260
+    cmp #&45 ; 'E'                                                    ; 5260: c9 45       .E  :b260[1]
+    bne cb203                                                         ; 5262: d0 9f       ..  :b262[1]
+    ldy #&fd                                                          ; 5264: a0 fd       ..  :b264[1]
+    bne loop_cb249                                                    ; 5266: d0 e1       ..  :b266[1]
+; &5268 referenced 1 time by &b23f
+.cb268
+    cmp #9                                                            ; 5268: c9 09       ..  :b268[1]
+    bne cb203                                                         ; 526a: d0 97       ..  :b26a[1]
+    lda #&0d                                                          ; 526c: a9 0d       ..  :b26c[1]
+    jsr sub_cbac4                                                     ; 526e: 20 c4 ba     .. :b26e[1]
+    bcs cb297                                                         ; 5271: b0 24       .$  :b271[1]
+    ldx #0                                                            ; 5273: a2 00       ..  :b273[1]
+; &5275 referenced 1 time by &b27e
+.loop_cb275
+    lda lb283,x                                                       ; 5275: bd 83 b2    ... :b275[1]
+    jsr oswrch                                                        ; 5278: 20 ee ff     .. :b278[1]
+    inx                                                               ; 527b: e8          .   :b27b[1]
+    cpx #&14                                                          ; 527c: e0 14       ..  :b27c[1]
+    bne loop_cb275                                                    ; 527e: d0 f5       ..  :b27e[1]
+; &5280 referenced 2 times by &b2a6, &b2c0
+.cb280
+    jmp cb203                                                         ; 5280: 4c 03 b2    L.. :b280[1]
+
+; &5283 referenced 1 time by &b275
+.lb283
+    equb &0a                                                          ; 5283: 0a          .   :b283[1]
+    equs "SRAM 1.05"                                                  ; 5284: 53 52 41... SRA :b284[1]
+    equb &0d, &0a                                                     ; 528d: 0d 0a       ..  :b28d[1]
+    equs "  SRAM"                                                     ; 528f: 20 20 53...   S :b28f[1]
+    equb &0d, &0a                                                     ; 5295: 0d 0a       ..  :b295[1]
+
+; &5297 referenced 2 times by &b271, &b2b0
+.cb297
+    jsr sub_cb9f5                                                     ; 5297: 20 f5 b9     .. :b297[1]
+    cpx #4                                                            ; 529a: e0 04       ..  :b29a[1]
+    beq cb2b2                                                         ; 529c: f0 14       ..  :b29c[1]
+    lda #0                                                            ; 529e: a9 00       ..  :b29e[1]
+; &52a0 referenced 2 times by &b2aa, &b2ae
+.cb2a0
+    tax                                                               ; 52a0: aa          .   :b2a0[1]
+    iny                                                               ; 52a1: c8          .   :b2a1[1]
+    lda (os_text_ptr),y                                               ; 52a2: b1 f2       ..  :b2a2[1]
+    cmp #&0d                                                          ; 52a4: c9 0d       ..  :b2a4[1]
+    beq cb280                                                         ; 52a6: f0 d8       ..  :b2a6[1]
+    cmp #&20 ; ' '                                                    ; 52a8: c9 20       .   :b2a8[1]
+    beq cb2a0                                                         ; 52aa: f0 f4       ..  :b2aa[1]
+    cpx #&20 ; ' '                                                    ; 52ac: e0 20       .   :b2ac[1]
+    bne cb2a0                                                         ; 52ae: d0 f0       ..  :b2ae[1]
+    beq cb297                                                         ; 52b0: f0 e5       ..  :b2b0[1]
+; &52b2 referenced 1 time by &b29c
+.cb2b2
+    ldy #0                                                            ; 52b2: a0 00       ..  :b2b2[1]
+; &52b4 referenced 1 time by &b2bb
+.loop_cb2b4
+    lda lb075,y                                                       ; 52b4: b9 75 b0    .u. :b2b4[1]
+    jsr oswrch                                                        ; 52b7: 20 ee ff     .. :b2b7[1]
+    iny                                                               ; 52ba: c8          .   :b2ba[1]
+    bne loop_cb2b4                                                    ; 52bb: d0 f7       ..  :b2bb[1]
+; &52bd referenced 1 time by &b2c6
+.loop_cb2bd
+    lda lb175,y                                                       ; 52bd: b9 75 b1    .u. :b2bd[1]
+    beq cb280                                                         ; 52c0: f0 be       ..  :b2c0[1]
+    jsr oswrch                                                        ; 52c2: 20 ee ff     .. :b2c2[1]
+    iny                                                               ; 52c5: c8          .   :b2c5[1]
+    bne loop_cb2bd                                                    ; 52c6: d0 f5       ..  :b2c6[1]
+; &52c8 referenced 1 time by &b1d2
+.sub_cb2c8
+    jsr cb82b                                                         ; 52c8: 20 2b b8     +. :b2c8[1]
+    lda #&ee                                                          ; 52cb: a9 ee       ..  :b2cb[1]
+    sta l00b8                                                         ; 52cd: 85 b8       ..  :b2cd[1]
+    ldy #&0b                                                          ; 52cf: a0 0b       ..  :b2cf[1]
+; &52d1 referenced 1 time by &b2e4
+.loop_cb2d1
+    lda (l00f0),y                                                     ; 52d1: b1 f0       ..  :b2d1[1]
+    cpy #0                                                            ; 52d3: c0 00       ..  :b2d3[1]
+    bne cb2e1                                                         ; 52d5: d0 0a       ..  :b2d5[1]
+    and #&c0                                                          ; 52d7: 29 c0       ).  :b2d7[1]
+    sta l00bc                                                         ; 52d9: 85 bc       ..  :b2d9[1]
+    lda (l00b8),y                                                     ; 52db: b1 b8       ..  :b2db[1]
+    and #&3f ; '?'                                                    ; 52dd: 29 3f       )?  :b2dd[1]
+    ora l00bc                                                         ; 52df: 05 bc       ..  :b2df[1]
+; &52e1 referenced 1 time by &b2d5
+.cb2e1
+    sta (l00b8),y                                                     ; 52e1: 91 b8       ..  :b2e1[1]
+    dey                                                               ; 52e3: 88          .   :b2e3[1]
+    bpl loop_cb2d1                                                    ; 52e4: 10 eb       ..  :b2e4[1]
+    cli                                                               ; 52e6: 58          X   :b2e6[1]
+; &52e7 referenced 1 time by &bbcd
+.cb2e7
+    jsr cb82b                                                         ; 52e7: 20 2b b8     +. :b2e7[1]
+    ldy #&f2                                                          ; 52ea: a0 f2       ..  :b2ea[1]
+    lda (l00b8),y                                                     ; 52ec: b1 b8       ..  :b2ec[1]
+    tax                                                               ; 52ee: aa          .   :b2ee[1]
+    iny                                                               ; 52ef: c8          .   :b2ef[1]
+    lda (l00b8),y                                                     ; 52f0: b1 b8       ..  :b2f0[1]
+    jsr sub_cb85d                                                     ; 52f2: 20 5d b8     ]. :b2f2[1]
+    bvs cb305                                                         ; 52f5: 70 0e       p.  :b2f5[1]
+    ldy #&f1                                                          ; 52f7: a0 f1       ..  :b2f7[1]
+    lda (l00b8),y                                                     ; 52f9: b1 b8       ..  :b2f9[1]
+    tay                                                               ; 52fb: a8          .   :b2fb[1]
+    cpy #&14                                                          ; 52fc: c0 14       ..  :b2fc[1]
+    bcc cb314                                                         ; 52fe: 90 14       ..  :b2fe[1]
+; &5300 referenced 2 times by &b324, &bcd3
+.cb300
+    ldx #0                                                            ; 5300: a2 00       ..  :b300[1]
+    jmp cb8fb                                                         ; 5302: 4c fb b8    L.. :b302[1]
+
+; &5305 referenced 1 time by &b2f5
+.cb305
+    jsr sub_cb6b1                                                     ; 5305: 20 b1 b6     .. :b305[1]
+    sty l00ba                                                         ; 5308: 84 ba       ..  :b308[1]
+    ldy #&f3                                                          ; 530a: a0 f3       ..  :b30a[1]
+    sta (l00b8),y                                                     ; 530c: 91 b8       ..  :b30c[1]
+    txa                                                               ; 530e: 8a          .   :b30e[1]
+    dey                                                               ; 530f: 88          .   :b30f[1]
+    sta (l00b8),y                                                     ; 5310: 91 b8       ..  :b310[1]
+    ldy l00ba                                                         ; 5312: a4 ba       ..  :b312[1]
+; &5314 referenced 1 time by &b2fe
+.cb314
+    jsr sub_cb6fe                                                     ; 5314: 20 fe b6     .. :b314[1]
+    tax                                                               ; 5317: aa          .   :b317[1]
+    tya                                                               ; 5318: 98          .   :b318[1]
+    ldy #&f1                                                          ; 5319: a0 f1       ..  :b319[1]
+    sta (l00b8),y                                                     ; 531b: 91 b8       ..  :b31b[1]
+    txa                                                               ; 531d: 8a          .   :b31d[1]
+    ldy #&ee                                                          ; 531e: a0 ee       ..  :b31e[1]
+    eor (l00b8),y                                                     ; 5320: 51 b8       Q.  :b320[1]
+    and #&40 ; '@'                                                    ; 5322: 29 40       )@  :b322[1]
+    bne cb300                                                         ; 5324: d0 da       ..  :b324[1]
+    tay                                                               ; 5326: a8          .   :b326[1]
+    ldx #&ba                                                          ; 5327: a2 ba       ..  :b327[1]
+    jsr osargs                                                        ; 5329: 20 da ff     .. :b329[1]
+    jsr cb82b                                                         ; 532c: 20 2b b8     +. :b32c[1]
+    tax                                                               ; 532f: aa          .   :b32f[1]
+    bne cb337                                                         ; 5330: d0 05       ..  :b330[1]
+    ldx #2                                                            ; 5332: a2 02       ..  :b332[1]
+    jmp cb8fb                                                         ; 5334: 4c fb b8    L.. :b334[1]
+
+; &5337 referenced 1 time by &b330
+.cb337
+    pha                                                               ; 5337: 48          H   :b337[1]
+    jsr sub_cbe9d                                                     ; 5338: 20 9d be     .. :b338[1]
+    pla                                                               ; 533b: 68          h   :b33b[1]
+    cmp #4                                                            ; 533c: c9 04       ..  :b33c[1]
+    bcs cb3ba                                                         ; 533e: b0 7a       .z  :b33e[1]
+    jsr sub_cb85d                                                     ; 5340: 20 5d b8     ]. :b340[1]
+    bpl cb375                                                         ; 5343: 10 30       .0  :b343[1]
+    jsr sub_cb5ce                                                     ; 5345: 20 ce b5     .. :b345[1]
+    jsr sub_cb607                                                     ; 5348: 20 07 b6     .. :b348[1]
+    bne cb371                                                         ; 534b: d0 24       .$  :b34b[1]
+    beq cb352                                                         ; 534d: f0 03       ..  :b34d[1]
+; &534f referenced 1 time by &b36f
+.cb34f
+    jsr sub_cb65f                                                     ; 534f: 20 5f b6     _. :b34f[1]
+; &5352 referenced 1 time by &b34d
+.cb352
+    ldy #&fa                                                          ; 5352: a0 fa       ..  :b352[1]
+    lda (l00b8),y                                                     ; 5354: b1 b8       ..  :b354[1]
+    tay                                                               ; 5356: a8          .   :b356[1]
+    jsr osbget                                                        ; 5357: 20 d7 ff     .. :b357[1]
+    jsr cb82b                                                         ; 535a: 20 2b b8     +. :b35a[1]
+    ldy #&f2                                                          ; 535d: a0 f2       ..  :b35d[1]
+    jsr sub_cb83f                                                     ; 535f: 20 3f b8     ?. :b35f[1]
+    tax                                                               ; 5362: aa          .   :b362[1]
+    ldy #&f1                                                          ; 5363: a0 f1       ..  :b363[1]
+    lda (l00b8),y                                                     ; 5365: b1 b8       ..  :b365[1]
+    tay                                                               ; 5367: a8          .   :b367[1]
+    txa                                                               ; 5368: 8a          .   :b368[1]
+    jsr sub_cb745                                                     ; 5369: 20 45 b7     E. :b369[1]
+    jsr sub_cb607                                                     ; 536c: 20 07 b6     .. :b36c[1]
+    beq cb34f                                                         ; 536f: f0 de       ..  :b36f[1]
+; &5371 referenced 3 times by &b34b, &b37b, &b3b8
+.cb371
+    jsr sub_cb5f2                                                     ; 5371: 20 f2 b5     .. :b371[1]
+    rts                                                               ; 5374: 60          `   :b374[1]
+
+; &5375 referenced 1 time by &b343
+.cb375
+    jsr sub_cb5ee                                                     ; 5375: 20 ee b5     .. :b375[1]
+    jsr sub_cb616                                                     ; 5378: 20 16 b6     .. :b378[1]
+    beq cb371                                                         ; 537b: f0 f4       ..  :b37b[1]
+    bne cb382                                                         ; 537d: d0 03       ..  :b37d[1]
+; &537f referenced 1 time by &b3b6
+.cb37f
+    jsr sub_cb65f                                                     ; 537f: 20 5f b6     _. :b37f[1]
+; &5382 referenced 1 time by &b37d
+.cb382
+    ldy #&f4                                                          ; 5382: a0 f4       ..  :b382[1]
+    lda (l00b8),y                                                     ; 5384: b1 b8       ..  :b384[1]
+    sec                                                               ; 5386: 38          8   :b386[1]
+    sbc #1                                                            ; 5387: e9 01       ..  :b387[1]
+    sta (l00b8),y                                                     ; 5389: 91 b8       ..  :b389[1]
+    cmp #&ff                                                          ; 538b: c9 ff       ..  :b38b[1]
+    bne cb397                                                         ; 538d: d0 08       ..  :b38d[1]
+    iny                                                               ; 538f: c8          .   :b38f[1]
+    lda (l00b8),y                                                     ; 5390: b1 b8       ..  :b390[1]
+    sec                                                               ; 5392: 38          8   :b392[1]
+    sbc #1                                                            ; 5393: e9 01       ..  :b393[1]
+    sta (l00b8),y                                                     ; 5395: 91 b8       ..  :b395[1]
+; &5397 referenced 1 time by &b38d
+.cb397
+    ldx #&f6                                                          ; 5397: a2 f6       ..  :b397[1]
+    ldy #&f2                                                          ; 5399: a0 f2       ..  :b399[1]
+    jsr sub_cb841                                                     ; 539b: 20 41 b8     A. :b39b[1]
+    ldy #&f1                                                          ; 539e: a0 f1       ..  :b39e[1]
+    lda (l00b8),y                                                     ; 53a0: b1 b8       ..  :b3a0[1]
+    tay                                                               ; 53a2: a8          .   :b3a2[1]
+    jsr osrdsc                                                        ; 53a3: 20 b9 ff     .. :b3a3[1]
+    tax                                                               ; 53a6: aa          .   :b3a6[1]
+    ldy #&fa                                                          ; 53a7: a0 fa       ..  :b3a7[1]
+    lda (l00b8),y                                                     ; 53a9: b1 b8       ..  :b3a9[1]
+    tay                                                               ; 53ab: a8          .   :b3ab[1]
+    txa                                                               ; 53ac: 8a          .   :b3ac[1]
+    jsr osbput                                                        ; 53ad: 20 d4 ff     .. :b3ad[1]
+    jsr cb82b                                                         ; 53b0: 20 2b b8     +. :b3b0[1]
+    jsr sub_cb616                                                     ; 53b3: 20 16 b6     .. :b3b3[1]
+    bne cb37f                                                         ; 53b6: d0 c7       ..  :b3b6[1]
+    beq cb371                                                         ; 53b8: f0 b7       ..  :b3b8[1]
+; &53ba referenced 1 time by &b33e
+.cb3ba
+    ldy #&f9                                                          ; 53ba: a0 f9       ..  :b3ba[1]
+    lda (l00b8),y                                                     ; 53bc: b1 b8       ..  :b3bc[1]
+    bmi cb3de                                                         ; 53be: 30 1e       0.  :b3be[1]
+    dey                                                               ; 53c0: 88          .   :b3c0[1]
+    ora (l00b8),y                                                     ; 53c1: 11 b8       ..  :b3c1[1]
+    bne cb406                                                         ; 53c3: d0 41       .A  :b3c3[1]
+    lda #0                                                            ; 53c5: a9 00       ..  :b3c5[1]
+    sta (l00b8),y                                                     ; 53c7: 91 b8       ..  :b3c7[1]
+    lda #1                                                            ; 53c9: a9 01       ..  :b3c9[1]
+    iny                                                               ; 53cb: c8          .   :b3cb[1]
+    sta (l00b8),y                                                     ; 53cc: 91 b8       ..  :b3cc[1]
+    ldy #&f6                                                          ; 53ce: a0 f6       ..  :b3ce[1]
+    lda #0                                                            ; 53d0: a9 00       ..  :b3d0[1]
+    sta (l00b8),y                                                     ; 53d2: 91 b8       ..  :b3d2[1]
+    ldx l00b9                                                         ; 53d4: a6 b9       ..  :b3d4[1]
+    inx                                                               ; 53d6: e8          .   :b3d6[1]
+    txa                                                               ; 53d7: 8a          .   :b3d7[1]
+    iny                                                               ; 53d8: c8          .   :b3d8[1]
+    sta (l00b8),y                                                     ; 53d9: 91 b8       ..  :b3d9[1]
+    jmp cb406                                                         ; 53db: 4c 06 b4    L.. :b3db[1]
+
+; &53de referenced 1 time by &b3be
+.cb3de
+    lda #osbyte_read_himem                                            ; 53de: a9 84       ..  :b3de[1]
+    jsr osbyte                                                        ; 53e0: 20 f4 ff     .. :b3e0[1]
+    tya                                                               ; 53e3: 98          .   :b3e3[1]
+    pha                                                               ; 53e4: 48          H   :b3e4[1]
+    txa                                                               ; 53e5: 8a          .   :b3e5[1]
+    pha                                                               ; 53e6: 48          H   :b3e6[1]
+    lda #osbyte_read_oshwm                                            ; 53e7: a9 83       ..  :b3e7[1]
+    jsr osbyte                                                        ; 53e9: 20 f4 ff     .. :b3e9[1]
+    jsr cb82b                                                         ; 53ec: 20 2b b8     +. :b3ec[1]
+    stx l00ba                                                         ; 53ef: 86 ba       ..  :b3ef[1]
+    sty l00bb                                                         ; 53f1: 84 bb       ..  :b3f1[1]
+    ldy #&f6                                                          ; 53f3: a0 f6       ..  :b3f3[1]
+    jsr sub_cb84e                                                     ; 53f5: 20 4e b8     N. :b3f5[1]
+    pla                                                               ; 53f8: 68          h   :b3f8[1]
+    sec                                                               ; 53f9: 38          8   :b3f9[1]
+    sbc l00ba                                                         ; 53fa: e5 ba       ..  :b3fa[1]
+    ldy #&f8                                                          ; 53fc: a0 f8       ..  :b3fc[1]
+    sta (l00b8),y                                                     ; 53fe: 91 b8       ..  :b3fe[1]
+    pla                                                               ; 5400: 68          h   :b400[1]
+    sbc l00bb                                                         ; 5401: e5 bb       ..  :b401[1]
+    iny                                                               ; 5403: c8          .   :b403[1]
+    sta (l00b8),y                                                     ; 5404: 91 b8       ..  :b404[1]
+; &5406 referenced 2 times by &b3c3, &b3db
+.cb406
+    jsr sub_cb85d                                                     ; 5406: 20 5d b8     ]. :b406[1]
+    bmi cb40e                                                         ; 5409: 30 03       0.  :b409[1]
+    jmp cb4d8                                                         ; 540b: 4c d8 b4    L.. :b40b[1]
+
+; &540e referenced 1 time by &b409
+.cb40e
+    jsr sub_cb5ce                                                     ; 540e: 20 ce b5     .. :b40e[1]
+    tsx                                                               ; 5411: ba          .   :b411[1]
+    txa                                                               ; 5412: 8a          .   :b412[1]
+    sec                                                               ; 5413: 38          8   :b413[1]
+    sbc #&10                                                          ; 5414: e9 10       ..  :b414[1]
+    tax                                                               ; 5416: aa          .   :b416[1]
+    txs                                                               ; 5417: 9a          .   :b417[1]
+    ldy #&f0                                                          ; 5418: a0 f0       ..  :b418[1]
+    lda (l00b8),y                                                     ; 541a: b1 b8       ..  :b41a[1]
+    pha                                                               ; 541c: 48          H   :b41c[1]
+    dey                                                               ; 541d: 88          .   :b41d[1]
+    lda (l00b8),y                                                     ; 541e: b1 b8       ..  :b41e[1]
+    pha                                                               ; 5420: 48          H   :b420[1]
+    dex                                                               ; 5421: ca          .   :b421[1]
+    ldy #1                                                            ; 5422: a0 01       ..  :b422[1]
+    lda #osfile_read_catalogue_info                                   ; 5424: a9 05       ..  :b424[1]
+    jsr osfile                                                        ; 5426: 20 dd ff     .. :b426[1]
+    jsr cb82b                                                         ; 5429: 20 2b b8     +. :b429[1]
+    tsx                                                               ; 542c: ba          .   :b42c[1]
+    lda l010b,x                                                       ; 542d: bd 0b 01    ... :b42d[1]
+    ldy #&f4                                                          ; 5430: a0 f4       ..  :b430[1]
+    sta (l00b8),y                                                     ; 5432: 91 b8       ..  :b432[1]
+    sta l00ba                                                         ; 5434: 85 ba       ..  :b434[1]
+    lda l010c,x                                                       ; 5436: bd 0c 01    ... :b436[1]
+    iny                                                               ; 5439: c8          .   :b439[1]
+    sta (l00b8),y                                                     ; 543a: 91 b8       ..  :b43a[1]
+    sta l00bb                                                         ; 543c: 85 bb       ..  :b43c[1]
+    lda l010d,x                                                       ; 543e: bd 0d 01    ... :b43e[1]
+    ora l010e,x                                                       ; 5441: 1d 0e 01    ... :b441[1]
+    beq cb44b                                                         ; 5444: f0 05       ..  :b444[1]
+; &5446 referenced 4 times by &b68c, &b6c7, &b715, &bc10
+.cb446
+    ldx #1                                                            ; 5446: a2 01       ..  :b446[1]
+    jmp cb8fb                                                         ; 5448: 4c fb b8    L.. :b448[1]
+
+; &544b referenced 1 time by &b444
+.cb44b
+    ldx #&12                                                          ; 544b: a2 12       ..  :b44b[1]
+; &544d referenced 1 time by &b44f
+.loop_cb44d
+    pla                                                               ; 544d: 68          h   :b44d[1]
+    dex                                                               ; 544e: ca          .   :b44e[1]
+    bne loop_cb44d                                                    ; 544f: d0 fc       ..  :b44f[1]
+    bit lb57f                                                         ; 5451: 2c 7f b5    ,.. :b451[1]
+    lda l00ba                                                         ; 5454: a5 ba       ..  :b454[1]
+    ora l00bb                                                         ; 5456: 05 bb       ..  :b456[1]
+    bne cb45e                                                         ; 5458: d0 04       ..  :b458[1]
+; &545a referenced 1 time by &b4d2
+.cb45a
+    jsr sub_cb5f2                                                     ; 545a: 20 f2 b5     .. :b45a[1]
+    rts                                                               ; 545d: 60          `   :b45d[1]
+
+; &545e referenced 2 times by &b458, &b4d5
+.cb45e
+    ldx #&bc                                                          ; 545e: a2 bc       ..  :b45e[1]
+    ldy #&f8                                                          ; 5460: a0 f8       ..  :b460[1]
+    jsr sub_cb841                                                     ; 5462: 20 41 b8     A. :b462[1]
+    ldy #&ba                                                          ; 5465: a0 ba       ..  :b465[1]
+    jsr sub_cb58b                                                     ; 5467: 20 8b b5     .. :b467[1]
+    bcs cb470                                                         ; 546a: b0 04       ..  :b46a[1]
+    jsr sub_cb580                                                     ; 546c: 20 80 b5     .. :b46c[1]
+    clv                                                               ; 546f: b8          .   :b46f[1]
+; &5470 referenced 1 time by &b46a
+.cb470
+    ldy #&fb                                                          ; 5470: a0 fb       ..  :b470[1]
+    jsr sub_cb84e                                                     ; 5472: 20 4e b8     N. :b472[1]
+    bvc cb4af                                                         ; 5475: 50 38       P8  :b475[1]
+    jsr sub_cb5f2                                                     ; 5477: 20 f2 b5     .. :b477[1]
+    tsx                                                               ; 547a: ba          .   :b47a[1]
+    txa                                                               ; 547b: 8a          .   :b47b[1]
+    sec                                                               ; 547c: 38          8   :b47c[1]
+    sbc #&0b                                                          ; 547d: e9 0b       ..  :b47d[1]
+    tax                                                               ; 547f: aa          .   :b47f[1]
+    txs                                                               ; 5480: 9a          .   :b480[1]
+    lda #0                                                            ; 5481: a9 00       ..  :b481[1]
+    pha                                                               ; 5483: 48          H   :b483[1]
+    lda #&ff                                                          ; 5484: a9 ff       ..  :b484[1]
+    pha                                                               ; 5486: 48          H   :b486[1]
+    pha                                                               ; 5487: 48          H   :b487[1]
+    ldy #&f7                                                          ; 5488: a0 f7       ..  :b488[1]
+    lda (l00b8),y                                                     ; 548a: b1 b8       ..  :b48a[1]
+    pha                                                               ; 548c: 48          H   :b48c[1]
+    dey                                                               ; 548d: 88          .   :b48d[1]
+    lda (l00b8),y                                                     ; 548e: b1 b8       ..  :b48e[1]
+    pha                                                               ; 5490: 48          H   :b490[1]
+    ldy #&f0                                                          ; 5491: a0 f0       ..  :b491[1]
+    lda (l00b8),y                                                     ; 5493: b1 b8       ..  :b493[1]
+    pha                                                               ; 5495: 48          H   :b495[1]
+    dey                                                               ; 5496: 88          .   :b496[1]
+    lda (l00b8),y                                                     ; 5497: b1 b8       ..  :b497[1]
+    pha                                                               ; 5499: 48          H   :b499[1]
+    tsx                                                               ; 549a: ba          .   :b49a[1]
+    inx                                                               ; 549b: e8          .   :b49b[1]
+    ldy #1                                                            ; 549c: a0 01       ..  :b49c[1]
+    lda #osfile_load                                                  ; 549e: a9 ff       ..  :b49e[1]
+    jsr osfile                                                        ; 54a0: 20 dd ff     .. :b4a0[1]
+    jsr cb82b                                                         ; 54a3: 20 2b b8     +. :b4a3[1]
+    ldx #&12                                                          ; 54a6: a2 12       ..  :b4a6[1]
+; &54a8 referenced 1 time by &b4aa
+.loop_cb4a8
+    pla                                                               ; 54a8: 68          h   :b4a8[1]
+    dex                                                               ; 54a9: ca          .   :b4a9[1]
+    bne loop_cb4a8                                                    ; 54aa: d0 fc       ..  :b4aa[1]
+    jmp cb4b4                                                         ; 54ac: 4c b4 b4    L.. :b4ac[1]
+
+; &54af referenced 1 time by &b475
+.cb4af
+    lda #4                                                            ; 54af: a9 04       ..  :b4af[1]
+    jsr sub_cb598                                                     ; 54b1: 20 98 b5     .. :b4b1[1]
+; &54b4 referenced 1 time by &b4ac
+.cb4b4
+    ldx #&b1                                                          ; 54b4: a2 b1       ..  :b4b4[1]
+    ldy #&f6                                                          ; 54b6: a0 f6       ..  :b4b6[1]
+    jsr sub_cb841                                                     ; 54b8: 20 41 b8     A. :b4b8[1]
+    ldx #&b3                                                          ; 54bb: a2 b3       ..  :b4bb[1]
+    ldy #&f2                                                          ; 54bd: a0 f2       ..  :b4bd[1]
+    jsr sub_cb841                                                     ; 54bf: 20 41 b8     A. :b4bf[1]
+    ldx #&be                                                          ; 54c2: a2 be       ..  :b4c2[1]
+    ldy #&fb                                                          ; 54c4: a0 fb       ..  :b4c4[1]
+    jsr sub_cb841                                                     ; 54c6: 20 41 b8     A. :b4c6[1]
+    sec                                                               ; 54c9: 38          8   :b4c9[1]
+    jsr cb795                                                         ; 54ca: 20 95 b7     .. :b4ca[1]
+    ldx #&b3                                                          ; 54cd: a2 b3       ..  :b4cd[1]
+    jsr sub_cb61e                                                     ; 54cf: 20 1e b6     .. :b4cf[1]
+    beq cb45a                                                         ; 54d2: f0 86       ..  :b4d2[1]
+    clv                                                               ; 54d4: b8          .   :b4d4[1]
+    jmp cb45e                                                         ; 54d5: 4c 5e b4    L^. :b4d5[1]
+
+; &54d8 referenced 1 time by &b40b
+.cb4d8
+    jsr sub_cb5ee                                                     ; 54d8: 20 ee b5     .. :b4d8[1]
+    bit lb57f                                                         ; 54db: 2c 7f b5    ,.. :b4db[1]
+    php                                                               ; 54de: 08          .   :b4de[1]
+; &54df referenced 1 time by &b531
+.cb4df
+    ldy #&f4                                                          ; 54df: a0 f4       ..  :b4df[1]
+    jsr sub_cb83f                                                     ; 54e1: 20 3f b8     ?. :b4e1[1]
+    jsr sub_cb616                                                     ; 54e4: 20 16 b6     .. :b4e4[1]
+    bne cb4ee                                                         ; 54e7: d0 05       ..  :b4e7[1]
+; &54e9 referenced 1 time by &b57c
+.cb4e9
+    plp                                                               ; 54e9: 28          (   :b4e9[1]
+    jsr sub_cb5f2                                                     ; 54ea: 20 f2 b5     .. :b4ea[1]
+    rts                                                               ; 54ed: 60          `   :b4ed[1]
+
+; &54ee referenced 1 time by &b4e7
+.cb4ee
+    ldx #&bc                                                          ; 54ee: a2 bc       ..  :b4ee[1]
+    ldy #&f8                                                          ; 54f0: a0 f8       ..  :b4f0[1]
+    jsr sub_cb841                                                     ; 54f2: 20 41 b8     A. :b4f2[1]
+    ldy #&ba                                                          ; 54f5: a0 ba       ..  :b4f5[1]
+    jsr sub_cb58b                                                     ; 54f7: 20 8b b5     .. :b4f7[1]
+    bcs cb502                                                         ; 54fa: b0 06       ..  :b4fa[1]
+    jsr sub_cb580                                                     ; 54fc: 20 80 b5     .. :b4fc[1]
+    plp                                                               ; 54ff: 28          (   :b4ff[1]
+    clv                                                               ; 5500: b8          .   :b500[1]
+    php                                                               ; 5501: 08          .   :b501[1]
+; &5502 referenced 1 time by &b4fa
+.cb502
+    ldy #&fb                                                          ; 5502: a0 fb       ..  :b502[1]
+    jsr sub_cb84e                                                     ; 5504: 20 4e b8     N. :b504[1]
+    ldx #&b1                                                          ; 5507: a2 b1       ..  :b507[1]
+    ldy #&f2                                                          ; 5509: a0 f2       ..  :b509[1]
+    jsr sub_cb841                                                     ; 550b: 20 41 b8     A. :b50b[1]
+    ldx #&b3                                                          ; 550e: a2 b3       ..  :b50e[1]
+    ldy #&f6                                                          ; 5510: a0 f6       ..  :b510[1]
+    jsr sub_cb841                                                     ; 5512: 20 41 b8     A. :b512[1]
+    ldx #&be                                                          ; 5515: a2 be       ..  :b515[1]
+    ldy #&fb                                                          ; 5517: a0 fb       ..  :b517[1]
+    jsr sub_cb841                                                     ; 5519: 20 41 b8     A. :b519[1]
+    clc                                                               ; 551c: 18          .   :b51c[1]
+    jsr cb795                                                         ; 551d: 20 95 b7     .. :b51d[1]
+    ldx #&b1                                                          ; 5520: a2 b1       ..  :b520[1]
+    jsr sub_cb61e                                                     ; 5522: 20 1e b6     .. :b522[1]
+    plp                                                               ; 5525: 28          (   :b525[1]
+    php                                                               ; 5526: 08          .   :b526[1]
+    bvs cb534                                                         ; 5527: 70 0b       p.  :b527[1]
+    lda #2                                                            ; 5529: a9 02       ..  :b529[1]
+    jsr sub_cb598                                                     ; 552b: 20 98 b5     .. :b52b[1]
+    plp                                                               ; 552e: 28          (   :b52e[1]
+    clv                                                               ; 552f: b8          .   :b52f[1]
+    php                                                               ; 5530: 08          .   :b530[1]
+    jmp cb4df                                                         ; 5531: 4c df b4    L.. :b531[1]
+
+; &5534 referenced 1 time by &b527
+.cb534
+    jsr sub_cb5f2                                                     ; 5534: 20 f2 b5     .. :b534[1]
+    lda #&ff                                                          ; 5537: a9 ff       ..  :b537[1]
+    pha                                                               ; 5539: 48          H   :b539[1]
+    pha                                                               ; 553a: 48          H   :b53a[1]
+    ldy #&f6                                                          ; 553b: a0 f6       ..  :b53b[1]
+    jsr sub_cb83f                                                     ; 553d: 20 3f b8     ?. :b53d[1]
+    ldy #&fb                                                          ; 5540: a0 fb       ..  :b540[1]
+    lda l00ba                                                         ; 5542: a5 ba       ..  :b542[1]
+    clc                                                               ; 5544: 18          .   :b544[1]
+    adc (l00b8),y                                                     ; 5545: 71 b8       q.  :b545[1]
+    tax                                                               ; 5547: aa          .   :b547[1]
+    lda l00bb                                                         ; 5548: a5 bb       ..  :b548[1]
+    iny                                                               ; 554a: c8          .   :b54a[1]
+    adc (l00b8),y                                                     ; 554b: 71 b8       q.  :b54b[1]
+    pha                                                               ; 554d: 48          H   :b54d[1]
+    txa                                                               ; 554e: 8a          .   :b54e[1]
+    pha                                                               ; 554f: 48          H   :b54f[1]
+    lda #&ff                                                          ; 5550: a9 ff       ..  :b550[1]
+    pha                                                               ; 5552: 48          H   :b552[1]
+    pha                                                               ; 5553: 48          H   :b553[1]
+    lda l00bb                                                         ; 5554: a5 bb       ..  :b554[1]
+    pha                                                               ; 5556: 48          H   :b556[1]
+    lda l00ba                                                         ; 5557: a5 ba       ..  :b557[1]
+    pha                                                               ; 5559: 48          H   :b559[1]
+    lda #&ff                                                          ; 555a: a9 ff       ..  :b55a[1]
+    ldx #8                                                            ; 555c: a2 08       ..  :b55c[1]
+; &555e referenced 1 time by &b560
+.loop_cb55e
+    pha                                                               ; 555e: 48          H   :b55e[1]
+    dex                                                               ; 555f: ca          .   :b55f[1]
+    bne loop_cb55e                                                    ; 5560: d0 fc       ..  :b560[1]
+    ldy #&f0                                                          ; 5562: a0 f0       ..  :b562[1]
+    lda (l00b8),y                                                     ; 5564: b1 b8       ..  :b564[1]
+    pha                                                               ; 5566: 48          H   :b566[1]
+    dey                                                               ; 5567: 88          .   :b567[1]
+    tsx                                                               ; 5568: ba          .   :b568[1]
+    lda (l00b8),y                                                     ; 5569: b1 b8       ..  :b569[1]
+    pha                                                               ; 556b: 48          H   :b56b[1]
+    ldy #1                                                            ; 556c: a0 01       ..  :b56c[1]
+    lda #osfile_save                                                  ; 556e: a9 00       ..  :b56e[1]
+    jsr osfile                                                        ; 5570: 20 dd ff     .. :b570[1]
+    jsr cb82b                                                         ; 5573: 20 2b b8     +. :b573[1]
+    ldx #&12                                                          ; 5576: a2 12       ..  :b576[1]
+; &5578 referenced 1 time by &b57a
+.loop_cb578
+    pla                                                               ; 5578: 68          h   :b578[1]
+    dex                                                               ; 5579: ca          .   :b579[1]
+    bne loop_cb578                                                    ; 557a: d0 fc       ..  :b57a[1]
+    jmp cb4e9                                                         ; 557c: 4c e9 b4    L.. :b57c[1]
+
+; &557f referenced 4 times by &b451, &b4db, &bae7, &bbda
+.lb57f
+    equb &40                                                          ; 557f: 40          @   :b57f[1]
+
+; &5580 referenced 7 times by &b46c, &b4fc, &bcfd, &bd08, &bd12, &bdaa, &bde4
+.sub_cb580
+    lda l0000,x                                                       ; 5580: b5 00       ..  :b580[1]
+    sta l0000,y                                                       ; 5582: 99 00 00    ... :b582[1]
+    lda l0001,x                                                       ; 5585: b5 01       ..  :b585[1]
+    sta l0001,y                                                       ; 5587: 99 01 00    ... :b587[1]
+    rts                                                               ; 558a: 60          `   :b58a[1]
+
+; &558b referenced 3 times by &b467, &b4f7, &b800
+.sub_cb58b
+    lda l0001,x                                                       ; 558b: b5 01       ..  :b58b[1]
+    cmp l0001,y                                                       ; 558d: d9 01 00    ... :b58d[1]
+    bne cb597                                                         ; 5590: d0 05       ..  :b590[1]
+    lda l0000,x                                                       ; 5592: b5 00       ..  :b592[1]
+    cmp l0000,y                                                       ; 5594: d9 00 00    ... :b594[1]
+; &5597 referenced 1 time by &b590
+.cb597
+    rts                                                               ; 5597: 60          `   :b597[1]
+
+; &5598 referenced 2 times by &b4b1, &b52b
+.sub_cb598
+    pha                                                               ; 5598: 48          H   :b598[1]
+    pha                                                               ; 5599: 48          H   :b599[1]
+    pha                                                               ; 559a: 48          H   :b59a[1]
+    pha                                                               ; 559b: 48          H   :b59b[1]
+    lda #0                                                            ; 559c: a9 00       ..  :b59c[1]
+    pha                                                               ; 559e: 48          H   :b59e[1]
+    pha                                                               ; 559f: 48          H   :b59f[1]
+    ldy #&fc                                                          ; 55a0: a0 fc       ..  :b5a0[1]
+    lda (l00b8),y                                                     ; 55a2: b1 b8       ..  :b5a2[1]
+    pha                                                               ; 55a4: 48          H   :b5a4[1]
+    dey                                                               ; 55a5: 88          .   :b5a5[1]
+    lda (l00b8),y                                                     ; 55a6: b1 b8       ..  :b5a6[1]
+    pha                                                               ; 55a8: 48          H   :b5a8[1]
+    lda #&ff                                                          ; 55a9: a9 ff       ..  :b5a9[1]
+    pha                                                               ; 55ab: 48          H   :b5ab[1]
+    pha                                                               ; 55ac: 48          H   :b5ac[1]
+    ldy #&f7                                                          ; 55ad: a0 f7       ..  :b5ad[1]
+    lda (l00b8),y                                                     ; 55af: b1 b8       ..  :b5af[1]
+    pha                                                               ; 55b1: 48          H   :b5b1[1]
+    dey                                                               ; 55b2: 88          .   :b5b2[1]
+    lda (l00b8),y                                                     ; 55b3: b1 b8       ..  :b5b3[1]
+    pha                                                               ; 55b5: 48          H   :b5b5[1]
+    tsx                                                               ; 55b6: ba          .   :b5b6[1]
+    ldy #&fa                                                          ; 55b7: a0 fa       ..  :b5b7[1]
+    lda (l00b8),y                                                     ; 55b9: b1 b8       ..  :b5b9[1]
+    pha                                                               ; 55bb: 48          H   :b5bb[1]
+    lda l0109,x                                                       ; 55bc: bd 09 01    ... :b5bc[1]
+    ldy #1                                                            ; 55bf: a0 01       ..  :b5bf[1]
+    jsr osgbpb                                                        ; 55c1: 20 d1 ff     .. :b5c1[1]
+    ldx #&0d                                                          ; 55c4: a2 0d       ..  :b5c4[1]
+; &55c6 referenced 1 time by &b5c8
+.loop_cb5c6
+    pla                                                               ; 55c6: 68          h   :b5c6[1]
+    dex                                                               ; 55c7: ca          .   :b5c7[1]
+    bne loop_cb5c6                                                    ; 55c8: d0 fc       ..  :b5c8[1]
+    jsr cb82b                                                         ; 55ca: 20 2b b8     +. :b5ca[1]
+    rts                                                               ; 55cd: 60          `   :b5cd[1]
+
+; &55ce referenced 2 times by &b345, &b40e
+.sub_cb5ce
+    lda #&40 ; '@'                                                    ; 55ce: a9 40       .@  :b5ce[1]
+; &55d0 referenced 1 time by &b5f0
+.cb5d0
+    pha                                                               ; 55d0: 48          H   :b5d0[1]
+    ldy #&ef                                                          ; 55d1: a0 ef       ..  :b5d1[1]
+    lda (l00b8),y                                                     ; 55d3: b1 b8       ..  :b5d3[1]
+    tax                                                               ; 55d5: aa          .   :b5d5[1]
+    iny                                                               ; 55d6: c8          .   :b5d6[1]
+    lda (l00b8),y                                                     ; 55d7: b1 b8       ..  :b5d7[1]
+    tay                                                               ; 55d9: a8          .   :b5d9[1]
+    pla                                                               ; 55da: 68          h   :b5da[1]
+    jsr osfind                                                        ; 55db: 20 ce ff     .. :b5db[1]
+    tax                                                               ; 55de: aa          .   :b5de[1]
+    bne cb5e6                                                         ; 55df: d0 05       ..  :b5df[1]
+    ldx #4                                                            ; 55e1: a2 04       ..  :b5e1[1]
+    jmp cb8fb                                                         ; 55e3: 4c fb b8    L.. :b5e3[1]
+
+; &55e6 referenced 1 time by &b5df
+.cb5e6
+    ldy #&fa                                                          ; 55e6: a0 fa       ..  :b5e6[1]
+    jsr cb82b                                                         ; 55e8: 20 2b b8     +. :b5e8[1]
+    sta (l00b8),y                                                     ; 55eb: 91 b8       ..  :b5eb[1]
+; &55ed referenced 1 time by &b5f6
+.loop_cb5ed
+    rts                                                               ; 55ed: 60          `   :b5ed[1]
+
+; &55ee referenced 2 times by &b375, &b4d8
+.sub_cb5ee
+    lda #&80                                                          ; 55ee: a9 80       ..  :b5ee[1]
+    bne cb5d0                                                         ; 55f0: d0 de       ..  :b5f0[1]
+; &55f2 referenced 6 times by &b21b, &b371, &b45a, &b477, &b4ea, &b534
+.sub_cb5f2
+    ldy #&fa                                                          ; 55f2: a0 fa       ..  :b5f2[1]
+    lda (l00b8),y                                                     ; 55f4: b1 b8       ..  :b5f4[1]
+    beq loop_cb5ed                                                    ; 55f6: f0 f5       ..  :b5f6[1]
+    pha                                                               ; 55f8: 48          H   :b5f8[1]
+    lda #0                                                            ; 55f9: a9 00       ..  :b5f9[1]
+    sta (l00b8),y                                                     ; 55fb: 91 b8       ..  :b5fb[1]
+    pla                                                               ; 55fd: 68          h   :b5fd[1]
+    tay                                                               ; 55fe: a8          .   :b5fe[1]
+    lda #0                                                            ; 55ff: a9 00       ..  :b5ff[1]
+    jsr osfind                                                        ; 5601: 20 ce ff     .. :b601[1]
+    jmp cb82b                                                         ; 5604: 4c 2b b8    L+. :b604[1]
+
+; &5607 referenced 2 times by &b348, &b36c
+.sub_cb607
+    ldy #&fa                                                          ; 5607: a0 fa       ..  :b607[1]
+    lda (l00b8),y                                                     ; 5609: b1 b8       ..  :b609[1]
+    tax                                                               ; 560b: aa          .   :b60b[1]
+    lda #1                                                            ; 560c: a9 01       ..  :b60c[1]
+    jsr sub_cb86f                                                     ; 560e: 20 6f b8     o. :b60e[1]
+    jsr cb82b                                                         ; 5611: 20 2b b8     +. :b611[1]
+    txa                                                               ; 5614: 8a          .   :b614[1]
+    rts                                                               ; 5615: 60          `   :b615[1]
+
+; &5616 referenced 4 times by &b378, &b3b3, &b4e4, &be5d
+.sub_cb616
+    ldy #&f4                                                          ; 5616: a0 f4       ..  :b616[1]
+    lda (l00b8),y                                                     ; 5618: b1 b8       ..  :b618[1]
+    iny                                                               ; 561a: c8          .   :b61a[1]
+    ora (l00b8),y                                                     ; 561b: 11 b8       ..  :b61b[1]
+    rts                                                               ; 561d: 60          `   :b61d[1]
+
+; &561e referenced 2 times by &b4cf, &b522
+.sub_cb61e
+    stx l00bc                                                         ; 561e: 86 bc       ..  :b61e[1]
+    ldy #&fb                                                          ; 5620: a0 fb       ..  :b620[1]
+    jsr sub_cb83f                                                     ; 5622: 20 3f b8     ?. :b622[1]
+    ldy #&f4                                                          ; 5625: a0 f4       ..  :b625[1]
+    lda (l00b8),y                                                     ; 5627: b1 b8       ..  :b627[1]
+    sec                                                               ; 5629: 38          8   :b629[1]
+    sbc l00ba                                                         ; 562a: e5 ba       ..  :b62a[1]
+    sta (l00b8),y                                                     ; 562c: 91 b8       ..  :b62c[1]
+    sta l00ba                                                         ; 562e: 85 ba       ..  :b62e[1]
+    iny                                                               ; 5630: c8          .   :b630[1]
+    lda (l00b8),y                                                     ; 5631: b1 b8       ..  :b631[1]
+    sbc l00bb                                                         ; 5633: e5 bb       ..  :b633[1]
+    sta (l00b8),y                                                     ; 5635: 91 b8       ..  :b635[1]
+    sta l00bb                                                         ; 5637: 85 bb       ..  :b637[1]
+    ora l00ba                                                         ; 5639: 05 ba       ..  :b639[1]
+    beq cb65e                                                         ; 563b: f0 21       .!  :b63b[1]
+    ldx l00bc                                                         ; 563d: a6 bc       ..  :b63d[1]
+    jsr sub_cb85d                                                     ; 563f: 20 5d b8     ]. :b63f[1]
+    bvc cb655                                                         ; 5642: 50 11       P.  :b642[1]
+    lda l0001,x                                                       ; 5644: b5 01       ..  :b644[1]
+    cmp #&c0                                                          ; 5646: c9 c0       ..  :b646[1]
+    bcc cb655                                                         ; 5648: 90 0b       ..  :b648[1]
+    lda #&10                                                          ; 564a: a9 10       ..  :b64a[1]
+    sta l0000,x                                                       ; 564c: 95 00       ..  :b64c[1]
+    lda #&80                                                          ; 564e: a9 80       ..  :b64e[1]
+    sta l0001,x                                                       ; 5650: 95 01       ..  :b650[1]
+    jsr sub_cb68f                                                     ; 5652: 20 8f b6     .. :b652[1]
+; &5655 referenced 2 times by &b642, &b648
+.cb655
+    ldx l00bc                                                         ; 5655: a6 bc       ..  :b655[1]
+    ldy #&f2                                                          ; 5657: a0 f2       ..  :b657[1]
+    jsr sub_cb850                                                     ; 5659: 20 50 b8     P. :b659[1]
+    lda #&ff                                                          ; 565c: a9 ff       ..  :b65c[1]
+; &565e referenced 1 time by &b63b
+.cb65e
+    rts                                                               ; 565e: 60          `   :b65e[1]
+
+; &565f referenced 2 times by &b34f, &b37f
+.sub_cb65f
+    ldx #&bd                                                          ; 565f: a2 bd       ..  :b65f[1]
+    ldy #&f2                                                          ; 5661: a0 f2       ..  :b661[1]
+    jsr sub_cb841                                                     ; 5663: 20 41 b8     A. :b663[1]
+    inc l00bd                                                         ; 5666: e6 bd       ..  :b666[1]
+    bne cb684                                                         ; 5668: d0 1a       ..  :b668[1]
+    inc l00be                                                         ; 566a: e6 be       ..  :b66a[1]
+    beq cb68c                                                         ; 566c: f0 1e       ..  :b66c[1]
+    jsr sub_cb85d                                                     ; 566e: 20 5d b8     ]. :b66e[1]
+    bvc cb684                                                         ; 5671: 50 11       P.  :b671[1]
+    lda l00be                                                         ; 5673: a5 be       ..  :b673[1]
+    cmp #&c0                                                          ; 5675: c9 c0       ..  :b675[1]
+    bne cb684                                                         ; 5677: d0 0b       ..  :b677[1]
+    jsr sub_cb68f                                                     ; 5679: 20 8f b6     .. :b679[1]
+    lda #&10                                                          ; 567c: a9 10       ..  :b67c[1]
+    sta l00bd                                                         ; 567e: 85 bd       ..  :b67e[1]
+    lda #&80                                                          ; 5680: a9 80       ..  :b680[1]
+    sta l00be                                                         ; 5682: 85 be       ..  :b682[1]
+; &5684 referenced 3 times by &b668, &b671, &b677
+.cb684
+    ldx #&bd                                                          ; 5684: a2 bd       ..  :b684[1]
+    ldy #&f2                                                          ; 5686: a0 f2       ..  :b686[1]
+    jsr sub_cb850                                                     ; 5688: 20 50 b8     P. :b688[1]
+    rts                                                               ; 568b: 60          `   :b68b[1]
+
+; &568c referenced 4 times by &b66c, &b698, &b69c, &b6ae
+.cb68c
+    jmp cb446                                                         ; 568c: 4c 46 b4    LF. :b68c[1]
+
+; &568f referenced 4 times by &b652, &b679, &b81f, &be77
+.sub_cb68f
+    ldy #&f1                                                          ; 568f: a0 f1       ..  :b68f[1]
+    lda (l00b8),y                                                     ; 5691: b1 b8       ..  :b691[1]
+    clc                                                               ; 5693: 18          .   :b693[1]
+    adc #1                                                            ; 5694: 69 01       i.  :b694[1]
+    cmp #&10                                                          ; 5696: c9 10       ..  :b696[1]
+    bcs cb68c                                                         ; 5698: b0 f2       ..  :b698[1]
+    cmp #2                                                            ; 569a: c9 02       ..  :b69a[1]
+    beq cb68c                                                         ; 569c: f0 ee       ..  :b69c[1]
+    cmp #&0e                                                          ; 569e: c9 0e       ..  :b69e[1]
+    bne cb6a6                                                         ; 56a0: d0 04       ..  :b6a0[1]
+    ldy #&fe                                                          ; 56a2: a0 fe       ..  :b6a2[1]
+    and (l00b8),y                                                     ; 56a4: 31 b8       1.  :b6a4[1]
+; &56a6 referenced 1 time by &b6a0
+.cb6a6
+    ldy #&f1                                                          ; 56a6: a0 f1       ..  :b6a6[1]
+    sta (l00b8),y                                                     ; 56a8: 91 b8       ..  :b6a8[1]
+    tay                                                               ; 56aa: a8          .   :b6aa[1]
+    jsr sub_cb6fe                                                     ; 56ab: 20 fe b6     .. :b6ab[1]
+    beq cb68c                                                         ; 56ae: f0 dc       ..  :b6ae[1]
+    rts                                                               ; 56b0: 60          `   :b6b0[1]
+
+; &56b1 referenced 2 times by &b305, &bcda
+.sub_cb6b1
+    ldy #&10                                                          ; 56b1: a0 10       ..  :b6b1[1]
+; &56b3 referenced 1 time by &b6c5
+.loop_cb6b3
+    cmp cb6ca,y                                                       ; 56b3: d9 ca b6    ... :b6b3[1]
+    bcc cb6ca                                                         ; 56b6: 90 12       ..  :b6b6[1]
+    bne cb6c2                                                         ; 56b8: d0 08       ..  :b6b8[1]
+    pha                                                               ; 56ba: 48          H   :b6ba[1]
+    txa                                                               ; 56bb: 8a          .   :b6bb[1]
+    cmp lb6c6,y                                                       ; 56bc: d9 c6 b6    ... :b6bc[1]
+    pla                                                               ; 56bf: 68          h   :b6bf[1]
+    bcc cb6ca                                                         ; 56c0: 90 08       ..  :b6c0[1]
+; &56c2 referenced 1 time by &b6b8
+.cb6c2
+    iny                                                               ; 56c2: c8          .   :b6c2[1]
+    cpy #&14                                                          ; 56c3: c0 14       ..  :b6c3[1]
+.sub_cb6c5
+lb6c6 = sub_cb6c5+1
+    bcc loop_cb6b3                                                    ; 56c5: 90 ec       ..  :b6c5[1]
+; &56c6 referenced 1 time by &b6bc
+    jmp cb446                                                         ; 56c7: 4c 46 b4    LF. :b6c7[1]
+
+; &56ca referenced 3 times by &b6b3, &b6b6, &b6c0
+.cb6ca
+    pha                                                               ; 56ca: 48          H   :b6ca[1]
+    txa                                                               ; 56cb: 8a          .   :b6cb[1]
+    clc                                                               ; 56cc: 18          .   :b6cc[1]
+.sub_cb6cd
+lb6ce = sub_cb6cd+1
+    adc lb6ce,y                                                       ; 56cd: 79 ce b6    y.. :b6cd[1]
+; &56ce referenced 1 time by &b6cd
+    tax                                                               ; 56d0: aa          .   :b6d0[1]
+    pla                                                               ; 56d1: 68          h   :b6d1[1]
+; &56d2 referenced 1 time by &b6d2
+.cb6d2
+    adc cb6d2,y                                                       ; 56d2: 79 d2 b6    y.. :b6d2[1]
+    rts                                                               ; 56d5: 60          `   :b6d5[1]
+
+    equb &f0, &e0, &d0, &c0, &3f, &7f, &bf, &ff, &10                  ; 56d6: f0 e0 d0... ... :b6d6[1]
+    equs " 0@"                                                        ; 56df: 20 30 40     0@ :b6df[1]
+    equb &80, &40,   0, &c0                                           ; 56e2: 80 40 00... .@. :b6e2[1]
+
+; &56e6 referenced 1 time by &b6fe
+.sub_cb6e6
+    cpy #&10                                                          ; 56e6: c0 10       ..  :b6e6[1]
+    bcs cb6eb                                                         ; 56e8: b0 01       ..  :b6e8[1]
+    rts                                                               ; 56ea: 60          `   :b6ea[1]
+
+; &56eb referenced 1 time by &b6e8
+.cb6eb
+    tya                                                               ; 56eb: 98          .   :b6eb[1]
+    sec                                                               ; 56ec: 38          8   :b6ec[1]
+    sbc #4                                                            ; 56ed: e9 04       ..  :b6ed[1]
+    tay                                                               ; 56ef: a8          .   :b6ef[1]
+    cpy #&0e                                                          ; 56f0: c0 0e       ..  :b6f0[1]
+    bcs cb6f5                                                         ; 56f2: b0 01       ..  :b6f2[1]
+    rts                                                               ; 56f4: 60          `   :b6f4[1]
+
+; &56f5 referenced 1 time by &b6f2
+.cb6f5
+    tya                                                               ; 56f5: 98          .   :b6f5[1]
+    and #1                                                            ; 56f6: 29 01       ).  :b6f6[1]
+    ldy #&fe                                                          ; 56f8: a0 fe       ..  :b6f8[1]
+    ora (l00b8),y                                                     ; 56fa: 11 b8       ..  :b6fa[1]
+    tay                                                               ; 56fc: a8          .   :b6fc[1]
+    rts                                                               ; 56fd: 60          `   :b6fd[1]
+
+; &56fe referenced 5 times by &b314, &b6ab, &bc44, &bc8e, &bce1
+.sub_cb6fe
+    jsr sub_cb6e6                                                     ; 56fe: 20 e6 b6     .. :b6fe[1]
+    tya                                                               ; 5701: 98          .   :b701[1]
+    tax                                                               ; 5702: aa          .   :b702[1]
+    lda lb726,y                                                       ; 5703: b9 26 b7    .&. :b703[1]
+    pha                                                               ; 5706: 48          H   :b706[1]
+    ldy #&ee                                                          ; 5707: a0 ee       ..  :b707[1]
+    and (l00b8),y                                                     ; 5709: 31 b8       1.  :b709[1]
+    bne cb718                                                         ; 570b: d0 0b       ..  :b70b[1]
+    lda (l00b8),y                                                     ; 570d: b1 b8       ..  :b70d[1]
+    and #&c0                                                          ; 570f: 29 c0       ).  :b70f[1]
+    cmp #&80                                                          ; 5711: c9 80       ..  :b711[1]
+    beq cb718                                                         ; 5713: f0 03       ..  :b713[1]
+    jmp cb446                                                         ; 5715: 4c 46 b4    LF. :b715[1]
+
+; &5718 referenced 2 times by &b70b, &b713
+.cb718
+    pla                                                               ; 5718: 68          h   :b718[1]
+    ldy #&fd                                                          ; 5719: a0 fd       ..  :b719[1]
+    and (l00b8),y                                                     ; 571b: 31 b8       1.  :b71b[1]
+    pha                                                               ; 571d: 48          H   :b71d[1]
+    txa                                                               ; 571e: 8a          .   :b71e[1]
+    tay                                                               ; 571f: a8          .   :b71f[1]
+    pla                                                               ; 5720: 68          h   :b720[1]
+    beq cb725                                                         ; 5721: f0 02       ..  :b721[1]
+    lda #&ff                                                          ; 5723: a9 ff       ..  :b723[1]
+; &5725 referenced 1 time by &b721
+.cb725
+    rts                                                               ; 5725: 60          `   :b725[1]
+
+; &5726 referenced 6 times by &b703, &b898, &b8c8, &b8db, &bc56, &bca1
+.lb726
+    equb   4,   8,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0   ; 5726: 04 08 00... ... :b726[1]
+    equb   1,   2, &10, &20                                           ; 5732: 01 02 10... ... :b732[1]
+
+; &5736 referenced 1 time by &b75a
+.cb736
+    sty romsel_copy                                                   ; 5736: 84 f4       ..  :b736[1]
+    sty romsel                                                        ; 5738: 8c 30 fe    .0. :b738[1]
+    ldy #0                                                            ; 573b: a0 00       ..  :b73b[1]
+    sta (l00ba),y                                                     ; 573d: 91 ba       ..  :b73d[1]
+    stx romsel_copy                                                   ; 573f: 86 f4       ..  :b73f[1]
+    stx romsel                                                        ; 5741: 8e 30 fe    .0. :b741[1]
+    rts                                                               ; 5744: 60          `   :b744[1]
+
+; &5745 referenced 5 times by &b369, &b8b7, &b8d1, &bc78, &bc9e
+.sub_cb745
+    sta l00bf                                                         ; 5745: 85 bf       ..  :b745[1]
+    txa                                                               ; 5747: 8a          .   :b747[1]
+    pha                                                               ; 5748: 48          H   :b748[1]
+    tya                                                               ; 5749: 98          .   :b749[1]
+    pha                                                               ; 574a: 48          H   :b74a[1]
+    ldx romsel_copy                                                   ; 574b: a6 f4       ..  :b74b[1]
+    lda l0df0,x                                                       ; 574d: bd f0 0d    ... :b74d[1]
+    sta l00b1                                                         ; 5750: 85 b1       ..  :b750[1]
+    inc l00b1                                                         ; 5752: e6 b1       ..  :b752[1]
+    lda #0                                                            ; 5754: a9 00       ..  :b754[1]
+    sta l00b0                                                         ; 5756: 85 b0       ..  :b756[1]
+    ldy #&0e                                                          ; 5758: a0 0e       ..  :b758[1]
+; &575a referenced 1 time by &b760
+.loop_cb75a
+    lda cb736,y                                                       ; 575a: b9 36 b7    .6. :b75a[1]
+    sta (l00b0),y                                                     ; 575d: 91 b0       ..  :b75d[1]
+    dey                                                               ; 575f: 88          .   :b75f[1]
+    bpl loop_cb75a                                                    ; 5760: 10 f8       ..  :b760[1]
+    pla                                                               ; 5762: 68          h   :b762[1]
+    pha                                                               ; 5763: 48          H   :b763[1]
+    tay                                                               ; 5764: a8          .   :b764[1]
+    lda l00bf                                                         ; 5765: a5 bf       ..  :b765[1]
+    jsr sub_cb771                                                     ; 5767: 20 71 b7     q. :b767[1]
+    pla                                                               ; 576a: 68          h   :b76a[1]
+    tay                                                               ; 576b: a8          .   :b76b[1]
+    pla                                                               ; 576c: 68          h   :b76c[1]
+    tax                                                               ; 576d: aa          .   :b76d[1]
+    lda l00bf                                                         ; 576e: a5 bf       ..  :b76e[1]
+    rts                                                               ; 5770: 60          `   :b770[1]
+
+; &5771 referenced 1 time by &b767
+.sub_cb771
+    jmp (l00b0)                                                       ; 5771: 6c b0 00    l.. :b771[1]
+
+; &5774 referenced 1 time by &b7be
+.lb774
+    equb &85, &f4, &8d, &30, &fe, &b1, &b1, &91, &b3, &c8, &d0,   5   ; 5774: 85 f4 8d... ... :b774[1]
+    equb &e6, &b2, &e6, &b4, &ca, &c4, &b5, &d0, &f0, &8a, &d0, &ed   ; 5780: e6 b2 e6... ... :b780[1]
+    equb &68, &85, &f4, &8d, &30, &fe, &4c, &d5, &b7                  ; 578c: 68 85 f4... h.. :b78c[1]
+
+; &5795 referenced 5 times by &b4ca, &b51d, &bd0b, &bdb0, &bded
+.cb795
+    ldy #&f1                                                          ; 5795: a0 f1       ..  :b795[1]
+    lda (l00b8),y                                                     ; 5797: b1 b8       ..  :b797[1]
+    sta l00b0                                                         ; 5799: 85 b0       ..  :b799[1]
+    ldx l00be                                                         ; 579b: a6 be       ..  :b79b[1]
+    ldy l00bf                                                         ; 579d: a4 bf       ..  :b79d[1]
+    lda #0                                                            ; 579f: a9 00       ..  :b79f[1]
+    rol a                                                             ; 57a1: 2a          *   :b7a1[1]
+    asl a                                                             ; 57a2: 0a          .   :b7a2[1]
+    sta l00b7                                                         ; 57a3: 85 b7       ..  :b7a3[1]
+    inc l00b7                                                         ; 57a5: e6 b7       ..  :b7a5[1]
+    jsr sub_cb85d                                                     ; 57a7: 20 5d b8     ]. :b7a7[1]
+    bvs cb7ed                                                         ; 57aa: 70 41       pA  :b7aa[1]
+    bvc cb7b2                                                         ; 57ac: 50 04       P.  :b7ac[1]
+; &57ae referenced 1 time by &b803
+.cb7ae
+    ldx l00be                                                         ; 57ae: a6 be       ..  :b7ae[1]
+    ldy l00bf                                                         ; 57b0: a4 bf       ..  :b7b0[1]
+; &57b2 referenced 1 time by &b7ac
+.cb7b2
+    stx l00b5                                                         ; 57b2: 86 b5       ..  :b7b2[1]
+    sty l00b6                                                         ; 57b4: 84 b6       ..  :b7b4[1]
+; &57b6 referenced 1 time by &b812
+.sub_cb7b6
+    lda l00b5                                                         ; 57b6: a5 b5       ..  :b7b6[1]
+    ora l00b6                                                         ; 57b8: 05 b6       ..  :b7b8[1]
+    beq cb7ec                                                         ; 57ba: f0 30       .0  :b7ba[1]
+    ldx #&20 ; ' '                                                    ; 57bc: a2 20       .   :b7bc[1]
+; &57be referenced 1 time by &b7c3
+.loop_cb7be
+    lda lb774,x                                                       ; 57be: bd 74 b7    .t. :b7be[1]
+    pha                                                               ; 57c1: 48          H   :b7c1[1]
+    dex                                                               ; 57c2: ca          .   :b7c2[1]
+    bpl loop_cb7be                                                    ; 57c3: 10 f9       ..  :b7c3[1]
+    tsx                                                               ; 57c5: ba          .   :b7c5[1]
+    lda romsel_copy                                                   ; 57c6: a5 f4       ..  :b7c6[1]
+    pha                                                               ; 57c8: 48          H   :b7c8[1]
+    lda #1                                                            ; 57c9: a9 01       ..  :b7c9[1]
+    pha                                                               ; 57cb: 48          H   :b7cb[1]
+    txa                                                               ; 57cc: 8a          .   :b7cc[1]
+    pha                                                               ; 57cd: 48          H   :b7cd[1]
+    lda l00b0                                                         ; 57ce: a5 b0       ..  :b7ce[1]
+    ldx l00b6                                                         ; 57d0: a6 b6       ..  :b7d0[1]
+    ldy #0                                                            ; 57d2: a0 00       ..  :b7d2[1]
+    rts                                                               ; 57d4: 60          `   :b7d4[1]
+
+    ldx #&21 ; '!'                                                    ; 57d5: a2 21       .!  :b7d5[1]
+; &57d7 referenced 1 time by &b7d9
+.loop_cb7d7
+    pla                                                               ; 57d7: 68          h   :b7d7[1]
+    dex                                                               ; 57d8: ca          .   :b7d8[1]
+    bne loop_cb7d7                                                    ; 57d9: d0 fc       ..  :b7d9[1]
+    ldx #2                                                            ; 57db: a2 02       ..  :b7db[1]
+; &57dd referenced 1 time by &b7ea
+.loop_cb7dd
+    lda l00b1,x                                                       ; 57dd: b5 b1       ..  :b7dd[1]
+    clc                                                               ; 57df: 18          .   :b7df[1]
+    adc l00b5                                                         ; 57e0: 65 b5       e.  :b7e0[1]
+    sta l00b1,x                                                       ; 57e2: 95 b1       ..  :b7e2[1]
+    bcc cb7e8                                                         ; 57e4: 90 02       ..  :b7e4[1]
+    inc l00b2,x                                                       ; 57e6: f6 b2       ..  :b7e6[1]
+; &57e8 referenced 1 time by &b7e4
+.cb7e8
+    dex                                                               ; 57e8: ca          .   :b7e8[1]
+    dex                                                               ; 57e9: ca          .   :b7e9[1]
+    bpl loop_cb7dd                                                    ; 57ea: 10 f1       ..  :b7ea[1]
+; &57ec referenced 1 time by &b7ba
+.cb7ec
+    rts                                                               ; 57ec: 60          `   :b7ec[1]
+
+; &57ed referenced 2 times by &b7aa, &b828
+.cb7ed
+    lda #0                                                            ; 57ed: a9 00       ..  :b7ed[1]
+    sec                                                               ; 57ef: 38          8   :b7ef[1]
+    ldx l00b7                                                         ; 57f0: a6 b7       ..  :b7f0[1]
+    sbc l00b0,x                                                       ; 57f2: f5 b0       ..  :b7f2[1]
+    sta l00b5                                                         ; 57f4: 85 b5       ..  :b7f4[1]
+    lda #&c0                                                          ; 57f6: a9 c0       ..  :b7f6[1]
+    sbc l00b1,x                                                       ; 57f8: f5 b1       ..  :b7f8[1]
+    sta l00b6                                                         ; 57fa: 85 b6       ..  :b7fa[1]
+    ldx #&b5                                                          ; 57fc: a2 b5       ..  :b7fc[1]
+    ldy #&be                                                          ; 57fe: a0 be       ..  :b7fe[1]
+    jsr sub_cb58b                                                     ; 5800: 20 8b b5     .. :b800[1]
+    bcs cb7ae                                                         ; 5803: b0 a9       ..  :b803[1]
+    lda l00be                                                         ; 5805: a5 be       ..  :b805[1]
+    sec                                                               ; 5807: 38          8   :b807[1]
+    sbc l00b5                                                         ; 5808: e5 b5       ..  :b808[1]
+    sta l00be                                                         ; 580a: 85 be       ..  :b80a[1]
+    lda l00bf                                                         ; 580c: a5 bf       ..  :b80c[1]
+    sbc l00b6                                                         ; 580e: e5 b6       ..  :b80e[1]
+    sta l00bf                                                         ; 5810: 85 bf       ..  :b810[1]
+    jsr sub_cb7b6                                                     ; 5812: 20 b6 b7     .. :b812[1]
+    lda #&10                                                          ; 5815: a9 10       ..  :b815[1]
+    ldx l00b7                                                         ; 5817: a6 b7       ..  :b817[1]
+    sta l00b0,x                                                       ; 5819: 95 b0       ..  :b819[1]
+    lda #&80                                                          ; 581b: a9 80       ..  :b81b[1]
+    sta l00b1,x                                                       ; 581d: 95 b1       ..  :b81d[1]
+    jsr sub_cb68f                                                     ; 581f: 20 8f b6     .. :b81f[1]
+    ldy #&f1                                                          ; 5822: a0 f1       ..  :b822[1]
+    lda (l00b8),y                                                     ; 5824: b1 b8       ..  :b824[1]
+    sta l00b0                                                         ; 5826: 85 b0       ..  :b826[1]
+    jmp cb7ed                                                         ; 5828: 4c ed b7    L.. :b828[1]
+
+; &582b referenced 16 times by &b1c1, &b2c8, &b2e7, &b32c, &b35a, &b3b0, &b3ec, &b429, &b4a3, &b573, &b5ca, &b5e8, &b604, &b611, &b86b, &beb5
+.cb82b
+    php                                                               ; 582b: 08          .   :b82b[1]
+    pha                                                               ; 582c: 48          H   :b82c[1]
+    txa                                                               ; 582d: 8a          .   :b82d[1]
+    pha                                                               ; 582e: 48          H   :b82e[1]
+    lda #0                                                            ; 582f: a9 00       ..  :b82f[1]
+    sta l00b8                                                         ; 5831: 85 b8       ..  :b831[1]
+    ldx romsel_copy                                                   ; 5833: a6 f4       ..  :b833[1]
+    lda l0df0,x                                                       ; 5835: bd f0 0d    ... :b835[1]
+    sta l00b9                                                         ; 5838: 85 b9       ..  :b838[1]
+    pla                                                               ; 583a: 68          h   :b83a[1]
+    tax                                                               ; 583b: aa          .   :b83b[1]
+    pla                                                               ; 583c: 68          h   :b83c[1]
+    plp                                                               ; 583d: 28          (   :b83d[1]
+    rts                                                               ; 583e: 60          `   :b83e[1]
+
+; &583f referenced 4 times by &b35f, &b4e1, &b53d, &b622
+.sub_cb83f
+    ldx #&ba                                                          ; 583f: a2 ba       ..  :b83f[1]
+; &5841 referenced 12 times by &b39b, &b462, &b4b8, &b4bf, &b4c6, &b4f2, &b50b, &b512, &b519, &b663, &bd4a, &bdc4
+.sub_cb841
+    pha                                                               ; 5841: 48          H   :b841[1]
+    lda (l00b8),y                                                     ; 5842: b1 b8       ..  :b842[1]
+    sta l0000,x                                                       ; 5844: 95 00       ..  :b844[1]
+    iny                                                               ; 5846: c8          .   :b846[1]
+    lda (l00b8),y                                                     ; 5847: b1 b8       ..  :b847[1]
+    sta l0001,x                                                       ; 5849: 95 01       ..  :b849[1]
+    dey                                                               ; 584b: 88          .   :b84b[1]
+    pla                                                               ; 584c: 68          h   :b84c[1]
+    rts                                                               ; 584d: 60          `   :b84d[1]
+
+; &584e referenced 3 times by &b3f5, &b472, &b504
+.sub_cb84e
+    ldx #&ba                                                          ; 584e: a2 ba       ..  :b84e[1]
+; &5850 referenced 5 times by &b659, &b688, &bb5c, &bb8d, &bd36
+.sub_cb850
+    pha                                                               ; 5850: 48          H   :b850[1]
+    lda l0000,x                                                       ; 5851: b5 00       ..  :b851[1]
+    sta (l00b8),y                                                     ; 5853: 91 b8       ..  :b853[1]
+    iny                                                               ; 5855: c8          .   :b855[1]
+    lda l0001,x                                                       ; 5856: b5 01       ..  :b856[1]
+    sta (l00b8),y                                                     ; 5858: 91 b8       ..  :b858[1]
+    dey                                                               ; 585a: 88          .   :b85a[1]
+    pla                                                               ; 585b: 68          h   :b85b[1]
+    rts                                                               ; 585c: 60          `   :b85c[1]
+
+; &585d referenced 8 times by &b2f2, &b340, &b406, &b63f, &b66e, &b7a7, &be64, &be9d
+.sub_cb85d
+    pha                                                               ; 585d: 48          H   :b85d[1]
+    tya                                                               ; 585e: 98          .   :b85e[1]
+    pha                                                               ; 585f: 48          H   :b85f[1]
+    ldy #&ee                                                          ; 5860: a0 ee       ..  :b860[1]
+    lda (l00b8),y                                                     ; 5862: b1 b8       ..  :b862[1]
+    sta l00b8                                                         ; 5864: 85 b8       ..  :b864[1]
+    pla                                                               ; 5866: 68          h   :b866[1]
+    tay                                                               ; 5867: a8          .   :b867[1]
+    pla                                                               ; 5868: 68          h   :b868[1]
+    bit l00b8                                                         ; 5869: 24 b8       $.  :b869[1]
+    jsr cb82b                                                         ; 586b: 20 2b b8     +. :b86b[1]
+    rts                                                               ; 586e: 60          `   :b86e[1]
+
+; &586f referenced 1 time by &b60e
+.sub_cb86f
+    jmp (fscv)                                                        ; 586f: 6c 1e 02    l.. :b86f[1]
+
+; &5872 referenced 2 times by &b9c7, &bc70
+.lb872
+    equb &60,   0,   0, &60,   0,   0,   2, &0c, &ff                  ; 5872: 60 00 00... `.. :b872[1]
+    equs "RAM"                                                        ; 587b: 52 41 4d    RAM :b87b[1]
+; &587e referenced 1 time by &b9a3
+.lb87e
+    equb 0                                                            ; 587e: 00          .   :b87e[1]
+    equs "(C)"                                                        ; 587f: 28 43 29    (C) :b87f[1]
+
+; &5882 referenced 1 time by &b200
+.sub_cb882
+    lda #0                                                            ; 5882: a9 00       ..  :b882[1]
+    ldy #&fd                                                          ; 5884: a0 fd       ..  :b884[1]
+    sta (l00b8),y                                                     ; 5886: 91 b8       ..  :b886[1]
+    ldy #&ee                                                          ; 5888: a0 ee       ..  :b888[1]
+    sta (l00b8),y                                                     ; 588a: 91 b8       ..  :b88a[1]
+    ldy #&fa                                                          ; 588c: a0 fa       ..  :b88c[1]
+    sta (l00b8),y                                                     ; 588e: 91 b8       ..  :b88e[1]
+    ldy #&ff                                                          ; 5890: a0 ff       ..  :b890[1]
+    lda #&4e ; 'N'                                                    ; 5892: a9 4e       .N  :b892[1]
+    sta (l00b8),y                                                     ; 5894: 91 b8       ..  :b894[1]
+    ldy #&0f                                                          ; 5896: a0 0f       ..  :b896[1]
+; &5898 referenced 1 time by &b8e7
+.cb898
+    lda lb726,y                                                       ; 5898: b9 26 b7    .&. :b898[1]
+    beq cb8e6                                                         ; 589b: f0 49       .I  :b89b[1]
+    tya                                                               ; 589d: 98          .   :b89d[1]
+    pha                                                               ; 589e: 48          H   :b89e[1]
+    lda #8                                                            ; 589f: a9 08       ..  :b89f[1]
+    sta osrdsc_ptr                                                    ; 58a1: 85 f6       ..  :b8a1[1]
+    sta l00ba                                                         ; 58a3: 85 ba       ..  :b8a3[1]
+    lda #&80                                                          ; 58a5: a9 80       ..  :b8a5[1]
+    sta l00f7                                                         ; 58a7: 85 f7       ..  :b8a7[1]
+    sta l00bb                                                         ; 58a9: 85 bb       ..  :b8a9[1]
+    jsr osrdsc                                                        ; 58ab: 20 b9 ff     .. :b8ab[1]
+    sta l00bd                                                         ; 58ae: 85 bd       ..  :b8ae[1]
+    pla                                                               ; 58b0: 68          h   :b8b0[1]
+    pha                                                               ; 58b1: 48          H   :b8b1[1]
+    tay                                                               ; 58b2: a8          .   :b8b2[1]
+    lda l00bd                                                         ; 58b3: a5 bd       ..  :b8b3[1]
+    eor #&ff                                                          ; 58b5: 49 ff       I.  :b8b5[1]
+    jsr sub_cb745                                                     ; 58b7: 20 45 b7     E. :b8b7[1]
+    jsr osrdsc                                                        ; 58ba: 20 b9 ff     .. :b8ba[1]
+    cmp l00bd                                                         ; 58bd: c5 bd       ..  :b8bd[1]
+    beq cb8e4                                                         ; 58bf: f0 23       .#  :b8bf[1]
+    pla                                                               ; 58c1: 68          h   :b8c1[1]
+    pha                                                               ; 58c2: 48          H   :b8c2[1]
+    tax                                                               ; 58c3: aa          .   :b8c3[1]
+    ldy #&ee                                                          ; 58c4: a0 ee       ..  :b8c4[1]
+    lda (l00b8),y                                                     ; 58c6: b1 b8       ..  :b8c6[1]
+    ora lb726,x                                                       ; 58c8: 1d 26 b7    .&. :b8c8[1]
+    sta (l00b8),y                                                     ; 58cb: 91 b8       ..  :b8cb[1]
+    txa                                                               ; 58cd: 8a          .   :b8cd[1]
+    tay                                                               ; 58ce: a8          .   :b8ce[1]
+    lda l00bd                                                         ; 58cf: a5 bd       ..  :b8cf[1]
+    jsr sub_cb745                                                     ; 58d1: 20 45 b7     E. :b8d1[1]
+    jsr sub_cb986                                                     ; 58d4: 20 86 b9     .. :b8d4[1]
+    cmp #2                                                            ; 58d7: c9 02       ..  :b8d7[1]
+    bne cb8e4                                                         ; 58d9: d0 09       ..  :b8d9[1]
+    lda lb726,y                                                       ; 58db: b9 26 b7    .&. :b8db[1]
+    ldy #&fd                                                          ; 58de: a0 fd       ..  :b8de[1]
+    ora (l00b8),y                                                     ; 58e0: 11 b8       ..  :b8e0[1]
+    sta (l00b8),y                                                     ; 58e2: 91 b8       ..  :b8e2[1]
+; &58e4 referenced 2 times by &b8bf, &b8d9
+.cb8e4
+    pla                                                               ; 58e4: 68          h   :b8e4[1]
+    tay                                                               ; 58e5: a8          .   :b8e5[1]
+; &58e6 referenced 1 time by &b89b
+.cb8e6
+    dey                                                               ; 58e6: 88          .   :b8e6[1]
+    bpl cb898                                                         ; 58e7: 10 af       ..  :b8e7[1]
+    ldy #&ee                                                          ; 58e9: a0 ee       ..  :b8e9[1]
+    lda (l00b8),y                                                     ; 58eb: b1 b8       ..  :b8eb[1]
+    ldx #0                                                            ; 58ed: a2 00       ..  :b8ed[1]
+    and #&0c                                                          ; 58ef: 29 0c       ).  :b8ef[1]
+    bne cb8f5                                                         ; 58f1: d0 02       ..  :b8f1[1]
+    ldx #&0e                                                          ; 58f3: a2 0e       ..  :b8f3[1]
+; &58f5 referenced 1 time by &b8f1
+.cb8f5
+    txa                                                               ; 58f5: 8a          .   :b8f5[1]
+    ldy #&fe                                                          ; 58f6: a0 fe       ..  :b8f6[1]
+    sta (l00b8),y                                                     ; 58f8: 91 b8       ..  :b8f8[1]
+    rts                                                               ; 58fa: 60          `   :b8fa[1]
+
+; &58fb referenced 6 times by &b302, &b334, &b448, &b5e3, &bafa, &bc51
+.cb8fb
+    lda #0                                                            ; 58fb: a9 00       ..  :b8fb[1]
+    sta l0100                                                         ; 58fd: 8d 00 01    ... :b8fd[1]
+    lda lb980,x                                                       ; 5900: bd 80 b9    ... :b900[1]
+    sta l0101                                                         ; 5903: 8d 01 01    ... :b903[1]
+    lda lb97a,x                                                       ; 5906: bd 7a b9    .z. :b906[1]
+    sta l00bf                                                         ; 5909: 85 bf       ..  :b909[1]
+    ldy lb979,x                                                       ; 590b: bc 79 b9    .y. :b90b[1]
+    ldx #0                                                            ; 590e: a2 00       ..  :b90e[1]
+; &5910 referenced 1 time by &b91a
+.loop_cb910
+    lda lb924,y                                                       ; 5910: b9 24 b9    .$. :b910[1]
+    sta l0102,x                                                       ; 5913: 9d 02 01    ... :b913[1]
+    inx                                                               ; 5916: e8          .   :b916[1]
+    iny                                                               ; 5917: c8          .   :b917[1]
+    cpy l00bf                                                         ; 5918: c4 bf       ..  :b918[1]
+    bcc loop_cb910                                                    ; 591a: 90 f4       ..  :b91a[1]
+    lda #0                                                            ; 591c: a9 00       ..  :b91c[1]
+    sta l0102,x                                                       ; 591e: 9d 02 01    ... :b91e[1]
+    jmp l0100                                                         ; 5921: 4c 00 01    L.. :b921[1]
+
+; &5924 referenced 1 time by &b910
+.lb924
+    equs "Illegal parameterIllegal addressNo filing systemBad comm"   ; 5924: 49 6c 6c... Ill :b924[1]
+    equs "andFile not foundRAM occupied"                              ; 595c: 61 6e 64... and :b95c[1]
+; &5979 referenced 1 time by &b90b
+.lb979
+    equb 0                                                            ; 5979: 00          .   :b979[1]
+; &597a referenced 1 time by &b906
+.lb97a
+    equb &11                                                          ; 597a: 11          .   :b97a[1]
+    equs " 0;IU"                                                      ; 597b: 20 30 3b...  0; :b97b[1]
+; &5980 referenced 1 time by &b900
+.lb980
+    equb &80, &81, &82, &fe, &d6, &83                                 ; 5980: 80 81 82... ... :b980[1]
+
+; &5986 referenced 3 times by &b8d4, &bc49, &bcb2
+.sub_cb986
+    txa                                                               ; 5986: 8a          .   :b986[1]
+    pha                                                               ; 5987: 48          H   :b987[1]
+    tya                                                               ; 5988: 98          .   :b988[1]
+    pha                                                               ; 5989: 48          H   :b989[1]
+    ldx #7                                                            ; 598a: a2 07       ..  :b98a[1]
+    stx osrdsc_ptr                                                    ; 598c: 86 f6       ..  :b98c[1]
+    lda #&80                                                          ; 598e: a9 80       ..  :b98e[1]
+    sta l00f7                                                         ; 5990: 85 f7       ..  :b990[1]
+    jsr osrdsc                                                        ; 5992: 20 b9 ff     .. :b992[1]
+    sta osrdsc_ptr                                                    ; 5995: 85 f6       ..  :b995[1]
+    ldx #0                                                            ; 5997: a2 00       ..  :b997[1]
+; &5999 referenced 1 time by &b9b1
+.loop_cb999
+    stx l00bf                                                         ; 5999: 86 bf       ..  :b999[1]
+    pla                                                               ; 599b: 68          h   :b99b[1]
+    pha                                                               ; 599c: 48          H   :b99c[1]
+    tay                                                               ; 599d: a8          .   :b99d[1]
+    jsr osrdsc                                                        ; 599e: 20 b9 ff     .. :b99e[1]
+    ldx l00bf                                                         ; 59a1: a6 bf       ..  :b9a1[1]
+    cmp lb87e,x                                                       ; 59a3: dd 7e b8    .~. :b9a3[1]
+    bne cb9ee                                                         ; 59a6: d0 46       .F  :b9a6[1]
+    inc osrdsc_ptr                                                    ; 59a8: e6 f6       ..  :b9a8[1]
+    bne cb9ae                                                         ; 59aa: d0 02       ..  :b9aa[1]
+    inc l00f7                                                         ; 59ac: e6 f7       ..  :b9ac[1]
+; &59ae referenced 1 time by &b9aa
+.cb9ae
+    inx                                                               ; 59ae: e8          .   :b9ae[1]
+    cpx #4                                                            ; 59af: e0 04       ..  :b9af[1]
+    bcc loop_cb999                                                    ; 59b1: 90 e6       ..  :b9b1[1]
+    lda #2                                                            ; 59b3: a9 02       ..  :b9b3[1]
+    sta l00bf                                                         ; 59b5: 85 bf       ..  :b9b5[1]
+    ldx #&0f                                                          ; 59b7: a2 0f       ..  :b9b7[1]
+    lda #&80                                                          ; 59b9: a9 80       ..  :b9b9[1]
+    sta l00f7                                                         ; 59bb: 85 f7       ..  :b9bb[1]
+; &59bd referenced 1 time by &b9cf
+.loop_cb9bd
+    stx osrdsc_ptr                                                    ; 59bd: 86 f6       ..  :b9bd[1]
+    pla                                                               ; 59bf: 68          h   :b9bf[1]
+    pha                                                               ; 59c0: 48          H   :b9c0[1]
+    tay                                                               ; 59c1: a8          .   :b9c1[1]
+    jsr osrdsc                                                        ; 59c2: 20 b9 ff     .. :b9c2[1]
+    ldx osrdsc_ptr                                                    ; 59c5: a6 f6       ..  :b9c5[1]
+    cmp lb872,x                                                       ; 59c7: dd 72 b8    .r. :b9c7[1]
+    bne cb9d9                                                         ; 59ca: d0 0d       ..  :b9ca[1]
+; &59cc referenced 1 time by &b9e5
+.loop_cb9cc
+    dex                                                               ; 59cc: ca          .   :b9cc[1]
+    cpx #6                                                            ; 59cd: e0 06       ..  :b9cd[1]
+    bcs loop_cb9bd                                                    ; 59cf: b0 ec       ..  :b9cf[1]
+; &59d1 referenced 1 time by &b9ec
+.loop_cb9d1
+    clc                                                               ; 59d1: 18          .   :b9d1[1]
+; &59d2 referenced 1 time by &b9f3
+.cb9d2
+    pla                                                               ; 59d2: 68          h   :b9d2[1]
+    tay                                                               ; 59d3: a8          .   :b9d3[1]
+    pla                                                               ; 59d4: 68          h   :b9d4[1]
+    tax                                                               ; 59d5: aa          .   :b9d5[1]
+    lda l00bf                                                         ; 59d6: a5 bf       ..  :b9d6[1]
+    rts                                                               ; 59d8: 60          `   :b9d8[1]
+
+; &59d9 referenced 1 time by &b9ca
+.cb9d9
+    cpx #&0a                                                          ; 59d9: e0 0a       ..  :b9d9[1]
+    bne cb9e8                                                         ; 59db: d0 0b       ..  :b9db[1]
+    cmp #&4f ; 'O'                                                    ; 59dd: c9 4f       .O  :b9dd[1]
+    bne cb9e8                                                         ; 59df: d0 07       ..  :b9df[1]
+    lda #1                                                            ; 59e1: a9 01       ..  :b9e1[1]
+    sta l00bf                                                         ; 59e3: 85 bf       ..  :b9e3[1]
+    jmp loop_cb9cc                                                    ; 59e5: 4c cc b9    L.. :b9e5[1]
+
+; &59e8 referenced 2 times by &b9db, &b9df
+.cb9e8
+    lda #0                                                            ; 59e8: a9 00       ..  :b9e8[1]
+    sta l00bf                                                         ; 59ea: 85 bf       ..  :b9ea[1]
+    beq loop_cb9d1                                                    ; 59ec: f0 e3       ..  :b9ec[1]
+; &59ee referenced 1 time by &b9a6
+.cb9ee
+    lda #&ff                                                          ; 59ee: a9 ff       ..  :b9ee[1]
+    sta l00bf                                                         ; 59f0: 85 bf       ..  :b9f0[1]
+    sec                                                               ; 59f2: 38          8   :b9f2[1]
+    bcs cb9d2                                                         ; 59f3: b0 dd       ..  :b9f3[1]
+; &59f5 referenced 2 times by &b225, &b297
+.sub_cb9f5
+    ldx #0                                                            ; 59f5: a2 00       ..  :b9f5[1]
+; &59f7 referenced 1 time by &ba25
+.cb9f7
+    tya                                                               ; 59f7: 98          .   :b9f7[1]
+    pha                                                               ; 59f8: 48          H   :b9f8[1]
+; &59f9 referenced 1 time by &ba0e
+.loop_cb9f9
+    lda (os_text_ptr),y                                               ; 59f9: b1 f2       ..  :b9f9[1]
+    bmi cba10                                                         ; 59fb: 30 13       0.  :b9fb[1]
+    cmp #&2e ; '.'                                                    ; 59fd: c9 2e       ..  :b9fd[1]
+    beq cba19                                                         ; 59ff: f0 18       ..  :b9ff[1]
+    cmp #&41 ; 'A'                                                    ; 5a01: c9 41       .A  :ba01[1]
+    bcc cba10                                                         ; 5a03: 90 0b       ..  :ba03[1]
+    eor sram_table,x                                                  ; 5a05: 5d 30 ba    ]0. :ba05[1]
+    and #&df                                                          ; 5a08: 29 df       ).  :ba08[1]
+    bne cba15                                                         ; 5a0a: d0 09       ..  :ba0a[1]
+    iny                                                               ; 5a0c: c8          .   :ba0c[1]
+    inx                                                               ; 5a0d: e8          .   :ba0d[1]
+    bne loop_cb9f9                                                    ; 5a0e: d0 e9       ..  :ba0e[1]
+; &5a10 referenced 2 times by &b9fb, &ba03
+.cba10
+    lda sram_table,x                                                  ; 5a10: bd 30 ba    .0. :ba10[1]
+    bmi cba28                                                         ; 5a13: 30 13       0.  :ba13[1]
+; &5a15 referenced 1 time by &ba0a
+.cba15
+    clc                                                               ; 5a15: 18          .   :ba15[1]
+    pla                                                               ; 5a16: 68          h   :ba16[1]
+    tay                                                               ; 5a17: a8          .   :ba17[1]
+    dey                                                               ; 5a18: 88          .   :ba18[1]
+; &5a19 referenced 1 time by &b9ff
+.cba19
+    iny                                                               ; 5a19: c8          .   :ba19[1]
+; &5a1a referenced 1 time by &ba20
+.loop_cba1a
+    inx                                                               ; 5a1a: e8          .   :ba1a[1]
+    lda cba2f,x                                                       ; 5a1b: bd 2f ba    ./. :ba1b[1]
+    beq cba2e                                                         ; 5a1e: f0 0e       ..  :ba1e[1]
+    bpl loop_cba1a                                                    ; 5a20: 10 f8       ..  :ba20[1]
+    bcs cba27                                                         ; 5a22: b0 03       ..  :ba22[1]
+    inx                                                               ; 5a24: e8          .   :ba24[1]
+    bcc cb9f7                                                         ; 5a25: 90 d0       ..  :ba25[1]
+; &5a27 referenced 1 time by &ba22
+.cba27
+    dex                                                               ; 5a27: ca          .   :ba27[1]
+; &5a28 referenced 1 time by &ba13
+.cba28
+    pla                                                               ; 5a28: 68          h   :ba28[1]
+    jsr sub_cbab9                                                     ; 5a29: 20 b9 ba     .. :ba29[1]
+    clc                                                               ; 5a2c: 18          .   :ba2c[1]
+    rts                                                               ; 5a2d: 60          `   :ba2d[1]
+
+; &5a2e referenced 1 time by &ba1e
+.cba2e
+    sec                                                               ; 5a2e: 38          8   :ba2e[1]
+; &5a2f referenced 1 time by &ba1b
+.cba2f
+    rts                                                               ; 5a2f: 60          `   :ba2f[1]
+
+; &5a30 referenced 3 times by &b234, &ba05, &ba10
+.sram_table
+    equs "SRAM"                                                       ; 5a30: 53 52 41... SRA :ba30[1]
+; &5a31 referenced 1 time by &b238
+    equb &ff, &ff                                                     ; 5a34: ff ff       ..  :ba34[1]
+    equs "SRLOAD"                                                     ; 5a36: 53 52 4c... SRL :ba36[1]
+    equb >(sub_cbb46-1)                                               ; 5a3c: bb          .   :ba3c[1]
+    equb <(sub_cbb46-1)                                               ; 5a3d: 45          E   :ba3d[1]
+    equs "SRSAVE"                                                     ; 5a3e: 53 52 53... SRS :ba3e[1]
+    equb >(sub_cbb4a-1)                                               ; 5a44: bb          .   :ba44[1]
+    equb <(sub_cbb4a-1)                                               ; 5a45: 49          I   :ba45[1]
+    equs "SRWRITE"                                                    ; 5a46: 53 52 57... SRW :ba46[1]
+    equb >(sub_cbbd3-1)                                               ; 5a4d: bb          .   :ba4d[1]
+    equb <(sub_cbbd3-1)                                               ; 5a4e: d2          .   :ba4e[1]
+    equs "SRREAD"                                                     ; 5a4f: 53 52 52... SRR :ba4f[1]
+    equb >(sub_cbbd7-1)                                               ; 5a55: bb          .   :ba55[1]
+    equb <(sub_cbbd7-1)                                               ; 5a56: d6          .   :ba56[1]
+    equs "SRDATA"                                                     ; 5a57: 53 52 44... SRD :ba57[1]
+    equb >(sub_cbc37-1)                                               ; 5a5d: bc          .   :ba5d[1]
+    equb <(sub_cbc37-1)                                               ; 5a5e: 36          6   :ba5e[1]
+    equs "SRROM"                                                      ; 5a5f: 53 52 52... SRR :ba5f[1]
+    equb >(sub_cbc81-1)                                               ; 5a64: bc          .   :ba64[1]
+    equb <(sub_cbc81-1)                                               ; 5a65: 80          .   :ba65[1]
+    equb 0                                                            ; 5a66: 00          .   :ba66[1]
+
+; &5a67 referenced 5 times by &bb51, &bb6c, &bbdd, &bbf3, &bc1c
+.sub_cba67
+    txa                                                               ; 5a67: 8a          .   :ba67[1]
+    pha                                                               ; 5a68: 48          H   :ba68[1]
+    jsr sub_cbab9                                                     ; 5a69: 20 b9 ba     .. :ba69[1]
+    lda #0                                                            ; 5a6c: a9 00       ..  :ba6c[1]
+    sta l00bc                                                         ; 5a6e: 85 bc       ..  :ba6e[1]
+    sta l00bd                                                         ; 5a70: 85 bd       ..  :ba70[1]
+    sta l00be                                                         ; 5a72: 85 be       ..  :ba72[1]
+    sta l00bf                                                         ; 5a74: 85 bf       ..  :ba74[1]
+    sec                                                               ; 5a76: 38          8   :ba76[1]
+    php                                                               ; 5a77: 08          .   :ba77[1]
+; &5a78 referenced 1 time by &baae
+.cba78
+    lda (os_text_ptr),y                                               ; 5a78: b1 f2       ..  :ba78[1]
+    cmp #&30 ; '0'                                                    ; 5a7a: c9 30       .0  :ba7a[1]
+    bcc cbab4                                                         ; 5a7c: 90 36       .6  :ba7c[1]
+    cmp #&3a ; ':'                                                    ; 5a7e: c9 3a       .:  :ba7e[1]
+    bcc cba8c                                                         ; 5a80: 90 0a       ..  :ba80[1]
+    cmp #&47 ; 'G'                                                    ; 5a82: c9 47       .G  :ba82[1]
+    bcs cbab4                                                         ; 5a84: b0 2e       ..  :ba84[1]
+    cmp #&41 ; 'A'                                                    ; 5a86: c9 41       .A  :ba86[1]
+    bcc cbab4                                                         ; 5a88: 90 2a       .*  :ba88[1]
+    sbc #7                                                            ; 5a8a: e9 07       ..  :ba8a[1]
+; &5a8c referenced 1 time by &ba80
+.cba8c
+    sec                                                               ; 5a8c: 38          8   :ba8c[1]
+    sbc #&30 ; '0'                                                    ; 5a8d: e9 30       .0  :ba8d[1]
+    plp                                                               ; 5a8f: 28          (   :ba8f[1]
+    php                                                               ; 5a90: 08          .   :ba90[1]
+    pha                                                               ; 5a91: 48          H   :ba91[1]
+    ldx #4                                                            ; 5a92: a2 04       ..  :ba92[1]
+; &5a94 referenced 1 time by &baa1
+.loop_cba94
+    asl l00bc                                                         ; 5a94: 06 bc       ..  :ba94[1]
+    rol l00bd                                                         ; 5a96: 26 bd       &.  :ba96[1]
+    bvc cba9e                                                         ; 5a98: 50 04       P.  :ba98[1]
+    rol l00be                                                         ; 5a9a: 26 be       &.  :ba9a[1]
+    rol l00bf                                                         ; 5a9c: 26 bf       &.  :ba9c[1]
+; &5a9e referenced 1 time by &ba98
+.cba9e
+    bcs cbab0                                                         ; 5a9e: b0 10       ..  :ba9e[1]
+    dex                                                               ; 5aa0: ca          .   :baa0[1]
+    bne loop_cba94                                                    ; 5aa1: d0 f1       ..  :baa1[1]
+    pla                                                               ; 5aa3: 68          h   :baa3[1]
+    ora l00bc                                                         ; 5aa4: 05 bc       ..  :baa4[1]
+    sta l00bc                                                         ; 5aa6: 85 bc       ..  :baa6[1]
+    plp                                                               ; 5aa8: 28          (   :baa8[1]
+    clc                                                               ; 5aa9: 18          .   :baa9[1]
+    php                                                               ; 5aaa: 08          .   :baaa[1]
+    iny                                                               ; 5aab: c8          .   :baab[1]
+    beq cbab1                                                         ; 5aac: f0 03       ..  :baac[1]
+    bcc cba78                                                         ; 5aae: 90 c8       ..  :baae[1]
+; &5ab0 referenced 1 time by &ba9e
+.cbab0
+    pla                                                               ; 5ab0: 68          h   :bab0[1]
+; &5ab1 referenced 1 time by &baac
+.cbab1
+    plp                                                               ; 5ab1: 28          (   :bab1[1]
+    sec                                                               ; 5ab2: 38          8   :bab2[1]
+    php                                                               ; 5ab3: 08          .   :bab3[1]
+; &5ab4 referenced 3 times by &ba7c, &ba84, &ba88
+.cbab4
+    plp                                                               ; 5ab4: 28          (   :bab4[1]
+    pla                                                               ; 5ab5: 68          h   :bab5[1]
+    tax                                                               ; 5ab6: aa          .   :bab6[1]
+    rts                                                               ; 5ab7: 60          `   :bab7[1]
+
+; &5ab8 referenced 1 time by &babd
+.loop_cbab8
+    iny                                                               ; 5ab8: c8          .   :bab8[1]
+; &5ab9 referenced 7 times by &ba29, &ba69, &bac5, &bad2, &bb02, &bb2b, &bbb0
+.sub_cbab9
+    lda (os_text_ptr),y                                               ; 5ab9: b1 f2       ..  :bab9[1]
+    cmp #&20 ; ' '                                                    ; 5abb: c9 20       .   :babb[1]
+    beq loop_cbab8                                                    ; 5abd: f0 f9       ..  :babd[1]
+    cmp #&0d                                                          ; 5abf: c9 0d       ..  :babf[1]
+    rts                                                               ; 5ac1: 60          `   :bac1[1]
+
+; &5ac2 referenced 4 times by &bbbe, &bc2c, &bc3d, &bc87
+.sub_cbac2
+    lda #&0d                                                          ; 5ac2: a9 0d       ..  :bac2[1]
+; &5ac4 referenced 3 times by &b26e, &bb67, &bbed
+.sub_cbac4
+    pha                                                               ; 5ac4: 48          H   :bac4[1]
+    jsr sub_cbab9                                                     ; 5ac5: 20 b9 ba     .. :bac5[1]
+    pla                                                               ; 5ac8: 68          h   :bac8[1]
+    cmp (os_text_ptr),y                                               ; 5ac9: d1 f2       ..  :bac9[1]
+    bne cbad0                                                         ; 5acb: d0 03       ..  :bacb[1]
+    clc                                                               ; 5acd: 18          .   :bacd[1]
+    iny                                                               ; 5ace: c8          .   :bace[1]
+    rts                                                               ; 5acf: 60          `   :bacf[1]
+
+; &5ad0 referenced 1 time by &bacb
+.cbad0
+    sec                                                               ; 5ad0: 38          8   :bad0[1]
+    rts                                                               ; 5ad1: 60          `   :bad1[1]
+
+; &5ad2 referenced 1 time by &bb4d
+.sub_cbad2
+    jsr sub_cbab9                                                     ; 5ad2: 20 b9 ba     .. :bad2[1]
+    tya                                                               ; 5ad5: 98          .   :bad5[1]
+    pha                                                               ; 5ad6: 48          H   :bad6[1]
+    clc                                                               ; 5ad7: 18          .   :bad7[1]
+    adc os_text_ptr                                                   ; 5ad8: 65 f2       e.  :bad8[1]
+    ldy #&ef                                                          ; 5ada: a0 ef       ..  :bada[1]
+    sta (l00b8),y                                                     ; 5adc: 91 b8       ..  :badc[1]
+    lda l00f3                                                         ; 5ade: a5 f3       ..  :bade[1]
+    adc #0                                                            ; 5ae0: 69 00       i.  :bae0[1]
+    iny                                                               ; 5ae2: c8          .   :bae2[1]
+    sta (l00b8),y                                                     ; 5ae3: 91 b8       ..  :bae3[1]
+    pla                                                               ; 5ae5: 68          h   :bae5[1]
+    tay                                                               ; 5ae6: a8          .   :bae6[1]
+    bit lb57f                                                         ; 5ae7: 2c 7f b5    ,.. :bae7[1]
+; &5aea referenced 1 time by &baf6
+.loop_cbaea
+    lda (os_text_ptr),y                                               ; 5aea: b1 f2       ..  :baea[1]
+    cmp #&20 ; ' '                                                    ; 5aec: c9 20       .   :baec[1]
+    beq cbafd                                                         ; 5aee: f0 0d       ..  :baee[1]
+    cmp #&0d                                                          ; 5af0: c9 0d       ..  :baf0[1]
+    beq cbafd                                                         ; 5af2: f0 09       ..  :baf2[1]
+    clv                                                               ; 5af4: b8          .   :baf4[1]
+    iny                                                               ; 5af5: c8          .   :baf5[1]
+    bne loop_cbaea                                                    ; 5af6: d0 f2       ..  :baf6[1]
+; &5af8 referenced 2 times by &bafd, &bbd0
+.cbaf8
+    ldx #3                                                            ; 5af8: a2 03       ..  :baf8[1]
+    jmp cb8fb                                                         ; 5afa: 4c fb b8    L.. :bafa[1]
+
+; &5afd referenced 2 times by &baee, &baf2
+.cbafd
+    bvs cbaf8                                                         ; 5afd: 70 f9       p.  :bafd[1]
+    rts                                                               ; 5aff: 60          `   :baff[1]
+
+; &5b00 referenced 4 times by &bb92, &bc21, &bc37, &bc81
+.sub_cbb00
+    stx l00bf                                                         ; 5b00: 86 bf       ..  :bb00[1]
+    jsr sub_cbab9                                                     ; 5b02: 20 b9 ba     .. :bb02[1]
+    ldx #3                                                            ; 5b05: a2 03       ..  :bb05[1]
+; &5b07 referenced 1 time by &bb34
+.cbb07
+    cmp lbb3e,x                                                       ; 5b07: dd 3e bb    .>. :bb07[1]
+    bcs cbb36                                                         ; 5b0a: b0 2a       .*  :bb0a[1]
+    cmp lbb3a,x                                                       ; 5b0c: dd 3a bb    .:. :bb0c[1]
+    bcc cbb33                                                         ; 5b0f: 90 22       ."  :bb0f[1]
+    sbc lbb42,x                                                       ; 5b11: fd 42 bb    .B. :bb11[1]
+    iny                                                               ; 5b14: c8          .   :bb14[1]
+    cmp #1                                                            ; 5b15: c9 01       ..  :bb15[1]
+    bne cbb2a                                                         ; 5b17: d0 11       ..  :bb17[1]
+    lda (os_text_ptr),y                                               ; 5b19: b1 f2       ..  :bb19[1]
+    cmp #&36 ; '6'                                                    ; 5b1b: c9 36       .6  :bb1b[1]
+    bcs cbb28                                                         ; 5b1d: b0 09       ..  :bb1d[1]
+    cmp #&30 ; '0'                                                    ; 5b1f: c9 30       .0  :bb1f[1]
+    bcc cbb28                                                         ; 5b21: 90 05       ..  :bb21[1]
+    sbc #&26 ; '&'                                                    ; 5b23: e9 26       .&  :bb23[1]
+    iny                                                               ; 5b25: c8          .   :bb25[1]
+    bne cbb2a                                                         ; 5b26: d0 02       ..  :bb26[1]
+; &5b28 referenced 2 times by &bb1d, &bb21
+.cbb28
+    lda #1                                                            ; 5b28: a9 01       ..  :bb28[1]
+; &5b2a referenced 2 times by &bb17, &bb26
+.cbb2a
+    pha                                                               ; 5b2a: 48          H   :bb2a[1]
+    jsr sub_cbab9                                                     ; 5b2b: 20 b9 ba     .. :bb2b[1]
+    pla                                                               ; 5b2e: 68          h   :bb2e[1]
+    ldx l00bf                                                         ; 5b2f: a6 bf       ..  :bb2f[1]
+    clc                                                               ; 5b31: 18          .   :bb31[1]
+    rts                                                               ; 5b32: 60          `   :bb32[1]
+
+; &5b33 referenced 1 time by &bb0f
+.cbb33
+    dex                                                               ; 5b33: ca          .   :bb33[1]
+    bpl cbb07                                                         ; 5b34: 10 d1       ..  :bb34[1]
+; &5b36 referenced 1 time by &bb0a
+.cbb36
+    ldx l00bf                                                         ; 5b36: a6 bf       ..  :bb36[1]
+    sec                                                               ; 5b38: 38          8   :bb38[1]
+    rts                                                               ; 5b39: 60          `   :bb39[1]
+
+; &5b3a referenced 1 time by &bb0c
+.lbb3a
+    equs "0AWw"                                                       ; 5b3a: 30 41 57... 0AW :bb3a[1]
+; &5b3e referenced 1 time by &bb07
+.lbb3e
+    equs ":G[{"                                                       ; 5b3e: 3a 47 5b... :G[ :bb3e[1]
+; &5b42 referenced 1 time by &bb11
+.lbb42
+    equs "07Gg"                                                       ; 5b42: 30 37 47... 07G :bb42[1]
+
+.sub_cbb46
+    lda #&c0                                                          ; 5b46: a9 c0       ..  :bb46[1]
+    bne cbb4c                                                         ; 5b48: d0 02       ..  :bb48[1]
+.sub_cbb4a
+    lda #&40 ; '@'                                                    ; 5b4a: a9 40       .@  :bb4a[1]
+; &5b4c referenced 1 time by &bb48
+.cbb4c
+    pha                                                               ; 5b4c: 48          H   :bb4c[1]
+    jsr sub_cbad2                                                     ; 5b4d: 20 d2 ba     .. :bb4d[1]
+    clv                                                               ; 5b50: b8          .   :bb50[1]
+    jsr sub_cba67                                                     ; 5b51: 20 67 ba     g. :bb51[1]
+    bcs cbb6f                                                         ; 5b54: b0 19       ..  :bb54[1]
+    sty l00ba                                                         ; 5b56: 84 ba       ..  :bb56[1]
+    ldx #&bc                                                          ; 5b58: a2 bc       ..  :bb58[1]
+    ldy #&f2                                                          ; 5b5a: a0 f2       ..  :bb5a[1]
+    jsr sub_cb850                                                     ; 5b5c: 20 50 b8     P. :bb5c[1]
+    ldy l00ba                                                         ; 5b5f: a4 ba       ..  :bb5f[1]
+    pla                                                               ; 5b61: 68          h   :bb61[1]
+    pha                                                               ; 5b62: 48          H   :bb62[1]
+    bmi cbb90                                                         ; 5b63: 30 2b       0+  :bb63[1]
+    lda #&2b ; '+'                                                    ; 5b65: a9 2b       .+  :bb65[1]
+    jsr sub_cbac4                                                     ; 5b67: 20 c4 ba     .. :bb67[1]
+    php                                                               ; 5b6a: 08          .   :bb6a[1]
+    clv                                                               ; 5b6b: b8          .   :bb6b[1]
+    jsr sub_cba67                                                     ; 5b6c: 20 67 ba     g. :bb6c[1]
+; &5b6f referenced 1 time by &bb54
+.cbb6f
+    bcs cbbd0                                                         ; 5b6f: b0 5f       ._  :bb6f[1]
+    sty l00ba                                                         ; 5b71: 84 ba       ..  :bb71[1]
+    plp                                                               ; 5b73: 28          (   :bb73[1]
+    bcc cbb89                                                         ; 5b74: 90 13       ..  :bb74[1]
+    ldy #&f2                                                          ; 5b76: a0 f2       ..  :bb76[1]
+    sec                                                               ; 5b78: 38          8   :bb78[1]
+    lda l00bc                                                         ; 5b79: a5 bc       ..  :bb79[1]
+    sec                                                               ; 5b7b: 38          8   :bb7b[1]
+    sbc (l00b8),y                                                     ; 5b7c: f1 b8       ..  :bb7c[1]
+    sta l00bc                                                         ; 5b7e: 85 bc       ..  :bb7e[1]
+    iny                                                               ; 5b80: c8          .   :bb80[1]
+    lda l00bd                                                         ; 5b81: a5 bd       ..  :bb81[1]
+    sbc (l00b8),y                                                     ; 5b83: f1 b8       ..  :bb83[1]
+    bcc cbbd0                                                         ; 5b85: 90 49       .I  :bb85[1]
+    sta l00bd                                                         ; 5b87: 85 bd       ..  :bb87[1]
+; &5b89 referenced 1 time by &bb74
+.cbb89
+    ldx #&bc                                                          ; 5b89: a2 bc       ..  :bb89[1]
+    ldy #&f4                                                          ; 5b8b: a0 f4       ..  :bb8b[1]
+    jsr sub_cb850                                                     ; 5b8d: 20 50 b8     P. :bb8d[1]
+; &5b90 referenced 1 time by &bb63
+.cbb90
+    ldy l00ba                                                         ; 5b90: a4 ba       ..  :bb90[1]
+    jsr sub_cbb00                                                     ; 5b92: 20 00 bb     .. :bb92[1]
+    sty l00ba                                                         ; 5b95: 84 ba       ..  :bb95[1]
+    bcs cbba1                                                         ; 5b97: b0 08       ..  :bb97[1]
+    ldy #&f1                                                          ; 5b99: a0 f1       ..  :bb99[1]
+    sta (l00b8),y                                                     ; 5b9b: 91 b8       ..  :bb9b[1]
+    pla                                                               ; 5b9d: 68          h   :bb9d[1]
+    and #&80                                                          ; 5b9e: 29 80       ).  :bb9e[1]
+    pha                                                               ; 5ba0: 48          H   :bba0[1]
+; &5ba1 referenced 1 time by &bb97
+.cbba1
+    pla                                                               ; 5ba1: 68          h   :bba1[1]
+    sta l00bb                                                         ; 5ba2: 85 bb       ..  :bba2[1]
+    ldy #&ee                                                          ; 5ba4: a0 ee       ..  :bba4[1]
+    lda (l00b8),y                                                     ; 5ba6: b1 b8       ..  :bba6[1]
+    and #&3f ; '?'                                                    ; 5ba8: 29 3f       )?  :bba8[1]
+    ora l00bb                                                         ; 5baa: 05 bb       ..  :bbaa[1]
+    sta (l00b8),y                                                     ; 5bac: 91 b8       ..  :bbac[1]
+    ldy l00ba                                                         ; 5bae: a4 ba       ..  :bbae[1]
+    jsr sub_cbab9                                                     ; 5bb0: 20 b9 ba     .. :bbb0[1]
+    and #&df                                                          ; 5bb3: 29 df       ).  :bbb3[1]
+    ldx #0                                                            ; 5bb5: a2 00       ..  :bbb5[1]
+    cmp #&51 ; 'Q'                                                    ; 5bb7: c9 51       .Q  :bbb7[1]
+    bne cbbbe                                                         ; 5bb9: d0 03       ..  :bbb9[1]
+    iny                                                               ; 5bbb: c8          .   :bbbb[1]
+    ldx #&ff                                                          ; 5bbc: a2 ff       ..  :bbbc[1]
+; &5bbe referenced 1 time by &bbb9
+.cbbbe
+    jsr sub_cbac2                                                     ; 5bbe: 20 c2 ba     .. :bbbe[1]
+    bcs cbbd0                                                         ; 5bc1: b0 0d       ..  :bbc1[1]
+    ldy #&f8                                                          ; 5bc3: a0 f8       ..  :bbc3[1]
+    lda #0                                                            ; 5bc5: a9 00       ..  :bbc5[1]
+    sta (l00b8),y                                                     ; 5bc7: 91 b8       ..  :bbc7[1]
+    iny                                                               ; 5bc9: c8          .   :bbc9[1]
+    txa                                                               ; 5bca: 8a          .   :bbca[1]
+    sta (l00b8),y                                                     ; 5bcb: 91 b8       ..  :bbcb[1]
+    jmp cb2e7                                                         ; 5bcd: 4c e7 b2    L.. :bbcd[1]
+
+; &5bd0 referenced 9 times by &bb6f, &bb85, &bbc1, &bbe0, &bbf6, &bc1f, &bc2f, &bc3a, &bc40
+.cbbd0
+    jmp cbaf8                                                         ; 5bd0: 4c f8 ba    L.. :bbd0[1]
+
+.sub_cbbd3
+    lda #&c0                                                          ; 5bd3: a9 c0       ..  :bbd3[1]
+    bne cbbd9                                                         ; 5bd5: d0 02       ..  :bbd5[1]
+.sub_cbbd7
+    lda #&40 ; '@'                                                    ; 5bd7: a9 40       .@  :bbd7[1]
+; &5bd9 referenced 1 time by &bbd5
+.cbbd9
+    pha                                                               ; 5bd9: 48          H   :bbd9[1]
+    bit lb57f                                                         ; 5bda: 2c 7f b5    ,.. :bbda[1]
+    jsr sub_cba67                                                     ; 5bdd: 20 67 ba     g. :bbdd[1]
+    bcs cbbd0                                                         ; 5be0: b0 ee       ..  :bbe0[1]
+    ldx #3                                                            ; 5be2: a2 03       ..  :bbe2[1]
+; &5be4 referenced 1 time by &bbe9
+.loop_cbbe4
+    lda l00bc,x                                                       ; 5be4: b5 bc       ..  :bbe4[1]
+    sta l00b1,x                                                       ; 5be6: 95 b1       ..  :bbe6[1]
+    dex                                                               ; 5be8: ca          .   :bbe8[1]
+    bpl loop_cbbe4                                                    ; 5be9: 10 f9       ..  :bbe9[1]
+    lda #&2b ; '+'                                                    ; 5beb: a9 2b       .+  :bbeb[1]
+    jsr sub_cbac4                                                     ; 5bed: 20 c4 ba     .. :bbed[1]
+    bcs cbbf3                                                         ; 5bf0: b0 01       ..  :bbf0[1]
+    clv                                                               ; 5bf2: b8          .   :bbf2[1]
+; &5bf3 referenced 1 time by &bbf0
+.cbbf3
+    jsr sub_cba67                                                     ; 5bf3: 20 67 ba     g. :bbf3[1]
+    bcs cbbd0                                                         ; 5bf6: b0 d8       ..  :bbf6[1]
+    bvc cbc13                                                         ; 5bf8: 50 19       P.  :bbf8[1]
+    sec                                                               ; 5bfa: 38          8   :bbfa[1]
+    ldx #0                                                            ; 5bfb: a2 00       ..  :bbfb[1]
+    sec                                                               ; 5bfd: 38          8   :bbfd[1]
+; &5bfe referenced 1 time by &bc08
+.loop_cbbfe
+    lda l00bc,x                                                       ; 5bfe: b5 bc       ..  :bbfe[1]
+    sbc l00b1,x                                                       ; 5c00: f5 b1       ..  :bc00[1]
+    sta l00bc,x                                                       ; 5c02: 95 bc       ..  :bc02[1]
+    inx                                                               ; 5c04: e8          .   :bc04[1]
+    txa                                                               ; 5c05: 8a          .   :bc05[1]
+    and #4                                                            ; 5c06: 29 04       ).  :bc06[1]
+    beq loop_cbbfe                                                    ; 5c08: f0 f4       ..  :bc08[1]
+    lda l00be                                                         ; 5c0a: a5 be       ..  :bc0a[1]
+    ora l00bf                                                         ; 5c0c: 05 bf       ..  :bc0c[1]
+    beq cbc13                                                         ; 5c0e: f0 03       ..  :bc0e[1]
+    jmp cb446                                                         ; 5c10: 4c 46 b4    LF. :bc10[1]
+
+; &5c13 referenced 2 times by &bbf8, &bc0e
+.cbc13
+    lda l00bc                                                         ; 5c13: a5 bc       ..  :bc13[1]
+    sta l00b5                                                         ; 5c15: 85 b5       ..  :bc15[1]
+    lda l00bd                                                         ; 5c17: a5 bd       ..  :bc17[1]
+    sta l00b6                                                         ; 5c19: 85 b6       ..  :bc19[1]
+    clv                                                               ; 5c1b: b8          .   :bc1b[1]
+    jsr sub_cba67                                                     ; 5c1c: 20 67 ba     g. :bc1c[1]
+    bcs cbbd0                                                         ; 5c1f: b0 af       ..  :bc1f[1]
+    jsr sub_cbb00                                                     ; 5c21: 20 00 bb     .. :bc21[1]
+    bcs cbc2c                                                         ; 5c24: b0 06       ..  :bc24[1]
+    sta l00b7                                                         ; 5c26: 85 b7       ..  :bc26[1]
+    pla                                                               ; 5c28: 68          h   :bc28[1]
+    and #&bf                                                          ; 5c29: 29 bf       ).  :bc29[1]
+    pha                                                               ; 5c2b: 48          H   :bc2b[1]
+; &5c2c referenced 1 time by &bc24
+.cbc2c
+    jsr sub_cbac2                                                     ; 5c2c: 20 c2 ba     .. :bc2c[1]
+    bcs cbbd0                                                         ; 5c2f: b0 9f       ..  :bc2f[1]
+    pla                                                               ; 5c31: 68          h   :bc31[1]
+    sta l00b0                                                         ; 5c32: 85 b0       ..  :bc32[1]
+    jmp cbcb9                                                         ; 5c34: 4c b9 bc    L.. :bc34[1]
+
+.sub_cbc37
+    jsr sub_cbb00                                                     ; 5c37: 20 00 bb     .. :bc37[1]
+; &5c3a referenced 2 times by &bc84, &bc8a
+.cbc3a
+    bcs cbbd0                                                         ; 5c3a: b0 94       ..  :bc3a[1]
+    pha                                                               ; 5c3c: 48          H   :bc3c[1]
+    jsr sub_cbac2                                                     ; 5c3d: 20 c2 ba     .. :bc3d[1]
+    bcs cbbd0                                                         ; 5c40: b0 8e       ..  :bc40[1]
+    pla                                                               ; 5c42: 68          h   :bc42[1]
+    tay                                                               ; 5c43: a8          .   :bc43[1]
+    jsr sub_cb6fe                                                     ; 5c44: 20 fe b6     .. :bc44[1]
+    bne cbc64                                                         ; 5c47: d0 1b       ..  :bc47[1]
+    jsr sub_cb986                                                     ; 5c49: 20 86 b9     .. :bc49[1]
+    tax                                                               ; 5c4c: aa          .   :bc4c[1]
+    bne cbc54                                                         ; 5c4d: d0 05       ..  :bc4d[1]
+    ldx #5                                                            ; 5c4f: a2 05       ..  :bc4f[1]
+    jmp cb8fb                                                         ; 5c51: 4c fb b8    L.. :bc51[1]
+
+; &5c54 referenced 1 time by &bc4d
+.cbc54
+    sty l00bf                                                         ; 5c54: 84 bf       ..  :bc54[1]
+    lda lb726,y                                                       ; 5c56: b9 26 b7    .&. :bc56[1]
+    ldy #&fd                                                          ; 5c59: a0 fd       ..  :bc59[1]
+    ora (l00b8),y                                                     ; 5c5b: 11 b8       ..  :bc5b[1]
+    sta (l00b8),y                                                     ; 5c5d: 91 b8       ..  :bc5d[1]
+    ldy l00bf                                                         ; 5c5f: a4 bf       ..  :bc5f[1]
+    jsr sub_cbc68                                                     ; 5c61: 20 68 bc     h. :bc61[1]
+; &5c64 referenced 1 time by &bc47
+.cbc64
+    jsr sub_cbec2                                                     ; 5c64: 20 c2 be     .. :bc64[1]
+    rts                                                               ; 5c67: 60          `   :bc67[1]
+
+; &5c68 referenced 2 times by &bc61, &bc95
+.sub_cbc68
+    ldx #&0f                                                          ; 5c68: a2 0f       ..  :bc68[1]
+    stx l00ba                                                         ; 5c6a: 86 ba       ..  :bc6a[1]
+    lda #&80                                                          ; 5c6c: a9 80       ..  :bc6c[1]
+    sta l00bb                                                         ; 5c6e: 85 bb       ..  :bc6e[1]
+; &5c70 referenced 1 time by &bc7e
+.loop_cbc70
+    lda lb872,x                                                       ; 5c70: bd 72 b8    .r. :bc70[1]
+    cpx #1                                                            ; 5c73: e0 01       ..  :bc73[1]
+    bne cbc78                                                         ; 5c75: d0 01       ..  :bc75[1]
+    tya                                                               ; 5c77: 98          .   :bc77[1]
+; &5c78 referenced 1 time by &bc75
+.cbc78
+    jsr sub_cb745                                                     ; 5c78: 20 45 b7     E. :bc78[1]
+    dex                                                               ; 5c7b: ca          .   :bc7b[1]
+    stx l00ba                                                         ; 5c7c: 86 ba       ..  :bc7c[1]
+    bpl loop_cbc70                                                    ; 5c7e: 10 f0       ..  :bc7e[1]
+    rts                                                               ; 5c80: 60          `   :bc80[1]
+
+.sub_cbc81
+    jsr sub_cbb00                                                     ; 5c81: 20 00 bb     .. :bc81[1]
+    bcs cbc3a                                                         ; 5c84: b0 b4       ..  :bc84[1]
+    pha                                                               ; 5c86: 48          H   :bc86[1]
+    jsr sub_cbac2                                                     ; 5c87: 20 c2 ba     .. :bc87[1]
+    bcs cbc3a                                                         ; 5c8a: b0 ae       ..  :bc8a[1]
+    pla                                                               ; 5c8c: 68          h   :bc8c[1]
+    tay                                                               ; 5c8d: a8          .   :bc8d[1]
+    jsr sub_cb6fe                                                     ; 5c8e: 20 fe b6     .. :bc8e[1]
+    beq cbcb2                                                         ; 5c91: f0 1f       ..  :bc91[1]
+; &5c93 referenced 1 time by &bcb6
+.cbc93
+    sty l00bc                                                         ; 5c93: 84 bc       ..  :bc93[1]
+    jsr sub_cbc68                                                     ; 5c95: 20 68 bc     h. :bc95[1]
+    lda #&0a                                                          ; 5c98: a9 0a       ..  :bc98[1]
+    sta l00ba                                                         ; 5c9a: 85 ba       ..  :bc9a[1]
+    lda #&4f ; 'O'                                                    ; 5c9c: a9 4f       .O  :bc9c[1]
+    jsr sub_cb745                                                     ; 5c9e: 20 45 b7     E. :bc9e[1]
+    lda lb726,y                                                       ; 5ca1: b9 26 b7    .&. :bca1[1]
+    eor #&ff                                                          ; 5ca4: 49 ff       I.  :bca4[1]
+    ldy #&fd                                                          ; 5ca6: a0 fd       ..  :bca6[1]
+    and (l00b8),y                                                     ; 5ca8: 31 b8       1.  :bca8[1]
+    sta (l00b8),y                                                     ; 5caa: 91 b8       ..  :bcaa[1]
+    ldy l00bc                                                         ; 5cac: a4 bc       ..  :bcac[1]
+    jsr sub_cbec2                                                     ; 5cae: 20 c2 be     .. :bcae[1]
+    rts                                                               ; 5cb1: 60          `   :bcb1[1]
+
+; &5cb2 referenced 1 time by &bc91
+.cbcb2
+    jsr sub_cb986                                                     ; 5cb2: 20 86 b9     .. :bcb2[1]
+    tax                                                               ; 5cb5: aa          .   :bcb5[1]
+    bne cbc93                                                         ; 5cb6: d0 db       ..  :bcb6[1]
+    rts                                                               ; 5cb8: 60          `   :bcb8[1]
+
+; &5cb9 referenced 2 times by &b1f6, &bc34
+.cbcb9
+    lda l00b0                                                         ; 5cb9: a5 b0       ..  :bcb9[1]
+    and #&c0                                                          ; 5cbb: 29 c0       ).  :bcbb[1]
+    sta l00be                                                         ; 5cbd: 85 be       ..  :bcbd[1]
+    ldy #&ee                                                          ; 5cbf: a0 ee       ..  :bcbf[1]
+    lda (l00b8),y                                                     ; 5cc1: b1 b8       ..  :bcc1[1]
+    and #&3f ; '?'                                                    ; 5cc3: 29 3f       )?  :bcc3[1]
+    ora l00be                                                         ; 5cc5: 05 be       ..  :bcc5[1]
+    sta (l00b8),y                                                     ; 5cc7: 91 b8       ..  :bcc7[1]
+    bit l00b0                                                         ; 5cc9: 24 b0       $.  :bcc9[1]
+    bvs cbcd6                                                         ; 5ccb: 70 09       p.  :bccb[1]
+    ldy l00b7                                                         ; 5ccd: a4 b7       ..  :bccd[1]
+    cpy #&14                                                          ; 5ccf: c0 14       ..  :bccf[1]
+    bcc cbce1                                                         ; 5cd1: 90 0e       ..  :bcd1[1]
+; &5cd3 referenced 1 time by &bcef
+.loop_cbcd3
+    jmp cb300                                                         ; 5cd3: 4c 00 b3    L.. :bcd3[1]
+
+; &5cd6 referenced 1 time by &bccb
+.cbcd6
+    ldx l00bc                                                         ; 5cd6: a6 bc       ..  :bcd6[1]
+    lda l00bd                                                         ; 5cd8: a5 bd       ..  :bcd8[1]
+    jsr sub_cb6b1                                                     ; 5cda: 20 b1 b6     .. :bcda[1]
+    stx l00bc                                                         ; 5cdd: 86 bc       ..  :bcdd[1]
+    sta l00bd                                                         ; 5cdf: 85 bd       ..  :bcdf[1]
+; &5ce1 referenced 1 time by &bcd1
+.cbce1
+    jsr sub_cb6fe                                                     ; 5ce1: 20 fe b6     .. :bce1[1]
+    pha                                                               ; 5ce4: 48          H   :bce4[1]
+    tya                                                               ; 5ce5: 98          .   :bce5[1]
+    ldy #&f1                                                          ; 5ce6: a0 f1       ..  :bce6[1]
+    sta (l00b8),y                                                     ; 5ce8: 91 b8       ..  :bce8[1]
+    pla                                                               ; 5cea: 68          h   :bcea[1]
+    eor l00b0                                                         ; 5ceb: 45 b0       E.  :bceb[1]
+    and #&40 ; '@'                                                    ; 5ced: 29 40       )@  :bced[1]
+    bne loop_cbcd3                                                    ; 5cef: d0 e2       ..  :bcef[1]
+    jsr sub_cbe9d                                                     ; 5cf1: 20 9d be     .. :bcf1[1]
+    jsr sub_cbe91                                                     ; 5cf4: 20 91 be     .. :bcf4[1]
+    bcs cbd1b                                                         ; 5cf7: b0 22       ."  :bcf7[1]
+; &5cf9 referenced 1 time by &bd21
+.cbcf9
+    ldx #&b5                                                          ; 5cf9: a2 b5       ..  :bcf9[1]
+    ldy #&be                                                          ; 5cfb: a0 be       ..  :bcfb[1]
+    jsr sub_cb580                                                     ; 5cfd: 20 80 b5     .. :bcfd[1]
+    rol l00b0                                                         ; 5d00: 26 b0       &.  :bd00[1]
+    bcc cbd0e                                                         ; 5d02: 90 0a       ..  :bd02[1]
+    ldx #&bc                                                          ; 5d04: a2 bc       ..  :bd04[1]
+    ldy #&b3                                                          ; 5d06: a0 b3       ..  :bd06[1]
+; &5d08 referenced 1 time by &bd19
+.loop_cbd08
+    jsr sub_cb580                                                     ; 5d08: 20 80 b5     .. :bd08[1]
+    jmp cb795                                                         ; 5d0b: 4c 95 b7    L.. :bd0b[1]
+
+; &5d0e referenced 1 time by &bd02
+.cbd0e
+    ldx #&b1                                                          ; 5d0e: a2 b1       ..  :bd0e[1]
+    ldy #&b3                                                          ; 5d10: a0 b3       ..  :bd10[1]
+    jsr sub_cb580                                                     ; 5d12: 20 80 b5     .. :bd12[1]
+    ldx #&bc                                                          ; 5d15: a2 bc       ..  :bd15[1]
+    ldy #&b1                                                          ; 5d17: a0 b1       ..  :bd17[1]
+    bne loop_cbd08                                                    ; 5d19: d0 ed       ..  :bd19[1]
+; &5d1b referenced 1 time by &bcf7
+.cbd1b
+    lda l00b3                                                         ; 5d1b: a5 b3       ..  :bd1b[1]
+    and l00b4                                                         ; 5d1d: 25 b4       %.  :bd1d[1]
+    cmp #&ff                                                          ; 5d1f: c9 ff       ..  :bd1f[1]
+    beq cbcf9                                                         ; 5d21: f0 d6       ..  :bd21[1]
+    lda l00bc                                                         ; 5d23: a5 bc       ..  :bd23[1]
+    pha                                                               ; 5d25: 48          H   :bd25[1]
+    lda l00bd                                                         ; 5d26: a5 bd       ..  :bd26[1]
+    pha                                                               ; 5d28: 48          H   :bd28[1]
+    ldx #3                                                            ; 5d29: a2 03       ..  :bd29[1]
+; &5d2b referenced 1 time by &bd30
+.loop_cbd2b
+    lda l00b1,x                                                       ; 5d2b: b5 b1       ..  :bd2b[1]
+    sta l00ba,x                                                       ; 5d2d: 95 ba       ..  :bd2d[1]
+    dex                                                               ; 5d2f: ca          .   :bd2f[1]
+    bpl loop_cbd2b                                                    ; 5d30: 10 f9       ..  :bd30[1]
+    ldx #&b5                                                          ; 5d32: a2 b5       ..  :bd32[1]
+    ldy #&f4                                                          ; 5d34: a0 f4       ..  :bd34[1]
+    jsr sub_cb850                                                     ; 5d36: 20 50 b8     P. :bd36[1]
+    bit l00b0                                                         ; 5d39: 24 b0       $.  :bd39[1]
+    bmi cbd40                                                         ; 5d3b: 30 03       0.  :bd3b[1]
+    jmp cbdba                                                         ; 5d3d: 4c ba bd    L.. :bd3d[1]
+
+; &5d40 referenced 1 time by &bd3b
+.cbd40
+    pla                                                               ; 5d40: 68          h   :bd40[1]
+    sta l00b4                                                         ; 5d41: 85 b4       ..  :bd41[1]
+    pla                                                               ; 5d43: 68          h   :bd43[1]
+    sta l00b3                                                         ; 5d44: 85 b3       ..  :bd44[1]
+; &5d46 referenced 1 time by &bdb6
+.cbd46
+    ldx #&be                                                          ; 5d46: a2 be       ..  :bd46[1]
+    ldy #&f4                                                          ; 5d48: a0 f4       ..  :bd48[1]
+    jsr sub_cb841                                                     ; 5d4a: 20 41 b8     A. :bd4a[1]
+    lda l00bf                                                         ; 5d4d: a5 bf       ..  :bd4d[1]
+    bne cbd7e                                                         ; 5d4f: d0 2d       .-  :bd4f[1]
+    ldx l00be                                                         ; 5d51: a6 be       ..  :bd51[1]
+    beq cbdb9                                                         ; 5d53: f0 64       .d  :bd53[1]
+    lda #0                                                            ; 5d55: a9 00       ..  :bd55[1]
+    sta (l00b8),y                                                     ; 5d57: 91 b8       ..  :bd57[1]
+    inc l00b9                                                         ; 5d59: e6 b9       ..  :bd59[1]
+    jsr cbe7b                                                         ; 5d5b: 20 7b be     {. :bd5b[1]
+    lda #0                                                            ; 5d5e: a9 00       ..  :bd5e[1]
+    ldx #&ba                                                          ; 5d60: a2 ba       ..  :bd60[1]
+    ldy #0                                                            ; 5d62: a0 00       ..  :bd62[1]
+    jsr tube_entry                                                    ; 5d64: 20 06 04     .. :bd64[1]
+    ldy #7                                                            ; 5d67: a0 07       ..  :bd67[1]
+    jsr cbe89                                                         ; 5d69: 20 89 be     .. :bd69[1]
+; &5d6c referenced 1 time by &bd7a
+.loop_cbd6c
+    lda tube_host_r3_data                                             ; 5d6c: ad e5 fe    ... :bd6c[1]
+    sta (l00b8),y                                                     ; 5d6f: 91 b8       ..  :bd6f[1]
+    ldx #3                                                            ; 5d71: a2 03       ..  :bd71[1]
+    jsr cbe8d                                                         ; 5d73: 20 8d be     .. :bd73[1]
+    nop                                                               ; 5d76: ea          .   :bd76[1]
+    iny                                                               ; 5d77: c8          .   :bd77[1]
+    cpy l00be                                                         ; 5d78: c4 be       ..  :bd78[1]
+    bne loop_cbd6c                                                    ; 5d7a: d0 f0       ..  :bd7a[1]
+    beq cbda3                                                         ; 5d7c: f0 25       .%  :bd7c[1]
+; &5d7e referenced 1 time by &bd4f
+.cbd7e
+    lda #0                                                            ; 5d7e: a9 00       ..  :bd7e[1]
+    sta l00be                                                         ; 5d80: 85 be       ..  :bd80[1]
+    lda #1                                                            ; 5d82: a9 01       ..  :bd82[1]
+    sta l00bf                                                         ; 5d84: 85 bf       ..  :bd84[1]
+    inc l00b9                                                         ; 5d86: e6 b9       ..  :bd86[1]
+    jsr cbe7b                                                         ; 5d88: 20 7b be     {. :bd88[1]
+    lda #6                                                            ; 5d8b: a9 06       ..  :bd8b[1]
+    ldx #&ba                                                          ; 5d8d: a2 ba       ..  :bd8d[1]
+    ldy #0                                                            ; 5d8f: a0 00       ..  :bd8f[1]
+    jsr tube_entry                                                    ; 5d91: 20 06 04     .. :bd91[1]
+    ldy #5                                                            ; 5d94: a0 05       ..  :bd94[1]
+    jsr cbe89                                                         ; 5d96: 20 89 be     .. :bd96[1]
+; &5d99 referenced 1 time by &bda1
+.loop_cbd99
+    lda tube_host_r3_data                                             ; 5d99: ad e5 fe    ... :bd99[1]
+    sta (l00b8),y                                                     ; 5d9c: 91 b8       ..  :bd9c[1]
+    lda (l00b8),y                                                     ; 5d9e: b1 b8       ..  :bd9e[1]
+    iny                                                               ; 5da0: c8          .   :bda0[1]
+    bne loop_cbd99                                                    ; 5da1: d0 f6       ..  :bda1[1]
+; &5da3 referenced 1 time by &bd7c
+.cbda3
+    jsr sub_cbe83                                                     ; 5da3: 20 83 be     .. :bda3[1]
+    ldx #&b8                                                          ; 5da6: a2 b8       ..  :bda6[1]
+    ldy #&b1                                                          ; 5da8: a0 b1       ..  :bda8[1]
+    jsr sub_cb580                                                     ; 5daa: 20 80 b5     .. :bdaa[1]
+    dec l00b9                                                         ; 5dad: c6 b9       ..  :bdad[1]
+    sec                                                               ; 5daf: 38          8   :bdaf[1]
+    jsr cb795                                                         ; 5db0: 20 95 b7     .. :bdb0[1]
+    jsr cbe47                                                         ; 5db3: 20 47 be     G. :bdb3[1]
+    jmp cbd46                                                         ; 5db6: 4c 46 bd    LF. :bdb6[1]
+
+; &5db9 referenced 2 times by &bd53, &bdcd
+.cbdb9
+    rts                                                               ; 5db9: 60          `   :bdb9[1]
+
+; &5dba referenced 1 time by &bd3d
+.cbdba
+    pla                                                               ; 5dba: 68          h   :bdba[1]
+    sta l00b2                                                         ; 5dbb: 85 b2       ..  :bdbb[1]
+    pla                                                               ; 5dbd: 68          h   :bdbd[1]
+    sta l00b1                                                         ; 5dbe: 85 b1       ..  :bdbe[1]
+; &5dc0 referenced 1 time by &be44
+.cbdc0
+    ldx #&be                                                          ; 5dc0: a2 be       ..  :bdc0[1]
+    ldy #&f4                                                          ; 5dc2: a0 f4       ..  :bdc2[1]
+    jsr sub_cb841                                                     ; 5dc4: 20 41 b8     A. :bdc4[1]
+    lda l00bf                                                         ; 5dc7: a5 bf       ..  :bdc7[1]
+    bne cbdd3                                                         ; 5dc9: d0 08       ..  :bdc9[1]
+    ldx l00be                                                         ; 5dcb: a6 be       ..  :bdcb[1]
+    beq cbdb9                                                         ; 5dcd: f0 ea       ..  :bdcd[1]
+    lda #1                                                            ; 5dcf: a9 01       ..  :bdcf[1]
+    bne cbddd                                                         ; 5dd1: d0 0a       ..  :bdd1[1]
+; &5dd3 referenced 1 time by &bdc9
+.cbdd3
+    lda #0                                                            ; 5dd3: a9 00       ..  :bdd3[1]
+    sta l00be                                                         ; 5dd5: 85 be       ..  :bdd5[1]
+    lda #1                                                            ; 5dd7: a9 01       ..  :bdd7[1]
+    sta l00bf                                                         ; 5dd9: 85 bf       ..  :bdd9[1]
+    lda #7                                                            ; 5ddb: a9 07       ..  :bddb[1]
+; &5ddd referenced 1 time by &bdd1
+.cbddd
+    pha                                                               ; 5ddd: 48          H   :bddd[1]
+    inc l00b9                                                         ; 5dde: e6 b9       ..  :bdde[1]
+    ldx #&b8                                                          ; 5de0: a2 b8       ..  :bde0[1]
+    ldy #&b3                                                          ; 5de2: a0 b3       ..  :bde2[1]
+    jsr sub_cb580                                                     ; 5de4: 20 80 b5     .. :bde4[1]
+    lda l00be                                                         ; 5de7: a5 be       ..  :bde7[1]
+    pha                                                               ; 5de9: 48          H   :bde9[1]
+    dec l00b9                                                         ; 5dea: c6 b9       ..  :bdea[1]
+    clc                                                               ; 5dec: 18          .   :bdec[1]
+    jsr cb795                                                         ; 5ded: 20 95 b7     .. :bded[1]
+    pla                                                               ; 5df0: 68          h   :bdf0[1]
+    sta l00be                                                         ; 5df1: 85 be       ..  :bdf1[1]
+    pla                                                               ; 5df3: 68          h   :bdf3[1]
+    cmp #1                                                            ; 5df4: c9 01       ..  :bdf4[1]
+    bne cbe21                                                         ; 5df6: d0 29       .)  :bdf6[1]
+    lda #0                                                            ; 5df8: a9 00       ..  :bdf8[1]
+    ldy #&f4                                                          ; 5dfa: a0 f4       ..  :bdfa[1]
+    sta (l00b8),y                                                     ; 5dfc: 91 b8       ..  :bdfc[1]
+    inc l00b9                                                         ; 5dfe: e6 b9       ..  :bdfe[1]
+    jsr cbe7b                                                         ; 5e00: 20 7b be     {. :be00[1]
+    lda #1                                                            ; 5e03: a9 01       ..  :be03[1]
+    ldx #&ba                                                          ; 5e05: a2 ba       ..  :be05[1]
+    ldy #0                                                            ; 5e07: a0 00       ..  :be07[1]
+    jsr tube_entry                                                    ; 5e09: 20 06 04     .. :be09[1]
+    ldy #0                                                            ; 5e0c: a0 00       ..  :be0c[1]
+; &5e0e referenced 1 time by &be1d
+.loop_cbe0e
+    lda (l00b8),y                                                     ; 5e0e: b1 b8       ..  :be0e[1]
+    sta tube_host_r3_data                                             ; 5e10: 8d e5 fe    ... :be10[1]
+    ldx #3                                                            ; 5e13: a2 03       ..  :be13[1]
+    jsr cbe8d                                                         ; 5e15: 20 8d be     .. :be15[1]
+    iny                                                               ; 5e18: c8          .   :be18[1]
+    cpy l00be                                                         ; 5e19: c4 be       ..  :be19[1]
+    cpy l00be                                                         ; 5e1b: c4 be       ..  :be1b[1]
+    bne loop_cbe0e                                                    ; 5e1d: d0 ef       ..  :be1d[1]
+    beq cbe3c                                                         ; 5e1f: f0 1b       ..  :be1f[1]
+; &5e21 referenced 1 time by &bdf6
+.cbe21
+    inc l00b9                                                         ; 5e21: e6 b9       ..  :be21[1]
+    jsr cbe7b                                                         ; 5e23: 20 7b be     {. :be23[1]
+    lda #7                                                            ; 5e26: a9 07       ..  :be26[1]
+    ldx #&ba                                                          ; 5e28: a2 ba       ..  :be28[1]
+    ldy #0                                                            ; 5e2a: a0 00       ..  :be2a[1]
+    jsr tube_entry                                                    ; 5e2c: 20 06 04     .. :be2c[1]
+    ldy #0                                                            ; 5e2f: a0 00       ..  :be2f[1]
+; &5e31 referenced 1 time by &be3a
+.loop_cbe31
+    lda (l00b8),y                                                     ; 5e31: b1 b8       ..  :be31[1]
+    sta tube_host_r3_data                                             ; 5e33: 8d e5 fe    ... :be33[1]
+    nop                                                               ; 5e36: ea          .   :be36[1]
+    nop                                                               ; 5e37: ea          .   :be37[1]
+    nop                                                               ; 5e38: ea          .   :be38[1]
+    iny                                                               ; 5e39: c8          .   :be39[1]
+    bne loop_cbe31                                                    ; 5e3a: d0 f5       ..  :be3a[1]
+; &5e3c referenced 1 time by &be1f
+.cbe3c
+    jsr sub_cbe83                                                     ; 5e3c: 20 83 be     .. :be3c[1]
+    dec l00b9                                                         ; 5e3f: c6 b9       ..  :be3f[1]
+    jsr cbe47                                                         ; 5e41: 20 47 be     G. :be41[1]
+    jmp cbdc0                                                         ; 5e44: 4c c0 bd    L.. :be44[1]
+
+; &5e47 referenced 3 times by &bdb3, &be41, &be50
+.cbe47
+    ldx #1                                                            ; 5e47: a2 01       ..  :be47[1]
+    inc l00ba,x                                                       ; 5e49: f6 ba       ..  :be49[1]
+    bne cbe52                                                         ; 5e4b: d0 05       ..  :be4b[1]
+    inx                                                               ; 5e4d: e8          .   :be4d[1]
+    cpx #4                                                            ; 5e4e: e0 04       ..  :be4e[1]
+    bcc cbe47                                                         ; 5e50: 90 f5       ..  :be50[1]
+; &5e52 referenced 1 time by &be4b
+.cbe52
+    ldy #&f5                                                          ; 5e52: a0 f5       ..  :be52[1]
+    lda (l00b8),y                                                     ; 5e54: b1 b8       ..  :be54[1]
+    sec                                                               ; 5e56: 38          8   :be56[1]
+    sbc #1                                                            ; 5e57: e9 01       ..  :be57[1]
+    bcc cbe7a                                                         ; 5e59: 90 1f       ..  :be59[1]
+    sta (l00b8),y                                                     ; 5e5b: 91 b8       ..  :be5b[1]
+    jsr sub_cb616                                                     ; 5e5d: 20 16 b6     .. :be5d[1]
+    beq cbe7a                                                         ; 5e60: f0 18       ..  :be60[1]
+    ldx l00b7                                                         ; 5e62: a6 b7       ..  :be62[1]
+    jsr sub_cb85d                                                     ; 5e64: 20 5d b8     ]. :be64[1]
+    bvc cbe7a                                                         ; 5e67: 50 11       P.  :be67[1]
+    lda l00b1,x                                                       ; 5e69: b5 b1       ..  :be69[1]
+    cmp #&c0                                                          ; 5e6b: c9 c0       ..  :be6b[1]
+    bcc cbe7a                                                         ; 5e6d: 90 0b       ..  :be6d[1]
+    lda #&10                                                          ; 5e6f: a9 10       ..  :be6f[1]
+    sta l00b0,x                                                       ; 5e71: 95 b0       ..  :be71[1]
+    lda #&80                                                          ; 5e73: a9 80       ..  :be73[1]
+    sta l00b1,x                                                       ; 5e75: 95 b1       ..  :be75[1]
+    jsr sub_cb68f                                                     ; 5e77: 20 8f b6     .. :be77[1]
+; &5e7a referenced 4 times by &be59, &be60, &be67, &be6d
+.cbe7a
+    rts                                                               ; 5e7a: 60          `   :be7a[1]
+
+; &5e7b referenced 5 times by &bd5b, &bd88, &be00, &be23, &be80
+.cbe7b
+    lda #&c8                                                          ; 5e7b: a9 c8       ..  :be7b[1]
+    jsr tube_entry                                                    ; 5e7d: 20 06 04     .. :be7d[1]
+    bcc cbe7b                                                         ; 5e80: 90 f9       ..  :be80[1]
+    rts                                                               ; 5e82: 60          `   :be82[1]
+
+; &5e83 referenced 2 times by &bda3, &be3c
+.sub_cbe83
+    lda #&88                                                          ; 5e83: a9 88       ..  :be83[1]
+    jsr tube_entry                                                    ; 5e85: 20 06 04     .. :be85[1]
+    rts                                                               ; 5e88: 60          `   :be88[1]
+
+; &5e89 referenced 3 times by &bd69, &bd96, &be8a
+.cbe89
+    dey                                                               ; 5e89: 88          .   :be89[1]
+    bne cbe89                                                         ; 5e8a: d0 fd       ..  :be8a[1]
+    rts                                                               ; 5e8c: 60          `   :be8c[1]
+
+; &5e8d referenced 3 times by &bd73, &be15, &be8e
+.cbe8d
+    dex                                                               ; 5e8d: ca          .   :be8d[1]
+    bne cbe8d                                                         ; 5e8e: d0 fd       ..  :be8e[1]
+    rts                                                               ; 5e90: 60          `   :be90[1]
+
+; &5e91 referenced 1 time by &bcf4
+.sub_cbe91
+    lda #osbyte_read_tube_presence                                    ; 5e91: a9 ea       ..  :be91[1]
+    ldx #0                                                            ; 5e93: a2 00       ..  :be93[1]
+    ldy #&ff                                                          ; 5e95: a0 ff       ..  :be95[1]
+    jsr osbyte                                                        ; 5e97: 20 f4 ff     .. :be97[1]
+    cpx #&ff                                                          ; 5e9a: e0 ff       ..  :be9a[1]
+    rts                                                               ; 5e9c: 60          `   :be9c[1]
+
+; &5e9d referenced 2 times by &b338, &bcf1
+.sub_cbe9d
+    jsr sub_cb85d                                                     ; 5e9d: 20 5d b8     ]. :be9d[1]
+    bpl cbec1                                                         ; 5ea0: 10 1f       ..  :bea0[1]
+    bvs cbec1                                                         ; 5ea2: 70 1d       p.  :bea2[1]
+    lda #0                                                            ; 5ea4: a9 00       ..  :bea4[1]
+    pha                                                               ; 5ea6: 48          H   :bea6[1]
+    ldy #&f1                                                          ; 5ea7: a0 f1       ..  :bea7[1]
+    lda (l00b8),y                                                     ; 5ea9: b1 b8       ..  :bea9[1]
+; &5eab referenced 1 time by &bec6
+.loop_cbeab
+    pha                                                               ; 5eab: 48          H   :beab[1]
+    lda #osbyte_read_rom_info_table_low                               ; 5eac: a9 aa       ..  :beac[1]
+    ldx #0                                                            ; 5eae: a2 00       ..  :beae[1]
+    ldy #&ff                                                          ; 5eb0: a0 ff       ..  :beb0[1]
+    jsr osbyte                                                        ; 5eb2: 20 f4 ff     .. :beb2[1]
+    jsr cb82b                                                         ; 5eb5: 20 2b b8     +. :beb5[1]
+    stx l00ba                                                         ; 5eb8: 86 ba       ..  :beb8[1]
+    sty l00bb                                                         ; 5eba: 84 bb       ..  :beba[1]
+    pla                                                               ; 5ebc: 68          h   :bebc[1]
+    tay                                                               ; 5ebd: a8          .   :bebd[1]
+    pla                                                               ; 5ebe: 68          h   :bebe[1]
+    sta (l00ba),y                                                     ; 5ebf: 91 ba       ..  :bebf[1]
+; &5ec1 referenced 2 times by &bea0, &bea2
+.cbec1
+    rts                                                               ; 5ec1: 60          `   :bec1[1]
+
+; &5ec2 referenced 2 times by &bc64, &bcae
+.sub_cbec2
+    lda #2                                                            ; 5ec2: a9 02       ..  :bec2[1]
+    pha                                                               ; 5ec4: 48          H   :bec4[1]
+    tya                                                               ; 5ec5: 98          .   :bec5[1]
+    bpl loop_cbeab                                                    ; 5ec6: 10 e3       ..  :bec6[1]
+; &5ec8 referenced 1 time by &8003
+.service_handler
+    cmp #service_claim_absolute_workspace                             ; 5ec8: c9 01       ..  :bec8[1]
+    bne cbee0                                                         ; 5eca: d0 14       ..  :beca[1]
+    pha                                                               ; 5ecc: 48          H   :becc[1]
+    tya                                                               ; 5ecd: 98          .   :becd[1]
+    pha                                                               ; 5ece: 48          H   :bece[1]
+    lda #osbyte_issue_service_request                                 ; 5ecf: a9 8f       ..  :becf[1]
+    ldx #service_check_swr_presence                                   ; 5ed1: a2 2b       .+  :bed1[1]
+    ldy romsel_copy                                                   ; 5ed3: a4 f4       ..  :bed3[1]
+    jsr osbyte                                                        ; 5ed5: 20 f4 ff     .. :bed5[1]
+    pla                                                               ; 5ed8: 68          h   :bed8[1]
+    tay                                                               ; 5ed9: a8          .   :bed9[1]
+    ldx romsel_copy                                                   ; 5eda: a6 f4       ..  :beda[1]
+    pla                                                               ; 5edc: 68          h   :bedc[1]
+; &5edd referenced 2 times by &bee2, &beec
+.general_service_handler_indirect
+    jmp general_service_handler                                       ; 5edd: 4c b1 b1    L.. :bedd[1]
+
+; &5ee0 referenced 1 time by &beca
+.cbee0
+    cmp #service_check_swr_presence                                   ; 5ee0: c9 2b       .+  :bee0[1]
+    bne general_service_handler_indirect                              ; 5ee2: d0 f9       ..  :bee2[1]
+    cpy romsel_copy                                                   ; 5ee4: c4 f4       ..  :bee4[1]
+    beq cbeee                                                         ; 5ee6: f0 06       ..  :bee6[1]
+; &5ee8 referenced 4 times by &bef8, &beff, &bf08, &bf4c
+.cbee8
+    ldx romsel_copy                                                   ; 5ee8: a6 f4       ..  :bee8[1]
+    lda #0                                                            ; 5eea: a9 00       ..  :beea[1]
+    beq general_service_handler_indirect                              ; 5eec: f0 ef       ..  :beec[1]
+; &5eee referenced 1 time by &bee6
+.cbeee
+    lda #&72 ; 'r'                                                    ; 5eee: a9 72       .r  :beee[1]
+    ldx #0                                                            ; 5ef0: a2 00       ..  :bef0[1]
+    jsr osbyte                                                        ; 5ef2: 20 f4 ff     .. :bef2[1]
+    jsr osbyte                                                        ; 5ef5: 20 f4 ff     .. :bef5[1]
+    bvs cbee8                                                         ; 5ef8: 70 ee       p.  :bef8[1]
+    lda #&ea                                                          ; 5efa: a9 ea       ..  :befa[1]
+    jsr sub_cbf82                                                     ; 5efc: 20 82 bf     .. :befc[1]
+    bne cbee8                                                         ; 5eff: d0 e7       ..  :beff[1]
+    lda #&d7                                                          ; 5f01: a9 d7       ..  :bf01[1]
+    ldy #&7f                                                          ; 5f03: a0 7f       ..  :bf03[1]
+    jsr sub_cbf84                                                     ; 5f05: 20 84 bf     .. :bf05[1]
+    bpl cbee8                                                         ; 5f08: 10 de       ..  :bf08[1]
+    jsr osnewl                                                        ; 5f0a: 20 e7 ff     .. :bf0a[1]
+    ldx #0                                                            ; 5f0d: a2 00       ..  :bf0d[1]
+    jsr sub_cbf7c                                                     ; 5f0f: 20 7c bf     |. :bf0f[1]
+    lda #&fd                                                          ; 5f12: a9 fd       ..  :bf12[1]
+    jsr sub_cbf82                                                     ; 5f14: 20 82 bf     .. :bf14[1]
+    beq cbf46                                                         ; 5f17: f0 2d       .-  :bf17[1]
+    tsx                                                               ; 5f19: ba          .   :bf19[1]
+    ldy #&30 ; '0'                                                    ; 5f1a: a0 30       .0  :bf1a[1]
+; &5f1c referenced 1 time by &bf21
+.loop_cbf1c
+    lda cbf8a,y                                                       ; 5f1c: b9 8a bf    ... :bf1c[1]
+    pha                                                               ; 5f1f: 48          H   :bf1f[1]
+    dey                                                               ; 5f20: 88          .   :bf20[1]
+    bne loop_cbf1c                                                    ; 5f21: d0 f9       ..  :bf21[1]
+    txa                                                               ; 5f23: 8a          .   :bf23[1]
+    tay                                                               ; 5f24: a8          .   :bf24[1]
+    lda #1                                                            ; 5f25: a9 01       ..  :bf25[1]
+    pha                                                               ; 5f27: 48          H   :bf27[1]
+    tsx                                                               ; 5f28: ba          .   :bf28[1]
+    inx                                                               ; 5f29: e8          .   :bf29[1]
+    txa                                                               ; 5f2a: 8a          .   :bf2a[1]
+    pha                                                               ; 5f2b: 48          H   :bf2b[1]
+    ldx #&0f                                                          ; 5f2c: a2 0f       ..  :bf2c[1]
+    lda #0                                                            ; 5f2e: a9 00       ..  :bf2e[1]
+    sta l00b0                                                         ; 5f30: 85 b0       ..  :bf30[1]
+    rts                                                               ; 5f32: 60          `   :bf32[1]
+
+; &5f33 referenced 1 time by &bfb8
+.cbf33
+    tya                                                               ; 5f33: 98          .   :bf33[1]
+    tax                                                               ; 5f34: aa          .   :bf34[1]
+    txs                                                               ; 5f35: 9a          .   :bf35[1]
+    lda l00b0                                                         ; 5f36: a5 b0       ..  :bf36[1]
+    asl a                                                             ; 5f38: 0a          .   :bf38[1]
+    asl a                                                             ; 5f39: 0a          .   :bf39[1]
+    clc                                                               ; 5f3a: 18          .   :bf3a[1]
+    adc #&0d                                                          ; 5f3b: 69 0d       i.  :bf3b[1]
+    tax                                                               ; 5f3d: aa          .   :bf3d[1]
+    jsr sub_cbf7c                                                     ; 5f3e: 20 7c bf     |. :bf3e[1]
+    ldx #&0a                                                          ; 5f41: a2 0a       ..  :bf41[1]
+    jsr sub_cbf7c                                                     ; 5f43: 20 7c bf     |. :bf43[1]
+; &5f46 referenced 1 time by &bf17
+.cbf46
+    jsr osnewl                                                        ; 5f46: 20 e7 ff     .. :bf46[1]
+    jsr osnewl                                                        ; 5f49: 20 e7 ff     .. :bf49[1]
+    jmp cbee8                                                         ; 5f4c: 4c e8 be    L.. :bf4c[1]
+
+; &5f4f referenced 1 time by &bf7c
+.lbf4f
+    equs "Acorn OS "                                                  ; 5f4f: 41 63 6f... Aco :bf4f[1]
+    equb   0, &4b,   7,   0, &36, &34,   0,   0, &38, &30,   0,   0   ; 5f58: 00 4b 07... .K. :bf58[1]
+    equb &39, &36,   0,   0                                           ; 5f64: 39 36 00... 96. :bf64[1]
+    equs "112"                                                        ; 5f68: 31 31 32    112 :bf68[1]
+    equb 0                                                            ; 5f6b: 00          .   :bf6b[1]
+    equs "128"                                                        ; 5f6c: 31 32 38    128 :bf6c[1]
+    equb 0                                                            ; 5f6f: 00          .   :bf6f[1]
+    equs "144"                                                        ; 5f70: 31 34 34    144 :bf70[1]
+    equb 0                                                            ; 5f73: 00          .   :bf73[1]
+    equs "160"                                                        ; 5f74: 31 36 30    160 :bf74[1]
+    equb 0                                                            ; 5f77: 00          .   :bf77[1]
+
+; &5f78 referenced 1 time by &bf7f
+.loop_cbf78
+    jsr oswrch                                                        ; 5f78: 20 ee ff     .. :bf78[1]
+    inx                                                               ; 5f7b: e8          .   :bf7b[1]
+; &5f7c referenced 3 times by &bf0f, &bf3e, &bf43
+.sub_cbf7c
+    lda lbf4f,x                                                       ; 5f7c: bd 4f bf    .O. :bf7c[1]
+    bne loop_cbf78                                                    ; 5f7f: d0 f7       ..  :bf7f[1]
+    rts                                                               ; 5f81: 60          `   :bf81[1]
+
+; &5f82 referenced 2 times by &befc, &bf14
+.sub_cbf82
+    ldy #&ff                                                          ; 5f82: a0 ff       ..  :bf82[1]
+; &5f84 referenced 1 time by &bf05
+.sub_cbf84
+    ldx #0                                                            ; 5f84: a2 00       ..  :bf84[1]
+    jsr osbyte                                                        ; 5f86: 20 f4 ff     .. :bf86[1]
+    txa                                                               ; 5f89: 8a          .   :bf89[1]
+; &5f8a referenced 1 time by &bf1c
+.cbf8a
+    rts                                                               ; 5f8a: 60          `   :bf8a[1]
+
+    lda romsel_copy                                                   ; 5f8b: a5 f4       ..  :bf8b[1]
+    pha                                                               ; 5f8d: 48          H   :bf8d[1]
+; &5f8e referenced 2 times by &bfac, &bfb0
+.cbf8e
+    stx romsel_copy                                                   ; 5f8e: 86 f4       ..  :bf8e[1]
+    stx romsel                                                        ; 5f90: 8e 30 fe    .0. :bf90[1]
+    lda lbfff                                                         ; 5f93: ad ff bf    ... :bf93[1]
+    pha                                                               ; 5f96: 48          H   :bf96[1]
+    eor #&a5                                                          ; 5f97: 49 a5       I.  :bf97[1]
+    sta lbfff                                                         ; 5f99: 8d ff bf    ... :bf99[1]
+    cmp lbfff                                                         ; 5f9c: cd ff bf    ... :bf9c[1]
+    bne cbfa3                                                         ; 5f9f: d0 02       ..  :bf9f[1]
+    inc l00b0                                                         ; 5fa1: e6 b0       ..  :bfa1[1]
+; &5fa3 referenced 1 time by &bf9f
+.cbfa3
+    pla                                                               ; 5fa3: 68          h   :bfa3[1]
+    sta lbfff                                                         ; 5fa4: 8d ff bf    ... :bfa4[1]
+    dex                                                               ; 5fa7: ca          .   :bfa7[1]
+    bmi cbfb2                                                         ; 5fa8: 30 08       0.  :bfa8[1]
+    cpx #&0b                                                          ; 5faa: e0 0b       ..  :bfaa[1]
+    bne cbf8e                                                         ; 5fac: d0 e0       ..  :bfac[1]
+    ldx #1                                                            ; 5fae: a2 01       ..  :bfae[1]
+    bne cbf8e                                                         ; 5fb0: d0 dc       ..  :bfb0[1]
+; &5fb2 referenced 1 time by &bfa8
+.cbfb2
+    pla                                                               ; 5fb2: 68          h   :bfb2[1]
+    sta romsel_copy                                                   ; 5fb3: 85 f4       ..  :bfb3[1]
+    sta romsel                                                        ; 5fb5: 8d 30 fe    .0. :bfb5[1]
+    jmp cbf33                                                         ; 5fb8: 4c 33 bf    L3. :bfb8[1]
+
+    equb &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff   ; 5fbb: ff ff ff... ... :bfbb[1]
+    equb &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff   ; 5fc7: ff ff ff... ... :bfc7[1]
+    equb &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff   ; 5fd3: ff ff ff... ... :bfd3[1]
+    equb &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff   ; 5fdf: ff ff ff... ... :bfdf[1]
+    equb &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff   ; 5feb: ff ff ff... ... :bfeb[1]
+    equb &ff, &ff, &ff, &ff, &ff, &ff, &ff, &ff                       ; 5ff7: ff ff ff... ... :bff7[1]
+; &5fff referenced 4 times by &bf93, &bf99, &bf9c, &bfa4
+.lbfff
+    equb &ff                                                          ; 5fff: ff          .   :bfff[1]
+    org l5075 + (lc000 - lb075)
+    copyblock lb075, lc000, l5075
+    clear lb075, lc000
+
+.pydis_end
+
+; Label references by decreasing frequency:
+;     l00b8:                    125
+;     l00b0:                    105
+;     l00ba:                     44
+;     l00bf:                     42
+;     l00bc:                     41
+;     l00b6:                     35
+;     l00be:                     31
+;     l00cd:                     31
+;     sub_c2077:                 31
+;     l00c2:                     30
+;     l00b1:                     29
+;     sub_c23e3:                 29
+;     l00b9:                     28
+;     l00bb:                     28
+;     l00b5:                     26
+;     l00bd:                     26
+;     l00b4:                     25
+;     l00b3:                     23
+;     l00c1:                     23
+;     os_text_ptr:               23
+;     osbyte:                    22
+;     romsel_copy:               21
+;     l0f0e:                     21
+;     c4ea0:                     21
+;     l00c4:                     20
+;     c209f:                     20
+;     l00b2:                     19
+;     l10c2:                     19
+;     l0001:                     18
+;     l00a8:                     18
+;     l00aa:                     18
+;     l00c5:                     18
+;     l00c9:                     18
+;     l10de:                     18
+;     l0000:                     17
+;     l00b7:                     17
+;     l0e0f:                     17
+;     l0f06:                     17
+;     l1000:                     17
+;     l00a2:                     16
+;     l00ab:                     16
+;     l00ae:                     16
+;     c43dc:                     16
+;     c582b:                     16
+;     l00c0:                     15
+;     l00c3:                     15
+;     l00c7:                     15
+;     l0f05:                     15
+;     l00cc:                     14
+;     l1117:                     14
+;     c4e70:                     14
+;     c4f7f:                     14
+;     l00a1:                     13
+;     l00a5:                     13
+;     l00c8:                     13
+;     l0f07:                     13
+;     sub_c414a:                 13
+;     tube_host_r3_data:         13
+;     l00ac:                     12
+;     sub_c274c:                 12
+;     sub_c5841:                 12
+;     osasci:                    12
+;     l00c6:                     11
+;     osrdsc_ptr:                11
+;     l0e08:                     11
+;     sub_c2038:                 11
+;     sub_c2149:                 11
+;     c396e:                     11
+;     c4c0f:                     11
+;     lfe84:                     11
+;     tube_host_r2_data:         11
+;     l00a9:                     10
+;     l1111:                     10
+;     l1112:                     10
+;     sub_c20c3:                 10
+;     c33e6:                     10
+;     c5203:                     10
+;     lfe87:                     10
+;     tube_host_r2_status:       10
+;     l00ca:                      9
+;     l1074:                      9
+;     l108a:                      9
+;     l1097:                      9
+;     l10c0:                      9
+;     l1110:                      9
+;     c5bd0:                      9
+;     l00ce:                      8
+;     l00ff:                      8
+;     l0100:                      8
+;     l0df0:                      8
+;     l0f04:                      8
+;     l1060:                      8
+;     l1082:                      8
+;     l108b:                      8
+;     l1090:                      8
+;     l1096:                      8
+;     l10ca:                      8
+;     l10cf:                      8
+;     l10d1:                      8
+;     sub_c21b0:                  8
+;     sub_c21bf:                  8
+;     c2816:                      8
+;     sub_c2b7b:                  8
+;     sub_c3ae5:                  8
+;     c4e79:                      8
+;     sub_c585d:                  8
+;     tube_host_r1_status:        8
+;     osfind:                     8
+;     l00a7:                      7
+;     l00cf:                      7
+;     l0f08:                      7
+;     l1075:                      7
+;     l10c9:                      7
+;     l10d2:                      7
+;     l1114:                      7
+;     c204f:                      7
+;     sub_c2284:                  7
+;     sub_c2380:                  7
+;     c2b8b:                      7
+;     sub_c499c:                  7
+;     sub_c5580:                  7
+;     sub_c5ab9:                  7
+;     osrdsc:                     7
+;     l0015:                      6
+;     l00f3:                      6
+;     l00f7:                      6
+;     l0f0f:                      6
+;     l1100:                      6
+;     sub_c202e:                  6
+;     sub_c2280:                  6
+;     sub_c22fe:                  6
+;     l261c:                      6
+;     sub_c27da:                  6
+;     c340c:                      6
+;     sub_c39ac:                  6
+;     sub_c3d8e:                  6
+;     sub_c3e75:                  6
+;     c4f58:                      6
+;     sub_c55f2:                  6
+;     l5726:                      6
+;     c58fb:                      6
+;     oswrch:                     6
+;     l00a6:                      5
+;     l00af:                      5
+;     l00f0:                      5
+;     l1087:                      5
+;     l1088:                      5
+;     l1099:                      5
+;     l10c7:                      5
+;     l10dd:                      5
+;     l110c:                      5
+;     l1115:                      5
+;     l1116:                      5
+;     sub_c20bb:                  5
+;     sub_c20ed:                  5
+;     sub_c20f3:                  5
+;     c2125:                      5
+;     sub_c230a:                  5
+;     sub_c2335:                  5
+;     sub_c2386:                  5
+;     sub_c240c:                  5
+;     c2ba2:                      5
+;     sub_c2f3f:                  5
+;     c3257:                      5
+;     c39a3:                      5
+;     sub_c3a6e:                  5
+;     sub_c3ab8:                  5
+;     sub_c40de:                  5
+;     sub_c41b4:                  5
+;     c4e97:                      5
+;     sub_c56fe:                  5
+;     sub_c5745:                  5
+;     c5795:                      5
+;     sub_c5850:                  5
+;     sub_c5a67:                  5
+;     c5e7b:                      5
+;     osnewl:                     5
+;     l0002:                      4
+;     l0e00:                      4
+;     l0f0c:                      4
+;     l0f0d:                      4
+;     l1069:                      4
+;     l1076:                      4
+;     l1077:                      4
+;     l1081:                      4
+;     l1086:                      4
+;     l1095:                      4
+;     l10c4:                      4
+;     l10cb:                      4
+;     l10cc:                      4
+;     l10ce:                      4
+;     l10d9:                      4
+;     l10da:                      4
+;     l110d:                      4
+;     l1113:                      4
+;     l111a:                      4
+;     l111d:                      4
+;     sub_c2023:                  4
+;     sub_c2048:                  4
+;     sub_c20c8:                  4
+;     sub_c2174:                  4
+;     c21a7:                      4
+;     sub_c221d:                  4
+;     c2225:                      4
+;     sub_c22b2:                  4
+;     sub_c2327:                  4
+;     sub_c23dc:                  4
+;     c2d74:                      4
+;     c2d91:                      4
+;     c2e0e:                      4
+;     c2e12:                      4
+;     c2e64:                      4
+;     sub_c2f6b:                  4
+;     c340e:                      4
+;     c3436:                      4
+;     c393b:                      4
+;     sub_c3965:                  4
+;     sub_c3a8d:                  4
+;     c3adf:                      4
+;     c3ae9:                      4
+;     sub_c4379:                  4
+;     c45e5:                      4
+;     sub_c49ca:                  4
+;     sub_c4acf:                  4
+;     sub_c4c18:                  4
+;     sub_c4c62:                  4
+;     c4d79:                      4
+;     c5446:                      4
+;     l557f:                      4
+;     sub_c5616:                  4
+;     c568c:                      4
+;     sub_c568f:                  4
+;     sub_c583f:                  4
+;     sub_c5ac2:                  4
+;     sub_c5b00:                  4
+;     c5e7a:                      4
+;     c5ee8:                      4
+;     l5fff:                      4
+;     romsel:                     4
+;     lfe85:                      4
+;     lfe86:                      4
+;     osbput:                     4
+;     osbget:                     4
+;     osfile:                     4
+;     osrdch:                     4
+;     l00ef:                      3
+;     l0107:                      3
+;     l0109:                      3
+;     bytev:                      3
+;     bytev+1:                    3
+;     l0ef8:                      3
+;     l1092:                      3
+;     l1093:                      3
+;     l1094:                      3
+;     l1098:                      3
+;     l109d:                      3
+;     l109f:                      3
+;     l10c3:                      3
+;     l10c5:                      3
+;     l10c6:                      3
+;     l10d0:                      3
+;     l10d3:                      3
+;     l10d6:                      3
+;     l10d7:                      3
+;     l1119:                      3
+;     l111c:                      3
+;     c2103:                      3
+;     sub_c21be:                  3
+;     c2290:                      3
+;     c22e6:                      3
+;     sub_c233a:                  3
+;     sub_c236e:                  3
+;     c2454:                      3
+;     sub_c2456:                  3
+;     c29d7:                      3
+;     sub_c2b86:                  3
+;     c2d41:                      3
+;     c2e53:                      3
+;     c2ecc:                      3
+;     c2f2a:                      3
+;     sub_c2f7a:                  3
+;     c30fb:                      3
+;     c31af:                      3
+;     c3214:                      3
+;     sub_c33fd:                  3
+;     c3444:                      3
+;     c34bc:                      3
+;     sub_c3526:                  3
+;     c3738:                      3
+;     sub_c3940:                  3
+;     c39ed:                      3
+;     c3a8c:                      3
+;     sub_c3be5:                  3
+;     c3c82:                      3
+;     c3d5d:                      3
+;     sub_c3e30:                  3
+;     sub_c3f0f:                  3
+;     sub_c3f16:                  3
+;     sub_c3f1e:                  3
+;     c406b:                      3
+;     c414f:                      3
+;     c41c0:                      3
+;     sub_c4315:                  3
+;     sub_c4384:                  3
+;     sub_c4530:                  3
+;     c4660:                      3
+;     sub_c49c2:                  3
+;     c4a42:                      3
+;     c4a44:                      3
+;     sub_c4c0c:                  3
+;     c4cc4:                      3
+;     sub_c4d5d:                  3
+;     c4d77:                      3
+;     l4f76:                      3
+;     c51d5:                      3
+;     c5371:                      3
+;     sub_c558b:                  3
+;     c5684:                      3
+;     c56ca:                      3
+;     sub_c584e:                  3
+;     sub_c5986:                  3
+;     l5a30:                      3
+;     c5ab4:                      3
+;     sub_c5ac4:                  3
+;     c5e47:                      3
+;     c5e89:                      3
+;     c5e8d:                      3
+;     sub_c5f7c:                  3
+;     lfe80:                      3
+;     tube_host_r1_data:          3
+;     osword:                     3
+;     oscli:                      3
+;     l0003:                      2
+;     l0012:                      2
+;     l0014:                      2
+;     l00a0:                      2
+;     l00a3:                      2
+;     l00a4:                      2
+;     l00ad:                      2
+;     l00fd:                      2
+;     l0101:                      2
+;     l0102:                      2
+;     l0105:                      2
+;     l010b:                      2
+;     l0128:                      2
+;     fscv:                       2
+;     l0700:                      2
+;     l0e07:                      2
+;     l0f0a:                      2
+;     l0f0b:                      2
+;     l1045:                      2
+;     l1062:                      2
+;     l1065:                      2
+;     l1067:                      2
+;     l1078:                      2
+;     l107d:                      2
+;     l107e:                      2
+;     l107f:                      2
+;     l1089:                      2
+;     l108c:                      2
+;     l1091:                      2
+;     l109a:                      2
+;     l109b:                      2
+;     l109e:                      2
+;     l10c1:                      2
+;     l10cd:                      2
+;     l10d8:                      2
+;     l10db:                      2
+;     l10dc:                      2
+;     l10e2:                      2
+;     l10e3:                      2
+;     l10e4:                      2
+;     l1109:                      2
+;     l110b:                      2
+;     l110e:                      2
+;     l110f:                      2
+;     l111b:                      2
+;     sub_c209a:                  2
+;     sub_c20e3:                  2
+;     c215d:                      2
+;     sub_c21ae:                  2
+;     sub_c21c5:                  2
+;     c222a:                      2
+;     c225d:                      2
+;     sub_c2266:                  2
+;     sub_c226d:                  2
+;     sub_c22bb:                  2
+;     sub_c22e8:                  2
+;     c22fd:                      2
+;     sub_c241b:                  2
+;     sub_c2439:                  2
+;     c2543:                      2
+;     sub_c2555:                  2
+;     c2560:                      2
+;     c25bc:                      2
+;     c2703:                      2
+;     c2705:                      2
+;     c273b:                      2
+;     sub_c2745:                  2
+;     sub_c27db:                  2
+;     sub_c27e3:                  2
+;     c2808:                      2
+;     c283f:                      2
+;     sub_c2855:                  2
+;     sub_c2862:                  2
+;     c28a6:                      2
+;     c28f4:                      2
+;     sub_c2951:                  2
+;     c298a:                      2
+;     c29a5:                      2
+;     c29b4:                      2
+;     sub_c29da:                  2
+;     c2a00:                      2
+;     c2a6e:                      2
+;     sub_c2a77:                  2
+;     sub_c2ab3:                  2
+;     sub_c2b4d:                  2
+;     sub_c2b64:                  2
+;     c2be3:                      2
+;     c2c12:                      2
+;     c2cb2:                      2
+;     c2d0d:                      2
+;     c2d13:                      2
+;     c2e0d:                      2
+;     c2e32:                      2
+;     c2e9f:                      2
+;     c2ea5:                      2
+;     c2eb7:                      2
+;     c2eeb:                      2
+;     c2f3e:                      2
+;     c30c7:                      2
+;     c31df:                      2
+;     sub_c3279:                  2
+;     c3289:                      2
+;     sub_c328a:                  2
+;     c3367:                      2
+;     sub_c33c5:                  2
+;     sub_c33d3:                  2
+;     sub_c33f5:                  2
+;     sub_c3432:                  2
+;     sub_c3445:                  2
+;     c34a9:                      2
+;     c34c6:                      2
+;     sub_c3516:                  2
+;     sub_c352e:                  2
+;     c35fd:                      2
+;     c3628:                      2
+;     c365a:                      2
+;     c36b7:                      2
+;     c37b3:                      2
+;     sub_c392c:                  2
+;     sub_c394c:                  2
+;     sub_c395a:                  2
+;     sub_c39f3:                  2
+;     sub_c3a0f:                  2
+;     sub_c3a50:                  2
+;     sub_c3a60:                  2
+;     sub_c3a63:                  2
+;     sub_c3a78:                  2
+;     sub_c3a82:                  2
+;     sub_c3aa3:                  2
+;     sub_c3ac8:                  2
+;     sub_c3ad8:                  2
+;     c3b6e:                      2
+;     sub_c3b79:                  2
+;     c3bc5:                      2
+;     sub_c3bf2:                  2
+;     sub_c3d1e:                  2
+;     c3dcd:                      2
+;     c3dd5:                      2
+;     sub_c3df4:                  2
+;     sub_c3e1e:                  2
+;     c3e41:                      2
+;     sub_c3e54:                  2
+;     sub_c3ef4:                  2
+;     sub_c3f14:                  2
+;     sub_c3f26:                  2
+;     c401d:                      2
+;     c4021:                      2
+;     c406c:                      2
+;     c40f5:                      2
+;     c410b:                      2
+;     sub_c4168:                  2
+;     c419f:                      2
+;     sub_c41c6:                  2
+;     l41d3:                      2
+;     c42f2:                      2
+;     sub_c4324:                  2
+;     c438b:                      2
+;     sub_c43ec:                  2
+;     c4411:                      2
+;     c4414:                      2
+;     sub_c451f:                  2
+;     c45ab:                      2
+;     sub_c45b2:                  2
+;     c4637:                      2
+;     c4845:                      2
+;     c486b:                      2
+;     c487a:                      2
+;     sub_c490d:                  2
+;     c497d:                      2
+;     c49ff:                      2
+;     c4a1c:                      2
+;     c4a51:                      2
+;     sub_c4a53:                  2
+;     sub_c4ac2:                  2
+;     sub_c4af1:                  2
+;     c4b1a:                      2
+;     c4b41:                      2
+;     c4b54:                      2
+;     c4bbc:                      2
+;     sub_c4c4e:                  2
+;     l4cdb:                      2
+;     c4d15:                      2
+;     c4dd7:                      2
+;     c4e11:                      2
+;     c4ed3:                      2
+;     c4ee8:                      2
+;     c4f37:                      2
+;     l4f75:                      2
+;     l4f77:                      2
+;     l4f78:                      2
+;     c4fad:                      2
+;     c4ffb:                      2
+;     c500a:                      2
+;     c5035:                      2
+;     sub_c5047:                  2
+;     c5280:                      2
+;     c5297:                      2
+;     c52a0:                      2
+;     c5300:                      2
+;     c5406:                      2
+;     c545e:                      2
+;     sub_c5598:                  2
+;     sub_c55ce:                  2
+;     sub_c55ee:                  2
+;     sub_c5607:                  2
+;     sub_c561e:                  2
+;     c5655:                      2
+;     sub_c565f:                  2
+;     sub_c56b1:                  2
+;     c5718:                      2
+;     c57ed:                      2
+;     l5872:                      2
+;     c58e4:                      2
+;     c59e8:                      2
+;     sub_c59f5:                  2
+;     c5a10:                      2
+;     c5af8:                      2
+;     c5afd:                      2
+;     c5b28:                      2
+;     c5b2a:                      2
+;     c5c13:                      2
+;     c5c3a:                      2
+;     sub_c5c68:                  2
+;     c5cb9:                      2
+;     c5db9:                      2
+;     sub_c5e83:                  2
+;     sub_c5e9d:                  2
+;     c5ec1:                      2
+;     sub_c5ec2:                  2
+;     c5edd:                      2
+;     sub_c5f82:                  2
+;     c5f8e:                      2
+;     tube_host_r4_status:        2
+;     gsinit:                     2
+;     gsread:                     2
+;     osgbpb:                     2
+;     osargs:                     2
+;     l0013:                      1
+;     l00f1:                      1
+;     l0103:                      1
+;     l0104:                      1
+;     l010c:                      1
+;     l010d:                      1
+;     l010e:                      1
+;     brkv:                       1
+;     brkv+1:                     1
+;     filev:                      1
+;     evntv:                      1
+;     evntv+1:                    1
+;     l028d:                      1
+;     l0cff:                      1
+;     l0e0e:                      1
+;     l0e10:                      1
+;     l0f00:                      1
+;     l0f09:                      1
+;     l0f10:                      1
+;     l1001:                      1
+;     l1002:                      1
+;     l1003:                      1
+;     l1004:                      1
+;     l1005:                      1
+;     l1006:                      1
+;     l1007:                      1
+;     l100e:                      1
+;     l1047:                      1
+;     l104d:                      1
+;     l104e:                      1
+;     l1050:                      1
+;     l1058:                      1
+;     l105f:                      1
+;     l1061:                      1
+;     l1063:                      1
+;     l1064:                      1
+;     l1072:                      1
+;     l1079:                      1
+;     l107a:                      1
+;     l1083:                      1
+;     l108f:                      1
+;     pydis_start:                1
+;     l2001:                      1
+;     l2002:                      1
+;     c2003:                      1
+;     l2004:                      1
+;     l2006:                      1
+;     l2007:                      1
+;     sub_c2020:                  1
+;     c2040:                      1
+;     c2064:                      1
+;     c2086:                      1
+;     c2093:                      1
+;     c2096:                      1
+;     sub_c209d:                  1
+;     sub_c20b8:                  1
+;     c20d0:                      1
+;     sub_c20d3:                  1
+;     sub_c20db:                  1
+;     sub_c20e6:                  1
+;     sub_c20f6:                  1
+;     c2111:                      1
+;     c2115:                      1
+;     c212e:                      1
+;     c213a:                      1
+;     c215b:                      1
+;     c215f:                      1
+;     c2161:                      1
+;     c216b:                      1
+;     c2184:                      1
+;     c218a:                      1
+;     c218c:                      1
+;     c21a2:                      1
+;     sub_c21b7:                  1
+;     c21bd:                      1
+;     sub_c21c0:                  1
+;     sub_c21c4:                  1
+;     sub_c21ca:                  1
+;     c220c:                      1
+;     c220d:                      1
+;     c221c:                      1
+;     sub_c2222:                  1
+;     c2243:                      1
+;     c226f:                      1
+;     c2286:                      1
+;     c228b:                      1
+;     c22be:                      1
+;     c22c7:                      1
+;     c22d1:                      1
+;     c22d9:                      1
+;     c22e7:                      1
+;     c22fb:                      1
+;     c2306:                      1
+;     c230d:                      1
+;     c2326:                      1
+;     c2332:                      1
+;     c2333:                      1
+;     c2370:                      1
+;     c2390:                      1
+;     c2397:                      1
+;     c23ab:                      1
+;     sub_c23bf:                  1
+;     c23cd:                      1
+;     sub_c23d1:                  1
+;     sub_c23d4:                  1
+;     c23e2:                      1
+;     sub_c23ee:                  1
+;     c23f0:                      1
+;     c23fa:                      1
+;     c2406:                      1
+;     c2425:                      1
+;     c242b:                      1
+;     sub_c242c:                  1
+;     c2436:                      1
+;     c2438:                      1
+;     c2453:                      1
+;     c2463:                      1
+;     c2477:                      1
+;     c2481:                      1
+;     c2482:                      1
+;     c2493:                      1
+;     c249d:                      1
+;     c24e7:                      1
+;     c2527:                      1
+;     c253e:                      1
+;     c2552:                      1
+;     c255f:                      1
+;     c2564:                      1
+;     c2573:                      1
+;     c257b:                      1
+;     c259b:                      1
+;     c25b5:                      1
+;     c25c5:                      1
+;     l25d3:                      1
+;     sub_c25e3:                  1
+;     sub_c2602:                  1
+;     l261d:                      1
+;     c2717:                      1
+;     c2725:                      1
+;     c2734:                      1
+;     c2759:                      1
+;     c2779:                      1
+;     c277c:                      1
+;     c27a0:                      1
+;     c27ab:                      1
+;     c27b8:                      1
+;     c27be:                      1
+;     c27c6:                      1
+;     c2815:                      1
+;     sub_c2826:                  1
+;     c2837:                      1
+;     c2864:                      1
+;     c2867:                      1
+;     c28bc:                      1
+;     c292d:                      1
+;     sub_c2932:                  1
+;     c2945:                      1
+;     c295f:                      1
+;     c2968:                      1
+;     c296b:                      1
+;     sub_c2979:                  1
+;     c2990:                      1
+;     c29ad:                      1
+;     c29c4:                      1
+;     c29ca:                      1
+;     c29e2:                      1
+;     c29f6:                      1
+;     c2a17:                      1
+;     c2a19:                      1
+;     c2a49:                      1
+;     c2a50:                      1
+;     c2a54:                      1
+;     c2a82:                      1
+;     c2ac8:                      1
+;     c2ad0:                      1
+;     c2ad8:                      1
+;     c2aeb:                      1
+;     c2af0:                      1
+;     c2afb:                      1
+;     c2b18:                      1
+;     sub_c2b25:                  1
+;     c2b60:                      1
+;     c2b77:                      1
+;     c2b80:                      1
+;     c2bea:                      1
+;     sub_c2bf6:                  1
+;     sub_c2bf9:                  1
+;     c2bfb:                      1
+;     c2c2e:                      1
+;     c2c3a:                      1
+;     c2c4e:                      1
+;     sub_c2c56:                  1
+;     c2c58:                      1
+;     c2c61:                      1
+;     sub_c2c65:                  1
+;     c2c71:                      1
+;     c2c87:                      1
+;     c2cae:                      1
+;     c2cc1:                      1
+;     c2cd6:                      1
+;     c2ce7:                      1
+;     c2cfc:                      1
+;     c2d03:                      1
+;     c2d14:                      1
+;     c2d17:                      1
+;     sub_c2d1a:                  1
+;     c2d5d:                      1
+;     c2d92:                      1
+;     c2dac:                      1
+;     c2dba:                      1
+;     sub_c2dc6:                  1
+;     c2dd2:                      1
+;     c2de2:                      1
+;     c2de9:                      1
+;     c2df0:                      1
+;     c2e03:                      1
+;     c2e14:                      1
+;     c2e4d:                      1
+;     c2e6f:                      1
+;     c2e72:                      1
+;     c2e85:                      1
+;     c2e9e:                      1
+;     c2eaf:                      1
+;     c2ecb:                      1
+;     c2edf:                      1
+;     sub_c2eec:                  1
+;     c2ef8:                      1
+;     sub_c2efa:                  1
+;     sub_c2eff:                  1
+;     c2f12:                      1
+;     c2f17:                      1
+;     c2f21:                      1
+;     sub_c2f33:                  1
+;     sub_c2f37:                  1
+;     sub_c2f4f:                  1
+;     sub_c2f5e:                  1
+;     c2f6c:                      1
+;     sub_c2f75:                  1
+;     c2f81:                      1
+;     sub_c2f82:                  1
+;     sub_c2f94:                  1
+;     c2f96:                      1
+;     c2fac:                      1
+;     c2fb5:                      1
+;     c2fc7:                      1
+;     sub_c303e:                  1
+;     c3047:                      1
+;     c3060:                      1
+;     c3066:                      1
+;     c30db:                      1
+;     c30e7:                      1
+;     sub_c3104:                  1
+;     c3108:                      1
+;     c3113:                      1
+;     c3115:                      1
+;     l311d:                      1
+;     l3121:                      1
+;     l312d:                      1
+;     l3139:                      1
+;     l313f:                      1
+;     l3145:                      1
+;     l3146:                      1
+;     l3191:                      1
+;     l31a0:                      1
+;     c31ba:                      1
+;     c31cc:                      1
+;     c31e7:                      1
+;     c31eb:                      1
+;     c31f3:                      1
+;     c31f9:                      1
+;     c3201:                      1
+;     c320d:                      1
+;     c321f:                      1
+;     c322b:                      1
+;     c3238:                      1
+;     c323b:                      1
+;     c323f:                      1
+;     c3249:                      1
+;     c325a:                      1
+;     c326a:                      1
+;     c3276:                      1
+;     c329c:                      1
+;     sub_c329d:                  1
+;     c32bd:                      1
+;     c32c4:                      1
+;     c32c7:                      1
+;     c32d6:                      1
+;     c32e3:                      1
+;     c32ef:                      1
+;     c3302:                      1
+;     c3355:                      1
+;     c3357:                      1
+;     c336b:                      1
+;     c336f:                      1
+;     c3379:                      1
+;     c3382:                      1
+;     c338d:                      1
+;     c3390:                      1
+;     c33a8:                      1
+;     c33b1:                      1
+;     sub_c33b4:                  1
+;     c33bd:                      1
+;     c33c4:                      1
+;     sub_c33d8:                  1
+;     c33da:                      1
+;     c33e2:                      1
+;     c33e5:                      1
+;     sub_c33f1:                  1
+;     sub_c33f9:                  1
+;     c33ff:                      1
+;     c3450:                      1
+;     c345c:                      1
+;     c348d:                      1
+;     c34c1:                      1
+;     c34c2:                      1
+;     c34d4:                      1
+;     c3504:                      1
+;     c3535:                      1
+;     sub_c3536:                  1
+;     c353a:                      1
+;     c3556:                      1
+;     c356d:                      1
+;     c356f:                      1
+;     c357d:                      1
+;     c3593:                      1
+;     c35b6:                      1
+;     c35d9:                      1
+;     c35e4:                      1
+;     c35e7:                      1
+;     c35ec:                      1
+;     c3618:                      1
+;     c3649:                      1
+;     c364a:                      1
+;     c3658:                      1
+;     sub_c365d:                  1
+;     c367a:                      1
+;     c3682:                      1
+;     c3683:                      1
+;     c369e:                      1
+;     c36c1:                      1
+;     c36c2:                      1
+;     c36c3:                      1
+;     c36e4:                      1
+;     c36e9:                      1
+;     c36ec:                      1
+;     c36f2:                      1
+;     c36f5:                      1
+;     c3700:                      1
+;     c3714:                      1
+;     c3736:                      1
+;     c373c:                      1
+;     c373d:                      1
+;     c375b:                      1
+;     c376c:                      1
+;     c379d:                      1
+;     c37c8:                      1
+;     c37e6:                      1
+;     sub_c37e8:                  1
+;     c3803:                      1
+;     c381f:                      1
+;     c382e:                      1
+;     sub_c3832:                  1
+;     c3835:                      1
+;     c3837:                      1
+;     c384c:                      1
+;     c3851:                      1
+;     c3859:                      1
+;     c385e:                      1
+;     c386b:                      1
+;     c3873:                      1
+;     c3881:                      1
+;     c38a0:                      1
+;     c38b1:                      1
+;     c38ba:                      1
+;     c38c1:                      1
+;     c38cd:                      1
+;     c38e4:                      1
+;     c38ed:                      1
+;     c38f0:                      1
+;     c3942:                      1
+;     c394b:                      1
+;     c394e:                      1
+;     c3964:                      1
+;     c3978:                      1
+;     sub_c3988:                  1
+;     c3993:                      1
+;     c39a8:                      1
+;     c39ea:                      1
+;     c3a2a:                      1
+;     sub_c3a32:                  1
+;     c3a3f:                      1
+;     sub_c3a4b:                  1
+;     c3a55:                      1
+;     c3a73:                      1
+;     c3a77:                      1
+;     sub_c3ad3:                  1
+;     c3ad4:                      1
+;     l3aec:                      1
+;     l3b0f:                      1
+;     l3b18:                      1
+;     l3b21:                      1
+;     l3b29:                      1
+;     l3b31:                      1
+;     l3b3a:                      1
+;     l3b43:                      1
+;     c3b50:                      1
+;     sub_c3b51:                  1
+;     c3b5e:                      1
+;     sub_c3b61:                  1
+;     c3b63:                      1
+;     c3bc2:                      1
+;     sub_c3bca:                  1
+;     sub_c3bcd:                  1
+;     c3bcf:                      1
+;     c3be4:                      1
+;     c3c00:                      1
+;     c3c16:                      1
+;     c3c33:                      1
+;     c3c38:                      1
+;     c3c51:                      1
+;     c3c58:                      1
+;     c3c5d:                      1
+;     c3c6b:                      1
+;     c3c8b:                      1
+;     c3c90:                      1
+;     c3ca8:                      1
+;     c3cee:                      1
+;     c3d03:                      1
+;     c3d12:                      1
+;     sub_c3d19:                  1
+;     c3d2b:                      1
+;     c3d43:                      1
+;     c3d57:                      1
+;     c3d67:                      1
+;     c3d71:                      1
+;     c3d72:                      1
+;     sub_c3d75:                  1
+;     c3d86:                      1
+;     c3d89:                      1
+;     c3db4:                      1
+;     c3dce:                      1
+;     c3e07:                      1
+;     c3e13:                      1
+;     c3e16:                      1
+;     c3e28:                      1
+;     c3e2a:                      1
+;     c3e4d:                      1
+;     c3e5c:                      1
+;     c3e6f:                      1
+;     c3e71:                      1
+;     c3e74:                      1
+;     c3e8c:                      1
+;     sub_c3e94:                  1
+;     c3eb3:                      1
+;     c3ec2:                      1
+;     c3ef1:                      1
+;     c3f0d:                      1
+;     c3f19:                      1
+;     c3f5e:                      1
+;     c3f64:                      1
+;     c3f6a:                      1
+;     c3f6b:                      1
+;     c3f6e:                      1
+;     sub_c3f7c:                  1
+;     sub_c3f82:                  1
+;     c3f88:                      1
+;     c3fd9:                      1
+;     c3ff4:                      1
+;     c4005:                      1
+;     c4054:                      1
+;     c4061:                      1
+;     c4075:                      1
+;     c40a9:                      1
+;     sub_c40b8:                  1
+;     sub_c40f6:                  1
+;     c411d:                      1
+;     c4132:                      1
+;     c4143:                      1
+;     c416e:                      1
+;     c417a:                      1
+;     c4183:                      1
+;     sub_c4190:                  1
+;     c41aa:                      1
+;     c41c1:                      1
+;     c41cc:                      1
+;     c41d2:                      1
+;     c427a:                      1
+;     c42ab:                      1
+;     c430d:                      1
+;     c4321:                      1
+;     c434a:                      1
+;     c4378:                      1
+;     c438c:                      1
+;     c438e:                      1
+;     c43ae:                      1
+;     c43bd:                      1
+;     sub_c43e4:                  1
+;     c43fb:                      1
+;     c440c:                      1
+;     c445d:                      1
+;     c447b:                      1
+;     c4487:                      1
+;     sub_c44e1:                  1
+;     c44fa:                      1
+;     c4521:                      1
+;     c4538:                      1
+;     c4547:                      1
+;     c4574:                      1
+;     c4595:                      1
+;     c45a0:                      1
+;     c45c4:                      1
+;     c45e2:                      1
+;     c45fb:                      1
+;     c4605:                      1
+;     c463a:                      1
+;     c4647:                      1
+;     c4652:                      1
+;     c465d:                      1
+;     sub_c4663:                  1
+;     c4675:                      1
+;     c468a:                      1
+;     c46b3:                      1
+;     c46b6:                      1
+;     c46bb:                      1
+;     c46ce:                      1
+;     c46e2:                      1
+;     c470a:                      1
+;     c4712:                      1
+;     c4721:                      1
+;     c4728:                      1
+;     c473a:                      1
+;     sub_c473d:                  1
+;     sub_c476c:                  1
+;     c476f:                      1
+;     sub_c4779:                  1
+;     c4787:                      1
+;     sub_c4788:                  1
+;     c47a4:                      1
+;     c47a7:                      1
+;     sub_c47c4:                  1
+;     sub_c47c5:                  1
+;     c47c6:                      1
+;     sub_c47ce:                  1
+;     c47e0:                      1
+;     c47e1:                      1
+;     c47f2:                      1
+;     c47f7:                      1
+;     c4818:                      1
+;     c482f:                      1
+;     c4856:                      1
+;     c48bd:                      1
+;     sub_c48be:                  1
+;     sub_c48e2:                  1
+;     c48fa:                      1
+;     c4902:                      1
+;     c490c:                      1
+;     c4941:                      1
+;     c4947:                      1
+;     c4953:                      1
+;     c495d:                      1
+;     c496c:                      1
+;     c4970:                      1
+;     c4982:                      1
+;     c498d:                      1
+;     c49ab:                      1
+;     c49b8:                      1
+;     sub_c49bf:                  1
+;     c49e7:                      1
+;     c4a01:                      1
+;     c4a0a:                      1
+;     c4a0d:                      1
+;     sub_c4a12:                  1
+;     c4a78:                      1
+;     c4a7a:                      1
+;     c4a86:                      1
+;     sub_c4a9a:                  1
+;     c4ab7:                      1
+;     c4ab8:                      1
+;     c4abe:                      1
+;     c4ace:                      1
+;     sub_c4add:                  1
+;     sub_c4aea:                  1
+;     c4b09:                      1
+;     c4b17:                      1
+;     c4b2e:                      1
+;     c4b35:                      1
+;     c4b3d:                      1
+;     c4b6b:                      1
+;     c4b7d:                      1
+;     c4b80:                      1
+;     c4b93:                      1
+;     c4ba4:                      1
+;     sub_c4ba9:                  1
+;     c4bad:                      1
+;     c4bcf:                      1
+;     c4bf4:                      1
+;     c4bfb:                      1
+;     c4c28:                      1
+;     c4c45:                      1
+;     c4c46:                      1
+;     sub_c4c47:                  1
+;     sub_c4c6a:                  1
+;     sub_c4c72:                  1
+;     c4cc7:                      1
+;     l4cf3:                      1
+;     c4d2d:                      1
+;     c4d3f:                      1
+;     c4d52:                      1
+;     c4d61:                      1
+;     c4d6e:                      1
+;     c4d81:                      1
+;     c4d86:                      1
+;     c4da2:                      1
+;     c4dae:                      1
+;     c4dc1:                      1
+;     l4ddb:                      1
+;     c4ddf:                      1
+;     c4df8:                      1
+;     c4e06:                      1
+;     c4e20:                      1
+;     c4e27:                      1
+;     c4e32:                      1
+;     c4e35:                      1
+;     c4e40:                      1
+;     c4e45:                      1
+;     c4e5b:                      1
+;     c4e62:                      1
+;     c4e82:                      1
+;     sub_c4ea9:                  1
+;     c4ed7:                      1
+;     c4ef8:                      1
+;     c4f13:                      1
+;     c4f2d:                      1
+;     c4f35:                      1
+;     c4f38:                      1
+;     c4f4b:                      1
+;     c4f54:                      1
+;     c4f5d:                      1
+;     c4f63:                      1
+;     l4f73:                      1
+;     c4f79:                      1
+;     sub_c4f8d:                  1
+;     sub_c4f9a:                  1
+;     c4fa1:                      1
+;     c4fab:                      1
+;     c4fae:                      1
+;     c4fbf:                      1
+;     c4fdc:                      1
+;     c4fdf:                      1
+;     c4fea:                      1
+;     c4ff3:                      1
+;     c4ffd:                      1
+;     c5005:                      1
+;     c5014:                      1
+;     c501f:                      1
+;     sub_c5040:                  1
+;     c505a:                      1
+;     c5070:                      1
+;     l5075:                      1
+;     l5175:                      1
+;     c51b1:                      1
+;     c51dd:                      1
+;     c51e3:                      1
+;     c51ed:                      1
+;     c51fc:                      1
+;     c520f:                      1
+;     c5221:                      1
+;     sub_c5234:                  1
+;     c523d:                      1
+;     c5249:                      1
+;     c5260:                      1
+;     c5268:                      1
+;     c5275:                      1
+;     l5283:                      1
+;     c52b2:                      1
+;     c52b4:                      1
+;     c52bd:                      1
+;     sub_c52c8:                  1
+;     c52d1:                      1
+;     c52e1:                      1
+;     c52e7:                      1
+;     c5305:                      1
+;     c5314:                      1
+;     c5337:                      1
+;     c534f:                      1
+;     c5352:                      1
+;     c5375:                      1
+;     c537f:                      1
+;     c5382:                      1
+;     c5397:                      1
+;     c53ba:                      1
+;     c53de:                      1
+;     c540e:                      1
+;     c544b:                      1
+;     c544d:                      1
+;     c545a:                      1
+;     c5470:                      1
+;     c54a8:                      1
+;     c54af:                      1
+;     c54b4:                      1
+;     c54d8:                      1
+;     c54df:                      1
+;     c54e9:                      1
+;     c54ee:                      1
+;     c5502:                      1
+;     c5534:                      1
+;     c555e:                      1
+;     c5578:                      1
+;     c5597:                      1
+;     c55c6:                      1
+;     c55d0:                      1
+;     c55e6:                      1
+;     c55ed:                      1
+;     c565e:                      1
+;     c56a6:                      1
+;     c56b3:                      1
+;     c56c2:                      1
+;     l56c6:                      1
+;     l56ce:                      1
+;     c56d2:                      1
+;     sub_c56e6:                  1
+;     c56eb:                      1
+;     c56f5:                      1
+;     c5725:                      1
+;     c5736:                      1
+;     c575a:                      1
+;     sub_c5771:                  1
+;     l5774:                      1
+;     c57ae:                      1
+;     c57b2:                      1
+;     sub_c57b6:                  1
+;     c57be:                      1
+;     c57d7:                      1
+;     c57dd:                      1
+;     c57e8:                      1
+;     c57ec:                      1
+;     sub_c586f:                  1
+;     l587e:                      1
+;     sub_c5882:                  1
+;     c5898:                      1
+;     c58e6:                      1
+;     c58f5:                      1
+;     c5910:                      1
+;     l5924:                      1
+;     l5979:                      1
+;     l597a:                      1
+;     l5980:                      1
+;     c5999:                      1
+;     c59ae:                      1
+;     c59bd:                      1
+;     c59cc:                      1
+;     c59d1:                      1
+;     c59d2:                      1
+;     c59d9:                      1
+;     c59ee:                      1
+;     c59f7:                      1
+;     c59f9:                      1
+;     c5a15:                      1
+;     c5a19:                      1
+;     c5a1a:                      1
+;     c5a27:                      1
+;     c5a28:                      1
+;     c5a2e:                      1
+;     c5a2f:                      1
+;     l5a31:                      1
+;     c5a78:                      1
+;     c5a8c:                      1
+;     c5a94:                      1
+;     c5a9e:                      1
+;     c5ab0:                      1
+;     c5ab1:                      1
+;     c5ab8:                      1
+;     c5ad0:                      1
+;     sub_c5ad2:                  1
+;     c5aea:                      1
+;     c5b07:                      1
+;     c5b33:                      1
+;     c5b36:                      1
+;     l5b3a:                      1
+;     l5b3e:                      1
+;     l5b42:                      1
+;     c5b4c:                      1
+;     c5b6f:                      1
+;     c5b89:                      1
+;     c5b90:                      1
+;     c5ba1:                      1
+;     c5bbe:                      1
+;     c5bd9:                      1
+;     c5be4:                      1
+;     c5bf3:                      1
+;     c5bfe:                      1
+;     c5c2c:                      1
+;     c5c54:                      1
+;     c5c64:                      1
+;     c5c70:                      1
+;     c5c78:                      1
+;     c5c93:                      1
+;     c5cb2:                      1
+;     c5cd3:                      1
+;     c5cd6:                      1
+;     c5ce1:                      1
+;     c5cf9:                      1
+;     c5d08:                      1
+;     c5d0e:                      1
+;     c5d1b:                      1
+;     c5d2b:                      1
+;     c5d40:                      1
+;     c5d46:                      1
+;     c5d6c:                      1
+;     c5d7e:                      1
+;     c5d99:                      1
+;     c5da3:                      1
+;     c5dba:                      1
+;     c5dc0:                      1
+;     c5dd3:                      1
+;     c5ddd:                      1
+;     c5e0e:                      1
+;     c5e21:                      1
+;     c5e31:                      1
+;     c5e3c:                      1
+;     c5e52:                      1
+;     sub_c5e91:                  1
+;     c5eab:                      1
+;     c5ec8:                      1
+;     c5ee0:                      1
+;     c5eee:                      1
+;     c5f1c:                      1
+;     c5f33:                      1
+;     c5f46:                      1
+;     l5f4f:                      1
+;     c5f78:                      1
+;     sub_c5f84:                  1
+;     c5f8a:                      1
+;     c5fa3:                      1
+;     c5fb2:                      1
+;     nmi_handler_rom_start:      1
+;     nmi3_handler_rom_start-1:   1
+;     tube_host_code2:            1
+;     tube_host_code2+256:        1
+;     tube_host_code3:            1
+;     tube_host_code1:            1
+;     tube_host_r4_data:          1
+
+; Automatically generated labels:
+;     c0032
+;     c0036
+;     c0041
+;     c0400
+;     c0432
+;     c0434
+;     c0463
+;     c047a
+;     c0482
+;     c0484
+;     c048c
+;     c0491
+;     c049b
+;     c04bc
+;     c04f7
+;     c053a
+;     c0552
+;     c0593
+;     c059c
+;     c059e
+;     c05a6
+;     c05fc
+;     c0636
+;     c0645
+;     c0665
+;     c06a7
+;     c0d60
+;     c0d74
+;     c0d80
+;     c2003
+;     c2040
+;     c204f
+;     c2064
+;     c2086
+;     c2093
+;     c2096
+;     c209f
+;     c20d0
+;     c2103
+;     c2111
+;     c2115
+;     c2125
+;     c212e
+;     c213a
+;     c215b
+;     c215d
+;     c215f
+;     c2161
+;     c216b
+;     c2184
+;     c218a
+;     c218c
+;     c21a2
+;     c21a7
+;     c21bd
+;     c220c
+;     c220d
+;     c221c
+;     c2225
+;     c222a
+;     c2243
+;     c225d
+;     c226f
+;     c2286
+;     c228b
+;     c2290
+;     c22be
+;     c22c7
+;     c22d1
+;     c22d9
+;     c22e6
+;     c22e7
+;     c22fb
+;     c22fd
+;     c2306
+;     c230d
+;     c2326
+;     c2332
+;     c2333
+;     c2370
+;     c2390
+;     c2397
+;     c23ab
+;     c23cd
+;     c23e2
+;     c23f0
+;     c23fa
+;     c2406
+;     c2425
+;     c242b
+;     c2436
+;     c2438
+;     c2453
+;     c2454
+;     c2463
+;     c2477
+;     c2481
+;     c2482
+;     c2493
+;     c249d
+;     c24e7
+;     c2527
+;     c253e
+;     c2543
+;     c2552
+;     c255f
+;     c2560
+;     c2564
+;     c2573
+;     c257b
+;     c259b
+;     c25b5
+;     c25bc
+;     c25c5
+;     c2703
+;     c2705
+;     c2717
+;     c2725
+;     c2734
+;     c273b
+;     c2759
+;     c2779
+;     c277c
+;     c27a0
+;     c27ab
+;     c27b8
+;     c27be
+;     c27c6
+;     c2808
+;     c2815
+;     c2816
+;     c2837
+;     c283f
+;     c2864
+;     c2867
+;     c28a6
+;     c28bc
+;     c28f4
+;     c292d
+;     c2945
+;     c295f
+;     c2968
+;     c296b
+;     c298a
+;     c2990
+;     c29a5
+;     c29ad
+;     c29b4
+;     c29c4
+;     c29ca
+;     c29d7
+;     c29e2
+;     c29f6
+;     c2a00
+;     c2a17
+;     c2a19
+;     c2a49
+;     c2a50
+;     c2a54
+;     c2a6e
+;     c2a82
+;     c2ac8
+;     c2ad0
+;     c2ad8
+;     c2aeb
+;     c2af0
+;     c2afb
+;     c2b18
+;     c2b60
+;     c2b77
+;     c2b80
+;     c2b8b
+;     c2ba2
+;     c2be3
+;     c2bea
+;     c2bfb
+;     c2c12
+;     c2c2e
+;     c2c3a
+;     c2c4e
+;     c2c58
+;     c2c61
+;     c2c71
+;     c2c87
+;     c2cae
+;     c2cb2
+;     c2cc1
+;     c2cd6
+;     c2ce7
+;     c2cfc
+;     c2d03
+;     c2d0d
+;     c2d13
+;     c2d14
+;     c2d17
+;     c2d41
+;     c2d5d
+;     c2d74
+;     c2d91
+;     c2d92
+;     c2dac
+;     c2dba
+;     c2dd2
+;     c2de2
+;     c2de9
+;     c2df0
+;     c2e03
+;     c2e0d
+;     c2e0e
+;     c2e12
+;     c2e14
+;     c2e32
+;     c2e4d
+;     c2e53
+;     c2e64
+;     c2e6f
+;     c2e72
+;     c2e85
+;     c2e9e
+;     c2e9f
+;     c2ea5
+;     c2eaf
+;     c2eb7
+;     c2ecb
+;     c2ecc
+;     c2edf
+;     c2eeb
+;     c2ef8
+;     c2f12
+;     c2f17
+;     c2f21
+;     c2f2a
+;     c2f3e
+;     c2f6c
+;     c2f81
+;     c2f96
+;     c2fac
+;     c2fb5
+;     c2fc7
+;     c3047
+;     c3060
+;     c3066
+;     c30c7
+;     c30db
+;     c30e7
+;     c30fb
+;     c3108
+;     c3113
+;     c3115
+;     c31af
+;     c31ba
+;     c31cc
+;     c31df
+;     c31e7
+;     c31eb
+;     c31f3
+;     c31f9
+;     c3201
+;     c320d
+;     c3214
+;     c321f
+;     c322b
+;     c3238
+;     c323b
+;     c323f
+;     c3249
+;     c3257
+;     c325a
+;     c326a
+;     c3276
+;     c3289
+;     c329c
+;     c32bd
+;     c32c4
+;     c32c7
+;     c32d6
+;     c32e3
+;     c32ef
+;     c3302
+;     c3355
+;     c3357
+;     c3367
+;     c336b
+;     c336f
+;     c3379
+;     c3382
+;     c338d
+;     c3390
+;     c33a8
+;     c33b1
+;     c33bd
+;     c33c4
+;     c33da
+;     c33e2
+;     c33e5
+;     c33e6
+;     c33ff
+;     c340c
+;     c340e
+;     c3436
+;     c3444
+;     c3450
+;     c345c
+;     c348d
+;     c34a9
+;     c34bc
+;     c34c1
+;     c34c2
+;     c34c6
+;     c34d4
+;     c3504
+;     c3535
+;     c353a
+;     c3556
+;     c356d
+;     c356f
+;     c357d
+;     c3593
+;     c35b6
+;     c35d9
+;     c35e4
+;     c35e7
+;     c35ec
+;     c35fd
+;     c3618
+;     c3628
+;     c3649
+;     c364a
+;     c3658
+;     c365a
+;     c367a
+;     c3682
+;     c3683
+;     c369e
+;     c36b7
+;     c36c1
+;     c36c2
+;     c36c3
+;     c36e4
+;     c36e9
+;     c36ec
+;     c36f2
+;     c36f5
+;     c3700
+;     c3714
+;     c3736
+;     c3738
+;     c373c
+;     c373d
+;     c375b
+;     c376c
+;     c379d
+;     c37b3
+;     c37c8
+;     c37e6
+;     c3803
+;     c381f
+;     c382e
+;     c3835
+;     c3837
+;     c384c
+;     c3851
+;     c3859
+;     c385e
+;     c386b
+;     c3873
+;     c3881
+;     c38a0
+;     c38b1
+;     c38ba
+;     c38c1
+;     c38cd
+;     c38e4
+;     c38ed
+;     c38f0
+;     c393b
+;     c3942
+;     c394b
+;     c394e
+;     c3964
+;     c396e
+;     c3978
+;     c3993
+;     c39a3
+;     c39a8
+;     c39ea
+;     c39ed
+;     c3a2a
+;     c3a3f
+;     c3a55
+;     c3a73
+;     c3a77
+;     c3a8c
+;     c3ad4
+;     c3adf
+;     c3ae9
+;     c3b50
+;     c3b5e
+;     c3b63
+;     c3b6e
+;     c3bc2
+;     c3bc5
+;     c3bcf
+;     c3be4
+;     c3c00
+;     c3c16
+;     c3c33
+;     c3c38
+;     c3c51
+;     c3c58
+;     c3c5d
+;     c3c6b
+;     c3c82
+;     c3c8b
+;     c3c90
+;     c3ca8
+;     c3cee
+;     c3d03
+;     c3d12
+;     c3d2b
+;     c3d43
+;     c3d57
+;     c3d5d
+;     c3d67
+;     c3d71
+;     c3d72
+;     c3d86
+;     c3d89
+;     c3db4
+;     c3dcd
+;     c3dce
+;     c3dd5
+;     c3e07
+;     c3e13
+;     c3e16
+;     c3e28
+;     c3e2a
+;     c3e41
+;     c3e4d
+;     c3e5c
+;     c3e6f
+;     c3e71
+;     c3e74
+;     c3e8c
+;     c3eb3
+;     c3ec2
+;     c3ef1
+;     c3f0d
+;     c3f19
+;     c3f5e
+;     c3f64
+;     c3f6a
+;     c3f6b
+;     c3f6e
+;     c3f88
+;     c3fd9
+;     c3ff4
+;     c4005
+;     c401d
+;     c4021
+;     c4054
+;     c4061
+;     c406b
+;     c406c
+;     c4075
+;     c40a9
+;     c40f5
+;     c410b
+;     c411d
+;     c4132
+;     c4143
+;     c414f
+;     c416e
+;     c417a
+;     c4183
+;     c419f
+;     c41aa
+;     c41c0
+;     c41c1
+;     c41cc
+;     c41d2
+;     c427a
+;     c42ab
+;     c42f2
+;     c430d
+;     c4321
+;     c434a
+;     c4378
+;     c438b
+;     c438c
+;     c438e
+;     c43ae
+;     c43bd
+;     c43dc
+;     c43fb
+;     c440c
+;     c4411
+;     c4414
+;     c445d
+;     c447b
+;     c4487
+;     c44fa
+;     c4521
+;     c4538
+;     c4547
+;     c4574
+;     c4595
+;     c45a0
+;     c45ab
+;     c45c4
+;     c45e2
+;     c45e5
+;     c45fb
+;     c4605
+;     c4637
+;     c463a
+;     c4647
+;     c4652
+;     c465d
+;     c4660
+;     c4675
+;     c468a
+;     c46b3
+;     c46b6
+;     c46bb
+;     c46ce
+;     c46e2
+;     c470a
+;     c4712
+;     c4721
+;     c4728
+;     c473a
+;     c476f
+;     c4787
+;     c47a4
+;     c47a7
+;     c47c6
+;     c47e0
+;     c47e1
+;     c47f2
+;     c47f7
+;     c4818
+;     c482f
+;     c4845
+;     c4856
+;     c486b
+;     c487a
+;     c48bd
+;     c48fa
+;     c4902
+;     c490c
+;     c4941
+;     c4947
+;     c4953
+;     c495d
+;     c496c
+;     c4970
+;     c497d
+;     c4982
+;     c498d
+;     c49ab
+;     c49b8
+;     c49e7
+;     c49ff
+;     c4a01
+;     c4a0a
+;     c4a0d
+;     c4a1c
+;     c4a42
+;     c4a44
+;     c4a51
+;     c4a78
+;     c4a7a
+;     c4a86
+;     c4ab7
+;     c4ab8
+;     c4abe
+;     c4ace
+;     c4b09
+;     c4b17
+;     c4b1a
+;     c4b2e
+;     c4b35
+;     c4b3d
+;     c4b41
+;     c4b54
+;     c4b6b
+;     c4b7d
+;     c4b80
+;     c4b93
+;     c4ba4
+;     c4bad
+;     c4bbc
+;     c4bcf
+;     c4bf4
+;     c4bfb
+;     c4c0f
+;     c4c28
+;     c4c45
+;     c4c46
+;     c4cc4
+;     c4cc7
+;     c4d15
+;     c4d2d
+;     c4d3f
+;     c4d52
+;     c4d61
+;     c4d6e
+;     c4d77
+;     c4d79
+;     c4d81
+;     c4d86
+;     c4da2
+;     c4dae
+;     c4dc1
+;     c4dd7
+;     c4ddf
+;     c4df8
+;     c4e06
+;     c4e11
+;     c4e20
+;     c4e27
+;     c4e32
+;     c4e35
+;     c4e40
+;     c4e45
+;     c4e5b
+;     c4e62
+;     c4e70
+;     c4e79
+;     c4e82
+;     c4e97
+;     c4ea0
+;     c4ed3
+;     c4ed7
+;     c4ee8
+;     c4ef8
+;     c4f13
+;     c4f2d
+;     c4f35
+;     c4f37
+;     c4f38
+;     c4f4b
+;     c4f54
+;     c4f58
+;     c4f5d
+;     c4f63
+;     c4f79
+;     c4f7f
+;     c4fa1
+;     c4fab
+;     c4fad
+;     c4fae
+;     c4fbf
+;     c4fdc
+;     c4fdf
+;     c4fea
+;     c4ff3
+;     c4ffb
+;     c4ffd
+;     c5005
+;     c500a
+;     c5014
+;     c501f
+;     c5035
+;     c505a
+;     c5070
+;     c51b1
+;     c51d5
+;     c51dd
+;     c51e3
+;     c51ed
+;     c51fc
+;     c5203
+;     c520f
+;     c5221
+;     c523d
+;     c5249
+;     c5260
+;     c5268
+;     c5275
+;     c5280
+;     c5297
+;     c52a0
+;     c52b2
+;     c52b4
+;     c52bd
+;     c52d1
+;     c52e1
+;     c52e7
+;     c5300
+;     c5305
+;     c5314
+;     c5337
+;     c534f
+;     c5352
+;     c5371
+;     c5375
+;     c537f
+;     c5382
+;     c5397
+;     c53ba
+;     c53de
+;     c5406
+;     c540e
+;     c5446
+;     c544b
+;     c544d
+;     c545a
+;     c545e
+;     c5470
+;     c54a8
+;     c54af
+;     c54b4
+;     c54d8
+;     c54df
+;     c54e9
+;     c54ee
+;     c5502
+;     c5534
+;     c555e
+;     c5578
+;     c5597
+;     c55c6
+;     c55d0
+;     c55e6
+;     c55ed
+;     c5655
+;     c565e
+;     c5684
+;     c568c
+;     c56a6
+;     c56b3
+;     c56c2
+;     c56ca
+;     c56d2
+;     c56eb
+;     c56f5
+;     c5718
+;     c5725
+;     c5736
+;     c575a
+;     c5795
+;     c57ae
+;     c57b2
+;     c57be
+;     c57d7
+;     c57dd
+;     c57e8
+;     c57ec
+;     c57ed
+;     c582b
+;     c5898
+;     c58e4
+;     c58e6
+;     c58f5
+;     c58fb
+;     c5910
+;     c5999
+;     c59ae
+;     c59bd
+;     c59cc
+;     c59d1
+;     c59d2
+;     c59d9
+;     c59e8
+;     c59ee
+;     c59f7
+;     c59f9
+;     c5a10
+;     c5a15
+;     c5a19
+;     c5a1a
+;     c5a27
+;     c5a28
+;     c5a2e
+;     c5a2f
+;     c5a78
+;     c5a8c
+;     c5a94
+;     c5a9e
+;     c5ab0
+;     c5ab1
+;     c5ab4
+;     c5ab8
+;     c5ad0
+;     c5aea
+;     c5af8
+;     c5afd
+;     c5b07
+;     c5b28
+;     c5b2a
+;     c5b33
+;     c5b36
+;     c5b4c
+;     c5b6f
+;     c5b89
+;     c5b90
+;     c5ba1
+;     c5bbe
+;     c5bd0
+;     c5bd9
+;     c5be4
+;     c5bf3
+;     c5bfe
+;     c5c13
+;     c5c2c
+;     c5c3a
+;     c5c54
+;     c5c64
+;     c5c70
+;     c5c78
+;     c5c93
+;     c5cb2
+;     c5cb9
+;     c5cd3
+;     c5cd6
+;     c5ce1
+;     c5cf9
+;     c5d08
+;     c5d0e
+;     c5d1b
+;     c5d2b
+;     c5d40
+;     c5d46
+;     c5d6c
+;     c5d7e
+;     c5d99
+;     c5da3
+;     c5db9
+;     c5dba
+;     c5dc0
+;     c5dd3
+;     c5ddd
+;     c5e0e
+;     c5e21
+;     c5e31
+;     c5e3c
+;     c5e47
+;     c5e52
+;     c5e7a
+;     c5e7b
+;     c5e89
+;     c5e8d
+;     c5eab
+;     c5ec1
+;     c5ec8
+;     c5edd
+;     c5ee0
+;     c5ee8
+;     c5eee
+;     c5f1c
+;     c5f33
+;     c5f46
+;     c5f78
+;     c5f8a
+;     c5f8e
+;     c5fa3
+;     c5fb2
+;     c8040
+;     c8093
+;     c8096
+;     c809f
+;     c80d0
+;     c8103
+;     c8111
+;     c8115
+;     c8125
+;     c812e
+;     c815b
+;     c815d
+;     c815f
+;     c8184
+;     c818a
+;     c81a2
+;     c81a7
+;     c81bd
+;     c8225
+;     c822a
+;     c8243
+;     c825d
+;     c8286
+;     c828b
+;     c8290
+;     c82be
+;     c82d9
+;     c82e6
+;     c82e7
+;     c82fb
+;     c82fd
+;     c8306
+;     c8332
+;     c8333
+;     c83ab
+;     c83cd
+;     c83e2
+;     c842b
+;     c8436
+;     c8438
+;     c8453
+;     c8454
+;     c8477
+;     c8481
+;     c8482
+;     c849d
+;     c853e
+;     c8543
+;     c855f
+;     c8560
+;     c8573
+;     c859b
+;     c85bc
+;     c85c5
+;     c8703
+;     c8705
+;     c8734
+;     c873b
+;     c8759
+;     c8779
+;     c877c
+;     c87ab
+;     c87b8
+;     c87c6
+;     c8808
+;     c8815
+;     c8816
+;     c8837
+;     c883f
+;     c8864
+;     c8867
+;     c88a6
+;     c88f4
+;     c892d
+;     c8945
+;     c8968
+;     c896b
+;     c898a
+;     c89a5
+;     c89ad
+;     c89b4
+;     c89d7
+;     c89e2
+;     c89f6
+;     c8a00
+;     c8a19
+;     c8a49
+;     c8a50
+;     c8a54
+;     c8a6e
+;     c8a82
+;     c8ad0
+;     c8aeb
+;     c8b18
+;     c8b60
+;     c8b77
+;     c8b8b
+;     c8ba2
+;     c8be3
+;     c8bfb
+;     c8c12
+;     c8c2e
+;     c8c3a
+;     c8c4e
+;     c8c61
+;     c8c87
+;     c8cae
+;     c8cb2
+;     c8cc1
+;     c8cd6
+;     c8ce7
+;     c8cfc
+;     c8d03
+;     c8d0d
+;     c8d13
+;     c8d41
+;     c8d5d
+;     c8d74
+;     c8d91
+;     c8d92
+;     c8dd2
+;     c8de2
+;     c8e03
+;     c8e0d
+;     c8e0e
+;     c8e12
+;     c8e32
+;     c8e4d
+;     c8e53
+;     c8e64
+;     c8e6f
+;     c8e72
+;     c8e9e
+;     c8e9f
+;     c8ea5
+;     c8eaf
+;     c8eb7
+;     c8ecb
+;     c8ecc
+;     c8edf
+;     c8eeb
+;     c8ef8
+;     c8f12
+;     c8f21
+;     c8f2a
+;     c8f3e
+;     c8f81
+;     c8fb5
+;     c8fc7
+;     c9060
+;     c9115
+;     c91af
+;     c91cc
+;     c91df
+;     c91eb
+;     c91f3
+;     c91f9
+;     c9201
+;     c920d
+;     c9214
+;     c921f
+;     c922b
+;     c9238
+;     c923b
+;     c923f
+;     c9249
+;     c9257
+;     c925a
+;     c926a
+;     c9276
+;     c9289
+;     c929c
+;     c92bd
+;     c92c4
+;     c92c7
+;     c92d6
+;     c92e3
+;     c9302
+;     c9367
+;     c936b
+;     c9379
+;     c938d
+;     c9390
+;     c93a8
+;     c93b1
+;     c93c4
+;     c93e2
+;     c93e5
+;     c93e6
+;     c93ff
+;     c940c
+;     c940e
+;     c9436
+;     c9444
+;     c9450
+;     c945c
+;     c948d
+;     c94a9
+;     c94bc
+;     c94c1
+;     c94c2
+;     c94c6
+;     c94d4
+;     c9504
+;     c9535
+;     c9556
+;     c956d
+;     c956f
+;     c95e4
+;     c95e7
+;     c95fd
+;     c9628
+;     c9649
+;     c964a
+;     c9658
+;     c965a
+;     c967a
+;     c9682
+;     c9683
+;     c969e
+;     c96b7
+;     c96c3
+;     c96e4
+;     c96e9
+;     c96ec
+;     c96f5
+;     c9700
+;     c9714
+;     c9736
+;     c9738
+;     c973c
+;     c973d
+;     c975b
+;     c976c
+;     c97b3
+;     c97e6
+;     c981f
+;     c982e
+;     c9835
+;     c984c
+;     c9859
+;     c986b
+;     c9873
+;     c98b1
+;     c98ba
+;     c98cd
+;     c98ed
+;     c98f0
+;     c993b
+;     c994b
+;     c996e
+;     c9978
+;     c9993
+;     c99a3
+;     c99ea
+;     c99ed
+;     c9a2a
+;     c9a3f
+;     c9a73
+;     c9a77
+;     c9a8c
+;     c9ad4
+;     c9adf
+;     c9ae9
+;     c9b6e
+;     c9bc2
+;     c9bc5
+;     c9c16
+;     c9c33
+;     c9c51
+;     c9c58
+;     c9c6b
+;     c9c8b
+;     c9cee
+;     c9d12
+;     c9d2b
+;     c9d57
+;     c9d5d
+;     c9d67
+;     c9d71
+;     c9d72
+;     c9d86
+;     c9d89
+;     c9db4
+;     c9dcd
+;     c9dce
+;     c9dd5
+;     c9e13
+;     c9e16
+;     c9e28
+;     c9e2a
+;     c9e41
+;     c9e5c
+;     c9e6f
+;     c9e71
+;     c9eb3
+;     c9ec2
+;     c9ef1
+;     c9f0d
+;     c9f19
+;     c9f5e
+;     c9f64
+;     c9f6a
+;     c9f6b
+;     c9f88
+;     c9fd9
+;     c9ff4
+;     ca005
+;     ca01d
+;     ca021
+;     ca054
+;     ca06b
+;     ca06c
+;     ca075
+;     ca0a9
+;     ca0f5
+;     ca10b
+;     ca14f
+;     ca17a
+;     ca183
+;     ca19f
+;     ca1c0
+;     ca1c1
+;     ca1d2
+;     ca27a
+;     ca2ab
+;     ca2f2
+;     ca30d
+;     ca321
+;     ca34a
+;     ca378
+;     ca38b
+;     ca38c
+;     ca38e
+;     ca3ae
+;     ca3bd
+;     ca3dc
+;     ca3fb
+;     ca40c
+;     ca411
+;     ca414
+;     ca45d
+;     ca47b
+;     ca4fa
+;     ca538
+;     ca547
+;     ca574
+;     ca595
+;     ca5a0
+;     ca5ab
+;     ca5c4
+;     ca5e2
+;     ca5e5
+;     ca5fb
+;     ca605
+;     ca637
+;     ca63a
+;     ca647
+;     ca652
+;     ca65d
+;     ca660
+;     ca675
+;     ca68a
+;     ca6b3
+;     ca6b6
+;     ca6bb
+;     ca6ce
+;     ca6e2
+;     ca70a
+;     ca712
+;     ca721
+;     ca728
+;     ca73a
+;     ca787
+;     ca7a4
+;     ca7f2
+;     ca7f7
+;     ca818
+;     ca82f
+;     ca845
+;     ca856
+;     ca86b
+;     ca87a
+;     ca8bd
+;     ca8fa
+;     ca902
+;     ca90c
+;     ca95d
+;     ca96c
+;     ca970
+;     ca97d
+;     ca982
+;     ca98d
+;     ca9b8
+;     ca9ff
+;     caa0a
+;     caa0d
+;     caa1c
+;     caa42
+;     caa44
+;     caa51
+;     caa78
+;     caa7a
+;     caa86
+;     caab7
+;     caabe
+;     caace
+;     cab09
+;     cab17
+;     cab1a
+;     cab2e
+;     cab35
+;     cab3d
+;     cab41
+;     cab54
+;     cab7d
+;     cab93
+;     caba4
+;     cabbc
+;     cabcf
+;     cabfb
+;     cac0f
+;     cac28
+;     cac45
+;     cacc4
+;     cacc7
+;     caed3
+;     caed7
+;     cb1d5
+;     cb1dd
+;     cb1fc
+;     cb203
+;     cb20f
+;     cb221
+;     cb23d
+;     cb260
+;     cb268
+;     cb280
+;     cb297
+;     cb2a0
+;     cb2b2
+;     cb2e1
+;     cb2e7
+;     cb300
+;     cb305
+;     cb314
+;     cb337
+;     cb34f
+;     cb352
+;     cb371
+;     cb375
+;     cb37f
+;     cb382
+;     cb397
+;     cb3ba
+;     cb3de
+;     cb406
+;     cb40e
+;     cb446
+;     cb44b
+;     cb45a
+;     cb45e
+;     cb470
+;     cb4af
+;     cb4b4
+;     cb4d8
+;     cb4df
+;     cb4e9
+;     cb4ee
+;     cb502
+;     cb534
+;     cb597
+;     cb5d0
+;     cb5e6
+;     cb655
+;     cb65e
+;     cb684
+;     cb68c
+;     cb6a6
+;     cb6c2
+;     cb6ca
+;     cb6d2
+;     cb6eb
+;     cb6f5
+;     cb718
+;     cb725
+;     cb736
+;     cb795
+;     cb7ae
+;     cb7b2
+;     cb7e8
+;     cb7ec
+;     cb7ed
+;     cb82b
+;     cb898
+;     cb8e4
+;     cb8e6
+;     cb8f5
+;     cb8fb
+;     cb9ae
+;     cb9d2
+;     cb9d9
+;     cb9e8
+;     cb9ee
+;     cb9f7
+;     cba10
+;     cba15
+;     cba19
+;     cba27
+;     cba28
+;     cba2e
+;     cba2f
+;     cba78
+;     cba8c
+;     cba9e
+;     cbab0
+;     cbab1
+;     cbab4
+;     cbad0
+;     cbaf8
+;     cbafd
+;     cbb07
+;     cbb28
+;     cbb2a
+;     cbb33
+;     cbb36
+;     cbb4c
+;     cbb6f
+;     cbb89
+;     cbb90
+;     cbba1
+;     cbbbe
+;     cbbd0
+;     cbbd9
+;     cbbf3
+;     cbc13
+;     cbc2c
+;     cbc3a
+;     cbc54
+;     cbc64
+;     cbc78
+;     cbc93
+;     cbcb2
+;     cbcb9
+;     cbcd6
+;     cbce1
+;     cbcf9
+;     cbd0e
+;     cbd1b
+;     cbd40
+;     cbd46
+;     cbd7e
+;     cbda3
+;     cbdb9
+;     cbdba
+;     cbdc0
+;     cbdd3
+;     cbddd
+;     cbe21
+;     cbe3c
+;     cbe47
+;     cbe52
+;     cbe7a
+;     cbe7b
+;     cbe89
+;     cbe8d
+;     cbec1
+;     cbee0
+;     cbee8
+;     cbeee
+;     cbf33
+;     cbf46
+;     cbf8a
+;     cbf8e
+;     cbfa3
+;     cbfb2
+;     l0000
+;     l0001
+;     l0002
+;     l0003
+;     l0012
+;     l0013
+;     l0014
+;     l0015
+;     l0053
+;     l0054
+;     l0055
+;     l0056
+;     l0057
+;     l00a0
+;     l00a1
+;     l00a2
+;     l00a3
+;     l00a4
+;     l00a5
+;     l00a6
+;     l00a7
+;     l00a8
+;     l00a9
+;     l00aa
+;     l00ab
+;     l00ac
+;     l00ad
+;     l00ae
+;     l00af
+;     l00b0
+;     l00b1
+;     l00b2
+;     l00b3
+;     l00b4
+;     l00b5
+;     l00b6
+;     l00b7
+;     l00b8
+;     l00b9
+;     l00ba
+;     l00bb
+;     l00bc
+;     l00bd
+;     l00be
+;     l00bf
+;     l00c0
+;     l00c1
+;     l00c2
+;     l00c3
+;     l00c4
+;     l00c5
+;     l00c6
+;     l00c7
+;     l00c8
+;     l00c9
+;     l00ca
+;     l00cc
+;     l00cd
+;     l00ce
+;     l00cf
+;     l00ef
+;     l00f0
+;     l00f1
+;     l00f3
+;     l00f7
+;     l00fd
+;     l00ff
+;     l0100
+;     l0101
+;     l0102
+;     l0103
+;     l0104
+;     l0105
+;     l0107
+;     l0109
+;     l010b
+;     l010c
+;     l010d
+;     l010e
+;     l0128
+;     l028d
+;     l04fc
+;     l0500
+;     l0600
+;     l06ce
+;     l0700
+;     l0cff
+;     l0d00
+;     l0d0f
+;     l0d12
+;     l0d1f
+;     l0d26
+;     l0d2a
+;     l0d30
+;     l0d3d
+;     l0d47
+;     l0d50
+;     l0d94
+;     l0df0
+;     l0e00
+;     l0e07
+;     l0e08
+;     l0e0e
+;     l0e0f
+;     l0e10
+;     l0ef8
+;     l0f00
+;     l0f04
+;     l0f05
+;     l0f06
+;     l0f07
+;     l0f08
+;     l0f09
+;     l0f0a
+;     l0f0b
+;     l0f0c
+;     l0f0d
+;     l0f0e
+;     l0f0f
+;     l0f10
+;     l1000
+;     l1001
+;     l1002
+;     l1003
+;     l1004
+;     l1005
+;     l1006
+;     l1007
+;     l100e
+;     l1045
+;     l1047
+;     l104d
+;     l104e
+;     l1050
+;     l1058
+;     l105f
+;     l1060
+;     l1061
+;     l1062
+;     l1063
+;     l1064
+;     l1065
+;     l1067
+;     l1069
+;     l1072
+;     l1074
+;     l1075
+;     l1076
+;     l1077
+;     l1078
+;     l1079
+;     l107a
+;     l107d
+;     l107e
+;     l107f
+;     l1081
+;     l1082
+;     l1083
+;     l1086
+;     l1087
+;     l1088
+;     l1089
+;     l108a
+;     l108b
+;     l108c
+;     l108f
+;     l1090
+;     l1091
+;     l1092
+;     l1093
+;     l1094
+;     l1095
+;     l1096
+;     l1097
+;     l1098
+;     l1099
+;     l109a
+;     l109b
+;     l109d
+;     l109e
+;     l109f
+;     l10c0
+;     l10c1
+;     l10c2
+;     l10c3
+;     l10c4
+;     l10c5
+;     l10c6
+;     l10c7
+;     l10c9
+;     l10ca
+;     l10cb
+;     l10cc
+;     l10cd
+;     l10ce
+;     l10cf
+;     l10d0
+;     l10d1
+;     l10d2
+;     l10d3
+;     l10d6
+;     l10d7
+;     l10d8
+;     l10d9
+;     l10da
+;     l10db
+;     l10dc
+;     l10dd
+;     l10de
+;     l10e2
+;     l10e3
+;     l10e4
+;     l1100
+;     l1109
+;     l110b
+;     l110c
+;     l110d
+;     l110e
+;     l110f
+;     l1110
+;     l1111
+;     l1112
+;     l1113
+;     l1114
+;     l1115
+;     l1116
+;     l1117
+;     l1119
+;     l111a
+;     l111b
+;     l111c
+;     l111d
+;     l2001
+;     l2002
+;     l2004
+;     l2006
+;     l2007
+;     l25d3
+;     l261c
+;     l261d
+;     l311d
+;     l3121
+;     l312d
+;     l3139
+;     l313f
+;     l3145
+;     l3146
+;     l3191
+;     l31a0
+;     l3aec
+;     l3b0f
+;     l3b18
+;     l3b21
+;     l3b29
+;     l3b31
+;     l3b3a
+;     l3b43
+;     l41d3
+;     l4cdb
+;     l4cf3
+;     l4ddb
+;     l4f73
+;     l4f75
+;     l4f76
+;     l4f77
+;     l4f78
+;     l5075
+;     l5175
+;     l5283
+;     l557f
+;     l56c6
+;     l56ce
+;     l5726
+;     l5774
+;     l5872
+;     l587e
+;     l5924
+;     l5979
+;     l597a
+;     l5980
+;     l5a30
+;     l5a31
+;     l5b3a
+;     l5b3e
+;     l5b42
+;     l5f4f
+;     l5fff
+;     l8001
+;     l8002
+;     l8004
+;     l911d
+;     l9121
+;     l9139
+;     l913f
+;     l9145
+;     l9146
+;     l9191
+;     l91a0
+;     l9aec
+;     l9b0f
+;     l9b18
+;     l9b21
+;     l9b29
+;     l9b31
+;     l9b3a
+;     l9b43
+;     la1d3
+;     lb075
+;     lb175
+;     lb283
+;     lb57f
+;     lb6c6
+;     lb6ce
+;     lb726
+;     lb774
+;     lb872
+;     lb87e
+;     lb924
+;     lb979
+;     lb97a
+;     lb980
+;     lbb3a
+;     lbb3e
+;     lbb42
+;     lbf4f
+;     lbfff
+;     lc000
+;     lfe80
+;     lfe84
+;     lfe85
+;     lfe86
+;     lfe87
+;     loop_c0029
+;     loop_c003b
+;     loop_c0446
+;     loop_c0466
+;     loop_c0471
+;     loop_c04a6
+;     loop_c04e1
+;     loop_c0564
+;     loop_c0577
+;     loop_c0586
+;     loop_c05ab
+;     loop_c05c7
+;     loop_c05d3
+;     loop_c05e6
+;     loop_c0604
+;     loop_c061d
+;     loop_c062b
+;     loop_c064c
+;     loop_c0657
+;     loop_c065a
+;     loop_c8064
+;     loop_c8086
+;     loop_c813a
+;     loop_c8161
+;     loop_c816b
+;     loop_c818c
+;     loop_c820c
+;     loop_c820d
+;     loop_c821c
+;     loop_c826f
+;     loop_c82c7
+;     loop_c82d1
+;     loop_c830d
+;     loop_c8326
+;     loop_c8370
+;     loop_c8390
+;     loop_c8397
+;     loop_c83f0
+;     loop_c83fa
+;     loop_c8406
+;     loop_c8425
+;     loop_c8463
+;     loop_c8493
+;     loop_c84e7
+;     loop_c8527
+;     loop_c8552
+;     loop_c8564
+;     loop_c857b
+;     loop_c85b5
+;     loop_c8717
+;     loop_c8725
+;     loop_c87a0
+;     loop_c87be
+;     loop_c88bc
+;     loop_c895f
+;     loop_c8990
+;     loop_c89c4
+;     loop_c89ca
+;     loop_c8a17
+;     loop_c8ac8
+;     loop_c8ad8
+;     loop_c8af0
+;     loop_c8afb
+;     loop_c8b80
+;     loop_c8bea
+;     loop_c8c58
+;     loop_c8c71
+;     loop_c8d14
+;     loop_c8d17
+;     loop_c8dac
+;     loop_c8dba
+;     loop_c8de9
+;     loop_c8df0
+;     loop_c8e14
+;     loop_c8e85
+;     loop_c8f17
+;     loop_c8f6c
+;     loop_c8f96
+;     loop_c8fac
+;     loop_c9047
+;     loop_c9108
+;     loop_c9113
+;     loop_c91ba
+;     loop_c91e7
+;     loop_c92ef
+;     loop_c9355
+;     loop_c9357
+;     loop_c936f
+;     loop_c9382
+;     loop_c93bd
+;     loop_c93da
+;     loop_c953a
+;     loop_c957d
+;     loop_c9593
+;     loop_c95b6
+;     loop_c95d9
+;     loop_c95ec
+;     loop_c9618
+;     loop_c96c2
+;     loop_c96f2
+;     loop_c979d
+;     loop_c97c8
+;     loop_c9803
+;     loop_c9837
+;     loop_c9851
+;     loop_c985e
+;     loop_c9881
+;     loop_c98a0
+;     loop_c98c1
+;     loop_c98e4
+;     loop_c9942
+;     loop_c994e
+;     loop_c9964
+;     loop_c99a8
+;     loop_c9b50
+;     loop_c9b5e
+;     loop_c9b63
+;     loop_c9bcf
+;     loop_c9be4
+;     loop_c9c38
+;     loop_c9c5d
+;     loop_c9c90
+;     loop_c9ca8
+;     loop_c9d03
+;     loop_c9d43
+;     loop_c9e07
+;     loop_c9e74
+;     loop_c9e8c
+;     loop_c9f6e
+;     loop_ca061
+;     loop_ca11d
+;     loop_ca132
+;     loop_ca143
+;     loop_ca16e
+;     loop_ca1aa
+;     loop_ca1cc
+;     loop_ca487
+;     loop_ca521
+;     loop_ca76f
+;     loop_ca7a7
+;     loop_ca7c6
+;     loop_ca7e0
+;     loop_ca7e1
+;     loop_ca941
+;     loop_ca947
+;     loop_ca953
+;     loop_ca9ab
+;     loop_ca9e7
+;     loop_caa01
+;     loop_caab8
+;     loop_cab6b
+;     loop_cab80
+;     loop_cabad
+;     loop_cabf4
+;     loop_cac46
+;     loop_caf13
+;     loop_caf2d
+;     loop_cb1e3
+;     loop_cb1ed
+;     loop_cb249
+;     loop_cb275
+;     loop_cb2b4
+;     loop_cb2bd
+;     loop_cb2d1
+;     loop_cb44d
+;     loop_cb4a8
+;     loop_cb55e
+;     loop_cb578
+;     loop_cb5c6
+;     loop_cb5ed
+;     loop_cb6b3
+;     loop_cb75a
+;     loop_cb7be
+;     loop_cb7d7
+;     loop_cb7dd
+;     loop_cb910
+;     loop_cb999
+;     loop_cb9bd
+;     loop_cb9cc
+;     loop_cb9d1
+;     loop_cb9f9
+;     loop_cba1a
+;     loop_cba94
+;     loop_cbab8
+;     loop_cbaea
+;     loop_cbbe4
+;     loop_cbbfe
+;     loop_cbc70
+;     loop_cbcd3
+;     loop_cbd08
+;     loop_cbd2b
+;     loop_cbd6c
+;     loop_cbd99
+;     loop_cbe0e
+;     loop_cbe31
+;     loop_cbeab
+;     loop_cbf1c
+;     loop_cbf78
+;     sub_c0050
+;     sub_c0414
+;     sub_c0421
+;     sub_c04c7
+;     sub_c04ce
+;     sub_c0520
+;     sub_c052d
+;     sub_c0537
+;     sub_c0542
+;     sub_c055e
+;     sub_c0582
+;     sub_c0596
+;     sub_c05a9
+;     sub_c05d1
+;     sub_c05f2
+;     sub_c05ff
+;     sub_c0607
+;     sub_c0627
+;     sub_c0d5e
+;     sub_c2020
+;     sub_c2023
+;     sub_c202e
+;     sub_c2038
+;     sub_c2048
+;     sub_c2077
+;     sub_c209a
+;     sub_c209d
+;     sub_c20b8
+;     sub_c20bb
+;     sub_c20c3
+;     sub_c20c8
+;     sub_c20d3
+;     sub_c20db
+;     sub_c20e3
+;     sub_c20e6
+;     sub_c20ed
+;     sub_c20f3
+;     sub_c20f6
+;     sub_c2149
+;     sub_c2174
+;     sub_c21ae
+;     sub_c21b0
+;     sub_c21b7
+;     sub_c21be
+;     sub_c21bf
+;     sub_c21c0
+;     sub_c21c4
+;     sub_c21c5
+;     sub_c21ca
+;     sub_c221d
+;     sub_c2222
+;     sub_c2266
+;     sub_c226d
+;     sub_c2280
+;     sub_c2284
+;     sub_c22b2
+;     sub_c22bb
+;     sub_c22e8
+;     sub_c22fe
+;     sub_c230a
+;     sub_c2327
+;     sub_c2335
+;     sub_c233a
+;     sub_c236e
+;     sub_c2380
+;     sub_c2386
+;     sub_c23bf
+;     sub_c23d1
+;     sub_c23d4
+;     sub_c23dc
+;     sub_c23e3
+;     sub_c23ee
+;     sub_c240c
+;     sub_c241b
+;     sub_c242c
+;     sub_c2439
+;     sub_c2456
+;     sub_c2555
+;     sub_c25e3
+;     sub_c2602
+;     sub_c2745
+;     sub_c274c
+;     sub_c27da
+;     sub_c27db
+;     sub_c27e3
+;     sub_c2826
+;     sub_c2855
+;     sub_c2862
+;     sub_c2932
+;     sub_c2951
+;     sub_c2979
+;     sub_c29da
+;     sub_c2a77
+;     sub_c2ab3
+;     sub_c2b25
+;     sub_c2b4d
+;     sub_c2b64
+;     sub_c2b7b
+;     sub_c2b86
+;     sub_c2bf6
+;     sub_c2bf9
+;     sub_c2c56
+;     sub_c2c65
+;     sub_c2d1a
+;     sub_c2dc6
+;     sub_c2eec
+;     sub_c2efa
+;     sub_c2eff
+;     sub_c2f33
+;     sub_c2f37
+;     sub_c2f3f
+;     sub_c2f4f
+;     sub_c2f5e
+;     sub_c2f6b
+;     sub_c2f75
+;     sub_c2f7a
+;     sub_c2f82
+;     sub_c2f94
+;     sub_c2fd2
+;     sub_c3030
+;     sub_c303e
+;     sub_c3067
+;     sub_c3104
+;     sub_c3279
+;     sub_c328a
+;     sub_c329d
+;     sub_c33b4
+;     sub_c33c5
+;     sub_c33d3
+;     sub_c33d8
+;     sub_c33f1
+;     sub_c33f5
+;     sub_c33f9
+;     sub_c33fd
+;     sub_c3432
+;     sub_c3445
+;     sub_c3516
+;     sub_c3526
+;     sub_c352e
+;     sub_c3536
+;     sub_c365d
+;     sub_c37e8
+;     sub_c3832
+;     sub_c392c
+;     sub_c3940
+;     sub_c394c
+;     sub_c395a
+;     sub_c3965
+;     sub_c3988
+;     sub_c39ac
+;     sub_c39f3
+;     sub_c3a0f
+;     sub_c3a32
+;     sub_c3a4b
+;     sub_c3a50
+;     sub_c3a60
+;     sub_c3a63
+;     sub_c3a6e
+;     sub_c3a78
+;     sub_c3a82
+;     sub_c3a8d
+;     sub_c3aa3
+;     sub_c3ab8
+;     sub_c3ac8
+;     sub_c3ad3
+;     sub_c3ad8
+;     sub_c3ae5
+;     sub_c3b51
+;     sub_c3b61
+;     sub_c3b79
+;     sub_c3bca
+;     sub_c3bcd
+;     sub_c3be5
+;     sub_c3bf2
+;     sub_c3d19
+;     sub_c3d1e
+;     sub_c3d75
+;     sub_c3d8e
+;     sub_c3df4
+;     sub_c3e1e
+;     sub_c3e30
+;     sub_c3e54
+;     sub_c3e75
+;     sub_c3e94
+;     sub_c3ef4
+;     sub_c3f0f
+;     sub_c3f14
+;     sub_c3f16
+;     sub_c3f1e
+;     sub_c3f26
+;     sub_c3f7c
+;     sub_c3f82
+;     sub_c40b8
+;     sub_c40de
+;     sub_c40f6
+;     sub_c414a
+;     sub_c4168
+;     sub_c4190
+;     sub_c41b4
+;     sub_c41c6
+;     sub_c4315
+;     sub_c4324
+;     sub_c4379
+;     sub_c4384
+;     sub_c43e4
+;     sub_c43ec
+;     sub_c44e1
+;     sub_c451f
+;     sub_c4530
+;     sub_c45b2
+;     sub_c4663
+;     sub_c473d
+;     sub_c476c
+;     sub_c4779
+;     sub_c4788
+;     sub_c47c4
+;     sub_c47c5
+;     sub_c47ce
+;     sub_c48be
+;     sub_c48e2
+;     sub_c490d
+;     sub_c499c
+;     sub_c49bf
+;     sub_c49c2
+;     sub_c49ca
+;     sub_c4a12
+;     sub_c4a53
+;     sub_c4a9a
+;     sub_c4ac2
+;     sub_c4acf
+;     sub_c4add
+;     sub_c4aea
+;     sub_c4af1
+;     sub_c4ba9
+;     sub_c4c0c
+;     sub_c4c18
+;     sub_c4c47
+;     sub_c4c4e
+;     sub_c4c62
+;     sub_c4c6a
+;     sub_c4c72
+;     sub_c4d5d
+;     sub_c4ea9
+;     sub_c4f8d
+;     sub_c4f9a
+;     sub_c5040
+;     sub_c5047
+;     sub_c5234
+;     sub_c52c8
+;     sub_c5580
+;     sub_c558b
+;     sub_c5598
+;     sub_c55ce
+;     sub_c55ee
+;     sub_c55f2
+;     sub_c5607
+;     sub_c5616
+;     sub_c561e
+;     sub_c565f
+;     sub_c568f
+;     sub_c56b1
+;     sub_c56e6
+;     sub_c56fe
+;     sub_c5745
+;     sub_c5771
+;     sub_c57b6
+;     sub_c583f
+;     sub_c5841
+;     sub_c584e
+;     sub_c5850
+;     sub_c585d
+;     sub_c586f
+;     sub_c5882
+;     sub_c5986
+;     sub_c59f5
+;     sub_c5a67
+;     sub_c5ab9
+;     sub_c5ac2
+;     sub_c5ac4
+;     sub_c5ad2
+;     sub_c5b00
+;     sub_c5c68
+;     sub_c5e83
+;     sub_c5e91
+;     sub_c5e9d
+;     sub_c5ec2
+;     sub_c5f7c
+;     sub_c5f82
+;     sub_c5f84
+;     sub_c8020
+;     sub_c809a
+;     sub_c809d
+;     sub_c80b8
+;     sub_c80bb
+;     sub_c80c3
+;     sub_c80c8
+;     sub_c80d3
+;     sub_c80db
+;     sub_c80e3
+;     sub_c80e6
+;     sub_c80ed
+;     sub_c80f3
+;     sub_c80f6
+;     sub_c8149
+;     sub_c8174
+;     sub_c81ae
+;     sub_c81b0
+;     sub_c81b7
+;     sub_c81be
+;     sub_c81bf
+;     sub_c81c0
+;     sub_c81c4
+;     sub_c81c5
+;     sub_c81ca
+;     sub_c821d
+;     sub_c8222
+;     sub_c8238
+;     sub_c8254
+;     sub_c8266
+;     sub_c826d
+;     sub_c8280
+;     sub_c8284
+;     sub_c82b2
+;     sub_c82bb
+;     sub_c82e8
+;     sub_c82fe
+;     sub_c830a
+;     sub_c8327
+;     sub_c8335
+;     sub_c833a
+;     sub_c836e
+;     sub_c8380
+;     sub_c8386
+;     sub_c83bf
+;     sub_c83d1
+;     sub_c83d4
+;     sub_c83e3
+;     sub_c83ee
+;     sub_c840c
+;     sub_c841b
+;     sub_c842c
+;     sub_c8439
+;     sub_c8456
+;     sub_c8555
+;     sub_c85e3
+;     sub_c8602
+;     sub_c8745
+;     sub_c8750
+;     sub_c8782
+;     sub_c8794
+;     sub_c87da
+;     sub_c87db
+;     sub_c87e3
+;     sub_c87ee
+;     sub_c8826
+;     sub_c8855
+;     sub_c8862
+;     sub_c8932
+;     sub_c893f
+;     sub_c8943
+;     sub_c8951
+;     sub_c8979
+;     sub_c89b7
+;     sub_c89da
+;     sub_c89e6
+;     sub_c8a77
+;     sub_c8ab3
+;     sub_c8b25
+;     sub_c8b47
+;     sub_c8b4d
+;     sub_c8b64
+;     sub_c8b7b
+;     sub_c8b86
+;     sub_c8bac
+;     sub_c8bf6
+;     sub_c8bf9
+;     sub_c8c56
+;     sub_c8c65
+;     sub_c8d1a
+;     sub_c8dc6
+;     sub_c8eec
+;     sub_c8efa
+;     sub_c8eff
+;     sub_c8f33
+;     sub_c8f37
+;     sub_c8f3f
+;     sub_c8f4f
+;     sub_c8f5e
+;     sub_c8f6b
+;     sub_c8f75
+;     sub_c8f7a
+;     sub_c8f82
+;     sub_c8f94
+;     sub_c9279
+;     sub_c928a
+;     sub_c929d
+;     sub_c93b4
+;     sub_c93c5
+;     sub_c93d3
+;     sub_c93d8
+;     sub_c93f1
+;     sub_c93f5
+;     sub_c93f9
+;     sub_c93fd
+;     sub_c9432
+;     sub_c9445
+;     sub_c9516
+;     sub_c9526
+;     sub_c952e
+;     sub_c9536
+;     sub_c965d
+;     sub_c9785
+;     sub_c97b6
+;     sub_c97c9
+;     sub_c97e8
+;     sub_c9832
+;     sub_c992c
+;     sub_c9940
+;     sub_c995a
+;     sub_c9965
+;     sub_c9988
+;     sub_c99ac
+;     sub_c99f3
+;     sub_c9a0f
+;     sub_c9a32
+;     sub_c9a4b
+;     sub_c9a50
+;     sub_c9a60
+;     sub_c9a63
+;     sub_c9a6e
+;     sub_c9a78
+;     sub_c9a82
+;     sub_c9a8d
+;     sub_c9aa3
+;     sub_c9ab8
+;     sub_c9ac8
+;     sub_c9ad3
+;     sub_c9ad8
+;     sub_c9b51
+;     sub_c9b59
+;     sub_c9b61
+;     sub_c9b79
+;     sub_c9bca
+;     sub_c9bcd
+;     sub_c9be5
+;     sub_c9bf2
+;     sub_c9c0c
+;     sub_c9d19
+;     sub_c9d1e
+;     sub_c9d75
+;     sub_c9d9b
+;     sub_c9df4
+;     sub_c9e1e
+;     sub_c9e30
+;     sub_c9e54
+;     sub_c9e75
+;     sub_c9e94
+;     sub_c9ef4
+;     sub_c9f0f
+;     sub_c9f14
+;     sub_c9f16
+;     sub_c9f1e
+;     sub_c9f26
+;     sub_c9f7c
+;     sub_c9f82
+;     sub_ca0b8
+;     sub_ca0de
+;     sub_ca0f6
+;     sub_ca106
+;     sub_ca137
+;     sub_ca14a
+;     sub_ca168
+;     sub_ca190
+;     sub_ca1b4
+;     sub_ca1c6
+;     sub_ca244
+;     sub_ca315
+;     sub_ca324
+;     sub_ca379
+;     sub_ca384
+;     sub_ca3e4
+;     sub_ca3ec
+;     sub_ca417
+;     sub_ca463
+;     sub_ca4e1
+;     sub_ca51f
+;     sub_ca530
+;     sub_ca5b2
+;     sub_ca5bb
+;     sub_ca5bf
+;     sub_ca663
+;     sub_ca73d
+;     sub_ca76c
+;     sub_ca779
+;     sub_ca788
+;     sub_ca7c4
+;     sub_ca7c5
+;     sub_ca7ce
+;     sub_ca7f3
+;     sub_ca7f6
+;     sub_ca8be
+;     sub_ca8e2
+;     sub_ca90d
+;     sub_ca9bf
+;     sub_ca9c2
+;     sub_ca9ca
+;     sub_ca9d0
+;     sub_caa12
+;     sub_caa53
+;     sub_caa9a
+;     sub_caac2
+;     sub_caacf
+;     sub_caadd
+;     sub_caaea
+;     sub_caaf1
+;     sub_caafd
+;     sub_cab04
+;     sub_cab46
+;     sub_caba9
+;     sub_cabc5
+;     sub_cac0c
+;     sub_cac18
+;     sub_cac47
+;     sub_cac4e
+;     sub_cac62
+;     sub_cac6a
+;     sub_cac72
+;     sub_cb234
+;     sub_cb2c8
+;     sub_cb580
+;     sub_cb58b
+;     sub_cb598
+;     sub_cb5ce
+;     sub_cb5ee
+;     sub_cb5f2
+;     sub_cb607
+;     sub_cb616
+;     sub_cb61e
+;     sub_cb65f
+;     sub_cb68f
+;     sub_cb6b1
+;     sub_cb6c5
+;     sub_cb6cd
+;     sub_cb6e6
+;     sub_cb6fe
+;     sub_cb745
+;     sub_cb771
+;     sub_cb7b6
+;     sub_cb83f
+;     sub_cb841
+;     sub_cb84e
+;     sub_cb850
+;     sub_cb85d
+;     sub_cb86f
+;     sub_cb882
+;     sub_cb986
+;     sub_cb9f5
+;     sub_cba67
+;     sub_cbab9
+;     sub_cbac2
+;     sub_cbac4
+;     sub_cbad2
+;     sub_cbb00
+;     sub_cbb46
+;     sub_cbb4a
+;     sub_cbbd3
+;     sub_cbbd7
+;     sub_cbc37
+;     sub_cbc68
+;     sub_cbc81
+;     sub_cbe83
+;     sub_cbe91
+;     sub_cbe9d
+;     sub_cbec2
+;     sub_cbf7c
+;     sub_cbf82
+;     sub_cbf84
+    assert <(c956d-1) == &6c
+    assert <(c956d-1) == &6c
+    assert <(l0128) == &28
+    assert <(l1000) == &00
+    assert <(sub_c8238-1) == &37
+    assert <(sub_c8254-1) == &53
+    assert <(sub_c8750-1) == &4f
+    assert <(sub_c8782-1) == &81
+    assert <(sub_c8794-1) == &93
+    assert <(sub_c87ee-1) == &ed
+    assert <(sub_c893f-1) == &3e
+    assert <(sub_c8943-1) == &42
+    assert <(sub_c89b7-1) == &b6
+    assert <(sub_c89e6-1) == &e5
+    assert <(sub_c8b47-1) == &46
+    assert <(sub_c8bac-1) == &ab
+    assert <(sub_c9b59-1) == &58
+    assert <(sub_ca106-1) == &05
+    assert <(sub_ca137-1) == &36
+    assert <(sub_ca244-1) == &43
+    assert <(sub_ca417-1) == &16
+    assert <(sub_ca463-1) == &62
+    assert <(sub_ca5bb-1) == &ba
+    assert <(sub_ca5bf-1) == &be
+    assert <(sub_ca7f3-1) == &f2
+    assert <(sub_ca7f6-1) == &f5
+    assert <(sub_ca9d0-1) == &cf
+    assert <(sub_caafd-1) == &fc
+    assert <(sub_cab04-1) == &03
+    assert <(sub_cab46-1) == &45
+    assert <(sub_cabc5-1) == &c4
+    assert <(sub_cbb46-1) == &45
+    assert <(sub_cbb4a-1) == &49
+    assert <(sub_cbbd3-1) == &d2
+    assert <(sub_cbbd7-1) == &d6
+    assert <(sub_cbc37-1) == &36
+    assert <(sub_cbc81-1) == &80
+    assert <tube_brkv_handler == &16
+    assert <tube_evntv_handler == &ad
+    assert >(c956d-1) == &95
+    assert >(c956d-1) == &95
+    assert >(l0128) == &01
+    assert >(l1000) == &10
+    assert >(sub_c8238-1) == &82
+    assert >(sub_c8254-1) == &82
+    assert >(sub_c8750-1) == &87
+    assert >(sub_c8782-1) == &87
+    assert >(sub_c8794-1) == &87
+    assert >(sub_c87ee-1) == &87
+    assert >(sub_c893f-1) == &89
+    assert >(sub_c8943-1) == &89
+    assert >(sub_c89b7-1) == &89
+    assert >(sub_c89e6-1) == &89
+    assert >(sub_c8b47-1) == &8b
+    assert >(sub_c8bac-1) == &8b
+    assert >(sub_c9b59-1) == &9b
+    assert >(sub_ca106-1) == &a1
+    assert >(sub_ca137-1) == &a1
+    assert >(sub_ca244-1) == &a2
+    assert >(sub_ca417-1) == &a4
+    assert >(sub_ca463-1) == &a4
+    assert >(sub_ca5bb-1) == &a5
+    assert >(sub_ca5bf-1) == &a5
+    assert >(sub_ca7f3-1) == &a7
+    assert >(sub_ca7f6-1) == &a7
+    assert >(sub_ca9d0-1) == &a9
+    assert >(sub_caafd-1) == &aa
+    assert >(sub_cab04-1) == &ab
+    assert >(sub_cab46-1) == &ab
+    assert >(sub_cabc5-1) == &ab
+    assert >(sub_cbb46-1) == &bb
+    assert >(sub_cbb4a-1) == &bb
+    assert >(sub_cbbd3-1) == &bb
+    assert >(sub_cbbd7-1) == &bb
+    assert >(sub_cbc37-1) == &bc
+    assert >(sub_cbc81-1) == &bc
+    assert >tube_brkv_handler == &00
+    assert >tube_evntv_handler == &06
+    assert copyright - rom_header == &11
+    assert jump_address_low == &51
+    assert nmi3_handler_rom_end-nmi3_handler_rom_start == &0e
+    assert nmi_XXX1-(nmi_beq+2) == &48
+    assert nmi_XXX10-(nmi_bcs+2) == &32
+    assert nmi_XXX11-(nmi_bcs+2) == &3b
+    assert nmi_XXX12-(nmi_bcs+2) == &3f
+    assert nmi_XXX13-(nmi_bcs+2) == &49
+    assert nmi_XXX14-(nmi_bcs+2) == &4d
+    assert nmi_XXX15-(nmi_bcs+2) == &55
+    assert nmi_XXX16-(nmi_bcs+2) == &5d
+    assert nmi_XXX17-(nmi_bcs+2) == &06
+    assert nmi_XXX18-(nmi_bcs+2) == &11
+    assert nmi_XXX19-(nmi_bcs+2) == &7b
+    assert nmi_XXX2-(nmi_beq+2) == &2f
+    assert nmi_XXX2-1 == &0d38
+    assert nmi_XXX20-(nmi_bcs+2) == &7f
+    assert nmi_XXX21-(nmi_bcs+2) == &26
+    assert nmi_XXX22-(nmi_bcs+2) == &77
+    assert nmi_XXX23-(nmi_bcs+2) == &24
+    assert nmi_XXX5-(nmi_cmp_imm_or_bcs+2) == &06
+    assert nmi_XXX7-(nmi_XXX6+2) == &06
+    assert nmi_XXX8-(nmi_beq+2) == &4d
+    assert nmi_handler2_rom_end-nmi_handler2_rom_start == &94
+    assert nmi_handler_rom_end-nmi_handler_rom_start-1 == &5d
+    assert opcode_bcs == &b0
+    assert opcode_rti == &40
+    assert osbyte_close_spool_exec == &77
+    assert osbyte_explode_chars == &14
+    assert osbyte_issue_service_request == &8f
+    assert osbyte_read_himem == &84
+    assert osbyte_read_oshwm == &83
+    assert osbyte_read_rom_info_table_low == &aa
+    assert osbyte_read_tube_presence == &ea
+    assert osbyte_read_write_spool_file_handle == &c7
+    assert osbyte_read_write_startup_options == &ff
+    assert osbyte_rw_exec_handle == &c6
+    assert osbyte_scan_keyboard_from_16 == &7a
+    assert osbyte_write_keys_pressed == &78
+    assert osfile_load == &ff
+    assert osfile_read_catalogue_info == &05
+    assert osfile_save == &00
+    assert service_absolute_workspace_claimed == &0a
+    assert service_boot == &03
+    assert service_check_swr_presence == &2b
+    assert service_claim_absolute_workspace == &01
+    assert service_claim_private_workspace == &02
+    assert service_help == &09
+    assert service_select_filing_system == &12
+    assert service_tube_post_init == &fe
+    assert service_unrecognised_command == &04
+    assert service_unrecognised_osword == &08
+    assert sub_c0520 == &0520
+    assert sub_c052d == &052d
+    assert sub_c0537 == &0537
+    assert sub_c0542 == &0542
+    assert sub_c055e == &055e
+    assert sub_c0596 == &0596
+    assert sub_c05a9 == &05a9
+    assert sub_c05d1 == &05d1
+    assert sub_c05f2 == &05f2
+    assert sub_c0607 == &0607
+    assert sub_c0627 == &0627
+    assert sub_c9785 == &9785
+    assert sub_c97b6 == &97b6
+    assert sub_c97c9 == &97c9
+    assert sub_c9c0c == &9c0c
+    assert sub_c9d9b == &9d9b
+    assert sub_c9e94 == &9e94
+    assert sub_c9f82 == &9f82
+    assert tube_brkv_handler_fwd == &16
+    assert tube_host_osword_0 == &0668
+
+save pydis_start, pydis_end

--- a/examples/known_good/dfs226b_xa.asm
+++ b/examples/known_good/dfs226b_xa.asm
@@ -1,0 +1,14627 @@
+// Constants
+opcode_bcs                            = 176
+opcode_rti                            = 64
+osbyte_close_spool_exec               = 119
+osbyte_explode_chars                  = 20
+osbyte_issue_service_request          = 143
+osbyte_read_himem                     = 132
+osbyte_read_oshwm                     = 131
+osbyte_read_rom_info_table_low        = 170
+osbyte_read_tube_presence             = 234
+osbyte_read_write_spool_file_handle   = 199
+osbyte_read_write_startup_options     = 255
+osbyte_rw_exec_handle                 = 198
+osbyte_scan_keyboard_from_16          = 122
+osbyte_write_keys_pressed             = 120
+osfile_load                           = 255
+osfile_read_catalogue_info            = 5
+osfile_save                           = 0
+service_absolute_workspace_claimed    = 10
+service_boot                          = 3
+service_check_swr_presence            = 43
+service_claim_absolute_workspace      = 1
+service_claim_private_workspace       = 2
+service_help                          = 9
+service_select_filing_system          = 18
+service_tube_post_init                = 254
+service_unrecognised_command          = 4
+service_unrecognised_osword           = 8
+tube_brkv_handler_fwd                 = 22
+
+// Memory locations
+l0000                   = $0000
+l0001                   = $0001
+l0002                   = $0002
+l0003                   = $0003
+l0012                   = $0012
+l0013                   = $0013
+l0014                   = $0014
+l0015                   = $0015
+l00a0                   = $00a0
+l00a1                   = $00a1
+l00a2                   = $00a2
+l00a3                   = $00a3
+l00a4                   = $00a4
+l00a5                   = $00a5
+l00a6                   = $00a6
+l00a7                   = $00a7
+l00a8                   = $00a8
+l00a9                   = $00a9
+l00aa                   = $00aa
+l00ab                   = $00ab
+l00ac                   = $00ac
+l00ad                   = $00ad
+l00ae                   = $00ae
+l00af                   = $00af
+l00b0                   = $00b0
+l00b1                   = $00b1
+l00b2                   = $00b2
+l00b3                   = $00b3
+l00b4                   = $00b4
+l00b5                   = $00b5
+l00b6                   = $00b6
+l00b7                   = $00b7
+l00b8                   = $00b8
+l00b9                   = $00b9
+l00ba                   = $00ba
+l00bb                   = $00bb
+l00bc                   = $00bc
+l00bd                   = $00bd
+l00be                   = $00be
+l00bf                   = $00bf
+l00c0                   = $00c0
+l00c1                   = $00c1
+l00c2                   = $00c2
+l00c3                   = $00c3
+l00c4                   = $00c4
+l00c5                   = $00c5
+l00c6                   = $00c6
+l00c7                   = $00c7
+l00c8                   = $00c8
+l00c9                   = $00c9
+l00ca                   = $00ca
+l00cc                   = $00cc
+l00cd                   = $00cd
+l00ce                   = $00ce
+l00cf                   = $00cf
+l00ef                   = $00ef
+l00f0                   = $00f0
+l00f1                   = $00f1
+os_text_ptr             = $00f2
+l00f3                   = $00f3
+romsel_copy             = $00f4
+osrdsc_ptr              = $00f6
+l00f7                   = $00f7
+l00fd                   = $00fd
+l00ff                   = $00ff
+l0100                   = $0100
+l0101                   = $0101
+l0102                   = $0102
+l0103                   = $0103
+l0104                   = $0104
+l0105                   = $0105
+l0107                   = $0107
+l0109                   = $0109
+l010b                   = $010b
+l010c                   = $010c
+l010d                   = $010d
+l010e                   = $010e
+l0128                   = $0128
+brkv                    = $0202
+bytev                   = $020a
+filev                   = $0212
+fscv                    = $021e
+evntv                   = $0220
+l028d                   = $028d
+l0700                   = $0700
+l0cff                   = $0cff
+l0df0                   = $0df0
+l0e00                   = $0e00
+l0e07                   = $0e07
+l0e08                   = $0e08
+l0e0e                   = $0e0e
+l0e0f                   = $0e0f
+l0e10                   = $0e10
+l0ef8                   = $0ef8
+l0f00                   = $0f00
+l0f04                   = $0f04
+l0f05                   = $0f05
+l0f06                   = $0f06
+l0f07                   = $0f07
+l0f08                   = $0f08
+l0f09                   = $0f09
+l0f0a                   = $0f0a
+l0f0b                   = $0f0b
+l0f0c                   = $0f0c
+l0f0d                   = $0f0d
+l0f0e                   = $0f0e
+l0f0f                   = $0f0f
+l0f10                   = $0f10
+l1000                   = $1000
+l1001                   = $1001
+l1002                   = $1002
+l1003                   = $1003
+l1004                   = $1004
+l1005                   = $1005
+l1006                   = $1006
+l1007                   = $1007
+l100e                   = $100e
+l1045                   = $1045
+l1047                   = $1047
+l104d                   = $104d
+l104e                   = $104e
+l1050                   = $1050
+l1058                   = $1058
+l105f                   = $105f
+l1060                   = $1060
+l1061                   = $1061
+l1062                   = $1062
+l1063                   = $1063
+l1064                   = $1064
+l1065                   = $1065
+l1067                   = $1067
+l1069                   = $1069
+l1072                   = $1072
+l1074                   = $1074
+l1075                   = $1075
+l1076                   = $1076
+l1077                   = $1077
+l1078                   = $1078
+l1079                   = $1079
+l107a                   = $107a
+l107d                   = $107d
+l107e                   = $107e
+l107f                   = $107f
+l1081                   = $1081
+l1082                   = $1082
+l1083                   = $1083
+l1086                   = $1086
+l1087                   = $1087
+l1088                   = $1088
+l1089                   = $1089
+l108a                   = $108a
+l108b                   = $108b
+l108c                   = $108c
+l108f                   = $108f
+l1090                   = $1090
+l1091                   = $1091
+l1092                   = $1092
+l1093                   = $1093
+l1094                   = $1094
+l1095                   = $1095
+l1096                   = $1096
+l1097                   = $1097
+l1098                   = $1098
+l1099                   = $1099
+l109a                   = $109a
+l109b                   = $109b
+l109d                   = $109d
+l109e                   = $109e
+l109f                   = $109f
+l10c0                   = $10c0
+l10c1                   = $10c1
+l10c2                   = $10c2
+l10c3                   = $10c3
+l10c4                   = $10c4
+l10c5                   = $10c5
+l10c6                   = $10c6
+l10c7                   = $10c7
+l10c9                   = $10c9
+l10ca                   = $10ca
+l10cb                   = $10cb
+l10cc                   = $10cc
+l10cd                   = $10cd
+l10ce                   = $10ce
+l10cf                   = $10cf
+l10d0                   = $10d0
+l10d1                   = $10d1
+l10d2                   = $10d2
+l10d3                   = $10d3
+l10d6                   = $10d6
+l10d7                   = $10d7
+l10d8                   = $10d8
+l10d9                   = $10d9
+l10da                   = $10da
+l10db                   = $10db
+l10dc                   = $10dc
+l10dd                   = $10dd
+l10de                   = $10de
+l10e2                   = $10e2
+l10e3                   = $10e3
+l10e4                   = $10e4
+l1100                   = $1100
+l1109                   = $1109
+l110b                   = $110b
+l110c                   = $110c
+l110d                   = $110d
+l110e                   = $110e
+l110f                   = $110f
+l1110                   = $1110
+l1111                   = $1111
+l1112                   = $1112
+l1113                   = $1113
+l1114                   = $1114
+l1115                   = $1115
+l1116                   = $1116
+l1117                   = $1117
+l1119                   = $1119
+l111a                   = $111a
+l111b                   = $111b
+l111c                   = $111c
+l111d                   = $111d
+nmi_handler_rom_end     = $9030
+nmi3_handler_rom_start  = $9030
+tube_host_code1         = $af79
+romsel                  = $fe30
+lfe80                   = $fe80
+lfe84                   = $fe84
+lfe85                   = $fe85
+lfe86                   = $fe86
+lfe87                   = $fe87
+tube_host_r1_status     = $fee0
+tube_host_r1_data       = $fee1
+tube_host_r2_status     = $fee2
+tube_host_r2_data       = $fee3
+tube_host_r3_data       = $fee5
+tube_host_r4_status     = $fee6
+tube_host_r4_data       = $fee7
+osrdsc                  = $ffb9
+gsinit                  = $ffc2
+gsread                  = $ffc5
+osfind                  = $ffce
+osgbpb                  = $ffd1
+osbput                  = $ffd4
+osbget                  = $ffd7
+osargs                  = $ffda
+osfile                  = $ffdd
+osrdch                  = $ffe0
+osasci                  = $ffe3
+osnewl                  = $ffe7
+oswrch                  = $ffee
+osword                  = $fff1
+osbyte                  = $fff4
+oscli                   = $fff7
+
+    * = $2000
+
+// Sideways ROM header
+// $2000 referenced 1 time by $04e2
+pydis_start
+* = $8000
+// Sideways ROM header
+// $2000 referenced 1 time by $04e2
+rom_header
+language_entry
+l8001 = rom_header+1
+l8002 = rom_header+2
+    .byt 0, 0, 0                                                      // 2000: 00 00 00    ... :8000[1]
+// $2001 referenced 1 time by $04e7
+// $2002 referenced 1 time by $04ec
+
+// $2003 referenced 1 time by $04f1
+service_entry
+l8004 = service_entry+1
+    jmp service_handler                                               // 2003: 4c c8 be    L.. :8003[1]
+
+// $2004 referenced 1 time by $04f4
+// $2006 referenced 1 time by $04d6
+rom_type
+    .byt $82                                                          // 2006: 82          .   :8006[1]
+// $2007 referenced 1 time by $04de
+copyright_offset
+    .byt copyright - rom_header                                       // 2007: 11          .   :8007[1]
+binary_version
+    .byt $7b                                                          // 2008: 7b          {   :8008[1]
+title
+    .asc "DFS"                                                        // 2009: 44 46 53    DFS :8009[1]
+version
+    .byt 0                                                            // 200c: 00          .   :800c[1]
+    .asc "2.26"                                                       // 200d: 32 2e 32... 2.2 :800d[1]
+copyright
+    .byt 0                                                            // 2011: 00          .   :8011[1]
+    .asc "(C)1985 Acorn", 0                                           // 2012: 28 43 29... (C) :8012[1]
+
+// $2020 referenced 1 time by $9575
+sub_c8020
+    jmp (fscv)                                                        // 2020: 6c 1e 02    l.. :8020[1]
+
+// $2023 referenced 4 times by $8a6e, $94c6, $94d5, $9c00
+generate_error_precheck_disc
+    jsr generate_error_precheck                                       // 2023: 20 38 80     8. :8023[1]
+    .byt 0                                                            // 2026: 00          .   :8026[1]
+    .asc "Disc "                                                      // 2027: 44 69 73... Dis :8027[1]
+
+    bcc generate_error2                                               // 202c: 90 21       .!  :802c[1]
+// $202e referenced 6 times by $8125, $889a, $89a5, $8a24, $8a3e, $8ba2
+generate_error_precheck_bad
+    jsr generate_error_precheck                                       // 202e: 20 38 80     8. :802e[1]
+    .byt 0                                                            // 2031: 00          .   :8031[1]
+    .asc "Bad "                                                       // 2032: 42 61 64... Bad :8032[1]
+
+    bcc generate_error2                                               // 2036: 90 17       ..  :8036[1]
+// $2038 referenced 11 times by $8023, $802e, $8b18, $8bd8, $9a55, $9c70, $9c82, $9e80, $9e8c, $9f6e, $9fc8
+generate_error_precheck
+    lda l10dd                                                         // 2038: ad dd 10    ... :8038[1]
+    bne c8040                                                         // 203b: d0 03       ..  :803b[1]
+    jsr sub_c9e30                                                     // 203d: 20 30 9e     0. :803d[1]
+// $2040 referenced 1 time by $803b
+c8040
+    lda #$ff                                                          // 2040: a9 ff       ..  :8040[1]
+    sta l1082                                                         // 2042: 8d 82 10    ... :8042[1]
+    sta l10dd                                                         // 2045: 8d dd 10    ... :8045[1]
+// Generate an OS error using inline data. Called as either:
+//         jsr XXX:equb errnum, "error message", 0
+//     to actually generate an error now, or as:
+//         jsr XXX:equb errnum, "partial error message",
+// instruction...
+//     to partially construct an error (on the stack) and continue
+// executing
+//     'instruction' afterwards; its opcode must have its top bit set.
+// Carry is
+//     always clear on exit.
+// $2048 referenced 4 times by $822a, $9439, $947c, $a14f
+generate_error
+    ldx #2                                                            // 2048: a2 02       ..  :8048[1]
+    lda #0                                                            // 204a: a9 00       ..  :804a[1]
+    sta l0100                                                         // 204c: 8d 00 01    ... :804c[1]
+// $204f referenced 7 times by $802c, $8036, $94da, $94e9, $94f7, $9507, $9511
+generate_error2
+    sta l00b3                                                         // 204f: 85 b3       ..  :804f[1]
+    pla                                                               // 2051: 68          h   :8051[1]
+    sta l00ae                                                         // 2052: 85 ae       ..  :8052[1]
+    pla                                                               // 2054: 68          h   :8054[1]
+    sta l00af                                                         // 2055: 85 af       ..  :8055[1]
+// XXX: Redundant lda l00b3? Is sta l00b3 above redundant too?
+    lda l00b3                                                         // 2057: a5 b3       ..  :8057[1]
+    ldy #0                                                            // 2059: a0 00       ..  :8059[1]
+    jsr inc16_ae                                                      // 205b: 20 dc 83     .. :805b[1]
+    lda (l00ae),y                                                     // 205e: b1 ae       ..  :805e[1]
+    sta l0101                                                         // 2060: 8d 01 01    ... :8060[1]
+    dex                                                               // 2063: ca          .   :8063[1]
+// $2064 referenced 1 time by $806f
+loop_c8064
+    jsr inc16_ae                                                      // 2064: 20 dc 83     .. :8064[1]
+    inx                                                               // 2067: e8          .   :8067[1]
+    lda (l00ae),y                                                     // 2068: b1 ae       ..  :8068[1]
+    sta l0100,x                                                       // 206a: 9d 00 01    ... :806a[1]
+    bmi c8096                                                         // 206d: 30 27       0'  :806d[1]
+    bne loop_c8064                                                    // 206f: d0 f3       ..  :806f[1]
+    jsr sub_c8f75                                                     // 2071: 20 75 8f     u. :8071[1]
+    jmp l0100                                                         // 2074: 4c 00 01    L.. :8074[1]
+
+// Print (XXX: using l809f, which seems to be quite fancy) an inline
+// string
+//     terminated by a top-bit set instruction to execute after
+// printing the string.
+//     Carry is always clear on exit.
+// $2077 referenced 31 times by $84a5, $84b0, $84c8, $84dc, $84f1, $850d, $87ce, $9558, $a10c, $a247, $a298, $a34d, $a364, $a394, $a3a3, $a3ae, $a3bd, $a3e4, $a3ec, $a5f0, $a5fb, $a605, $a667, $a678, $a68a, $a699, $a70a, $a719, $aa5a, $aa65, $aebf
+print_inline_l809f_top_bit_clear
+    sta l00b3                                                         // 2077: 85 b3       ..  :8077[1]
+    pla                                                               // 2079: 68          h   :8079[1]
+    sta l00ae                                                         // 207a: 85 ae       ..  :807a[1]
+    pla                                                               // 207c: 68          h   :807c[1]
+    sta l00af                                                         // 207d: 85 af       ..  :807d[1]
+    lda l00b3                                                         // 207f: a5 b3       ..  :807f[1]
+    pha                                                               // 2081: 48          H   :8081[1]
+    tya                                                               // 2082: 98          .   :8082[1]
+    pha                                                               // 2083: 48          H   :8083[1]
+    ldy #0                                                            // 2084: a0 00       ..  :8084[1]
+// $2086 referenced 1 time by $8090
+loop_c8086
+    jsr inc16_ae                                                      // 2086: 20 dc 83     .. :8086[1]
+    lda (l00ae),y                                                     // 2089: b1 ae       ..  :8089[1]
+    bmi c8093                                                         // 208b: 30 06       0.  :808b[1]
+    jsr c809f                                                         // 208d: 20 9f 80     .. :808d[1]
+    jmp loop_c8086                                                    // 2090: 4c 86 80    L.. :8090[1]
+
+// $2093 referenced 1 time by $808b
+c8093
+    pla                                                               // 2093: 68          h   :8093[1]
+    tay                                                               // 2094: a8          .   :8094[1]
+    pla                                                               // 2095: 68          h   :8095[1]
+// $2096 referenced 1 time by $806d
+c8096
+    clc                                                               // 2096: 18          .   :8096[1]
+    jmp (l00ae)                                                       // 2097: 6c ae 00    l.. :8097[1]
+
+// $209a referenced 2 times by $84ff, $8519
+sub_c809a
+    jsr sub_c80c3                                                     // 209a: 20 c3 80     .. :809a[1]
+// $209d referenced 1 time by $8187
+sub_c809d
+    lda #$2e // '.'                                                   // 209d: a9 2e       ..  :809d[1]
+// $209f referenced 20 times by $808d, $80c6, $8184, $8191, $81a2, $849d, $84ea, $8505, $851f, $a1c3, $a3df, $a40c, $a621, $a6bd, $a6c0, $aa6d, $aa7b, $aa87, $aa8c, $aabe
+c809f
+    jsr sub_c83e3                                                     // 209f: 20 e3 83     .. :809f[1]
+    pha                                                               // 20a2: 48          H   :80a2[1]
+    lda #$ec                                                          // 20a3: a9 ec       ..  :80a3[1]
+    jsr osbyte_read                                                   // 20a5: 20 e5 9a     .. :80a5[1]
+    txa                                                               // 20a8: 8a          .   :80a8[1]
+    pha                                                               // 20a9: 48          H   :80a9[1]
+    ora #$10                                                          // 20aa: 09 10       ..  :80aa[1]
+    jsr sub_c9ad3                                                     // 20ac: 20 d3 9a     .. :80ac[1]
+    pla                                                               // 20af: 68          h   :80af[1]
+    tax                                                               // 20b0: aa          .   :80b0[1]
+    pla                                                               // 20b1: 68          h   :80b1[1]
+    jsr osasci                                                        // 20b2: 20 e3 ff     .. :80b2[1]
+    jmp c9ad4                                                         // 20b5: 4c d4 9a    L.. :80b5[1]
+
+// $20b8 referenced 1 time by $aa62
+sub_c80b8
+    jsr sub_c841b                                                     // 20b8: 20 1b 84     .. :80b8[1]
+// $20bb referenced 5 times by $8368, $8373, $84ad, $a295, $a6c6
+sub_c80bb
+    pha                                                               // 20bb: 48          H   :80bb[1]
+    jsr sub_c81bf                                                     // 20bc: 20 bf 81     .. :80bc[1]
+    jsr sub_c80c3                                                     // 20bf: 20 c3 80     .. :80bf[1]
+    pla                                                               // 20c2: 68          h   :80c2[1]
+// $20c3 referenced 10 times by $809a, $80bf, $8362, $84c0, $84d9, $a25c, $a291, $a361, $a36f, $a696
+sub_c80c3
+    jsr sub_c80c8                                                     // 20c3: 20 c8 80     .. :80c3[1]
+    bne c809f                                                         // 20c6: d0 d7       ..  :80c6[1]
+// $20c8 referenced 4 times by $80c3, $952e, $a9ca, $ac6a
+sub_c80c8
+    and #$0f                                                          // 20c8: 29 0f       ).  :80c8[1]
+    cmp #$0a                                                          // 20ca: c9 0a       ..  :80ca[1]
+    bcc c80d0                                                         // 20cc: 90 02       ..  :80cc[1]
+    adc #6                                                            // 20ce: 69 06       i.  :80ce[1]
+// $20d0 referenced 1 time by $80cc
+c80d0
+    adc #$30 // '0'                                                   // 20d0: 69 30       i0  :80d0[1]
+    rts                                                               // 20d2: 60          `   :80d2[1]
+
+// $20d3 referenced 1 time by $979d
+sub_c80d3
+    jsr sub_c80e3                                                     // 20d3: 20 e3 80     .. :80d3[1]
+    dex                                                               // 20d6: ca          .   :80d6[1]
+    dex                                                               // 20d7: ca          .   :80d7[1]
+    jsr sub_c80db                                                     // 20d8: 20 db 80     .. :80d8[1]
+// $20db referenced 1 time by $80d8
+sub_c80db
+    lda (l00b0),y                                                     // 20db: b1 b0       ..  :80db[1]
+    sta l1072,x                                                       // 20dd: 9d 72 10    .r. :80dd[1]
+    inx                                                               // 20e0: e8          .   :80e0[1]
+    iny                                                               // 20e1: c8          .   :80e1[1]
+    rts                                                               // 20e2: 60          `   :80e2[1]
+
+// $20e3 referenced 2 times by $80d3, $979a
+sub_c80e3
+    jsr sub_c80e6                                                     // 20e3: 20 e6 80     .. :80e3[1]
+// $20e6 referenced 1 time by $80e3
+sub_c80e6
+    lda (l00b0),y                                                     // 20e6: b1 b0       ..  :80e6[1]
+    sta l00ba,x                                                       // 20e8: 95 ba       ..  :80e8[1]
+    inx                                                               // 20ea: e8          .   :80ea[1]
+    iny                                                               // 20eb: c8          .   :80eb[1]
+    rts                                                               // 20ec: 60          `   :80ec[1]
+
+// $20ed referenced 5 times by $821d, $89ec, $8bb2, $8bc7, $a46c
+sub_c80ed
+    jsr sub_c8b7b                                                     // 20ed: 20 7b 8b     {. :80ed[1]
+    jmp c8103                                                         // 20f0: 4c 03 81    L.. :80f0[1]
+
+// $20f3 referenced 5 times by $8222, $8879, $8a77, $9a78, $9c22
+sub_c80f3
+    jsr sub_c8b7b                                                     // 20f3: 20 7b 8b     {. :80f3[1]
+// $20f6 referenced 1 time by $8892
+sub_c80f6
+    lda l00ba                                                         // 20f6: a5 ba       ..  :80f6[1]
+    sta os_text_ptr                                                   // 20f8: 85 f2       ..  :80f8[1]
+    lda l00bb                                                         // 20fa: a5 bb       ..  :80fa[1]
+    sta l00f3                                                         // 20fc: 85 f3       ..  :80fc[1]
+    ldy #0                                                            // 20fe: a0 00       ..  :80fe[1]
+    jsr clc_jmp_gsinit                                                // 2100: 20 4c 87     L. :8100[1]
+// $2103 referenced 3 times by $80f0, $8113, $8123
+c8103
+    ldx #$20 // ' '                                                   // 2103: a2 20       .   :8103[1]
+    jsr sub_c8149                                                     // 2105: 20 49 81     I. :8105[1]
+    bcs c8125                                                         // 2108: b0 1b       ..  :8108[1]
+    sta l1000                                                         // 210a: 8d 00 10    ... :810a[1]
+    cmp #$2e // '.'                                                   // 210d: c9 2e       ..  :810d[1]
+    bne c8115                                                         // 210f: d0 04       ..  :810f[1]
+// $2111 referenced 1 time by $8136
+c8111
+    stx l00cc                                                         // 2111: 86 cc       ..  :8111[1]
+    beq c8103                                                         // 2113: f0 ee       ..  :8113[1]
+// $2115 referenced 1 time by $810f
+c8115
+    cmp #$3a // ':'                                                   // 2115: c9 3a       .:  :8115[1]
+    bne c812e                                                         // 2117: d0 15       ..  :8117[1]
+    jsr c8b8b                                                         // 2119: 20 8b 8b     .. :8119[1]
+    jsr sub_c8149                                                     // 211c: 20 49 81     I. :811c[1]
+    bcs c8125                                                         // 211f: b0 04       ..  :811f[1]
+    cmp #$2e // '.'                                                   // 2121: c9 2e       ..  :8121[1]
+    beq c8103                                                         // 2123: f0 de       ..  :8123[1]
+// $2125 referenced 5 times by $8108, $811f, $8147, $8155, $8159
+c8125
+    jsr generate_error_precheck_bad                                   // 2125: 20 2e 80     .. :8125[1]
+    .byt $cc                                                          // 2128: cc          .   :8128[1]
+    .asc "name"                                                       // 2129: 6e 61 6d... nam :8129[1]
+    .byt 0                                                            // 212d: 00          .   :812d[1]
+
+// $212e referenced 1 time by $8117
+c812e
+    tax                                                               // 212e: aa          .   :812e[1]
+    jsr sub_c8149                                                     // 212f: 20 49 81     I. :812f[1]
+    bcs c815d                                                         // 2132: b0 29       .)  :8132[1]
+    cmp #$2e // '.'                                                   // 2134: c9 2e       ..  :8134[1]
+    beq c8111                                                         // 2136: f0 d9       ..  :8136[1]
+    ldx #1                                                            // 2138: a2 01       ..  :8138[1]
+// $213a referenced 1 time by $8145
+loop_c813a
+    sta l1000,x                                                       // 213a: 9d 00 10    ... :813a[1]
+    inx                                                               // 213d: e8          .   :813d[1]
+    jsr sub_c8149                                                     // 213e: 20 49 81     I. :813e[1]
+    bcs c815f                                                         // 2141: b0 1c       ..  :8141[1]
+    cpx #7                                                            // 2143: e0 07       ..  :8143[1]
+    bne loop_c813a                                                    // 2145: d0 f3       ..  :8145[1]
+    beq c8125                                                         // 2147: f0 dc       ..  :8147[1]
+// $2149 referenced 11 times by $8105, $811c, $812f, $813e, $8990, $899c, $89af, $89cb, $8a19, $8b8b, $a143
+sub_c8149
+    jsr gsread                                                        // 2149: 20 c5 ff     .. :8149[1]
+    php                                                               // 214c: 08          .   :814c[1]
+    and #$7f                                                          // 214d: 29 7f       ).  :814d[1]
+    cmp #$0d                                                          // 214f: c9 0d       ..  :814f[1]
+    beq c815b                                                         // 2151: f0 08       ..  :8151[1]
+    cmp #$20 // ' '                                                   // 2153: c9 20       .   :8153[1]
+    bcc c8125                                                         // 2155: 90 ce       ..  :8155[1]
+    cmp #$7f                                                          // 2157: c9 7f       ..  :8157[1]
+    beq c8125                                                         // 2159: f0 ca       ..  :8159[1]
+// $215b referenced 1 time by $8151
+c815b
+    plp                                                               // 215b: 28          (   :815b[1]
+    rts                                                               // 215c: 60          `   :815c[1]
+
+// $215d referenced 2 times by $8132, $8248
+c815d
+    ldx #1                                                            // 215d: a2 01       ..  :815d[1]
+// $215f referenced 1 time by $8141
+c815f
+    lda #$20 // ' '                                                   // 215f: a9 20       .   :815f[1]
+// $2161 referenced 1 time by $8167
+loop_c8161
+    sta l1000,x                                                       // 2161: 9d 00 10    ... :8161[1]
+    inx                                                               // 2164: e8          .   :8164[1]
+    cpx #$40 // '@'                                                   // 2165: e0 40       .@  :8165[1]
+    bne loop_c8161                                                    // 2167: d0 f8       ..  :8167[1]
+    ldx #6                                                            // 2169: a2 06       ..  :8169[1]
+// $216b referenced 1 time by $8171
+loop_c816b
+    lda l1000,x                                                       // 216b: bd 00 10    ... :816b[1]
+    sta l00c5,x                                                       // 216e: 95 c5       ..  :816e[1]
+    dex                                                               // 2170: ca          .   :8170[1]
+    bpl loop_c816b                                                    // 2171: 10 f8       ..  :8171[1]
+    rts                                                               // 2173: 60          `   :8173[1]
+
+// $2174 referenced 4 times by $833d, $85cd, $875e, $87a5
+sub_c8174
+    jsr sub_c83e3                                                     // 2174: 20 e3 83     .. :8174[1]
+    lda l0e0f,y                                                       // 2177: b9 0f 0e    ... :8177[1]
+    php                                                               // 217a: 08          .   :817a[1]
+    and #$7f                                                          // 217b: 29 7f       ).  :817b[1]
+    bne c8184                                                         // 217d: d0 05       ..  :817d[1]
+    jsr sub_cac0c                                                     // 217f: 20 0c ac     .. :817f[1]
+    beq c818a                                                         // 2182: f0 06       ..  :8182[1]
+// $2184 referenced 1 time by $817d
+c8184
+    jsr c809f                                                         // 2184: 20 9f 80     .. :8184[1]
+    jsr sub_c809d                                                     // 2187: 20 9d 80     .. :8187[1]
+// $218a referenced 1 time by $8182
+c818a
+    ldx #6                                                            // 218a: a2 06       ..  :818a[1]
+// $218c referenced 1 time by $8196
+loop_c818c
+    lda l0e08,y                                                       // 218c: b9 08 0e    ... :818c[1]
+    and #$7f                                                          // 218f: 29 7f       ).  :818f[1]
+    jsr c809f                                                         // 2191: 20 9f 80     .. :8191[1]
+    iny                                                               // 2194: c8          .   :8194[1]
+    dex                                                               // 2195: ca          .   :8195[1]
+    bpl loop_c818c                                                    // 2196: 10 f4       ..  :8196[1]
+    jsr sub_cac0c                                                     // 2198: 20 0c ac     .. :8198[1]
+    lda #$20 // ' '                                                   // 219b: a9 20       .   :819b[1]
+    plp                                                               // 219d: 28          (   :819d[1]
+    bpl c81a2                                                         // 219e: 10 02       ..  :819e[1]
+    lda #$4c // 'L'                                                   // 21a0: a9 4c       .L  :81a0[1]
+// $21a2 referenced 1 time by $819e
+c81a2
+    jsr c809f                                                         // 21a2: 20 9f 80     .. :81a2[1]
+    ldy #1                                                            // 21a5: a0 01       ..  :81a5[1]
+// $21a7 referenced 4 times by $81ab, $84c5, $850a, $85c2
+c81a7
+    jsr cac0f                                                         // 21a7: 20 0f ac     .. :81a7[1]
+    dey                                                               // 21aa: 88          .   :81aa[1]
+    bne c81a7                                                         // 21ab: d0 fa       ..  :81ab[1]
+    rts                                                               // 21ad: 60          `   :81ad[1]
+
+// $21ae referenced 2 times by $88a9, $8b6b
+sub_c81ae
+    lsr                                                               // 21ae: 4a          J   :81ae[1]
+    lsr                                                               // 21af: 4a          J   :81af[1]
+// $21b0 referenced 8 times by $81f5, $85e6, $9cdb, $9cfd, $a2c6, $a49f, $a505, $a8e6
+sub_c81b0
+    lsr                                                               // 21b0: 4a          J   :81b0[1]
+    lsr                                                               // 21b1: 4a          J   :81b1[1]
+    lsr                                                               // 21b2: 4a          J   :81b2[1]
+    lsr                                                               // 21b3: 4a          J   :81b3[1]
+    and #3                                                            // 21b4: 29 03       ).  :81b4[1]
+    rts                                                               // 21b6: 60          `   :81b6[1]
+
+// $21b7 referenced 1 time by $8b54
+sub_c81b7
+    and #8                                                            // 21b7: 29 08       ).  :81b7[1]
+    beq c81bd                                                         // 21b9: f0 02       ..  :81b9[1]
+    lda #3                                                            // 21bb: a9 03       ..  :81bb[1]
+// $21bd referenced 1 time by $81b9
+c81bd
+    rts                                                               // 21bd: 60          `   :81bd[1]
+
+// $21be referenced 3 times by $9cb3, $9d0c, $9e00
+sub_c81be
+    lsr                                                               // 21be: 4a          J   :81be[1]
+// $21bf referenced 8 times by $80bc, $84d5, $9527, $9644, $98fb, $a18d, $a9c3, $ac63
+sub_c81bf
+    lsr                                                               // 21bf: 4a          J   :81bf[1]
+// $21c0 referenced 1 time by $a90d
+sub_c81c0
+    lsr                                                               // 21c0: 4a          J   :81c0[1]
+    lsr                                                               // 21c1: 4a          J   :81c1[1]
+    lsr                                                               // 21c2: 4a          J   :81c2[1]
+    rts                                                               // 21c3: 60          `   :81c3[1]
+
+// $21c4 referenced 1 time by $9e2a
+sub_c81c4
+    asl                                                               // 21c4: 0a          .   :81c4[1]
+// $21c5 referenced 2 times by $8a5d, $9bae
+sub_c81c5
+    asl                                                               // 21c5: 0a          .   :81c5[1]
+    asl                                                               // 21c6: 0a          .   :81c6[1]
+    asl                                                               // 21c7: 0a          .   :81c7[1]
+    asl                                                               // 21c8: 0a          .   :81c8[1]
+    rts                                                               // 21c9: 60          `   :81c9[1]
+
+// $21ca referenced 1 time by $8867
+sub_c81ca
+    lda #5                                                            // 21ca: a9 05       ..  :81ca[1]
+    sta l1095                                                         // 21cc: 8d 95 10    ... :81cc[1]
+    lda l00cd                                                         // 21cf: a5 cd       ..  :81cf[1]
+    sta l1090                                                         // 21d1: 8d 90 10    ... :81d1[1]
+    lda #$0a                                                          // 21d4: a9 0a       ..  :81d4[1]
+    sta l00b0                                                         // 21d6: 85 b0       ..  :81d6[1]
+    lda l00bc                                                         // 21d8: a5 bc       ..  :81d8[1]
+    sta l1091                                                         // 21da: 8d 91 10    ... :81da[1]
+    lda l00bd                                                         // 21dd: a5 bd       ..  :81dd[1]
+    sta l1092                                                         // 21df: 8d 92 10    ... :81df[1]
+    lda l1074                                                         // 21e2: ad 74 10    .t. :81e2[1]
+    sta l1093                                                         // 21e5: 8d 93 10    ... :81e5[1]
+    lda l1075                                                         // 21e8: ad 75 10    .u. :81e8[1]
+    sta l1094                                                         // 21eb: 8d 94 10    ... :81eb[1]
+    lda #$ff                                                          // 21ee: a9 ff       ..  :81ee[1]
+    sta l1097                                                         // 21f0: 8d 97 10    ... :81f0[1]
+    lda l00c2                                                         // 21f3: a5 c2       ..  :81f3[1]
+    jsr sub_c81b0                                                     // 21f5: 20 b0 81     .. :81f5[1]
+    sta l109a                                                         // 21f8: 8d 9a 10    ... :81f8[1]
+    lda l00c0                                                         // 21fb: a5 c0       ..  :81fb[1]
+    sta l109b                                                         // 21fd: 8d 9b 10    ... :81fd[1]
+    lda l00c1                                                         // 2200: a5 c1       ..  :8200[1]
+    sta l1099                                                         // 2202: 8d 99 10    ... :8202[1]
+    lda l00c2                                                         // 2205: a5 c2       ..  :8205[1]
+    and #3                                                            // 2207: 29 03       ).  :8207[1]
+    tax                                                               // 2209: aa          .   :8209[1]
+    lda l00c3                                                         // 220a: a5 c3       ..  :820a[1]
+// $220c referenced 1 time by $8215
+loop_c820c
+    sec                                                               // 220c: 38          8   :820c[1]
+// $220d referenced 1 time by $8212
+loop_c820d
+    inc l1097                                                         // 220d: ee 97 10    ... :820d[1]
+    sbc l00b0                                                         // 2210: e5 b0       ..  :8210[1]
+    bcs loop_c820d                                                    // 2212: b0 f9       ..  :8212[1]
+    dex                                                               // 2214: ca          .   :8214[1]
+    bpl loop_c820c                                                    // 2215: 10 f5       ..  :8215[1]
+    adc l00b0                                                         // 2217: 65 b0       e.  :8217[1]
+    sta l1098                                                         // 2219: 8d 98 10    ... :8219[1]
+// $221c referenced 1 time by $8228
+loop_c821c
+    rts                                                               // 221c: 60          `   :821c[1]
+
+// $221d referenced 4 times by $825a, $8756, $8788, $879d
+sub_c821d
+    jsr sub_c80ed                                                     // 221d: 20 ed 80     .. :821d[1]
+    bmi c8225                                                         // 2220: 30 03       0.  :8220[1]
+// $2222 referenced 1 time by $881b
+sub_c8222
+    jsr sub_c80f3                                                     // 2222: 20 f3 80     .. :8222[1]
+// $2225 referenced 4 times by $8220, $824e, $8bb7, $a478
+c8225
+    jsr sub_c8284                                                     // 2225: 20 84 82     .. :8225[1]
+    bcs loop_c821c                                                    // 2228: b0 f2       ..  :8228[1]
+// $222a referenced 2 times by $89fd, $ab17
+c822a
+    jsr generate_error                                                // 222a: 20 48 80     H. :822a[1]
+    .byt $d6                                                          // 222d: d6          .   :822d[1]
+    .asc "Not found"                                                  // 222e: 4e 6f 74... Not :822e[1]
+    .byt 0                                                            // 2237: 00          .   :8237[1]
+
+sub_c8238
+    jsr sub_c8b7b                                                     // 2238: 20 7b 8b     {. :8238[1]
+    jsr clc_jmp_gsinit                                                // 223b: 20 4c 87     L. :823b[1]
+    beq c8243                                                         // 223e: f0 03       ..  :823e[1]
+    jsr c898a                                                         // 2240: 20 8a 89     .. :8240[1]
+// $2243 referenced 1 time by $823e
+c8243
+    lda #$2a // '*'                                                   // 2243: a9 2a       .*  :8243[1]
+    sta l1000                                                         // 2245: 8d 00 10    ... :8245[1]
+    jsr c815d                                                         // 2248: 20 5d 81     ]. :8248[1]
+    jsr sub_c99ac                                                     // 224b: 20 ac 99     .. :824b[1]
+    jsr c8225                                                         // 224e: 20 25 82     %. :824e[1]
+    jmp c825d                                                         // 2251: 4c 5d 82    L]. :8251[1]
+
+sub_c8254
+    jsr sub_c99ac                                                     // 2254: 20 ac 99     .. :8254[1]
+    jsr sub_ca14a                                                     // 2257: 20 4a a1     J. :8257[1]
+    jsr sub_c821d                                                     // 225a: 20 1d 82     .. :825a[1]
+// $225d referenced 2 times by $8251, $8263
+c825d
+    jsr sub_c833a                                                     // 225d: 20 3a 83     :. :825d[1]
+    jsr sub_c8280                                                     // 2260: 20 80 82     .. :8260[1]
+    bcs c825d                                                         // 2263: b0 f8       ..  :8263[1]
+    rts                                                               // 2265: 60          `   :8265[1]
+
+// $2266 referenced 2 times by $887f, $8895
+sub_c8266
+    jsr sub_c93f9                                                     // 2266: 20 f9 93     .. :8266[1]
+    lda #0                                                            // 2269: a9 00       ..  :8269[1]
+    beq c828b                                                         // 226b: f0 1e       ..  :826b[1]
+// $226d referenced 2 times by $9bd9, $a4f2
+sub_c826d
+    ldx #6                                                            // 226d: a2 06       ..  :826d[1]
+// $226f referenced 1 time by $8275
+loop_c826f
+    lda l00c5,x                                                       // 226f: b5 c5       ..  :826f[1]
+    sta l1058,x                                                       // 2271: 9d 58 10    .X. :8271[1]
+    dex                                                               // 2274: ca          .   :8274[1]
+    bpl loop_c826f                                                    // 2275: 10 f8       ..  :8275[1]
+    lda #$20 // ' '                                                   // 2277: a9 20       .   :8277[1]
+    sta l105f                                                         // 2279: 8d 5f 10    ._. :8279[1]
+    lda #$58 // 'X'                                                   // 227c: a9 58       .X  :827c[1]
+    bne c8286                                                         // 227e: d0 06       ..  :827e[1]
+// $2280 referenced 6 times by $8260, $877c, $87ab, $87c6, $8a10, $a4db
+sub_c8280
+    ldx #0                                                            // 2280: a2 00       ..  :8280[1]
+    beq c8290                                                         // 2282: f0 0c       ..  :8282[1]
+// $2284 referenced 7 times by $8225, $87bb, $89f8, $8a7a, $8bcf, $9a7b, $9c28
+sub_c8284
+    lda #0                                                            // 2284: a9 00       ..  :8284[1]
+// $2286 referenced 1 time by $827e
+c8286
+    pha                                                               // 2286: 48          H   :8286[1]
+    jsr sub_c93fd                                                     // 2287: 20 fd 93     .. :8287[1]
+    pla                                                               // 228a: 68          h   :828a[1]
+// $228b referenced 1 time by $826b
+c828b
+    tax                                                               // 228b: aa          .   :828b[1]
+    lda #0                                                            // 228c: a9 00       ..  :828c[1]
+    sta l00b6                                                         // 228e: 85 b6       ..  :828e[1]
+// $2290 referenced 3 times by $8282, $82a4, $82ad
+c8290
+    ldy #0                                                            // 2290: a0 00       ..  :8290[1]
+    lda #$0e                                                          // 2292: a9 0e       ..  :8292[1]
+    sta l00b7                                                         // 2294: 85 b7       ..  :8294[1]
+    lda l00b6                                                         // 2296: a5 b6       ..  :8296[1]
+    cmp l0f05                                                         // 2298: cd 05 0f    ... :8298[1]
+    bcs c82e6                                                         // 229b: b0 49       .I  :829b[1]
+    adc #8                                                            // 229d: 69 08       i.  :829d[1]
+    sta l00b6                                                         // 229f: 85 b6       ..  :829f[1]
+    jsr sub_c82bb                                                     // 22a1: 20 bb 82     .. :82a1[1]
+    bcc c8290                                                         // 22a4: 90 ea       ..  :82a4[1]
+    lda l00cc                                                         // 22a6: a5 cc       ..  :82a6[1]
+    ldy #7                                                            // 22a8: a0 07       ..  :82a8[1]
+    jsr sub_c82e8                                                     // 22aa: 20 e8 82     .. :82aa[1]
+    bne c8290                                                         // 22ad: d0 e1       ..  :82ad[1]
+    ldy l00b6                                                         // 22af: a4 b6       ..  :82af[1]
+    sec                                                               // 22b1: 38          8   :82b1[1]
+// $22b2 referenced 4 times by $87e8, $8aca, $a27c, $a848
+sub_c82b2
+    dey                                                               // 22b2: 88          .   :82b2[1]
+    dey                                                               // 22b3: 88          .   :82b3[1]
+    dey                                                               // 22b4: 88          .   :82b4[1]
+    dey                                                               // 22b5: 88          .   :82b5[1]
+    dey                                                               // 22b6: 88          .   :82b6[1]
+    dey                                                               // 22b7: 88          .   :82b7[1]
+    dey                                                               // 22b8: 88          .   :82b8[1]
+    dey                                                               // 22b9: 88          .   :82b9[1]
+    rts                                                               // 22ba: 60          `   :82ba[1]
+
+// $22bb referenced 2 times by $82a1, $82c7
+sub_c82bb
+    jsr sub_c83e3                                                     // 22bb: 20 e3 83     .. :82bb[1]
+// $22be referenced 1 time by $82e4
+c82be
+    lda l1000,x                                                       // 22be: bd 00 10    ... :82be[1]
+    cmp l10ce                                                         // 22c1: cd ce 10    ... :82c1[1]
+    bne c82d9                                                         // 22c4: d0 13       ..  :82c4[1]
+    inx                                                               // 22c6: e8          .   :82c6[1]
+// $22c7 referenced 1 time by $82cf
+loop_c82c7
+    jsr sub_c82bb                                                     // 22c7: 20 bb 82     .. :82c7[1]
+    bcs c82e7                                                         // 22ca: b0 1b       ..  :82ca[1]
+    iny                                                               // 22cc: c8          .   :82cc[1]
+    cpy #7                                                            // 22cd: c0 07       ..  :82cd[1]
+    bcc loop_c82c7                                                    // 22cf: 90 f6       ..  :82cf[1]
+// $22d1 referenced 1 time by $82db
+loop_c82d1
+    lda l1000,x                                                       // 22d1: bd 00 10    ... :82d1[1]
+    cmp #$20 // ' '                                                   // 22d4: c9 20       .   :82d4[1]
+    bne c82e6                                                         // 22d6: d0 0e       ..  :82d6[1]
+    rts                                                               // 22d8: 60          `   :82d8[1]
+
+// $22d9 referenced 1 time by $82c4
+c82d9
+    cpy #7                                                            // 22d9: c0 07       ..  :82d9[1]
+    bcs loop_c82d1                                                    // 22db: b0 f4       ..  :82db[1]
+    jsr sub_c82e8                                                     // 22dd: 20 e8 82     .. :82dd[1]
+    bne c82e6                                                         // 22e0: d0 04       ..  :82e0[1]
+    inx                                                               // 22e2: e8          .   :82e2[1]
+    iny                                                               // 22e3: c8          .   :82e3[1]
+    bne c82be                                                         // 22e4: d0 d8       ..  :82e4[1]
+// $22e6 referenced 3 times by $829b, $82d6, $82e0
+c82e6
+    clc                                                               // 22e6: 18          .   :82e6[1]
+// $22e7 referenced 1 time by $82ca
+c82e7
+    rts                                                               // 22e7: 60          `   :82e7[1]
+
+// $22e8 referenced 2 times by $82aa, $82dd
+sub_c82e8
+    cmp l10ce                                                         // 22e8: cd ce 10    ... :82e8[1]
+    beq c82fd                                                         // 22eb: f0 10       ..  :82eb[1]
+    cmp l10cd                                                         // 22ed: cd cd 10    ... :82ed[1]
+    beq c82fd                                                         // 22f0: f0 0b       ..  :82f0[1]
+    jsr sub_c8327                                                     // 22f2: 20 27 83     '. :82f2[1]
+    eor (l00b6),y                                                     // 22f5: 51 b6       Q.  :82f5[1]
+    bcs c82fb                                                         // 22f7: b0 02       ..  :82f7[1]
+    and #$5f // '_'                                                   // 22f9: 29 5f       )_  :82f9[1]
+// $22fb referenced 1 time by $82f7
+c82fb
+    and #$7f                                                          // 22fb: 29 7f       ).  :82fb[1]
+// $22fd referenced 2 times by $82eb, $82f0
+c82fd
+    rts                                                               // 22fd: 60          `   :82fd[1]
+
+// $22fe referenced 6 times by $8441, $8567, $857e, $858e, $aa2b, $aa3b
+sub_c82fe
+    php                                                               // 22fe: 08          .   :82fe[1]
+    jsr sub_c8327                                                     // 22ff: 20 27 83     '. :82ff[1]
+    bcs c8306                                                         // 2302: b0 02       ..  :8302[1]
+    and #$5f // '_'                                                   // 2304: 29 5f       )_  :8304[1]
+// $2306 referenced 1 time by $8302
+c8306
+    and #$7f                                                          // 2306: 29 7f       ).  :8306[1]
+    plp                                                               // 2308: 28          (   :8308[1]
+    rts                                                               // 2309: 60          `   :8309[1]
+
+// $230a referenced 5 times by $878e, $87e3, $8a7f, $99c4, $a4f7
+sub_c830a
+    jsr sub_c9a60                                                     // 230a: 20 60 9a     `. :830a[1]
+// $230d referenced 1 time by $831d
+loop_c830d
+    lda l0e10,y                                                       // 230d: b9 10 0e    ... :830d[1]
+    sta l0e08,y                                                       // 2310: 99 08 0e    ... :8310[1]
+    lda l0f10,y                                                       // 2313: b9 10 0f    ... :8313[1]
+    sta l0f08,y                                                       // 2316: 99 08 0f    ... :8316[1]
+    iny                                                               // 2319: c8          .   :8319[1]
+    cpy l0f05                                                         // 231a: cc 05 0f    ... :831a[1]
+    bcc loop_c830d                                                    // 231d: 90 ee       ..  :831d[1]
+    tya                                                               // 231f: 98          .   :831f[1]
+    sbc #8                                                            // 2320: e9 08       ..  :8320[1]
+    sta l0f05                                                         // 2322: 8d 05 0f    ... :8322[1]
+    clc                                                               // 2325: 18          .   :8325[1]
+// $2326 referenced 1 time by $8338
+loop_c8326
+    rts                                                               // 2326: 60          `   :8326[1]
+
+// $2327 referenced 4 times by $82f2, $82ff, $8736, $98a8
+sub_c8327
+    pha                                                               // 2327: 48          H   :8327[1]
+    and #$5f // '_'                                                   // 2328: 29 5f       )_  :8328[1]
+    cmp #$41 // 'A'                                                   // 232a: c9 41       .A  :832a[1]
+    bcc c8332                                                         // 232c: 90 04       ..  :832c[1]
+    cmp #$5b // '['                                                   // 232e: c9 5b       .[  :832e[1]
+    bcc c8333                                                         // 2330: 90 01       ..  :8330[1]
+// $2332 referenced 1 time by $832c
+c8332
+    sec                                                               // 2332: 38          8   :8332[1]
+// $2333 referenced 1 time by $8330
+c8333
+    pla                                                               // 2333: 68          h   :8333[1]
+    rts                                                               // 2334: 60          `   :8334[1]
+
+// $2335 referenced 5 times by $878b, $884f, $8a0d, $8b04, $a2ad
+sub_c8335
+    bit l10c6                                                         // 2335: 2c c6 10    ,.. :8335[1]
+    bmi loop_c8326                                                    // 2338: 30 ec       0.  :8338[1]
+// $233a referenced 3 times by $825d, $a30f, $a482
+sub_c833a
+    jsr sub_c83e3                                                     // 233a: 20 e3 83     .. :833a[1]
+    jsr sub_c8174                                                     // 233d: 20 74 81     t. :833d[1]
+    tya                                                               // 2340: 98          .   :8340[1]
+    pha                                                               // 2341: 48          H   :8341[1]
+    lda #$60 // '`'                                                   // 2342: a9 60       .`  :8342[1]
+    sta l00b0                                                         // 2344: 85 b0       ..  :8344[1]
+    lda #$10                                                          // 2346: a9 10       ..  :8346[1]
+    sta l00b1                                                         // 2348: 85 b1       ..  :8348[1]
+    jsr sub_c8386                                                     // 234a: 20 86 83     .. :834a[1]
+    ldy #2                                                            // 234d: a0 02       ..  :834d[1]
+    jsr cac0f                                                         // 234f: 20 0f ac     .. :834f[1]
+    jsr sub_c836e                                                     // 2352: 20 6e 83     n. :8352[1]
+    jsr sub_c836e                                                     // 2355: 20 6e 83     n. :8355[1]
+    jsr sub_c836e                                                     // 2358: 20 6e 83     n. :8358[1]
+    pla                                                               // 235b: 68          h   :835b[1]
+    tay                                                               // 235c: a8          .   :835c[1]
+    lda l0f0e,y                                                       // 235d: b9 0e 0f    ... :835d[1]
+    and #3                                                            // 2360: 29 03       ).  :8360[1]
+    jsr sub_c80c3                                                     // 2362: 20 c3 80     .. :8362[1]
+    lda l0f0f,y                                                       // 2365: b9 0f 0f    ... :8365[1]
+    jsr sub_c80bb                                                     // 2368: 20 bb 80     .. :8368[1]
+    jmp ca3dc                                                         // 236b: 4c dc a3    L.. :836b[1]
+
+// $236e referenced 3 times by $8352, $8355, $8358
+sub_c836e
+    ldx #3                                                            // 236e: a2 03       ..  :836e[1]
+// $2370 referenced 1 time by $8378
+loop_c8370
+    lda l1062,y                                                       // 2370: b9 62 10    .b. :8370[1]
+    jsr sub_c80bb                                                     // 2373: 20 bb 80     .. :8373[1]
+    dey                                                               // 2376: 88          .   :8376[1]
+    dex                                                               // 2377: ca          .   :8377[1]
+    bne loop_c8370                                                    // 2378: d0 f6       ..  :8378[1]
+    jsr sub_c87db                                                     // 237a: 20 db 87     .. :837a[1]
+    jmp cac0f                                                         // 237d: 4c 0f ac    L.. :837d[1]
+
+// $2380 referenced 7 times by $89bd, $975e, $9bf8, $a26a, $a4d1, $a4ef, $a7fc
+sub_c8380
+    jsr sub_c83e3                                                     // 2380: 20 e3 83     .. :8380[1]
+    jmp c940c                                                         // 2383: 4c 0c 94    L.. :8383[1]
+
+// $2386 referenced 5 times by $834a, $8821, $885f, $99b8, $99c1
+sub_c8386
+    jsr sub_c83e3                                                     // 2386: 20 e3 83     .. :8386[1]
+    tya                                                               // 2389: 98          .   :8389[1]
+    pha                                                               // 238a: 48          H   :838a[1]
+    tax                                                               // 238b: aa          .   :838b[1]
+    ldy #$12                                                          // 238c: a0 12       ..  :838c[1]
+    lda #0                                                            // 238e: a9 00       ..  :838e[1]
+// $2390 referenced 1 time by $8395
+loop_c8390
+    dey                                                               // 2390: 88          .   :8390[1]
+    sta (l00b0),y                                                     // 2391: 91 b0       ..  :8391[1]
+    cpy #2                                                            // 2393: c0 02       ..  :8393[1]
+    bne loop_c8390                                                    // 2395: d0 f9       ..  :8395[1]
+// $2397 referenced 1 time by $839e
+loop_c8397
+    jsr sub_c83d1                                                     // 2397: 20 d1 83     .. :8397[1]
+    iny                                                               // 239a: c8          .   :839a[1]
+    iny                                                               // 239b: c8          .   :839b[1]
+    cpy #$0e                                                          // 239c: c0 0e       ..  :839c[1]
+    bne loop_c8397                                                    // 239e: d0 f7       ..  :839e[1]
+    pla                                                               // 23a0: 68          h   :83a0[1]
+    tax                                                               // 23a1: aa          .   :83a1[1]
+    lda l0e0f,x                                                       // 23a2: bd 0f 0e    ... :83a2[1]
+    bpl c83ab                                                         // 23a5: 10 04       ..  :83a5[1]
+    lda #8                                                            // 23a7: a9 08       ..  :83a7[1]
+    sta (l00b0),y                                                     // 23a9: 91 b0       ..  :83a9[1]
+// $23ab referenced 1 time by $83a5
+c83ab
+    lda l0f0e,x                                                       // 23ab: bd 0e 0f    ... :83ab[1]
+    ldy #4                                                            // 23ae: a0 04       ..  :83ae[1]
+    jsr sub_c83bf                                                     // 23b0: 20 bf 83     .. :83b0[1]
+    ldy #$0c                                                          // 23b3: a0 0c       ..  :83b3[1]
+    lsr                                                               // 23b5: 4a          J   :83b5[1]
+    lsr                                                               // 23b6: 4a          J   :83b6[1]
+    pha                                                               // 23b7: 48          H   :83b7[1]
+    and #3                                                            // 23b8: 29 03       ).  :83b8[1]
+    sta (l00b0),y                                                     // 23ba: 91 b0       ..  :83ba[1]
+    pla                                                               // 23bc: 68          h   :83bc[1]
+    ldy #8                                                            // 23bd: a0 08       ..  :83bd[1]
+// $23bf referenced 1 time by $83b0
+sub_c83bf
+    lsr                                                               // 23bf: 4a          J   :83bf[1]
+    lsr                                                               // 23c0: 4a          J   :83c0[1]
+    pha                                                               // 23c1: 48          H   :83c1[1]
+    and #3                                                            // 23c2: 29 03       ).  :83c2[1]
+    cmp #3                                                            // 23c4: c9 03       ..  :83c4[1]
+    bne c83cd                                                         // 23c6: d0 05       ..  :83c6[1]
+    lda #$ff                                                          // 23c8: a9 ff       ..  :83c8[1]
+    sta (l00b0),y                                                     // 23ca: 91 b0       ..  :83ca[1]
+    iny                                                               // 23cc: c8          .   :83cc[1]
+// $23cd referenced 1 time by $83c6
+c83cd
+    sta (l00b0),y                                                     // 23cd: 91 b0       ..  :83cd[1]
+    pla                                                               // 23cf: 68          h   :83cf[1]
+    rts                                                               // 23d0: 60          `   :83d0[1]
+
+// $23d1 referenced 1 time by $8397
+sub_c83d1
+    jsr sub_c83d4                                                     // 23d1: 20 d4 83     .. :83d1[1]
+// $23d4 referenced 1 time by $83d1
+sub_c83d4
+    lda l0f08,x                                                       // 23d4: bd 08 0f    ... :83d4[1]
+    sta (l00b0),y                                                     // 23d7: 91 b0       ..  :83d7[1]
+    inx                                                               // 23d9: e8          .   :83d9[1]
+    iny                                                               // 23da: c8          .   :83da[1]
+    rts                                                               // 23db: 60          `   :83db[1]
+
+// $23dc referenced 4 times by $805b, $8064, $8086, $a9ab
+inc16_ae
+    inc l00ae                                                         // 23dc: e6 ae       ..  :83dc[1]
+    bne c83e2                                                         // 23de: d0 02       ..  :83de[1]
+    inc l00af                                                         // 23e0: e6 af       ..  :83e0[1]
+// $23e2 referenced 1 time by $83de
+c83e2
+    rts                                                               // 23e2: 60          `   :83e2[1]
+
+// $23e3 referenced 29 times by $809f, $8174, $82bb, $833a, $8380, $8386, $8951, $8a32, $96c3, $97cd, $993b, $99f3, $9a0f, $9a32, $9a63, $9ac8, $9ad8, $9b51, $9bf2, $9c10, $9d9b, $9f7c, $9f82, $a06c, $a190, $a1b4, $a379, $a384, $ac72
+sub_c83e3
+    pha                                                               // 23e3: 48          H   :83e3[1]
+    txa                                                               // 23e4: 8a          .   :83e4[1]
+    pha                                                               // 23e5: 48          H   :83e5[1]
+    tya                                                               // 23e6: 98          .   :83e6[1]
+    pha                                                               // 23e7: 48          H   :83e7[1]
+    lda #$84                                                          // 23e8: a9 84       ..  :83e8[1]
+    pha                                                               // 23ea: 48          H   :83ea[1]
+    lda #5                                                            // 23eb: a9 05       ..  :83eb[1]
+    pha                                                               // 23ed: 48          H   :83ed[1]
+// $23ee referenced 1 time by $8411
+sub_c83ee
+    ldy #5                                                            // 23ee: a0 05       ..  :83ee[1]
+// $23f0 referenced 1 time by $83f6
+loop_c83f0
+    tsx                                                               // 23f0: ba          .   :83f0[1]
+    lda l0107,x                                                       // 23f1: bd 07 01    ... :83f1[1]
+    pha                                                               // 23f4: 48          H   :83f4[1]
+    dey                                                               // 23f5: 88          .   :83f5[1]
+    bne loop_c83f0                                                    // 23f6: d0 f8       ..  :83f6[1]
+    ldy #$0a                                                          // 23f8: a0 0a       ..  :83f8[1]
+// $23fa referenced 1 time by $8402
+loop_c83fa
+    lda l0109,x                                                       // 23fa: bd 09 01    ... :83fa[1]
+    sta l010b,x                                                       // 23fd: 9d 0b 01    ... :83fd[1]
+    dex                                                               // 2400: ca          .   :8400[1]
+    dey                                                               // 2401: 88          .   :8401[1]
+    bne loop_c83fa                                                    // 2402: d0 f6       ..  :8402[1]
+    pla                                                               // 2404: 68          h   :8404[1]
+    pla                                                               // 2405: 68          h   :8405[1]
+// $2406 referenced 1 time by $8418
+loop_c8406
+    pla                                                               // 2406: 68          h   :8406[1]
+    tay                                                               // 2407: a8          .   :8407[1]
+    pla                                                               // 2408: 68          h   :8408[1]
+    tax                                                               // 2409: aa          .   :8409[1]
+    pla                                                               // 240a: 68          h   :840a[1]
+    rts                                                               // 240b: 60          `   :840b[1]
+
+// $240c referenced 5 times by $841b, $9785, $9c16, $9e94, $aadd
+sub_c840c
+    pha                                                               // 240c: 48          H   :840c[1]
+    txa                                                               // 240d: 8a          .   :840d[1]
+    pha                                                               // 240e: 48          H   :840e[1]
+    tya                                                               // 240f: 98          .   :840f[1]
+    pha                                                               // 2410: 48          H   :8410[1]
+    jsr sub_c83ee                                                     // 2411: 20 ee 83     .. :8411[1]
+    tsx                                                               // 2414: ba          .   :8414[1]
+    sta l0103,x                                                       // 2415: 9d 03 01    ... :8415[1]
+    jmp loop_c8406                                                    // 2418: 4c 06 84    L.. :8418[1]
+
+// $241b referenced 2 times by $80b8, $a9bf
+sub_c841b
+    jsr sub_c840c                                                     // 241b: 20 0c 84     .. :841b[1]
+    tay                                                               // 241e: a8          .   :841e[1]
+    beq c842b                                                         // 241f: f0 0a       ..  :841f[1]
+    clc                                                               // 2421: 18          .   :8421[1]
+    sed                                                               // 2422: f8          .   :8422[1]
+    lda #0                                                            // 2423: a9 00       ..  :8423[1]
+// $2425 referenced 1 time by $8428
+loop_c8425
+    adc #1                                                            // 2425: 69 01       i.  :8425[1]
+    dey                                                               // 2427: 88          .   :8427[1]
+    bne loop_c8425                                                    // 2428: d0 fb       ..  :8428[1]
+    cld                                                               // 242a: d8          .   :842a[1]
+// $242b referenced 1 time by $841f
+c842b
+    rts                                                               // 242b: 60          `   :842b[1]
+
+// $242c referenced 1 time by $abb1
+sub_c842c
+    and #$7f                                                          // 242c: 29 7f       ).  :842c[1]
+    cmp #$7f                                                          // 242e: c9 7f       ..  :842e[1]
+    beq c8436                                                         // 2430: f0 04       ..  :8430[1]
+    cmp #$20 // ' '                                                   // 2432: c9 20       .   :8432[1]
+    bcs c8438                                                         // 2434: b0 02       ..  :8434[1]
+// $2436 referenced 1 time by $8430
+c8436
+    lda #$2e // '.'                                                   // 2436: a9 2e       ..  :8436[1]
+// $2438 referenced 1 time by $8434
+c8438
+    rts                                                               // 2438: 60          `   :8438[1]
+
+// $2439 referenced 2 times by $8444, $8463
+sub_c8439
+    sec                                                               // 2439: 38          8   :8439[1]
+    sbc #$30 // '0'                                                   // 243a: e9 30       .0  :843a[1]
+    bcc c8454                                                         // 243c: 90 16       ..  :843c[1]
+    cmp #$0a                                                          // 243e: c9 0a       ..  :843e[1]
+    rts                                                               // 2440: 60          `   :8440[1]
+
+    jsr sub_c82fe                                                     // 2441: 20 fe 82     .. :8441[1]
+    jsr sub_c8439                                                     // 2444: 20 39 84     9. :8444[1]
+    bcc c8453                                                         // 2447: 90 0a       ..  :8447[1]
+    sbc #7                                                            // 2449: e9 07       ..  :8449[1]
+    bcc c8454                                                         // 244b: 90 07       ..  :844b[1]
+    cmp #$0a                                                          // 244d: c9 0a       ..  :844d[1]
+    bcc c8454                                                         // 244f: 90 03       ..  :844f[1]
+    cmp #$10                                                          // 2451: c9 10       ..  :8451[1]
+// $2453 referenced 1 time by $8447
+c8453
+    rts                                                               // 2453: 60          `   :8453[1]
+
+// $2454 referenced 3 times by $843c, $844b, $844f
+c8454
+    sec                                                               // 2454: 38          8   :8454[1]
+    rts                                                               // 2455: 60          `   :8455[1]
+
+// $2456 referenced 3 times by $87f7, $a5ce, $a9e7
+sub_c8456
+    jsr clc_jmp_gsinit                                                // 2456: 20 4c 87     L. :8456[1]
+    sec                                                               // 2459: 38          8   :8459[1]
+    beq c8482                                                         // 245a: f0 26       .&  :845a[1]
+    php                                                               // 245c: 08          .   :845c[1]
+    lda #0                                                            // 245d: a9 00       ..  :845d[1]
+    sta l00b9                                                         // 245f: 85 b9       ..  :845f[1]
+    beq c8477                                                         // 2461: f0 14       ..  :8461[1]
+// $2463 referenced 1 time by $847a
+loop_c8463
+    jsr sub_c8439                                                     // 2463: 20 39 84     9. :8463[1]
+    bcs c8481                                                         // 2466: b0 19       ..  :8466[1]
+    sta l00b8                                                         // 2468: 85 b8       ..  :8468[1]
+    lda l00b9                                                         // 246a: a5 b9       ..  :846a[1]
+    asl                                                               // 246c: 0a          .   :846c[1]
+    sta l00b9                                                         // 246d: 85 b9       ..  :846d[1]
+    asl                                                               // 246f: 0a          .   :846f[1]
+    asl                                                               // 2470: 0a          .   :8470[1]
+    adc l00b9                                                         // 2471: 65 b9       e.  :8471[1]
+    adc l00b8                                                         // 2473: 65 b8       e.  :8473[1]
+    sta l00b9                                                         // 2475: 85 b9       ..  :8475[1]
+// $2477 referenced 1 time by $8461
+c8477
+    jsr gsread                                                        // 2477: 20 c5 ff     .. :8477[1]
+    bcc loop_c8463                                                    // 247a: 90 e7       ..  :847a[1]
+    lda l00b9                                                         // 247c: a5 b9       ..  :847c[1]
+    plp                                                               // 247e: 28          (   :847e[1]
+    clc                                                               // 247f: 18          .   :847f[1]
+    rts                                                               // 2480: 60          `   :8480[1]
+
+// $2481 referenced 1 time by $8466
+c8481
+    plp                                                               // 2481: 28          (   :8481[1]
+// $2482 referenced 1 time by $845a
+c8482
+    rts                                                               // 2482: 60          `   :8482[1]
+
+    jsr sub_c8745                                                     // 2483: 20 45 87     E. :8483[1]
+    jsr sub_c8b86                                                     // 2486: 20 86 8b     .. :8486[1]
+    jsr c940c                                                         // 2489: 20 0c 94     .. :8489[1]
+    ldy #$ff                                                          // 248c: a0 ff       ..  :848c[1]
+    sty l00a8                                                         // 248e: 84 a8       ..  :848e[1]
+    iny                                                               // 2490: c8          .   :8490[1]
+    sty l00aa                                                         // 2491: 84 aa       ..  :8491[1]
+// $2493 referenced 1 time by $84a3
+loop_c8493
+    lda l0e00,y                                                       // 2493: b9 00 0e    ... :8493[1]
+    cpy #8                                                            // 2496: c0 08       ..  :8496[1]
+    bcc c849d                                                         // 2498: 90 03       ..  :8498[1]
+    lda l0ef8,y                                                       // 249a: b9 f8 0e    ... :849a[1]
+// $249d referenced 1 time by $8498
+c849d
+    jsr c809f                                                         // 249d: 20 9f 80     .. :849d[1]
+    iny                                                               // 24a0: c8          .   :84a0[1]
+    cpy #$0c                                                          // 24a1: c0 0c       ..  :84a1[1]
+    bne loop_c8493                                                    // 24a3: d0 ee       ..  :84a3[1]
+    jsr print_inline_l809f_top_bit_clear                              // 24a5: 20 77 80     w. :84a5[1]
+    .asc " ("                                                         // 24a8: 20 28        (  :84a8[1]
+
+    lda l0f04                                                         // 24aa: ad 04 0f    ... :84aa[1]
+    jsr sub_c80bb                                                     // 24ad: 20 bb 80     .. :84ad[1]
+    jsr print_inline_l809f_top_bit_clear                              // 24b0: 20 77 80     w. :84b0[1]
+    .asc ") FM", $0d, "Drive "                                        // 24b3: 29 20 46... ) F :84b3[1]
+
+    lda l00cd                                                         // 24be: a5 cd       ..  :84be[1]
+    jsr sub_c80c3                                                     // 24c0: 20 c3 80     .. :84c0[1]
+    ldy #$0d                                                          // 24c3: a0 0d       ..  :84c3[1]
+    jsr c81a7                                                         // 24c5: 20 a7 81     .. :84c5[1]
+    jsr print_inline_l809f_top_bit_clear                              // 24c8: 20 77 80     w. :84c8[1]
+    .asc "Option "                                                    // 24cb: 4f 70 74... Opt :84cb[1]
+
+    lda l0f06                                                         // 24d2: ad 06 0f    ... :84d2[1]
+    jsr sub_c81bf                                                     // 24d5: 20 bf 81     .. :84d5[1]
+    pha                                                               // 24d8: 48          H   :84d8[1]
+    jsr sub_c80c3                                                     // 24d9: 20 c3 80     .. :84d9[1]
+    jsr print_inline_l809f_top_bit_clear                              // 24dc: 20 77 80     w. :84dc[1]
+    .asc " ("                                                         // 24df: 20 28        (  :84df[1]
+
+    ldy #3                                                            // 24e1: a0 03       ..  :84e1[1]
+    pla                                                               // 24e3: 68          h   :84e3[1]
+    asl                                                               // 24e4: 0a          .   :84e4[1]
+    asl                                                               // 24e5: 0a          .   :84e5[1]
+    tax                                                               // 24e6: aa          .   :84e6[1]
+// $24e7 referenced 1 time by $84ef
+loop_c84e7
+    lda opt4_table,x                                                  // 24e7: bd d3 85    ... :84e7[1]
+    jsr c809f                                                         // 24ea: 20 9f 80     .. :84ea[1]
+    inx                                                               // 24ed: e8          .   :84ed[1]
+    dey                                                               // 24ee: 88          .   :84ee[1]
+    bpl loop_c84e7                                                    // 24ef: 10 f6       ..  :84ef[1]
+    jsr print_inline_l809f_top_bit_clear                              // 24f1: 20 77 80     w. :84f1[1]
+    .asc ")", $0d, "Dir. :"                                           // 24f4: 29 0d 44... ).D :84f4[1]
+
+    lda l10ca                                                         // 24fc: ad ca 10    ... :84fc[1]
+    jsr sub_c809a                                                     // 24ff: 20 9a 80     .. :84ff[1]
+    lda l10c9                                                         // 2502: ad c9 10    ... :8502[1]
+    jsr c809f                                                         // 2505: 20 9f 80     .. :8505[1]
+    ldy #$0b                                                          // 2508: a0 0b       ..  :8508[1]
+    jsr c81a7                                                         // 250a: 20 a7 81     .. :850a[1]
+    jsr print_inline_l809f_top_bit_clear                              // 250d: 20 77 80     w. :850d[1]
+    .asc "Lib. :"                                                     // 2510: 4c 69 62... Lib :8510[1]
+
+    lda l10cc                                                         // 2516: ad cc 10    ... :8516[1]
+    jsr sub_c809a                                                     // 2519: 20 9a 80     .. :8519[1]
+    lda l10cb                                                         // 251c: ad cb 10    ... :851c[1]
+    jsr c809f                                                         // 251f: 20 9f 80     .. :851f[1]
+    jsr ca3dc                                                         // 2522: 20 dc a3     .. :8522[1]
+    ldy #0                                                            // 2525: a0 00       ..  :8525[1]
+// $2527 referenced 1 time by $8541
+loop_c8527
+    cpy l0f05                                                         // 2527: cc 05 0f    ... :8527[1]
+    bcs c8543                                                         // 252a: b0 17       ..  :852a[1]
+    lda l0e0f,y                                                       // 252c: b9 0f 0e    ... :852c[1]
+    eor l10c9                                                         // 252f: 4d c9 10    M.. :852f[1]
+    and #$5f // '_'                                                   // 2532: 29 5f       )_  :8532[1]
+    bne c853e                                                         // 2534: d0 08       ..  :8534[1]
+    lda l0e0f,y                                                       // 2536: b9 0f 0e    ... :8536[1]
+    and #$80                                                          // 2539: 29 80       ).  :8539[1]
+    sta l0e0f,y                                                       // 253b: 99 0f 0e    ... :853b[1]
+// $253e referenced 1 time by $8534
+c853e
+    jsr sub_c87da                                                     // 253e: 20 da 87     .. :853e[1]
+    bcc loop_c8527                                                    // 2541: 90 e4       ..  :8541[1]
+// $2543 referenced 2 times by $852a, $85d0
+c8543
+    ldy #0                                                            // 2543: a0 00       ..  :8543[1]
+    jsr sub_c8555                                                     // 2545: 20 55 85     U. :8545[1]
+    bcc c8560                                                         // 2548: 90 16       ..  :8548[1]
+    lda #$ff                                                          // 254a: a9 ff       ..  :854a[1]
+    sta l1082                                                         // 254c: 8d 82 10    ... :854c[1]
+    jmp ca3dc                                                         // 254f: 4c dc a3    L.. :854f[1]
+
+// $2552 referenced 1 time by $855d
+loop_c8552
+    jsr sub_c87da                                                     // 2552: 20 da 87     .. :8552[1]
+// $2555 referenced 2 times by $8545, $8573
+sub_c8555
+    cpy l0f05                                                         // 2555: cc 05 0f    ... :8555[1]
+    bcs c855f                                                         // 2558: b0 05       ..  :8558[1]
+    lda l0e08,y                                                       // 255a: b9 08 0e    ... :855a[1]
+    bmi loop_c8552                                                    // 255d: 30 f3       0.  :855d[1]
+// $255f referenced 1 time by $8558
+c855f
+    rts                                                               // 255f: 60          `   :855f[1]
+
+// $2560 referenced 2 times by $8548, $8594
+c8560
+    sty l00ab                                                         // 2560: 84 ab       ..  :8560[1]
+    ldx #0                                                            // 2562: a2 00       ..  :8562[1]
+// $2564 referenced 1 time by $8571
+loop_c8564
+    lda l0e08,y                                                       // 2564: b9 08 0e    ... :8564[1]
+    jsr sub_c82fe                                                     // 2567: 20 fe 82     .. :8567[1]
+    sta l1060,x                                                       // 256a: 9d 60 10    .`. :856a[1]
+    iny                                                               // 256d: c8          .   :856d[1]
+    inx                                                               // 256e: e8          .   :856e[1]
+    cpx #8                                                            // 256f: e0 08       ..  :856f[1]
+    bne loop_c8564                                                    // 2571: d0 f1       ..  :8571[1]
+// $2573 referenced 1 time by $8599
+c8573
+    jsr sub_c8555                                                     // 2573: 20 55 85     U. :8573[1]
+    bcs c859b                                                         // 2576: b0 23       .#  :8576[1]
+    sec                                                               // 2578: 38          8   :8578[1]
+    ldx #6                                                            // 2579: a2 06       ..  :8579[1]
+// $257b referenced 1 time by $8586
+loop_c857b
+    lda l0e0e,y                                                       // 257b: b9 0e 0e    ... :857b[1]
+    jsr sub_c82fe                                                     // 257e: 20 fe 82     .. :857e[1]
+    sbc l1060,x                                                       // 2581: fd 60 10    .`. :8581[1]
+    dey                                                               // 2584: 88          .   :8584[1]
+    dex                                                               // 2585: ca          .   :8585[1]
+    bpl loop_c857b                                                    // 2586: 10 f3       ..  :8586[1]
+    jsr sub_c87db                                                     // 2588: 20 db 87     .. :8588[1]
+    lda l0e0f,y                                                       // 258b: b9 0f 0e    ... :858b[1]
+    jsr sub_c82fe                                                     // 258e: 20 fe 82     .. :858e[1]
+    sbc l1067                                                         // 2591: ed 67 10    .g. :8591[1]
+    bcc c8560                                                         // 2594: 90 ca       ..  :8594[1]
+    jsr sub_c87da                                                     // 2596: 20 da 87     .. :8596[1]
+    bcs c8573                                                         // 2599: b0 d8       ..  :8599[1]
+// $259b referenced 1 time by $8576
+c859b
+    ldy l00ab                                                         // 259b: a4 ab       ..  :859b[1]
+    lda l0e08,y                                                       // 259d: b9 08 0e    ... :859d[1]
+    ora #$80                                                          // 25a0: 09 80       ..  :85a0[1]
+    sta l0e08,y                                                       // 25a2: 99 08 0e    ... :85a2[1]
+    lda l1067                                                         // 25a5: ad 67 10    .g. :85a5[1]
+    cmp l00aa                                                         // 25a8: c5 aa       ..  :85a8[1]
+    beq c85bc                                                         // 25aa: f0 10       ..  :85aa[1]
+    ldx l00aa                                                         // 25ac: a6 aa       ..  :85ac[1]
+    sta l00aa                                                         // 25ae: 85 aa       ..  :85ae[1]
+    bne c85bc                                                         // 25b0: d0 0a       ..  :85b0[1]
+    jsr ca3dc                                                         // 25b2: 20 dc a3     .. :85b2[1]
+// $25b5 referenced 1 time by $85be
+loop_c85b5
+    jsr ca3dc                                                         // 25b5: 20 dc a3     .. :85b5[1]
+    ldy #$ff                                                          // 25b8: a0 ff       ..  :85b8[1]
+    bne c85c5                                                         // 25ba: d0 09       ..  :85ba[1]
+// $25bc referenced 2 times by $85aa, $85b0
+c85bc
+    ldy l00a8                                                         // 25bc: a4 a8       ..  :85bc[1]
+    bne loop_c85b5                                                    // 25be: d0 f5       ..  :85be[1]
+    ldy #5                                                            // 25c0: a0 05       ..  :85c0[1]
+    jsr c81a7                                                         // 25c2: 20 a7 81     .. :85c2[1]
+// $25c5 referenced 1 time by $85ba
+c85c5
+    iny                                                               // 25c5: c8          .   :85c5[1]
+    sty l00a8                                                         // 25c6: 84 a8       ..  :85c6[1]
+    ldy l00ab                                                         // 25c8: a4 ab       ..  :85c8[1]
+    jsr sub_cac0c                                                     // 25ca: 20 0c ac     .. :85ca[1]
+    jsr sub_c8174                                                     // 25cd: 20 74 81     t. :85cd[1]
+    jmp c8543                                                         // 25d0: 4c 43 85    LC. :85d0[1]
+
+// $25d3 referenced 1 time by $84e7
+opt4_table
+    .asc "off", 0                                                     // 25d3: 6f 66 66... off :85d3[1]
+    .asc "LOAD"                                                       // 25d7: 4c 4f 41... LOA :85d7[1]
+    .asc "RUN", 0                                                     // 25db: 52 55 4e... RUN :85db[1]
+    .asc "EXEC"                                                       // 25df: 45 58 45... EXE :85df[1]
+
+// $25e3 referenced 1 time by $8acd
+sub_c85e3
+    lda l0f0e,y                                                       // 25e3: b9 0e 0f    ... :85e3[1]
+    jsr sub_c81b0                                                     // 25e6: 20 b0 81     .. :85e6[1]
+    sta l00c2                                                         // 25e9: 85 c2       ..  :85e9[1]
+    clc                                                               // 25eb: 18          .   :85eb[1]
+    lda #$ff                                                          // 25ec: a9 ff       ..  :85ec[1]
+    adc l0f0c,y                                                       // 25ee: 79 0c 0f    y.. :85ee[1]
+    lda l0f0f,y                                                       // 25f1: b9 0f 0f    ... :85f1[1]
+    adc l0f0d,y                                                       // 25f4: 79 0d 0f    y.. :85f4[1]
+    sta l00c3                                                         // 25f7: 85 c3       ..  :85f7[1]
+    lda l0f0e,y                                                       // 25f9: b9 0e 0f    ... :85f9[1]
+    and #3                                                            // 25fc: 29 03       ).  :85fc[1]
+    adc l00c2                                                         // 25fe: 65 c2       e.  :85fe[1]
+    sta l00c2                                                         // 2600: 85 c2       ..  :8600[1]
+// $2602 referenced 1 time by $8ac2
+sub_c8602
+    sec                                                               // 2602: 38          8   :8602[1]
+    lda l0f07,y                                                       // 2603: b9 07 0f    ... :8603[1]
+    sbc l00c3                                                         // 2606: e5 c3       ..  :8606[1]
+    pha                                                               // 2608: 48          H   :8608[1]
+    lda l0f06,y                                                       // 2609: b9 06 0f    ... :8609[1]
+    and #3                                                            // 260c: 29 03       ).  :860c[1]
+    sbc l00c2                                                         // 260e: e5 c2       ..  :860e[1]
+    tax                                                               // 2610: aa          .   :8610[1]
+    lda #0                                                            // 2611: a9 00       ..  :8611[1]
+    cmp l00c0                                                         // 2613: c5 c0       ..  :8613[1]
+    pla                                                               // 2615: 68          h   :8615[1]
+    sbc l00c1                                                         // 2616: e5 c1       ..  :8616[1]
+    txa                                                               // 2618: 8a          .   :8618[1]
+    sbc l00c4                                                         // 2619: e5 c4       ..  :8619[1]
+    rts                                                               // 261b: 60          `   :861b[1]
+
+// $261c referenced 6 times by $870e, $8719, $8726, $873c, $a16f, $a187
+command_table
+    .asc "ACCESS"                                                     // 261c: 41 43 43... ACC :861c[1]
+// $261d referenced 1 time by $8740
+    .byt >(sub_c89e6-1)                                               // 2622: 89          .   :8622[1]
+    .byt <(sub_c89e6-1)                                               // 2623: e5          .   :8623[1]
+    .byt $32                                                          // 2624: 32          2   :8624[1]
+    .asc "BACKUP"                                                     // 2625: 42 41 43... BAC :8625[1]
+    .byt >(sub_ca417-1)                                               // 262b: a4          .   :862b[1]
+    .byt <(sub_ca417-1)                                               // 262c: 16          .   :862c[1]
+    .byt 4                                                            // 262d: 04          .   :862d[1]
+    .asc "CLOSE"                                                      // 262e: 43 4c 4f... CLO :862e[1]
+    .byt >(sub_c9b59-1)                                               // 2633: 9b          .   :8633[1]
+    .byt <(sub_c9b59-1)                                               // 2634: 58          X   :8634[1]
+    .byt 0                                                            // 2635: 00          .   :8635[1]
+    .asc "COMPACT"                                                    // 2636: 43 4f 4d... COM :8636[1]
+    .byt >(sub_ca244-1)                                               // 263d: a2          .   :863d[1]
+    .byt <(sub_ca244-1)                                               // 263e: 43          C   :863e[1]
+    .byt 7                                                            // 263f: 07          .   :863f[1]
+    .asc "COPY"                                                       // 2640: 43 4f 50... COP :8640[1]
+    .byt >(sub_ca463-1)                                               // 2644: a4          .   :8644[1]
+    .byt <(sub_ca463-1)                                               // 2645: 62          b   :8645[1]
+    .byt $24                                                          // 2646: 24          $   :8646[1]
+    .asc "DELETE"                                                     // 2647: 44 45 4c... DEL :8647[1]
+    .byt >(sub_c8782-1)                                               // 264d: 87          .   :864d[1]
+    .byt <(sub_c8782-1)                                               // 264e: 81          .   :864e[1]
+    .byt 1                                                            // 264f: 01          .   :864f[1]
+    .asc "DESTROY"                                                    // 2650: 44 45 53... DES :8650[1]
+    .byt >(sub_c8794-1)                                               // 2657: 87          .   :8657[1]
+    .byt <(sub_c8794-1)                                               // 2658: 93          .   :8658[1]
+    .byt 2                                                            // 2659: 02          .   :8659[1]
+    .asc "DIR"                                                        // 265a: 44 49 52    DIR :865a[1]
+    .byt >(sub_c893f-1)                                               // 265d: 89          .   :865d[1]
+    .byt <(sub_c893f-1)                                               // 265e: 3e          >   :865e[1]
+    .byt 6                                                            // 265f: 06          .   :865f[1]
+    .asc "DRIVE"                                                      // 2660: 44 52 49... DRI :8660[1]
+    .byt >(sub_c87ee-1)                                               // 2665: 87          .   :8665[1]
+    .byt <(sub_c87ee-1)                                               // 2666: ed          .   :8666[1]
+    .byt 9                                                            // 2667: 09          .   :8667[1]
+    .asc "ENABLE"                                                     // 2668: 45 4e 41... ENA :8668[1]
+    .byt >(sub_c8b47-1)                                               // 266e: 8b          .   :866e[1]
+    .byt <(sub_c8b47-1)                                               // 266f: 46          F   :866f[1]
+    .byt 0                                                            // 2670: 00          .   :8670[1]
+    .asc "EX"                                                         // 2671: 45 58       EX  :8671[1]
+    .byt >(sub_c8238-1)                                               // 2673: 82          .   :8673[1]
+    .byt <(sub_c8238-1)                                               // 2674: 37          7   :8674[1]
+    .byt 6                                                            // 2675: 06          .   :8675[1]
+    .asc "FORM"                                                       // 2676: 46 4f 52... FOR :8676[1]
+    .byt >(sub_ca5bf-1)                                               // 267a: a5          .   :867a[1]
+    .byt <(sub_ca5bf-1)                                               // 267b: be          .   :867b[1]
+    .byt $ba                                                          // 267c: ba          .   :867c[1]
+    .asc "FREE"                                                       // 267d: 46 52 45... FRE :867d[1]
+    .byt >(sub_ca7f3-1)                                               // 2681: a7          .   :8681[1]
+    .byt <(sub_ca7f3-1)                                               // 2682: f2          .   :8682[1]
+    .byt 7                                                            // 2683: 07          .   :8683[1]
+    .asc "INFO"                                                       // 2684: 49 4e 46... INF :8684[1]
+    .byt >(sub_c8254-1)                                               // 2688: 82          .   :8688[1]
+    .byt <(sub_c8254-1)                                               // 2689: 53          S   :8689[1]
+    .byt 2                                                            // 268a: 02          .   :868a[1]
+    .asc "LIB"                                                        // 268b: 4c 49 42    LIB :868b[1]
+    .byt >(sub_c8943-1)                                               // 268e: 89          .   :868e[1]
+    .byt <(sub_c8943-1)                                               // 268f: 42          B   :868f[1]
+    .byt 6                                                            // 2690: 06          .   :8690[1]
+    .asc "MAP"                                                        // 2691: 4d 41 50    MAP :8691[1]
+    .byt >(sub_ca7f6-1)                                               // 2694: a7          .   :8694[1]
+    .byt <(sub_ca7f6-1)                                               // 2695: f5          .   :8695[1]
+    .byt 7                                                            // 2696: 07          .   :8696[1]
+    .asc "RENAME"                                                     // 2697: 52 45 4e... REN :8697[1]
+    .byt >(sub_c8bac-1)                                               // 269d: 8b          .   :869d[1]
+    .byt <(sub_c8bac-1)                                               // 269e: ab          .   :869e[1]
+    .byt 5                                                            // 269f: 05          .   :869f[1]
+    .asc "TITLE"                                                      // 26a0: 54 49 54... TIT :86a0[1]
+    .byt >(sub_c89b7-1)                                               // 26a5: 89          .   :86a5[1]
+    .byt <(sub_c89b7-1)                                               // 26a6: b6          .   :86a6[1]
+    .byt 8                                                            // 26a7: 08          .   :86a7[1]
+    .asc "VERIFY"                                                     // 26a8: 56 45 52... VER :86a8[1]
+    .byt >(sub_ca5bb-1)                                               // 26ae: a5          .   :86ae[1]
+    .byt <(sub_ca5bb-1)                                               // 26af: ba          .   :86af[1]
+    .byt $0b                                                          // 26b0: 0b          .   :86b0[1]
+    .asc "WIPE"                                                       // 26b1: 57 49 50... WIP :86b1[1]
+    .byt >(sub_c8750-1)                                               // 26b5: 87          .   :86b5[1]
+    .byt <(sub_c8750-1)                                               // 26b6: 4f          O   :86b6[1]
+    .byt   2, $88, $72                                                // 26b7: 02 88 72    ..r :86b7[1]
+    .asc "BUILD"                                                      // 26ba: 42 55 49... BUI :86ba[1]
+    .byt >(sub_cabc5-1)                                               // 26bf: ab          .   :86bf[1]
+    .byt <(sub_cabc5-1)                                               // 26c0: c4          .   :86c0[1]
+    .byt 1                                                            // 26c1: 01          .   :86c1[1]
+    .asc "DISC"                                                       // 26c2: 44 49 53... DIS :86c2[1]
+    .byt >(c956d-1)                                                   // 26c6: 95          .   :86c6[1]
+    .byt <(c956d-1)                                                   // 26c7: 6c          l   :86c7[1]
+    .byt 0                                                            // 26c8: 00          .   :86c8[1]
+    .asc "DUMP"                                                       // 26c9: 44 55 4d... DUM :86c9[1]
+    .byt >(sub_cab46-1)                                               // 26cd: ab          .   :86cd[1]
+    .byt <(sub_cab46-1)                                               // 26ce: 45          E   :86ce[1]
+    .byt 1                                                            // 26cf: 01          .   :86cf[1]
+    .asc "LIST"                                                       // 26d0: 4c 49 53... LIS :86d0[1]
+    .byt >(sub_cab04-1)                                               // 26d4: ab          .   :86d4[1]
+    .byt <(sub_cab04-1)                                               // 26d5: 03          .   :86d5[1]
+    .byt 1                                                            // 26d6: 01          .   :86d6[1]
+    .asc "ROMS"                                                       // 26d7: 52 4f 4d... ROM :86d7[1]
+    .byt >(sub_ca9d0-1)                                               // 26db: a9          .   :86db[1]
+    .byt <(sub_ca9d0-1)                                               // 26dc: cf          .   :86dc[1]
+    .byt $0c                                                          // 26dd: 0c          .   :86dd[1]
+    .asc "TYPE"                                                       // 26de: 54 59 50... TYP :86de[1]
+    .byt >(sub_caafd-1)                                               // 26e2: aa          .   :86e2[1]
+    .byt <(sub_caafd-1)                                               // 26e3: fc          .   :86e3[1]
+    .byt 1                                                            // 26e4: 01          .   :86e4[1]
+    .asc "DISK"                                                       // 26e5: 44 49 53... DIS :86e5[1]
+    .byt >(c956d-1)                                                   // 26e9: 95          .   :86e9[1]
+    .byt <(c956d-1)                                                   // 26ea: 6c          l   :86ea[1]
+    .byt   0, $86, $1a                                                // 26eb: 00 86 1a    ... :86eb[1]
+    .asc "DFS"                                                        // 26ee: 44 46 53    DFS :86ee[1]
+    .byt >(sub_ca106-1)                                               // 26f1: a1          .   :86f1[1]
+    .byt <(sub_ca106-1)                                               // 26f2: 05          .   :86f2[1]
+    .byt 0                                                            // 26f3: 00          .   :86f3[1]
+    .asc "UTILS"                                                      // 26f4: 55 54 49... UTI :86f4[1]
+    .byt >(sub_ca137-1)                                               // 26f9: a1          .   :86f9[1]
+    .byt <(sub_ca137-1)                                               // 26fa: 36          6   :86fa[1]
+    .byt   0, $a1                                                     // 26fb: 00 a1       ..  :86fb[1]
+    .asc "= E"                                                        // 26fd: 3d 20 45    = E :86fd[1]
+    .byt $87, $a2, $fd                                                // 2700: 87 a2 fd    ... :8700[1]
+
+// $2703 referenced 2 times by $96f2, $a134
+c8703
+    tya                                                               // 2703: 98          .   :8703[1]
+    pha                                                               // 2704: 48          H   :8704[1]
+// $2705 referenced 2 times by $872f, $8739
+c8705
+    inx                                                               // 2705: e8          .   :8705[1]
+    inx                                                               // 2706: e8          .   :8706[1]
+    pla                                                               // 2707: 68          h   :8707[1]
+    pha                                                               // 2708: 48          H   :8708[1]
+    tay                                                               // 2709: a8          .   :8709[1]
+    jsr clc_jmp_gsinit                                                // 270a: 20 4c 87     L. :870a[1]
+    inx                                                               // 270d: e8          .   :870d[1]
+    lda command_table,x                                               // 270e: bd 1c 86    ... :870e[1]
+    bmi c873b                                                         // 2711: 30 28       0(  :8711[1]
+    dex                                                               // 2713: ca          .   :8713[1]
+    dey                                                               // 2714: 88          .   :8714[1]
+    stx l00bf                                                         // 2715: 86 bf       ..  :8715[1]
+// $2717 referenced 1 time by $8722
+loop_c8717
+    inx                                                               // 2717: e8          .   :8717[1]
+    iny                                                               // 2718: c8          .   :8718[1]
+    lda command_table,x                                               // 2719: bd 1c 86    ... :8719[1]
+    bmi c8734                                                         // 271c: 30 16       0.  :871c[1]
+    eor (os_text_ptr),y                                               // 271e: 51 f2       Q.  :871e[1]
+    and #$5f // '_'                                                   // 2720: 29 5f       )_  :8720[1]
+    beq loop_c8717                                                    // 2722: f0 f3       ..  :8722[1]
+    dex                                                               // 2724: ca          .   :8724[1]
+// $2725 referenced 1 time by $8729
+loop_c8725
+    inx                                                               // 2725: e8          .   :8725[1]
+    lda command_table,x                                               // 2726: bd 1c 86    ... :8726[1]
+    bpl loop_c8725                                                    // 2729: 10 fa       ..  :8729[1]
+    lda (os_text_ptr),y                                               // 272b: b1 f2       ..  :872b[1]
+    cmp #$2e // '.'                                                   // 272d: c9 2e       ..  :872d[1]
+    bne c8705                                                         // 272f: d0 d4       ..  :872f[1]
+    iny                                                               // 2731: c8          .   :8731[1]
+    bcs c873b                                                         // 2732: b0 07       ..  :8732[1]
+// $2734 referenced 1 time by $871c
+c8734
+    lda (os_text_ptr),y                                               // 2734: b1 f2       ..  :8734[1]
+    jsr sub_c8327                                                     // 2736: 20 27 83     '. :8736[1]
+    bcc c8705                                                         // 2739: 90 ca       ..  :8739[1]
+// $273b referenced 2 times by $8711, $8732
+c873b
+    pla                                                               // 273b: 68          h   :873b[1]
+    lda command_table,x                                               // 273c: bd 1c 86    ... :873c[1]
+    pha                                                               // 273f: 48          H   :873f[1]
+    lda command_table+1,x                                             // 2740: bd 1d 86    ... :8740[1]
+    pha                                                               // 2743: 48          H   :8743[1]
+    rts                                                               // 2744: 60          `   :8744[1]
+
+// $2745 referenced 2 times by $8483, $8870
+sub_c8745
+    stx os_text_ptr                                                   // 2745: 86 f2       ..  :8745[1]
+    sty l00f3                                                         // 2747: 84 f3       ..  :8747[1]
+    ldy #0                                                            // 2749: a0 00       ..  :8749[1]
+    rts                                                               // 274b: 60          `   :874b[1]
+
+// $274c referenced 12 times by $8100, $823b, $8456, $870a, $897e, $89f1, $8b86, $a13e, $a14a, $a5e5, $a657, $a9f7
+clc_jmp_gsinit
+    clc                                                               // 274c: 18          .   :874c[1]
+    jmp gsinit                                                        // 274d: 4c c2 ff    L.. :874d[1]
+
+sub_c8750
+    jsr sub_c99ac                                                     // 2750: 20 ac 99     .. :8750[1]
+    jsr sub_ca14a                                                     // 2753: 20 4a a1     J. :8753[1]
+    jsr sub_c821d                                                     // 2756: 20 1d 82     .. :8756[1]
+// $2759 referenced 1 time by $877f
+c8759
+    lda l0e0f,y                                                       // 2759: b9 0f 0e    ... :8759[1]
+    bmi c877c                                                         // 275c: 30 1e       0.  :875c[1]
+    jsr sub_c8174                                                     // 275e: 20 74 81     t. :875e[1]
+    jsr sub_ca3e4                                                     // 2761: 20 e4 a3     .. :8761[1]
+    bne c8779                                                         // 2764: d0 13       ..  :8764[1]
+    ldx l00b6                                                         // 2766: a6 b6       ..  :8766[1]
+    jsr sub_c9bf2                                                     // 2768: 20 f2 9b     .. :8768[1]
+    stx l00b6                                                         // 276b: 86 b6       ..  :876b[1]
+    jsr sub_c87e3                                                     // 276d: 20 e3 87     .. :876d[1]
+    sty l00ab                                                         // 2770: 84 ab       ..  :8770[1]
+    jsr c93e6                                                         // 2772: 20 e6 93     .. :8772[1]
+    lda l00ab                                                         // 2775: a5 ab       ..  :8775[1]
+    sta l00b6                                                         // 2777: 85 b6       ..  :8777[1]
+// $2779 referenced 1 time by $8764
+c8779
+    jsr ca3dc                                                         // 2779: 20 dc a3     .. :8779[1]
+// $277c referenced 1 time by $875c
+c877c
+    jsr sub_c8280                                                     // 277c: 20 80 82     .. :877c[1]
+    bcs c8759                                                         // 277f: b0 d8       ..  :877f[1]
+    rts                                                               // 2781: 60          `   :8781[1]
+
+sub_c8782
+    jsr c99a3                                                         // 2782: 20 a3 99     .. :8782[1]
+    jsr sub_ca14a                                                     // 2785: 20 4a a1     J. :8785[1]
+    jsr sub_c821d                                                     // 2788: 20 1d 82     .. :8788[1]
+    jsr sub_c8335                                                     // 278b: 20 35 83     5. :878b[1]
+    jsr sub_c830a                                                     // 278e: 20 0a 83     .. :878e[1]
+    jmp c93e6                                                         // 2791: 4c e6 93    L.. :8791[1]
+
+sub_c8794
+    jsr sub_ca315                                                     // 2794: 20 15 a3     .. :8794[1]
+    jsr sub_c99ac                                                     // 2797: 20 ac 99     .. :8797[1]
+    jsr sub_ca14a                                                     // 279a: 20 4a a1     J. :879a[1]
+    jsr sub_c821d                                                     // 279d: 20 1d 82     .. :879d[1]
+// $27a0 referenced 1 time by $87ae
+loop_c87a0
+    lda l0e0f,y                                                       // 27a0: b9 0f 0e    ... :87a0[1]
+    bmi c87ab                                                         // 27a3: 30 06       0.  :87a3[1]
+    jsr sub_c8174                                                     // 27a5: 20 74 81     t. :87a5[1]
+    jsr ca3dc                                                         // 27a8: 20 dc a3     .. :87a8[1]
+// $27ab referenced 1 time by $87a3
+c87ab
+    jsr sub_c8280                                                     // 27ab: 20 80 82     .. :87ab[1]
+    bcs loop_c87a0                                                    // 27ae: b0 f0       ..  :87ae[1]
+    jsr sub_ca3ec                                                     // 27b0: 20 ec a3     .. :87b0[1]
+    beq c87b8                                                         // 27b3: f0 03       ..  :87b3[1]
+    jmp ca3dc                                                         // 27b5: 4c dc a3    L.. :87b5[1]
+
+// $27b8 referenced 1 time by $87b3
+c87b8
+    jsr sub_c9bf2                                                     // 27b8: 20 f2 9b     .. :87b8[1]
+    jsr sub_c8284                                                     // 27bb: 20 84 82     .. :87bb[1]
+// $27be referenced 1 time by $87c9
+loop_c87be
+    lda l0e0f,y                                                       // 27be: b9 0f 0e    ... :87be[1]
+    bmi c87c6                                                         // 27c1: 30 03       0.  :87c1[1]
+    jsr sub_c87e3                                                     // 27c3: 20 e3 87     .. :87c3[1]
+// $27c6 referenced 1 time by $87c1
+c87c6
+    jsr sub_c8280                                                     // 27c6: 20 80 82     .. :87c6[1]
+    bcs loop_c87be                                                    // 27c9: b0 f3       ..  :87c9[1]
+    jsr c93e6                                                         // 27cb: 20 e6 93     .. :87cb[1]
+    jsr print_inline_l809f_top_bit_clear                              // 27ce: 20 77 80     w. :87ce[1]
+    .asc $0d, "Deleted", $0d                                          // 27d1: 0d 44 65... .De :87d1[1]
+
+// $27da referenced 6 times by $853e, $8552, $8596, $8b0c, $8be5, $98b5
+sub_c87da
+    iny                                                               // 27da: c8          .   :87da[1]
+// $27db referenced 2 times by $837a, $8588
+sub_c87db
+    iny                                                               // 27db: c8          .   :87db[1]
+    iny                                                               // 27dc: c8          .   :87dc[1]
+    iny                                                               // 27dd: c8          .   :87dd[1]
+    iny                                                               // 27de: c8          .   :87de[1]
+    iny                                                               // 27df: c8          .   :87df[1]
+    iny                                                               // 27e0: c8          .   :87e0[1]
+    iny                                                               // 27e1: c8          .   :87e1[1]
+    rts                                                               // 27e2: 60          `   :87e2[1]
+
+// $27e3 referenced 2 times by $876d, $87c3
+sub_c87e3
+    jsr sub_c830a                                                     // 27e3: 20 0a 83     .. :87e3[1]
+    ldy l00b6                                                         // 27e6: a4 b6       ..  :87e6[1]
+    jsr sub_c82b2                                                     // 27e8: 20 b2 82     .. :87e8[1]
+    sty l00b6                                                         // 27eb: 84 b6       ..  :87eb[1]
+    rts                                                               // 27ed: 60          `   :87ed[1]
+
+sub_c87ee
+    jsr sub_ca14a                                                     // 27ee: 20 4a a1     J. :87ee[1]
+    jsr c8b8b                                                         // 27f1: 20 8b 8b     .. :87f1[1]
+    sta l10ca                                                         // 27f4: 8d ca 10    ... :87f4[1]
+    jsr sub_c8456                                                     // 27f7: 20 56 84     V. :87f7[1]
+    beq c8815                                                         // 27fa: f0 19       ..  :87fa[1]
+    cmp #$28 // '('                                                   // 27fc: c9 28       .(  :87fc[1]
+    beq c8808                                                         // 27fe: f0 08       ..  :87fe[1]
+    cmp #$50 // 'P'                                                   // 2800: c9 50       .P  :8800[1]
+    clc                                                               // 2802: 18          .   :8802[1]
+    beq c8808                                                         // 2803: f0 03       ..  :8803[1]
+    jmp ca14f                                                         // 2805: 4c 4f a1    LO. :8805[1]
+
+// $2808 referenced 2 times by $87fe, $8803
+c8808
+    php                                                               // 2808: 08          .   :8808[1]
+    ldx l10ca                                                         // 2809: ae ca 10    ... :8809[1]
+    lda l10de,x                                                       // 280c: bd de 10    ... :880c[1]
+    rol                                                               // 280f: 2a          *   :880f[1]
+    plp                                                               // 2810: 28          (   :8810[1]
+    ror                                                               // 2811: 6a          j   :8811[1]
+    sta l10de,x                                                       // 2812: 9d de 10    ... :8812[1]
+// $2815 referenced 1 time by $87fa
+c8815
+    rts                                                               // 2815: 60          `   :8815[1]
+
+// $2816 referenced 8 times by $888f, $8985, $898d, $8b83, $8b9d, $9bef, $a475, $a4ce
+c8816
+    and #3                                                            // 2816: 29 03       ).  :8816[1]
+    sta l00cd                                                         // 2818: 85 cd       ..  :8818[1]
+    rts                                                               // 281a: 60          `   :881a[1]
+
+    jsr sub_c8222                                                     // 281b: 20 22 82     ". :881b[1]
+    jsr sub_c9a82                                                     // 281e: 20 82 9a     .. :881e[1]
+    jsr sub_c8386                                                     // 2821: 20 86 83     .. :8821[1]
+    lda #$80                                                          // 2824: a9 80       ..  :8824[1]
+// $2826 referenced 1 time by $88f6
+sub_c8826
+    sta l1096                                                         // 2826: 8d 96 10    ... :8826[1]
+    sty l00ba                                                         // 2829: 84 ba       ..  :8829[1]
+    ldx #0                                                            // 282b: a2 00       ..  :882b[1]
+    lda l00be                                                         // 282d: a5 be       ..  :882d[1]
+    bne c8837                                                         // 282f: d0 06       ..  :882f[1]
+    iny                                                               // 2831: c8          .   :8831[1]
+    iny                                                               // 2832: c8          .   :8832[1]
+    ldx #2                                                            // 2833: a2 02       ..  :8833[1]
+    bne c883f                                                         // 2835: d0 08       ..  :8835[1]
+// $2837 referenced 1 time by $882f
+c8837
+    lda l0f0e,y                                                       // 2837: b9 0e 0f    ... :8837[1]
+    sta l00c2                                                         // 283a: 85 c2       ..  :883a[1]
+    jsr sub_c8b4d                                                     // 283c: 20 4d 8b     M. :883c[1]
+// $283f referenced 2 times by $8835, $8848
+c883f
+    lda l0f08,y                                                       // 283f: b9 08 0f    ... :883f[1]
+    sta l00bc,x                                                       // 2842: 95 bc       ..  :8842[1]
+    iny                                                               // 2844: c8          .   :8844[1]
+    inx                                                               // 2845: e8          .   :8845[1]
+    cpx #8                                                            // 2846: e0 08       ..  :8846[1]
+    bne c883f                                                         // 2848: d0 f5       ..  :8848[1]
+    jsr sub_c8b64                                                     // 284a: 20 64 8b     d. :884a[1]
+    ldy l00ba                                                         // 284d: a4 ba       ..  :884d[1]
+    jsr sub_c8335                                                     // 284f: 20 35 83     5. :884f[1]
+    jmp c8867                                                         // 2852: 4c 67 88    Lg. :8852[1]
+
+// $2855 referenced 2 times by $9f61, $a561
+sub_c8855
+    lda #$80                                                          // 2855: a9 80       ..  :8855[1]
+    bne c8864                                                         // 2857: d0 0b       ..  :8857[1]
+    jsr sub_c8a77                                                     // 2859: 20 77 8a     w. :8859[1]
+    jsr sub_c9a82                                                     // 285c: 20 82 9a     .. :885c[1]
+    jsr sub_c8386                                                     // 285f: 20 86 83     .. :885f[1]
+// $2862 referenced 2 times by $9f51, $a587
+sub_c8862
+    lda #$a0                                                          // 2862: a9 a0       ..  :8862[1]
+// $2864 referenced 1 time by $8857
+c8864
+    sta l1096                                                         // 2864: 8d 96 10    ... :8864[1]
+// $2867 referenced 1 time by $8852
+c8867
+    jsr sub_c81ca                                                     // 2867: 20 ca 81     .. :8867[1]
+    jsr sub_c9445                                                     // 286a: 20 45 94     E. :886a[1]
+    lda #1                                                            // 286d: a9 01       ..  :886d[1]
+    rts                                                               // 286f: 60          `   :886f[1]
+
+    jsr sub_c8745                                                     // 2870: 20 45 87     E. :8870[1]
+    jsr sub_c8932                                                     // 2873: 20 32 89     2. :8873[1]
+    sty l10da                                                         // 2876: 8c da 10    ... :8876[1]
+    jsr sub_c80f3                                                     // 2879: 20 f3 80     .. :8879[1]
+    sty l10d9                                                         // 287c: 8c d9 10    ... :887c[1]
+    jsr sub_c8266                                                     // 287f: 20 66 82     f. :887f[1]
+    bcs c88a6                                                         // 2882: b0 22       ."  :8882[1]
+    ldy l10da                                                         // 2884: ac da 10    ... :8884[1]
+    lda l10cb                                                         // 2887: ad cb 10    ... :8887[1]
+    sta l00cc                                                         // 288a: 85 cc       ..  :888a[1]
+    lda l10cc                                                         // 288c: ad cc 10    ... :888c[1]
+    jsr c8816                                                         // 288f: 20 16 88     .. :888f[1]
+    jsr sub_c80f6                                                     // 2892: 20 f6 80     .. :8892[1]
+    jsr sub_c8266                                                     // 2895: 20 66 82     f. :8895[1]
+    bcs c88a6                                                         // 2898: b0 0c       ..  :8898[1]
+    jsr generate_error_precheck_bad                                   // 289a: 20 2e 80     .. :889a[1]
+    .byt $fe                                                          // 289d: fe          .   :889d[1]
+    .asc "command"                                                    // 289e: 63 6f 6d... com :889e[1]
+    .byt 0                                                            // 28a5: 00          .   :88a5[1]
+
+// $28a6 referenced 2 times by $8882, $8898
+c88a6
+    lda l0f0e,y                                                       // 28a6: b9 0e 0f    ... :88a6[1]
+    jsr sub_c81ae                                                     // 28a9: 20 ae 81     .. :88a9[1]
+    cmp #3                                                            // 28ac: c9 03       ..  :88ac[1]
+    bne c88f4                                                         // 28ae: d0 44       .D  :88ae[1]
+    lda l0f0a,y                                                       // 28b0: b9 0a 0f    ... :88b0[1]
+    and l0f0b,y                                                       // 28b3: 39 0b 0f    9.. :88b3[1]
+    cmp #$ff                                                          // 28b6: c9 ff       ..  :88b6[1]
+    bne c88f4                                                         // 28b8: d0 3a       .:  :88b8[1]
+    ldx #6                                                            // 28ba: a2 06       ..  :88ba[1]
+// $28bc referenced 1 time by $88c3
+loop_c88bc
+    lda l1000,x                                                       // 28bc: bd 00 10    ... :88bc[1]
+    sta l1007,x                                                       // 28bf: 9d 07 10    ... :88bf[1]
+    dex                                                               // 28c2: ca          .   :88c2[1]
+    bpl loop_c88bc                                                    // 28c3: 10 f7       ..  :88c3[1]
+    lda #$0d                                                          // 28c5: a9 0d       ..  :88c5[1]
+    sta l100e                                                         // 28c7: 8d 0e 10    ... :88c7[1]
+    lda #$45 // 'E'                                                   // 28ca: a9 45       .E  :88ca[1]
+    sta l1000                                                         // 28cc: 8d 00 10    ... :88cc[1]
+    lda #$2e // '.'                                                   // 28cf: a9 2e       ..  :88cf[1]
+    sta l1001                                                         // 28d1: 8d 01 10    ... :88d1[1]
+    lda #$3a // ':'                                                   // 28d4: a9 3a       .:  :88d4[1]
+    sta l1002                                                         // 28d6: 8d 02 10    ... :88d6[1]
+    lda l00cd                                                         // 28d9: a5 cd       ..  :88d9[1]
+    ora #$30 // '0'                                                   // 28db: 09 30       .0  :88db[1]
+    sta l1003                                                         // 28dd: 8d 03 10    ... :88dd[1]
+    lda #$2e // '.'                                                   // 28e0: a9 2e       ..  :88e0[1]
+    sta l1004                                                         // 28e2: 8d 04 10    ... :88e2[1]
+    sta l1006                                                         // 28e5: 8d 06 10    ... :88e5[1]
+    lda l00cc                                                         // 28e8: a5 cc       ..  :88e8[1]
+    sta l1005                                                         // 28ea: 8d 05 10    ... :88ea[1]
+    ldx #<(l1000)                                                     // 28ed: a2 00       ..  :88ed[1]
+    ldy #>(l1000)                                                     // 28ef: a0 10       ..  :88ef[1]
+    jmp oscli                                                         // 28f1: 4c f7 ff    L.. :88f1[1]
+
+// $28f4 referenced 2 times by $88ae, $88b8
+c88f4
+    lda #$81                                                          // 28f4: a9 81       ..  :88f4[1]
+    jsr sub_c8826                                                     // 28f6: 20 26 88     &. :88f6[1]
+    clc                                                               // 28f9: 18          .   :88f9[1]
+    lda l10d9                                                         // 28fa: ad d9 10    ... :88fa[1]
+    tay                                                               // 28fd: a8          .   :88fd[1]
+    adc os_text_ptr                                                   // 28fe: 65 f2       e.  :88fe[1]
+    sta l10d9                                                         // 2900: 8d d9 10    ... :8900[1]
+    lda l00f3                                                         // 2903: a5 f3       ..  :8903[1]
+    adc #0                                                            // 2905: 69 00       i.  :8905[1]
+    sta l10da                                                         // 2907: 8d da 10    ... :8907[1]
+    lda l1076                                                         // 290a: ad 76 10    .v. :890a[1]
+    and l1077                                                         // 290d: 2d 77 10    -w. :890d[1]
+    ora l10d6                                                         // 2910: 0d d6 10    ... :8910[1]
+    cmp #$ff                                                          // 2913: c9 ff       ..  :8913[1]
+    beq c892d                                                         // 2915: f0 16       ..  :8915[1]
+    lda l00be                                                         // 2917: a5 be       ..  :8917[1]
+    sta l1074                                                         // 2919: 8d 74 10    .t. :8919[1]
+    lda l00bf                                                         // 291c: a5 bf       ..  :891c[1]
+    sta l1075                                                         // 291e: 8d 75 10    .u. :891e[1]
+    jsr sub_c8f6b                                                     // 2921: 20 6b 8f     k. :8921[1]
+    ldx #$74 // 't'                                                   // 2924: a2 74       .t  :8924[1]
+    ldy #$10                                                          // 2926: a0 10       ..  :8926[1]
+    lda #4                                                            // 2928: a9 04       ..  :8928[1]
+    jmp tube_entry                                                    // 292a: 4c 06 04    L.. :892a[1]
+
+// $292d referenced 1 time by $8915
+c892d
+    lda #1                                                            // 292d: a9 01       ..  :892d[1]
+    jmp (l00be)                                                       // 292f: 6c be 00    l.. :892f[1]
+
+// $2932 referenced 1 time by $8873
+sub_c8932
+    lda #$ff                                                          // 2932: a9 ff       ..  :8932[1]
+    sta l00be                                                         // 2934: 85 be       ..  :8934[1]
+    lda os_text_ptr                                                   // 2936: a5 f2       ..  :8936[1]
+    sta l00ba                                                         // 2938: 85 ba       ..  :8938[1]
+    lda l00f3                                                         // 293a: a5 f3       ..  :893a[1]
+    sta l00bb                                                         // 293c: 85 bb       ..  :893c[1]
+    rts                                                               // 293e: 60          `   :893e[1]
+
+sub_c893f
+    ldx #0                                                            // 293f: a2 00       ..  :893f[1]
+    beq c8945                                                         // 2941: f0 02       ..  :8941[1]
+sub_c8943
+    ldx #2                                                            // 2943: a2 02       ..  :8943[1]
+// $2945 referenced 1 time by $8941
+c8945
+    jsr sub_c8979                                                     // 2945: 20 79 89     y. :8945[1]
+    sta l10ca,x                                                       // 2948: 9d ca 10    ... :8948[1]
+    lda l00cc                                                         // 294b: a5 cc       ..  :894b[1]
+    sta l10c9,x                                                       // 294d: 9d c9 10    ... :894d[1]
+    rts                                                               // 2950: 60          `   :8950[1]
+
+// $2951 referenced 2 times by $96b4, $9729
+sub_c8951
+    jsr sub_c83e3                                                     // 2951: 20 e3 83     .. :8951[1]
+    lda l00b0                                                         // 2954: a5 b0       ..  :8954[1]
+    pha                                                               // 2956: 48          H   :8956[1]
+    lda l00b1                                                         // 2957: a5 b1       ..  :8957[1]
+    pha                                                               // 2959: 48          H   :8959[1]
+    jsr sub_c9ab8                                                     // 295a: 20 b8 9a     .. :895a[1]
+    ldy #0                                                            // 295d: a0 00       ..  :895d[1]
+// $295f referenced 1 time by $8970
+loop_c895f
+    cpy #$c0                                                          // 295f: c0 c0       ..  :895f[1]
+    bcc c8968                                                         // 2961: 90 05       ..  :8961[1]
+    lda l1000,y                                                       // 2963: b9 00 10    ... :8963[1]
+    bcs c896b                                                         // 2966: b0 03       ..  :8966[1]
+// $2968 referenced 1 time by $8961
+c8968
+    lda l1100,y                                                       // 2968: b9 00 11    ... :8968[1]
+// $296b referenced 1 time by $8966
+c896b
+    sta (l00b0),y                                                     // 296b: 91 b0       ..  :896b[1]
+    iny                                                               // 296d: c8          .   :896d[1]
+    cpy #$ee                                                          // 296e: c0 ee       ..  :896e[1]
+    bne loop_c895f                                                    // 2970: d0 ed       ..  :8970[1]
+    pla                                                               // 2972: 68          h   :8972[1]
+    sta l00b1                                                         // 2973: 85 b1       ..  :8973[1]
+    pla                                                               // 2975: 68          h   :8975[1]
+    sta l00b0                                                         // 2976: 85 b0       ..  :8976[1]
+    rts                                                               // 2978: 60          `   :8978[1]
+
+// $2979 referenced 1 time by $8945
+sub_c8979
+    lda l10c9                                                         // 2979: ad c9 10    ... :8979[1]
+    sta l00cc                                                         // 297c: 85 cc       ..  :897c[1]
+    jsr clc_jmp_gsinit                                                // 297e: 20 4c 87     L. :897e[1]
+    bne c898a                                                         // 2981: d0 07       ..  :8981[1]
+    lda #0                                                            // 2983: a9 00       ..  :8983[1]
+    jsr c8816                                                         // 2985: 20 16 88     .. :8985[1]
+    beq c89b4                                                         // 2988: f0 2a       .*  :8988[1]
+// $298a referenced 2 times by $8240, $8981
+c898a
+    lda l10ca                                                         // 298a: ad ca 10    ... :898a[1]
+    jsr c8816                                                         // 298d: 20 16 88     .. :898d[1]
+// $2990 referenced 1 time by $89a3
+loop_c8990
+    jsr sub_c8149                                                     // 2990: 20 49 81     I. :8990[1]
+    bcs c89a5                                                         // 2993: b0 10       ..  :8993[1]
+    cmp #$3a // ':'                                                   // 2995: c9 3a       .:  :8995[1]
+    bne c89ad                                                         // 2997: d0 14       ..  :8997[1]
+    jsr c8b8b                                                         // 2999: 20 8b 8b     .. :8999[1]
+    jsr sub_c8149                                                     // 299c: 20 49 81     I. :899c[1]
+    bcs c89b4                                                         // 299f: b0 13       ..  :899f[1]
+    cmp #$2e // '.'                                                   // 29a1: c9 2e       ..  :89a1[1]
+    beq loop_c8990                                                    // 29a3: f0 eb       ..  :89a3[1]
+// $29a5 referenced 2 times by $8993, $89b2
+c89a5
+    jsr generate_error_precheck_bad                                   // 29a5: 20 2e 80     .. :89a5[1]
+    .byt $ce                                                          // 29a8: ce          .   :89a8[1]
+    .asc "dir"                                                        // 29a9: 64 69 72    dir :89a9[1]
+    .byt 0                                                            // 29ac: 00          .   :89ac[1]
+
+// $29ad referenced 1 time by $8997
+c89ad
+    sta l00cc                                                         // 29ad: 85 cc       ..  :89ad[1]
+    jsr sub_c8149                                                     // 29af: 20 49 81     I. :89af[1]
+    bcc c89a5                                                         // 29b2: 90 f1       ..  :89b2[1]
+// $29b4 referenced 2 times by $8988, $899f
+c89b4
+    lda l00cd                                                         // 29b4: a5 cd       ..  :89b4[1]
+    rts                                                               // 29b6: 60          `   :89b6[1]
+
+sub_c89b7
+    jsr sub_ca14a                                                     // 29b7: 20 4a a1     J. :89b7[1]
+    jsr sub_c8b7b                                                     // 29ba: 20 7b 8b     {. :89ba[1]
+    jsr sub_c8380                                                     // 29bd: 20 80 83     .. :89bd[1]
+    ldx #$0b                                                          // 29c0: a2 0b       ..  :89c0[1]
+    lda #0                                                            // 29c2: a9 00       ..  :89c2[1]
+// $29c4 referenced 1 time by $89c8
+loop_c89c4
+    jsr sub_c89da                                                     // 29c4: 20 da 89     .. :89c4[1]
+    dex                                                               // 29c7: ca          .   :89c7[1]
+    bpl loop_c89c4                                                    // 29c8: 10 fa       ..  :89c8[1]
+// $29ca referenced 1 time by $89d5
+loop_c89ca
+    inx                                                               // 29ca: e8          .   :89ca[1]
+    jsr sub_c8149                                                     // 29cb: 20 49 81     I. :89cb[1]
+    bcs c89d7                                                         // 29ce: b0 07       ..  :89ce[1]
+    jsr sub_c89da                                                     // 29d0: 20 da 89     .. :89d0[1]
+    cpx #$0b                                                          // 29d3: e0 0b       ..  :89d3[1]
+    bcc loop_c89ca                                                    // 29d5: 90 f3       ..  :89d5[1]
+// $29d7 referenced 3 times by $89ce, $8a15, $99ed
+c89d7
+    jmp c93e6                                                         // 29d7: 4c e6 93    L.. :89d7[1]
+
+// $29da referenced 2 times by $89c4, $89d0
+sub_c89da
+    cpx #8                                                            // 29da: e0 08       ..  :89da[1]
+    bcc c89e2                                                         // 29dc: 90 04       ..  :89dc[1]
+    sta l0ef8,x                                                       // 29de: 9d f8 0e    ... :89de[1]
+    rts                                                               // 29e1: 60          `   :89e1[1]
+
+// $29e2 referenced 1 time by $89dc
+c89e2
+    sta l0e00,x                                                       // 29e2: 9d 00 0e    ... :89e2[1]
+    rts                                                               // 29e5: 60          `   :89e5[1]
+
+sub_c89e6
+    jsr sub_c99ac                                                     // 29e6: 20 ac 99     .. :89e6[1]
+    jsr sub_ca14a                                                     // 29e9: 20 4a a1     J. :89e9[1]
+    jsr sub_c80ed                                                     // 29ec: 20 ed 80     .. :89ec[1]
+    ldx #0                                                            // 29ef: a2 00       ..  :89ef[1]
+    jsr clc_jmp_gsinit                                                // 29f1: 20 4c 87     L. :89f1[1]
+    bne c8a19                                                         // 29f4: d0 23       .#  :89f4[1]
+// $29f6 referenced 1 time by $8a1c
+c89f6
+    stx l00aa                                                         // 29f6: 86 aa       ..  :89f6[1]
+    jsr sub_c8284                                                     // 29f8: 20 84 82     .. :89f8[1]
+    bcs c8a00                                                         // 29fb: b0 03       ..  :89fb[1]
+    jmp c822a                                                         // 29fd: 4c 2a 82    L*. :89fd[1]
+
+// $2a00 referenced 2 times by $89fb, $8a13
+c8a00
+    jsr sub_c9a63                                                     // 2a00: 20 63 9a     c. :8a00[1]
+    lda l0e0f,y                                                       // 2a03: b9 0f 0e    ... :8a03[1]
+    and #$7f                                                          // 2a06: 29 7f       ).  :8a06[1]
+    ora l00aa                                                         // 2a08: 05 aa       ..  :8a08[1]
+    sta l0e0f,y                                                       // 2a0a: 99 0f 0e    ... :8a0a[1]
+    jsr sub_c8335                                                     // 2a0d: 20 35 83     5. :8a0d[1]
+    jsr sub_c8280                                                     // 2a10: 20 80 82     .. :8a10[1]
+    bcs c8a00                                                         // 2a13: b0 eb       ..  :8a13[1]
+    bcc c89d7                                                         // 2a15: 90 c0       ..  :8a15[1]
+// $2a17 referenced 1 time by $8a22
+loop_c8a17
+    ldx #$80                                                          // 2a17: a2 80       ..  :8a17[1]
+// $2a19 referenced 1 time by $89f4
+c8a19
+    jsr sub_c8149                                                     // 2a19: 20 49 81     I. :8a19[1]
+    bcs c89f6                                                         // 2a1c: b0 d8       ..  :8a1c[1]
+    and #$5f // '_'                                                   // 2a1e: 29 5f       )_  :8a1e[1]
+    cmp #$4c // 'L'                                                   // 2a20: c9 4c       .L  :8a20[1]
+    beq loop_c8a17                                                    // 2a22: f0 f3       ..  :8a22[1]
+    jsr generate_error_precheck_bad                                   // 2a24: 20 2e 80     .. :8a24[1]
+    .byt $cf                                                          // 2a27: cf          .   :8a27[1]
+    .asc "attribute"                                                  // 2a28: 61 74 74... att :8a28[1]
+    .byt 0                                                            // 2a31: 00          .   :8a31[1]
+
+    jsr sub_c83e3                                                     // 2a32: 20 e3 83     .. :8a32[1]
+    txa                                                               // 2a35: 8a          .   :8a35[1]
+    cmp #4                                                            // 2a36: c9 04       ..  :8a36[1]
+    beq c8a54                                                         // 2a38: f0 1a       ..  :8a38[1]
+    cmp #2                                                            // 2a3a: c9 02       ..  :8a3a[1]
+    bcc c8a49                                                         // 2a3c: 90 0b       ..  :8a3c[1]
+    jsr generate_error_precheck_bad                                   // 2a3e: 20 2e 80     .. :8a3e[1]
+    .byt $cb                                                          // 2a41: cb          .   :8a41[1]
+    .asc "option"                                                     // 2a42: 6f 70 74... opt :8a42[1]
+    .byt 0                                                            // 2a48: 00          .   :8a48[1]
+
+// $2a49 referenced 1 time by $8a3c
+c8a49
+    ldx #$ff                                                          // 2a49: a2 ff       ..  :8a49[1]
+    tya                                                               // 2a4b: 98          .   :8a4b[1]
+    beq c8a50                                                         // 2a4c: f0 02       ..  :8a4c[1]
+    ldx #0                                                            // 2a4e: a2 00       ..  :8a4e[1]
+// $2a50 referenced 1 time by $8a4c
+c8a50
+    stx l10c6                                                         // 2a50: 8e c6 10    ... :8a50[1]
+    rts                                                               // 2a53: 60          `   :8a53[1]
+
+// $2a54 referenced 1 time by $8a38
+c8a54
+    tya                                                               // 2a54: 98          .   :8a54[1]
+    pha                                                               // 2a55: 48          H   :8a55[1]
+    jsr sub_c8b7b                                                     // 2a56: 20 7b 8b     {. :8a56[1]
+    jsr c940c                                                         // 2a59: 20 0c 94     .. :8a59[1]
+    pla                                                               // 2a5c: 68          h   :8a5c[1]
+    jsr sub_c81c5                                                     // 2a5d: 20 c5 81     .. :8a5d[1]
+    eor l0f06                                                         // 2a60: 4d 06 0f    M.. :8a60[1]
+    and #$30 // '0'                                                   // 2a63: 29 30       )0  :8a63[1]
+    eor l0f06                                                         // 2a65: 4d 06 0f    M.. :8a65[1]
+    sta l0f06                                                         // 2a68: 8d 06 0f    ... :8a68[1]
+    jmp c93e6                                                         // 2a6b: 4c e6 93    L.. :8a6b[1]
+
+// $2a6e referenced 2 times by $8ac8, $a414
+c8a6e
+    jsr generate_error_precheck_disc                                  // 2a6e: 20 23 80     #. :8a6e[1]
+    .byt $c6                                                          // 2a71: c6          .   :8a71[1]
+    .asc "full"                                                       // 2a72: 66 75 6c... ful :8a72[1]
+    .byt 0                                                            // 2a76: 00          .   :8a76[1]
+
+// $2a77 referenced 2 times by $8859, $9c4e
+sub_c8a77
+    jsr sub_c80f3                                                     // 2a77: 20 f3 80     .. :8a77[1]
+    jsr sub_c8284                                                     // 2a7a: 20 84 82     .. :8a7a[1]
+    bcc c8a82                                                         // 2a7d: 90 03       ..  :8a7d[1]
+    jsr sub_c830a                                                     // 2a7f: 20 0a 83     .. :8a7f[1]
+// $2a82 referenced 1 time by $8a7d
+c8a82
+    lda l00c0                                                         // 2a82: a5 c0       ..  :8a82[1]
+    pha                                                               // 2a84: 48          H   :8a84[1]
+    lda l00c1                                                         // 2a85: a5 c1       ..  :8a85[1]
+    pha                                                               // 2a87: 48          H   :8a87[1]
+    sec                                                               // 2a88: 38          8   :8a88[1]
+    lda l00c2                                                         // 2a89: a5 c2       ..  :8a89[1]
+    sbc l00c0                                                         // 2a8b: e5 c0       ..  :8a8b[1]
+    sta l00c0                                                         // 2a8d: 85 c0       ..  :8a8d[1]
+    lda l00c3                                                         // 2a8f: a5 c3       ..  :8a8f[1]
+    sbc l00c1                                                         // 2a91: e5 c1       ..  :8a91[1]
+    sta l00c1                                                         // 2a93: 85 c1       ..  :8a93[1]
+    lda l107a                                                         // 2a95: ad 7a 10    .z. :8a95[1]
+    sbc l1078                                                         // 2a98: ed 78 10    .x. :8a98[1]
+    sta l00c4                                                         // 2a9b: 85 c4       ..  :8a9b[1]
+    jsr sub_c8ab3                                                     // 2a9d: 20 b3 8a     .. :8a9d[1]
+    lda l1079                                                         // 2aa0: ad 79 10    .y. :8aa0[1]
+    sta l1075                                                         // 2aa3: 8d 75 10    .u. :8aa3[1]
+    lda l1078                                                         // 2aa6: ad 78 10    .x. :8aa6[1]
+    sta l1074                                                         // 2aa9: 8d 74 10    .t. :8aa9[1]
+    pla                                                               // 2aac: 68          h   :8aac[1]
+    sta l00bd                                                         // 2aad: 85 bd       ..  :8aad[1]
+    pla                                                               // 2aaf: 68          h   :8aaf[1]
+    sta l00bc                                                         // 2ab0: 85 bc       ..  :8ab0[1]
+    rts                                                               // 2ab2: 60          `   :8ab2[1]
+
+// $2ab3 referenced 2 times by $8a9d, $a50a
+sub_c8ab3
+    lda #0                                                            // 2ab3: a9 00       ..  :8ab3[1]
+    sta l00c2                                                         // 2ab5: 85 c2       ..  :8ab5[1]
+    lda #2                                                            // 2ab7: a9 02       ..  :8ab7[1]
+    sta l00c3                                                         // 2ab9: 85 c3       ..  :8ab9[1]
+    ldy l0f05                                                         // 2abb: ac 05 0f    ... :8abb[1]
+    cpy #$f8                                                          // 2abe: c0 f8       ..  :8abe[1]
+    bcs c8b18                                                         // 2ac0: b0 56       .V  :8ac0[1]
+    jsr sub_c8602                                                     // 2ac2: 20 02 86     .. :8ac2[1]
+    jmp c8ad0                                                         // 2ac5: 4c d0 8a    L.. :8ac5[1]
+
+// $2ac8 referenced 1 time by $8ad1
+loop_c8ac8
+    beq c8a6e                                                         // 2ac8: f0 a4       ..  :8ac8[1]
+    jsr sub_c82b2                                                     // 2aca: 20 b2 82     .. :8aca[1]
+    jsr sub_c85e3                                                     // 2acd: 20 e3 85     .. :8acd[1]
+// $2ad0 referenced 1 time by $8ac5
+c8ad0
+    tya                                                               // 2ad0: 98          .   :8ad0[1]
+    bcc loop_c8ac8                                                    // 2ad1: 90 f5       ..  :8ad1[1]
+    sty l00b0                                                         // 2ad3: 84 b0       ..  :8ad3[1]
+    ldy l0f05                                                         // 2ad5: ac 05 0f    ... :8ad5[1]
+// $2ad8 referenced 1 time by $8ae9
+loop_c8ad8
+    cpy l00b0                                                         // 2ad8: c4 b0       ..  :8ad8[1]
+    beq c8aeb                                                         // 2ada: f0 0f       ..  :8ada[1]
+    lda l0e07,y                                                       // 2adc: b9 07 0e    ... :8adc[1]
+    sta l0e0f,y                                                       // 2adf: 99 0f 0e    ... :8adf[1]
+    lda l0f07,y                                                       // 2ae2: b9 07 0f    ... :8ae2[1]
+    sta l0f0f,y                                                       // 2ae5: 99 0f 0f    ... :8ae5[1]
+    dey                                                               // 2ae8: 88          .   :8ae8[1]
+    bcs loop_c8ad8                                                    // 2ae9: b0 ed       ..  :8ae9[1]
+// $2aeb referenced 1 time by $8ada
+c8aeb
+    ldx #0                                                            // 2aeb: a2 00       ..  :8aeb[1]
+    jsr sub_c8b25                                                     // 2aed: 20 25 8b     %. :8aed[1]
+// $2af0 referenced 1 time by $8af9
+loop_c8af0
+    lda l00c5,x                                                       // 2af0: b5 c5       ..  :8af0[1]
+    sta l0e08,y                                                       // 2af2: 99 08 0e    ... :8af2[1]
+    iny                                                               // 2af5: c8          .   :8af5[1]
+    inx                                                               // 2af6: e8          .   :8af6[1]
+    cpx #8                                                            // 2af7: e0 08       ..  :8af7[1]
+    bne loop_c8af0                                                    // 2af9: d0 f5       ..  :8af9[1]
+// $2afb referenced 1 time by $8b02
+loop_c8afb
+    lda l00bb,x                                                       // 2afb: b5 bb       ..  :8afb[1]
+    dey                                                               // 2afd: 88          .   :8afd[1]
+    sta l0f08,y                                                       // 2afe: 99 08 0f    ... :8afe[1]
+    dex                                                               // 2b01: ca          .   :8b01[1]
+    bne loop_c8afb                                                    // 2b02: d0 f7       ..  :8b02[1]
+    jsr sub_c8335                                                     // 2b04: 20 35 83     5. :8b04[1]
+    tya                                                               // 2b07: 98          .   :8b07[1]
+    pha                                                               // 2b08: 48          H   :8b08[1]
+    ldy l0f05                                                         // 2b09: ac 05 0f    ... :8b09[1]
+    jsr sub_c87da                                                     // 2b0c: 20 da 87     .. :8b0c[1]
+    sty l0f05                                                         // 2b0f: 8c 05 0f    ... :8b0f[1]
+    jsr c93e6                                                         // 2b12: 20 e6 93     .. :8b12[1]
+    pla                                                               // 2b15: 68          h   :8b15[1]
+    tay                                                               // 2b16: a8          .   :8b16[1]
+    rts                                                               // 2b17: 60          `   :8b17[1]
+
+// $2b18 referenced 1 time by $8ac0
+c8b18
+    jsr generate_error_precheck                                       // 2b18: 20 38 80     8. :8b18[1]
+    .byt $be                                                          // 2b1b: be          .   :8b1b[1]
+    .asc "Cat full"                                                   // 2b1c: 43 61 74... Cat :8b1c[1]
+    .byt 0                                                            // 2b24: 00          .   :8b24[1]
+
+// $2b25 referenced 1 time by $8aed
+sub_c8b25
+    lda l1076                                                         // 2b25: ad 76 10    .v. :8b25[1]
+    and #3                                                            // 2b28: 29 03       ).  :8b28[1]
+    asl                                                               // 2b2a: 0a          .   :8b2a[1]
+    asl                                                               // 2b2b: 0a          .   :8b2b[1]
+    eor l00c4                                                         // 2b2c: 45 c4       E.  :8b2c[1]
+    and #$fc                                                          // 2b2e: 29 fc       ).  :8b2e[1]
+    eor l00c4                                                         // 2b30: 45 c4       E.  :8b30[1]
+    asl                                                               // 2b32: 0a          .   :8b32[1]
+    asl                                                               // 2b33: 0a          .   :8b33[1]
+    eor l1074                                                         // 2b34: 4d 74 10    Mt. :8b34[1]
+    and #$fc                                                          // 2b37: 29 fc       ).  :8b37[1]
+    eor l1074                                                         // 2b39: 4d 74 10    Mt. :8b39[1]
+    asl                                                               // 2b3c: 0a          .   :8b3c[1]
+    asl                                                               // 2b3d: 0a          .   :8b3d[1]
+    eor l00c2                                                         // 2b3e: 45 c2       E.  :8b3e[1]
+    and #$fc                                                          // 2b40: 29 fc       ).  :8b40[1]
+    eor l00c2                                                         // 2b42: 45 c2       E.  :8b42[1]
+    sta l00c2                                                         // 2b44: 85 c2       ..  :8b44[1]
+    rts                                                               // 2b46: 60          `   :8b46[1]
+
+sub_c8b47
+    lda #1                                                            // 2b47: a9 01       ..  :8b47[1]
+    sta l10c7                                                         // 2b49: 8d c7 10    ... :8b49[1]
+    rts                                                               // 2b4c: 60          `   :8b4c[1]
+
+// $2b4d referenced 2 times by $883c, $a4fd
+sub_c8b4d
+    lda #0                                                            // 2b4d: a9 00       ..  :8b4d[1]
+    sta l1075                                                         // 2b4f: 8d 75 10    .u. :8b4f[1]
+    lda l00c2                                                         // 2b52: a5 c2       ..  :8b52[1]
+    jsr sub_c81b7                                                     // 2b54: 20 b7 81     .. :8b54[1]
+    cmp #3                                                            // 2b57: c9 03       ..  :8b57[1]
+    bne c8b60                                                         // 2b59: d0 05       ..  :8b59[1]
+    lda #$ff                                                          // 2b5b: a9 ff       ..  :8b5b[1]
+    sta l1075                                                         // 2b5d: 8d 75 10    .u. :8b5d[1]
+// $2b60 referenced 1 time by $8b59
+c8b60
+    sta l1074                                                         // 2b60: 8d 74 10    .t. :8b60[1]
+    rts                                                               // 2b63: 60          `   :8b63[1]
+
+// $2b64 referenced 2 times by $884a, $a500
+sub_c8b64
+    lda #0                                                            // 2b64: a9 00       ..  :8b64[1]
+    sta l1077                                                         // 2b66: 8d 77 10    .w. :8b66[1]
+    lda l00c2                                                         // 2b69: a5 c2       ..  :8b69[1]
+    jsr sub_c81ae                                                     // 2b6b: 20 ae 81     .. :8b6b[1]
+    cmp #3                                                            // 2b6e: c9 03       ..  :8b6e[1]
+    bne c8b77                                                         // 2b70: d0 05       ..  :8b70[1]
+    lda #$ff                                                          // 2b72: a9 ff       ..  :8b72[1]
+    sta l1077                                                         // 2b74: 8d 77 10    .w. :8b74[1]
+// $2b77 referenced 1 time by $8b70
+c8b77
+    sta l1076                                                         // 2b77: 8d 76 10    .v. :8b77[1]
+    rts                                                               // 2b7a: 60          `   :8b7a[1]
+
+// $2b7b referenced 8 times by $80ed, $80f3, $8238, $89ba, $8a56, $975b, $988b, $98d7
+sub_c8b7b
+    lda l10c9                                                         // 2b7b: ad c9 10    ... :8b7b[1]
+    sta l00cc                                                         // 2b7e: 85 cc       ..  :8b7e[1]
+// $2b80 referenced 1 time by $8b89
+loop_c8b80
+    lda l10ca                                                         // 2b80: ad ca 10    ... :8b80[1]
+    jmp c8816                                                         // 2b83: 4c 16 88    L.. :8b83[1]
+
+// $2b86 referenced 3 times by $8486, $a244, $a7f9
+sub_c8b86
+    jsr clc_jmp_gsinit                                                // 2b86: 20 4c 87     L. :8b86[1]
+    beq loop_c8b80                                                    // 2b89: f0 f5       ..  :8b89[1]
+// $2b8b referenced 7 times by $8119, $87f1, $8999, $8b92, $a327, $a330, $a637
+c8b8b
+    jsr sub_c8149                                                     // 2b8b: 20 49 81     I. :8b8b[1]
+    bcs c8ba2                                                         // 2b8e: b0 12       ..  :8b8e[1]
+    cmp #$3a // ':'                                                   // 2b90: c9 3a       .:  :8b90[1]
+    beq c8b8b                                                         // 2b92: f0 f7       ..  :8b92[1]
+    sec                                                               // 2b94: 38          8   :8b94[1]
+    sbc #$30 // '0'                                                   // 2b95: e9 30       .0  :8b95[1]
+    bcc c8ba2                                                         // 2b97: 90 09       ..  :8b97[1]
+    cmp #4                                                            // 2b99: c9 04       ..  :8b99[1]
+    bcs c8ba2                                                         // 2b9b: b0 05       ..  :8b9b[1]
+    jsr c8816                                                         // 2b9d: 20 16 88     .. :8b9d[1]
+    clc                                                               // 2ba0: 18          .   :8ba0[1]
+    rts                                                               // 2ba1: 60          `   :8ba1[1]
+
+// $2ba2 referenced 5 times by $8b8e, $8b97, $8b9b, $8bcd, $a660
+c8ba2
+    jsr generate_error_precheck_bad                                   // 2ba2: 20 2e 80     .. :8ba2[1]
+    .byt $cd                                                          // 2ba5: cd          .   :8ba5[1]
+    .asc "drive"                                                      // 2ba6: 64 72 69... dri :8ba6[1]
+    .byt 0                                                            // 2bab: 00          .   :8bab[1]
+
+sub_c8bac
+    jsr c99a3                                                         // 2bac: 20 a3 99     .. :8bac[1]
+    jsr sub_ca14a                                                     // 2baf: 20 4a a1     J. :8baf[1]
+    jsr sub_c80ed                                                     // 2bb2: 20 ed 80     .. :8bb2[1]
+    tya                                                               // 2bb5: 98          .   :8bb5[1]
+    pha                                                               // 2bb6: 48          H   :8bb6[1]
+    jsr c8225                                                         // 2bb7: 20 25 82     %. :8bb7[1]
+    jsr sub_c9a60                                                     // 2bba: 20 60 9a     `. :8bba[1]
+    sty l00c4                                                         // 2bbd: 84 c4       ..  :8bbd[1]
+    pla                                                               // 2bbf: 68          h   :8bbf[1]
+    tay                                                               // 2bc0: a8          .   :8bc0[1]
+    jsr sub_ca14a                                                     // 2bc1: 20 4a a1     J. :8bc1[1]
+    lda l00cd                                                         // 2bc4: a5 cd       ..  :8bc4[1]
+    pha                                                               // 2bc6: 48          H   :8bc6[1]
+    jsr sub_c80ed                                                     // 2bc7: 20 ed 80     .. :8bc7[1]
+    pla                                                               // 2bca: 68          h   :8bca[1]
+    cmp l00cd                                                         // 2bcb: c5 cd       ..  :8bcb[1]
+    bne c8ba2                                                         // 2bcd: d0 d3       ..  :8bcd[1]
+    jsr sub_c8284                                                     // 2bcf: 20 84 82     .. :8bcf[1]
+    bcc c8be3                                                         // 2bd2: 90 0f       ..  :8bd2[1]
+    cpy l00c4                                                         // 2bd4: c4 c4       ..  :8bd4[1]
+    beq c8be3                                                         // 2bd6: f0 0b       ..  :8bd6[1]
+    jsr generate_error_precheck                                       // 2bd8: 20 38 80     8. :8bd8[1]
+    .byt $c4                                                          // 2bdb: c4          .   :8bdb[1]
+    .asc "Exists"                                                     // 2bdc: 45 78 69... Exi :8bdc[1]
+    .byt 0                                                            // 2be2: 00          .   :8be2[1]
+
+// $2be3 referenced 2 times by $8bd2, $8bd6
+c8be3
+    ldy l00c4                                                         // 2be3: a4 c4       ..  :8be3[1]
+    jsr sub_c87da                                                     // 2be5: 20 da 87     .. :8be5[1]
+    ldx #7                                                            // 2be8: a2 07       ..  :8be8[1]
+// $2bea referenced 1 time by $8bf1
+loop_c8bea
+    lda l00c5,x                                                       // 2bea: b5 c5       ..  :8bea[1]
+    sta l0e07,y                                                       // 2bec: 99 07 0e    ... :8bec[1]
+    dey                                                               // 2bef: 88          .   :8bef[1]
+    dex                                                               // 2bf0: ca          .   :8bf0[1]
+    bpl loop_c8bea                                                    // 2bf1: 10 f7       ..  :8bf1[1]
+    jmp c93e6                                                         // 2bf3: 4c e6 93    L.. :8bf3[1]
+
+// $2bf6 referenced 1 time by $9466
+sub_c8bf6
+    clc                                                               // 2bf6: 18          .   :8bf6[1]
+    bcc c8bfb                                                         // 2bf7: 90 02       ..  :8bf7[1]
+// $2bf9 referenced 1 time by $9211
+sub_c8bf9
+    cli                                                               // 2bf9: 58          X   :8bf9[1]
+    sec                                                               // 2bfa: 38          8   :8bfa[1]
+// $2bfb referenced 1 time by $8bf7
+c8bfb
+    ror l00b2                                                         // 2bfb: 66 b2       f.  :8bfb[1]
+    stx l00b0                                                         // 2bfd: 86 b0       ..  :8bfd[1]
+    sty l00b1                                                         // 2bff: 84 b1       ..  :8bff[1]
+    cld                                                               // 2c01: d8          .   :8c01[1]
+    jsr sub_c8c65                                                     // 2c02: 20 65 8c     e. :8c02[1]
+    lda l00a2                                                         // 2c05: a5 a2       ..  :8c05[1]
+    bne c8c12                                                         // 2c07: d0 09       ..  :8c07[1]
+    ldy #5                                                            // 2c09: a0 05       ..  :8c09[1]
+    lda (l00b0),y                                                     // 2c0b: b1 b0       ..  :8c0b[1]
+    beq c8c12                                                         // 2c0d: f0 03       ..  :8c0d[1]
+    jsr sub_c8d1a                                                     // 2c0f: 20 1a 8d     .. :8c0f[1]
+// $2c12 referenced 2 times by $8c07, $8c0d
+c8c12
+    ldy #5                                                            // 2c12: a0 05       ..  :8c12[1]
+    lda (l00b0),y                                                     // 2c14: b1 b0       ..  :8c14[1]
+    clc                                                               // 2c16: 18          .   :8c16[1]
+    adc #7                                                            // 2c17: 69 07       i.  :8c17[1]
+    tay                                                               // 2c19: a8          .   :8c19[1]
+    lda l00a2                                                         // 2c1a: a5 a2       ..  :8c1a[1]
+    jsr sub_c8c56                                                     // 2c1c: 20 56 8c     V. :8c1c[1]
+    sta (l00b0),y                                                     // 2c1f: 91 b0       ..  :8c1f[1]
+    ldx l00a7                                                         // 2c21: a6 a7       ..  :8c21[1]
+    cpx #$80                                                          // 2c23: e0 80       ..  :8c23[1]
+    bne c8c2e                                                         // 2c25: d0 07       ..  :8c25[1]
+    lda lfe84                                                         // 2c27: ad 84 fe    ... :8c27[1]
+    and #$20 // ' '                                                   // 2c2a: 29 20       )   :8c2a[1]
+    ora (l00b0),y                                                     // 2c2c: 11 b0       ..  :8c2c[1]
+// $2c2e referenced 1 time by $8c25
+c8c2e
+    pha                                                               // 2c2e: 48          H   :8c2e[1]
+    and #$df                                                          // 2c2f: 29 df       ).  :8c2f[1]
+    cmp #$18                                                          // 2c31: c9 18       ..  :8c31[1]
+    bne c8c3a                                                         // 2c33: d0 05       ..  :8c33[1]
+    lda #$ff                                                          // 2c35: a9 ff       ..  :8c35[1]
+    sta l1087                                                         // 2c37: 8d 87 10    ... :8c37[1]
+// $2c3a referenced 1 time by $8c33
+c8c3a
+    lda l00cd                                                         // 2c3a: a5 cd       ..  :8c3a[1]
+    and #1                                                            // 2c3c: 29 01       ).  :8c3c[1]
+    tay                                                               // 2c3e: a8          .   :8c3e[1]
+    lda l00ce                                                         // 2c3f: a5 ce       ..  :8c3f[1]
+    sta l1088,y                                                       // 2c41: 99 88 10    ... :8c41[1]
+    jsr c8f2a                                                         // 2c44: 20 2a 8f     *. :8c44[1]
+    bit l00a1                                                         // 2c47: 24 a1       $.  :8c47[1]
+    bpl c8c4e                                                         // 2c49: 10 03       ..  :8c49[1]
+    jsr sub_c8f7a                                                     // 2c4b: 20 7a 8f     z. :8c4b[1]
+// $2c4e referenced 1 time by $8c49
+c8c4e
+    jsr sub_c8f5e                                                     // 2c4e: 20 5e 8f     ^. :8c4e[1]
+    lda lfe87                                                         // 2c51: ad 87 fe    ... :8c51[1]
+    pla                                                               // 2c54: 68          h   :8c54[1]
+    rts                                                               // 2c55: 60          `   :8c55[1]
+
+// $2c56 referenced 1 time by $8c1c
+sub_c8c56
+    ldx #5                                                            // 2c56: a2 05       ..  :8c56[1]
+// $2c58 referenced 1 time by $8c5e
+loop_c8c58
+    cmp l9139,x                                                       // 2c58: dd 39 91    .9. :8c58[1]
+    beq c8c61                                                         // 2c5b: f0 04       ..  :8c5b[1]
+    dex                                                               // 2c5d: ca          .   :8c5d[1]
+    bpl loop_c8c58                                                    // 2c5e: 10 f8       ..  :8c5e[1]
+    rts                                                               // 2c60: 60          `   :8c60[1]
+
+// $2c61 referenced 1 time by $8c5b
+c8c61
+    lda l913f,x                                                       // 2c61: bd 3f 91    .?. :8c61[1]
+    rts                                                               // 2c64: 60          `   :8c64[1]
+
+// $2c65 referenced 1 time by $8c02
+sub_c8c65
+    jsr sub_c8f4f                                                     // 2c65: 20 4f 8f     O. :8c65[1]
+    jsr sub_c8f82                                                     // 2c68: 20 82 8f     .. :8c68[1]
+    lda #0                                                            // 2c6b: a9 00       ..  :8c6b[1]
+    sta l00a1                                                         // 2c6d: 85 a1       ..  :8c6d[1]
+    ldy #9                                                            // 2c6f: a0 09       ..  :8c6f[1]
+// $2c71 referenced 1 time by $8c79
+loop_c8c71
+    lda (l00b0),y                                                     // 2c71: b1 b0       ..  :8c71[1]
+    sta l00aa,y                                                       // 2c73: 99 aa 00    ... :8c73[1]
+    iny                                                               // 2c76: c8          .   :8c76[1]
+    cpy #$0c                                                          // 2c77: c0 0c       ..  :8c77[1]
+    bne loop_c8c71                                                    // 2c79: d0 f6       ..  :8c79[1]
+    ldy #6                                                            // 2c7b: a0 06       ..  :8c7b[1]
+    lda (l00b0),y                                                     // 2c7d: b1 b0       ..  :8c7d[1]
+    and #$f0                                                          // 2c7f: 29 f0       ).  :8c7f[1]
+    cmp #$a0                                                          // 2c81: c9 a0       ..  :8c81[1]
+    beq c8c87                                                         // 2c83: f0 02       ..  :8c83[1]
+    cmp #$f0                                                          // 2c85: c9 f0       ..  :8c85[1]
+// $2c87 referenced 1 time by $8c83
+c8c87
+    ror l00a1                                                         // 2c87: 66 a1       f.  :8c87[1]
+    ldy #3                                                            // 2c89: a0 03       ..  :8c89[1]
+    lda (l00b0),y                                                     // 2c8b: b1 b0       ..  :8c8b[1]
+    iny                                                               // 2c8d: c8          .   :8c8d[1]
+    and (l00b0),y                                                     // 2c8e: 31 b0       1.  :8c8e[1]
+    cmp #$ff                                                          // 2c90: c9 ff       ..  :8c90[1]
+    clc                                                               // 2c92: 18          .   :8c92[1]
+    beq c8cb2                                                         // 2c93: f0 1d       ..  :8c93[1]
+    jsr sub_c8f3f                                                     // 2c95: 20 3f 8f     ?. :8c95[1]
+    clc                                                               // 2c98: 18          .   :8c98[1]
+    bmi c8cb2                                                         // 2c99: 30 17       0.  :8c99[1]
+    jsr sub_c8f6b                                                     // 2c9b: 20 6b 8f     k. :8c9b[1]
+    lda l00a1                                                         // 2c9e: a5 a1       ..  :8c9e[1]
+    rol                                                               // 2ca0: 2a          *   :8ca0[1]
+    rol                                                               // 2ca1: 2a          *   :8ca1[1]
+    and #1                                                            // 2ca2: 29 01       ).  :8ca2[1]
+    eor #1                                                            // 2ca4: 49 01       I.  :8ca4[1]
+    ldx l00b0                                                         // 2ca6: a6 b0       ..  :8ca6[1]
+    ldy l00b1                                                         // 2ca8: a4 b1       ..  :8ca8[1]
+    inx                                                               // 2caa: e8          .   :8caa[1]
+    bne c8cae                                                         // 2cab: d0 01       ..  :8cab[1]
+    iny                                                               // 2cad: c8          .   :8cad[1]
+// $2cae referenced 1 time by $8cab
+c8cae
+    jsr tube_entry                                                    // 2cae: 20 06 04     .. :8cae[1]
+    sec                                                               // 2cb1: 38          8   :8cb1[1]
+// $2cb2 referenced 2 times by $8c93, $8c99
+c8cb2
+    ror l00a1                                                         // 2cb2: 66 a1       f.  :8cb2[1]
+    jsr sub_c8f94                                                     // 2cb4: 20 94 8f     .. :8cb4[1]
+    ldy #0                                                            // 2cb7: a0 00       ..  :8cb7[1]
+    lda (l00b0),y                                                     // 2cb9: b1 b0       ..  :8cb9[1]
+    bmi c8cc1                                                         // 2cbb: 30 04       0.  :8cbb[1]
+    and #$0f                                                          // 2cbd: 29 0f       ).  :8cbd[1]
+    sta l00cd                                                         // 2cbf: 85 cd       ..  :8cbf[1]
+// $2cc1 referenced 1 time by $8cbb
+c8cc1
+    lda l00cd                                                         // 2cc1: a5 cd       ..  :8cc1[1]
+    and #3                                                            // 2cc3: 29 03       ).  :8cc3[1]
+    tax                                                               // 2cc5: aa          .   :8cc5[1]
+    lda l10de,x                                                       // 2cc6: bd de 10    ... :8cc6[1]
+    sta l108a                                                         // 2cc9: 8d 8a 10    ... :8cc9[1]
+    lda l00cd                                                         // 2ccc: a5 cd       ..  :8ccc[1]
+    ldy #$0a                                                          // 2cce: a0 0a       ..  :8cce[1]
+    and #8                                                            // 2cd0: 29 08       ).  :8cd0[1]
+    beq c8cd6                                                         // 2cd2: f0 02       ..  :8cd2[1]
+    ldy #$10                                                          // 2cd4: a0 10       ..  :8cd4[1]
+// $2cd6 referenced 1 time by $8cd2
+c8cd6
+    sty l00a3                                                         // 2cd6: 84 a3       ..  :8cd6[1]
+    eor l911d,x                                                       // 2cd8: 5d 1d 91    ].. :8cd8[1]
+    sta lfe80                                                         // 2cdb: 8d 80 fe    ... :8cdb[1]
+    lsr                                                               // 2cde: 4a          J   :8cde[1]
+    ldx l1088                                                         // 2cdf: ae 88 10    ... :8cdf[1]
+    bcs c8ce7                                                         // 2ce2: b0 03       ..  :8ce2[1]
+    ldx l1089                                                         // 2ce4: ae 89 10    ... :8ce4[1]
+// $2ce7 referenced 1 time by $8ce2
+c8ce7
+    ldy #0                                                            // 2ce7: a0 00       ..  :8ce7[1]
+    sty l00a2                                                         // 2ce9: 84 a2       ..  :8ce9[1]
+    lda l1087                                                         // 2ceb: ad 87 10    ... :8ceb[1]
+    bit l1087                                                         // 2cee: 2c 87 10    ,.. :8cee[1]
+    bcc c8cfc                                                         // 2cf1: 90 09       ..  :8cf1[1]
+    bpl c8d0d                                                         // 2cf3: 10 18       ..  :8cf3[1]
+    sty l1088                                                         // 2cf5: 8c 88 10    ... :8cf5[1]
+    and #$7f                                                          // 2cf8: 29 7f       ).  :8cf8[1]
+    bpl c8d03                                                         // 2cfa: 10 07       ..  :8cfa[1]
+// $2cfc referenced 1 time by $8cf1
+c8cfc
+    bvc c8d0d                                                         // 2cfc: 50 0f       P.  :8cfc[1]
+    sty l1089                                                         // 2cfe: 8c 89 10    ... :8cfe[1]
+    and #$bf                                                          // 2d01: 29 bf       ).  :8d01[1]
+// $2d03 referenced 1 time by $8cfa
+c8d03
+    sta l1087                                                         // 2d03: 8d 87 10    ... :8d03[1]
+    lda #0                                                            // 2d06: a9 00       ..  :8d06[1]
+    jsr c8e12                                                         // 2d08: 20 12 8e     .. :8d08[1]
+    ldx #0                                                            // 2d0b: a2 00       ..  :8d0b[1]
+// $2d0d referenced 2 times by $8cf3, $8cfc
+c8d0d
+    txa                                                               // 2d0d: 8a          .   :8d0d[1]
+    sta l00ce                                                         // 2d0e: 85 ce       ..  :8d0e[1]
+    jsr c8f2a                                                         // 2d10: 20 2a 8f     *. :8d10[1]
+// $2d13 referenced 2 times by $8d1d, $8d25
+c8d13
+    rts                                                               // 2d13: 60          `   :8d13[1]
+
+// $2d14 referenced 1 time by $8d29
+loop_c8d14
+    jmp c8eaf                                                         // 2d14: 4c af 8e    L.. :8d14[1]
+
+// $2d17 referenced 1 time by $8d2d
+loop_c8d17
+    jmp c8e12                                                         // 2d17: 4c 12 8e    L.. :8d17[1]
+
+// $2d1a referenced 1 time by $8c0f
+sub_c8d1a
+    jsr sub_c8eff                                                     // 2d1a: 20 ff 8e     .. :8d1a[1]
+    bne c8d13                                                         // 2d1d: d0 f4       ..  :8d1d[1]
+    ldy #6                                                            // 2d1f: a0 06       ..  :8d1f[1]
+    lda (l00b0),y                                                     // 2d21: b1 b0       ..  :8d21[1]
+    cmp #$10                                                          // 2d23: c9 10       ..  :8d23[1]
+    beq c8d13                                                         // 2d25: f0 ec       ..  :8d25[1]
+    cmp #$c0                                                          // 2d27: c9 c0       ..  :8d27[1]
+    beq loop_c8d14                                                    // 2d29: f0 e9       ..  :8d29[1]
+    cmp #$e0                                                          // 2d2b: c9 e0       ..  :8d2b[1]
+    bcs loop_c8d17                                                    // 2d2d: b0 e8       ..  :8d2d[1]
+    ldy #8                                                            // 2d2f: a0 08       ..  :8d2f[1]
+    lda (l00b0),y                                                     // 2d31: b1 b0       ..  :8d31[1]
+    bit l00b2                                                         // 2d33: 24 b2       $.  :8d33[1]
+    bmi c8d92                                                         // 2d35: 30 5b       0[  :8d35[1]
+    ldx l00b5                                                         // 2d37: a6 b5       ..  :8d37[1]
+    beq c8d41                                                         // 2d39: f0 06       ..  :8d39[1]
+    inc l00b3                                                         // 2d3b: e6 b3       ..  :8d3b[1]
+    bne c8d41                                                         // 2d3d: d0 02       ..  :8d3d[1]
+    inc l00b4                                                         // 2d3f: e6 b4       ..  :8d3f[1]
+// $2d41 referenced 3 times by $8d39, $8d3d, $8d8f
+c8d41
+    jsr nmi_handler2_rom_end                                          // 2d41: 20 fb 90     .. :8d41[1]
+    sta l00cf                                                         // 2d44: 85 cf       ..  :8d44[1]
+    sbc l00a3                                                         // 2d46: e5 a3       ..  :8d46[1]
+    eor #$ff                                                          // 2d48: 49 ff       I.  :8d48[1]
+    clc                                                               // 2d4a: 18          .   :8d4a[1]
+    adc #1                                                            // 2d4b: 69 01       i.  :8d4b[1]
+    sta l00a5                                                         // 2d4d: 85 a5       ..  :8d4d[1]
+    lda l00b4                                                         // 2d4f: a5 b4       ..  :8d4f[1]
+    bne c8d74                                                         // 2d51: d0 21       .!  :8d51[1]
+    lda l00b3                                                         // 2d53: a5 b3       ..  :8d53[1]
+    beq c8d91                                                         // 2d55: f0 3a       .:  :8d55[1]
+    cmp l00a5                                                         // 2d57: c5 a5       ..  :8d57[1]
+    beq c8d5d                                                         // 2d59: f0 02       ..  :8d59[1]
+    bcs c8d74                                                         // 2d5b: b0 17       ..  :8d5b[1]
+// $2d5d referenced 1 time by $8d59
+c8d5d
+    sta l00a5                                                         // 2d5d: 85 a5       ..  :8d5d[1]
+    ldx l00b5                                                         // 2d5f: a6 b5       ..  :8d5f[1]
+    beq c8d74                                                         // 2d61: f0 11       ..  :8d61[1]
+    stx l00a6                                                         // 2d63: 86 a6       ..  :8d63[1]
+    ror l00a1                                                         // 2d65: 66 a1       f.  :8d65[1]
+    sec                                                               // 2d67: 38          8   :8d67[1]
+    rol l00a1                                                         // 2d68: 26 a1       &.  :8d68[1]
+    cmp #1                                                            // 2d6a: c9 01       ..  :8d6a[1]
+    bne c8d74                                                         // 2d6c: d0 06       ..  :8d6c[1]
+    lda nmi_lda_immXXX4+1                                             // 2d6e: ad 22 0d    .". :8d6e[1]
+    sta nmi_lda_immXXX3+1                                             // 2d71: 8d 4c 0d    .L. :8d71[1]
+// $2d74 referenced 4 times by $8d51, $8d5b, $8d61, $8d6c
+c8d74
+    lda l00b3                                                         // 2d74: a5 b3       ..  :8d74[1]
+    sec                                                               // 2d76: 38          8   :8d76[1]
+    sbc l00a5                                                         // 2d77: e5 a5       ..  :8d77[1]
+    sta l00b3                                                         // 2d79: 85 b3       ..  :8d79[1]
+    lda l00b4                                                         // 2d7b: a5 b4       ..  :8d7b[1]
+    sbc #0                                                            // 2d7d: e9 00       ..  :8d7d[1]
+    sta l00b4                                                         // 2d7f: 85 b4       ..  :8d7f[1]
+    jsr c8e0e                                                         // 2d81: 20 0e 8e     .. :8d81[1]
+    bne c8d91                                                         // 2d84: d0 0b       ..  :8d84[1]
+    lda l00b3                                                         // 2d86: a5 b3       ..  :8d86[1]
+    ora l00b4                                                         // 2d88: 05 b4       ..  :8d88[1]
+    beq c8d91                                                         // 2d8a: f0 05       ..  :8d8a[1]
+    jsr c8ecc                                                         // 2d8c: 20 cc 8e     .. :8d8c[1]
+    beq c8d41                                                         // 2d8f: f0 b0       ..  :8d8f[1]
+// $2d91 referenced 4 times by $8d55, $8d84, $8d8a, $8d9d
+c8d91
+    rts                                                               // 2d91: 60          `   :8d91[1]
+
+// $2d92 referenced 1 time by $8d35
+c8d92
+    jsr nmi_handler2_rom_end                                          // 2d92: 20 fb 90     .. :8d92[1]
+    sta l00cf                                                         // 2d95: 85 cf       ..  :8d95[1]
+    ldy #9                                                            // 2d97: a0 09       ..  :8d97[1]
+    lda (l00b0),y                                                     // 2d99: b1 b0       ..  :8d99[1]
+    and #$1f                                                          // 2d9b: 29 1f       ).  :8d9b[1]
+    beq c8d91                                                         // 2d9d: f0 f2       ..  :8d9d[1]
+    sta l00a5                                                         // 2d9f: 85 a5       ..  :8d9f[1]
+    bit l00a1                                                         // 2da1: 24 a1       $.  :8da1[1]
+    bvs c8e0e                                                         // 2da3: 70 69       pi  :8da3[1]
+    bit l108a                                                         // 2da5: 2c 8a 10    ,.. :8da5[1]
+    bvc c8e0e                                                         // 2da8: 50 64       Pd  :8da8[1]
+    ldx #$33 // '3'                                                   // 2daa: a2 33       .3  :8daa[1]
+// $2dac referenced 1 time by $8db3
+loop_c8dac
+    lda c0d60,x                                                       // 2dac: bd 60 0d    .`. :8dac[1]
+    sta l1000,x                                                       // 2daf: 9d 00 10    ... :8daf[1]
+    dex                                                               // 2db2: ca          .   :8db2[1]
+    bpl loop_c8dac                                                    // 2db3: 10 f7       ..  :8db3[1]
+    jsr sub_c8dc6                                                     // 2db5: 20 c6 8d     .. :8db5[1]
+    ldx #$33 // '3'                                                   // 2db8: a2 33       .3  :8db8[1]
+// $2dba referenced 1 time by $8dc1
+loop_c8dba
+    lda l1000,x                                                       // 2dba: bd 00 10    ... :8dba[1]
+    sta c0d60,x                                                       // 2dbd: 9d 60 0d    .`. :8dbd[1]
+    dex                                                               // 2dc0: ca          .   :8dc0[1]
+    bpl loop_c8dba                                                    // 2dc1: 10 f7       ..  :8dc1[1]
+    lda l00a2                                                         // 2dc3: a5 a2       ..  :8dc3[1]
+    rts                                                               // 2dc5: 60          `   :8dc5[1]
+
+// $2dc6 referenced 1 time by $8db5
+sub_c8dc6
+    lda #0                                                            // 2dc6: a9 00       ..  :8dc6[1]
+    sta l00b4                                                         // 2dc8: 85 b4       ..  :8dc8[1]
+    lda (l00b0),y                                                     // 2dca: b1 b0       ..  :8dca[1]
+    and #$e0                                                          // 2dcc: 29 e0       ).  :8dcc[1]
+    bne c8dd2                                                         // 2dce: d0 02       ..  :8dce[1]
+    lda #$10                                                          // 2dd0: a9 10       ..  :8dd0[1]
+// $2dd2 referenced 1 time by $8dce
+c8dd2
+    asl                                                               // 2dd2: 0a          .   :8dd2[1]
+    rol l00b4                                                         // 2dd3: 26 b4       &.  :8dd3[1]
+    asl                                                               // 2dd5: 0a          .   :8dd5[1]
+    rol l00b4                                                         // 2dd6: 26 b4       &.  :8dd6[1]
+    asl                                                               // 2dd8: 0a          .   :8dd8[1]
+    rol l00b4                                                         // 2dd9: 26 b4       &.  :8dd9[1]
+    sta l00b3                                                         // 2ddb: 85 b3       ..  :8ddb[1]
+    tax                                                               // 2ddd: aa          .   :8ddd[1]
+    beq c8de2                                                         // 2dde: f0 02       ..  :8dde[1]
+    inc l00b4                                                         // 2de0: e6 b4       ..  :8de0[1]
+// $2de2 referenced 1 time by $8dde
+c8de2
+    jsr nmi3_handler_rom_end                                          // 2de2: 20 3e 90     >. :8de2[1]
+    lda #$14                                                          // 2de5: a9 14       ..  :8de5[1]
+    sta l00b7                                                         // 2de7: 85 b7       ..  :8de7[1]
+// $2de9 referenced 1 time by $8dfc
+loop_c8de9
+    lda #$e0                                                          // 2de9: a9 e0       ..  :8de9[1]
+    sta l00a2                                                         // 2deb: 85 a2       ..  :8deb[1]
+    sta lfe84                                                         // 2ded: 8d 84 fe    ... :8ded[1]
+// $2df0 referenced 1 time by $8df2
+loop_c8df0
+    lda l00a2                                                         // 2df0: a5 a2       ..  :8df0[1]
+    bmi loop_c8df0                                                    // 2df2: 30 fc       0.  :8df2[1]
+    bne c8e0d                                                         // 2df4: d0 17       ..  :8df4[1]
+    lda l00a5                                                         // 2df6: a5 a5       ..  :8df6[1]
+    beq c8e03                                                         // 2df8: f0 09       ..  :8df8[1]
+    dec l00b7                                                         // 2dfa: c6 b7       ..  :8dfa[1]
+    bne loop_c8de9                                                    // 2dfc: d0 eb       ..  :8dfc[1]
+    lda #$10                                                          // 2dfe: a9 10       ..  :8dfe[1]
+    sta l00a2                                                         // 2e00: 85 a2       ..  :8e00[1]
+    rts                                                               // 2e02: 60          `   :8e02[1]
+
+// $2e03 referenced 1 time by $8df8
+c8e03
+    lda l00b6                                                         // 2e03: a5 b6       ..  :8e03[1]
+    eor #$fb                                                          // 2e05: 49 fb       I.  :8e05[1]
+    beq c8e0d                                                         // 2e07: f0 04       ..  :8e07[1]
+    lda #$20 // ' '                                                   // 2e09: a9 20       .   :8e09[1]
+    sta l00a2                                                         // 2e0b: 85 a2       ..  :8e0b[1]
+// $2e0d referenced 2 times by $8df4, $8e07
+c8e0d
+    rts                                                               // 2e0d: 60          `   :8e0d[1]
+
+// $2e0e referenced 4 times by $8d81, $8da3, $8da8, $8ec2
+c8e0e
+    ldy #6                                                            // 2e0e: a0 06       ..  :8e0e[1]
+    lda (l00b0),y                                                     // 2e10: b1 b0       ..  :8e10[1]
+// $2e12 referenced 4 times by $8d08, $8d17, $8efc, $8f21
+c8e12
+    ldy #$ff                                                          // 2e12: a0 ff       ..  :8e12[1]
+// $2e14 referenced 1 time by $8e18
+loop_c8e14
+    iny                                                               // 2e14: c8          .   :8e14[1]
+    cmp l9121,y                                                       // 2e15: d9 21 91    .!. :8e15[1]
+    bne loop_c8e14                                                    // 2e18: d0 fa       ..  :8e18[1]
+    pha                                                               // 2e1a: 48          H   :8e1a[1]
+    lda nmi_and_table,y                                               // 2e1b: b9 2d 91    .-. :8e1b[1]
+    sta nmi_and_imm+1                                                 // 2e1e: 8d 05 0d    ... :8e1e[1]
+    ror l00a2                                                         // 2e21: 66 a2       f.  :8e21[1]
+    pla                                                               // 2e23: 68          h   :8e23[1]
+    bpl c8e72                                                         // 2e24: 10 4c       .L  :8e24[1]
+    bit l00a1                                                         // 2e26: 24 a1       $.  :8e26[1]
+    bvc c8e32                                                         // 2e28: 50 08       P.  :8e28[1]
+    ldy l00ce                                                         // 2e2a: a4 ce       ..  :8e2a[1]
+    cpy #$14                                                          // 2e2c: c0 14       ..  :8e2c[1]
+    bcc c8e32                                                         // 2e2e: 90 02       ..  :8e2e[1]
+    ora #2                                                            // 2e30: 09 02       ..  :8e30[1]
+// $2e32 referenced 2 times by $8e28, $8e2e
+c8e32
+    sta l00a7                                                         // 2e32: 85 a7       ..  :8e32[1]
+    ldy #1                                                            // 2e34: a0 01       ..  :8e34[1]
+    cmp #$c0                                                          // 2e36: c9 c0       ..  :8e36[1]
+    beq c8e53                                                         // 2e38: f0 19       ..  :8e38[1]
+    ora #4                                                            // 2e3a: 09 04       ..  :8e3a[1]
+    bcs c8e53                                                         // 2e3c: b0 15       ..  :8e3c[1]
+    ldy l00a5                                                         // 2e3e: a4 a5       ..  :8e3e[1]
+    cmp #$85                                                          // 2e40: c9 85       ..  :8e40[1]
+    beq c8e4d                                                         // 2e42: f0 09       ..  :8e42[1]
+    cmp #$87                                                          // 2e44: c9 87       ..  :8e44[1]
+    bne c8e53                                                         // 2e46: d0 0b       ..  :8e46[1]
+    lda #nmi_XXX1-(nmi_beq+2)                                         // 2e48: a9 48       .H  :8e48[1]
+    sta nmi_beq+1                                                     // 2e4a: 8d 09 0d    ... :8e4a[1]
+// $2e4d referenced 1 time by $8e42
+c8e4d
+    lda #$80                                                          // 2e4d: a9 80       ..  :8e4d[1]
+    sta l00a7                                                         // 2e4f: 85 a7       ..  :8e4f[1]
+    lda #$84                                                          // 2e51: a9 84       ..  :8e51[1]
+// $2e53 referenced 3 times by $8e38, $8e3c, $8e46
+c8e53
+    sty l00a5                                                         // 2e53: 84 a5       ..  :8e53[1]
+    sta lfe84                                                         // 2e55: 8d 84 fe    ... :8e55[1]
+    cmp #$f0                                                          // 2e58: c9 f0       ..  :8e58[1]
+    bcc c8e64                                                         // 2e5a: 90 08       ..  :8e5a[1]
+    jsr c8e9f                                                         // 2e5c: 20 9f 8e     .. :8e5c[1]
+    and #$5c // '\'                                                   // 2e5f: 29 5c       )\  :8e5f[1]
+    sta l00a2                                                         // 2e61: 85 a2       ..  :8e61[1]
+    rts                                                               // 2e63: 60          `   :8e63[1]
+
+// $2e64 referenced 4 times by $8e5a, $8e66, $8e7f, $8e83
+c8e64
+    lda l00a2                                                         // 2e64: a5 a2       ..  :8e64[1]
+    bmi c8e64                                                         // 2e66: 30 fc       0.  :8e66[1]
+    cmp #$20 // ' '                                                   // 2e68: c9 20       .   :8e68[1]
+    bne c8e6f                                                         // 2e6a: d0 03       ..  :8e6a[1]
+    jsr c8ea5                                                         // 2e6c: 20 a5 8e     .. :8e6c[1]
+// $2e6f referenced 1 time by $8e6a
+c8e6f
+    lda l00a2                                                         // 2e6f: a5 a2       ..  :8e6f[1]
+    rts                                                               // 2e71: 60          `   :8e71[1]
+
+// $2e72 referenced 1 time by $8e24
+c8e72
+    ldy #1                                                            // 2e72: a0 01       ..  :8e72[1]
+    sty l00a5                                                         // 2e74: 84 a5       ..  :8e74[1]
+    ora l00a4                                                         // 2e76: 05 a4       ..  :8e76[1]
+    sta l00a7                                                         // 2e78: 85 a7       ..  :8e78[1]
+    sta lfe84                                                         // 2e7a: 8d 84 fe    ... :8e7a[1]
+    bit l00b2                                                         // 2e7d: 24 b2       $.  :8e7d[1]
+    bmi c8e64                                                         // 2e7f: 30 e3       0.  :8e7f[1]
+    cmp #$20 // ' '                                                   // 2e81: c9 20       .   :8e81[1]
+    bcs c8e64                                                         // 2e83: b0 df       ..  :8e83[1]
+// $2e85 referenced 1 time by $8e8b
+loop_c8e85
+    lda l00a2                                                         // 2e85: a5 a2       ..  :8e85[1]
+    bpl c8e9e                                                         // 2e87: 10 15       ..  :8e87[1]
+    lda l00ff                                                         // 2e89: a5 ff       ..  :8e89[1]
+    bpl loop_c8e85                                                    // 2e8b: 10 f8       ..  :8e8b[1]
+    lda #opcode_rti                                                   // 2e8d: a9 40       .@  :8e8d[1]
+    sta nmi_handler_ram                                               // 2e8f: 8d 00 0d    ... :8e8f[1]
+    lda #0                                                            // 2e92: a9 00       ..  :8e92[1]
+    sta lfe80                                                         // 2e94: 8d 80 fe    ... :8e94[1]
+    lda l00ff                                                         // 2e97: a5 ff       ..  :8e97[1]
+    sta l1082                                                         // 2e99: 8d 82 10    ... :8e99[1]
+    sta l00a2                                                         // 2e9c: 85 a2       ..  :8e9c[1]
+// $2e9e referenced 1 time by $8e87
+c8e9e
+    rts                                                               // 2e9e: 60          `   :8e9e[1]
+
+// $2e9f referenced 2 times by $8e5c, $8ea3
+c8e9f
+    lda lfe84                                                         // 2e9f: ad 84 fe    ... :8e9f[1]
+    ror                                                               // 2ea2: 6a          j   :8ea2[1]
+    bcc c8e9f                                                         // 2ea3: 90 fa       ..  :8ea3[1]
+// $2ea5 referenced 2 times by $8e6c, $8ea9
+c8ea5
+    lda lfe84                                                         // 2ea5: ad 84 fe    ... :8ea5[1]
+    ror                                                               // 2ea8: 6a          j   :8ea8[1]
+    bcs c8ea5                                                         // 2ea9: b0 fa       ..  :8ea9[1]
+    lda lfe84                                                         // 2eab: ad 84 fe    ... :8eab[1]
+    rts                                                               // 2eae: 60          `   :8eae[1]
+
+// $2eaf referenced 1 time by $8d14
+c8eaf
+    lda #nmi_XXX1-(nmi_beq+2)                                         // 2eaf: a9 48       .H  :8eaf[1]
+    sta nmi_lda_immXXX3+1                                             // 2eb1: 8d 4c 0d    .L. :8eb1[1]
+    ldx nmi_beq+1                                                     // 2eb4: ae 09 0d    ... :8eb4[1]
+// $2eb7 referenced 2 times by $8eb9, $8ec9
+c8eb7
+    sbc #1                                                            // 2eb7: e9 01       ..  :8eb7[1]
+    bne c8eb7                                                         // 2eb9: d0 fc       ..  :8eb9[1]
+    stx nmi_beq+1                                                     // 2ebb: 8e 09 0d    ... :8ebb[1]
+    lda #4                                                            // 2ebe: a9 04       ..  :8ebe[1]
+    sta l00a6                                                         // 2ec0: 85 a6       ..  :8ec0[1]
+    jsr c8e0e                                                         // 2ec2: 20 0e 8e     .. :8ec2[1]
+    bne c8ecb                                                         // 2ec5: d0 04       ..  :8ec5[1]
+    dec l00b3                                                         // 2ec7: c6 b3       ..  :8ec7[1]
+    bne c8eb7                                                         // 2ec9: d0 ec       ..  :8ec9[1]
+// $2ecb referenced 1 time by $8ec5
+c8ecb
+    rts                                                               // 2ecb: 60          `   :8ecb[1]
+
+// $2ecc referenced 3 times by $8d8c, $8ee2, $8ee7
+c8ecc
+    jsr sub_c8eec                                                     // 2ecc: 20 ec 8e     .. :8ecc[1]
+    bne c8eeb                                                         // 2ecf: d0 1a       ..  :8ecf[1]
+    lda l00cd                                                         // 2ed1: a5 cd       ..  :8ed1[1]
+    and #1                                                            // 2ed3: 29 01       ).  :8ed3[1]
+    asl                                                               // 2ed5: 0a          .   :8ed5[1]
+    tay                                                               // 2ed6: a8          .   :8ed6[1]
+    lda l00ce                                                         // 2ed7: a5 ce       ..  :8ed7[1]
+    bit l108a                                                         // 2ed9: 2c 8a 10    ,.. :8ed9[1]
+    bpl c8edf                                                         // 2edc: 10 01       ..  :8edc[1]
+    lsr                                                               // 2ede: 4a          J   :8ede[1]
+// $2edf referenced 1 time by $8edc
+c8edf
+    cmp l108b,y                                                       // 2edf: d9 8b 10    ... :8edf[1]
+    beq c8ecc                                                         // 2ee2: f0 e8       ..  :8ee2[1]
+    cmp l108c,y                                                       // 2ee4: d9 8c 10    ... :8ee4[1]
+    beq c8ecc                                                         // 2ee7: f0 e3       ..  :8ee7[1]
+    lda #0                                                            // 2ee9: a9 00       ..  :8ee9[1]
+// $2eeb referenced 2 times by $8ecf, $8ef6
+c8eeb
+    rts                                                               // 2eeb: 60          `   :8eeb[1]
+
+// $2eec referenced 1 time by $8ecc
+sub_c8eec
+    bit l108a                                                         // 2eec: 2c 8a 10    ,.. :8eec[1]
+    bpl c8ef8                                                         // 2eef: 10 07       ..  :8eef[1]
+    lda #$40 // '@'                                                   // 2ef1: a9 40       .@  :8ef1[1]
+    jsr sub_c8efa                                                     // 2ef3: 20 fa 8e     .. :8ef3[1]
+    bne c8eeb                                                         // 2ef6: d0 f3       ..  :8ef6[1]
+// $2ef8 referenced 1 time by $8eef
+c8ef8
+    lda #$50 // 'P'                                                   // 2ef8: a9 50       .P  :8ef8[1]
+// $2efa referenced 1 time by $8ef3
+sub_c8efa
+    inc l00ce                                                         // 2efa: e6 ce       ..  :8efa[1]
+    jmp c8e12                                                         // 2efc: 4c 12 8e    L.. :8efc[1]
+
+// $2eff referenced 1 time by $8d1a
+sub_c8eff
+    lda l00cd                                                         // 2eff: a5 cd       ..  :8eff[1]
+    and #1                                                            // 2f01: 29 01       ).  :8f01[1]
+    asl                                                               // 2f03: 0a          .   :8f03[1]
+    tax                                                               // 2f04: aa          .   :8f04[1]
+    ldy #7                                                            // 2f05: a0 07       ..  :8f05[1]
+    lda (l00b0),y                                                     // 2f07: b1 b0       ..  :8f07[1]
+    jsr sub_c8f33                                                     // 2f09: 20 33 8f     3. :8f09[1]
+    bit l108a                                                         // 2f0c: 2c 8a 10    ,.. :8f0c[1]
+    bpl c8f12                                                         // 2f0f: 10 01       ..  :8f0f[1]
+    asl                                                               // 2f11: 0a          .   :8f11[1]
+// $2f12 referenced 1 time by $8f0f
+c8f12
+    sta l00ce                                                         // 2f12: 85 ce       ..  :8f12[1]
+    tay                                                               // 2f14: a8          .   :8f14[1]
+    beq c8f21                                                         // 2f15: f0 0a       ..  :8f15[1]
+// $2f17 referenced 1 time by $8f1d
+loop_c8f17
+    sta lfe87                                                         // 2f17: 8d 87 fe    ... :8f17[1]
+    cmp lfe87                                                         // 2f1a: cd 87 fe    ... :8f1a[1]
+    bne loop_c8f17                                                    // 2f1d: d0 f8       ..  :8f1d[1]
+    lda #$10                                                          // 2f1f: a9 10       ..  :8f1f[1]
+// $2f21 referenced 1 time by $8f15
+c8f21
+    jsr c8e12                                                         // 2f21: 20 12 8e     .. :8f21[1]
+    bne c8f3e                                                         // 2f24: d0 18       ..  :8f24[1]
+    ldy #7                                                            // 2f26: a0 07       ..  :8f26[1]
+    lda (l00b0),y                                                     // 2f28: b1 b0       ..  :8f28[1]
+// $2f2a referenced 3 times by $8c44, $8d10, $8f30
+c8f2a
+    sta lfe85                                                         // 2f2a: 8d 85 fe    ... :8f2a[1]
+    cmp lfe85                                                         // 2f2d: cd 85 fe    ... :8f2d[1]
+    bne c8f2a                                                         // 2f30: d0 f8       ..  :8f30[1]
+    rts                                                               // 2f32: 60          `   :8f32[1]
+
+// $2f33 referenced 1 time by $8f09
+sub_c8f33
+    jsr sub_c8f37                                                     // 2f33: 20 37 8f     7. :8f33[1]
+    inx                                                               // 2f36: e8          .   :8f36[1]
+// $2f37 referenced 1 time by $8f33
+sub_c8f37
+    cmp l108b,x                                                       // 2f37: dd 8b 10    ... :8f37[1]
+    bcc c8f3e                                                         // 2f3a: 90 02       ..  :8f3a[1]
+    adc #0                                                            // 2f3c: 69 00       i.  :8f3c[1]
+// $2f3e referenced 2 times by $8f24, $8f3a
+c8f3e
+    rts                                                               // 2f3e: 60          `   :8f3e[1]
+
+// $2f3f referenced 5 times by $8c95, $8f75, $92b0, $932b, $9628
+sub_c8f3f
+    lda #osbyte_read_tube_presence                                    // 2f3f: a9 ea       ..  :8f3f[1]
+    ldx #0                                                            // 2f41: a2 00       ..  :8f41[1]
+    ldy #$ff                                                          // 2f43: a0 ff       ..  :8f43[1]
+    jsr osbyte                                                        // 2f45: 20 f4 ff     .. :8f45[1]
+    txa                                                               // 2f48: 8a          .   :8f48[1]
+    eor #$ff                                                          // 2f49: 49 ff       I.  :8f49[1]
+    sta l10d6                                                         // 2f4b: 8d d6 10    ... :8f4b[1]
+    rts                                                               // 2f4e: 60          `   :8f4e[1]
+
+// $2f4f referenced 1 time by $8c65
+sub_c8f4f
+    lda #osbyte_issue_service_request                                 // 2f4f: a9 8f       ..  :8f4f[1]
+    ldx #$0c                                                          // 2f51: a2 0c       ..  :8f51[1]
+    ldy #$ff                                                          // 2f53: a0 ff       ..  :8f53[1]
+    jsr osbyte                                                        // 2f55: 20 f4 ff     .. :8f55[1]
+    sty l00a0                                                         // 2f58: 84 a0       ..  :8f58[1]
+    inc l10d3                                                         // 2f5a: ee d3 10    ... :8f5a[1]
+    rts                                                               // 2f5d: 60          `   :8f5d[1]
+
+// $2f5e referenced 1 time by $8c4e
+sub_c8f5e
+    ldy l00a0                                                         // 2f5e: a4 a0       ..  :8f5e[1]
+    lda #osbyte_issue_service_request                                 // 2f60: a9 8f       ..  :8f60[1]
+    ldx #$0b                                                          // 2f62: a2 0b       ..  :8f62[1]
+    jsr osbyte                                                        // 2f64: 20 f4 ff     .. :8f64[1]
+    dec l10d3                                                         // 2f67: ce d3 10    ... :8f67[1]
+    rts                                                               // 2f6a: 60          `   :8f6a[1]
+
+// $2f6b referenced 4 times by $8921, $8c9b, $933e, $9819
+sub_c8f6b
+    pha                                                               // 2f6b: 48          H   :8f6b[1]
+// $2f6c referenced 1 time by $8f71
+loop_c8f6c
+    lda #$c1                                                          // 2f6c: a9 c1       ..  :8f6c[1]
+    jsr tube_entry                                                    // 2f6e: 20 06 04     .. :8f6e[1]
+    bcc loop_c8f6c                                                    // 2f71: 90 f9       ..  :8f71[1]
+    pla                                                               // 2f73: 68          h   :8f73[1]
+    rts                                                               // 2f74: 60          `   :8f74[1]
+
+// $2f75 referenced 1 time by $8071
+sub_c8f75
+    jsr sub_c8f3f                                                     // 2f75: 20 3f 8f     ?. :8f75[1]
+    bmi c8f81                                                         // 2f78: 30 07       0.  :8f78[1]
+// $2f7a referenced 3 times by $8c4b, $9364, $97e3
+sub_c8f7a
+    pha                                                               // 2f7a: 48          H   :8f7a[1]
+    lda #$81                                                          // 2f7b: a9 81       ..  :8f7b[1]
+    jsr tube_entry                                                    // 2f7d: 20 06 04     .. :8f7d[1]
+    pla                                                               // 2f80: 68          h   :8f80[1]
+// $2f81 referenced 1 time by $8f78
+c8f81
+    rts                                                               // 2f81: 60          `   :8f81[1]
+
+// $2f82 referenced 1 time by $8c68
+sub_c8f82
+    lda #osbyte_read_write_startup_options                            // 2f82: a9 ff       ..  :8f82[1]
+    ldx #0                                                            // 2f84: a2 00       ..  :8f84[1]
+    tay                                                               // 2f86: a8          .   :8f86[1]
+    jsr osbyte                                                        // 2f87: 20 f4 ff     .. :8f87[1]
+    txa                                                               // 2f8a: 8a          .   :8f8a[1]
+    lsr                                                               // 2f8b: 4a          J   :8f8b[1]
+    lsr                                                               // 2f8c: 4a          J   :8f8c[1]
+    lsr                                                               // 2f8d: 4a          J   :8f8d[1]
+    lsr                                                               // 2f8e: 4a          J   :8f8e[1]
+    and #3                                                            // 2f8f: 29 03       ).  :8f8f[1]
+    sta l00a4                                                         // 2f91: 85 a4       ..  :8f91[1]
+    rts                                                               // 2f93: 60          `   :8f93[1]
+
+// $2f94 referenced 1 time by $8cb4
+sub_c8f94
+    ldx #nmi_handler_rom_end-nmi_handler_rom_start-1                  // 2f94: a2 5d       .]  :8f94[1]
+// $2f96 referenced 1 time by $8f9d
+loop_c8f96
+    lda nmi_handler_rom_start,x                                       // 2f96: bd d2 8f    ... :8f96[1]
+    sta nmi_handler_ram,x                                             // 2f99: 9d 00 0d    ... :8f99[1]
+    dex                                                               // 2f9c: ca          .   :8f9c[1]
+    bpl loop_c8f96                                                    // 2f9d: 10 f7       ..  :8f9d[1]
+    ldx #3                                                            // 2f9f: a2 03       ..  :8f9f[1]
+    bit l00a1                                                         // 2fa1: 24 a1       $.  :8fa1[1]
+    bvc c8fb5                                                         // 2fa3: 50 10       P.  :8fa3[1]
+    lda #nmi_XXX8-(nmi_beq+2)                                         // 2fa5: a9 4d       .M  :8fa5[1]
+    sta nmi_lda_immXXX4+1                                             // 2fa7: 8d 22 0d    .". :8fa7[1]
+    ldx #nmi3_handler_rom_end-nmi3_handler_rom_start                  // 2faa: a2 0e       ..  :8faa[1]
+// $2fac referenced 1 time by $8fb3
+loop_c8fac
+    lda nmi3_handler_rom_start-1,x                                    // 2fac: bd 2f 90    ./. :8fac[1]
+    sta nmi_XXX2-1,x                                                  // 2faf: 9d 38 0d    .8. :8faf[1]
+    dex                                                               // 2fb2: ca          .   :8fb2[1]
+    bne loop_c8fac                                                    // 2fb3: d0 f7       ..  :8fb3[1]
+// $2fb5 referenced 1 time by $8fa3
+c8fb5
+    bit l00a1                                                         // 2fb5: 24 a1       $.  :8fb5[1]
+    bmi c8fc7                                                         // 2fb7: 30 0e       0.  :8fb7[1]
+    ldy #1                                                            // 2fb9: a0 01       ..  :8fb9[1]
+    lda (l00b0),y                                                     // 2fbb: b1 b0       ..  :8fbb[1]
+    sta nmi_lda_abs+1,x                                               // 2fbd: 9d 3a 0d    .:. :8fbd[1]
+    iny                                                               // 2fc0: c8          .   :8fc0[1]
+    lda (l00b0),y                                                     // 2fc1: b1 b0       ..  :8fc1[1]
+    sta nmi_lda_abs+2,x                                               // 2fc3: 9d 3b 0d    .;. :8fc3[1]
+    rts                                                               // 2fc6: 60          `   :8fc6[1]
+
+// $2fc7 referenced 1 time by $8fb7
+c8fc7
+    lda #opcode_bcs                                                   // 2fc7: a9 b0       ..  :8fc7[1]
+    sta nmi_XXX6                                                      // 2fc9: 8d 3f 0d    .?. :8fc9[1]
+    lda #nmi_XXX7-(nmi_XXX6+2)                                        // 2fcc: a9 06       ..  :8fcc[1]
+    sta nmi_XXX6+1                                                    // 2fce: 8d 40 0d    .@. :8fce[1]
+    rts                                                               // 2fd1: 60          `   :8fd1[1]
+
+nmi_handler_rom_start
+* = $2fd2
+* = $0d00
+nmi_handler_ram
+    pha                                                               // 2fd2: 48          H   :0d00[5]
+    lda lfe84                                                         // 2fd3: ad 84 fe    ... :0d01[5]
+// The operand of this and is modified at runtime.
+nmi_and_imm
+    and #$18                                                          // 2fd6: 29 18       ).  :0d04[5]
+    cmp #3                                                            // 2fd8: c9 03       ..  :0d06[5]
+// The operand of this "beq" is modified at runtime.
+nmi_beq
+    beq nmi_XXX2                                                      // 2fda: f0 2f       ./  :0d08[5]
+    and #$fc                                                          // 2fdc: 29 fc       ).  :0d0a[5]
+    bne l0d12                                                         // 2fde: d0 04       ..  :0d0c[5]
+    dec l00a5                                                         // 2fe0: c6 a5       ..  :0d0e[5]
+    bne nmi_lda_zp                                                    // 2fe2: d0 04       ..  :0d10[5]
+l0d12
+    sta l00a2                                                         // 2fe4: 85 a2       ..  :0d12[5]
+    pla                                                               // 2fe6: 68          h   :0d14[5]
+    rti                                                               // 2fe7: 40          @   :0d15[5]
+
+// The operand of this lda is modified at runtime.
+nmi_lda_zp
+    lda l00a5                                                         // 2fe8: a5 a5       ..  :0d16[5]
+// This instruction is patched at runtime to toggle between cmp #/bcs.
+nmi_cmp_imm_or_bcs
+    cmp #1                                                            // 2fea: c9 01       ..  :0d18[5]
+    bne l0d26                                                         // 2fec: d0 0a       ..  :0d1a[5]
+    lda l00a1                                                         // 2fee: a5 a1       ..  :0d1c[5]
+    ror                                                               // 2ff0: 6a          j   :0d1e[5]
+l0d1f
+nmi_XXX5 = l0d1f+1
+    bcc l0d26                                                         // 2ff1: 90 05       ..  :0d1f[5]
+// One patched variant of the code transfers control to nmi_XXX5,
+// which is the
+//     second byte of the following bcc instruction. That is always
+// &05, which is
+//     ORA #. XXX: correct?
+// The operand of this lda is modified at runtime.
+nmi_lda_immXXX4
+    lda #nmi_XXX1-(nmi_beq+2)                                         // 2ff3: a9 48       .H  :0d21[5]
+    sta nmi_lda_immXXX3+1                                             // 2ff5: 8d 4c 0d    .L. :0d23[5]
+l0d26
+    inc l00cf                                                         // 2ff8: e6 cf       ..  :0d26[5]
+    lda l00cf                                                         // 2ffa: a5 cf       ..  :0d28[5]
+l0d2a
+    sta lfe86                                                         // 2ffc: 8d 86 fe    ... :0d2a[5]
+    cmp lfe86                                                         // 2fff: cd 86 fe    ... :0d2d[5]
+    bne l0d2a                                                         // 3002: d0 f8       ..  :0d30[5]
+    lda l00a7                                                         // 3004: a5 a7       ..  :0d32[5]
+    sta lfe84                                                         // 3006: 8d 84 fe    ... :0d34[5]
+    pla                                                               // 3009: 68          h   :0d37[5]
+    rti                                                               // 300a: 40          @   :0d38[5]
+
+nmi_XXX2
+    lda lfe87                                                         // 300b: ad 87 fe    ... :0d39[5]
+// The operand of this sta is modified at runtime.
+nmi_sta_abs
+    sta tube_host_r3_data                                             // 300e: 8d e5 fe    ... :0d3c[5]
+// The first two bytes of the following instruction may be patched at
+// runtime.
+nmi_XXX6
+    inc nmi_sta_abs+1                                                 // 3011: ee 3d 0d    .=. :0d3f[5]
+    bne nmi_XXX7                                                      // 3014: d0 03       ..  :0d42[5]
+    inc nmi_sta_abs+2                                                 // 3016: ee 3e 0d    .>. :0d44[5]
+nmi_XXX7
+    dec l00a6                                                         // 3019: c6 a6       ..  :0d47[5]
+    bne l0d50                                                         // 301b: d0 05       ..  :0d49[5]
+// The operand of this lda is modified at runtime.
+nmi_lda_immXXX3
+    lda #nmi_XXX2-(nmi_beq+2)                                         // 301d: a9 2f       ./  :0d4b[5]
+    sta nmi_beq+1                                                     // 301f: 8d 09 0d    ... :0d4d[5]
+l0d50
+    pla                                                               // 3022: 68          h   :0d50[5]
+    rti                                                               // 3023: 40          @   :0d51[5]
+
+nmi_XXX1
+    lda lfe87                                                         // 3024: ad 87 fe    ... :0d52[5]
+    pla                                                               // 3027: 68          h   :0d55[5]
+    rti                                                               // 3028: 40          @   :0d56[5]
+
+nmi_XXX8
+    lda #0                                                            // 3029: a9 00       ..  :0d57[5]
+    sta lfe87                                                         // 302b: 8d 87 fe    ... :0d59[5]
+    pla                                                               // 302e: 68          h   :0d5c[5]
+    rti                                                               // 302f: 40          @   :0d5d[5]
+
+// The operand of this lda is modified at runtime.
+* = $3030
+// The operand of this lda is modified at runtime.
+// The operand of this lda is modified at runtime.
+* = $0d39
+// The operand of this lda is modified at runtime.
+nmi_lda_abs
+    lda tube_host_r3_data                                             // 3030: ad e5 fe    ... :0d39[6]
+    sta lfe87                                                         // 3033: 8d 87 fe    ... :0d3c[6]
+    inc nmi_lda_abs+1                                                 // 3036: ee 3a 0d    .:. :0d3f[6]
+    bne nmi_XXX7                                                      // 3039: d0 03       ..  :0d42[6]
+    inc nmi_lda_abs+2                                                 // 303b: ee 3b 0d    .;. :0d44[6]
+// $303e referenced 1 time by $8de2
+* = $303e
+// $303e referenced 1 time by $8de2
+// $303e referenced 1 time by $8de2
+* = $903e
+// $303e referenced 1 time by $8de2
+nmi3_handler_rom_end
+    ldx nmi_sta_abs+1                                                 // 303e: ae 3d 0d    .=. :903e[1]
+    lda nmi_sta_abs+2                                                 // 3041: ad 3e 0d    .>. :9041[1]
+    pha                                                               // 3044: 48          H   :9044[1]
+    ldy #nmi_handler2_rom_end-nmi_handler2_rom_start                  // 3045: a0 94       ..  :9045[1]
+// $3047 referenced 1 time by $904e
+loop_c9047
+    lda nmi_handler2_rom_start-1,y                                    // 3047: b9 66 90    .f. :9047[1]
+    sta l0cff,y                                                       // 304a: 99 ff 0c    ... :904a[1]
+    dey                                                               // 304d: 88          .   :904d[1]
+    bne loop_c9047                                                    // 304e: d0 f7       ..  :904e[1]
+    pla                                                               // 3050: 68          h   :9050[1]
+    bit l00a1                                                         // 3051: 24 a1       $.  :9051[1]
+    bpl c9060                                                         // 3053: 10 0b       ..  :9053[1]
+    lda #opcode_bcs                                                   // 3055: a9 b0       ..  :9055[1]
+    sta nmi_cmp_imm_or_bcs                                            // 3057: 8d 18 0d    ... :9057[1]
+    lda #nmi_XXX5-(nmi_cmp_imm_or_bcs+2)                              // 305a: a9 06       ..  :905a[1]
+    sta nmi_cmp_imm_or_bcs+1                                          // 305c: 8d 19 0d    ... :905c[1]
+    rts                                                               // 305f: 60          `   :905f[1]
+
+// $3060 referenced 1 time by $9053
+c9060
+    stx nmi_lda_zp                                                    // 3060: 8e 16 0d    ... :9060[1]
+    sta nmi_lda_zp+1                                                  // 3063: 8d 17 0d    ... :9063[1]
+// $3066 referenced 1 time by $9047
+    rts                                                               // 3066: 60          `   :9066[1]
+
+nmi_handler2_rom_start
+* = $3067
+* = $0d00
+    pha                                                               // 3067: 48          H   :0d00[7]
+    lda lfe84                                                         // 3068: ad 84 fe    ... :0d01[7]
+    and #$1b                                                          // 306b: 29 1b       ).  :0d04[7]
+    cmp #3                                                            // 306d: c9 03       ..  :0d06[7]
+    bne l0d0f                                                         // 306f: d0 05       ..  :0d08[7]
+    lda lfe87                                                         // 3071: ad 87 fe    ... :0d0a[7]
+// The operand of this bcs is modified at runtime
+nmi_bcs
+    bcs nmi_XXX21                                                     // 3074: b0 26       .&  :0d0d[7]
+l0d0f
+    and #$fc                                                          // 3076: 29 fc       ).  :0d0f[7]
+    sta l00a2                                                         // 3078: 85 a2       ..  :0d11[7]
+    pla                                                               // 307a: 68          h   :0d13[7]
+    rti                                                               // 307b: 40          @   :0d14[7]
+
+// The operand of this sta is modified at runtime.
+nmi_XXX17
+nmi_sta_abs2
+    sta tube_host_r3_data                                             // 307c: 8d e5 fe    ... :0d15[7]
+    inc nmi_sta_abs2+1                                                // 307f: ee 16 0d    ... :0d18[7]
+    bne nmi_XXX18                                                     // 3082: d0 03       ..  :0d1b[7]
+    inc nmi_sta_abs2+2                                                // 3084: ee 17 0d    ... :0d1d[7]
+nmi_XXX18
+    dec l00a6                                                         // 3087: c6 a6       ..  :0d20[7]
+    bne nmi_XXX23                                                     // 3089: d0 0f       ..  :0d22[7]
+    dec l00a7                                                         // 308b: c6 a7       ..  :0d24[7]
+    bne nmi_XXX23                                                     // 308d: d0 0b       ..  :0d26[7]
+    lda #nmi_XXX22-(nmi_bcs+2)                                        // 308f: a9 77       .w  :0d28[7]
+    dec l00a5                                                         // 3091: c6 a5       ..  :0d2a[7]
+    bne l0d30                                                         // 3093: d0 02       ..  :0d2c[7]
+    lda #nmi_XXX23-(nmi_bcs+2)                                        // 3095: a9 24       .$  :0d2e[7]
+l0d30
+    sta nmi_bcs+1                                                     // 3097: 8d 0e 0d    ... :0d30[7]
+nmi_XXX23
+    pla                                                               // 309a: 68          h   :0d33[7]
+    rti                                                               // 309b: 40          @   :0d34[7]
+
+nmi_XXX21
+    cmp #$fe                                                          // 309c: c9 fe       ..  :0d35[7]
+    beq l0d3d                                                         // 309e: f0 04       ..  :0d37[7]
+    cmp #$ce                                                          // 30a0: c9 ce       ..  :0d39[7]
+    bne nmi_XXX23                                                     // 30a2: d0 f6       ..  :0d3b[7]
+l0d3d
+    lda #nmi_XXX10-(nmi_bcs+2)                                        // 30a4: a9 32       .2  :0d3d[7]
+    bne l0d30                                                         // 30a6: d0 ef       ..  :0d3f[7]
+nmi_XXX10
+    sbc lfe87                                                         // 30a8: ed 87 fe    ... :0d41[7]
+    sta l00b5                                                         // 30ab: 85 b5       ..  :0d44[7]
+    lda #nmi_XXX11-(nmi_bcs+2)                                        // 30ad: a9 3b       .;  :0d46[7]
+    bne l0d30                                                         // 30af: d0 e6       ..  :0d48[7]
+nmi_XXX11
+    lda #nmi_XXX12-(nmi_bcs+2)                                        // 30b1: a9 3f       .?  :0d4a[7]
+    bne l0d30                                                         // 30b3: d0 e2       ..  :0d4c[7]
+nmi_XXX12
+    sbc l00cf                                                         // 30b5: e5 cf       ..  :0d4e[7]
+    ora l00b5                                                         // 30b7: 05 b5       ..  :0d50[7]
+    sta l00b5                                                         // 30b9: 85 b5       ..  :0d52[7]
+    lda #nmi_XXX13-(nmi_bcs+2)                                        // 30bb: a9 49       .I  :0d54[7]
+    bne l0d30                                                         // 30bd: d0 d8       ..  :0d56[7]
+nmi_XXX13
+    lda #nmi_XXX14-(nmi_bcs+2)                                        // 30bf: a9 4d       .M  :0d58[7]
+    bne l0d30                                                         // 30c1: d0 d4       ..  :0d5a[7]
+nmi_XXX14
+    lda l00b3                                                         // 30c3: a5 b3       ..  :0d5c[7]
+    sta l00a6                                                         // 30c5: 85 a6       ..  :0d5e[7]
+// $30c7 referenced 2 times by $8dac, $8dbd
+c0d60
+    lda #nmi_XXX15-(nmi_bcs+2)                                        // 30c7: a9 55       .U  :0d60[7]
+    bne l0d30                                                         // 30c9: d0 cc       ..  :0d62[7]
+nmi_XXX15
+    lda l00b4                                                         // 30cb: a5 b4       ..  :0d64[7]
+    sta l00a7                                                         // 30cd: 85 a7       ..  :0d66[7]
+    lda #nmi_XXX16-(nmi_bcs+2)                                        // 30cf: a9 5d       .]  :0d68[7]
+    bne l0d30                                                         // 30d1: d0 c4       ..  :0d6a[7]
+nmi_XXX16
+    cmp #$fb                                                          // 30d3: c9 fb       ..  :0d6c[7]
+    beq c0d74                                                         // 30d5: f0 04       ..  :0d6e[7]
+    cmp #$f8                                                          // 30d7: c9 f8       ..  :0d70[7]
+    bne nmi_XXX23                                                     // 30d9: d0 bf       ..  :0d72[7]
+// $30db referenced 1 time by $0d6e
+c0d74
+    sta l00b6                                                         // 30db: 85 b6       ..  :0d74[7]
+    lda l00b5                                                         // 30dd: a5 b5       ..  :0d76[7]
+    bne c0d80                                                         // 30df: d0 06       ..  :0d78[7]
+    inc l00cf                                                         // 30e1: e6 cf       ..  :0d7a[7]
+    lda #nmi_XXX17-(nmi_bcs+2)                                        // 30e3: a9 06       ..  :0d7c[7]
+    bne l0d30                                                         // 30e5: d0 b0       ..  :0d7e[7]
+// $30e7 referenced 1 time by $0d78
+c0d80
+    inc l00a5                                                         // 30e7: e6 a5       ..  :0d80[7]
+    lda #nmi_XXX18-(nmi_bcs+2)                                        // 30e9: a9 11       ..  :0d82[7]
+    bne l0d30                                                         // 30eb: d0 aa       ..  :0d84[7]
+nmi_XXX22
+    lda #nmi_XXX19-(nmi_bcs+2)                                        // 30ed: a9 7b       .{  :0d86[7]
+    bne l0d30                                                         // 30ef: d0 a6       ..  :0d88[7]
+nmi_XXX19
+    lda #nmi_XXX20-(nmi_bcs+2)                                        // 30f1: a9 7f       ..  :0d8a[7]
+    bne l0d30                                                         // 30f3: d0 a2       ..  :0d8c[7]
+nmi_XXX20
+    bne nmi_XXX23                                                     // 30f5: d0 a3       ..  :0d8e[7]
+    lda #nmi_XXX21-(nmi_bcs+2)                                        // 30f7: a9 26       .&  :0d90[7]
+    bne l0d30                                                         // 30f9: d0 9c       ..  :0d92[7]
+// $30fb referenced 3 times by $8d41, $8d92, $9101
+* = $30fb
+// $30fb referenced 3 times by $8d41, $8d92, $9101
+// $30fb referenced 3 times by $8d41, $8d92, $9101
+* = $90fb
+// $30fb referenced 3 times by $8d41, $8d92, $9101
+nmi_handler2_rom_end
+    sta lfe86                                                         // 30fb: 8d 86 fe    ... :90fb[1]
+    cmp lfe86                                                         // 30fe: cd 86 fe    ... :90fe[1]
+    bne nmi_handler2_rom_end                                          // 3101: d0 f8       ..  :9101[1]
+    rts                                                               // 3103: 60          `   :9103[1]
+
+// $3104 referenced 1 time by $966b
+set_c_iff_have_fdc
+    ldx #0                                                            // 3104: a2 00       ..  :9104[1]
+    lda #$5a // 'Z'                                                   // 3106: a9 5a       .Z  :9106[1]
+// $3108 referenced 1 time by $9111
+loop_c9108
+    sta lfe85                                                         // 3108: 8d 85 fe    ... :9108[1]
+    cmp lfe85                                                         // 310b: cd 85 fe    ... :910b[1]
+    beq c9115                                                         // 310e: f0 05       ..  :910e[1]
+    dex                                                               // 3110: ca          .   :9110[1]
+    bne loop_c9108                                                    // 3111: d0 f5       ..  :9111[1]
+// $3113 referenced 1 time by $911a
+loop_c9113
+    clc                                                               // 3113: 18          .   :9113[1]
+    rts                                                               // 3114: 60          `   :9114[1]
+
+// $3115 referenced 1 time by $910e
+c9115
+    lda lfe80                                                         // 3115: ad 80 fe    ... :9115[1]
+    and #3                                                            // 3118: 29 03       ).  :9118[1]
+    beq loop_c9113                                                    // 311a: f0 f7       ..  :911a[1]
+    rts                                                               // 311c: 60          `   :911c[1]
+
+// $311d referenced 1 time by $8cd8
+l911d
+    .asc ")*-."                                                       // 311d: 29 2a 2d... )*- :911d[1]
+// $3121 referenced 1 time by $8e15
+l9121
+    .byt   0, $10, $40, $50, $80, $81, $83, $a0, $a1, $c0, $e0, $f0   // 3121: 00 10 40... ..@ :9121[1]
+// $312d referenced 1 time by $8e1b
+nmi_and_table
+    .byt $18, $18, $18, $18, $3f, $1f, $1f, $5f, $5f, $17, $1b, $5f   // 312d: 18 18 18... ... :912d[1]
+// $3139 referenced 1 time by $8c58
+l9139
+    .byt   8, $10, $18, $20, $40,   0                                 // 3139: 08 10 18... ... :9139[1]
+// $313f referenced 1 time by $8c61
+l913f
+    .byt $0e, $18, $0c, $20, $12,   0                                 // 313f: 0e 18 0c... ... :913f[1]
+// $3145 referenced 1 time by $92e3
+l9145
+    .byt $6d                                                          // 3145: 6d          m   :9145[1]
+// $3146 referenced 1 time by $92e8
+l9146
+    .byt $91, $49, $91, $3c, $0c,   3,   1,   1,   1,   1,   1,   1   // 3146: 91 49 91... .I. :9146[1]
+    .byt $16, $0c,   3,   1, $ff,   1,   1, $18,   4, $4e,   0, $f5   // 3152: 16 0c 03... ... :9152[1]
+    .byt $fe,   0,   0,   0,   0, $f7, $4e,   0, $f5, $fb, $5a, $5a   // 315e: fe 00 00... ... :915e[1]
+    .byt $f7, $4e, $4e, $10,   6,   0,   1,   1,   1,   1,   1,   1   // 316a: f7 4e 4e... .NN :916a[1]
+    .byt $0b,   6,   0,   1, $ff,   1,   1, $13,   3, $ff,   0,   0   // 3176: 0b 06 00... ... :9176[1]
+    .byt $fe,   0,   0,   0,   0, $f7, $ff,   0,   0, $fb, $e5, $e5   // 3182: fe 00 00... ... :9182[1]
+    .byt $f7, $ff, $ff                                                // 318e: f7 ff ff    ... :918e[1]
+// $3191 referenced 1 time by $91df
+l9191
+    .byt $0a, $0b, $0e, $0f, $12, $13, $16, $17, $1b, $1e, $1f        // 3191: 0a 0b 0e... ... :9191[1]
+    .asc "#) 0"                                                       // 319c: 23 29 20... #)  :919c[1]
+// $31a0 referenced 1 time by $9201
+l91a0
+    .byt $a0, $a0, $a1, $a1, $80, $80, $81, $81, $c0, $83, $83, $f0   // 31a0: a0 a0 a1... ... :91a0[1]
+    .byt $10, $e0, $f0                                                // 31ac: 10 e0 f0    ... :91ac[1]
+
+// $31af referenced 3 times by $9758, $a6dc, $a700
+c91af
+    lda #$ff                                                          // 31af: a9 ff       ..  :91af[1]
+    sta l1082                                                         // 31b1: 8d 82 10    ... :91b1[1]
+    stx l00c7                                                         // 31b4: 86 c7       ..  :91b4[1]
+    sty l00c8                                                         // 31b6: 84 c8       ..  :91b6[1]
+    ldy #$0c                                                          // 31b8: a0 0c       ..  :91b8[1]
+// $31ba referenced 1 time by $91c0
+loop_c91ba
+    lda (l00c7),y                                                     // 31ba: b1 c7       ..  :91ba[1]
+    sta l00ba,y                                                       // 31bc: 99 ba 00    ... :91bc[1]
+    dey                                                               // 31bf: 88          .   :91bf[1]
+    bpl loop_c91ba                                                    // 31c0: 10 f8       ..  :91c0[1]
+    ldx #$0c                                                          // 31c2: a2 0c       ..  :91c2[1]
+    lda l00bf                                                         // 31c4: a5 bf       ..  :91c4[1]
+    cmp #$0a                                                          // 31c6: c9 0a       ..  :91c6[1]
+    bne c91cc                                                         // 31c8: d0 02       ..  :91c8[1]
+    ldx #$0e                                                          // 31ca: a2 0e       ..  :91ca[1]
+// $31cc referenced 1 time by $91c8
+c91cc
+    lda l00c0                                                         // 31cc: a5 c0       ..  :91cc[1]
+    and #$3f // '?'                                                   // 31ce: 29 3f       )?  :91ce[1]
+    cmp #$3a // ':'                                                   // 31d0: c9 3a       .:  :91d0[1]
+    beq c921f                                                         // 31d2: f0 4b       .K  :91d2[1]
+    cmp #$3d // '='                                                   // 31d4: c9 3d       .=  :91d4[1]
+    beq c923f                                                         // 31d6: f0 67       .g  :91d6[1]
+    cmp #$35 // '5'                                                   // 31d8: c9 35       .5  :91d8[1]
+    bne c91df                                                         // 31da: d0 03       ..  :91da[1]
+    jmp c925a                                                         // 31dc: 4c 5a 92    LZ. :91dc[1]
+
+// $31df referenced 2 times by $91da, $91e5
+c91df
+    cmp l9191,x                                                       // 31df: dd 91 91    ... :91df[1]
+    beq c91eb                                                         // 31e2: f0 07       ..  :91e2[1]
+    dex                                                               // 31e4: ca          .   :91e4[1]
+    bpl c91df                                                         // 31e5: 10 f8       ..  :91e5[1]
+// $31e7 referenced 1 time by $91ff
+loop_c91e7
+    lda #$fe                                                          // 31e7: a9 fe       ..  :91e7[1]
+    bmi c9214                                                         // 31e9: 30 29       0)  :91e9[1]
+// $31eb referenced 1 time by $91e2
+c91eb
+    cmp #$23 // '#'                                                   // 31eb: c9 23       .#  :91eb[1]
+    beq c91f3                                                         // 31ed: f0 04       ..  :91ed[1]
+    cpx #4                                                            // 31ef: e0 04       ..  :91ef[1]
+    bcs c9201                                                         // 31f1: b0 0e       ..  :91f1[1]
+// $31f3 referenced 1 time by $91ed
+c91f3
+    lda l00ba                                                         // 31f3: a5 ba       ..  :91f3[1]
+    bpl c91f9                                                         // 31f5: 10 02       ..  :91f5[1]
+    lda l00cd                                                         // 31f7: a5 cd       ..  :91f7[1]
+// $31f9 referenced 1 time by $91f5
+c91f9
+    and #3                                                            // 31f9: 29 03       ).  :91f9[1]
+    tay                                                               // 31fb: a8          .   :91fb[1]
+    lda l10de,y                                                       // 31fc: b9 de 10    ... :91fc[1]
+    bmi loop_c91e7                                                    // 31ff: 30 e6       0.  :91ff[1]
+// $3201 referenced 1 time by $91f1
+c9201
+    ldy l91a0,x                                                       // 3201: bc a0 91    ... :9201[1]
+    sty l00c0                                                         // 3204: 84 c0       ..  :9204[1]
+    cpy #$f0                                                          // 3206: c0 f0       ..  :9206[1]
+    bne c920d                                                         // 3208: d0 03       ..  :9208[1]
+    jsr sub_c929d                                                     // 320a: 20 9d 92     .. :920a[1]
+// $320d referenced 1 time by $9208
+c920d
+    ldx #$ba                                                          // 320d: a2 ba       ..  :920d[1]
+    ldy #0                                                            // 320f: a0 00       ..  :920f[1]
+    jsr sub_c8bf9                                                     // 3211: 20 f9 8b     .. :9211[1]
+// $3214 referenced 3 times by $91e9, $9257, $9276
+c9214
+    pha                                                               // 3214: 48          H   :9214[1]
+    lda l00bf                                                         // 3215: a5 bf       ..  :9215[1]
+    clc                                                               // 3217: 18          .   :9217[1]
+    adc #7                                                            // 3218: 69 07       i.  :9218[1]
+    tay                                                               // 321a: a8          .   :921a[1]
+    pla                                                               // 321b: 68          h   :921b[1]
+    sta (l00c7),y                                                     // 321c: 91 c7       ..  :921c[1]
+    rts                                                               // 321e: 60          `   :921e[1]
+
+// $321f referenced 1 time by $91d2
+c921f
+    jsr sub_c928a                                                     // 321f: 20 8a 92     .. :921f[1]
+    bcs c922b                                                         // 3222: b0 07       ..  :9222[1]
+    lda l00c2                                                         // 3224: a5 c2       ..  :9224[1]
+    sta l108b,x                                                       // 3226: 9d 8b 10    ... :9226[1]
+    bcc c923b                                                         // 3229: 90 10       ..  :9229[1]
+// $322b referenced 1 time by $9222
+c922b
+    jsr sub_c9279                                                     // 322b: 20 79 92     y. :922b[1]
+    bcc c9257                                                         // 322e: 90 27       .'  :922e[1]
+    lda l00c2                                                         // 3230: a5 c2       ..  :9230[1]
+    ldy l10de,x                                                       // 3232: bc de 10    ... :9232[1]
+    bpl c9238                                                         // 3235: 10 01       ..  :9235[1]
+    asl                                                               // 3237: 0a          .   :9237[1]
+// $3238 referenced 1 time by $9235
+c9238
+    sta l1088,x                                                       // 3238: 9d 88 10    ... :9238[1]
+// $323b referenced 1 time by $9229
+c923b
+    lda #0                                                            // 323b: a9 00       ..  :923b[1]
+    beq c9257                                                         // 323d: f0 18       ..  :923d[1]
+// $323f referenced 1 time by $91d6
+c923f
+    jsr sub_c928a                                                     // 323f: 20 8a 92     .. :923f[1]
+    bcs c9249                                                         // 3242: b0 05       ..  :9242[1]
+    lda l108b,x                                                       // 3244: bd 8b 10    ... :9244[1]
+    bcc c9257                                                         // 3247: 90 0e       ..  :9247[1]
+// $3249 referenced 1 time by $9242
+c9249
+    jsr sub_c9279                                                     // 3249: 20 79 92     y. :9249[1]
+    bcc c9257                                                         // 324c: 90 09       ..  :924c[1]
+    lda l1088,x                                                       // 324e: bd 88 10    ... :924e[1]
+    ldy l10de,x                                                       // 3251: bc de 10    ... :9251[1]
+    bpl c9257                                                         // 3254: 10 01       ..  :9254[1]
+    lsr                                                               // 3256: 4a          J   :9256[1]
+// $3257 referenced 5 times by $922e, $923d, $9247, $924c, $9254
+c9257
+    jmp c9214                                                         // 3257: 4c 14 92    L.. :9257[1]
+
+// $325a referenced 1 time by $91dc
+c925a
+    lda #$ff                                                          // 325a: a9 ff       ..  :925a[1]
+    ldx #0                                                            // 325c: a2 00       ..  :925c[1]
+    ldy l00c1                                                         // 325e: a4 c1       ..  :925e[1]
+    cpy #$10                                                          // 3260: c0 10       ..  :9260[1]
+    beq c926a                                                         // 3262: f0 06       ..  :9262[1]
+    cpy #$18                                                          // 3264: c0 18       ..  :9264[1]
+    bne c9276                                                         // 3266: d0 0e       ..  :9266[1]
+    inx                                                               // 3268: e8          .   :9268[1]
+    inx                                                               // 3269: e8          .   :9269[1]
+// $326a referenced 1 time by $9262
+c926a
+    lda l00c2                                                         // 326a: a5 c2       ..  :926a[1]
+    sta l108b,x                                                       // 326c: 9d 8b 10    ... :926c[1]
+    lda l00c3                                                         // 326f: a5 c3       ..  :926f[1]
+    sta l108c,x                                                       // 3271: 9d 8c 10    ... :9271[1]
+    lda #0                                                            // 3274: a9 00       ..  :9274[1]
+// $3276 referenced 1 time by $9266
+c9276
+    jmp c9214                                                         // 3276: 4c 14 92    L.. :9276[1]
+
+// $3279 referenced 2 times by $922b, $9249
+sub_c9279
+    ldx #0                                                            // 3279: a2 00       ..  :9279[1]
+    lda l00c1                                                         // 327b: a5 c1       ..  :927b[1]
+    cmp #$12                                                          // 327d: c9 12       ..  :927d[1]
+    beq c9289                                                         // 327f: f0 08       ..  :927f[1]
+    inx                                                               // 3281: e8          .   :9281[1]
+    cmp #$1a                                                          // 3282: c9 1a       ..  :9282[1]
+    beq c9289                                                         // 3284: f0 03       ..  :9284[1]
+    lda #$fe                                                          // 3286: a9 fe       ..  :9286[1]
+    clc                                                               // 3288: 18          .   :9288[1]
+// $3289 referenced 2 times by $927f, $9284
+c9289
+    rts                                                               // 3289: 60          `   :9289[1]
+
+// $328a referenced 2 times by $921f, $923f
+sub_c928a
+    lda l00c1                                                         // 328a: a5 c1       ..  :928a[1]
+    and #$f6                                                          // 328c: 29 f6       ).  :928c[1]
+    cmp #$10                                                          // 328e: c9 10       ..  :928e[1]
+    sec                                                               // 3290: 38          8   :9290[1]
+    bne c929c                                                         // 3291: d0 09       ..  :9291[1]
+    lda l00c1                                                         // 3293: a5 c1       ..  :9293[1]
+    lsr                                                               // 3295: 4a          J   :9295[1]
+    lsr                                                               // 3296: 4a          J   :9296[1]
+    ora l00c1                                                         // 3297: 05 c1       ..  :9297[1]
+    and #3                                                            // 3299: 29 03       ).  :9299[1]
+    tax                                                               // 329b: aa          .   :929b[1]
+// $329c referenced 1 time by $9291
+c929c
+    rts                                                               // 329c: 60          `   :929c[1]
+
+// $329d referenced 1 time by $920a
+sub_c929d
+    jsr sub_c9a8d                                                     // 329d: 20 8d 9a     .. :929d[1]
+    lda l00bb                                                         // 32a0: a5 bb       ..  :92a0[1]
+    sta l00b0                                                         // 32a2: 85 b0       ..  :92a2[1]
+    sta l00b4                                                         // 32a4: 85 b4       ..  :92a4[1]
+    clc                                                               // 32a6: 18          .   :92a6[1]
+    adc #$80                                                          // 32a7: 69 80       i.  :92a7[1]
+    sta l00b2                                                         // 32a9: 85 b2       ..  :92a9[1]
+    lda l00bc                                                         // 32ab: a5 bc       ..  :92ab[1]
+    sta l00b1                                                         // 32ad: 85 b1       ..  :92ad[1]
+    php                                                               // 32af: 08          .   :92af[1]
+    jsr sub_c8f3f                                                     // 32b0: 20 3f 8f     ?. :92b0[1]
+    bmi c92bd                                                         // 32b3: 30 08       0.  :92b3[1]
+    lda l00bd                                                         // 32b5: a5 bd       ..  :92b5[1]
+    ora l00be                                                         // 32b7: 05 be       ..  :92b7[1]
+    cmp #$ff                                                          // 32b9: c9 ff       ..  :92b9[1]
+    bne c92c4                                                         // 32bb: d0 07       ..  :92bb[1]
+// $32bd referenced 1 time by $92b3
+c92bd
+    lda l00b1                                                         // 32bd: a5 b1       ..  :92bd[1]
+    cmp l10cf                                                         // 32bf: cd cf 10    ... :92bf[1]
+    bcs c92c7                                                         // 32c2: b0 03       ..  :92c2[1]
+// $32c4 referenced 1 time by $92bb
+c92c4
+    lda l10cf                                                         // 32c4: ad cf 10    ... :92c4[1]
+// $32c7 referenced 1 time by $92c2
+c92c7
+    plp                                                               // 32c7: 28          (   :92c7[1]
+    sta l00b5                                                         // 32c8: 85 b5       ..  :92c8[1]
+    adc #0                                                            // 32ca: 69 00       i.  :92ca[1]
+    sta l00b3                                                         // 32cc: 85 b3       ..  :92cc[1]
+    inc l00b5                                                         // 32ce: e6 b5       ..  :92ce[1]
+    lda l00ba                                                         // 32d0: a5 ba       ..  :92d0[1]
+    bpl c92d6                                                         // 32d2: 10 02       ..  :92d2[1]
+    lda #0                                                            // 32d4: a9 00       ..  :92d4[1]
+// $32d6 referenced 1 time by $92d2
+c92d6
+    rol                                                               // 32d6: 2a          *   :92d6[1]
+    rol                                                               // 32d7: 2a          *   :92d7[1]
+    rol                                                               // 32d8: 2a          *   :92d8[1]
+    sta l108a                                                         // 32d9: 8d 8a 10    ... :92d9[1]
+    ldx #2                                                            // 32dc: a2 02       ..  :92dc[1]
+    rol                                                               // 32de: 2a          *   :92de[1]
+    bmi c92e3                                                         // 32df: 30 02       0.  :92df[1]
+    ldx #0                                                            // 32e1: a2 00       ..  :92e1[1]
+// $32e3 referenced 1 time by $92df
+c92e3
+    lda l9145,x                                                       // 32e3: bd 45 91    .E. :92e3[1]
+    sta l00b6                                                         // 32e6: 85 b6       ..  :92e6[1]
+    lda l9146,x                                                       // 32e8: bd 46 91    .F. :92e8[1]
+    sta l00b7                                                         // 32eb: 85 b7       ..  :92eb[1]
+    ldy #$23 // '#'                                                   // 32ed: a0 23       .#  :92ed[1]
+// $32ef referenced 1 time by $92f4
+loop_c92ef
+    lda (l00b6),y                                                     // 32ef: b1 b6       ..  :92ef[1]
+    sta (l00b2),y                                                     // 32f1: 91 b2       ..  :92f1[1]
+    dey                                                               // 32f3: 88          .   :92f3[1]
+    bpl loop_c92ef                                                    // 32f4: 10 f9       ..  :92f4[1]
+    iny                                                               // 32f6: c8          .   :92f6[1]
+    sty l00b6                                                         // 32f7: 84 b6       ..  :92f7[1]
+    lda l00c3                                                         // 32f9: a5 c3       ..  :92f9[1]
+    pha                                                               // 32fb: 48          H   :92fb[1]
+    and #$e0                                                          // 32fc: 29 e0       ).  :92fc[1]
+    bne c9302                                                         // 32fe: d0 02       ..  :92fe[1]
+    lda #$10                                                          // 3300: a9 10       ..  :9300[1]
+// $3302 referenced 1 time by $92fe
+c9302
+    asl                                                               // 3302: 0a          .   :9302[1]
+    rol l00b6                                                         // 3303: 26 b6       &.  :9303[1]
+    asl                                                               // 3305: 0a          .   :9305[1]
+    rol l00b6                                                         // 3306: 26 b6       &.  :9306[1]
+    asl                                                               // 3308: 0a          .   :9308[1]
+    rol l00b6                                                         // 3309: 26 b6       &.  :9309[1]
+    ldy #$0d                                                          // 330b: a0 0d       ..  :930b[1]
+    sta (l00b2),y                                                     // 330d: 91 b2       ..  :930d[1]
+    lda l00b6                                                         // 330f: a5 b6       ..  :930f[1]
+    iny                                                               // 3311: c8          .   :9311[1]
+    sta (l00b2),y                                                     // 3312: 91 b2       ..  :9312[1]
+    pla                                                               // 3314: 68          h   :9314[1]
+    and #$1f                                                          // 3315: 29 1f       ).  :9315[1]
+    sta l00b9                                                         // 3317: 85 b9       ..  :9317[1]
+    lda l00c2                                                         // 3319: a5 c2       ..  :9319[1]
+    ldy #$10                                                          // 331b: a0 10       ..  :931b[1]
+    sta (l00b2),y                                                     // 331d: 91 b2       ..  :931d[1]
+    lda l00c5                                                         // 331f: a5 c5       ..  :931f[1]
+    ldy #0                                                            // 3321: a0 00       ..  :9321[1]
+    sta (l00b2),y                                                     // 3323: 91 b2       ..  :9323[1]
+    tya                                                               // 3325: 98          .   :9325[1]
+    sta l00b8                                                         // 3326: 85 b8       ..  :9326[1]
+    jsr sub_c93d3                                                     // 3328: 20 d3 93     .. :9328[1]
+    jsr sub_c8f3f                                                     // 332b: 20 3f 8f     ?. :932b[1]
+    bmi c9367                                                         // 332e: 30 37       07  :932e[1]
+    lda l00bd                                                         // 3330: a5 bd       ..  :9330[1]
+    and l00be                                                         // 3332: 25 be       %.  :9332[1]
+    cmp #$ff                                                          // 3334: c9 ff       ..  :9334[1]
+    beq c9367                                                         // 3336: f0 2f       ./  :9336[1]
+    lda #$ff                                                          // 3338: a9 ff       ..  :9338[1]
+    sta l00bd                                                         // 333a: 85 bd       ..  :933a[1]
+    sta l00be                                                         // 333c: 85 be       ..  :933c[1]
+    jsr sub_c8f6b                                                     // 333e: 20 6b 8f     k. :933e[1]
+    ldx #$bb                                                          // 3341: a2 bb       ..  :9341[1]
+    ldy #0                                                            // 3343: a0 00       ..  :9343[1]
+    tya                                                               // 3345: 98          .   :9345[1]
+    jsr tube_entry                                                    // 3346: 20 06 04     .. :9346[1]
+    ldx l00b5                                                         // 3349: a6 b5       ..  :9349[1]
+    dex                                                               // 334b: ca          .   :934b[1]
+    stx l00b1                                                         // 334c: 86 b1       ..  :934c[1]
+    lda l00b9                                                         // 334e: a5 b9       ..  :934e[1]
+    asl                                                               // 3350: 0a          .   :9350[1]
+    asl                                                               // 3351: 0a          .   :9351[1]
+    tax                                                               // 3352: aa          .   :9352[1]
+    ldy #0                                                            // 3353: a0 00       ..  :9353[1]
+// $3355 referenced 1 time by $9362
+loop_c9355
+    lda #7                                                            // 3355: a9 07       ..  :9355[1]
+// $3357 referenced 1 time by $9359
+loop_c9357
+    sbc #1                                                            // 3357: e9 01       ..  :9357[1]
+    bne loop_c9357                                                    // 3359: d0 fc       ..  :9359[1]
+    lda tube_host_r3_data                                             // 335b: ad e5 fe    ... :935b[1]
+    sta (l00b0),y                                                     // 335e: 91 b0       ..  :935e[1]
+    iny                                                               // 3360: c8          .   :9360[1]
+    dex                                                               // 3361: ca          .   :9361[1]
+    bpl loop_c9355                                                    // 3362: 10 f1       ..  :9362[1]
+    jsr sub_c8f7a                                                     // 3364: 20 7a 8f     z. :9364[1]
+// $3367 referenced 2 times by $932e, $9336
+c9367
+    lda l00b5                                                         // 3367: a5 b5       ..  :9367[1]
+    sta l00bc                                                         // 3369: 85 bc       ..  :9369[1]
+// $336b referenced 1 time by $939c
+c936b
+    ldy #$16                                                          // 336b: a0 16       ..  :936b[1]
+    ldx #0                                                            // 336d: a2 00       ..  :936d[1]
+// $336f referenced 1 time by $937c
+loop_c936f
+    lda (l00b0,x)                                                     // 336f: a1 b0       ..  :936f[1]
+    sta (l00b2),y                                                     // 3371: 91 b2       ..  :9371[1]
+    inc l00b0                                                         // 3373: e6 b0       ..  :9373[1]
+    bne c9379                                                         // 3375: d0 02       ..  :9375[1]
+    inc l00b1                                                         // 3377: e6 b1       ..  :9377[1]
+// $3379 referenced 1 time by $9375
+c9379
+    iny                                                               // 3379: c8          .   :9379[1]
+    cpy #$1a                                                          // 337a: c0 1a       ..  :937a[1]
+    bne loop_c936f                                                    // 337c: d0 f1       ..  :937c[1]
+    lda #1                                                            // 337e: a9 01       ..  :937e[1]
+    sta l00b6                                                         // 3380: 85 b6       ..  :9380[1]
+// $3382 referenced 1 time by $9396
+loop_c9382
+    lda l00b6                                                         // 3382: a5 b6       ..  :9382[1]
+    cmp #$0e                                                          // 3384: c9 0e       ..  :9384[1]
+    bne c938d                                                         // 3386: d0 05       ..  :9386[1]
+    jsr sub_c93b4                                                     // 3388: 20 b4 93     .. :9388[1]
+    beq c9390                                                         // 338b: f0 03       ..  :938b[1]
+// $338d referenced 1 time by $9386
+c938d
+    jsr sub_c93d3                                                     // 338d: 20 d3 93     .. :938d[1]
+// $3390 referenced 1 time by $938b
+c9390
+    inc l00b6                                                         // 3390: e6 b6       ..  :9390[1]
+    lda l00b6                                                         // 3392: a5 b6       ..  :9392[1]
+    cmp #$11                                                          // 3394: c9 11       ..  :9394[1]
+    bne loop_c9382                                                    // 3396: d0 ea       ..  :9396[1]
+    inc l00b8                                                         // 3398: e6 b8       ..  :9398[1]
+    dec l00b9                                                         // 339a: c6 b9       ..  :939a[1]
+    bne c936b                                                         // 339c: d0 cd       ..  :939c[1]
+    tay                                                               // 339e: a8          .   :939e[1]
+    lda #$0e                                                          // 339f: a9 0e       ..  :939f[1]
+    bit l108a                                                         // 33a1: 2c 8a 10    ,.. :93a1[1]
+    bvc c93a8                                                         // 33a4: 50 02       P.  :93a4[1]
+    lda #$1a                                                          // 33a6: a9 1a       ..  :93a6[1]
+// $33a8 referenced 1 time by $93a4
+c93a8
+    clc                                                               // 33a8: 18          .   :93a8[1]
+    adc l00bc                                                         // 33a9: 65 bc       e.  :93a9[1]
+    sbc l00b5                                                         // 33ab: e5 b5       ..  :93ab[1]
+    bcs c93b1                                                         // 33ad: b0 02       ..  :93ad[1]
+    lda #1                                                            // 33af: a9 01       ..  :93af[1]
+// $33b1 referenced 1 time by $93ad
+c93b1
+    sta (l00b2),y                                                     // 33b1: 91 b2       ..  :93b1[1]
+    tya                                                               // 33b3: 98          .   :93b3[1]
+// $33b4 referenced 1 time by $9388
+sub_c93b4
+    jsr sub_c93c5                                                     // 33b4: 20 c5 93     .. :93b4[1]
+    beq c93c4                                                         // 33b7: f0 0b       ..  :93b7[1]
+    stx l00b7                                                         // 33b9: 86 b7       ..  :93b9[1]
+    ldx #0                                                            // 33bb: a2 00       ..  :93bb[1]
+// $33bd referenced 1 time by $93c2
+loop_c93bd
+    jsr sub_c93d8                                                     // 33bd: 20 d8 93     .. :93bd[1]
+    dec l00b7                                                         // 33c0: c6 b7       ..  :93c0[1]
+    bne loop_c93bd                                                    // 33c2: d0 f9       ..  :93c2[1]
+// $33c4 referenced 1 time by $93b7
+c93c4
+    rts                                                               // 33c4: 60          `   :93c4[1]
+
+// $33c5 referenced 2 times by $93b4, $93d3
+sub_c93c5
+    tay                                                               // 33c5: a8          .   :93c5[1]
+    lda (l00b2),y                                                     // 33c6: b1 b2       ..  :93c6[1]
+    tax                                                               // 33c8: aa          .   :93c8[1]
+    tya                                                               // 33c9: 98          .   :93c9[1]
+    clc                                                               // 33ca: 18          .   :93ca[1]
+    adc #$12                                                          // 33cb: 69 12       i.  :93cb[1]
+    tay                                                               // 33cd: a8          .   :93cd[1]
+    lda (l00b2),y                                                     // 33ce: b1 b2       ..  :93ce[1]
+    cpx #0                                                            // 33d0: e0 00       ..  :93d0[1]
+    rts                                                               // 33d2: 60          `   :93d2[1]
+
+// $33d3 referenced 2 times by $9328, $938d
+sub_c93d3
+    jsr sub_c93c5                                                     // 33d3: 20 c5 93     .. :93d3[1]
+    beq c93e5                                                         // 33d6: f0 0d       ..  :93d6[1]
+// $33d8 referenced 1 time by $93bd
+sub_c93d8
+    ldy #0                                                            // 33d8: a0 00       ..  :93d8[1]
+// $33da referenced 1 time by $93e3
+loop_c93da
+    sta (l00b4),y                                                     // 33da: 91 b4       ..  :93da[1]
+    inc l00b4                                                         // 33dc: e6 b4       ..  :93dc[1]
+    bne c93e2                                                         // 33de: d0 02       ..  :93de[1]
+    inc l00b5                                                         // 33e0: e6 b5       ..  :93e0[1]
+// $33e2 referenced 1 time by $93de
+c93e2
+    dex                                                               // 33e2: ca          .   :93e2[1]
+    bne loop_c93da                                                    // 33e3: d0 f5       ..  :93e3[1]
+// $33e5 referenced 1 time by $93d6
+c93e5
+    rts                                                               // 33e5: 60          `   :93e5[1]
+
+// $33e6 referenced 10 times by $8772, $8791, $87cb, $89d7, $8a6b, $8b12, $8bf3, $9bbc, $9fff, $a30a
+c93e6
+    lda l0f04                                                         // 33e6: ad 04 0f    ... :93e6[1]
+    clc                                                               // 33e9: 18          .   :93e9[1]
+    sed                                                               // 33ea: f8          .   :93ea[1]
+    adc #1                                                            // 33eb: 69 01       i.  :93eb[1]
+    sta l0f04                                                         // 33ed: 8d 04 0f    ... :93ed[1]
+    cld                                                               // 33f0: d8          .   :93f0[1]
+// $33f1 referenced 1 time by $a737
+sub_c93f1
+    ldy #$a0                                                          // 33f1: a0 a0       ..  :93f1[1]
+    bne c940e                                                         // 33f3: d0 19       ..  :93f3[1]
+// $33f5 referenced 2 times by $9636, $a7ce
+sub_c93f5
+    ldy #$81                                                          // 33f5: a0 81       ..  :93f5[1]
+    bne c940e                                                         // 33f7: d0 15       ..  :93f7[1]
+// $33f9 referenced 1 time by $8266
+sub_c93f9
+    ldy #$81                                                          // 33f9: a0 81       ..  :93f9[1]
+    bne c93ff                                                         // 33fb: d0 02       ..  :93fb[1]
+// $33fd referenced 3 times by $8287, $988e, $98da
+sub_c93fd
+    ldy #$80                                                          // 33fd: a0 80       ..  :93fd[1]
+// $33ff referenced 1 time by $93fb
+c93ff
+    bit lfe84                                                         // 33ff: 2c 84 fe    ,.. :93ff[1]
+    bpl c940e                                                         // 3402: 10 0a       ..  :9402[1]
+    lda l1082                                                         // 3404: ad 82 10    ... :9404[1]
+    cmp l00cd                                                         // 3407: c5 cd       ..  :9407[1]
+    bne c940e                                                         // 3409: d0 03       ..  :9409[1]
+    rts                                                               // 340b: 60          `   :940b[1]
+
+// $340c referenced 6 times by $8383, $8489, $8a59, $a431, $a448, $a460
+c940c
+    ldy #$80                                                          // 340c: a0 80       ..  :940c[1]
+// $340e referenced 4 times by $93f3, $93f7, $9402, $9409
+c940e
+    jsr sub_c9536                                                     // 340e: 20 36 95     6. :940e[1]
+    sty l1096                                                         // 3411: 8c 96 10    ... :9411[1]
+    lda l00cd                                                         // 3414: a5 cd       ..  :9414[1]
+    sta l1090                                                         // 3416: 8d 90 10    ... :9416[1]
+    lda #2                                                            // 3419: a9 02       ..  :9419[1]
+    sta l1099                                                         // 341b: 8d 99 10    ... :941b[1]
+    lda #$0e                                                          // 341e: a9 0e       ..  :941e[1]
+    sta l1092                                                         // 3420: 8d 92 10    ... :9420[1]
+    dec l1093                                                         // 3423: ce 93 10    ... :9423[1]
+    dec l1094                                                         // 3426: ce 94 10    ... :9426[1]
+    jsr sub_c9445                                                     // 3429: 20 45 94     E. :9429[1]
+    lda l00cd                                                         // 342c: a5 cd       ..  :942c[1]
+    sta l1082                                                         // 342e: 8d 82 10    ... :942e[1]
+    rts                                                               // 3431: 60          `   :9431[1]
+
+// $3432 referenced 2 times by $944d, $a6f9
+sub_c9432
+    bit l00ff                                                         // 3432: 24 ff       $.  :9432[1]
+    bpl c9444                                                         // 3434: 10 0e       ..  :9434[1]
+// $3436 referenced 4 times by $946c, $a411, $a65d, $abc2
+c9436
+    jsr sub_c9ad8                                                     // 3436: 20 d8 9a     .. :9436[1]
+    jsr generate_error                                                // 3439: 20 48 80     H. :9439[1]
+    .byt $11                                                          // 343c: 11          .   :943c[1]
+    .asc "Escape"                                                     // 343d: 45 73 63... Esc :943d[1]
+    .byt 0                                                            // 3443: 00          .   :9443[1]
+
+// $3444 referenced 3 times by $9434, $946a, $947a
+c9444
+    rts                                                               // 3444: 60          `   :9444[1]
+
+// $3445 referenced 2 times by $886a, $9429
+sub_c9445
+    jsr sub_c9516                                                     // 3445: 20 16 95     .. :9445[1]
+    lda #6                                                            // 3448: a9 06       ..  :9448[1]
+    sta l109e                                                         // 344a: 8d 9e 10    ... :944a[1]
+    jsr sub_c9432                                                     // 344d: 20 32 94     2. :944d[1]
+// $3450 referenced 1 time by $94bf
+c9450
+    lda l1097                                                         // 3450: ad 97 10    ... :9450[1]
+    ldx l1090                                                         // 3453: ae 90 10    ... :9453[1]
+    ldy l10de,x                                                       // 3456: bc de 10    ... :9456[1]
+    bpl c945c                                                         // 3459: 10 01       ..  :9459[1]
+    asl                                                               // 345b: 0a          .   :945b[1]
+// $345c referenced 1 time by $9459
+c945c
+    ldy #$18                                                          // 345c: a0 18       ..  :945c[1]
+    cmp #$50 // 'P'                                                   // 345e: c9 50       .P  :945e[1]
+    bcs c94c1                                                         // 3460: b0 5f       ._  :9460[1]
+    ldx #$90                                                          // 3462: a2 90       ..  :9462[1]
+    ldy #$10                                                          // 3464: a0 10       ..  :9464[1]
+    jsr sub_c8bf6                                                     // 3466: 20 f6 8b     .. :9466[1]
+    tay                                                               // 3469: a8          .   :9469[1]
+    beq c9444                                                         // 346a: f0 d8       ..  :946a[1]
+    bmi c9436                                                         // 346c: 30 c8       0.  :946c[1]
+    cmp #$12                                                          // 346e: c9 12       ..  :946e[1]
+    beq c94c6                                                         // 3470: f0 54       .T  :9470[1]
+    cmp #$20 // ' '                                                   // 3472: c9 20       .   :9472[1]
+    bne c948d                                                         // 3474: d0 17       ..  :9474[1]
+    lda l1096                                                         // 3476: ad 96 10    ... :9476[1]
+    ror                                                               // 3479: 6a          j   :9479[1]
+    bcs c9444                                                         // 347a: b0 c8       ..  :947a[1]
+    jsr generate_error                                                // 347c: 20 48 80     H. :947c[1]
+    .byt $bc                                                          // 347f: bc          .   :947f[1]
+    .asc "Execute only"                                               // 3480: 45 78 65... Exe :9480[1]
+    .byt 0                                                            // 348c: 00          .   :948c[1]
+
+// $348d referenced 1 time by $9474
+c948d
+    cmp #$18                                                          // 348d: c9 18       ..  :948d[1]
+    bne c94bc                                                         // 348f: d0 2b       .+  :948f[1]
+    lda l108a                                                         // 3491: ad 8a 10    ... :9491[1]
+    cmp #4                                                            // 3494: c9 04       ..  :9494[1]
+    bne c94a9                                                         // 3496: d0 11       ..  :9496[1]
+    ldx l1096                                                         // 3498: ae 96 10    ... :9498[1]
+    cpx #$81                                                          // 349b: e0 81       ..  :949b[1]
+    bne c94a9                                                         // 349d: d0 0a       ..  :949d[1]
+    lda #$ff                                                          // 349f: a9 ff       ..  :949f[1]
+    eor l108b                                                         // 34a1: 4d 8b 10    M.. :94a1[1]
+    sta l108b                                                         // 34a4: 8d 8b 10    ... :94a4[1]
+    bcs c94bc                                                         // 34a7: b0 13       ..  :94a7[1]
+// $34a9 referenced 2 times by $9496, $949d
+c94a9
+    ldx l00ce                                                         // 34a9: a6 ce       ..  :94a9[1]
+    beq c94bc                                                         // 34ab: f0 0f       ..  :94ab[1]
+    rol                                                               // 34ad: 2a          *   :94ad[1]
+    and #$80                                                          // 34ae: 29 80       ).  :94ae[1]
+    ldx l1090                                                         // 34b0: ae 90 10    ... :94b0[1]
+    eor l10de,x                                                       // 34b3: 5d de 10    ].. :94b3[1]
+    sta l10de,x                                                       // 34b6: 9d de 10    ... :94b6[1]
+    jsr sub_c9516                                                     // 34b9: 20 16 95     .. :94b9[1]
+// $34bc referenced 3 times by $948f, $94a7, $94ab
+c94bc
+    dec l109e                                                         // 34bc: ce 9e 10    ... :94bc[1]
+    bne c9450                                                         // 34bf: d0 8f       ..  :94bf[1]
+// $34c1 referenced 1 time by $9460
+c94c1
+    tya                                                               // 34c1: 98          .   :94c1[1]
+// $34c2 referenced 1 time by $a70f
+c94c2
+    cmp #$12                                                          // 34c2: c9 12       ..  :94c2[1]
+    bne c94d4                                                         // 34c4: d0 0e       ..  :94c4[1]
+// $34c6 referenced 2 times by $9470, $9523
+c94c6
+    jsr generate_error_precheck_disc                                  // 34c6: 20 23 80     #. :94c6[1]
+    .byt $c9                                                          // 34c9: c9          .   :94c9[1]
+    .asc "read only"                                                  // 34ca: 72 65 61... rea :94ca[1]
+    .byt 0                                                            // 34d3: 00          .   :94d3[1]
+
+// $34d4 referenced 1 time by $94c4
+c94d4
+    pha                                                               // 34d4: 48          H   :94d4[1]
+    jsr generate_error_precheck_disc                                  // 34d5: 20 23 80     #. :94d5[1]
+    .byt 0                                                            // 34d8: 00          .   :94d8[1]
+
+    nop                                                               // 34d9: ea          .   :94d9[1]
+    jsr generate_error2                                               // 34da: 20 4f 80     O. :94da[1]
+    .byt $c7                                                          // 34dd: c7          .   :94dd[1]
+    .asc "fault "                                                     // 34de: 66 61 75... fau :94de[1]
+
+    nop                                                               // 34e4: ea          .   :94e4[1]
+    pla                                                               // 34e5: 68          h   :94e5[1]
+    jsr sub_c9526                                                     // 34e6: 20 26 95     &. :94e6[1]
+    jsr generate_error2                                               // 34e9: 20 4f 80     O. :94e9[1]
+    .byt 0                                                            // 34ec: 00          .   :94ec[1]
+    .asc " at :"                                                      // 34ed: 20 61 74...  at :94ed[1]
+
+    lda l00cd                                                         // 34f2: a5 cd       ..  :94f2[1]
+    jsr sub_c952e                                                     // 34f4: 20 2e 95     .. :94f4[1]
+    jsr generate_error2                                               // 34f7: 20 4f 80     O. :94f7[1]
+    .byt 0                                                            // 34fa: 00          .   :94fa[1]
+    .asc " "                                                          // 34fb: 20              :94fb[1]
+
+    lda l00ce                                                         // 34fc: a5 ce       ..  :94fc[1]
+    bit l108a                                                         // 34fe: 2c 8a 10    ,.. :94fe[1]
+    bpl c9504                                                         // 3501: 10 01       ..  :9501[1]
+    lsr                                                               // 3503: 4a          J   :9503[1]
+// $3504 referenced 1 time by $9501
+c9504
+    jsr sub_c9526                                                     // 3504: 20 26 95     &. :9504[1]
+    jsr generate_error2                                               // 3507: 20 4f 80     O. :9507[1]
+    .byt 0                                                            // 350a: 00          .   :950a[1]
+    .asc $2f                                                          // 350b: 2f          /   :950b[1]
+
+    lda l00cf                                                         // 350c: a5 cf       ..  :950c[1]
+    jsr sub_c9526                                                     // 350e: 20 26 95     &. :950e[1]
+    jsr generate_error2                                               // 3511: 20 4f 80     O. :9511[1]
+    .byt $c7,   0                                                     // 3514: c7 00       ..  :9514[1]
+
+// $3516 referenced 2 times by $9445, $94b9
+sub_c9516
+    lda l1096                                                         // 3516: ad 96 10    ... :9516[1]
+    cmp #$a0                                                          // 3519: c9 a0       ..  :9519[1]
+    bcc c9535                                                         // 351b: 90 18       ..  :951b[1]
+    ldx l1090                                                         // 351d: ae 90 10    ... :951d[1]
+    lda l10de,x                                                       // 3520: bd de 10    ... :9520[1]
+    bmi c94c6                                                         // 3523: 30 a1       0.  :9523[1]
+    rts                                                               // 3525: 60          `   :9525[1]
+
+// $3526 referenced 3 times by $94e6, $9504, $950e
+sub_c9526
+    pha                                                               // 3526: 48          H   :9526[1]
+    jsr sub_c81bf                                                     // 3527: 20 bf 81     .. :9527[1]
+    jsr sub_c952e                                                     // 352a: 20 2e 95     .. :952a[1]
+    pla                                                               // 352d: 68          h   :952d[1]
+// $352e referenced 2 times by $94f4, $952a
+sub_c952e
+    jsr sub_c80c8                                                     // 352e: 20 c8 80     .. :952e[1]
+    sta l0100,x                                                       // 3531: 9d 00 01    ... :9531[1]
+    inx                                                               // 3534: e8          .   :9534[1]
+// $3535 referenced 1 time by $951b
+c9535
+    rts                                                               // 3535: 60          `   :9535[1]
+
+// $3536 referenced 1 time by $940e
+sub_c9536
+    ldx #$0d                                                          // 3536: a2 0d       ..  :9536[1]
+    lda #0                                                            // 3538: a9 00       ..  :9538[1]
+// $353a referenced 1 time by $953e
+loop_c953a
+    sta l108f,x                                                       // 353a: 9d 8f 10    ... :953a[1]
+    dex                                                               // 353d: ca          .   :953d[1]
+    bne loop_c953a                                                    // 353e: d0 fa       ..  :953e[1]
+    lda #5                                                            // 3540: a9 05       ..  :9540[1]
+    sta l1095                                                         // 3542: 8d 95 10    ... :9542[1]
+    rts                                                               // 3545: 60          `   :9545[1]
+
+    .asc "L.!BOOT", $0d                                               // 3546: 4c 2e 21... L.! :9546[1]
+    .asc "E.!BOOT", $0d                                               // 354e: 45 2e 21... E.! :954e[1]
+
+// $3556 referenced 1 time by $96e9
+c9556
+    lda l00b3                                                         // 3556: a5 b3       ..  :9556[1]
+    jsr print_inline_l809f_top_bit_clear                              // 3558: 20 77 80     w. :9558[1]
+    .asc "Acorn 1770 DFS", $0d, $0d                                   // 355b: 41 63 6f... Aco :955b[1]
+
+    bcc c956f                                                         // 356b: 90 02       ..  :956b[1]
+// $356d referenced 1 time by $96fd
+c956d
+    lda #$ff                                                          // 356d: a9 ff       ..  :956d[1]
+// $356f referenced 1 time by $956b
+c956f
+    jsr zero_stacked_XXX                                              // 356f: 20 8e 9d     .. :956f[1]
+    pha                                                               // 3572: 48          H   :9572[1]
+    lda #6                                                            // 3573: a9 06       ..  :9573[1]
+    jsr sub_c8020                                                     // 3575: 20 20 80      . :9575[1]
+    lda lfe87                                                         // 3578: ad 87 fe    ... :9578[1]
+    ldx #$0d                                                          // 357b: a2 0d       ..  :957b[1]
+// $357d referenced 1 time by $9584
+loop_c957d
+    lda l9aec,x                                                       // 357d: bd ec 9a    ... :957d[1]
+    sta filev,x                                                       // 3580: 9d 12 02    ... :9580[1]
+    dex                                                               // 3583: ca          .   :9583[1]
+    bpl loop_c957d                                                    // 3584: 10 f7       ..  :9584[1]
+    lda #$a8                                                          // 3586: a9 a8       ..  :9586[1]
+    jsr osbyte_read                                                   // 3588: 20 e5 9a     .. :9588[1]
+    sty l00b1                                                         // 358b: 84 b1       ..  :958b[1]
+    stx l00b0                                                         // 358d: 86 b0       ..  :958d[1]
+    ldx #7                                                            // 358f: a2 07       ..  :958f[1]
+    ldy #$1b                                                          // 3591: a0 1b       ..  :9591[1]
+// $3593 referenced 1 time by $95a5
+loop_c9593
+    lda c9adf,y                                                       // 3593: b9 df 9a    ... :9593[1]
+    sta (l00b0),y                                                     // 3596: 91 b0       ..  :9596[1]
+    iny                                                               // 3598: c8          .   :9598[1]
+    lda c9adf,y                                                       // 3599: b9 df 9a    ... :9599[1]
+    sta (l00b0),y                                                     // 359c: 91 b0       ..  :959c[1]
+    iny                                                               // 359e: c8          .   :959e[1]
+    lda romsel_copy                                                   // 359f: a5 f4       ..  :959f[1]
+    sta (l00b0),y                                                     // 35a1: 91 b0       ..  :95a1[1]
+    iny                                                               // 35a3: c8          .   :95a3[1]
+    dex                                                               // 35a4: ca          .   :95a4[1]
+    bne loop_c9593                                                    // 35a5: d0 ec       ..  :95a5[1]
+    sty l1082                                                         // 35a7: 8c 82 10    ... :95a7[1]
+    sty l1083                                                         // 35aa: 8c 83 10    ... :95aa[1]
+    stx l00cd                                                         // 35ad: 86 cd       ..  :95ad[1]
+    lda #$ff                                                          // 35af: a9 ff       ..  :95af[1]
+    sta l1087                                                         // 35b1: 8d 87 10    ... :95b1[1]
+    ldy #3                                                            // 35b4: a0 03       ..  :95b4[1]
+// $35b6 referenced 1 time by $95ba
+loop_c95b6
+    sta l108b,y                                                       // 35b6: 99 8b 10    ... :95b6[1]
+    dey                                                               // 35b9: 88          .   :95b9[1]
+    bpl loop_c95b6                                                    // 35ba: 10 fa       ..  :95ba[1]
+    ldx #$0f                                                          // 35bc: a2 0f       ..  :95bc[1]
+    jsr c9adf                                                         // 35be: 20 df 9a     .. :95be[1]
+    jsr sub_c9ab8                                                     // 35c1: 20 b8 9a     .. :95c1[1]
+    ldy #$d3                                                          // 35c4: a0 d3       ..  :95c4[1]
+    lda (l00b0),y                                                     // 35c6: b1 b0       ..  :95c6[1]
+    bpl c95fd                                                         // 35c8: 10 33       .3  :95c8[1]
+    pla                                                               // 35ca: 68          h   :95ca[1]
+    pha                                                               // 35cb: 48          H   :95cb[1]
+    beq c95fd                                                         // 35cc: f0 2f       ./  :95cc[1]
+    ldy #$d4                                                          // 35ce: a0 d4       ..  :95ce[1]
+    lda (l00b0),y                                                     // 35d0: b1 b0       ..  :95d0[1]
+    bmi c9628                                                         // 35d2: 30 54       0T  :95d2[1]
+    jsr sub_c9aa3                                                     // 35d4: 20 a3 9a     .. :95d4[1]
+    ldy #0                                                            // 35d7: a0 00       ..  :95d7[1]
+// $35d9 referenced 1 time by $95e8
+loop_c95d9
+    lda (l00b0),y                                                     // 35d9: b1 b0       ..  :95d9[1]
+    cpy #$c0                                                          // 35db: c0 c0       ..  :95db[1]
+    bcc c95e4                                                         // 35dd: 90 05       ..  :95dd[1]
+    sta l1000,y                                                       // 35df: 99 00 10    ... :95df[1]
+    bcs c95e7                                                         // 35e2: b0 03       ..  :95e2[1]
+// $35e4 referenced 1 time by $95dd
+c95e4
+    sta l1100,y                                                       // 35e4: 99 00 11    ... :95e4[1]
+// $35e7 referenced 1 time by $95e2
+c95e7
+    dey                                                               // 35e7: 88          .   :95e7[1]
+    bne loop_c95d9                                                    // 35e8: d0 ef       ..  :95e8[1]
+    lda #$a0                                                          // 35ea: a9 a0       ..  :95ea[1]
+// $35ec referenced 1 time by $95f9
+loop_c95ec
+    tay                                                               // 35ec: a8          .   :95ec[1]
+    pha                                                               // 35ed: 48          H   :95ed[1]
+    lda #$3f // '?'                                                   // 35ee: a9 3f       .?  :95ee[1]
+    jsr sub_c9f16                                                     // 35f0: 20 16 9f     .. :95f0[1]
+    pla                                                               // 35f3: 68          h   :95f3[1]
+    sta l111d,y                                                       // 35f4: 99 1d 11    ... :95f4[1]
+    sbc #$1f                                                          // 35f7: e9 1f       ..  :95f7[1]
+    bne loop_c95ec                                                    // 35f9: d0 f1       ..  :95f9[1]
+    beq c9628                                                         // 35fb: f0 2b       .+  :95fb[1]
+// $35fd referenced 2 times by $95c8, $95cc
+c95fd
+    jsr sub_c9aa3                                                     // 35fd: 20 a3 9a     .. :95fd[1]
+    lda #$24 // '$'                                                   // 3600: a9 24       .$  :9600[1]
+    sta l10c9                                                         // 3602: 8d c9 10    ... :9602[1]
+    sta l10cb                                                         // 3605: 8d cb 10    ... :9605[1]
+    ldy #0                                                            // 3608: a0 00       ..  :9608[1]
+    sty l10ca                                                         // 360a: 8c ca 10    ... :960a[1]
+    sty l10cc                                                         // 360d: 8c cc 10    ... :960d[1]
+    ldy #0                                                            // 3610: a0 00       ..  :9610[1]
+    sty l10c0                                                         // 3612: 8c c0 10    ... :9612[1]
+    ldx #3                                                            // 3615: a2 03       ..  :9615[1]
+    tya                                                               // 3617: 98          .   :9617[1]
+// $3618 referenced 1 time by $961c
+loop_c9618
+    sta l10de,x                                                       // 3618: 9d de 10    ... :9618[1]
+    dex                                                               // 361b: ca          .   :961b[1]
+    bne loop_c9618                                                    // 361c: d0 fa       ..  :961c[1]
+    dey                                                               // 361e: 88          .   :961e[1]
+    sty l10c7                                                         // 361f: 8c c7 10    ... :961f[1]
+    sty l10c6                                                         // 3622: 8c c6 10    ... :9622[1]
+    sty l10dd                                                         // 3625: 8c dd 10    ... :9625[1]
+// $3628 referenced 2 times by $95d2, $95fb
+c9628
+    jsr sub_c8f3f                                                     // 3628: 20 3f 8f     ?. :9628[1]
+    pla                                                               // 362b: 68          h   :962b[1]
+    bne c9649                                                         // 362c: d0 1b       ..  :962c[1]
+    lda #4                                                            // 362e: a9 04       ..  :962e[1]
+    ora l10de                                                         // 3630: 0d de 10    ... :9630[1]
+    sta l10de                                                         // 3633: 8d de 10    ... :9633[1]
+    jsr sub_c93f5                                                     // 3636: 20 f5 93     .. :9636[1]
+    lda #$fb                                                          // 3639: a9 fb       ..  :9639[1]
+    and l10de                                                         // 363b: 2d de 10    -.. :963b[1]
+    sta l10de                                                         // 363e: 8d de 10    ... :963e[1]
+    lda l0f06                                                         // 3641: ad 06 0f    ... :9641[1]
+    jsr sub_c81bf                                                     // 3644: 20 bf 81     .. :9644[1]
+    bne c964a                                                         // 3647: d0 01       ..  :9647[1]
+// $3649 referenced 1 time by $962c
+c9649
+    rts                                                               // 3649: 60          `   :9649[1]
+
+// $364a referenced 1 time by $9647
+c964a
+    ldy #$95                                                          // 364a: a0 95       ..  :964a[1]
+    ldx #$46 // 'F'                                                   // 364c: a2 46       .F  :964c[1]
+    cmp #2                                                            // 364e: c9 02       ..  :964e[1]
+    bcc c965a                                                         // 3650: 90 08       ..  :9650[1]
+    beq c9658                                                         // 3652: f0 04       ..  :9652[1]
+    ldx #$4e // 'N'                                                   // 3654: a2 4e       .N  :9654[1]
+    bne c965a                                                         // 3656: d0 02       ..  :9656[1]
+// $3658 referenced 1 time by $9652
+c9658
+    ldx #$50 // 'P'                                                   // 3658: a2 50       .P  :9658[1]
+// $365a referenced 2 times by $9650, $9656
+c965a
+    jmp oscli                                                         // 365a: 4c f7 ff    L.. :965a[1]
+
+// $365d referenced 1 time by $b1b1
+sub_c965d
+    jsr service_handler_help_and_tube                                 // 365d: 20 a9 ae     .. :965d[1]
+    pha                                                               // 3660: 48          H   :9660[1]
+    lda l0df0,x                                                       // 3661: bd f0 0d    ... :9661[1]
+    bmi pla_rts                                                       // 3664: 30 5b       0[  :9664[1]
+    pla                                                               // 3666: 68          h   :9666[1]
+    cmp #service_claim_absolute_workspace                             // 3667: c9 01       ..  :9667[1]
+    bne c9683                                                         // 3669: d0 18       ..  :9669[1]
+    jsr set_c_iff_have_fdc                                            // 366b: 20 04 91     .. :966b[1]
+    ldx romsel_copy                                                   // 366e: a6 f4       ..  :966e[1]
+    bcs c967a                                                         // 3670: b0 08       ..  :9670[1]
+    lda #$80                                                          // 3672: a9 80       ..  :9672[1]
+    sta l0df0,x                                                       // 3674: 9d f0 0d    ... :9674[1]
+    lda #1                                                            // 3677: a9 01       ..  :9677[1]
+    rts                                                               // 3679: 60          `   :9679[1]
+
+// $367a referenced 1 time by $9670
+c967a
+    lda #service_claim_absolute_workspace                             // 367a: a9 01       ..  :967a[1]
+    cpy #$17                                                          // 367c: c0 17       ..  :967c[1]
+    bcs c9682                                                         // 367e: b0 02       ..  :967e[1]
+    ldy #$17                                                          // 3680: a0 17       ..  :9680[1]
+// $3682 referenced 1 time by $967e
+c9682
+    rts                                                               // 3682: 60          `   :9682[1]
+
+// $3683 referenced 1 time by $9669
+c9683
+    cmp #service_claim_private_workspace                              // 3683: c9 02       ..  :9683[1]
+    bne c96c3                                                         // 3685: d0 3c       .<  :9685[1]
+    pha                                                               // 3687: 48          H   :9687[1]
+    tya                                                               // 3688: 98          .   :9688[1]
+    pha                                                               // 3689: 48          H   :9689[1]
+    sta l00b1                                                         // 368a: 85 b1       ..  :968a[1]
+    ldy l0df0,x                                                       // 368c: bc f0 0d    ... :968c[1]
+    sta l0df0,x                                                       // 368f: 9d f0 0d    ... :968f[1]
+    lda #0                                                            // 3692: a9 00       ..  :9692[1]
+    sta l00b0                                                         // 3694: 85 b0       ..  :9694[1]
+    cpy l00b1                                                         // 3696: c4 b1       ..  :9696[1]
+    beq c969e                                                         // 3698: f0 04       ..  :9698[1]
+    ldy #$d3                                                          // 369a: a0 d3       ..  :969a[1]
+    sta (l00b0),y                                                     // 369c: 91 b0       ..  :969c[1]
+// $369e referenced 1 time by $9698
+c969e
+    lda #$fd                                                          // 369e: a9 fd       ..  :969e[1]
+    jsr osbyte_read                                                   // 36a0: 20 e5 9a     .. :96a0[1]
+    dex                                                               // 36a3: ca          .   :96a3[1]
+    txa                                                               // 36a4: 8a          .   :96a4[1]
+    ldy #$d3                                                          // 36a5: a0 d3       ..  :96a5[1]
+    and (l00b0),y                                                     // 36a7: 31 b0       1.  :96a7[1]
+    sta (l00b0),y                                                     // 36a9: 91 b0       ..  :96a9[1]
+    php                                                               // 36ab: 08          .   :96ab[1]
+    iny                                                               // 36ac: c8          .   :96ac[1]
+    plp                                                               // 36ad: 28          (   :96ad[1]
+    bpl c96b7                                                         // 36ae: 10 07       ..  :96ae[1]
+    lda (l00b0),y                                                     // 36b0: b1 b0       ..  :96b0[1]
+    bpl c96b7                                                         // 36b2: 10 03       ..  :96b2[1]
+    jsr sub_c8951                                                     // 36b4: 20 51 89     Q. :96b4[1]
+// $36b7 referenced 2 times by $96ae, $96b2
+c96b7
+    lda #0                                                            // 36b7: a9 00       ..  :96b7[1]
+    sta (l00b0),y                                                     // 36b9: 91 b0       ..  :96b9[1]
+    ldx romsel_copy                                                   // 36bb: a6 f4       ..  :96bb[1]
+    pla                                                               // 36bd: 68          h   :96bd[1]
+    tay                                                               // 36be: a8          .   :96be[1]
+    iny                                                               // 36bf: c8          .   :96bf[1]
+    iny                                                               // 36c0: c8          .   :96c0[1]
+// $36c1 referenced 1 time by $9664
+pla_rts
+    pla                                                               // 36c1: 68          h   :96c1[1]
+// $36c2 referenced 1 time by $96df
+loop_c96c2
+    rts                                                               // 36c2: 60          `   :96c2[1]
+
+// $36c3 referenced 1 time by $9685
+c96c3
+    jsr sub_c83e3                                                     // 36c3: 20 e3 83     .. :96c3[1]
+    cmp #service_boot                                                 // 36c6: c9 03       ..  :96c6[1]
+    bne c96ec                                                         // 36c8: d0 22       ."  :96c8[1]
+    sty l00b3                                                         // 36ca: 84 b3       ..  :96ca[1]
+    lda #0                                                            // 36cc: a9 00       ..  :96cc[1]
+    sta l10de                                                         // 36ce: 8d de 10    ... :96ce[1]
+    lda #osbyte_scan_keyboard_from_16                                 // 36d1: a9 7a       .z  :96d1[1]
+    jsr osbyte                                                        // 36d3: 20 f4 ff     .. :96d3[1]
+    txa                                                               // 36d6: 8a          .   :96d6[1]
+    bmi c96e9                                                         // 36d7: 30 10       0.  :96d7[1]
+    cmp #$32 // '2'                                                   // 36d9: c9 32       .2  :96d9[1]
+    beq c96e4                                                         // 36db: f0 07       ..  :96db[1]
+    cmp #$61 // 'a'                                                   // 36dd: c9 61       .a  :96dd[1]
+    bne loop_c96c2                                                    // 36df: d0 e1       ..  :96df[1]
+    jsr sub_cac72                                                     // 36e1: 20 72 ac     r. :96e1[1]
+// $36e4 referenced 1 time by $96db
+c96e4
+    lda #osbyte_write_keys_pressed                                    // 36e4: a9 78       .x  :96e4[1]
+    jsr osbyte                                                        // 36e6: 20 f4 ff     .. :96e6[1]
+// $36e9 referenced 1 time by $96d7
+c96e9
+    jmp c9556                                                         // 36e9: 4c 56 95    LV. :96e9[1]
+
+// $36ec referenced 1 time by $96c8
+c96ec
+    cmp #service_unrecognised_command                                 // 36ec: c9 04       ..  :96ec[1]
+    bne c96f5                                                         // 36ee: d0 05       ..  :96ee[1]
+    ldx #$9b                                                          // 36f0: a2 9b       ..  :96f0[1]
+// $36f2 referenced 1 time by $970a
+loop_c96f2
+    jmp c8703                                                         // 36f2: 4c 03 87    L.. :96f2[1]
+
+// $36f5 referenced 1 time by $96ee
+c96f5
+    cmp #service_select_filing_system                                 // 36f5: c9 12       ..  :96f5[1]
+    bne c9700                                                         // 36f7: d0 07       ..  :96f7[1]
+    cpy #4                                                            // 36f9: c0 04       ..  :96f9[1]
+    bne c973c                                                         // 36fb: d0 3f       .?  :96fb[1]
+    jmp c956d                                                         // 36fd: 4c 6d 95    Lm. :96fd[1]
+
+// $3700 referenced 1 time by $96f7
+c9700
+    cmp #service_help                                                 // 3700: c9 09       ..  :9700[1]
+    bne c9714                                                         // 3702: d0 10       ..  :9702[1]
+    lda (os_text_ptr),y                                               // 3704: b1 f2       ..  :9704[1]
+    ldx #$cf                                                          // 3706: a2 cf       ..  :9706[1]
+    cmp #$0d                                                          // 3708: c9 0d       ..  :9708[1]
+    bne loop_c96f2                                                    // 370a: d0 e6       ..  :970a[1]
+    tya                                                               // 370c: 98          .   :970c[1]
+    inx                                                               // 370d: e8          .   :970d[1]
+    inx                                                               // 370e: e8          .   :970e[1]
+    ldy #2                                                            // 370f: a0 02       ..  :970f[1]
+    jmp ca10b                                                         // 3711: 4c 0b a1    L.. :9711[1]
+
+// $3714 referenced 1 time by $9702
+c9714
+    jsr zero_stacked_XXX                                              // 3714: 20 8e 9d     .. :9714[1]
+    cmp #service_absolute_workspace_claimed                           // 3717: c9 0a       ..  :9717[1]
+    bne c973d                                                         // 3719: d0 22       ."  :9719[1]
+    jsr sub_c9ab8                                                     // 371b: 20 b8 9a     .. :971b[1]
+    ldy #$d4                                                          // 371e: a0 d4       ..  :971e[1]
+    lda (l00b0),y                                                     // 3720: b1 b0       ..  :9720[1]
+    bpl c9736                                                         // 3722: 10 12       ..  :9722[1]
+    ldy #0                                                            // 3724: a0 00       ..  :9724[1]
+    jsr sub_c9d75                                                     // 3726: 20 75 9d     u. :9726[1]
+    jsr sub_c8951                                                     // 3729: 20 51 89     Q. :9729[1]
+    jsr sub_c9ab8                                                     // 372c: 20 b8 9a     .. :972c[1]
+    ldy #$d4                                                          // 372f: a0 d4       ..  :972f[1]
+    lda #0                                                            // 3731: a9 00       ..  :9731[1]
+    sta (l00b0),y                                                     // 3733: 91 b0       ..  :9733[1]
+    rts                                                               // 3735: 60          `   :9735[1]
+
+// $3736 referenced 1 time by $9722
+c9736
+    lda #$0a                                                          // 3736: a9 0a       ..  :9736[1]
+// $3738 referenced 3 times by $973f, $9743, $9747
+c9738
+    tsx                                                               // 3738: ba          .   :9738[1]
+    sta l0105,x                                                       // 3739: 9d 05 01    ... :9739[1]
+// $373c referenced 1 time by $96fb
+c973c
+    rts                                                               // 373c: 60          `   :973c[1]
+
+// $373d referenced 1 time by $9719
+c973d
+    cmp #service_unrecognised_osword                                  // 373d: c9 08       ..  :973d[1]
+    bne c9738                                                         // 373f: d0 f7       ..  :973f[1]
+    ldy l00ef                                                         // 3741: a4 ef       ..  :9741[1]
+    bmi c9738                                                         // 3743: 30 f3       0.  :9743[1]
+    cpy #$7d // '}'                                                   // 3745: c0 7d       .}  :9745[1]
+    bcc c9738                                                         // 3747: 90 ef       ..  :9747[1]
+    ldx l00f0                                                         // 3749: a6 f0       ..  :9749[1]
+    stx l00c7                                                         // 374b: 86 c7       ..  :974b[1]
+    ldx l00f1                                                         // 374d: a6 f1       ..  :974d[1]
+    stx l00c8                                                         // 374f: 86 c8       ..  :974f[1]
+    iny                                                               // 3751: c8          .   :9751[1]
+    bpl c975b                                                         // 3752: 10 07       ..  :9752[1]
+    ldx l00c7                                                         // 3754: a6 c7       ..  :9754[1]
+    ldy l00c8                                                         // 3756: a4 c8       ..  :9756[1]
+    jmp c91af                                                         // 3758: 4c af 91    L.. :9758[1]
+
+// $375b referenced 1 time by $9752
+c975b
+    jsr sub_c8b7b                                                     // 375b: 20 7b 8b     {. :975b[1]
+    jsr sub_c8380                                                     // 375e: 20 80 83     .. :975e[1]
+    iny                                                               // 3761: c8          .   :9761[1]
+    bmi c976c                                                         // 3762: 30 08       0.  :9762[1]
+    ldy #0                                                            // 3764: a0 00       ..  :9764[1]
+    lda l0f04                                                         // 3766: ad 04 0f    ... :9766[1]
+    sta (l00c7),y                                                     // 3769: 91 c7       ..  :9769[1]
+    rts                                                               // 376b: 60          `   :976b[1]
+
+// $376c referenced 1 time by $9762
+c976c
+    lda #0                                                            // 376c: a9 00       ..  :976c[1]
+    tay                                                               // 376e: a8          .   :976e[1]
+    sta (l00c7),y                                                     // 376f: 91 c7       ..  :976f[1]
+    iny                                                               // 3771: c8          .   :9771[1]
+    lda l0f07                                                         // 3772: ad 07 0f    ... :9772[1]
+    sta (l00c7),y                                                     // 3775: 91 c7       ..  :9775[1]
+    iny                                                               // 3777: c8          .   :9777[1]
+    lda l0f06                                                         // 3778: ad 06 0f    ... :9778[1]
+    and #3                                                            // 377b: 29 03       ).  :977b[1]
+    sta (l00c7),y                                                     // 377d: 91 c7       ..  :977d[1]
+    iny                                                               // 377f: c8          .   :977f[1]
+    lda #0                                                            // 3780: a9 00       ..  :9780[1]
+    sta (l00c7),y                                                     // 3782: 91 c7       ..  :9782[1]
+    rts                                                               // 3784: 60          `   :9784[1]
+
+sub_c9785
+    jsr sub_c840c                                                     // 3785: 20 0c 84     .. :9785[1]
+    pha                                                               // 3788: 48          H   :9788[1]
+    jsr c99a3                                                         // 3789: 20 a3 99     .. :9789[1]
+    stx l00b0                                                         // 378c: 86 b0       ..  :978c[1]
+    stx l10db                                                         // 378e: 8e db 10    ... :978e[1]
+    sty l00b1                                                         // 3791: 84 b1       ..  :9791[1]
+    sty l10dc                                                         // 3793: 8c dc 10    ... :9793[1]
+    ldx #0                                                            // 3796: a2 00       ..  :9796[1]
+    ldy #0                                                            // 3798: a0 00       ..  :9798[1]
+    jsr sub_c80e3                                                     // 379a: 20 e3 80     .. :979a[1]
+// $379d referenced 1 time by $97a2
+loop_c979d
+    jsr sub_c80d3                                                     // 379d: 20 d3 80     .. :979d[1]
+    cpy #$12                                                          // 37a0: c0 12       ..  :97a0[1]
+    bne loop_c979d                                                    // 37a2: d0 f9       ..  :97a2[1]
+    pla                                                               // 37a4: 68          h   :97a4[1]
+    tax                                                               // 37a5: aa          .   :97a5[1]
+    inx                                                               // 37a6: e8          .   :97a6[1]
+    cpx #8                                                            // 37a7: e0 08       ..  :97a7[1]
+    bcs c97b3                                                         // 37a9: b0 08       ..  :97a9[1]
+    lda l9b29,x                                                       // 37ab: bd 29 9b    .). :97ab[1]
+    pha                                                               // 37ae: 48          H   :97ae[1]
+    lda l9b21,x                                                       // 37af: bd 21 9b    .!. :97af[1]
+    pha                                                               // 37b2: 48          H   :97b2[1]
+// $37b3 referenced 2 times by $97a9, $97b8
+c97b3
+    lda #0                                                            // 37b3: a9 00       ..  :97b3[1]
+    rts                                                               // 37b5: 60          `   :97b5[1]
+
+sub_c97b6
+    cmp #9                                                            // 37b6: c9 09       ..  :97b6[1]
+    bcs c97b3                                                         // 37b8: b0 f9       ..  :97b8[1]
+    stx l00b5                                                         // 37ba: 86 b5       ..  :97ba[1]
+    tax                                                               // 37bc: aa          .   :97bc[1]
+    lda l9b18,x                                                       // 37bd: bd 18 9b    ... :97bd[1]
+    pha                                                               // 37c0: 48          H   :97c0[1]
+    lda l9b0f,x                                                       // 37c1: bd 0f 9b    ... :97c1[1]
+    pha                                                               // 37c4: 48          H   :97c4[1]
+    txa                                                               // 37c5: 8a          .   :97c5[1]
+    ldx l00b5                                                         // 37c6: a6 b5       ..  :97c6[1]
+// $37c8 referenced 1 time by $97cb
+loop_c97c8
+    rts                                                               // 37c8: 60          `   :97c8[1]
+
+sub_c97c9
+    cmp #9                                                            // 37c9: c9 09       ..  :97c9[1]
+    bcs loop_c97c8                                                    // 37cb: b0 fb       ..  :97cb[1]
+    jsr sub_c83e3                                                     // 37cd: 20 e3 83     .. :97cd[1]
+    jsr zero_stacked_XXX                                              // 37d0: 20 8e 9d     .. :97d0[1]
+    stx l107d                                                         // 37d3: 8e 7d 10    .}. :97d3[1]
+    sty l107e                                                         // 37d6: 8c 7e 10    .~. :97d6[1]
+    tay                                                               // 37d9: a8          .   :97d9[1]
+    jsr sub_c97e8                                                     // 37da: 20 e8 97     .. :97da[1]
+    php                                                               // 37dd: 08          .   :97dd[1]
+    bit l1081                                                         // 37de: 2c 81 10    ,.. :97de[1]
+    bpl c97e6                                                         // 37e1: 10 03       ..  :97e1[1]
+    jsr sub_c8f7a                                                     // 37e3: 20 7a 8f     z. :97e3[1]
+// $37e6 referenced 1 time by $97e1
+c97e6
+    plp                                                               // 37e6: 28          (   :97e6[1]
+    rts                                                               // 37e7: 60          `   :97e7[1]
+
+// $37e8 referenced 1 time by $97da
+sub_c97e8
+    lda l9b31,y                                                       // 37e8: b9 31 9b    .1. :97e8[1]
+    sta l10d7                                                         // 37eb: 8d d7 10    ... :97eb[1]
+    lda l9b3a,y                                                       // 37ee: b9 3a 9b    .:. :97ee[1]
+    sta l10d8                                                         // 37f1: 8d d8 10    ... :97f1[1]
+    lda l9b43,y                                                       // 37f4: b9 43 9b    .C. :97f4[1]
+    lsr                                                               // 37f7: 4a          J   :97f7[1]
+    php                                                               // 37f8: 08          .   :97f8[1]
+    lsr                                                               // 37f9: 4a          J   :97f9[1]
+    php                                                               // 37fa: 08          .   :97fa[1]
+    sta l107f                                                         // 37fb: 8d 7f 10    ... :97fb[1]
+    jsr sub_c995a                                                     // 37fe: 20 5a 99     Z. :97fe[1]
+    ldy #$0c                                                          // 3801: a0 0c       ..  :9801[1]
+// $3803 referenced 1 time by $9809
+loop_c9803
+    lda (l00b4),y                                                     // 3803: b1 b4       ..  :9803[1]
+    sta l1060,y                                                       // 3805: 99 60 10    .`. :9805[1]
+    dey                                                               // 3808: 88          .   :9808[1]
+    bpl loop_c9803                                                    // 3809: 10 f8       ..  :9809[1]
+    lda l1063                                                         // 380b: ad 63 10    .c. :980b[1]
+    and l1064                                                         // 380e: 2d 64 10    -d. :980e[1]
+    ora l10d6                                                         // 3811: 0d d6 10    ... :9811[1]
+    clc                                                               // 3814: 18          .   :9814[1]
+    adc #1                                                            // 3815: 69 01       i.  :9815[1]
+    beq c981f                                                         // 3817: f0 06       ..  :9817[1]
+    jsr sub_c8f6b                                                     // 3819: 20 6b 8f     k. :9819[1]
+    clc                                                               // 381c: 18          .   :981c[1]
+    lda #$ff                                                          // 381d: a9 ff       ..  :981d[1]
+// $381f referenced 1 time by $9817
+c981f
+    sta l1081                                                         // 381f: 8d 81 10    ... :981f[1]
+    lda l107f                                                         // 3822: ad 7f 10    ... :9822[1]
+    bcs c982e                                                         // 3825: b0 07       ..  :9825[1]
+    ldx #$61 // 'a'                                                   // 3827: a2 61       .a  :9827[1]
+    ldy #$10                                                          // 3829: a0 10       ..  :9829[1]
+    jsr tube_entry                                                    // 382b: 20 06 04     .. :982b[1]
+// $382e referenced 1 time by $9825
+c982e
+    plp                                                               // 382e: 28          (   :982e[1]
+    bcs c9835                                                         // 382f: b0 04       ..  :982f[1]
+    plp                                                               // 3831: 28          (   :9831[1]
+// $3832 referenced 1 time by $9861
+sub_c9832
+    jmp (l10d7)                                                       // 3832: 6c d7 10    l.. :9832[1]
+
+// $3835 referenced 1 time by $982f
+c9835
+    ldx #3                                                            // 3835: a2 03       ..  :9835[1]
+// $3837 referenced 1 time by $983d
+loop_c9837
+    lda l1069,x                                                       // 3837: bd 69 10    .i. :9837[1]
+    sta l00b6,x                                                       // 383a: 95 b6       ..  :983a[1]
+    dex                                                               // 383c: ca          .   :983c[1]
+    bpl loop_c9837                                                    // 383d: 10 f8       ..  :983d[1]
+    ldx #$b6                                                          // 383f: a2 b6       ..  :983f[1]
+    ldy l1060                                                         // 3841: ac 60 10    .`. :9841[1]
+    lda #0                                                            // 3844: a9 00       ..  :9844[1]
+    plp                                                               // 3846: 28          (   :9846[1]
+    bcs c984c                                                         // 3847: b0 03       ..  :9847[1]
+    jsr ca06c                                                         // 3849: 20 6c a0     l. :9849[1]
+// $384c referenced 1 time by $9847
+c984c
+    jsr c9dd5                                                         // 384c: 20 d5 9d     .. :984c[1]
+    ldx #3                                                            // 384f: a2 03       ..  :984f[1]
+// $3851 referenced 1 time by $9857
+loop_c9851
+    lda l00b6,x                                                       // 3851: b5 b6       ..  :9851[1]
+    sta l1069,x                                                       // 3853: 9d 69 10    .i. :9853[1]
+    dex                                                               // 3856: ca          .   :9856[1]
+    bpl loop_c9851                                                    // 3857: 10 f8       ..  :9857[1]
+// $3859 referenced 1 time by $989b
+c9859
+    jsr invert_l1065                                                  // 3859: 20 4c 99     L. :9859[1]
+    bmi c986b                                                         // 385c: 30 0d       0.  :985c[1]
+// $385e referenced 1 time by $9870
+loop_c985e
+    ldy l1060                                                         // 385e: ac 60 10    .`. :985e[1]
+    jsr sub_c9832                                                     // 3861: 20 32 98     2. :9861[1]
+    bcs c9873                                                         // 3864: b0 0d       ..  :9864[1]
+    ldx #9                                                            // 3866: a2 09       ..  :9866[1]
+    jsr sub_c9940                                                     // 3868: 20 40 99     @. :9868[1]
+// $386b referenced 1 time by $985c
+c986b
+    ldx #5                                                            // 386b: a2 05       ..  :986b[1]
+    jsr sub_c9940                                                     // 386d: 20 40 99     @. :986d[1]
+    bne loop_c985e                                                    // 3870: d0 ec       ..  :9870[1]
+    clc                                                               // 3872: 18          .   :9872[1]
+// $3873 referenced 1 time by $9864
+c9873
+    php                                                               // 3873: 08          .   :9873[1]
+    jsr invert_l1065                                                  // 3874: 20 4c 99     L. :9874[1]
+    ldx #5                                                            // 3877: a2 05       ..  :9877[1]
+    jsr sub_c9940                                                     // 3879: 20 40 99     @. :9879[1]
+    ldy #$0c                                                          // 387c: a0 0c       ..  :987c[1]
+    jsr sub_c995a                                                     // 387e: 20 5a 99     Z. :987e[1]
+// $3881 referenced 1 time by $9887
+loop_c9881
+    lda l1060,y                                                       // 3881: b9 60 10    .`. :9881[1]
+    sta (l00b4),y                                                     // 3884: 91 b4       ..  :9884[1]
+    dey                                                               // 3886: 88          .   :9886[1]
+    bpl loop_c9881                                                    // 3887: 10 f8       ..  :9887[1]
+    plp                                                               // 3889: 28          (   :9889[1]
+    rts                                                               // 388a: 60          `   :988a[1]
+
+    jsr sub_c8b7b                                                     // 388b: 20 7b 8b     {. :988b[1]
+    jsr sub_c93fd                                                     // 388e: 20 fd 93     .. :988e[1]
+    lda #$9d                                                          // 3891: a9 9d       ..  :9891[1]
+    sta l10d7                                                         // 3893: 8d d7 10    ... :9893[1]
+    lda #$98                                                          // 3896: a9 98       ..  :9896[1]
+    sta l10d8                                                         // 3898: 8d d8 10    ... :9898[1]
+    bne c9859                                                         // 389b: d0 bc       ..  :989b[1]
+    ldy l1069                                                         // 389d: ac 69 10    .i. :989d[1]
+// $38a0 referenced 1 time by $98b8
+loop_c98a0
+    cpy l0f05                                                         // 38a0: cc 05 0f    ... :98a0[1]
+    bcs c98cd                                                         // 38a3: b0 28       .(  :98a3[1]
+    lda l0e0f,y                                                       // 38a5: b9 0f 0e    ... :98a5[1]
+    jsr sub_c8327                                                     // 38a8: 20 27 83     '. :98a8[1]
+    eor l00cc                                                         // 38ab: 45 cc       E.  :98ab[1]
+    bcs c98b1                                                         // 38ad: b0 02       ..  :98ad[1]
+    and #$df                                                          // 38af: 29 df       ).  :98af[1]
+// $38b1 referenced 1 time by $98ad
+c98b1
+    and #$7f                                                          // 38b1: 29 7f       ).  :98b1[1]
+    beq c98ba                                                         // 38b3: f0 05       ..  :98b3[1]
+    jsr sub_c87da                                                     // 38b5: 20 da 87     .. :98b5[1]
+    bne loop_c98a0                                                    // 38b8: d0 e6       ..  :98b8[1]
+// $38ba referenced 1 time by $98b3
+c98ba
+    lda #7                                                            // 38ba: a9 07       ..  :98ba[1]
+    jsr c996e                                                         // 38bc: 20 6e 99     n. :98bc[1]
+    sta l00b0                                                         // 38bf: 85 b0       ..  :98bf[1]
+// $38c1 referenced 1 time by $98ca
+loop_c98c1
+    lda l0e08,y                                                       // 38c1: b9 08 0e    ... :98c1[1]
+    jsr c996e                                                         // 38c4: 20 6e 99     n. :98c4[1]
+    iny                                                               // 38c7: c8          .   :98c7[1]
+    dec l00b0                                                         // 38c8: c6 b0       ..  :98c8[1]
+    bne loop_c98c1                                                    // 38ca: d0 f5       ..  :98ca[1]
+    clc                                                               // 38cc: 18          .   :98cc[1]
+// $38cd referenced 1 time by $98a3
+c98cd
+    sty l1069                                                         // 38cd: 8c 69 10    .i. :98cd[1]
+    lda l0f04                                                         // 38d0: ad 04 0f    ... :98d0[1]
+    sta l1060                                                         // 38d3: 8d 60 10    .`. :98d3[1]
+    rts                                                               // 38d6: 60          `   :98d6[1]
+
+    jsr sub_c8b7b                                                     // 38d7: 20 7b 8b     {. :98d7[1]
+    jsr sub_c93fd                                                     // 38da: 20 fd 93     .. :98da[1]
+    lda #$0c                                                          // 38dd: a9 0c       ..  :98dd[1]
+    jsr c996e                                                         // 38df: 20 6e 99     n. :98df[1]
+    ldy #0                                                            // 38e2: a0 00       ..  :98e2[1]
+// $38e4 referenced 1 time by $98f6
+loop_c98e4
+    cpy #8                                                            // 38e4: c0 08       ..  :98e4[1]
+    bcs c98ed                                                         // 38e6: b0 05       ..  :98e6[1]
+    lda l0e00,y                                                       // 38e8: b9 00 0e    ... :98e8[1]
+    bcc c98f0                                                         // 38eb: 90 03       ..  :98eb[1]
+// $38ed referenced 1 time by $98e6
+c98ed
+    lda l0ef8,y                                                       // 38ed: b9 f8 0e    ... :98ed[1]
+// $38f0 referenced 1 time by $98eb
+c98f0
+    jsr c996e                                                         // 38f0: 20 6e 99     n. :98f0[1]
+    iny                                                               // 38f3: c8          .   :98f3[1]
+    cpy #$0c                                                          // 38f4: c0 0c       ..  :98f4[1]
+    bne loop_c98e4                                                    // 38f6: d0 ec       ..  :98f6[1]
+    lda l0f06                                                         // 38f8: ad 06 0f    ... :98f8[1]
+    jsr sub_c81bf                                                     // 38fb: 20 bf 81     .. :98fb[1]
+    jsr c996e                                                         // 38fe: 20 6e 99     n. :98fe[1]
+    lda l00cd                                                         // 3901: a5 cd       ..  :9901[1]
+    jmp c996e                                                         // 3903: 4c 6e 99    Ln. :9903[1]
+
+    jsr sub_c9965                                                     // 3906: 20 65 99     e. :9906[1]
+    lda l10ca                                                         // 3909: ad ca 10    ... :9909[1]
+    ora #$30 // '0'                                                   // 390c: 09 30       .0  :990c[1]
+    jsr c996e                                                         // 390e: 20 6e 99     n. :990e[1]
+    jsr sub_c9965                                                     // 3911: 20 65 99     e. :9911[1]
+    lda l10c9                                                         // 3914: ad c9 10    ... :9914[1]
+    bne c996e                                                         // 3917: d0 55       .U  :9917[1]
+    jsr sub_c9965                                                     // 3919: 20 65 99     e. :9919[1]
+    lda l10cc                                                         // 391c: ad cc 10    ... :991c[1]
+    ora #$30 // '0'                                                   // 391f: 09 30       .0  :991f[1]
+    jsr c996e                                                         // 3921: 20 6e 99     n. :9921[1]
+    jsr sub_c9965                                                     // 3924: 20 65 99     e. :9924[1]
+    lda l10cb                                                         // 3927: ad cb 10    ... :9927[1]
+    bne c996e                                                         // 392a: d0 42       .B  :992a[1]
+// $392c referenced 2 times by $9978, $9993
+sub_c992c
+    pha                                                               // 392c: 48          H   :992c[1]
+    lda l1061                                                         // 392d: ad 61 10    .a. :992d[1]
+    sta l00b8                                                         // 3930: 85 b8       ..  :9930[1]
+    lda l1062                                                         // 3932: ad 62 10    .b. :9932[1]
+    sta l00b9                                                         // 3935: 85 b9       ..  :9935[1]
+    ldx #0                                                            // 3937: a2 00       ..  :9937[1]
+    pla                                                               // 3939: 68          h   :9939[1]
+    rts                                                               // 393a: 60          `   :993a[1]
+
+// $393b referenced 4 times by $9976, $997d, $9990, $9998
+c993b
+    jsr sub_c83e3                                                     // 393b: 20 e3 83     .. :993b[1]
+    ldx #1                                                            // 393e: a2 01       ..  :993e[1]
+// $3940 referenced 3 times by $9868, $986d, $9879
+sub_c9940
+    ldy #4                                                            // 3940: a0 04       ..  :9940[1]
+// $3942 referenced 1 time by $9949
+loop_c9942
+    inc l1060,x                                                       // 3942: fe 60 10    .`. :9942[1]
+    bne c994b                                                         // 3945: d0 04       ..  :9945[1]
+    inx                                                               // 3947: e8          .   :9947[1]
+    dey                                                               // 3948: 88          .   :9948[1]
+    bne loop_c9942                                                    // 3949: d0 f7       ..  :9949[1]
+// $394b referenced 1 time by $9945
+c994b
+    rts                                                               // 394b: 60          `   :994b[1]
+
+// Invert the 32-bit value at l1065
+// $394c referenced 2 times by $9859, $9874
+invert_l1065
+    ldx #3                                                            // 394c: a2 03       ..  :994c[1]
+// $394e referenced 1 time by $9957
+loop_c994e
+    lda #$ff                                                          // 394e: a9 ff       ..  :994e[1]
+    eor l1065,x                                                       // 3950: 5d 65 10    ]e. :9950[1]
+    sta l1065,x                                                       // 3953: 9d 65 10    .e. :9953[1]
+    dex                                                               // 3956: ca          .   :9956[1]
+    bpl loop_c994e                                                    // 3957: 10 f5       ..  :9957[1]
+    rts                                                               // 3959: 60          `   :9959[1]
+
+// $395a referenced 2 times by $97fe, $987e
+sub_c995a
+    lda l107d                                                         // 395a: ad 7d 10    .}. :995a[1]
+    sta l00b4                                                         // 395d: 85 b4       ..  :995d[1]
+    lda l107e                                                         // 395f: ad 7e 10    .~. :995f[1]
+    sta l00b5                                                         // 3962: 85 b5       ..  :9962[1]
+// $3964 referenced 1 time by $996c
+loop_c9964
+    rts                                                               // 3964: 60          `   :9964[1]
+
+// $3965 referenced 4 times by $9906, $9911, $9919, $9924
+sub_c9965
+    lda #1                                                            // 3965: a9 01       ..  :9965[1]
+    bne c996e                                                         // 3967: d0 05       ..  :9967[1]
+    jsr sub_c9e94                                                     // 3969: 20 94 9e     .. :9969[1]
+    bcs loop_c9964                                                    // 396c: b0 f6       ..  :996c[1]
+// $396e referenced 11 times by $98bc, $98c4, $98df, $98f0, $98fe, $9903, $990e, $9917, $9921, $992a, $9967
+c996e
+    bit l1081                                                         // 396e: 2c 81 10    ,.. :996e[1]
+    bpl c9978                                                         // 3971: 10 05       ..  :9971[1]
+    sta tube_host_r3_data                                             // 3973: 8d e5 fe    ... :9973[1]
+    bmi c993b                                                         // 3976: 30 c3       0.  :9976[1]
+// $3978 referenced 1 time by $9971
+c9978
+    jsr sub_c992c                                                     // 3978: 20 2c 99     ,. :9978[1]
+    sta (l00b8,x)                                                     // 397b: 81 b8       ..  :997b[1]
+    jmp c993b                                                         // 397d: 4c 3b 99    L;. :997d[1]
+
+    jsr sub_c9988                                                     // 3980: 20 88 99     .. :9980[1]
+    jsr sub_c9f82                                                     // 3983: 20 82 9f     .. :9983[1]
+    clc                                                               // 3986: 18          .   :9986[1]
+    rts                                                               // 3987: 60          `   :9987[1]
+
+// $3988 referenced 1 time by $9980
+sub_c9988
+    bit l1081                                                         // 3988: 2c 81 10    ,.. :9988[1]
+    bpl c9993                                                         // 398b: 10 06       ..  :998b[1]
+    lda tube_host_r3_data                                             // 398d: ad e5 fe    ... :998d[1]
+    jmp c993b                                                         // 3990: 4c 3b 99    L;. :9990[1]
+
+// $3993 referenced 1 time by $998b
+c9993
+    jsr sub_c992c                                                     // 3993: 20 2c 99     ,. :9993[1]
+    lda (l00b8,x)                                                     // 3996: a1 b8       ..  :9996[1]
+    jmp c993b                                                         // 3998: 4c 3b 99    L;. :9998[1]
+
+    bit l10c7                                                         // 399b: 2c c7 10    ,.. :999b[1]
+    bmi c99a3                                                         // 399e: 30 03       0.  :999e[1]
+    dec l10c7                                                         // 39a0: ce c7 10    ... :99a0[1]
+// $39a3 referenced 5 times by $8782, $8bac, $9789, $999e, $9c25
+c99a3
+    lda #$ff                                                          // 39a3: a9 ff       ..  :99a3[1]
+    sta l10ce                                                         // 39a5: 8d ce 10    ... :99a5[1]
+// $39a8 referenced 1 time by $99b3
+loop_c99a8
+    sta l10cd                                                         // 39a8: 8d cd 10    ... :99a8[1]
+    rts                                                               // 39ab: 60          `   :99ab[1]
+
+// $39ac referenced 6 times by $824b, $8254, $8750, $8797, $89e6, $a463
+sub_c99ac
+    lda #$2a // '*'                                                   // 39ac: a9 2a       .*  :99ac[1]
+    sta l10ce                                                         // 39ae: 8d ce 10    ... :99ae[1]
+    lda #$23 // '#'                                                   // 39b1: a9 23       .#  :99b1[1]
+    bne loop_c99a8                                                    // 39b3: d0 f3       ..  :99b3[1]
+    jsr sub_c9a6e                                                     // 39b5: 20 6e 9a     n. :99b5[1]
+    jsr sub_c8386                                                     // 39b8: 20 86 83     .. :99b8[1]
+    lda #1                                                            // 39bb: a9 01       ..  :99bb[1]
+    rts                                                               // 39bd: 60          `   :99bd[1]
+
+    jsr sub_c9a4b                                                     // 39be: 20 4b 9a     K. :99be[1]
+    jsr sub_c8386                                                     // 39c1: 20 86 83     .. :99c1[1]
+    jsr sub_c830a                                                     // 39c4: 20 0a 83     .. :99c4[1]
+    bcc c99ed                                                         // 39c7: 90 24       .$  :99c7[1]
+    jsr sub_c9a6e                                                     // 39c9: 20 6e 9a     n. :99c9[1]
+    jsr sub_c99f3                                                     // 39cc: 20 f3 99     .. :99cc[1]
+    jsr sub_c9a0f                                                     // 39cf: 20 0f 9a     .. :99cf[1]
+    bvc c99ea                                                         // 39d2: 50 16       P.  :99d2[1]
+    jsr sub_c9a6e                                                     // 39d4: 20 6e 9a     n. :99d4[1]
+    jsr sub_c9a0f                                                     // 39d7: 20 0f 9a     .. :99d7[1]
+    bvc c99ed                                                         // 39da: 50 11       P.  :99da[1]
+    jsr sub_c9a6e                                                     // 39dc: 20 6e 9a     n. :99dc[1]
+    jsr sub_c99f3                                                     // 39df: 20 f3 99     .. :99df[1]
+    bvc c99ed                                                         // 39e2: 50 09       P.  :99e2[1]
+    jsr sub_c9a6e                                                     // 39e4: 20 6e 9a     n. :99e4[1]
+    jsr sub_c9a63                                                     // 39e7: 20 63 9a     c. :99e7[1]
+// $39ea referenced 1 time by $99d2
+c99ea
+    jsr sub_c9a32                                                     // 39ea: 20 32 9a     2. :99ea[1]
+// $39ed referenced 3 times by $99c7, $99da, $99e2
+c99ed
+    jsr c89d7                                                         // 39ed: 20 d7 89     .. :99ed[1]
+    lda #1                                                            // 39f0: a9 01       ..  :99f0[1]
+    rts                                                               // 39f2: 60          `   :99f2[1]
+
+// $39f3 referenced 2 times by $99cc, $99df
+sub_c99f3
+    jsr sub_c83e3                                                     // 39f3: 20 e3 83     .. :99f3[1]
+    ldy #2                                                            // 39f6: a0 02       ..  :99f6[1]
+    lda (l00b0),y                                                     // 39f8: b1 b0       ..  :99f8[1]
+    sta l0f08,x                                                       // 39fa: 9d 08 0f    ... :99fa[1]
+    iny                                                               // 39fd: c8          .   :99fd[1]
+    lda (l00b0),y                                                     // 39fe: b1 b0       ..  :99fe[1]
+    sta l0f09,x                                                       // 3a00: 9d 09 0f    ... :9a00[1]
+    iny                                                               // 3a03: c8          .   :9a03[1]
+    lda (l00b0),y                                                     // 3a04: b1 b0       ..  :9a04[1]
+    asl                                                               // 3a06: 0a          .   :9a06[1]
+    asl                                                               // 3a07: 0a          .   :9a07[1]
+    eor l0f0e,x                                                       // 3a08: 5d 0e 0f    ].. :9a08[1]
+    and #$0c                                                          // 3a0b: 29 0c       ).  :9a0b[1]
+    bpl c9a2a                                                         // 3a0d: 10 1b       ..  :9a0d[1]
+// $3a0f referenced 2 times by $99cf, $99d7
+sub_c9a0f
+    jsr sub_c83e3                                                     // 3a0f: 20 e3 83     .. :9a0f[1]
+    ldy #6                                                            // 3a12: a0 06       ..  :9a12[1]
+    lda (l00b0),y                                                     // 3a14: b1 b0       ..  :9a14[1]
+    sta l0f0a,x                                                       // 3a16: 9d 0a 0f    ... :9a16[1]
+    iny                                                               // 3a19: c8          .   :9a19[1]
+    lda (l00b0),y                                                     // 3a1a: b1 b0       ..  :9a1a[1]
+    sta l0f0b,x                                                       // 3a1c: 9d 0b 0f    ... :9a1c[1]
+    iny                                                               // 3a1f: c8          .   :9a1f[1]
+    lda (l00b0),y                                                     // 3a20: b1 b0       ..  :9a20[1]
+    ror                                                               // 3a22: 6a          j   :9a22[1]
+    ror                                                               // 3a23: 6a          j   :9a23[1]
+    ror                                                               // 3a24: 6a          j   :9a24[1]
+    eor l0f0e,x                                                       // 3a25: 5d 0e 0f    ].. :9a25[1]
+    and #$c0                                                          // 3a28: 29 c0       ).  :9a28[1]
+// $3a2a referenced 1 time by $9a0d
+c9a2a
+    eor l0f0e,x                                                       // 3a2a: 5d 0e 0f    ].. :9a2a[1]
+    sta l0f0e,x                                                       // 3a2d: 9d 0e 0f    ... :9a2d[1]
+    clv                                                               // 3a30: b8          .   :9a30[1]
+    rts                                                               // 3a31: 60          `   :9a31[1]
+
+// $3a32 referenced 1 time by $99ea
+sub_c9a32
+    jsr sub_c83e3                                                     // 3a32: 20 e3 83     .. :9a32[1]
+    ldy #$0e                                                          // 3a35: a0 0e       ..  :9a35[1]
+    lda (l00b0),y                                                     // 3a37: b1 b0       ..  :9a37[1]
+    and #$0a                                                          // 3a39: 29 0a       ).  :9a39[1]
+    beq c9a3f                                                         // 3a3b: f0 02       ..  :9a3b[1]
+    lda #$80                                                          // 3a3d: a9 80       ..  :9a3d[1]
+// $3a3f referenced 1 time by $9a3b
+c9a3f
+    eor l0e0f,x                                                       // 3a3f: 5d 0f 0e    ].. :9a3f[1]
+    and #$80                                                          // 3a42: 29 80       ).  :9a42[1]
+    eor l0e0f,x                                                       // 3a44: 5d 0f 0e    ].. :9a44[1]
+    sta l0e0f,x                                                       // 3a47: 9d 0f 0e    ... :9a47[1]
+    rts                                                               // 3a4a: 60          `   :9a4a[1]
+
+// $3a4b referenced 1 time by $99be
+sub_c9a4b
+    jsr sub_c9a78                                                     // 3a4b: 20 78 9a     x. :9a4b[1]
+    bcc c9a73                                                         // 3a4e: 90 23       .#  :9a4e[1]
+// $3a50 referenced 2 times by $9a60, $9c55
+sub_c9a50
+    lda l0e0f,y                                                       // 3a50: b9 0f 0e    ... :9a50[1]
+    bpl c9a77                                                         // 3a53: 10 22       ."  :9a53[1]
+// $3a55 referenced 1 time by $9f6b
+generate_error_precheck_locked
+    jsr generate_error_precheck                                       // 3a55: 20 38 80     8. :9a55[1]
+    .byt $c3                                                          // 3a58: c3          .   :9a58[1]
+    .asc "Locked"                                                     // 3a59: 4c 6f 63... Loc :9a59[1]
+    .byt 0                                                            // 3a5f: 00          .   :9a5f[1]
+
+// $3a60 referenced 2 times by $830a, $8bba
+sub_c9a60
+    jsr sub_c9a50                                                     // 3a60: 20 50 9a     P. :9a60[1]
+// $3a63 referenced 2 times by $8a00, $99e7
+sub_c9a63
+    jsr sub_c83e3                                                     // 3a63: 20 e3 83     .. :9a63[1]
+    jsr sub_c9d1e                                                     // 3a66: 20 1e 9d     .. :9a66[1]
+    bcc c9a8c                                                         // 3a69: 90 21       .!  :9a69[1]
+    jmp generate_error_precheck_open                                  // 3a6b: 4c 82 9c    L.. :9a6b[1]
+
+// $3a6e referenced 5 times by $99b5, $99c9, $99d4, $99dc, $99e4
+sub_c9a6e
+    jsr sub_c9a78                                                     // 3a6e: 20 78 9a     x. :9a6e[1]
+    bcs c9a8c                                                         // 3a71: b0 19       ..  :9a71[1]
+// $3a73 referenced 1 time by $9a4e
+c9a73
+    pla                                                               // 3a73: 68          h   :9a73[1]
+    pla                                                               // 3a74: 68          h   :9a74[1]
+    lda #0                                                            // 3a75: a9 00       ..  :9a75[1]
+// $3a77 referenced 1 time by $9a53
+c9a77
+    rts                                                               // 3a77: 60          `   :9a77[1]
+
+// $3a78 referenced 2 times by $9a4b, $9a6e
+sub_c9a78
+    jsr sub_c80f3                                                     // 3a78: 20 f3 80     .. :9a78[1]
+    jsr sub_c8284                                                     // 3a7b: 20 84 82     .. :9a7b[1]
+    bcc c9a8c                                                         // 3a7e: 90 0c       ..  :9a7e[1]
+    tya                                                               // 3a80: 98          .   :9a80[1]
+    tax                                                               // 3a81: aa          .   :9a81[1]
+// $3a82 referenced 2 times by $881e, $885c
+sub_c9a82
+    lda l10db                                                         // 3a82: ad db 10    ... :9a82[1]
+    sta l00b0                                                         // 3a85: 85 b0       ..  :9a85[1]
+    lda l10dc                                                         // 3a87: ad dc 10    ... :9a87[1]
+    sta l00b1                                                         // 3a8a: 85 b1       ..  :9a8a[1]
+// $3a8c referenced 3 times by $9a69, $9a71, $9a7e
+c9a8c
+    rts                                                               // 3a8c: 60          `   :9a8c[1]
+
+// $3a8d referenced 4 times by $929d, $a267, $a34a, $a64f
+sub_c9a8d
+    lda #osbyte_read_oshwm                                            // 3a8d: a9 83       ..  :9a8d[1]
+    jsr osbyte                                                        // 3a8f: 20 f4 ff     .. :9a8f[1]
+    sty l10cf                                                         // 3a92: 8c cf 10    ... :9a92[1]
+    lda #osbyte_read_himem                                            // 3a95: a9 84       ..  :9a95[1]
+    jsr osbyte                                                        // 3a97: 20 f4 ff     .. :9a97[1]
+    tya                                                               // 3a9a: 98          .   :9a9a[1]
+    sec                                                               // 3a9b: 38          8   :9a9b[1]
+    sbc l10cf                                                         // 3a9c: ed cf 10    ... :9a9c[1]
+    sta l10d0                                                         // 3a9f: 8d d0 10    ... :9a9f[1]
+    rts                                                               // 3aa2: 60          `   :9aa2[1]
+
+// $3aa3 referenced 2 times by $95d4, $95fd
+sub_c9aa3
+    ldx #$0a                                                          // 3aa3: a2 0a       ..  :9aa3[1]
+    jsr c9adf                                                         // 3aa5: 20 df 9a     .. :9aa5[1]
+    jsr sub_c9ab8                                                     // 3aa8: 20 b8 9a     .. :9aa8[1]
+    ldy #$d3                                                          // 3aab: a0 d3       ..  :9aab[1]
+    lda #$ff                                                          // 3aad: a9 ff       ..  :9aad[1]
+    sta (l00b0),y                                                     // 3aaf: 91 b0       ..  :9aaf[1]
+    sta l10d3                                                         // 3ab1: 8d d3 10    ... :9ab1[1]
+    iny                                                               // 3ab4: c8          .   :9ab4[1]
+    sta (l00b0),y                                                     // 3ab5: 91 b0       ..  :9ab5[1]
+    rts                                                               // 3ab7: 60          `   :9ab7[1]
+
+// $3ab8 referenced 5 times by $895a, $95c1, $971b, $972c, $9aa8
+sub_c9ab8
+    pha                                                               // 3ab8: 48          H   :9ab8[1]
+    ldx romsel_copy                                                   // 3ab9: a6 f4       ..  :9ab9[1]
+    lda #0                                                            // 3abb: a9 00       ..  :9abb[1]
+    sta l00b0                                                         // 3abd: 85 b0       ..  :9abd[1]
+    lda l0df0,x                                                       // 3abf: bd f0 0d    ... :9abf[1]
+    and #$3f // '?'                                                   // 3ac2: 29 3f       )?  :9ac2[1]
+    sta l00b1                                                         // 3ac4: 85 b1       ..  :9ac4[1]
+    pla                                                               // 3ac6: 68          h   :9ac6[1]
+    rts                                                               // 3ac7: 60          `   :9ac7[1]
+
+// $3ac8 referenced 2 times by $a3d4, $a3fb
+sub_c9ac8
+    jsr sub_c83e3                                                     // 3ac8: 20 e3 83     .. :9ac8[1]
+    lda #$0f                                                          // 3acb: a9 0f       ..  :9acb[1]
+    ldx #1                                                            // 3acd: a2 01       ..  :9acd[1]
+    ldy #0                                                            // 3acf: a0 00       ..  :9acf[1]
+    beq c9ae9                                                         // 3ad1: f0 16       ..  :9ad1[1]
+// $3ad3 referenced 1 time by $80ac
+sub_c9ad3
+    tax                                                               // 3ad3: aa          .   :9ad3[1]
+// $3ad4 referenced 1 time by $80b5
+c9ad4
+    lda #3                                                            // 3ad4: a9 03       ..  :9ad4[1]
+    bne c9ae9                                                         // 3ad6: d0 11       ..  :9ad6[1]
+// $3ad8 referenced 2 times by $9436, $abbc
+sub_c9ad8
+    jsr sub_c83e3                                                     // 3ad8: 20 e3 83     .. :9ad8[1]
+    lda #$7e // '~'                                                   // 3adb: a9 7e       .~  :9adb[1]
+    bne c9ae9                                                         // 3add: d0 0a       ..  :9add[1]
+// $3adf referenced 4 times by $9593, $9599, $95be, $9aa5
+c9adf
+    lda #$8f                                                          // 3adf: a9 8f       ..  :9adf[1]
+    bne c9ae9                                                         // 3ae1: d0 06       ..  :9ae1[1]
+    lda #osbyte_read_write_startup_options                            // 3ae3: a9 ff       ..  :9ae3[1]
+// $3ae5 referenced 8 times by $80a5, $9588, $96a0, $9e32, $9e43, $aae2, $ac7c, $aeb7
+osbyte_read
+    ldx #0                                                            // 3ae5: a2 00       ..  :9ae5[1]
+    ldy #$ff                                                          // 3ae7: a0 ff       ..  :9ae7[1]
+// $3ae9 referenced 4 times by $9ad1, $9ad6, $9add, $9ae1
+c9ae9
+    jmp osbyte                                                        // 3ae9: 4c f4 ff    L.. :9ae9[1]
+
+// $3aec referenced 1 time by $957d
+l9aec
+    .byt $1b, $ff, $1e, $ff, $21, $ff, $24, $ff, $27, $ff, $2a, $ff   // 3aec: 1b ff 1e... ... :9aec[1]
+    .byt $2d, $ff                                                     // 3af8: 2d ff       -.  :9af8[1]
+    .word sub_c9785                                                   // 3afa: 85 97       ..  :9afa[1]
+    .byt 0                                                            // 3afc: 00          .   :9afc[1]
+    .word sub_c9d9b                                                   // 3afd: 9b 9d       ..  :9afd[1]
+    .byt 0                                                            // 3aff: 00          .   :9aff[1]
+    .word sub_c9e94                                                   // 3b00: 94 9e       ..  :9b00[1]
+    .byt 0                                                            // 3b02: 00          .   :9b02[1]
+    .word sub_c9f82                                                   // 3b03: 82 9f       ..  :9b03[1]
+    .byt 0                                                            // 3b05: 00          .   :9b05[1]
+    .word sub_c97c9                                                   // 3b06: c9 97       ..  :9b06[1]
+    .byt 0                                                            // 3b08: 00          .   :9b08[1]
+    .word sub_c9c0c                                                   // 3b09: 0c 9c       ..  :9b09[1]
+    .byt 0                                                            // 3b0b: 00          .   :9b0b[1]
+    .word sub_c97b6                                                   // 3b0c: b6 97       ..  :9b0c[1]
+    .byt 0                                                            // 3b0e: 00          .   :9b0e[1]
+// $3b0f referenced 1 time by $97c1
+l9b0f
+    .asc "1\o"                                                        // 3b0f: 31 5c 6f    1\o :9b0f[1]
+    .byt $fd, $6f, $82, $50, $4b, $9a                                 // 3b12: fd 6f 82... .o. :9b12[1]
+// $3b18 referenced 1 time by $97bd
+l9b18
+    .byt $8a, $9e, $88, $86, $88, $84, $9b, $9b, $99                  // 3b18: 8a 9e 88... ... :9b18[1]
+// $3b21 referenced 1 time by $97af
+l9b21
+    .byt $1a, $58, $c8, $db, $d3, $e3, $b4, $bd                       // 3b21: 1a 58 c8... .X. :9b21[1]
+// $3b29 referenced 1 time by $97ab
+l9b29
+    .byt $88, $88, $99, $99, $99, $99, $99, $99                       // 3b29: 88 88 99... ... :9b29[1]
+// $3b31 referenced 1 time by $97e8
+l9b31
+    .byt $1b, $80, $80, $69, $69, $d7,   6, $19, $8b                  // 3b31: 1b 80 80... ... :9b31[1]
+// $3b3a referenced 1 time by $97ee
+l9b3a
+    .byt $86, $99, $99, $99, $99, $98, $99, $99, $98                  // 3b3a: 86 99 99... ... :9b3a[1]
+// $3b43 referenced 1 time by $97f4
+l9b43
+    .byt   4,   2,   3,   6,   7,   4,   4,   4,   4, $a2, $11, $a0   // 3b43: 04 02 03... ... :9b43[1]
+    .byt $15                                                          // 3b4f: 15          .   :9b4f[1]
+
+// $3b50 referenced 1 time by $9b66
+loop_c9b50
+    rts                                                               // 3b50: 60          `   :9b50[1]
+
+// $3b51 referenced 1 time by $9b5e
+sub_c9b51
+    jsr sub_c83e3                                                     // 3b51: 20 e3 83     .. :9b51[1]
+    lda #osbyte_close_spool_exec                                      // 3b54: a9 77       .w  :9b54[1]
+    jmp osbyte                                                        // 3b56: 4c f4 ff    L.. :9b56[1]
+
+sub_c9b59
+    lda #$20 // ' '                                                   // 3b59: a9 20       .   :9b59[1]
+    sta l1086                                                         // 3b5b: 8d 86 10    ... :9b5b[1]
+// $3b5e referenced 1 time by $9b74
+loop_c9b5e
+    jsr sub_c9b51                                                     // 3b5e: 20 51 9b     Q. :9b5e[1]
+// $3b61 referenced 1 time by $9d81
+sub_c9b61
+    lda #0                                                            // 3b61: a9 00       ..  :9b61[1]
+// $3b63 referenced 1 time by $9b6c
+loop_c9b63
+    clc                                                               // 3b63: 18          .   :9b63[1]
+    adc #$20 // ' '                                                   // 3b64: 69 20       i   :9b64[1]
+    beq loop_c9b50                                                    // 3b66: f0 e8       ..  :9b66[1]
+    tay                                                               // 3b68: a8          .   :9b68[1]
+    jsr sub_c9b79                                                     // 3b69: 20 79 9b     y. :9b69[1]
+    bne loop_c9b63                                                    // 3b6c: d0 f5       ..  :9b6c[1]
+// $3b6e referenced 2 times by $9c13, $9d86
+c9b6e
+    lda #$20 // ' '                                                   // 3b6e: a9 20       .   :9b6e[1]
+    sta l1086                                                         // 3b70: 8d 86 10    ... :9b70[1]
+    tya                                                               // 3b73: 98          .   :9b73[1]
+    beq loop_c9b5e                                                    // 3b74: f0 e8       ..  :9b74[1]
+    jsr sub_c9e75                                                     // 3b76: 20 75 9e     u. :9b76[1]
+// $3b79 referenced 2 times by $9b69, $a264
+sub_c9b79
+    pha                                                               // 3b79: 48          H   :9b79[1]
+    jsr sub_c9df4                                                     // 3b7a: 20 f4 9d     .. :9b7a[1]
+    bcs c9bc5                                                         // 3b7d: b0 46       .F  :9b7d[1]
+    lda l111b,y                                                       // 3b7f: b9 1b 11    ... :9b7f[1]
+    eor #$ff                                                          // 3b82: 49 ff       I.  :9b82[1]
+    and l10c0                                                         // 3b84: 2d c0 10    -.. :9b84[1]
+    sta l10c0                                                         // 3b87: 8d c0 10    ... :9b87[1]
+    lda l1117,y                                                       // 3b8a: b9 17 11    ... :9b8a[1]
+    and #$60 // '`'                                                   // 3b8d: 29 60       )`  :9b8d[1]
+    beq c9bc5                                                         // 3b8f: f0 34       .4  :9b8f[1]
+    jsr sub_c9bca                                                     // 3b91: 20 ca 9b     .. :9b91[1]
+    lda l1117,y                                                       // 3b94: b9 17 11    ... :9b94[1]
+    and l1086                                                         // 3b97: 2d 86 10    -.. :9b97[1]
+    beq c9bc2                                                         // 3b9a: f0 26       .&  :9b9a[1]
+    ldx l10c3                                                         // 3b9c: ae c3 10    ... :9b9c[1]
+    lda l1114,y                                                       // 3b9f: b9 14 11    ... :9b9f[1]
+    sta l0f0c,x                                                       // 3ba2: 9d 0c 0f    ... :9ba2[1]
+    lda l1115,y                                                       // 3ba5: b9 15 11    ... :9ba5[1]
+    sta l0f0d,x                                                       // 3ba8: 9d 0d 0f    ... :9ba8[1]
+    lda l1116,y                                                       // 3bab: b9 16 11    ... :9bab[1]
+    jsr sub_c81c5                                                     // 3bae: 20 c5 81     .. :9bae[1]
+    eor l0f0e,x                                                       // 3bb1: 5d 0e 0f    ].. :9bb1[1]
+    and #$30 // '0'                                                   // 3bb4: 29 30       )0  :9bb4[1]
+    eor l0f0e,x                                                       // 3bb6: 5d 0e 0f    ].. :9bb6[1]
+    sta l0f0e,x                                                       // 3bb9: 9d 0e 0f    ... :9bb9[1]
+    jsr c93e6                                                         // 3bbc: 20 e6 93     .. :9bbc[1]
+    ldy l10c2                                                         // 3bbf: ac c2 10    ... :9bbf[1]
+// $3bc2 referenced 1 time by $9b9a
+c9bc2
+    jsr sub_c9f1e                                                     // 3bc2: 20 1e 9f     .. :9bc2[1]
+// $3bc5 referenced 2 times by $9b7d, $9b8f
+c9bc5
+    ldx l10c5                                                         // 3bc5: ae c5 10    ... :9bc5[1]
+    pla                                                               // 3bc8: 68          h   :9bc8[1]
+    rts                                                               // 3bc9: 60          `   :9bc9[1]
+
+// $3bca referenced 1 time by $9b91
+sub_c9bca
+    jsr sub_c9be5                                                     // 3bca: 20 e5 9b     .. :9bca[1]
+// $3bcd referenced 1 time by $9f9f
+sub_c9bcd
+    ldx #6                                                            // 3bcd: a2 06       ..  :9bcd[1]
+// $3bcf referenced 1 time by $9bd7
+loop_c9bcf
+    lda l110c,y                                                       // 3bcf: b9 0c 11    ... :9bcf[1]
+    sta l00c5,x                                                       // 3bd2: 95 c5       ..  :9bd2[1]
+    dey                                                               // 3bd4: 88          .   :9bd4[1]
+    dey                                                               // 3bd5: 88          .   :9bd5[1]
+    dex                                                               // 3bd6: ca          .   :9bd6[1]
+    bpl loop_c9bcf                                                    // 3bd7: 10 f6       ..  :9bd7[1]
+    jsr sub_c826d                                                     // 3bd9: 20 6d 82     m. :9bd9[1]
+    bcc generate_error_precheck_disc_changed                          // 3bdc: 90 22       ."  :9bdc[1]
+    sty l10c3                                                         // 3bde: 8c c3 10    ... :9bde[1]
+    ldy l10c2                                                         // 3be1: ac c2 10    ... :9be1[1]
+// $3be4 referenced 1 time by $9bfe
+loop_c9be4
+    rts                                                               // 3be4: 60          `   :9be4[1]
+
+// $3be5 referenced 3 times by $9bca, $9eb8, $9f93
+sub_c9be5
+    lda l110e,y                                                       // 3be5: b9 0e 11    ... :9be5[1]
+    and #$7f                                                          // 3be8: 29 7f       ).  :9be8[1]
+    sta l00cc                                                         // 3bea: 85 cc       ..  :9bea[1]
+    lda l1117,y                                                       // 3bec: b9 17 11    ... :9bec[1]
+    jmp c8816                                                         // 3bef: 4c 16 88    L.. :9bef[1]
+
+// $3bf2 referenced 2 times by $8768, $87b8
+sub_c9bf2
+    jsr sub_c83e3                                                     // 3bf2: 20 e3 83     .. :9bf2[1]
+    lda l0f04                                                         // 3bf5: ad 04 0f    ... :9bf5[1]
+    jsr sub_c8380                                                     // 3bf8: 20 80 83     .. :9bf8[1]
+    cmp l0f04                                                         // 3bfb: cd 04 0f    ... :9bfb[1]
+    beq loop_c9be4                                                    // 3bfe: f0 e4       ..  :9bfe[1]
+// $3c00 referenced 1 time by $9bdc
+generate_error_precheck_disc_changed
+    jsr generate_error_precheck_disc                                  // 3c00: 20 23 80     #. :9c00[1]
+    .byt $c8                                                          // 3c03: c8          .   :9c03[1]
+    .asc "changed"                                                    // 3c04: 63 68 61... cha :9c04[1]
+    .byt 0                                                            // 3c0b: 00          .   :9c0b[1]
+
+sub_c9c0c
+    and #$c0                                                          // 3c0c: 29 c0       ).  :9c0c[1]
+    bne c9c16                                                         // 3c0e: d0 06       ..  :9c0e[1]
+    jsr sub_c83e3                                                     // 3c10: 20 e3 83     .. :9c10[1]
+    jmp c9b6e                                                         // 3c13: 4c 6e 9b    Ln. :9c13[1]
+
+// $3c16 referenced 1 time by $9c0e
+c9c16
+    jsr sub_c840c                                                     // 3c16: 20 0c 84     .. :9c16[1]
+    stx l00ba                                                         // 3c19: 86 ba       ..  :9c19[1]
+    sty l00bb                                                         // 3c1b: 84 bb       ..  :9c1b[1]
+    sta l00b4                                                         // 3c1d: 85 b4       ..  :9c1d[1]
+    bit l00b4                                                         // 3c1f: 24 b4       $.  :9c1f[1]
+    php                                                               // 3c21: 08          .   :9c21[1]
+    jsr sub_c80f3                                                     // 3c22: 20 f3 80     .. :9c22[1]
+    jsr c99a3                                                         // 3c25: 20 a3 99     .. :9c25[1]
+    jsr sub_c8284                                                     // 3c28: 20 84 82     .. :9c28[1]
+    bcs c9c51                                                         // 3c2b: b0 24       .$  :9c2b[1]
+    plp                                                               // 3c2d: 28          (   :9c2d[1]
+    bvc c9c33                                                         // 3c2e: 50 03       P.  :9c2e[1]
+    lda #0                                                            // 3c30: a9 00       ..  :9c30[1]
+    rts                                                               // 3c32: 60          `   :9c32[1]
+
+// $3c33 referenced 1 time by $9c2e
+c9c33
+    php                                                               // 3c33: 08          .   :9c33[1]
+    lda #0                                                            // 3c34: a9 00       ..  :9c34[1]
+    ldx #7                                                            // 3c36: a2 07       ..  :9c36[1]
+// $3c38 referenced 1 time by $9c3e
+loop_c9c38
+    sta l00bc,x                                                       // 3c38: 95 bc       ..  :9c38[1]
+    sta l1074,x                                                       // 3c3a: 9d 74 10    .t. :9c3a[1]
+    dex                                                               // 3c3d: ca          .   :9c3d[1]
+    bpl loop_c9c38                                                    // 3c3e: 10 f8       ..  :9c3e[1]
+    dec l00be                                                         // 3c40: c6 be       ..  :9c40[1]
+    dec l00bf                                                         // 3c42: c6 bf       ..  :9c42[1]
+    dec l1076                                                         // 3c44: ce 76 10    .v. :9c44[1]
+    dec l1077                                                         // 3c47: ce 77 10    .w. :9c47[1]
+    lda #$40 // '@'                                                   // 3c4a: a9 40       .@  :9c4a[1]
+    sta l00c3                                                         // 3c4c: 85 c3       ..  :9c4c[1]
+    jsr sub_c8a77                                                     // 3c4e: 20 77 8a     w. :9c4e[1]
+// $3c51 referenced 1 time by $9c2b
+c9c51
+    plp                                                               // 3c51: 28          (   :9c51[1]
+    php                                                               // 3c52: 08          .   :9c52[1]
+    bvs c9c58                                                         // 3c53: 70 03       p.  :9c53[1]
+    jsr sub_c9a50                                                     // 3c55: 20 50 9a     P. :9c55[1]
+// $3c58 referenced 1 time by $9c53
+c9c58
+    jsr sub_c9d1e                                                     // 3c58: 20 1e 9d     .. :9c58[1]
+    bcc c9c6b                                                         // 3c5b: 90 0e       ..  :9c5b[1]
+// $3c5d referenced 1 time by $9c69
+loop_c9c5d
+    lda l110c,y                                                       // 3c5d: b9 0c 11    ... :9c5d[1]
+    bpl generate_error_precheck_open                                  // 3c60: 10 20       .   :9c60[1]
+    plp                                                               // 3c62: 28          (   :9c62[1]
+    php                                                               // 3c63: 08          .   :9c63[1]
+    bmi generate_error_precheck_open                                  // 3c64: 30 1c       0.  :9c64[1]
+    jsr sub_c9d19                                                     // 3c66: 20 19 9d     .. :9c66[1]
+    bcs loop_c9c5d                                                    // 3c69: b0 f2       ..  :9c69[1]
+// $3c6b referenced 1 time by $9c5b
+c9c6b
+    ldy l10c2                                                         // 3c6b: ac c2 10    ... :9c6b[1]
+    bne c9c8b                                                         // 3c6e: d0 1b       ..  :9c6e[1]
+    jsr generate_error_precheck                                       // 3c70: 20 38 80     8. :9c70[1]
+    .byt $c0                                                          // 3c73: c0          .   :9c73[1]
+    .asc "Too many open"                                              // 3c74: 54 6f 6f... Too :9c74[1]
+    .byt 0                                                            // 3c81: 00          .   :9c81[1]
+
+// $3c82 referenced 3 times by $9a6b, $9c60, $9c64
+generate_error_precheck_open
+    jsr generate_error_precheck                                       // 3c82: 20 38 80     8. :9c82[1]
+    .byt $c2                                                          // 3c85: c2          .   :9c85[1]
+    .asc "Open"                                                       // 3c86: 4f 70 65... Ope :9c86[1]
+    .byt 0                                                            // 3c8a: 00          .   :9c8a[1]
+
+// $3c8b referenced 1 time by $9c6e
+c9c8b
+    lda #8                                                            // 3c8b: a9 08       ..  :9c8b[1]
+    sta l10c4                                                         // 3c8d: 8d c4 10    ... :9c8d[1]
+// $3c90 referenced 1 time by $9ca2
+loop_c9c90
+    lda l0e08,x                                                       // 3c90: bd 08 0e    ... :9c90[1]
+    sta l1100,y                                                       // 3c93: 99 00 11    ... :9c93[1]
+    iny                                                               // 3c96: c8          .   :9c96[1]
+    lda l0f08,x                                                       // 3c97: bd 08 0f    ... :9c97[1]
+    sta l1100,y                                                       // 3c9a: 99 00 11    ... :9c9a[1]
+    iny                                                               // 3c9d: c8          .   :9c9d[1]
+    inx                                                               // 3c9e: e8          .   :9c9e[1]
+    dec l10c4                                                         // 3c9f: ce c4 10    ... :9c9f[1]
+    bne loop_c9c90                                                    // 3ca2: d0 ec       ..  :9ca2[1]
+    ldx #$10                                                          // 3ca4: a2 10       ..  :9ca4[1]
+    lda #0                                                            // 3ca6: a9 00       ..  :9ca6[1]
+// $3ca8 referenced 1 time by $9cad
+loop_c9ca8
+    sta l1100,y                                                       // 3ca8: 99 00 11    ... :9ca8[1]
+    iny                                                               // 3cab: c8          .   :9cab[1]
+    dex                                                               // 3cac: ca          .   :9cac[1]
+    bne loop_c9ca8                                                    // 3cad: d0 f9       ..  :9cad[1]
+    lda l10c2                                                         // 3caf: ad c2 10    ... :9caf[1]
+    tay                                                               // 3cb2: a8          .   :9cb2[1]
+    jsr sub_c81be                                                     // 3cb3: 20 be 81     .. :9cb3[1]
+    adc #$11                                                          // 3cb6: 69 11       i.  :9cb6[1]
+    sta l1113,y                                                       // 3cb8: 99 13 11    ... :9cb8[1]
+    lda l10c1                                                         // 3cbb: ad c1 10    ... :9cbb[1]
+    sta l111b,y                                                       // 3cbe: 99 1b 11    ... :9cbe[1]
+    ora l10c0                                                         // 3cc1: 0d c0 10    ... :9cc1[1]
+    sta l10c0                                                         // 3cc4: 8d c0 10    ... :9cc4[1]
+    lda l1109,y                                                       // 3cc7: b9 09 11    ... :9cc7[1]
+    adc #$ff                                                          // 3cca: 69 ff       i.  :9cca[1]
+    lda l110b,y                                                       // 3ccc: b9 0b 11    ... :9ccc[1]
+    adc #0                                                            // 3ccf: 69 00       i.  :9ccf[1]
+    sta l1119,y                                                       // 3cd1: 99 19 11    ... :9cd1[1]
+    lda l110d,y                                                       // 3cd4: b9 0d 11    ... :9cd4[1]
+    ora #$0f                                                          // 3cd7: 09 0f       ..  :9cd7[1]
+    adc #0                                                            // 3cd9: 69 00       i.  :9cd9[1]
+    jsr sub_c81b0                                                     // 3cdb: 20 b0 81     .. :9cdb[1]
+    sta l111a,y                                                       // 3cde: 99 1a 11    ... :9cde[1]
+    plp                                                               // 3ce1: 28          (   :9ce1[1]
+    bvc c9d12                                                         // 3ce2: 50 2e       P.  :9ce2[1]
+    bmi c9cee                                                         // 3ce4: 30 08       0.  :9ce4[1]
+    lda #$80                                                          // 3ce6: a9 80       ..  :9ce6[1]
+    ora l110c,y                                                       // 3ce8: 19 0c 11    ... :9ce8[1]
+    sta l110c,y                                                       // 3ceb: 99 0c 11    ... :9ceb[1]
+// $3cee referenced 1 time by $9ce4
+c9cee
+    lda l1109,y                                                       // 3cee: b9 09 11    ... :9cee[1]
+    sta l1114,y                                                       // 3cf1: 99 14 11    ... :9cf1[1]
+    lda l110b,y                                                       // 3cf4: b9 0b 11    ... :9cf4[1]
+    sta l1115,y                                                       // 3cf7: 99 15 11    ... :9cf7[1]
+    lda l110d,y                                                       // 3cfa: b9 0d 11    ... :9cfa[1]
+    jsr sub_c81b0                                                     // 3cfd: 20 b0 81     .. :9cfd[1]
+    sta l1116,y                                                       // 3d00: 99 16 11    ... :9d00[1]
+// $3d03 referenced 1 time by $9d17
+loop_c9d03
+    lda l00cd                                                         // 3d03: a5 cd       ..  :9d03[1]
+    ora l1117,y                                                       // 3d05: 19 17 11    ... :9d05[1]
+    sta l1117,y                                                       // 3d08: 99 17 11    ... :9d08[1]
+    tya                                                               // 3d0b: 98          .   :9d0b[1]
+    jsr sub_c81be                                                     // 3d0c: 20 be 81     .. :9d0c[1]
+    ora #$10                                                          // 3d0f: 09 10       ..  :9d0f[1]
+    rts                                                               // 3d11: 60          `   :9d11[1]
+
+// $3d12 referenced 1 time by $9ce2
+c9d12
+    lda #$20 // ' '                                                   // 3d12: a9 20       .   :9d12[1]
+    sta l1117,y                                                       // 3d14: 99 17 11    ... :9d14[1]
+    bne loop_c9d03                                                    // 3d17: d0 ea       ..  :9d17[1]
+// $3d19 referenced 1 time by $9c66
+sub_c9d19
+    txa                                                               // 3d19: 8a          .   :9d19[1]
+    pha                                                               // 3d1a: 48          H   :9d1a[1]
+    jmp c9d5d                                                         // 3d1b: 4c 5d 9d    L]. :9d1b[1]
+
+// $3d1e referenced 2 times by $9a66, $9c58
+sub_c9d1e
+    lda #0                                                            // 3d1e: a9 00       ..  :9d1e[1]
+    sta l10c2                                                         // 3d20: 8d c2 10    ... :9d20[1]
+    lda #8                                                            // 3d23: a9 08       ..  :9d23[1]
+    sta l00b5                                                         // 3d25: 85 b5       ..  :9d25[1]
+    tya                                                               // 3d27: 98          .   :9d27[1]
+    tax                                                               // 3d28: aa          .   :9d28[1]
+    ldy #$a0                                                          // 3d29: a0 a0       ..  :9d29[1]
+// $3d2b referenced 1 time by $9d6f
+c9d2b
+    sty l00b3                                                         // 3d2b: 84 b3       ..  :9d2b[1]
+    txa                                                               // 3d2d: 8a          .   :9d2d[1]
+    pha                                                               // 3d2e: 48          H   :9d2e[1]
+    lda #8                                                            // 3d2f: a9 08       ..  :9d2f[1]
+    sta l00b2                                                         // 3d31: 85 b2       ..  :9d31[1]
+    lda l00b5                                                         // 3d33: a5 b5       ..  :9d33[1]
+    bit l10c0                                                         // 3d35: 2c c0 10    ,.. :9d35[1]
+    beq c9d57                                                         // 3d38: f0 1d       ..  :9d38[1]
+    lda l1117,y                                                       // 3d3a: b9 17 11    ... :9d3a[1]
+    eor l00cd                                                         // 3d3d: 45 cd       E.  :9d3d[1]
+    and #3                                                            // 3d3f: 29 03       ).  :9d3f[1]
+    bne c9d5d                                                         // 3d41: d0 1a       ..  :9d41[1]
+// $3d43 referenced 1 time by $9d52
+loop_c9d43
+    lda l0e08,x                                                       // 3d43: bd 08 0e    ... :9d43[1]
+    eor l1100,y                                                       // 3d46: 59 00 11    Y.. :9d46[1]
+    and #$7f                                                          // 3d49: 29 7f       ).  :9d49[1]
+    bne c9d5d                                                         // 3d4b: d0 10       ..  :9d4b[1]
+    inx                                                               // 3d4d: e8          .   :9d4d[1]
+    iny                                                               // 3d4e: c8          .   :9d4e[1]
+    iny                                                               // 3d4f: c8          .   :9d4f[1]
+    dec l00b2                                                         // 3d50: c6 b2       ..  :9d50[1]
+    bne loop_c9d43                                                    // 3d52: d0 ef       ..  :9d52[1]
+    sec                                                               // 3d54: 38          8   :9d54[1]
+    bcs c9d67                                                         // 3d55: b0 10       ..  :9d55[1]
+// $3d57 referenced 1 time by $9d38
+c9d57
+    sty l10c2                                                         // 3d57: 8c c2 10    ... :9d57[1]
+    sta l10c1                                                         // 3d5a: 8d c1 10    ... :9d5a[1]
+// $3d5d referenced 3 times by $9d1b, $9d41, $9d4b
+c9d5d
+    sec                                                               // 3d5d: 38          8   :9d5d[1]
+    lda l00b3                                                         // 3d5e: a5 b3       ..  :9d5e[1]
+    sbc #$20 // ' '                                                   // 3d60: e9 20       .   :9d60[1]
+    sta l00b3                                                         // 3d62: 85 b3       ..  :9d62[1]
+    asl l00b5                                                         // 3d64: 06 b5       ..  :9d64[1]
+    clc                                                               // 3d66: 18          .   :9d66[1]
+// $3d67 referenced 1 time by $9d55
+c9d67
+    pla                                                               // 3d67: 68          h   :9d67[1]
+    tax                                                               // 3d68: aa          .   :9d68[1]
+    ldy l00b3                                                         // 3d69: a4 b3       ..  :9d69[1]
+    lda l00b5                                                         // 3d6b: a5 b5       ..  :9d6b[1]
+    bcs c9d71                                                         // 3d6d: b0 02       ..  :9d6d[1]
+    bne c9d2b                                                         // 3d6f: d0 ba       ..  :9d6f[1]
+// $3d71 referenced 1 time by $9d6d
+c9d71
+    rts                                                               // 3d71: 60          `   :9d71[1]
+
+// $3d72 referenced 1 time by $9da0
+c9d72
+    jsr zero_stacked_XXX                                              // 3d72: 20 8e 9d     .. :9d72[1]
+// $3d75 referenced 1 time by $9726
+sub_c9d75
+    lda l10c0                                                         // 3d75: ad c0 10    ... :9d75[1]
+    pha                                                               // 3d78: 48          H   :9d78[1]
+    lda #0                                                            // 3d79: a9 00       ..  :9d79[1]
+    sta l1086                                                         // 3d7b: 8d 86 10    ... :9d7b[1]
+    tya                                                               // 3d7e: 98          .   :9d7e[1]
+    bne c9d86                                                         // 3d7f: d0 05       ..  :9d7f[1]
+    jsr sub_c9b61                                                     // 3d81: 20 61 9b     a. :9d81[1]
+    beq c9d89                                                         // 3d84: f0 03       ..  :9d84[1]
+// $3d86 referenced 1 time by $9d7f
+c9d86
+    jsr c9b6e                                                         // 3d86: 20 6e 9b     n. :9d86[1]
+// $3d89 referenced 1 time by $9d84
+c9d89
+    pla                                                               // 3d89: 68          h   :9d89[1]
+    sta l10c0                                                         // 3d8a: 8d c0 10    ... :9d8a[1]
+    rts                                                               // 3d8d: 60          `   :9d8d[1]
+
+// $3d8e referenced 6 times by $956f, $9714, $97d0, $9d72, $9daa, $9db8
+zero_stacked_XXX
+    pha                                                               // 3d8e: 48          H   :9d8e[1]
+    txa                                                               // 3d8f: 8a          .   :9d8f[1]
+    pha                                                               // 3d90: 48          H   :9d90[1]
+    lda #0                                                            // 3d91: a9 00       ..  :9d91[1]
+    tsx                                                               // 3d93: ba          .   :9d93[1]
+    sta l0109,x                                                       // 3d94: 9d 09 01    ... :9d94[1]
+    pla                                                               // 3d97: 68          h   :9d97[1]
+    tax                                                               // 3d98: aa          .   :9d98[1]
+    pla                                                               // 3d99: 68          h   :9d99[1]
+    rts                                                               // 3d9a: 60          `   :9d9a[1]
+
+sub_c9d9b
+    jsr sub_c83e3                                                     // 3d9b: 20 e3 83     .. :9d9b[1]
+    cmp #$ff                                                          // 3d9e: c9 ff       ..  :9d9e[1]
+    beq c9d72                                                         // 3da0: f0 d0       ..  :9da0[1]
+    cpy #0                                                            // 3da2: c0 00       ..  :9da2[1]
+    beq c9db4                                                         // 3da4: f0 0e       ..  :9da4[1]
+    cmp #3                                                            // 3da6: c9 03       ..  :9da6[1]
+    bcs c9dcd                                                         // 3da8: b0 23       .#  :9da8[1]
+    jsr zero_stacked_XXX                                              // 3daa: 20 8e 9d     .. :9daa[1]
+    cmp #1                                                            // 3dad: c9 01       ..  :9dad[1]
+    bne c9dd5                                                         // 3daf: d0 24       .$  :9daf[1]
+    jmp ca06c                                                         // 3db1: 4c 6c a0    Ll. :9db1[1]
+
+// $3db4 referenced 1 time by $9da4
+c9db4
+    cmp #2                                                            // 3db4: c9 02       ..  :9db4[1]
+    bcs c9dcd                                                         // 3db6: b0 15       ..  :9db6[1]
+    jsr zero_stacked_XXX                                              // 3db8: 20 8e 9d     .. :9db8[1]
+    beq c9dce                                                         // 3dbb: f0 11       ..  :9dbb[1]
+    lda #$ff                                                          // 3dbd: a9 ff       ..  :9dbd[1]
+    sta l0002,x                                                       // 3dbf: 95 02       ..  :9dbf[1]
+    sta l0003,x                                                       // 3dc1: 95 03       ..  :9dc1[1]
+    lda l10d9                                                         // 3dc3: ad d9 10    ... :9dc3[1]
+    sta l0000,x                                                       // 3dc6: 95 00       ..  :9dc6[1]
+    lda l10da                                                         // 3dc8: ad da 10    ... :9dc8[1]
+    sta l0001,x                                                       // 3dcb: 95 01       ..  :9dcb[1]
+// $3dcd referenced 2 times by $9da8, $9db6
+c9dcd
+    rts                                                               // 3dcd: 60          `   :9dcd[1]
+
+// $3dce referenced 1 time by $9dbb
+c9dce
+    lda #4                                                            // 3dce: a9 04       ..  :9dce[1]
+    tsx                                                               // 3dd0: ba          .   :9dd0[1]
+    sta l0105,x                                                       // 3dd1: 9d 05 01    ... :9dd1[1]
+    rts                                                               // 3dd4: 60          `   :9dd4[1]
+
+// $3dd5 referenced 2 times by $984c, $9daf
+c9dd5
+    jsr sub_c9e75                                                     // 3dd5: 20 75 9e     u. :9dd5[1]
+    sty l10c2                                                         // 3dd8: 8c c2 10    ... :9dd8[1]
+    asl                                                               // 3ddb: 0a          .   :9ddb[1]
+    adc l10c2                                                         // 3ddc: 6d c2 10    m.. :9ddc[1]
+    tay                                                               // 3ddf: a8          .   :9ddf[1]
+    lda l1110,y                                                       // 3de0: b9 10 11    ... :9de0[1]
+    sta l0000,x                                                       // 3de3: 95 00       ..  :9de3[1]
+    lda l1111,y                                                       // 3de5: b9 11 11    ... :9de5[1]
+    sta l0001,x                                                       // 3de8: 95 01       ..  :9de8[1]
+    lda l1112,y                                                       // 3dea: b9 12 11    ... :9dea[1]
+    sta l0002,x                                                       // 3ded: 95 02       ..  :9ded[1]
+    lda #0                                                            // 3def: a9 00       ..  :9def[1]
+    sta l0003,x                                                       // 3df1: 95 03       ..  :9df1[1]
+    rts                                                               // 3df3: 60          `   :9df3[1]
+
+// $3df4 referenced 2 times by $9b7a, $9e78
+sub_c9df4
+    pha                                                               // 3df4: 48          H   :9df4[1]
+    stx l10c5                                                         // 3df5: 8e c5 10    ... :9df5[1]
+    tya                                                               // 3df8: 98          .   :9df8[1]
+    and #$e0                                                          // 3df9: 29 e0       ).  :9df9[1]
+    sta l10c2                                                         // 3dfb: 8d c2 10    ... :9dfb[1]
+    beq c9e13                                                         // 3dfe: f0 13       ..  :9dfe[1]
+    jsr sub_c81be                                                     // 3e00: 20 be 81     .. :9e00[1]
+    tay                                                               // 3e03: a8          .   :9e03[1]
+    lda #0                                                            // 3e04: a9 00       ..  :9e04[1]
+    sec                                                               // 3e06: 38          8   :9e06[1]
+// $3e07 referenced 1 time by $9e09
+loop_c9e07
+    ror                                                               // 3e07: 6a          j   :9e07[1]
+    dey                                                               // 3e08: 88          .   :9e08[1]
+    bne loop_c9e07                                                    // 3e09: d0 fc       ..  :9e09[1]
+    ldy l10c2                                                         // 3e0b: ac c2 10    ... :9e0b[1]
+    bit l10c0                                                         // 3e0e: 2c c0 10    ,.. :9e0e[1]
+    bne c9e16                                                         // 3e11: d0 03       ..  :9e11[1]
+// $3e13 referenced 1 time by $9dfe
+c9e13
+    pla                                                               // 3e13: 68          h   :9e13[1]
+    sec                                                               // 3e14: 38          8   :9e14[1]
+    rts                                                               // 3e15: 60          `   :9e15[1]
+
+// $3e16 referenced 1 time by $9e11
+c9e16
+    pla                                                               // 3e16: 68          h   :9e16[1]
+    clc                                                               // 3e17: 18          .   :9e17[1]
+    rts                                                               // 3e18: 60          `   :9e18[1]
+
+    .byt $48, $8a, $4c, $20, $9e                                      // 3e19: 48 8a 4c... H.L :9e19[1]
+
+// $3e1e referenced 2 times by $9e56, $9e75
+sub_c9e1e
+    pha                                                               // 3e1e: 48          H   :9e1e[1]
+    tya                                                               // 3e1f: 98          .   :9e1f[1]
+    cmp #$10                                                          // 3e20: c9 10       ..  :9e20[1]
+    bcc c9e28                                                         // 3e22: 90 04       ..  :9e22[1]
+    cmp #$18                                                          // 3e24: c9 18       ..  :9e24[1]
+    bcc c9e2a                                                         // 3e26: 90 02       ..  :9e26[1]
+// $3e28 referenced 1 time by $9e22
+c9e28
+    lda #8                                                            // 3e28: a9 08       ..  :9e28[1]
+// $3e2a referenced 1 time by $9e26
+c9e2a
+    jsr sub_c81c4                                                     // 3e2a: 20 c4 81     .. :9e2a[1]
+    tay                                                               // 3e2d: a8          .   :9e2d[1]
+    pla                                                               // 3e2e: 68          h   :9e2e[1]
+    rts                                                               // 3e2f: 60          `   :9e2f[1]
+
+// $3e30 referenced 3 times by $803d, $9e7d, $9fc5
+sub_c9e30
+    lda #osbyte_rw_exec_handle                                        // 3e30: a9 c6       ..  :9e30[1]
+    jsr osbyte_read                                                   // 3e32: 20 e5 9a     .. :9e32[1]
+    txa                                                               // 3e35: 8a          .   :9e35[1]
+    beq c9e41                                                         // 3e36: f0 09       ..  :9e36[1]
+    jsr sub_c9e54                                                     // 3e38: 20 54 9e     T. :9e38[1]
+    bne c9e41                                                         // 3e3b: d0 04       ..  :9e3b[1]
+    lda #osbyte_rw_exec_handle                                        // 3e3d: a9 c6       ..  :9e3d[1]
+    bne osbyte_write_0                                                // 3e3f: d0 0c       ..  :9e3f[1]
+// $3e41 referenced 2 times by $9e36, $9e3b
+c9e41
+    lda #osbyte_read_write_spool_file_handle                          // 3e41: a9 c7       ..  :9e41[1]
+    jsr osbyte_read                                                   // 3e43: 20 e5 9a     .. :9e43[1]
+    jsr sub_c9e54                                                     // 3e46: 20 54 9e     T. :9e46[1]
+    bne c9e5c                                                         // 3e49: d0 11       ..  :9e49[1]
+    lda #osbyte_read_write_spool_file_handle                          // 3e4b: a9 c7       ..  :9e4b[1]
+// $3e4d referenced 1 time by $9e3f
+osbyte_write_0
+    ldx #0                                                            // 3e4d: a2 00       ..  :9e4d[1]
+    ldy #0                                                            // 3e4f: a0 00       ..  :9e4f[1]
+    jmp osbyte                                                        // 3e51: 4c f4 ff    L.. :9e51[1]
+
+// $3e54 referenced 2 times by $9e38, $9e46
+sub_c9e54
+    txa                                                               // 3e54: 8a          .   :9e54[1]
+    tay                                                               // 3e55: a8          .   :9e55[1]
+    jsr sub_c9e1e                                                     // 3e56: 20 1e 9e     .. :9e56[1]
+    cpy l10c2                                                         // 3e59: cc c2 10    ... :9e59[1]
+// $3e5c referenced 1 time by $9e49
+c9e5c
+    rts                                                               // 3e5c: 60          `   :9e5c[1]
+
+    pha                                                               // 3e5d: 48          H   :9e5d[1]
+    tya                                                               // 3e5e: 98          .   :9e5e[1]
+    pha                                                               // 3e5f: 48          H   :9e5f[1]
+    txa                                                               // 3e60: 8a          .   :9e60[1]
+    tay                                                               // 3e61: a8          .   :9e61[1]
+    jsr sub_c9e75                                                     // 3e62: 20 75 9e     u. :9e62[1]
+    tya                                                               // 3e65: 98          .   :9e65[1]
+    jsr sub_ca0de                                                     // 3e66: 20 de a0     .. :9e66[1]
+    bne c9e6f                                                         // 3e69: d0 04       ..  :9e69[1]
+    ldx #$ff                                                          // 3e6b: a2 ff       ..  :9e6b[1]
+    bne c9e71                                                         // 3e6d: d0 02       ..  :9e6d[1]
+// $3e6f referenced 1 time by $9e69
+c9e6f
+    ldx #0                                                            // 3e6f: a2 00       ..  :9e6f[1]
+// $3e71 referenced 1 time by $9e6d
+c9e71
+    pla                                                               // 3e71: 68          h   :9e71[1]
+    tay                                                               // 3e72: a8          .   :9e72[1]
+    pla                                                               // 3e73: 68          h   :9e73[1]
+// $3e74 referenced 1 time by $9e7b
+loop_c9e74
+    rts                                                               // 3e74: 60          `   :9e74[1]
+
+// $3e75 referenced 6 times by $9b76, $9dd5, $9e62, $9e97, $9f85, $a06f
+sub_c9e75
+    jsr sub_c9e1e                                                     // 3e75: 20 1e 9e     .. :9e75[1]
+    jsr sub_c9df4                                                     // 3e78: 20 f4 9d     .. :9e78[1]
+    bcc loop_c9e74                                                    // 3e7b: 90 f7       ..  :9e7b[1]
+    jsr sub_c9e30                                                     // 3e7d: 20 30 9e     0. :9e7d[1]
+    jsr generate_error_precheck                                       // 3e80: 20 38 80     8. :9e80[1]
+    .byt $de                                                          // 3e83: de          .   :9e83[1]
+    .asc "Channel"                                                    // 3e84: 43 68 61... Cha :9e84[1]
+    .byt 0                                                            // 3e8b: 00          .   :9e8b[1]
+
+// $3e8c referenced 1 time by $9ea5
+loop_c9e8c
+    jsr generate_error_precheck                                       // 3e8c: 20 38 80     8. :9e8c[1]
+    .byt $df                                                          // 3e8f: df          .   :9e8f[1]
+    .asc "EOF"                                                        // 3e90: 45 4f 46    EOF :9e90[1]
+    .byt 0                                                            // 3e93: 00          .   :9e93[1]
+
+// $3e94 referenced 1 time by $9969
+sub_c9e94
+    jsr sub_c840c                                                     // 3e94: 20 0c 84     .. :9e94[1]
+    jsr sub_c9e75                                                     // 3e97: 20 75 9e     u. :9e97[1]
+    tya                                                               // 3e9a: 98          .   :9e9a[1]
+    jsr sub_ca0de                                                     // 3e9b: 20 de a0     .. :9e9b[1]
+    bne c9eb3                                                         // 3e9e: d0 13       ..  :9e9e[1]
+    lda l1117,y                                                       // 3ea0: b9 17 11    ... :9ea0[1]
+    and #$10                                                          // 3ea3: 29 10       ).  :9ea3[1]
+    bne loop_c9e8c                                                    // 3ea5: d0 e5       ..  :9ea5[1]
+    lda #$10                                                          // 3ea7: a9 10       ..  :9ea7[1]
+    jsr sub_c9f0f                                                     // 3ea9: 20 0f 9f     .. :9ea9[1]
+    ldx l10c5                                                         // 3eac: ae c5 10    ... :9eac[1]
+    lda #$fe                                                          // 3eaf: a9 fe       ..  :9eaf[1]
+    sec                                                               // 3eb1: 38          8   :9eb1[1]
+    rts                                                               // 3eb2: 60          `   :9eb2[1]
+
+// $3eb3 referenced 1 time by $9e9e
+c9eb3
+    lda l1117,y                                                       // 3eb3: b9 17 11    ... :9eb3[1]
+    bmi c9ec2                                                         // 3eb6: 30 0a       0.  :9eb6[1]
+    jsr sub_c9be5                                                     // 3eb8: 20 e5 9b     .. :9eb8[1]
+    jsr sub_c9f1e                                                     // 3ebb: 20 1e 9f     .. :9ebb[1]
+    sec                                                               // 3ebe: 38          8   :9ebe[1]
+    jsr sub_c9f26                                                     // 3ebf: 20 26 9f     &. :9ebf[1]
+// $3ec2 referenced 1 time by $9eb6
+c9ec2
+    lda l1110,y                                                       // 3ec2: b9 10 11    ... :9ec2[1]
+    sta l00ba                                                         // 3ec5: 85 ba       ..  :9ec5[1]
+    lda l1113,y                                                       // 3ec7: b9 13 11    ... :9ec7[1]
+    sta l00bb                                                         // 3eca: 85 bb       ..  :9eca[1]
+    ldy #0                                                            // 3ecc: a0 00       ..  :9ecc[1]
+    lda (l00ba),y                                                     // 3ece: b1 ba       ..  :9ece[1]
+    pha                                                               // 3ed0: 48          H   :9ed0[1]
+    ldy l10c2                                                         // 3ed1: ac c2 10    ... :9ed1[1]
+    ldx l00ba                                                         // 3ed4: a6 ba       ..  :9ed4[1]
+    inx                                                               // 3ed6: e8          .   :9ed6[1]
+    txa                                                               // 3ed7: 8a          .   :9ed7[1]
+    sta l1110,y                                                       // 3ed8: 99 10 11    ... :9ed8[1]
+    bne c9ef1                                                         // 3edb: d0 14       ..  :9edb[1]
+    clc                                                               // 3edd: 18          .   :9edd[1]
+    lda l1111,y                                                       // 3ede: b9 11 11    ... :9ede[1]
+    adc #1                                                            // 3ee1: 69 01       i.  :9ee1[1]
+    sta l1111,y                                                       // 3ee3: 99 11 11    ... :9ee3[1]
+    lda l1112,y                                                       // 3ee6: b9 12 11    ... :9ee6[1]
+    adc #0                                                            // 3ee9: 69 00       i.  :9ee9[1]
+    sta l1112,y                                                       // 3eeb: 99 12 11    ... :9eeb[1]
+    jsr sub_c9f14                                                     // 3eee: 20 14 9f     .. :9eee[1]
+// $3ef1 referenced 1 time by $9edb
+c9ef1
+    clc                                                               // 3ef1: 18          .   :9ef1[1]
+    pla                                                               // 3ef2: 68          h   :9ef2[1]
+    rts                                                               // 3ef3: 60          `   :9ef3[1]
+
+// $3ef4 referenced 2 times by $9f5e, $a018
+sub_c9ef4
+    clc                                                               // 3ef4: 18          .   :9ef4[1]
+    lda l110f,y                                                       // 3ef5: b9 0f 11    ... :9ef5[1]
+    adc l1111,y                                                       // 3ef8: 79 11 11    y.. :9ef8[1]
+    sta l00c3                                                         // 3efb: 85 c3       ..  :9efb[1]
+    sta l111c,y                                                       // 3efd: 99 1c 11    ... :9efd[1]
+    lda l110d,y                                                       // 3f00: b9 0d 11    ... :9f00[1]
+    and #3                                                            // 3f03: 29 03       ).  :9f03[1]
+    adc l1112,y                                                       // 3f05: 79 12 11    y.. :9f05[1]
+    sta l00c2                                                         // 3f08: 85 c2       ..  :9f08[1]
+    sta l111d,y                                                       // 3f0a: 99 1d 11    ... :9f0a[1]
+// $3f0d referenced 1 time by $a0db
+c9f0d
+    lda #$80                                                          // 3f0d: a9 80       ..  :9f0d[1]
+// $3f0f referenced 3 times by $9ea9, $a035, $a05c
+sub_c9f0f
+    ora l1117,y                                                       // 3f0f: 19 17 11    ... :9f0f[1]
+    bne c9f19                                                         // 3f12: d0 05       ..  :9f12[1]
+// $3f14 referenced 2 times by $9eee, $a041
+sub_c9f14
+    lda #$7f                                                          // 3f14: a9 7f       ..  :9f14[1]
+// $3f16 referenced 3 times by $95f0, $9f59, $a0ba
+sub_c9f16
+    and l1117,y                                                       // 3f16: 39 17 11    9.. :9f16[1]
+// $3f19 referenced 1 time by $9f12
+c9f19
+    sta l1117,y                                                       // 3f19: 99 17 11    ... :9f19[1]
+    clc                                                               // 3f1c: 18          .   :9f1c[1]
+    rts                                                               // 3f1d: 60          `   :9f1d[1]
+
+// $3f1e referenced 3 times by $9bc2, $9ebb, $a00a
+sub_c9f1e
+    lda l1117,y                                                       // 3f1e: b9 17 11    ... :9f1e[1]
+    and #$40 // '@'                                                   // 3f21: 29 40       )@  :9f21[1]
+    beq c9f6a                                                         // 3f23: f0 45       .E  :9f23[1]
+    clc                                                               // 3f25: 18          .   :9f25[1]
+// $3f26 referenced 2 times by $9ebf, $a01e
+sub_c9f26
+    php                                                               // 3f26: 08          .   :9f26[1]
+    inc l10dd                                                         // 3f27: ee dd 10    ... :9f27[1]
+    ldy l10c2                                                         // 3f2a: ac c2 10    ... :9f2a[1]
+    lda l1113,y                                                       // 3f2d: b9 13 11    ... :9f2d[1]
+    sta l00bd                                                         // 3f30: 85 bd       ..  :9f30[1]
+    lda #$ff                                                          // 3f32: a9 ff       ..  :9f32[1]
+    sta l1074                                                         // 3f34: 8d 74 10    .t. :9f34[1]
+    sta l1075                                                         // 3f37: 8d 75 10    .u. :9f37[1]
+    lda #0                                                            // 3f3a: a9 00       ..  :9f3a[1]
+    sta l00bc                                                         // 3f3c: 85 bc       ..  :9f3c[1]
+    sta l00c0                                                         // 3f3e: 85 c0       ..  :9f3e[1]
+    lda #1                                                            // 3f40: a9 01       ..  :9f40[1]
+    sta l00c1                                                         // 3f42: 85 c1       ..  :9f42[1]
+    plp                                                               // 3f44: 28          (   :9f44[1]
+    bcs c9f5e                                                         // 3f45: b0 17       ..  :9f45[1]
+    lda l111c,y                                                       // 3f47: b9 1c 11    ... :9f47[1]
+    sta l00c3                                                         // 3f4a: 85 c3       ..  :9f4a[1]
+    lda l111d,y                                                       // 3f4c: b9 1d 11    ... :9f4c[1]
+    sta l00c2                                                         // 3f4f: 85 c2       ..  :9f4f[1]
+    jsr sub_c8862                                                     // 3f51: 20 62 88     b. :9f51[1]
+    ldy l10c2                                                         // 3f54: ac c2 10    ... :9f54[1]
+    lda #$bf                                                          // 3f57: a9 bf       ..  :9f57[1]
+    jsr sub_c9f16                                                     // 3f59: 20 16 9f     .. :9f59[1]
+    bcc c9f64                                                         // 3f5c: 90 06       ..  :9f5c[1]
+// $3f5e referenced 1 time by $9f45
+c9f5e
+    jsr sub_c9ef4                                                     // 3f5e: 20 f4 9e     .. :9f5e[1]
+    jsr sub_c8855                                                     // 3f61: 20 55 88     U. :9f61[1]
+// $3f64 referenced 1 time by $9f5c
+c9f64
+    dec l10dd                                                         // 3f64: ce dd 10    ... :9f64[1]
+    ldy l10c2                                                         // 3f67: ac c2 10    ... :9f67[1]
+// $3f6a referenced 1 time by $9f23
+c9f6a
+    rts                                                               // 3f6a: 60          `   :9f6a[1]
+
+// $3f6b referenced 1 time by $9f91
+c9f6b
+    jmp generate_error_precheck_locked                                // 3f6b: 4c 55 9a    LU. :9f6b[1]
+
+// $3f6e referenced 1 time by $9f8c
+loop_c9f6e
+    jsr generate_error_precheck                                       // 3f6e: 20 38 80     8. :9f6e[1]
+    .byt $c1                                                          // 3f71: c1          .   :9f71[1]
+    .asc "Read only"                                                  // 3f72: 52 65 61... Rea :9f72[1]
+    .byt 0                                                            // 3f7b: 00          .   :9f7b[1]
+
+// $3f7c referenced 1 time by $a09a
+sub_c9f7c
+    jsr sub_c83e3                                                     // 3f7c: 20 e3 83     .. :9f7c[1]
+    jmp c9f88                                                         // 3f7f: 4c 88 9f    L.. :9f7f[1]
+
+// $3f82 referenced 1 time by $9983
+sub_c9f82
+    jsr sub_c83e3                                                     // 3f82: 20 e3 83     .. :9f82[1]
+    jsr sub_c9e75                                                     // 3f85: 20 75 9e     u. :9f85[1]
+// $3f88 referenced 1 time by $9f7f
+c9f88
+    pha                                                               // 3f88: 48          H   :9f88[1]
+    lda l110c,y                                                       // 3f89: b9 0c 11    ... :9f89[1]
+    bmi loop_c9f6e                                                    // 3f8c: 30 e0       0.  :9f8c[1]
+    lda l110e,y                                                       // 3f8e: b9 0e 11    ... :9f8e[1]
+    bmi c9f6b                                                         // 3f91: 30 d8       0.  :9f91[1]
+    jsr sub_c9be5                                                     // 3f93: 20 e5 9b     .. :9f93[1]
+    tya                                                               // 3f96: 98          .   :9f96[1]
+    clc                                                               // 3f97: 18          .   :9f97[1]
+    adc #4                                                            // 3f98: 69 04       i.  :9f98[1]
+    jsr sub_ca0de                                                     // 3f9a: 20 de a0     .. :9f9a[1]
+    bne ca005                                                         // 3f9d: d0 66       .f  :9f9d[1]
+    jsr sub_c9bcd                                                     // 3f9f: 20 cd 9b     .. :9f9f[1]
+    ldx l10c3                                                         // 3fa2: ae c3 10    ... :9fa2[1]
+    sec                                                               // 3fa5: 38          8   :9fa5[1]
+    lda l0f07,x                                                       // 3fa6: bd 07 0f    ... :9fa6[1]
+    sbc l0f0f,x                                                       // 3fa9: fd 0f 0f    ... :9fa9[1]
+    pha                                                               // 3fac: 48          H   :9fac[1]
+    lda l0f06,x                                                       // 3fad: bd 06 0f    ... :9fad[1]
+    sbc l0f0e,x                                                       // 3fb0: fd 0e 0f    ... :9fb0[1]
+    and #3                                                            // 3fb3: 29 03       ).  :9fb3[1]
+    cmp l111a,y                                                       // 3fb5: d9 1a 11    ... :9fb5[1]
+    bne c9fd9                                                         // 3fb8: d0 1f       ..  :9fb8[1]
+    pla                                                               // 3fba: 68          h   :9fba[1]
+    cmp l1119,y                                                       // 3fbb: d9 19 11    ... :9fbb[1]
+    bne c9ff4                                                         // 3fbe: d0 34       .4  :9fbe[1]
+    sty l00b4                                                         // 3fc0: 84 b4       ..  :9fc0[1]
+    sty l10c2                                                         // 3fc2: 8c c2 10    ... :9fc2[1]
+    jsr sub_c9e30                                                     // 3fc5: 20 30 9e     0. :9fc5[1]
+    jsr generate_error_precheck                                       // 3fc8: 20 38 80     8. :9fc8[1]
+    .byt $bf                                                          // 3fcb: bf          .   :9fcb[1]
+    .asc "Can't extend"                                               // 3fcc: 43 61 6e... Can :9fcc[1]
+    .byt 0                                                            // 3fd8: 00          .   :9fd8[1]
+
+// $3fd9 referenced 1 time by $9fb8
+c9fd9
+    lda l111a,y                                                       // 3fd9: b9 1a 11    ... :9fd9[1]
+    clc                                                               // 3fdc: 18          .   :9fdc[1]
+    adc #1                                                            // 3fdd: 69 01       i.  :9fdd[1]
+    sta l111a,y                                                       // 3fdf: 99 1a 11    ... :9fdf[1]
+    asl                                                               // 3fe2: 0a          .   :9fe2[1]
+    asl                                                               // 3fe3: 0a          .   :9fe3[1]
+    asl                                                               // 3fe4: 0a          .   :9fe4[1]
+    asl                                                               // 3fe5: 0a          .   :9fe5[1]
+    eor l0f0e,x                                                       // 3fe6: 5d 0e 0f    ].. :9fe6[1]
+    and #$30 // '0'                                                   // 3fe9: 29 30       )0  :9fe9[1]
+    eor l0f0e,x                                                       // 3feb: 5d 0e 0f    ].. :9feb[1]
+    sta l0f0e,x                                                       // 3fee: 9d 0e 0f    ... :9fee[1]
+    pla                                                               // 3ff1: 68          h   :9ff1[1]
+    lda #0                                                            // 3ff2: a9 00       ..  :9ff2[1]
+// $3ff4 referenced 1 time by $9fbe
+c9ff4
+    sta l0f0d,x                                                       // 3ff4: 9d 0d 0f    ... :9ff4[1]
+    sta l1119,y                                                       // 3ff7: 99 19 11    ... :9ff7[1]
+    lda #0                                                            // 3ffa: a9 00       ..  :9ffa[1]
+    sta l0f0c,x                                                       // 3ffc: 9d 0c 0f    ... :9ffc[1]
+    jsr c93e6                                                         // 3fff: 20 e6 93     .. :9fff[1]
+    ldy l10c2                                                         // 4002: ac c2 10    ... :a002[1]
+// $4005 referenced 1 time by $9f9d
+ca005
+    lda l1117,y                                                       // 4005: b9 17 11    ... :a005[1]
+    bmi ca021                                                         // 4008: 30 17       0.  :a008[1]
+    jsr sub_c9f1e                                                     // 400a: 20 1e 9f     .. :a00a[1]
+    lda l1114,y                                                       // 400d: b9 14 11    ... :a00d[1]
+    bne ca01d                                                         // 4010: d0 0b       ..  :a010[1]
+    tya                                                               // 4012: 98          .   :a012[1]
+    jsr sub_ca0de                                                     // 4013: 20 de a0     .. :a013[1]
+    bne ca01d                                                         // 4016: d0 05       ..  :a016[1]
+    jsr sub_c9ef4                                                     // 4018: 20 f4 9e     .. :a018[1]
+    bne ca021                                                         // 401b: d0 04       ..  :a01b[1]
+// $401d referenced 2 times by $a010, $a016
+ca01d
+    sec                                                               // 401d: 38          8   :a01d[1]
+    jsr sub_c9f26                                                     // 401e: 20 26 9f     &. :a01e[1]
+// $4021 referenced 2 times by $a008, $a01b
+ca021
+    lda l1110,y                                                       // 4021: b9 10 11    ... :a021[1]
+    sta l00ba                                                         // 4024: 85 ba       ..  :a024[1]
+    lda l1113,y                                                       // 4026: b9 13 11    ... :a026[1]
+    sta l00bb                                                         // 4029: 85 bb       ..  :a029[1]
+    pla                                                               // 402b: 68          h   :a02b[1]
+    ldy #0                                                            // 402c: a0 00       ..  :a02c[1]
+    sta (l00ba),y                                                     // 402e: 91 ba       ..  :a02e[1]
+    ldy l10c2                                                         // 4030: ac c2 10    ... :a030[1]
+    lda #$40 // '@'                                                   // 4033: a9 40       .@  :a033[1]
+    jsr sub_c9f0f                                                     // 4035: 20 0f 9f     .. :a035[1]
+    inc l00ba                                                         // 4038: e6 ba       ..  :a038[1]
+    lda l00ba                                                         // 403a: a5 ba       ..  :a03a[1]
+    sta l1110,y                                                       // 403c: 99 10 11    ... :a03c[1]
+    bne ca054                                                         // 403f: d0 13       ..  :a03f[1]
+    jsr sub_c9f14                                                     // 4041: 20 14 9f     .. :a041[1]
+    lda l1111,y                                                       // 4044: b9 11 11    ... :a044[1]
+    adc #1                                                            // 4047: 69 01       i.  :a047[1]
+    sta l1111,y                                                       // 4049: 99 11 11    ... :a049[1]
+    lda l1112,y                                                       // 404c: b9 12 11    ... :a04c[1]
+    adc #0                                                            // 404f: 69 00       i.  :a04f[1]
+    sta l1112,y                                                       // 4051: 99 12 11    ... :a051[1]
+// $4054 referenced 1 time by $a03f
+ca054
+    tya                                                               // 4054: 98          .   :a054[1]
+    jsr sub_ca0de                                                     // 4055: 20 de a0     .. :a055[1]
+    bcc ca06b                                                         // 4058: 90 11       ..  :a058[1]
+    lda #$20 // ' '                                                   // 405a: a9 20       .   :a05a[1]
+    jsr sub_c9f0f                                                     // 405c: 20 0f 9f     .. :a05c[1]
+    ldx #2                                                            // 405f: a2 02       ..  :a05f[1]
+// $4061 referenced 1 time by $a069
+loop_ca061
+    lda l1110,y                                                       // 4061: b9 10 11    ... :a061[1]
+    sta l1114,y                                                       // 4064: 99 14 11    ... :a064[1]
+    iny                                                               // 4067: c8          .   :a067[1]
+    dex                                                               // 4068: ca          .   :a068[1]
+    bpl loop_ca061                                                    // 4069: 10 f6       ..  :a069[1]
+// $406b referenced 3 times by $a058, $a0d1, $a0d9
+ca06b
+    rts                                                               // 406b: 60          `   :a06b[1]
+
+// $406c referenced 2 times by $9849, $9db1
+ca06c
+    jsr sub_c83e3                                                     // 406c: 20 e3 83     .. :a06c[1]
+    jsr sub_c9e75                                                     // 406f: 20 75 9e     u. :a06f[1]
+    ldy l10c2                                                         // 4072: ac c2 10    ... :a072[1]
+// $4075 referenced 1 time by $a0a6
+ca075
+    jsr sub_ca0f6                                                     // 4075: 20 f6 a0     .. :a075[1]
+    bcs ca0a9                                                         // 4078: b0 2f       ./  :a078[1]
+    lda l1114,y                                                       // 407a: b9 14 11    ... :a07a[1]
+    sta l1110,y                                                       // 407d: 99 10 11    ... :a07d[1]
+    lda l1115,y                                                       // 4080: b9 15 11    ... :a080[1]
+    sta l1111,y                                                       // 4083: 99 11 11    ... :a083[1]
+    lda l1116,y                                                       // 4086: b9 16 11    ... :a086[1]
+    sta l1112,y                                                       // 4089: 99 12 11    ... :a089[1]
+    jsr sub_ca0b8                                                     // 408c: 20 b8 a0     .. :a08c[1]
+    lda l00b6                                                         // 408f: a5 b6       ..  :a08f[1]
+    pha                                                               // 4091: 48          H   :a091[1]
+    lda l00b7                                                         // 4092: a5 b7       ..  :a092[1]
+    pha                                                               // 4094: 48          H   :a094[1]
+    lda l00b8                                                         // 4095: a5 b8       ..  :a095[1]
+    pha                                                               // 4097: 48          H   :a097[1]
+    lda #0                                                            // 4098: a9 00       ..  :a098[1]
+    jsr sub_c9f7c                                                     // 409a: 20 7c 9f     |. :a09a[1]
+    pla                                                               // 409d: 68          h   :a09d[1]
+    sta l00b8                                                         // 409e: 85 b8       ..  :a09e[1]
+    pla                                                               // 40a0: 68          h   :a0a0[1]
+    sta l00b7                                                         // 40a1: 85 b7       ..  :a0a1[1]
+    pla                                                               // 40a3: 68          h   :a0a3[1]
+    sta l00b6                                                         // 40a4: 85 b6       ..  :a0a4[1]
+    jmp ca075                                                         // 40a6: 4c 75 a0    Lu. :a0a6[1]
+
+// $40a9 referenced 1 time by $a078
+ca0a9
+    lda l0000,x                                                       // 40a9: b5 00       ..  :a0a9[1]
+    sta l1110,y                                                       // 40ab: 99 10 11    ... :a0ab[1]
+    lda l0001,x                                                       // 40ae: b5 01       ..  :a0ae[1]
+    sta l1111,y                                                       // 40b0: 99 11 11    ... :a0b0[1]
+    lda l0002,x                                                       // 40b3: b5 02       ..  :a0b3[1]
+    sta l1112,y                                                       // 40b5: 99 12 11    ... :a0b5[1]
+// $40b8 referenced 1 time by $a08c
+sub_ca0b8
+    lda #$6f // 'o'                                                   // 40b8: a9 6f       .o  :a0b8[1]
+    jsr sub_c9f16                                                     // 40ba: 20 16 9f     .. :a0ba[1]
+    lda l110f,y                                                       // 40bd: b9 0f 11    ... :a0bd[1]
+    adc l1111,y                                                       // 40c0: 79 11 11    y.. :a0c0[1]
+    sta l10c4                                                         // 40c3: 8d c4 10    ... :a0c3[1]
+    lda l110d,y                                                       // 40c6: b9 0d 11    ... :a0c6[1]
+    and #3                                                            // 40c9: 29 03       ).  :a0c9[1]
+    adc l1112,y                                                       // 40cb: 79 12 11    y.. :a0cb[1]
+    cmp l111d,y                                                       // 40ce: d9 1d 11    ... :a0ce[1]
+    bne ca06b                                                         // 40d1: d0 98       ..  :a0d1[1]
+    lda l10c4                                                         // 40d3: ad c4 10    ... :a0d3[1]
+    cmp l111c,y                                                       // 40d6: d9 1c 11    ... :a0d6[1]
+    bne ca06b                                                         // 40d9: d0 90       ..  :a0d9[1]
+    jmp c9f0d                                                         // 40db: 4c 0d 9f    L.. :a0db[1]
+
+// $40de referenced 5 times by $9e66, $9e9b, $9f9a, $a013, $a055
+sub_ca0de
+    tax                                                               // 40de: aa          .   :a0de[1]
+    lda l1112,y                                                       // 40df: b9 12 11    ... :a0df[1]
+    cmp l1116,x                                                       // 40e2: dd 16 11    ... :a0e2[1]
+    bne ca0f5                                                         // 40e5: d0 0e       ..  :a0e5[1]
+    lda l1111,y                                                       // 40e7: b9 11 11    ... :a0e7[1]
+    cmp l1115,x                                                       // 40ea: dd 15 11    ... :a0ea[1]
+    bne ca0f5                                                         // 40ed: d0 06       ..  :a0ed[1]
+    lda l1110,y                                                       // 40ef: b9 10 11    ... :a0ef[1]
+    cmp l1114,x                                                       // 40f2: dd 14 11    ... :a0f2[1]
+// $40f5 referenced 2 times by $a0e5, $a0ed
+ca0f5
+    rts                                                               // 40f5: 60          `   :a0f5[1]
+
+// $40f6 referenced 1 time by $a075
+sub_ca0f6
+    lda l1114,y                                                       // 40f6: b9 14 11    ... :a0f6[1]
+    cmp l0000,x                                                       // 40f9: d5 00       ..  :a0f9[1]
+    lda l1115,y                                                       // 40fb: b9 15 11    ... :a0fb[1]
+    sbc l0001,x                                                       // 40fe: f5 01       ..  :a0fe[1]
+    lda l1116,y                                                       // 4100: b9 16 11    ... :a100[1]
+    sbc l0002,x                                                       // 4103: f5 02       ..  :a103[1]
+    rts                                                               // 4105: 60          `   :a105[1]
+
+sub_ca106
+    tya                                                               // 4106: 98          .   :a106[1]
+    ldx #$ff                                                          // 4107: a2 ff       ..  :a107[1]
+    ldy #$14                                                          // 4109: a0 14       ..  :a109[1]
+// $410b referenced 2 times by $9711, $a13c
+ca10b
+    pha                                                               // 410b: 48          H   :a10b[1]
+    jsr print_inline_l809f_top_bit_clear                              // 410c: 20 77 80     w. :a10c[1]
+    .asc $0d, "DFS 2.26", $0d                                         // 410f: 0d 44 46... .DF :a10f[1]
+
+    stx l00bf                                                         // 4119: 86 bf       ..  :a119[1]
+    sty l00b7                                                         // 411b: 84 b7       ..  :a11b[1]
+// $411d referenced 1 time by $a12e
+loop_ca11d
+    lda #0                                                            // 411d: a9 00       ..  :a11d[1]
+    sta l00b9                                                         // 411f: 85 b9       ..  :a11f[1]
+    ldy #2                                                            // 4121: a0 02       ..  :a121[1]
+    jsr sub_ca1c6                                                     // 4123: 20 c6 a1     .. :a123[1]
+    jsr sub_ca168                                                     // 4126: 20 68 a1     h. :a126[1]
+    jsr ca3dc                                                         // 4129: 20 dc a3     .. :a129[1]
+    dec l00b7                                                         // 412c: c6 b7       ..  :a12c[1]
+    bne loop_ca11d                                                    // 412e: d0 ed       ..  :a12e[1]
+    pla                                                               // 4130: 68          h   :a130[1]
+    tay                                                               // 4131: a8          .   :a131[1]
+// $4132 referenced 1 time by $a148
+loop_ca132
+    ldx #$cf                                                          // 4132: a2 cf       ..  :a132[1]
+    jmp c8703                                                         // 4134: 4c 03 87    L.. :a134[1]
+
+sub_ca137
+    tya                                                               // 4137: 98          .   :a137[1]
+    ldx #$9d                                                          // 4138: a2 9d       ..  :a138[1]
+    ldy #6                                                            // 413a: a0 06       ..  :a13a[1]
+    bne ca10b                                                         // 413c: d0 cd       ..  :a13c[1]
+    jsr clc_jmp_gsinit                                                // 413e: 20 4c 87     L. :a13e[1]
+    beq ca1c0                                                         // 4141: f0 7d       .}  :a141[1]
+// $4143 referenced 1 time by $a146
+loop_ca143
+    jsr sub_c8149                                                     // 4143: 20 49 81     I. :a143[1]
+    bcc loop_ca143                                                    // 4146: 90 fb       ..  :a146[1]
+    bcs loop_ca132                                                    // 4148: b0 e8       ..  :a148[1]
+// $414a referenced 13 times by $8257, $8753, $8785, $879a, $87ee, $89b7, $89e9, $8baf, $8bc1, $a324, $a32d, $a469, $a5cb
+sub_ca14a
+    jsr clc_jmp_gsinit                                                // 414a: 20 4c 87     L. :a14a[1]
+    bne ca1c0                                                         // 414d: d0 71       .q  :a14d[1]
+// $414f referenced 3 times by $8805, $a5e2, $ac25
+ca14f
+    jsr generate_error                                                // 414f: 20 48 80     H. :a14f[1]
+    .byt $dc                                                          // 4152: dc          .   :a152[1]
+    .asc "Syntax: "                                                   // 4153: 53 79 6e... Syn :a153[1]
+
+    stx l00b9                                                         // 415b: 86 b9       ..  :a15b[1]
+    jsr sub_ca168                                                     // 415d: 20 68 a1     h. :a15d[1]
+    lda #0                                                            // 4160: a9 00       ..  :a160[1]
+    jsr sub_ca1b4                                                     // 4162: 20 b4 a1     .. :a162[1]
+    jmp l0100                                                         // 4165: 4c 00 01    L.. :a165[1]
+
+// $4168 referenced 2 times by $a126, $a15d
+sub_ca168
+    ldx l00bf                                                         // 4168: a6 bf       ..  :a168[1]
+    lda #9                                                            // 416a: a9 09       ..  :a16a[1]
+    sta l00b8                                                         // 416c: 85 b8       ..  :a16c[1]
+// $416e referenced 1 time by $a177
+loop_ca16e
+    inx                                                               // 416e: e8          .   :a16e[1]
+    lda command_table,x                                               // 416f: bd 1c 86    ... :a16f[1]
+    bmi ca17a                                                         // 4172: 30 06       0.  :a172[1]
+    jsr sub_ca1b4                                                     // 4174: 20 b4 a1     .. :a174[1]
+    jmp loop_ca16e                                                    // 4177: 4c 6e a1    Ln. :a177[1]
+
+// $417a referenced 1 time by $a172
+ca17a
+    ldy l00b8                                                         // 417a: a4 b8       ..  :a17a[1]
+    cpy #$0c                                                          // 417c: c0 0c       ..  :a17c[1]
+    beq ca183                                                         // 417e: f0 03       ..  :a17e[1]
+    jsr sub_ca1c6                                                     // 4180: 20 c6 a1     .. :a180[1]
+// $4183 referenced 1 time by $a17e
+ca183
+    inx                                                               // 4183: e8          .   :a183[1]
+    inx                                                               // 4184: e8          .   :a184[1]
+    stx l00bf                                                         // 4185: 86 bf       ..  :a185[1]
+    lda command_table,x                                               // 4187: bd 1c 86    ... :a187[1]
+    jsr sub_ca190                                                     // 418a: 20 90 a1     .. :a18a[1]
+    jsr sub_c81bf                                                     // 418d: 20 bf 81     .. :a18d[1]
+// $4190 referenced 1 time by $a18a
+sub_ca190
+    jsr sub_c83e3                                                     // 4190: 20 e3 83     .. :a190[1]
+    and #$0f                                                          // 4193: 29 0f       ).  :a193[1]
+    beq ca1c0                                                         // 4195: f0 29       .)  :a195[1]
+    tay                                                               // 4197: a8          .   :a197[1]
+    lda #$20 // ' '                                                   // 4198: a9 20       .   :a198[1]
+    jsr sub_ca1b4                                                     // 419a: 20 b4 a1     .. :a19a[1]
+    ldx #$ff                                                          // 419d: a2 ff       ..  :a19d[1]
+// $419f referenced 2 times by $a1a3, $a1a6
+ca19f
+    inx                                                               // 419f: e8          .   :a19f[1]
+    lda la1d3,x                                                       // 41a0: bd d3 a1    ... :a1a0[1]
+    bpl ca19f                                                         // 41a3: 10 fa       ..  :a1a3[1]
+    dey                                                               // 41a5: 88          .   :a1a5[1]
+    bne ca19f                                                         // 41a6: d0 f7       ..  :a1a6[1]
+    and #$7f                                                          // 41a8: 29 7f       ).  :a1a8[1]
+// $41aa referenced 1 time by $a1b1
+loop_ca1aa
+    jsr sub_ca1b4                                                     // 41aa: 20 b4 a1     .. :a1aa[1]
+    inx                                                               // 41ad: e8          .   :a1ad[1]
+    lda la1d3,x                                                       // 41ae: bd d3 a1    ... :a1ae[1]
+    bpl loop_ca1aa                                                    // 41b1: 10 f7       ..  :a1b1[1]
+    rts                                                               // 41b3: 60          `   :a1b3[1]
+
+// $41b4 referenced 5 times by $a162, $a174, $a19a, $a1aa, $a1cc
+sub_ca1b4
+    jsr sub_c83e3                                                     // 41b4: 20 e3 83     .. :a1b4[1]
+    ldx l00b9                                                         // 41b7: a6 b9       ..  :a1b7[1]
+    beq ca1c1                                                         // 41b9: f0 06       ..  :a1b9[1]
+    inc l00b9                                                         // 41bb: e6 b9       ..  :a1bb[1]
+    sta l0100,x                                                       // 41bd: 9d 00 01    ... :a1bd[1]
+// $41c0 referenced 3 times by $a141, $a14d, $a195
+ca1c0
+    rts                                                               // 41c0: 60          `   :a1c0[1]
+
+// $41c1 referenced 1 time by $a1b9
+ca1c1
+    dec l00b8                                                         // 41c1: c6 b8       ..  :a1c1[1]
+    jmp c809f                                                         // 41c3: 4c 9f 80    L.. :a1c3[1]
+
+// $41c6 referenced 2 times by $a123, $a180
+sub_ca1c6
+    lda l00b9                                                         // 41c6: a5 b9       ..  :a1c6[1]
+    bne ca1d2                                                         // 41c8: d0 08       ..  :a1c8[1]
+    lda #$20 // ' '                                                   // 41ca: a9 20       .   :a1ca[1]
+// $41cc referenced 1 time by $a1d0
+loop_ca1cc
+    jsr sub_ca1b4                                                     // 41cc: 20 b4 a1     .. :a1cc[1]
+    dey                                                               // 41cf: 88          .   :a1cf[1]
+    bne loop_ca1cc                                                    // 41d0: d0 fa       ..  :a1d0[1]
+// $41d2 referenced 1 time by $a1c8
+ca1d2
+    rts                                                               // 41d2: 60          `   :a1d2[1]
+
+// $41d3 referenced 2 times by $a1a0, $a1ae
+la1d3
+    .byt $bc                                                          // 41d3: bc          .   :a1d3[1]
+    .asc "fsp>"                                                       // 41d4: 66 73 70... fsp :a1d4[1]
+    .byt $bc                                                          // 41d8: bc          .   :a1d8[1]
+    .asc "afsp>"                                                      // 41d9: 61 66 73... afs :a1d9[1]
+    .byt $a8, $4c, $29, $bc                                           // 41de: a8 4c 29... .L) :a1de[1]
+    .asc "source> <dest.>"                                            // 41e2: 73 6f 75... sou :a1e2[1]
+    .byt $bc                                                          // 41f1: bc          .   :a1f1[1]
+    .asc "old fsp> <new fsp>"                                         // 41f2: 6f 6c 64... old :a1f2[1]
+    .byt $a8                                                          // 4204: a8          .   :a204[1]
+    .asc "<dir>)"                                                     // 4205: 3c 64 69... <di :a205[1]
+    .byt $a8                                                          // 420b: a8          .   :a20b[1]
+    .asc "<drive>)"                                                   // 420c: 3c 64 72... <dr :a20c[1]
+    .byt $bc                                                          // 4214: bc          .   :a214[1]
+    .asc "title>"                                                     // 4215: 74 69 74... tit :a215[1]
+    .byt $bc                                                          // 421b: bc          .   :a21b[1]
+    .asc "drive> (40)(80)"                                            // 421c: 64 72 69... dri :a21c[1]
+    .byt $b4                                                          // 422b: b4          .   :a22b[1]
+    .asc "0", $2f, "80"                                               // 422c: 30 2f 38... 0/8 :a22c[1]
+    .byt $a8                                                          // 4230: a8          .   :a230[1]
+    .asc "<drive>)..."                                                // 4231: 3c 64 72... <dr :a231[1]
+    .byt $a8                                                          // 423c: a8          .   :a23c[1]
+    .asc "<rom>)"                                                     // 423d: 3c 72 6f... <ro :a23d[1]
+    .byt $ff                                                          // 4243: ff          .   :a243[1]
+
+sub_ca244
+    jsr sub_c8b86                                                     // 4244: 20 86 8b     .. :a244[1]
+    jsr print_inline_l809f_top_bit_clear                              // 4247: 20 77 80     w. :a247[1]
+    .asc "Compacting :"                                               // 424a: 43 6f 6d... Com :a24a[1]
+
+    sta l10d1                                                         // 4256: 8d d1 10    ... :a256[1]
+    sta l10d2                                                         // 4259: 8d d2 10    ... :a259[1]
+    jsr sub_c80c3                                                     // 425c: 20 c3 80     .. :a25c[1]
+    jsr ca3dc                                                         // 425f: 20 dc a3     .. :a25f[1]
+    ldy #0                                                            // 4262: a0 00       ..  :a262[1]
+    jsr sub_c9b79                                                     // 4264: 20 79 9b     y. :a264[1]
+    jsr sub_c9a8d                                                     // 4267: 20 8d 9a     .. :a267[1]
+    jsr sub_c8380                                                     // 426a: 20 80 83     .. :a26a[1]
+    ldy l0f05                                                         // 426d: ac 05 0f    ... :a26d[1]
+    sty l00ca                                                         // 4270: 84 ca       ..  :a270[1]
+    lda #2                                                            // 4272: a9 02       ..  :a272[1]
+    sta l00c8                                                         // 4274: 85 c8       ..  :a274[1]
+    lda #0                                                            // 4276: a9 00       ..  :a276[1]
+    sta l00c9                                                         // 4278: 85 c9       ..  :a278[1]
+// $427a referenced 1 time by $a312
+ca27a
+    ldy l00ca                                                         // 427a: a4 ca       ..  :a27a[1]
+    jsr sub_c82b2                                                     // 427c: 20 b2 82     .. :a27c[1]
+    cpy #$f8                                                          // 427f: c0 f8       ..  :a27f[1]
+    bne ca2ab                                                         // 4281: d0 28       .(  :a281[1]
+    lda l0f07                                                         // 4283: ad 07 0f    ... :a283[1]
+    sec                                                               // 4286: 38          8   :a286[1]
+    sbc l00c8                                                         // 4287: e5 c8       ..  :a287[1]
+    pha                                                               // 4289: 48          H   :a289[1]
+    lda l0f06                                                         // 428a: ad 06 0f    ... :a28a[1]
+    and #3                                                            // 428d: 29 03       ).  :a28d[1]
+    sbc l00c9                                                         // 428f: e5 c9       ..  :a28f[1]
+    jsr sub_c80c3                                                     // 4291: 20 c3 80     .. :a291[1]
+    pla                                                               // 4294: 68          h   :a294[1]
+    jsr sub_c80bb                                                     // 4295: 20 bb 80     .. :a295[1]
+    jsr print_inline_l809f_top_bit_clear                              // 4298: 20 77 80     w. :a298[1]
+    .asc " free sectors", $0d                                         // 429b: 20 66 72...  fr :a29b[1]
+
+    nop                                                               // 42a9: ea          .   :a2a9[1]
+    rts                                                               // 42aa: 60          `   :a2aa[1]
+
+// $42ab referenced 1 time by $a281
+ca2ab
+    sty l00ca                                                         // 42ab: 84 ca       ..  :a2ab[1]
+    jsr sub_c8335                                                     // 42ad: 20 35 83     5. :a2ad[1]
+    ldy l00ca                                                         // 42b0: a4 ca       ..  :a2b0[1]
+    lda l0f0c,y                                                       // 42b2: b9 0c 0f    ... :a2b2[1]
+    cmp #1                                                            // 42b5: c9 01       ..  :a2b5[1]
+    lda #0                                                            // 42b7: a9 00       ..  :a2b7[1]
+    sta l00bc                                                         // 42b9: 85 bc       ..  :a2b9[1]
+    sta l00c0                                                         // 42bb: 85 c0       ..  :a2bb[1]
+    adc l0f0d,y                                                       // 42bd: 79 0d 0f    y.. :a2bd[1]
+    sta l00c4                                                         // 42c0: 85 c4       ..  :a2c0[1]
+    lda l0f0e,y                                                       // 42c2: b9 0e 0f    ... :a2c2[1]
+    php                                                               // 42c5: 08          .   :a2c5[1]
+    jsr sub_c81b0                                                     // 42c6: 20 b0 81     .. :a2c6[1]
+    plp                                                               // 42c9: 28          (   :a2c9[1]
+    adc #0                                                            // 42ca: 69 00       i.  :a2ca[1]
+    sta l00c5                                                         // 42cc: 85 c5       ..  :a2cc[1]
+    lda l0f0f,y                                                       // 42ce: b9 0f 0f    ... :a2ce[1]
+    sta l00c6                                                         // 42d1: 85 c6       ..  :a2d1[1]
+    lda l0f0e,y                                                       // 42d3: b9 0e 0f    ... :a2d3[1]
+    and #3                                                            // 42d6: 29 03       ).  :a2d6[1]
+    sta l00c7                                                         // 42d8: 85 c7       ..  :a2d8[1]
+    cmp l00c9                                                         // 42da: c5 c9       ..  :a2da[1]
+    bne ca2f2                                                         // 42dc: d0 14       ..  :a2dc[1]
+    lda l00c6                                                         // 42de: a5 c6       ..  :a2de[1]
+    cmp l00c8                                                         // 42e0: c5 c8       ..  :a2e0[1]
+    bne ca2f2                                                         // 42e2: d0 0e       ..  :a2e2[1]
+    clc                                                               // 42e4: 18          .   :a2e4[1]
+    adc l00c4                                                         // 42e5: 65 c4       e.  :a2e5[1]
+    sta l00c8                                                         // 42e7: 85 c8       ..  :a2e7[1]
+    lda l00c9                                                         // 42e9: a5 c9       ..  :a2e9[1]
+    adc l00c5                                                         // 42eb: 65 c5       e.  :a2eb[1]
+    sta l00c9                                                         // 42ed: 85 c9       ..  :a2ed[1]
+    jmp ca30d                                                         // 42ef: 4c 0d a3    L.. :a2ef[1]
+
+// $42f2 referenced 2 times by $a2dc, $a2e2
+ca2f2
+    lda l00c8                                                         // 42f2: a5 c8       ..  :a2f2[1]
+    sta l0f0f,y                                                       // 42f4: 99 0f 0f    ... :a2f4[1]
+    lda l0f0e,y                                                       // 42f7: b9 0e 0f    ... :a2f7[1]
+    and #$fc                                                          // 42fa: 29 fc       ).  :a2fa[1]
+    ora l00c9                                                         // 42fc: 05 c9       ..  :a2fc[1]
+    sta l0f0e,y                                                       // 42fe: 99 0e 0f    ... :a2fe[1]
+    lda #0                                                            // 4301: a9 00       ..  :a301[1]
+    sta l00a8                                                         // 4303: 85 a8       ..  :a303[1]
+    sta l00a9                                                         // 4305: 85 a9       ..  :a305[1]
+    jsr sub_ca530                                                     // 4307: 20 30 a5     0. :a307[1]
+    jsr c93e6                                                         // 430a: 20 e6 93     .. :a30a[1]
+// $430d referenced 1 time by $a2ef
+ca30d
+    ldy l00ca                                                         // 430d: a4 ca       ..  :a30d[1]
+    jsr sub_c833a                                                     // 430f: 20 3a 83     :. :a30f[1]
+    jmp ca27a                                                         // 4312: 4c 7a a2    Lz. :a312[1]
+
+// $4315 referenced 3 times by $8794, $a41a, $a64c
+sub_ca315
+    bit l10c7                                                         // 4315: 2c c7 10    ,.. :a315[1]
+    bpl ca378                                                         // 4318: 10 5e       .^  :a318[1]
+    jsr sub_ca3ec                                                     // 431a: 20 ec a3     .. :a31a[1]
+    beq ca321                                                         // 431d: f0 02       ..  :a31d[1]
+    pla                                                               // 431f: 68          h   :a31f[1]
+    pla                                                               // 4320: 68          h   :a320[1]
+// $4321 referenced 1 time by $a31d
+ca321
+    jmp ca3dc                                                         // 4321: 4c dc a3    L.. :a321[1]
+
+// $4324 referenced 2 times by $a417, $a466
+sub_ca324
+    jsr sub_ca14a                                                     // 4324: 20 4a a1     J. :a324[1]
+    jsr c8b8b                                                         // 4327: 20 8b 8b     .. :a327[1]
+    sta l10d1                                                         // 432a: 8d d1 10    ... :a32a[1]
+    jsr sub_ca14a                                                     // 432d: 20 4a a1     J. :a32d[1]
+    jsr c8b8b                                                         // 4330: 20 8b 8b     .. :a330[1]
+    sta l10d2                                                         // 4333: 8d d2 10    ... :a333[1]
+    tya                                                               // 4336: 98          .   :a336[1]
+    pha                                                               // 4337: 48          H   :a337[1]
+    lda #0                                                            // 4338: a9 00       ..  :a338[1]
+    sta l00a9                                                         // 433a: 85 a9       ..  :a33a[1]
+    lda l10d2                                                         // 433c: ad d2 10    ... :a33c[1]
+    cmp l10d1                                                         // 433f: cd d1 10    ... :a33f[1]
+    bne ca34a                                                         // 4342: d0 06       ..  :a342[1]
+    lda #$ff                                                          // 4344: a9 ff       ..  :a344[1]
+    sta l00a9                                                         // 4346: 85 a9       ..  :a346[1]
+    sta l00aa                                                         // 4348: 85 aa       ..  :a348[1]
+// $434a referenced 1 time by $a342
+ca34a
+    jsr sub_c9a8d                                                     // 434a: 20 8d 9a     .. :a34a[1]
+    jsr print_inline_l809f_top_bit_clear                              // 434d: 20 77 80     w. :a34d[1]
+    .asc "Copying from :"                                             // 4350: 43 6f 70... Cop :a350[1]
+
+    lda l10d1                                                         // 435e: ad d1 10    ... :a35e[1]
+    jsr sub_c80c3                                                     // 4361: 20 c3 80     .. :a361[1]
+    jsr print_inline_l809f_top_bit_clear                              // 4364: 20 77 80     w. :a364[1]
+    .asc " to :"                                                      // 4367: 20 74 6f...  to :a367[1]
+
+    lda l10d2                                                         // 436c: ad d2 10    ... :a36c[1]
+    jsr sub_c80c3                                                     // 436f: 20 c3 80     .. :a36f[1]
+    jsr ca3dc                                                         // 4372: 20 dc a3     .. :a372[1]
+    pla                                                               // 4375: 68          h   :a375[1]
+    tay                                                               // 4376: a8          .   :a376[1]
+    clc                                                               // 4377: 18          .   :a377[1]
+// $4378 referenced 1 time by $a318
+ca378
+    rts                                                               // 4378: 60          `   :a378[1]
+
+// $4379 referenced 4 times by $a429, $a46f, $a4c8, $a55b
+sub_ca379
+    jsr sub_c83e3                                                     // 4379: 20 e3 83     .. :a379[1]
+    bit l00a9                                                         // 437c: 24 a9       $.  :a37c[1]
+    bpl ca38b                                                         // 437e: 10 0b       ..  :a37e[1]
+    lda #0                                                            // 4380: a9 00       ..  :a380[1]
+    beq ca38e                                                         // 4382: f0 0a       ..  :a382[1]
+// $4384 referenced 3 times by $a440, $a4e4, $a581
+sub_ca384
+    jsr sub_c83e3                                                     // 4384: 20 e3 83     .. :a384[1]
+    bit l00a9                                                         // 4387: 24 a9       $.  :a387[1]
+    bmi ca38c                                                         // 4389: 30 01       0.  :a389[1]
+// $438b referenced 2 times by $a37e, $a390
+ca38b
+    rts                                                               // 438b: 60          `   :a38b[1]
+
+// $438c referenced 1 time by $a389
+ca38c
+    lda #$80                                                          // 438c: a9 80       ..  :a38c[1]
+// $438e referenced 1 time by $a382
+ca38e
+    cmp l00aa                                                         // 438e: c5 aa       ..  :a38e[1]
+    beq ca38b                                                         // 4390: f0 f9       ..  :a390[1]
+    sta l00aa                                                         // 4392: 85 aa       ..  :a392[1]
+    jsr print_inline_l809f_top_bit_clear                              // 4394: 20 77 80     w. :a394[1]
+    .asc "Insert "                                                    // 4397: 49 6e 73... Ins :a397[1]
+
+    nop                                                               // 439e: ea          .   :a39e[1]
+    bit l00aa                                                         // 439f: 24 aa       $.  :a39f[1]
+    bmi ca3ae                                                         // 43a1: 30 0b       0.  :a3a1[1]
+    jsr print_inline_l809f_top_bit_clear                              // 43a3: 20 77 80     w. :a3a3[1]
+    .asc "source"                                                     // 43a6: 73 6f 75... sou :a3a6[1]
+
+    bcc ca3bd                                                         // 43ac: 90 0f       ..  :a3ac[1]
+// $43ae referenced 1 time by $a3a1
+ca3ae
+    jsr print_inline_l809f_top_bit_clear                              // 43ae: 20 77 80     w. :a3ae[1]
+    .asc "destination"                                                // 43b1: 64 65 73... des :a3b1[1]
+
+    nop                                                               // 43bc: ea          .   :a3bc[1]
+// $43bd referenced 1 time by $a3ac
+ca3bd
+    jsr print_inline_l809f_top_bit_clear                              // 43bd: 20 77 80     w. :a3bd[1]
+    .asc " disc and hit a key"                                        // 43c0: 20 64 69...  di :a3c0[1]
+
+    nop                                                               // 43d3: ea          .   :a3d3[1]
+    jsr sub_c9ac8                                                     // 43d4: 20 c8 9a     .. :a3d4[1]
+    jsr osrdch                                                        // 43d7: 20 e0 ff     .. :a3d7[1]
+    bcs ca411                                                         // 43da: b0 35       .5  :a3da[1]
+// $43dc referenced 16 times by $836b, $8522, $854f, $85b2, $85b5, $8779, $87a8, $87b5, $a129, $a25f, $a321, $a372, $a62f, $a6b0, $a73a, $aa95
+ca3dc
+    pha                                                               // 43dc: 48          H   :a3dc[1]
+    lda #$0d                                                          // 43dd: a9 0d       ..  :a3dd[1]
+    jsr c809f                                                         // 43df: 20 9f 80     .. :a3df[1]
+    pla                                                               // 43e2: 68          h   :a3e2[1]
+    rts                                                               // 43e3: 60          `   :a3e3[1]
+
+// $43e4 referenced 1 time by $8761
+sub_ca3e4
+    jsr print_inline_l809f_top_bit_clear                              // 43e4: 20 77 80     w. :a3e4[1]
+    .asc " : "                                                        // 43e7: 20 3a 20     :  :a3e7[1]
+
+    bcc ca3fb                                                         // 43ea: 90 0f       ..  :a3ea[1]
+// $43ec referenced 2 times by $87b0, $a31a
+sub_ca3ec
+    jsr print_inline_l809f_top_bit_clear                              // 43ec: 20 77 80     w. :a3ec[1]
+    .asc "Go (Y", $2f, "N) ? "                                        // 43ef: 47 6f 20... Go  :a3ef[1]
+
+    nop                                                               // 43fa: ea          .   :a3fa[1]
+// $43fb referenced 1 time by $a3ea
+ca3fb
+    jsr sub_c9ac8                                                     // 43fb: 20 c8 9a     .. :a3fb[1]
+    jsr osrdch                                                        // 43fe: 20 e0 ff     .. :a3fe[1]
+    bcs ca411                                                         // 4401: b0 0e       ..  :a401[1]
+    and #$5f // '_'                                                   // 4403: 29 5f       )_  :a403[1]
+    cmp #$59 // 'Y'                                                   // 4405: c9 59       .Y  :a405[1]
+    php                                                               // 4407: 08          .   :a407[1]
+    beq ca40c                                                         // 4408: f0 02       ..  :a408[1]
+    lda #$4e // 'N'                                                   // 440a: a9 4e       .N  :a40a[1]
+// $440c referenced 1 time by $a408
+ca40c
+    jsr c809f                                                         // 440c: 20 9f 80     .. :a40c[1]
+    plp                                                               // 440f: 28          (   :a40f[1]
+    rts                                                               // 4410: 60          `   :a410[1]
+
+// $4411 referenced 2 times by $a3da, $a401
+ca411
+    jmp c9436                                                         // 4411: 4c 36 94    L6. :a411[1]
+
+// $4414 referenced 2 times by $a452, $a45b
+ca414
+    jmp c8a6e                                                         // 4414: 4c 6e 8a    Ln. :a414[1]
+
+sub_ca417
+    jsr sub_ca324                                                     // 4417: 20 24 a3     $. :a417[1]
+    jsr sub_ca315                                                     // 441a: 20 15 a3     .. :a41a[1]
+    lda #0                                                            // 441d: a9 00       ..  :a41d[1]
+    sta l00c7                                                         // 441f: 85 c7       ..  :a41f[1]
+    sta l00c9                                                         // 4421: 85 c9       ..  :a421[1]
+    sta l00c8                                                         // 4423: 85 c8       ..  :a423[1]
+    sta l00c6                                                         // 4425: 85 c6       ..  :a425[1]
+    sta l00a8                                                         // 4427: 85 a8       ..  :a427[1]
+    jsr sub_ca379                                                     // 4429: 20 79 a3     y. :a429[1]
+    lda l10d1                                                         // 442c: ad d1 10    ... :a42c[1]
+    sta l00cd                                                         // 442f: 85 cd       ..  :a42f[1]
+    jsr c940c                                                         // 4431: 20 0c 94     .. :a431[1]
+    lda l0f07                                                         // 4434: ad 07 0f    ... :a434[1]
+    sta l00c4                                                         // 4437: 85 c4       ..  :a437[1]
+    lda l0f06                                                         // 4439: ad 06 0f    ... :a439[1]
+    and #3                                                            // 443c: 29 03       ).  :a43c[1]
+    sta l00c5                                                         // 443e: 85 c5       ..  :a43e[1]
+    jsr sub_ca384                                                     // 4440: 20 84 a3     .. :a440[1]
+    lda l10d2                                                         // 4443: ad d2 10    ... :a443[1]
+    sta l00cd                                                         // 4446: 85 cd       ..  :a446[1]
+    jsr c940c                                                         // 4448: 20 0c 94     .. :a448[1]
+    lda l0f06                                                         // 444b: ad 06 0f    ... :a44b[1]
+    and #3                                                            // 444e: 29 03       ).  :a44e[1]
+    cmp l00c5                                                         // 4450: c5 c5       ..  :a450[1]
+    bcc ca414                                                         // 4452: 90 c0       ..  :a452[1]
+    bne ca45d                                                         // 4454: d0 07       ..  :a454[1]
+    lda l0f07                                                         // 4456: ad 07 0f    ... :a456[1]
+    cmp l00c4                                                         // 4459: c5 c4       ..  :a459[1]
+    bcc ca414                                                         // 445b: 90 b7       ..  :a45b[1]
+// $445d referenced 1 time by $a454
+ca45d
+    jsr sub_ca530                                                     // 445d: 20 30 a5     0. :a45d[1]
+    jmp c940c                                                         // 4460: 4c 0c 94    L.. :a460[1]
+
+sub_ca463
+    jsr sub_c99ac                                                     // 4463: 20 ac 99     .. :a463[1]
+    jsr sub_ca324                                                     // 4466: 20 24 a3     $. :a466[1]
+    jsr sub_ca14a                                                     // 4469: 20 4a a1     J. :a469[1]
+    jsr sub_c80ed                                                     // 446c: 20 ed 80     .. :a46c[1]
+    jsr sub_ca379                                                     // 446f: 20 79 a3     y. :a46f[1]
+    lda l10d1                                                         // 4472: ad d1 10    ... :a472[1]
+    jsr c8816                                                         // 4475: 20 16 88     .. :a475[1]
+    jsr c8225                                                         // 4478: 20 25 82     %. :a478[1]
+// $447b referenced 1 time by $a4de
+ca47b
+    lda l00cc                                                         // 447b: a5 cc       ..  :a47b[1]
+    pha                                                               // 447d: 48          H   :a47d[1]
+    lda l00b6                                                         // 447e: a5 b6       ..  :a47e[1]
+    sta l00ab                                                         // 4480: 85 ab       ..  :a480[1]
+    jsr sub_c833a                                                     // 4482: 20 3a 83     :. :a482[1]
+    ldx #0                                                            // 4485: a2 00       ..  :a485[1]
+// $4487 referenced 1 time by $a49b
+loop_ca487
+    lda l0e08,y                                                       // 4487: b9 08 0e    ... :a487[1]
+    sta l00c5,x                                                       // 448a: 95 c5       ..  :a48a[1]
+    sta l1050,x                                                       // 448c: 9d 50 10    .P. :a48c[1]
+    lda l0f08,y                                                       // 448f: b9 08 0f    ... :a48f[1]
+    sta l00bb,x                                                       // 4492: 95 bb       ..  :a492[1]
+    sta l1047,x                                                       // 4494: 9d 47 10    .G. :a494[1]
+    inx                                                               // 4497: e8          .   :a497[1]
+    iny                                                               // 4498: c8          .   :a498[1]
+    cpx #8                                                            // 4499: e0 08       ..  :a499[1]
+    bne loop_ca487                                                    // 449b: d0 ea       ..  :a49b[1]
+    lda l00c1                                                         // 449d: a5 c1       ..  :a49d[1]
+    jsr sub_c81b0                                                     // 449f: 20 b0 81     .. :a49f[1]
+    sta l00c3                                                         // 44a2: 85 c3       ..  :a4a2[1]
+    lda l00bf                                                         // 44a4: a5 bf       ..  :a4a4[1]
+    clc                                                               // 44a6: 18          .   :a4a6[1]
+    adc #$ff                                                          // 44a7: 69 ff       i.  :a4a7[1]
+    lda l00c0                                                         // 44a9: a5 c0       ..  :a4a9[1]
+    adc #0                                                            // 44ab: 69 00       i.  :a4ab[1]
+    sta l00c4                                                         // 44ad: 85 c4       ..  :a4ad[1]
+    lda l00c3                                                         // 44af: a5 c3       ..  :a4af[1]
+    adc #0                                                            // 44b1: 69 00       i.  :a4b1[1]
+    sta l00c5                                                         // 44b3: 85 c5       ..  :a4b3[1]
+    lda l104e                                                         // 44b5: ad 4e 10    .N. :a4b5[1]
+    sta l00c6                                                         // 44b8: 85 c6       ..  :a4b8[1]
+    lda l104d                                                         // 44ba: ad 4d 10    .M. :a4ba[1]
+    and #3                                                            // 44bd: 29 03       ).  :a4bd[1]
+    sta l00c7                                                         // 44bf: 85 c7       ..  :a4bf[1]
+    lda #$ff                                                          // 44c1: a9 ff       ..  :a4c1[1]
+    sta l00a8                                                         // 44c3: 85 a8       ..  :a4c3[1]
+    jsr sub_ca530                                                     // 44c5: 20 30 a5     0. :a4c5[1]
+    jsr sub_ca379                                                     // 44c8: 20 79 a3     y. :a4c8[1]
+    lda l10d1                                                         // 44cb: ad d1 10    ... :a4cb[1]
+    jsr c8816                                                         // 44ce: 20 16 88     .. :a4ce[1]
+    jsr sub_c8380                                                     // 44d1: 20 80 83     .. :a4d1[1]
+    lda l00ab                                                         // 44d4: a5 ab       ..  :a4d4[1]
+    sta l00b6                                                         // 44d6: 85 b6       ..  :a4d6[1]
+    pla                                                               // 44d8: 68          h   :a4d8[1]
+    sta l00cc                                                         // 44d9: 85 cc       ..  :a4d9[1]
+    jsr sub_c8280                                                     // 44db: 20 80 82     .. :a4db[1]
+    bcs ca47b                                                         // 44de: b0 9b       ..  :a4de[1]
+    rts                                                               // 44e0: 60          `   :a4e0[1]
+
+// $44e1 referenced 1 time by $a56d
+sub_ca4e1
+    jsr sub_ca51f                                                     // 44e1: 20 1f a5     .. :a4e1[1]
+    jsr sub_ca384                                                     // 44e4: 20 84 a3     .. :a4e4[1]
+    lda l10d2                                                         // 44e7: ad d2 10    ... :a4e7[1]
+    sta l00cd                                                         // 44ea: 85 cd       ..  :a4ea[1]
+    lda l00cc                                                         // 44ec: a5 cc       ..  :a4ec[1]
+    pha                                                               // 44ee: 48          H   :a4ee[1]
+    jsr sub_c8380                                                     // 44ef: 20 80 83     .. :a4ef[1]
+    jsr sub_c826d                                                     // 44f2: 20 6d 82     m. :a4f2[1]
+    bcc ca4fa                                                         // 44f5: 90 03       ..  :a4f5[1]
+    jsr sub_c830a                                                     // 44f7: 20 0a 83     .. :a4f7[1]
+// $44fa referenced 1 time by $a4f5
+ca4fa
+    pla                                                               // 44fa: 68          h   :a4fa[1]
+    sta l00cc                                                         // 44fb: 85 cc       ..  :a4fb[1]
+    jsr sub_c8b4d                                                     // 44fd: 20 4d 8b     M. :a4fd[1]
+    jsr sub_c8b64                                                     // 4500: 20 64 8b     d. :a500[1]
+    lda l00c2                                                         // 4503: a5 c2       ..  :a503[1]
+    jsr sub_c81b0                                                     // 4505: 20 b0 81     .. :a505[1]
+    sta l00c4                                                         // 4508: 85 c4       ..  :a508[1]
+    jsr sub_c8ab3                                                     // 450a: 20 b3 8a     .. :a50a[1]
+    lda l00c2                                                         // 450d: a5 c2       ..  :a50d[1]
+    and #3                                                            // 450f: 29 03       ).  :a50f[1]
+    pha                                                               // 4511: 48          H   :a511[1]
+    lda l00c3                                                         // 4512: a5 c3       ..  :a512[1]
+    pha                                                               // 4514: 48          H   :a514[1]
+    jsr sub_ca51f                                                     // 4515: 20 1f a5     .. :a515[1]
+    pla                                                               // 4518: 68          h   :a518[1]
+    sta l00c8                                                         // 4519: 85 c8       ..  :a519[1]
+    pla                                                               // 451b: 68          h   :a51b[1]
+    sta l00c9                                                         // 451c: 85 c9       ..  :a51c[1]
+    rts                                                               // 451e: 60          `   :a51e[1]
+
+// $451f referenced 2 times by $a4e1, $a515
+sub_ca51f
+    ldx #$11                                                          // 451f: a2 11       ..  :a51f[1]
+// $4521 referenced 1 time by $a52d
+loop_ca521
+    lda l1045,x                                                       // 4521: bd 45 10    .E. :a521[1]
+    ldy l00ba,x                                                       // 4524: b4 ba       ..  :a524[1]
+    sta l00ba,x                                                       // 4526: 95 ba       ..  :a526[1]
+    tya                                                               // 4528: 98          .   :a528[1]
+    sta l1045,x                                                       // 4529: 9d 45 10    .E. :a529[1]
+    dex                                                               // 452c: ca          .   :a52c[1]
+    bpl loop_ca521                                                    // 452d: 10 f2       ..  :a52d[1]
+    rts                                                               // 452f: 60          `   :a52f[1]
+
+// $4530 referenced 3 times by $a307, $a45d, $a4c5
+sub_ca530
+    lda #0                                                            // 4530: a9 00       ..  :a530[1]
+    sta l00bc                                                         // 4532: 85 bc       ..  :a532[1]
+    sta l00c0                                                         // 4534: 85 c0       ..  :a534[1]
+    beq ca5ab                                                         // 4536: f0 73       .s  :a536[1]
+// $4538 referenced 1 time by $a5af
+ca538
+    lda l00c4                                                         // 4538: a5 c4       ..  :a538[1]
+    tay                                                               // 453a: a8          .   :a53a[1]
+    cmp l10d0                                                         // 453b: cd d0 10    ... :a53b[1]
+    lda l00c5                                                         // 453e: a5 c5       ..  :a53e[1]
+    sbc #0                                                            // 4540: e9 00       ..  :a540[1]
+    bcc ca547                                                         // 4542: 90 03       ..  :a542[1]
+    ldy l10d0                                                         // 4544: ac d0 10    ... :a544[1]
+// $4547 referenced 1 time by $a542
+ca547
+    sty l00c1                                                         // 4547: 84 c1       ..  :a547[1]
+    lda l00c6                                                         // 4549: a5 c6       ..  :a549[1]
+    sta l00c3                                                         // 454b: 85 c3       ..  :a54b[1]
+    lda l00c7                                                         // 454d: a5 c7       ..  :a54d[1]
+    sta l00c2                                                         // 454f: 85 c2       ..  :a54f[1]
+    lda l10cf                                                         // 4551: ad cf 10    ... :a551[1]
+    sta l00bd                                                         // 4554: 85 bd       ..  :a554[1]
+    lda l10d1                                                         // 4556: ad d1 10    ... :a556[1]
+    sta l00cd                                                         // 4559: 85 cd       ..  :a559[1]
+    jsr sub_ca379                                                     // 455b: 20 79 a3     y. :a55b[1]
+    jsr sub_ca5b2                                                     // 455e: 20 b2 a5     .. :a55e[1]
+    jsr sub_c8855                                                     // 4561: 20 55 88     U. :a561[1]
+    lda l10d2                                                         // 4564: ad d2 10    ... :a564[1]
+    sta l00cd                                                         // 4567: 85 cd       ..  :a567[1]
+    bit l00a8                                                         // 4569: 24 a8       $.  :a569[1]
+    bpl ca574                                                         // 456b: 10 07       ..  :a56b[1]
+    jsr sub_ca4e1                                                     // 456d: 20 e1 a4     .. :a56d[1]
+    lda #0                                                            // 4570: a9 00       ..  :a570[1]
+    sta l00a8                                                         // 4572: 85 a8       ..  :a572[1]
+// $4574 referenced 1 time by $a56b
+ca574
+    lda l00c8                                                         // 4574: a5 c8       ..  :a574[1]
+    sta l00c3                                                         // 4576: 85 c3       ..  :a576[1]
+    lda l00c9                                                         // 4578: a5 c9       ..  :a578[1]
+    sta l00c2                                                         // 457a: 85 c2       ..  :a57a[1]
+    lda l10cf                                                         // 457c: ad cf 10    ... :a57c[1]
+    sta l00bd                                                         // 457f: 85 bd       ..  :a57f[1]
+    jsr sub_ca384                                                     // 4581: 20 84 a3     .. :a581[1]
+    jsr sub_ca5b2                                                     // 4584: 20 b2 a5     .. :a584[1]
+    jsr sub_c8862                                                     // 4587: 20 62 88     b. :a587[1]
+    lda l00c1                                                         // 458a: a5 c1       ..  :a58a[1]
+    clc                                                               // 458c: 18          .   :a58c[1]
+    adc l00c8                                                         // 458d: 65 c8       e.  :a58d[1]
+    sta l00c8                                                         // 458f: 85 c8       ..  :a58f[1]
+    bcc ca595                                                         // 4591: 90 02       ..  :a591[1]
+    inc l00c9                                                         // 4593: e6 c9       ..  :a593[1]
+// $4595 referenced 1 time by $a591
+ca595
+    lda l00c1                                                         // 4595: a5 c1       ..  :a595[1]
+    clc                                                               // 4597: 18          .   :a597[1]
+    adc l00c6                                                         // 4598: 65 c6       e.  :a598[1]
+    sta l00c6                                                         // 459a: 85 c6       ..  :a59a[1]
+    bcc ca5a0                                                         // 459c: 90 02       ..  :a59c[1]
+    inc l00c7                                                         // 459e: e6 c7       ..  :a59e[1]
+// $45a0 referenced 1 time by $a59c
+ca5a0
+    sec                                                               // 45a0: 38          8   :a5a0[1]
+    lda l00c4                                                         // 45a1: a5 c4       ..  :a5a1[1]
+    sbc l00c1                                                         // 45a3: e5 c1       ..  :a5a3[1]
+    sta l00c4                                                         // 45a5: 85 c4       ..  :a5a5[1]
+    bcs ca5ab                                                         // 45a7: b0 02       ..  :a5a7[1]
+    dec l00c5                                                         // 45a9: c6 c5       ..  :a5a9[1]
+// $45ab referenced 2 times by $a536, $a5a7
+ca5ab
+    lda l00c4                                                         // 45ab: a5 c4       ..  :a5ab[1]
+    ora l00c5                                                         // 45ad: 05 c5       ..  :a5ad[1]
+    bne ca538                                                         // 45af: d0 87       ..  :a5af[1]
+    rts                                                               // 45b1: 60          `   :a5b1[1]
+
+// $45b2 referenced 2 times by $a55e, $a584
+sub_ca5b2
+    lda #$ff                                                          // 45b2: a9 ff       ..  :a5b2[1]
+    sta l1074                                                         // 45b4: 8d 74 10    .t. :a5b4[1]
+    sta l1075                                                         // 45b7: 8d 75 10    .u. :a5b7[1]
+    rts                                                               // 45ba: 60          `   :a5ba[1]
+
+sub_ca5bb
+    lda #0                                                            // 45bb: a9 00       ..  :a5bb[1]
+    beq ca5c4                                                         // 45bd: f0 05       ..  :a5bd[1]
+sub_ca5bf
+    lda #$ff                                                          // 45bf: a9 ff       ..  :a5bf[1]
+    sta l1082                                                         // 45c1: 8d 82 10    ... :a5c1[1]
+// $45c4 referenced 1 time by $a5bd
+ca5c4
+    sta l00c9                                                         // 45c4: 85 c9       ..  :a5c4[1]
+    sta l1090                                                         // 45c6: 8d 90 10    ... :a5c6[1]
+    bpl ca5e5                                                         // 45c9: 10 1a       ..  :a5c9[1]
+    jsr sub_ca14a                                                     // 45cb: 20 4a a1     J. :a5cb[1]
+    jsr sub_c8456                                                     // 45ce: 20 56 84     V. :a5ce[1]
+    sta l109f                                                         // 45d1: 8d 9f 10    ... :a5d1[1]
+    bcs ca5e2                                                         // 45d4: b0 0c       ..  :a5d4[1]
+    cmp #$23 // '#'                                                   // 45d6: c9 23       .#  :a5d6[1]
+    beq ca5e5                                                         // 45d8: f0 0b       ..  :a5d8[1]
+    cmp #$28 // '('                                                   // 45da: c9 28       .(  :a5da[1]
+    beq ca5e5                                                         // 45dc: f0 07       ..  :a5dc[1]
+    cmp #$50 // 'P'                                                   // 45de: c9 50       .P  :a5de[1]
+    beq ca5e5                                                         // 45e0: f0 03       ..  :a5e0[1]
+// $45e2 referenced 1 time by $a5d4
+ca5e2
+    jmp ca14f                                                         // 45e2: 4c 4f a1    LO. :a5e2[1]
+
+// $45e5 referenced 4 times by $a5c9, $a5d8, $a5dc, $a5e0
+ca5e5
+    jsr clc_jmp_gsinit                                                // 45e5: 20 4c 87     L. :a5e5[1]
+    sty l00ca                                                         // 45e8: 84 ca       ..  :a5e8[1]
+    bne ca637                                                         // 45ea: d0 4b       .K  :a5ea[1]
+    bit l00c9                                                         // 45ec: 24 c9       $.  :a5ec[1]
+    bmi ca5fb                                                         // 45ee: 30 0b       0.  :a5ee[1]
+    jsr print_inline_l809f_top_bit_clear                              // 45f0: 20 77 80     w. :a5f0[1]
+    .asc "Verify"                                                     // 45f3: 56 65 72... Ver :a5f3[1]
+
+    bcc ca605                                                         // 45f9: 90 0a       ..  :a5f9[1]
+// $45fb referenced 1 time by $a5ee
+ca5fb
+    jsr print_inline_l809f_top_bit_clear                              // 45fb: 20 77 80     w. :a5fb[1]
+    .asc "Format"                                                     // 45fe: 46 6f 72... For :a5fe[1]
+
+    nop                                                               // 4604: ea          .   :a604[1]
+// $4605 referenced 1 time by $a5f9
+ca605
+    jsr print_inline_l809f_top_bit_clear                              // 4605: 20 77 80     w. :a605[1]
+    .asc " which drive ? "                                            // 4608: 20 77 68...  wh :a608[1]
+
+    nop                                                               // 4617: ea          .   :a617[1]
+    jsr osrdch                                                        // 4618: 20 e0 ff     .. :a618[1]
+    bcs ca65d                                                         // 461b: b0 40       .@  :a61b[1]
+    cmp #$20 // ' '                                                   // 461d: c9 20       .   :a61d[1]
+    bcc ca660                                                         // 461f: 90 3f       .?  :a61f[1]
+    jsr c809f                                                         // 4621: 20 9f 80     .. :a621[1]
+    sec                                                               // 4624: 38          8   :a624[1]
+    sbc #$30 // '0'                                                   // 4625: e9 30       .0  :a625[1]
+    bcc ca660                                                         // 4627: 90 37       .7  :a627[1]
+    cmp #4                                                            // 4629: c9 04       ..  :a629[1]
+    bcs ca660                                                         // 462b: b0 33       .3  :a62b[1]
+    sta l00cd                                                         // 462d: 85 cd       ..  :a62d[1]
+    jsr ca3dc                                                         // 462f: 20 dc a3     .. :a62f[1]
+    ldy l00ca                                                         // 4632: a4 ca       ..  :a632[1]
+    jmp ca63a                                                         // 4634: 4c 3a a6    L:. :a634[1]
+
+// $4637 referenced 2 times by $a5ea, $a65a
+ca637
+    jsr c8b8b                                                         // 4637: 20 8b 8b     .. :a637[1]
+// $463a referenced 1 time by $a634
+ca63a
+    sty l00ca                                                         // 463a: 84 ca       ..  :a63a[1]
+    bit l00c9                                                         // 463c: 24 c9       $.  :a63c[1]
+    bpl ca647                                                         // 463e: 10 07       ..  :a63e[1]
+    ldx l00cd                                                         // 4640: a6 cd       ..  :a640[1]
+    lda #0                                                            // 4642: a9 00       ..  :a642[1]
+    sta l10de,x                                                       // 4644: 9d de 10    ... :a644[1]
+// $4647 referenced 1 time by $a63e
+ca647
+    bit l1090                                                         // 4647: 2c 90 10    ,.. :a647[1]
+    bpl ca652                                                         // 464a: 10 06       ..  :a64a[1]
+    jsr sub_ca315                                                     // 464c: 20 15 a3     .. :a64c[1]
+    jsr sub_c9a8d                                                     // 464f: 20 8d 9a     .. :a64f[1]
+// $4652 referenced 1 time by $a64a
+ca652
+    jsr sub_ca663                                                     // 4652: 20 63 a6     c. :a652[1]
+    ldy l00ca                                                         // 4655: a4 ca       ..  :a655[1]
+    jsr clc_jmp_gsinit                                                // 4657: 20 4c 87     L. :a657[1]
+    bne ca637                                                         // 465a: d0 db       ..  :a65a[1]
+    rts                                                               // 465c: 60          `   :a65c[1]
+
+// $465d referenced 1 time by $a61b
+ca65d
+    jmp c9436                                                         // 465d: 4c 36 94    L6. :a65d[1]
+
+// $4660 referenced 3 times by $a61f, $a627, $a62b
+ca660
+    jmp c8ba2                                                         // 4660: 4c a2 8b    L.. :a660[1]
+
+// $4663 referenced 1 time by $a652
+sub_ca663
+    bit l00c9                                                         // 4663: 24 c9       $.  :a663[1]
+    bmi ca675                                                         // 4665: 30 0e       0.  :a665[1]
+    jsr print_inline_l809f_top_bit_clear                              // 4667: 20 77 80     w. :a667[1]
+    .asc "Verifying"                                                  // 466a: 56 65 72... Ver :a66a[1]
+
+    bcc ca68a                                                         // 4673: 90 15       ..  :a673[1]
+// $4675 referenced 1 time by $a665
+ca675
+    jsr sub_ca76c                                                     // 4675: 20 6c a7     l. :a675[1]
+    jsr print_inline_l809f_top_bit_clear                              // 4678: 20 77 80     w. :a678[1]
+    .asc "Formatting"                                                 // 467b: 46 6f 72... For :a67b[1]
+
+    ldx l00cd                                                         // 4685: a6 cd       ..  :a685[1]
+    stx l1090                                                         // 4687: 8e 90 10    ... :a687[1]
+// $468a referenced 1 time by $a673
+ca68a
+    jsr print_inline_l809f_top_bit_clear                              // 468a: 20 77 80     w. :a68a[1]
+    .asc " drive "                                                    // 468d: 20 64 72...  dr :a68d[1]
+
+    lda l00cd                                                         // 4694: a5 cd       ..  :a694[1]
+    jsr sub_c80c3                                                     // 4696: 20 c3 80     .. :a696[1]
+    jsr print_inline_l809f_top_bit_clear                              // 4699: 20 77 80     w. :a699[1]
+    .asc " track   "                                                  // 469c: 20 74 72...  tr :a69c[1]
+
+    nop                                                               // 46a5: ea          .   :a6a5[1]
+    bit l00c9                                                         // 46a6: 24 c9       $.  :a6a6[1]
+    bmi ca6b6                                                         // 46a8: 30 0c       0.  :a6a8[1]
+    jsr sub_ca7ce                                                     // 46aa: 20 ce a7     .. :a6aa[1]
+    txa                                                               // 46ad: 8a          .   :a6ad[1]
+    bne ca6b3                                                         // 46ae: d0 03       ..  :a6ae[1]
+    jmp ca3dc                                                         // 46b0: 4c dc a3    L.. :a6b0[1]
+
+// $46b3 referenced 1 time by $a6ae
+ca6b3
+    sta l109f                                                         // 46b3: 8d 9f 10    ... :a6b3[1]
+// $46b6 referenced 1 time by $a6a8
+ca6b6
+    lda #0                                                            // 46b6: a9 00       ..  :a6b6[1]
+    sta l1097                                                         // 46b8: 8d 97 10    ... :a6b8[1]
+// $46bb referenced 1 time by $a731
+ca6bb
+    lda #8                                                            // 46bb: a9 08       ..  :a6bb[1]
+    jsr c809f                                                         // 46bd: 20 9f 80     .. :a6bd[1]
+    jsr c809f                                                         // 46c0: 20 9f 80     .. :a6c0[1]
+    lda l1097                                                         // 46c3: ad 97 10    ... :a6c3[1]
+    jsr sub_c80bb                                                     // 46c6: 20 bb 80     .. :a6c6[1]
+    lda #6                                                            // 46c9: a9 06       ..  :a6c9[1]
+    sta l109d                                                         // 46cb: 8d 9d 10    ... :a6cb[1]
+// $46ce referenced 1 time by $a708
+ca6ce
+    jsr sub_ca73d                                                     // 46ce: 20 3d a7     =. :a6ce[1]
+    bit l00c9                                                         // 46d1: 24 c9       $.  :a6d1[1]
+    bpl ca6e2                                                         // 46d3: 10 0d       ..  :a6d3[1]
+    jsr sub_ca788                                                     // 46d5: 20 88 a7     .. :a6d5[1]
+    ldx #$90                                                          // 46d8: a2 90       ..  :a6d8[1]
+    ldy #$10                                                          // 46da: a0 10       ..  :a6da[1]
+    jsr c91af                                                         // 46dc: 20 af 91     .. :a6dc[1]
+    tax                                                               // 46df: aa          .   :a6df[1]
+    bne ca70a                                                         // 46e0: d0 28       .(  :a6e0[1]
+// $46e2 referenced 1 time by $a6d3
+ca6e2
+    lda #0                                                            // 46e2: a9 00       ..  :a6e2[1]
+    sta l1098                                                         // 46e4: 8d 98 10    ... :a6e4[1]
+    lda l1099                                                         // 46e7: ad 99 10    ... :a6e7[1]
+    and #$1f                                                          // 46ea: 29 1f       ).  :a6ea[1]
+    sta l1099                                                         // 46ec: 8d 99 10    ... :a6ec[1]
+    lda #3                                                            // 46ef: a9 03       ..  :a6ef[1]
+    sta l1095                                                         // 46f1: 8d 95 10    ... :a6f1[1]
+    lda #$5f // '_'                                                   // 46f4: a9 5f       ._  :a6f4[1]
+    sta l1096                                                         // 46f6: 8d 96 10    ... :a6f6[1]
+    jsr sub_c9432                                                     // 46f9: 20 32 94     2. :a6f9[1]
+    ldx #$90                                                          // 46fc: a2 90       ..  :a6fc[1]
+    ldy #$10                                                          // 46fe: a0 10       ..  :a6fe[1]
+    jsr c91af                                                         // 4700: 20 af 91     .. :a700[1]
+    beq ca712                                                         // 4703: f0 0d       ..  :a703[1]
+    dec l109d                                                         // 4705: ce 9d 10    ... :a705[1]
+    bne ca6ce                                                         // 4708: d0 c4       ..  :a708[1]
+// $470a referenced 1 time by $a6e0
+ca70a
+    jsr print_inline_l809f_top_bit_clear                              // 470a: 20 77 80     w. :a70a[1]
+    .asc "?"                                                          // 470d: 3f          ?   :a70d[1]
+
+    nop                                                               // 470e: ea          .   :a70e[1]
+    jmp c94c2                                                         // 470f: 4c c2 94    L.. :a70f[1]
+
+// $4712 referenced 1 time by $a703
+ca712
+    lda l109d                                                         // 4712: ad 9d 10    ... :a712[1]
+    cmp #6                                                            // 4715: c9 06       ..  :a715[1]
+    beq ca721                                                         // 4717: f0 08       ..  :a717[1]
+    jsr print_inline_l809f_top_bit_clear                              // 4719: 20 77 80     w. :a719[1]
+    .asc "?   "                                                       // 471c: 3f 20 20... ?   :a71c[1]
+
+    nop                                                               // 4720: ea          .   :a720[1]
+// $4721 referenced 1 time by $a717
+ca721
+    bit l00c9                                                         // 4721: 24 c9       $.  :a721[1]
+    bpl ca728                                                         // 4723: 10 03       ..  :a723[1]
+    jsr sub_ca779                                                     // 4725: 20 79 a7     y. :a725[1]
+// $4728 referenced 1 time by $a723
+ca728
+    inc l1097                                                         // 4728: ee 97 10    ... :a728[1]
+    lda l1097                                                         // 472b: ad 97 10    ... :a72b[1]
+    cmp l109f                                                         // 472e: cd 9f 10    ... :a72e[1]
+    bne ca6bb                                                         // 4731: d0 88       ..  :a731[1]
+    bit l00c9                                                         // 4733: 24 c9       $.  :a733[1]
+    bpl ca73a                                                         // 4735: 10 03       ..  :a735[1]
+    jsr sub_c93f1                                                     // 4737: 20 f1 93     .. :a737[1]
+// $473a referenced 1 time by $a735
+ca73a
+    jmp ca3dc                                                         // 473a: 4c dc a3    L.. :a73a[1]
+
+// $473d referenced 1 time by $a6ce
+sub_ca73d
+    ldx #0                                                            // 473d: a2 00       ..  :a73d[1]
+    stx l1091                                                         // 473f: 8e 91 10    ... :a73f[1]
+    stx l109a                                                         // 4742: 8e 9a 10    ... :a742[1]
+    dex                                                               // 4745: ca          .   :a745[1]
+    stx l1093                                                         // 4746: 8e 93 10    ... :a746[1]
+    stx l1094                                                         // 4749: 8e 94 10    ... :a749[1]
+    lda l10cf                                                         // 474c: ad cf 10    ... :a74c[1]
+    sta l1092                                                         // 474f: 8d 92 10    ... :a74f[1]
+    lda #5                                                            // 4752: a9 05       ..  :a752[1]
+    sta l1095                                                         // 4754: 8d 95 10    ... :a754[1]
+    lda #$63 // 'c'                                                   // 4757: a9 63       .c  :a757[1]
+    sta l1096                                                         // 4759: 8d 96 10    ... :a759[1]
+    lda #$2a // '*'                                                   // 475c: a9 2a       .*  :a75c[1]
+    sta l1099                                                         // 475e: 8d 99 10    ... :a75e[1]
+    ldx #$10                                                          // 4761: a2 10       ..  :a761[1]
+    ldy #$13                                                          // 4763: a0 13       ..  :a763[1]
+    stx l109b                                                         // 4765: 8e 9b 10    ... :a765[1]
+    sty l1098                                                         // 4768: 8c 98 10    ... :a768[1]
+    rts                                                               // 476b: 60          `   :a76b[1]
+
+// $476c referenced 1 time by $a675
+sub_ca76c
+    lda #0                                                            // 476c: a9 00       ..  :a76c[1]
+    tay                                                               // 476e: a8          .   :a76e[1]
+// $476f referenced 1 time by $a776
+loop_ca76f
+    sta l0e00,y                                                       // 476f: 99 00 0e    ... :a76f[1]
+    sta l0f00,y                                                       // 4772: 99 00 0f    ... :a772[1]
+    iny                                                               // 4775: c8          .   :a775[1]
+    bne loop_ca76f                                                    // 4776: d0 f7       ..  :a776[1]
+    rts                                                               // 4778: 60          `   :a778[1]
+
+// $4779 referenced 1 time by $a725
+sub_ca779
+    lda #$0a                                                          // 4779: a9 0a       ..  :a779[1]
+    clc                                                               // 477b: 18          .   :a77b[1]
+    adc l0f07                                                         // 477c: 6d 07 0f    m.. :a77c[1]
+    sta l0f07                                                         // 477f: 8d 07 0f    ... :a77f[1]
+    bcc ca787                                                         // 4782: 90 03       ..  :a782[1]
+    inc l0f06                                                         // 4784: ee 06 0f    ... :a784[1]
+// $4787 referenced 1 time by $a782
+ca787
+    rts                                                               // 4787: 60          `   :a787[1]
+
+// $4788 referenced 1 time by $a6d5
+sub_ca788
+    lda #0                                                            // 4788: a9 00       ..  :a788[1]
+    sta l00b0                                                         // 478a: 85 b0       ..  :a78a[1]
+    lda l10cf                                                         // 478c: ad cf 10    ... :a78c[1]
+    sta l00b1                                                         // 478f: 85 b1       ..  :a78f[1]
+    lda #$0a                                                          // 4791: a9 0a       ..  :a791[1]
+    sta l00b2                                                         // 4793: 85 b2       ..  :a793[1]
+    lda l1097                                                         // 4795: ad 97 10    ... :a795[1]
+    beq ca7a4                                                         // 4798: f0 0a       ..  :a798[1]
+    ldy #2                                                            // 479a: a0 02       ..  :a79a[1]
+    lda (l00b0),y                                                     // 479c: b1 b0       ..  :a79c[1]
+    clc                                                               // 479e: 18          .   :a79e[1]
+    adc #7                                                            // 479f: 69 07       i.  :a79f[1]
+    jsr sub_ca7c5                                                     // 47a1: 20 c5 a7     .. :a7a1[1]
+// $47a4 referenced 1 time by $a798
+ca7a4
+    tax                                                               // 47a4: aa          .   :a7a4[1]
+    ldy #0                                                            // 47a5: a0 00       ..  :a7a5[1]
+// $47a7 referenced 1 time by $a7c1
+loop_ca7a7
+    lda l1097                                                         // 47a7: ad 97 10    ... :a7a7[1]
+    sta (l00b0),y                                                     // 47aa: 91 b0       ..  :a7aa[1]
+    iny                                                               // 47ac: c8          .   :a7ac[1]
+    lda #0                                                            // 47ad: a9 00       ..  :a7ad[1]
+    sta (l00b0),y                                                     // 47af: 91 b0       ..  :a7af[1]
+    iny                                                               // 47b1: c8          .   :a7b1[1]
+    txa                                                               // 47b2: 8a          .   :a7b2[1]
+    sta (l00b0),y                                                     // 47b3: 91 b0       ..  :a7b3[1]
+    iny                                                               // 47b5: c8          .   :a7b5[1]
+    lda #1                                                            // 47b6: a9 01       ..  :a7b6[1]
+    sta (l00b0),y                                                     // 47b8: 91 b0       ..  :a7b8[1]
+    iny                                                               // 47ba: c8          .   :a7ba[1]
+    inx                                                               // 47bb: e8          .   :a7bb[1]
+    jsr sub_ca7c4                                                     // 47bc: 20 c4 a7     .. :a7bc[1]
+    dec l00b2                                                         // 47bf: c6 b2       ..  :a7bf[1]
+    bne loop_ca7a7                                                    // 47c1: d0 e4       ..  :a7c1[1]
+    rts                                                               // 47c3: 60          `   :a7c3[1]
+
+// $47c4 referenced 1 time by $a7bc
+sub_ca7c4
+    txa                                                               // 47c4: 8a          .   :a7c4[1]
+// $47c5 referenced 1 time by $a7a1
+sub_ca7c5
+    sec                                                               // 47c5: 38          8   :a7c5[1]
+// $47c6 referenced 1 time by $a7c8
+loop_ca7c6
+    sbc #$0a                                                          // 47c6: e9 0a       ..  :a7c6[1]
+    bcs loop_ca7c6                                                    // 47c8: b0 fc       ..  :a7c8[1]
+    adc #$0a                                                          // 47ca: 69 0a       i.  :a7ca[1]
+    tax                                                               // 47cc: aa          .   :a7cc[1]
+    rts                                                               // 47cd: 60          `   :a7cd[1]
+
+// $47ce referenced 1 time by $a6aa
+sub_ca7ce
+    jsr sub_c93f5                                                     // 47ce: 20 f5 93     .. :a7ce[1]
+    lda l0f06                                                         // 47d1: ad 06 0f    ... :a7d1[1]
+    and #3                                                            // 47d4: 29 03       ).  :a7d4[1]
+    tax                                                               // 47d6: aa          .   :a7d6[1]
+    lda l0f07                                                         // 47d7: ad 07 0f    ... :a7d7[1]
+    ldy #$0a                                                          // 47da: a0 0a       ..  :a7da[1]
+    sty l00b0                                                         // 47dc: 84 b0       ..  :a7dc[1]
+    ldy #$ff                                                          // 47de: a0 ff       ..  :a7de[1]
+// $47e0 referenced 1 time by $a7e7
+loop_ca7e0
+    sec                                                               // 47e0: 38          8   :a7e0[1]
+// $47e1 referenced 1 time by $a7e4
+loop_ca7e1
+    iny                                                               // 47e1: c8          .   :a7e1[1]
+    sbc l00b0                                                         // 47e2: e5 b0       ..  :a7e2[1]
+    bcs loop_ca7e1                                                    // 47e4: b0 fb       ..  :a7e4[1]
+    dex                                                               // 47e6: ca          .   :a7e6[1]
+    bpl loop_ca7e0                                                    // 47e7: 10 f7       ..  :a7e7[1]
+    adc l00b0                                                         // 47e9: 65 b0       e.  :a7e9[1]
+    pha                                                               // 47eb: 48          H   :a7eb[1]
+    tya                                                               // 47ec: 98          .   :a7ec[1]
+    tax                                                               // 47ed: aa          .   :a7ed[1]
+    pla                                                               // 47ee: 68          h   :a7ee[1]
+    beq ca7f2                                                         // 47ef: f0 01       ..  :a7ef[1]
+    inx                                                               // 47f1: e8          .   :a7f1[1]
+// $47f2 referenced 1 time by $a7ef
+ca7f2
+    rts                                                               // 47f2: 60          `   :a7f2[1]
+
+sub_ca7f3
+    sec                                                               // 47f3: 38          8   :a7f3[1]
+    bcs ca7f7                                                         // 47f4: b0 01       ..  :a7f4[1]
+sub_ca7f6
+    clc                                                               // 47f6: 18          .   :a7f6[1]
+// $47f7 referenced 1 time by $a7f4
+ca7f7
+    ror l00c6                                                         // 47f7: 66 c6       f.  :a7f7[1]
+    jsr sub_c8b86                                                     // 47f9: 20 86 8b     .. :a7f9[1]
+    jsr sub_c8380                                                     // 47fc: 20 80 83     .. :a7fc[1]
+    bit l00c6                                                         // 47ff: 24 c6       $.  :a7ff[1]
+    bmi ca818                                                         // 4801: 30 15       0.  :a801[1]
+    jsr print_inline_osasci_top_bit_clear                             // 4803: 20 9c a9     .. :a803[1]
+    .asc "Address :  Length", $0d                                     // 4806: 41 64 64... Add :a806[1]
+
+// $4818 referenced 1 time by $a801
+ca818
+    lda l0f06                                                         // 4818: ad 06 0f    ... :a818[1]
+    and #3                                                            // 481b: 29 03       ).  :a81b[1]
+    sta l00c5                                                         // 481d: 85 c5       ..  :a81d[1]
+    sta l00c2                                                         // 481f: 85 c2       ..  :a81f[1]
+    lda l0f07                                                         // 4821: ad 07 0f    ... :a821[1]
+    sta l00c4                                                         // 4824: 85 c4       ..  :a824[1]
+    sec                                                               // 4826: 38          8   :a826[1]
+    sbc #2                                                            // 4827: e9 02       ..  :a827[1]
+    sta l00c1                                                         // 4829: 85 c1       ..  :a829[1]
+    bcs ca82f                                                         // 482b: b0 02       ..  :a82b[1]
+    dec l00c2                                                         // 482d: c6 c2       ..  :a82d[1]
+// $482f referenced 1 time by $a82b
+ca82f
+    lda #2                                                            // 482f: a9 02       ..  :a82f[1]
+    sta l00bb                                                         // 4831: 85 bb       ..  :a831[1]
+    lda #0                                                            // 4833: a9 00       ..  :a833[1]
+    sta l00bc                                                         // 4835: 85 bc       ..  :a835[1]
+    sta l00bf                                                         // 4837: 85 bf       ..  :a837[1]
+    sta l00c0                                                         // 4839: 85 c0       ..  :a839[1]
+    lda l0f05                                                         // 483b: ad 05 0f    ... :a83b[1]
+    and #$f8                                                          // 483e: 29 f8       ).  :a83e[1]
+    tay                                                               // 4840: a8          .   :a840[1]
+    beq ca86b                                                         // 4841: f0 28       .(  :a841[1]
+    bne ca856                                                         // 4843: d0 11       ..  :a843[1]
+// $4845 referenced 2 times by $a869, $a889
+ca845
+    jsr sub_ca8e2                                                     // 4845: 20 e2 a8     .. :a845[1]
+    jsr sub_c82b2                                                     // 4848: 20 b2 82     .. :a848[1]
+    lda l00c4                                                         // 484b: a5 c4       ..  :a84b[1]
+    sec                                                               // 484d: 38          8   :a84d[1]
+    sbc l00bb                                                         // 484e: e5 bb       ..  :a84e[1]
+    lda l00c5                                                         // 4850: a5 c5       ..  :a850[1]
+    sbc l00bc                                                         // 4852: e5 bc       ..  :a852[1]
+    bcc ca86b                                                         // 4854: 90 15       ..  :a854[1]
+// $4856 referenced 1 time by $a843
+ca856
+    lda l0f07,y                                                       // 4856: b9 07 0f    ... :a856[1]
+    sec                                                               // 4859: 38          8   :a859[1]
+    sbc l00bb                                                         // 485a: e5 bb       ..  :a85a[1]
+    sta l00c1                                                         // 485c: 85 c1       ..  :a85c[1]
+    php                                                               // 485e: 08          .   :a85e[1]
+    lda l0f06,y                                                       // 485f: b9 06 0f    ... :a85f[1]
+    and #3                                                            // 4862: 29 03       ).  :a862[1]
+    plp                                                               // 4864: 28          (   :a864[1]
+    sbc l00bc                                                         // 4865: e5 bc       ..  :a865[1]
+    sta l00c2                                                         // 4867: 85 c2       ..  :a867[1]
+    bcc ca845                                                         // 4869: 90 da       ..  :a869[1]
+// $486b referenced 2 times by $a841, $a854
+ca86b
+    sty l00bd                                                         // 486b: 84 bd       ..  :a86b[1]
+    bit l00c6                                                         // 486d: 24 c6       $.  :a86d[1]
+    bmi ca87a                                                         // 486f: 30 09       0.  :a86f[1]
+    lda l00c1                                                         // 4871: a5 c1       ..  :a871[1]
+    ora l00c2                                                         // 4873: 05 c2       ..  :a873[1]
+    beq ca87a                                                         // 4875: f0 03       ..  :a875[1]
+    jsr sub_ca8be                                                     // 4877: 20 be a8     .. :a877[1]
+// $487a referenced 2 times by $a86f, $a875
+ca87a
+    lda l00c1                                                         // 487a: a5 c1       ..  :a87a[1]
+    clc                                                               // 487c: 18          .   :a87c[1]
+    adc l00bf                                                         // 487d: 65 bf       e.  :a87d[1]
+    sta l00bf                                                         // 487f: 85 bf       ..  :a87f[1]
+    lda l00c2                                                         // 4881: a5 c2       ..  :a881[1]
+    adc l00c0                                                         // 4883: 65 c0       e.  :a883[1]
+    sta l00c0                                                         // 4885: 85 c0       ..  :a885[1]
+    ldy l00bd                                                         // 4887: a4 bd       ..  :a887[1]
+    bne ca845                                                         // 4889: d0 ba       ..  :a889[1]
+    bit l00c6                                                         // 488b: 24 c6       $.  :a88b[1]
+    bpl ca8bd                                                         // 488d: 10 2e       ..  :a88d[1]
+    tay                                                               // 488f: a8          .   :a88f[1]
+    ldx l00bf                                                         // 4890: a6 bf       ..  :a890[1]
+    lda #$f8                                                          // 4892: a9 f8       ..  :a892[1]
+    sec                                                               // 4894: 38          8   :a894[1]
+    sbc l0f05                                                         // 4895: ed 05 0f    ... :a895[1]
+    jsr sub_ca90d                                                     // 4898: 20 0d a9     .. :a898[1]
+    jsr print_inline_osasci_top_bit_clear                             // 489b: 20 9c a9     .. :a89b[1]
+    .asc "Free", $0d                                                  // 489e: 46 72 65... Fre :a89e[1]
+
+    lda l00c4                                                         // 48a3: a5 c4       ..  :a8a3[1]
+    sec                                                               // 48a5: 38          8   :a8a5[1]
+    sbc l00bf                                                         // 48a6: e5 bf       ..  :a8a6[1]
+    tax                                                               // 48a8: aa          .   :a8a8[1]
+    lda l00c5                                                         // 48a9: a5 c5       ..  :a8a9[1]
+    sbc l00c0                                                         // 48ab: e5 c0       ..  :a8ab[1]
+    tay                                                               // 48ad: a8          .   :a8ad[1]
+    lda l0f05                                                         // 48ae: ad 05 0f    ... :a8ae[1]
+    jsr sub_ca90d                                                     // 48b1: 20 0d a9     .. :a8b1[1]
+    jsr print_inline_osasci_top_bit_clear                             // 48b4: 20 9c a9     .. :a8b4[1]
+    .asc "Used", $0d                                                  // 48b7: 55 73 65... Use :a8b7[1]
+
+    nop                                                               // 48bc: ea          .   :a8bc[1]
+// $48bd referenced 1 time by $a88d
+ca8bd
+    rts                                                               // 48bd: 60          `   :a8bd[1]
+
+// $48be referenced 1 time by $a877
+sub_ca8be
+    lda l00bc                                                         // 48be: a5 bc       ..  :a8be[1]
+    jsr sub_ca9ca                                                     // 48c0: 20 ca a9     .. :a8c0[1]
+    lda l00bb                                                         // 48c3: a5 bb       ..  :a8c3[1]
+    jsr sub_ca9c2                                                     // 48c5: 20 c2 a9     .. :a8c5[1]
+    jsr print_inline_osasci_top_bit_clear                             // 48c8: 20 9c a9     .. :a8c8[1]
+    .asc "     :  "                                                   // 48cb: 20 20 20...     :a8cb[1]
+
+    lda l00c2                                                         // 48d3: a5 c2       ..  :a8d3[1]
+    jsr sub_ca9ca                                                     // 48d5: 20 ca a9     .. :a8d5[1]
+    lda l00c1                                                         // 48d8: a5 c1       ..  :a8d8[1]
+    jsr sub_ca9c2                                                     // 48da: 20 c2 a9     .. :a8da[1]
+    lda #$0d                                                          // 48dd: a9 0d       ..  :a8dd[1]
+    jsr osasci                                                        // 48df: 20 e3 ff     .. :a8df[1]
+// $48e2 referenced 1 time by $a845
+sub_ca8e2
+    lda l0f06,y                                                       // 48e2: b9 06 0f    ... :a8e2[1]
+    pha                                                               // 48e5: 48          H   :a8e5[1]
+    jsr sub_c81b0                                                     // 48e6: 20 b0 81     .. :a8e6[1]
+    sta l00bc                                                         // 48e9: 85 bc       ..  :a8e9[1]
+    pla                                                               // 48eb: 68          h   :a8eb[1]
+    and #3                                                            // 48ec: 29 03       ).  :a8ec[1]
+    clc                                                               // 48ee: 18          .   :a8ee[1]
+    adc l00bc                                                         // 48ef: 65 bc       e.  :a8ef[1]
+    sta l00bc                                                         // 48f1: 85 bc       ..  :a8f1[1]
+    lda l0f04,y                                                       // 48f3: b9 04 0f    ... :a8f3[1]
+    beq ca8fa                                                         // 48f6: f0 02       ..  :a8f6[1]
+    lda #1                                                            // 48f8: a9 01       ..  :a8f8[1]
+// $48fa referenced 1 time by $a8f6
+ca8fa
+    clc                                                               // 48fa: 18          .   :a8fa[1]
+    adc l0f05,y                                                       // 48fb: 79 05 0f    y.. :a8fb[1]
+    bcc ca902                                                         // 48fe: 90 02       ..  :a8fe[1]
+    inc l00bc                                                         // 4900: e6 bc       ..  :a900[1]
+// $4902 referenced 1 time by $a8fe
+ca902
+    clc                                                               // 4902: 18          .   :a902[1]
+    adc l0f07,y                                                       // 4903: 79 07 0f    y.. :a903[1]
+    sta l00bb                                                         // 4906: 85 bb       ..  :a906[1]
+    bcc ca90c                                                         // 4908: 90 02       ..  :a908[1]
+    inc l00bc                                                         // 490a: e6 bc       ..  :a90a[1]
+// $490c referenced 1 time by $a908
+ca90c
+    rts                                                               // 490c: 60          `   :a90c[1]
+
+// $490d referenced 2 times by $a898, $a8b1
+sub_ca90d
+    jsr sub_c81c0                                                     // 490d: 20 c0 81     .. :a90d[1]
+    jsr sub_ca9bf                                                     // 4910: 20 bf a9     .. :a910[1]
+    jsr print_inline_osasci_top_bit_clear                             // 4913: 20 9c a9     .. :a913[1]
+    .asc " Files "                                                    // 4916: 20 46 69...  Fi :a916[1]
+
+    stx l00bc                                                         // 491d: 86 bc       ..  :a91d[1]
+    sty l00bd                                                         // 491f: 84 bd       ..  :a91f[1]
+    tya                                                               // 4921: 98          .   :a921[1]
+    jsr sub_ca9ca                                                     // 4922: 20 ca a9     .. :a922[1]
+    txa                                                               // 4925: 8a          .   :a925[1]
+    jsr sub_ca9c2                                                     // 4926: 20 c2 a9     .. :a926[1]
+    jsr print_inline_osasci_top_bit_clear                             // 4929: 20 9c a9     .. :a929[1]
+    .asc " Sectors "                                                  // 492c: 20 53 65...  Se :a92c[1]
+
+    lda #0                                                            // 4935: a9 00       ..  :a935[1]
+    sta l00bb                                                         // 4937: 85 bb       ..  :a937[1]
+    sta l00be                                                         // 4939: 85 be       ..  :a939[1]
+    ldx #$1f                                                          // 493b: a2 1f       ..  :a93b[1]
+    stx l00c1                                                         // 493d: 86 c1       ..  :a93d[1]
+    ldx #9                                                            // 493f: a2 09       ..  :a93f[1]
+// $4941 referenced 1 time by $a945
+loop_ca941
+    sta l1000,x                                                       // 4941: 9d 00 10    ... :a941[1]
+    dex                                                               // 4944: ca          .   :a944[1]
+    bpl loop_ca941                                                    // 4945: 10 fa       ..  :a945[1]
+// $4947 referenced 1 time by $a966
+loop_ca947
+    asl l00bb                                                         // 4947: 06 bb       ..  :a947[1]
+    rol l00bc                                                         // 4949: 26 bc       &.  :a949[1]
+    rol l00bd                                                         // 494b: 26 bd       &.  :a94b[1]
+    rol l00be                                                         // 494d: 26 be       &.  :a94d[1]
+    ldx #0                                                            // 494f: a2 00       ..  :a94f[1]
+    ldy #9                                                            // 4951: a0 09       ..  :a951[1]
+// $4953 referenced 1 time by $a962
+loop_ca953
+    lda l1000,x                                                       // 4953: bd 00 10    ... :a953[1]
+    rol                                                               // 4956: 2a          *   :a956[1]
+    cmp #$0a                                                          // 4957: c9 0a       ..  :a957[1]
+    bcc ca95d                                                         // 4959: 90 02       ..  :a959[1]
+    sbc #$0a                                                          // 495b: e9 0a       ..  :a95b[1]
+// $495d referenced 1 time by $a959
+ca95d
+    sta l1000,x                                                       // 495d: 9d 00 10    ... :a95d[1]
+    inx                                                               // 4960: e8          .   :a960[1]
+    dey                                                               // 4961: 88          .   :a961[1]
+    bpl loop_ca953                                                    // 4962: 10 ef       ..  :a962[1]
+    dec l00c1                                                         // 4964: c6 c1       ..  :a964[1]
+    bpl loop_ca947                                                    // 4966: 10 df       ..  :a966[1]
+    ldy #$20 // ' '                                                   // 4968: a0 20       .   :a968[1]
+    ldx #5                                                            // 496a: a2 05       ..  :a96a[1]
+// $496c referenced 1 time by $a98e
+ca96c
+    bne ca970                                                         // 496c: d0 02       ..  :a96c[1]
+    ldy #$2c // ','                                                   // 496e: a0 2c       .,  :a96e[1]
+// $4970 referenced 1 time by $a96c
+ca970
+    lda l1000,x                                                       // 4970: bd 00 10    ... :a970[1]
+    bne ca97d                                                         // 4973: d0 08       ..  :a973[1]
+    cpy #$2c // ','                                                   // 4975: c0 2c       .,  :a975[1]
+    beq ca97d                                                         // 4977: f0 04       ..  :a977[1]
+    lda #$20 // ' '                                                   // 4979: a9 20       .   :a979[1]
+    bne ca982                                                         // 497b: d0 05       ..  :a97b[1]
+// $497d referenced 2 times by $a973, $a977
+ca97d
+    ldy #$2c // ','                                                   // 497d: a0 2c       .,  :a97d[1]
+    clc                                                               // 497f: 18          .   :a97f[1]
+    adc #$30 // '0'                                                   // 4980: 69 30       i0  :a980[1]
+// $4982 referenced 1 time by $a97b
+ca982
+    jsr osasci                                                        // 4982: 20 e3 ff     .. :a982[1]
+    cpx #3                                                            // 4985: e0 03       ..  :a985[1]
+    bne ca98d                                                         // 4987: d0 04       ..  :a987[1]
+    tya                                                               // 4989: 98          .   :a989[1]
+    jsr osasci                                                        // 498a: 20 e3 ff     .. :a98a[1]
+// $498d referenced 1 time by $a987
+ca98d
+    dex                                                               // 498d: ca          .   :a98d[1]
+    bpl ca96c                                                         // 498e: 10 dc       ..  :a98e[1]
+    jsr print_inline_osasci_top_bit_clear                             // 4990: 20 9c a9     .. :a990[1]
+    .asc " Bytes "                                                    // 4993: 20 42 79...  By :a993[1]
+
+    nop                                                               // 499a: ea          .   :a99a[1]
+    rts                                                               // 499b: 60          `   :a99b[1]
+
+// $499c referenced 7 times by $a803, $a89b, $a8b4, $a8c8, $a913, $a929, $a990
+print_inline_osasci_top_bit_clear
+    sta l00b3                                                         // 499c: 85 b3       ..  :a99c[1]
+    pla                                                               // 499e: 68          h   :a99e[1]
+    sta l00ae                                                         // 499f: 85 ae       ..  :a99f[1]
+    pla                                                               // 49a1: 68          h   :a9a1[1]
+    sta l00af                                                         // 49a2: 85 af       ..  :a9a2[1]
+    lda l00b3                                                         // 49a4: a5 b3       ..  :a9a4[1]
+    pha                                                               // 49a6: 48          H   :a9a6[1]
+    tya                                                               // 49a7: 98          .   :a9a7[1]
+    pha                                                               // 49a8: 48          H   :a9a8[1]
+    ldy #0                                                            // 49a9: a0 00       ..  :a9a9[1]
+// $49ab referenced 1 time by $a9b5
+loop_ca9ab
+    jsr inc16_ae                                                      // 49ab: 20 dc 83     .. :a9ab[1]
+    lda (l00ae),y                                                     // 49ae: b1 ae       ..  :a9ae[1]
+    bmi ca9b8                                                         // 49b0: 30 06       0.  :a9b0[1]
+    jsr osasci                                                        // 49b2: 20 e3 ff     .. :a9b2[1]
+    jmp loop_ca9ab                                                    // 49b5: 4c ab a9    L.. :a9b5[1]
+
+// $49b8 referenced 1 time by $a9b0
+ca9b8
+    pla                                                               // 49b8: 68          h   :a9b8[1]
+    tay                                                               // 49b9: a8          .   :a9b9[1]
+    pla                                                               // 49ba: 68          h   :a9ba[1]
+    clc                                                               // 49bb: 18          .   :a9bb[1]
+    jmp (l00ae)                                                       // 49bc: 6c ae 00    l.. :a9bc[1]
+
+// $49bf referenced 1 time by $a910
+sub_ca9bf
+    jsr sub_c841b                                                     // 49bf: 20 1b 84     .. :a9bf[1]
+// $49c2 referenced 3 times by $a8c5, $a8da, $a926
+sub_ca9c2
+    pha                                                               // 49c2: 48          H   :a9c2[1]
+    jsr sub_c81bf                                                     // 49c3: 20 bf 81     .. :a9c3[1]
+    jsr sub_ca9ca                                                     // 49c6: 20 ca a9     .. :a9c6[1]
+    pla                                                               // 49c9: 68          h   :a9c9[1]
+// $49ca referenced 4 times by $a8c0, $a8d5, $a922, $a9c6
+sub_ca9ca
+    jsr sub_c80c8                                                     // 49ca: 20 c8 80     .. :a9ca[1]
+    jmp osasci                                                        // 49cd: 4c e3 ff    L.. :a9cd[1]
+
+sub_ca9d0
+    lda #0                                                            // 49d0: a9 00       ..  :a9d0[1]
+    sta l00a8                                                         // 49d2: 85 a8       ..  :a9d2[1]
+    jsr sub_caaea                                                     // 49d4: 20 ea aa     .. :a9d4[1]
+    lda #$0f                                                          // 49d7: a9 0f       ..  :a9d7[1]
+    sta l00aa                                                         // 49d9: 85 aa       ..  :a9d9[1]
+    jsr sub_caadd                                                     // 49db: 20 dd aa     .. :a9db[1]
+    sec                                                               // 49de: 38          8   :a9de[1]
+    jsr gsinit                                                        // 49df: 20 c2 ff     .. :a9df[1]
+    sty l00ab                                                         // 49e2: 84 ab       ..  :a9e2[1]
+    clc                                                               // 49e4: 18          .   :a9e4[1]
+    beq ca9ff                                                         // 49e5: f0 18       ..  :a9e5[1]
+// $49e7 referenced 1 time by $a9fc
+loop_ca9e7
+    jsr sub_c8456                                                     // 49e7: 20 56 84     V. :a9e7[1]
+    bcs ca9ff                                                         // 49ea: b0 13       ..  :a9ea[1]
+    sty l00ab                                                         // 49ec: 84 ab       ..  :a9ec[1]
+    and #$0f                                                          // 49ee: 29 0f       ).  :a9ee[1]
+    sta l00aa                                                         // 49f0: 85 aa       ..  :a9f0[1]
+    jsr sub_caa53                                                     // 49f2: 20 53 aa     S. :a9f2[1]
+    ldy l00ab                                                         // 49f5: a4 ab       ..  :a9f5[1]
+    jsr clc_jmp_gsinit                                                // 49f7: 20 4c 87     L. :a9f7[1]
+    sty l00ab                                                         // 49fa: 84 ab       ..  :a9fa[1]
+    bne loop_ca9e7                                                    // 49fc: d0 e9       ..  :a9fc[1]
+    rts                                                               // 49fe: 60          `   :a9fe[1]
+
+// $49ff referenced 2 times by $a9e5, $a9ea
+ca9ff
+    ror l00a8                                                         // 49ff: 66 a8       f.  :a9ff[1]
+// $4a01 referenced 1 time by $aa0f
+loop_caa01
+    bit l00a8                                                         // 4a01: 24 a8       $.  :aa01[1]
+    bpl caa0a                                                         // 4a03: 10 05       ..  :aa03[1]
+    jsr sub_caa12                                                     // 4a05: 20 12 aa     .. :aa05[1]
+    bcc caa0d                                                         // 4a08: 90 03       ..  :aa08[1]
+// $4a0a referenced 1 time by $aa03
+caa0a
+    jsr sub_caa53                                                     // 4a0a: 20 53 aa     S. :aa0a[1]
+// $4a0d referenced 1 time by $aa08
+caa0d
+    dec l00aa                                                         // 4a0d: c6 aa       ..  :aa0d[1]
+    bpl loop_caa01                                                    // 4a0f: 10 f0       ..  :aa0f[1]
+    rts                                                               // 4a11: 60          `   :aa11[1]
+
+// $4a12 referenced 1 time by $aa05
+sub_caa12
+    lda #9                                                            // 4a12: a9 09       ..  :aa12[1]
+    sta osrdsc_ptr                                                    // 4a14: 85 f6       ..  :aa14[1]
+    lda #$80                                                          // 4a16: a9 80       ..  :aa16[1]
+    sta l00f7                                                         // 4a18: 85 f7       ..  :aa18[1]
+    ldy l00ab                                                         // 4a1a: a4 ab       ..  :aa1a[1]
+// $4a1c referenced 2 times by $aa39, $aa40
+caa1c
+    lda (os_text_ptr),y                                               // 4a1c: b1 f2       ..  :aa1c[1]
+    cmp #$0d                                                          // 4a1e: c9 0d       ..  :aa1e[1]
+    beq caa44                                                         // 4a20: f0 22       ."  :aa20[1]
+    cmp #$22 // '"'                                                   // 4a22: c9 22       ."  :aa22[1]
+    beq caa44                                                         // 4a24: f0 1e       ..  :aa24[1]
+    iny                                                               // 4a26: c8          .   :aa26[1]
+    cmp #$2a // '*'                                                   // 4a27: c9 2a       .*  :aa27[1]
+    beq caa51                                                         // 4a29: f0 26       .&  :aa29[1]
+    jsr sub_c82fe                                                     // 4a2b: 20 fe 82     .. :aa2b[1]
+    sta l00ae                                                         // 4a2e: 85 ae       ..  :aa2e[1]
+    jsr sub_caacf                                                     // 4a30: 20 cf aa     .. :aa30[1]
+    beq caa42                                                         // 4a33: f0 0d       ..  :aa33[1]
+    ldx l00ae                                                         // 4a35: a6 ae       ..  :aa35[1]
+    cpx #$23 // '#'                                                   // 4a37: e0 23       .#  :aa37[1]
+    beq caa1c                                                         // 4a39: f0 e1       ..  :aa39[1]
+    jsr sub_c82fe                                                     // 4a3b: 20 fe 82     .. :aa3b[1]
+    cmp l00ae                                                         // 4a3e: c5 ae       ..  :aa3e[1]
+    beq caa1c                                                         // 4a40: f0 da       ..  :aa40[1]
+// $4a42 referenced 3 times by $aa33, $aa4f, $aa57
+caa42
+    clc                                                               // 4a42: 18          .   :aa42[1]
+    rts                                                               // 4a43: 60          `   :aa43[1]
+
+// $4a44 referenced 3 times by $aa20, $aa24, $aa4b
+caa44
+    jsr sub_caacf                                                     // 4a44: 20 cf aa     .. :aa44[1]
+    beq caa51                                                         // 4a47: f0 08       ..  :aa47[1]
+    cmp #$20 // ' '                                                   // 4a49: c9 20       .   :aa49[1]
+    beq caa44                                                         // 4a4b: f0 f7       ..  :aa4b[1]
+    cmp #$0d                                                          // 4a4d: c9 0d       ..  :aa4d[1]
+    bne caa42                                                         // 4a4f: d0 f1       ..  :aa4f[1]
+// $4a51 referenced 2 times by $aa29, $aa47
+caa51
+    sec                                                               // 4a51: 38          8   :aa51[1]
+    rts                                                               // 4a52: 60          `   :aa52[1]
+
+// $4a53 referenced 2 times by $a9f2, $aa0a
+sub_caa53
+    ldy l00aa                                                         // 4a53: a4 aa       ..  :aa53[1]
+    lda (l00b4),y                                                     // 4a55: b1 b4       ..  :aa55[1]
+    beq caa42                                                         // 4a57: f0 e9       ..  :aa57[1]
+    pha                                                               // 4a59: 48          H   :aa59[1]
+    jsr print_inline_l809f_top_bit_clear                              // 4a5a: 20 77 80     w. :aa5a[1]
+    .asc "Rom "                                                       // 4a5d: 52 6f 6d... Rom :aa5d[1]
+
+    tya                                                               // 4a61: 98          .   :aa61[1]
+    jsr sub_c80b8                                                     // 4a62: 20 b8 80     .. :aa62[1]
+    jsr print_inline_l809f_top_bit_clear                              // 4a65: 20 77 80     w. :aa65[1]
+    .asc " : "                                                        // 4a68: 20 3a 20     :  :aa68[1]
+
+    lda #$28 // '('                                                   // 4a6b: a9 28       .(  :aa6b[1]
+    jsr c809f                                                         // 4a6d: 20 9f 80     .. :aa6d[1]
+    pla                                                               // 4a70: 68          h   :aa70[1]
+    pha                                                               // 4a71: 48          H   :aa71[1]
+    bmi caa78                                                         // 4a72: 30 04       0.  :aa72[1]
+    ldy #$20 // ' '                                                   // 4a74: a0 20       .   :aa74[1]
+    bne caa7a                                                         // 4a76: d0 02       ..  :aa76[1]
+// $4a78 referenced 1 time by $aa72
+caa78
+    ldy #$53 // 'S'                                                   // 4a78: a0 53       .S  :aa78[1]
+// $4a7a referenced 1 time by $aa76
+caa7a
+    tya                                                               // 4a7a: 98          .   :aa7a[1]
+    jsr c809f                                                         // 4a7b: 20 9f 80     .. :aa7b[1]
+    pla                                                               // 4a7e: 68          h   :aa7e[1]
+    ldy #$20 // ' '                                                   // 4a7f: a0 20       .   :aa7f[1]
+    asl                                                               // 4a81: 0a          .   :aa81[1]
+    bpl caa86                                                         // 4a82: 10 02       ..  :aa82[1]
+    ldy #$4c // 'L'                                                   // 4a84: a0 4c       .L  :aa84[1]
+// $4a86 referenced 1 time by $aa82
+caa86
+    tya                                                               // 4a86: 98          .   :aa86[1]
+    jsr c809f                                                         // 4a87: 20 9f 80     .. :aa87[1]
+    lda #$29 // ')'                                                   // 4a8a: a9 29       .)  :aa8a[1]
+    jsr c809f                                                         // 4a8c: 20 9f 80     .. :aa8c[1]
+    jsr cac0f                                                         // 4a8f: 20 0f ac     .. :aa8f[1]
+    jsr sub_caa9a                                                     // 4a92: 20 9a aa     .. :aa92[1]
+    jsr ca3dc                                                         // 4a95: 20 dc a3     .. :aa95[1]
+    sec                                                               // 4a98: 38          8   :aa98[1]
+    rts                                                               // 4a99: 60          `   :aa99[1]
+
+// $4a9a referenced 1 time by $aa92
+sub_caa9a
+    lda #7                                                            // 4a9a: a9 07       ..  :aa9a[1]
+    sta osrdsc_ptr                                                    // 4a9c: 85 f6       ..  :aa9c[1]
+    lda #$80                                                          // 4a9e: a9 80       ..  :aa9e[1]
+    sta l00f7                                                         // 4aa0: 85 f7       ..  :aaa0[1]
+    jsr sub_caacf                                                     // 4aa2: 20 cf aa     .. :aaa2[1]
+    sta l00ae                                                         // 4aa5: 85 ae       ..  :aaa5[1]
+    inc osrdsc_ptr                                                    // 4aa7: e6 f6       ..  :aaa7[1]
+    ldy #$1e                                                          // 4aa9: a0 1e       ..  :aaa9[1]
+    jsr sub_caac2                                                     // 4aab: 20 c2 aa     .. :aaab[1]
+    bcs caab7                                                         // 4aae: b0 07       ..  :aaae[1]
+    jsr cac0f                                                         // 4ab0: 20 0f ac     .. :aab0[1]
+    dey                                                               // 4ab3: 88          .   :aab3[1]
+    jsr sub_caac2                                                     // 4ab4: 20 c2 aa     .. :aab4[1]
+// $4ab7 referenced 1 time by $aaae
+caab7
+    rts                                                               // 4ab7: 60          `   :aab7[1]
+
+// $4ab8 referenced 1 time by $aacb
+loop_caab8
+    cmp #$20 // ' '                                                   // 4ab8: c9 20       .   :aab8[1]
+    bcs caabe                                                         // 4aba: b0 02       ..  :aaba[1]
+    lda #$20 // ' '                                                   // 4abc: a9 20       .   :aabc[1]
+// $4abe referenced 1 time by $aaba
+caabe
+    jsr c809f                                                         // 4abe: 20 9f 80     .. :aabe[1]
+    dey                                                               // 4ac1: 88          .   :aac1[1]
+// $4ac2 referenced 2 times by $aaab, $aab4
+sub_caac2
+    lda osrdsc_ptr                                                    // 4ac2: a5 f6       ..  :aac2[1]
+    cmp l00ae                                                         // 4ac4: c5 ae       ..  :aac4[1]
+    bcs caace                                                         // 4ac6: b0 06       ..  :aac6[1]
+    jsr sub_caacf                                                     // 4ac8: 20 cf aa     .. :aac8[1]
+    bne loop_caab8                                                    // 4acb: d0 eb       ..  :aacb[1]
+    clc                                                               // 4acd: 18          .   :aacd[1]
+// $4ace referenced 1 time by $aac6
+caace
+    rts                                                               // 4ace: 60          `   :aace[1]
+
+// $4acf referenced 4 times by $aa30, $aa44, $aaa2, $aac8
+sub_caacf
+    tya                                                               // 4acf: 98          .   :aacf[1]
+    pha                                                               // 4ad0: 48          H   :aad0[1]
+    ldy l00aa                                                         // 4ad1: a4 aa       ..  :aad1[1]
+    jsr osrdsc                                                        // 4ad3: 20 b9 ff     .. :aad3[1]
+    inc osrdsc_ptr                                                    // 4ad6: e6 f6       ..  :aad6[1]
+    tax                                                               // 4ad8: aa          .   :aad8[1]
+    pla                                                               // 4ad9: 68          h   :aad9[1]
+    tay                                                               // 4ada: a8          .   :aada[1]
+    txa                                                               // 4adb: 8a          .   :aadb[1]
+    rts                                                               // 4adc: 60          `   :aadc[1]
+
+// $4add referenced 1 time by $a9db
+sub_caadd
+    jsr sub_c840c                                                     // 4add: 20 0c 84     .. :aadd[1]
+    lda #$aa                                                          // 4ae0: a9 aa       ..  :aae0[1]
+    jsr osbyte_read                                                   // 4ae2: 20 e5 9a     .. :aae2[1]
+    stx l00b4                                                         // 4ae5: 86 b4       ..  :aae5[1]
+    sty l00b5                                                         // 4ae7: 84 b5       ..  :aae7[1]
+    rts                                                               // 4ae9: 60          `   :aae9[1]
+
+// $4aea referenced 1 time by $a9d4
+sub_caaea
+    tsx                                                               // 4aea: ba          .   :aaea[1]
+    lda #0                                                            // 4aeb: a9 00       ..  :aaeb[1]
+    sta l0107,x                                                       // 4aed: 9d 07 01    ... :aaed[1]
+    rts                                                               // 4af0: 60          `   :aaf0[1]
+
+// $4af1 referenced 2 times by $ab51, $abd5
+sub_caaf1
+    ldx romsel_copy                                                   // 4af1: a6 f4       ..  :aaf1[1]
+    lda l0df0,x                                                       // 4af3: bd f0 0d    ... :aaf3[1]
+    and #$3f // '?'                                                   // 4af6: 29 3f       )?  :aaf6[1]
+    sta l00ad                                                         // 4af8: 85 ad       ..  :aaf8[1]
+    inc l00ad                                                         // 4afa: e6 ad       ..  :aafa[1]
+    rts                                                               // 4afc: 60          `   :aafc[1]
+
+sub_caafd
+    jsr sub_cac18                                                     // 4afd: 20 18 ac     .. :aafd[1]
+    lda #0                                                            // 4b00: a9 00       ..  :ab00[1]
+    beq cab09                                                         // 4b02: f0 05       ..  :ab02[1]
+sub_cab04
+    jsr sub_cac18                                                     // 4b04: 20 18 ac     .. :ab04[1]
+    lda #$ff                                                          // 4b07: a9 ff       ..  :ab07[1]
+// $4b09 referenced 1 time by $ab02
+cab09
+    sta l00ab                                                         // 4b09: 85 ab       ..  :ab09[1]
+    lda #$40 // '@'                                                   // 4b0b: a9 40       .@  :ab0b[1]
+    jsr osfind                                                        // 4b0d: 20 ce ff     .. :ab0d[1]
+    tay                                                               // 4b10: a8          .   :ab10[1]
+    lda #$0d                                                          // 4b11: a9 0d       ..  :ab11[1]
+    cpy #0                                                            // 4b13: c0 00       ..  :ab13[1]
+    bne cab35                                                         // 4b15: d0 1e       ..  :ab15[1]
+// $4b17 referenced 1 time by $ab4f
+cab17
+    jmp c822a                                                         // 4b17: 4c 2a 82    L*. :ab17[1]
+
+// $4b1a referenced 2 times by $ab21, $ab3a
+cab1a
+    jsr osbget                                                        // 4b1a: 20 d7 ff     .. :ab1a[1]
+    bcs cab3d                                                         // 4b1d: b0 1e       ..  :ab1d[1]
+    cmp #$0a                                                          // 4b1f: c9 0a       ..  :ab1f[1]
+    beq cab1a                                                         // 4b21: f0 f7       ..  :ab21[1]
+    plp                                                               // 4b23: 28          (   :ab23[1]
+    bne cab2e                                                         // 4b24: d0 08       ..  :ab24[1]
+    pha                                                               // 4b26: 48          H   :ab26[1]
+    jsr sub_cac4e                                                     // 4b27: 20 4e ac     N. :ab27[1]
+    jsr cac0f                                                         // 4b2a: 20 0f ac     .. :ab2a[1]
+    pla                                                               // 4b2d: 68          h   :ab2d[1]
+// $4b2e referenced 1 time by $ab24
+cab2e
+    jsr osasci                                                        // 4b2e: 20 e3 ff     .. :ab2e[1]
+    bit l00ff                                                         // 4b31: 24 ff       $.  :ab31[1]
+    bmi cab54                                                         // 4b33: 30 1f       0.  :ab33[1]
+// $4b35 referenced 1 time by $ab15
+cab35
+    and l00ab                                                         // 4b35: 25 ab       %.  :ab35[1]
+    cmp #$0d                                                          // 4b37: c9 0d       ..  :ab37[1]
+    php                                                               // 4b39: 08          .   :ab39[1]
+    jmp cab1a                                                         // 4b3a: 4c 1a ab    L.. :ab3a[1]
+
+// $4b3d referenced 1 time by $ab1d
+cab3d
+    plp                                                               // 4b3d: 28          (   :ab3d[1]
+    jsr osnewl                                                        // 4b3e: 20 e7 ff     .. :ab3e[1]
+// $4b41 referenced 2 times by $aba5, $abbf
+cab41
+    lda #0                                                            // 4b41: a9 00       ..  :ab41[1]
+    jmp osfind                                                        // 4b43: 4c ce ff    L.. :ab43[1]
+
+sub_cab46
+    jsr sub_cac18                                                     // 4b46: 20 18 ac     .. :ab46[1]
+    lda #$40 // '@'                                                   // 4b49: a9 40       .@  :ab49[1]
+    jsr osfind                                                        // 4b4b: 20 ce ff     .. :ab4b[1]
+    tay                                                               // 4b4e: a8          .   :ab4e[1]
+    beq cab17                                                         // 4b4f: f0 c6       ..  :ab4f[1]
+    jsr sub_caaf1                                                     // 4b51: 20 f1 aa     .. :ab51[1]
+// $4b54 referenced 2 times by $ab33, $aba7
+cab54
+    bit l00ff                                                         // 4b54: 24 ff       $.  :ab54[1]
+    bmi cabbc                                                         // 4b56: 30 64       0d  :ab56[1]
+    lda l00a9                                                         // 4b58: a5 a9       ..  :ab58[1]
+    jsr sub_cac62                                                     // 4b5a: 20 62 ac     b. :ab5a[1]
+    lda l00a8                                                         // 4b5d: a5 a8       ..  :ab5d[1]
+    jsr sub_cac62                                                     // 4b5f: 20 62 ac     b. :ab5f[1]
+    jsr cac0f                                                         // 4b62: 20 0f ac     .. :ab62[1]
+    lda #8                                                            // 4b65: a9 08       ..  :ab65[1]
+    sta l00ac                                                         // 4b67: 85 ac       ..  :ab67[1]
+    ldx #0                                                            // 4b69: a2 00       ..  :ab69[1]
+// $4b6b referenced 1 time by $ab7a
+loop_cab6b
+    jsr osbget                                                        // 4b6b: 20 d7 ff     .. :ab6b[1]
+    bcs cab7d                                                         // 4b6e: b0 0d       ..  :ab6e[1]
+    sta (l00ac,x)                                                     // 4b70: 81 ac       ..  :ab70[1]
+    jsr sub_cac62                                                     // 4b72: 20 62 ac     b. :ab72[1]
+    jsr cac0f                                                         // 4b75: 20 0f ac     .. :ab75[1]
+    dec l00ac                                                         // 4b78: c6 ac       ..  :ab78[1]
+    bne loop_cab6b                                                    // 4b7a: d0 ef       ..  :ab7a[1]
+    clc                                                               // 4b7c: 18          .   :ab7c[1]
+// $4b7d referenced 1 time by $ab6e
+cab7d
+    php                                                               // 4b7d: 08          .   :ab7d[1]
+    bcc cab93                                                         // 4b7e: 90 13       ..  :ab7e[1]
+// $4b80 referenced 1 time by $ab91
+loop_cab80
+    lda #$2a // '*'                                                   // 4b80: a9 2a       .*  :ab80[1]
+    jsr osasci                                                        // 4b82: 20 e3 ff     .. :ab82[1]
+    jsr osasci                                                        // 4b85: 20 e3 ff     .. :ab85[1]
+    jsr cac0f                                                         // 4b88: 20 0f ac     .. :ab88[1]
+    lda #0                                                            // 4b8b: a9 00       ..  :ab8b[1]
+    sta (l00ac,x)                                                     // 4b8d: 81 ac       ..  :ab8d[1]
+    dec l00ac                                                         // 4b8f: c6 ac       ..  :ab8f[1]
+    bne loop_cab80                                                    // 4b91: d0 ed       ..  :ab91[1]
+// $4b93 referenced 1 time by $ab7e
+cab93
+    jsr sub_caba9                                                     // 4b93: 20 a9 ab     .. :ab93[1]
+    jsr osnewl                                                        // 4b96: 20 e7 ff     .. :ab96[1]
+    lda #8                                                            // 4b99: a9 08       ..  :ab99[1]
+    clc                                                               // 4b9b: 18          .   :ab9b[1]
+    adc l00a8                                                         // 4b9c: 65 a8       e.  :ab9c[1]
+    sta l00a8                                                         // 4b9e: 85 a8       ..  :ab9e[1]
+    bcc caba4                                                         // 4ba0: 90 02       ..  :aba0[1]
+    inc l00a9                                                         // 4ba2: e6 a9       ..  :aba2[1]
+// $4ba4 referenced 1 time by $aba0
+caba4
+    plp                                                               // 4ba4: 28          (   :aba4[1]
+    bcs cab41                                                         // 4ba5: b0 9a       ..  :aba5[1]
+    bcc cab54                                                         // 4ba7: 90 ab       ..  :aba7[1]
+// $4ba9 referenced 1 time by $ab93
+sub_caba9
+    lda #8                                                            // 4ba9: a9 08       ..  :aba9[1]
+    sta l00ac                                                         // 4bab: 85 ac       ..  :abab[1]
+// $4bad referenced 1 time by $abb9
+loop_cabad
+    ldx #0                                                            // 4bad: a2 00       ..  :abad[1]
+    lda (l00ac,x)                                                     // 4baf: a1 ac       ..  :abaf[1]
+    jsr sub_c842c                                                     // 4bb1: 20 2c 84     ,. :abb1[1]
+    jsr osasci                                                        // 4bb4: 20 e3 ff     .. :abb4[1]
+    dec l00ac                                                         // 4bb7: c6 ac       ..  :abb7[1]
+    bne loop_cabad                                                    // 4bb9: d0 f2       ..  :abb9[1]
+    rts                                                               // 4bbb: 60          `   :abbb[1]
+
+// $4bbc referenced 2 times by $ab56, $ac02
+cabbc
+    jsr sub_c9ad8                                                     // 4bbc: 20 d8 9a     .. :abbc[1]
+    jsr cab41                                                         // 4bbf: 20 41 ab     A. :abbf[1]
+    jmp c9436                                                         // 4bc2: 4c 36 94    L6. :abc2[1]
+
+sub_cabc5
+    jsr sub_cac18                                                     // 4bc5: 20 18 ac     .. :abc5[1]
+    lda #$80                                                          // 4bc8: a9 80       ..  :abc8[1]
+    jsr osfind                                                        // 4bca: 20 ce ff     .. :abca[1]
+    sta l00ab                                                         // 4bcd: 85 ab       ..  :abcd[1]
+// $4bcf referenced 1 time by $ac09
+cabcf
+    jsr sub_cac4e                                                     // 4bcf: 20 4e ac     N. :abcf[1]
+    jsr cac0f                                                         // 4bd2: 20 0f ac     .. :abd2[1]
+    jsr sub_caaf1                                                     // 4bd5: 20 f1 aa     .. :abd5[1]
+    ldx #$ac                                                          // 4bd8: a2 ac       ..  :abd8[1]
+    ldy #$ff                                                          // 4bda: a0 ff       ..  :abda[1]
+    sty l00ae                                                         // 4bdc: 84 ae       ..  :abdc[1]
+    sty l00b0                                                         // 4bde: 84 b0       ..  :abde[1]
+    iny                                                               // 4be0: c8          .   :abe0[1]
+    sty l00ac                                                         // 4be1: 84 ac       ..  :abe1[1]
+    lda #$20 // ' '                                                   // 4be3: a9 20       .   :abe3[1]
+    sta l00af                                                         // 4be5: 85 af       ..  :abe5[1]
+    tya                                                               // 4be7: 98          .   :abe7[1]
+    jsr osword                                                        // 4be8: 20 f1 ff     .. :abe8[1]
+    php                                                               // 4beb: 08          .   :abeb[1]
+    sty l00aa                                                         // 4bec: 84 aa       ..  :abec[1]
+    ldy l00ab                                                         // 4bee: a4 ab       ..  :abee[1]
+    ldx #0                                                            // 4bf0: a2 00       ..  :abf0[1]
+    beq cabfb                                                         // 4bf2: f0 07       ..  :abf2[1]
+// $4bf4 referenced 1 time by $abff
+loop_cabf4
+    lda (l00ac,x)                                                     // 4bf4: a1 ac       ..  :abf4[1]
+    jsr osbput                                                        // 4bf6: 20 d4 ff     .. :abf6[1]
+    inc l00ac                                                         // 4bf9: e6 ac       ..  :abf9[1]
+// $4bfb referenced 1 time by $abf2
+cabfb
+    lda l00ac                                                         // 4bfb: a5 ac       ..  :abfb[1]
+    cmp l00aa                                                         // 4bfd: c5 aa       ..  :abfd[1]
+    bne loop_cabf4                                                    // 4bff: d0 f3       ..  :abff[1]
+    plp                                                               // 4c01: 28          (   :ac01[1]
+    bcs cabbc                                                         // 4c02: b0 b8       ..  :ac02[1]
+    lda #$0d                                                          // 4c04: a9 0d       ..  :ac04[1]
+    jsr osbput                                                        // 4c06: 20 d4 ff     .. :ac06[1]
+    jmp cabcf                                                         // 4c09: 4c cf ab    L.. :ac09[1]
+
+// $4c0c referenced 3 times by $817f, $8198, $85ca
+sub_cac0c
+    jsr cac0f                                                         // 4c0c: 20 0f ac     .. :ac0c[1]
+// $4c0f referenced 11 times by $81a7, $834f, $837d, $aa8f, $aab0, $ab2a, $ab62, $ab75, $ab88, $abd2, $ac0c
+cac0f
+    pha                                                               // 4c0f: 48          H   :ac0f[1]
+    lda #$20 // ' '                                                   // 4c10: a9 20       .   :ac10[1]
+    jsr osasci                                                        // 4c12: 20 e3 ff     .. :ac12[1]
+    pla                                                               // 4c15: 68          h   :ac15[1]
+    clc                                                               // 4c16: 18          .   :ac16[1]
+    rts                                                               // 4c17: 60          `   :ac17[1]
+
+// $4c18 referenced 4 times by $aafd, $ab04, $ab46, $abc5
+sub_cac18
+    tsx                                                               // 4c18: ba          .   :ac18[1]
+    lda #0                                                            // 4c19: a9 00       ..  :ac19[1]
+    sta l0107,x                                                       // 4c1b: 9d 07 01    ... :ac1b[1]
+    jsr sub_cac47                                                     // 4c1e: 20 47 ac     G. :ac1e[1]
+    cmp #$0d                                                          // 4c21: c9 0d       ..  :ac21[1]
+    bne cac28                                                         // 4c23: d0 03       ..  :ac23[1]
+    jmp ca14f                                                         // 4c25: 4c 4f a1    LO. :ac25[1]
+
+// $4c28 referenced 1 time by $ac23
+cac28
+    lda #0                                                            // 4c28: a9 00       ..  :ac28[1]
+    sta l00a8                                                         // 4c2a: 85 a8       ..  :ac2a[1]
+    sta l00a9                                                         // 4c2c: 85 a9       ..  :ac2c[1]
+    pha                                                               // 4c2e: 48          H   :ac2e[1]
+    tya                                                               // 4c2f: 98          .   :ac2f[1]
+    clc                                                               // 4c30: 18          .   :ac30[1]
+    adc os_text_ptr                                                   // 4c31: 65 f2       e.  :ac31[1]
+    tax                                                               // 4c33: aa          .   :ac33[1]
+    lda l00f3                                                         // 4c34: a5 f3       ..  :ac34[1]
+    adc #0                                                            // 4c36: 69 00       i.  :ac36[1]
+    tay                                                               // 4c38: a8          .   :ac38[1]
+    pla                                                               // 4c39: 68          h   :ac39[1]
+    rts                                                               // 4c3a: 60          `   :ac3a[1]
+
+    tya                                                               // 4c3b: 98          .   :ac3b[1]
+    clc                                                               // 4c3c: 18          .   :ac3c[1]
+    adc os_text_ptr                                                   // 4c3d: 65 f2       e.  :ac3d[1]
+    sta os_text_ptr                                                   // 4c3f: 85 f2       ..  :ac3f[1]
+    bcc cac45                                                         // 4c41: 90 02       ..  :ac41[1]
+    inc os_text_ptr                                                   // 4c43: e6 f2       ..  :ac43[1]
+// $4c45 referenced 1 time by $ac41
+cac45
+    rts                                                               // 4c45: 60          `   :ac45[1]
+
+// $4c46 referenced 1 time by $ac4b
+loop_cac46
+    iny                                                               // 4c46: c8          .   :ac46[1]
+// $4c47 referenced 1 time by $ac1e
+sub_cac47
+    lda (os_text_ptr),y                                               // 4c47: b1 f2       ..  :ac47[1]
+    cmp #$20 // ' '                                                   // 4c49: c9 20       .   :ac49[1]
+    beq loop_cac46                                                    // 4c4b: f0 f9       ..  :ac4b[1]
+    rts                                                               // 4c4d: 60          `   :ac4d[1]
+
+// $4c4e referenced 2 times by $ab27, $abcf
+sub_cac4e
+    sed                                                               // 4c4e: f8          .   :ac4e[1]
+    clc                                                               // 4c4f: 18          .   :ac4f[1]
+    lda l00a8                                                         // 4c50: a5 a8       ..  :ac50[1]
+    adc #1                                                            // 4c52: 69 01       i.  :ac52[1]
+    sta l00a8                                                         // 4c54: 85 a8       ..  :ac54[1]
+    lda l00a9                                                         // 4c56: a5 a9       ..  :ac56[1]
+    adc #0                                                            // 4c58: 69 00       i.  :ac58[1]
+    sta l00a9                                                         // 4c5a: 85 a9       ..  :ac5a[1]
+    cld                                                               // 4c5c: d8          .   :ac5c[1]
+    jsr sub_cac62                                                     // 4c5d: 20 62 ac     b. :ac5d[1]
+    lda l00a8                                                         // 4c60: a5 a8       ..  :ac60[1]
+// $4c62 referenced 4 times by $ab5a, $ab5f, $ab72, $ac5d
+sub_cac62
+    pha                                                               // 4c62: 48          H   :ac62[1]
+    jsr sub_c81bf                                                     // 4c63: 20 bf 81     .. :ac63[1]
+    jsr sub_cac6a                                                     // 4c66: 20 6a ac     j. :ac66[1]
+    pla                                                               // 4c69: 68          h   :ac69[1]
+// $4c6a referenced 1 time by $ac66
+sub_cac6a
+    jsr sub_c80c8                                                     // 4c6a: 20 c8 80     .. :ac6a[1]
+    jsr osasci                                                        // 4c6d: 20 e3 ff     .. :ac6d[1]
+    sec                                                               // 4c70: 38          8   :ac70[1]
+    rts                                                               // 4c71: 60          `   :ac71[1]
+
+// $4c72 referenced 1 time by $96e1
+sub_cac72
+    jsr sub_c83e3                                                     // 4c72: 20 e3 83     .. :ac72[1]
+    lda #$40 // '@'                                                   // 4c75: a9 40       .@  :ac75[1]
+    sta l10de                                                         // 4c77: 8d de 10    ... :ac77[1]
+    lda #$a8                                                          // 4c7a: a9 a8       ..  :ac7a[1]
+    jsr osbyte_read                                                   // 4c7c: 20 e5 9a     .. :ac7c[1]
+    stx l00b0                                                         // 4c7f: 86 b0       ..  :ac7f[1]
+    sty l00b1                                                         // 4c81: 84 b1       ..  :ac81[1]
+    ldy #$0f                                                          // 4c83: a0 0f       ..  :ac83[1]
+    lda #$4c // 'L'                                                   // 4c85: a9 4c       .L  :ac85[1]
+    sta l10e2                                                         // 4c87: 8d e2 10    ... :ac87[1]
+    lda bytev                                                         // 4c8a: ad 0a 02    ... :ac8a[1]
+    sta l10e3                                                         // 4c8d: 8d e3 10    ... :ac8d[1]
+    lda bytev+1                                                       // 4c90: ad 0b 02    ... :ac90[1]
+    sta l10e4                                                         // 4c93: 8d e4 10    ... :ac93[1]
+    php                                                               // 4c96: 08          .   :ac96[1]
+    sei                                                               // 4c97: 78          x   :ac97[1]
+    lda #$0f                                                          // 4c98: a9 0f       ..  :ac98[1]
+    sta bytev                                                         // 4c9a: 8d 0a 02    ... :ac9a[1]
+    lda #$ff                                                          // 4c9d: a9 ff       ..  :ac9d[1]
+    sta bytev+1                                                       // 4c9f: 8d 0b 02    ... :ac9f[1]
+    lda #$b2                                                          // 4ca2: a9 b2       ..  :aca2[1]
+    sta (l00b0),y                                                     // 4ca4: 91 b0       ..  :aca4[1]
+    iny                                                               // 4ca6: c8          .   :aca6[1]
+    lda #$ac                                                          // 4ca7: a9 ac       ..  :aca7[1]
+    sta (l00b0),y                                                     // 4ca9: 91 b0       ..  :aca9[1]
+    iny                                                               // 4cab: c8          .   :acab[1]
+    lda romsel_copy                                                   // 4cac: a5 f4       ..  :acac[1]
+    sta (l00b0),y                                                     // 4cae: 91 b0       ..  :acae[1]
+    plp                                                               // 4cb0: 28          (   :acb0[1]
+    rts                                                               // 4cb1: 60          `   :acb1[1]
+
+    cmp #0                                                            // 4cb2: c9 00       ..  :acb2[1]
+    beq cacc7                                                         // 4cb4: f0 11       ..  :acb4[1]
+    cmp #$81                                                          // 4cb6: c9 81       ..  :acb6[1]
+    bne cacc4                                                         // 4cb8: d0 0a       ..  :acb8[1]
+    cpy #$ff                                                          // 4cba: c0 ff       ..  :acba[1]
+    bne cacc4                                                         // 4cbc: d0 06       ..  :acbc[1]
+    cpx #0                                                            // 4cbe: e0 00       ..  :acbe[1]
+    bne cacc4                                                         // 4cc0: d0 02       ..  :acc0[1]
+    dex                                                               // 4cc2: ca          .   :acc2[1]
+    rts                                                               // 4cc3: 60          `   :acc3[1]
+
+// $4cc4 referenced 3 times by $acb8, $acbc, $acc0
+cacc4
+    jmp l10e2                                                         // 4cc4: 4c e2 10    L.. :acc4[1]
+
+// $4cc7 referenced 1 time by $acb4
+cacc7
+    php                                                               // 4cc7: 08          .   :acc7[1]
+    sei                                                               // 4cc8: 78          x   :acc8[1]
+    lda l10e3                                                         // 4cc9: ad e3 10    ... :acc9[1]
+    sta bytev                                                         // 4ccc: 8d 0a 02    ... :accc[1]
+    lda l10e4                                                         // 4ccf: ad e4 10    ... :accf[1]
+    sta bytev+1                                                       // 4cd2: 8d 0b 02    ... :acd2[1]
+    lda #0                                                            // 4cd5: a9 00       ..  :acd5[1]
+    ldx #1                                                            // 4cd7: a2 01       ..  :acd7[1]
+    plp                                                               // 4cd9: 28          (   :acd9[1]
+    rts                                                               // 4cda: 60          `   :acda[1]
+
+// $4cdb referenced 2 times by $0050, $af1c
+tube_host_code2
+* = $4cdb
+// $4cdb referenced 2 times by $0050, $af1c
+// $4cdb referenced 2 times by $0050, $af1c
+* = $0500
+// $4cdb referenced 2 times by $0050, $af1c
+l0500
+    .word          sub_c0537,          sub_c0596,          sub_c05f2  // 4cdb: 37 05 96... 7.. :0500[3]
+    .word          sub_c0607,          sub_c0627, tube_host_osword_0  // 4ce1: 07 06 27... ..' :0506[3]
+    .word          sub_c055e,          sub_c052d,          sub_c0520  // 4ce7: 5e 05 2d... ^.- :050c[3]
+    .word          sub_c0542,          sub_c05a9,          sub_c05d1  // 4ced: 42 05 a9... B.. :0512[3]
+// Table of flags used by tube_entry_small_a to set up registers 1/4
+// for the
+// selected operation.
+// $4cf3 referenced 1 time by $0453
+tube_entry_flags
+    .byt $86, $88, $96, $98, $18, $18, $82, $18                       // 4cf3: 86 88 96... ... :0518[3]
+
+sub_c0520
+    jsr read_tube_r2_data                                             // 4cfb: 20 c5 06     .. :0520[3]
+    tay                                                               // 4cfe: a8          .   :0523[3]
+    jsr read_tube_r2_data                                             // 4cff: 20 c5 06     .. :0524[3]
+    jsr osbput                                                        // 4d02: 20 d4 ff     .. :0527[3]
+    jmp c059c                                                         // 4d05: 4c 9c 05    L.. :052a[3]
+
+sub_c052d
+    jsr read_tube_r2_data                                             // 4d08: 20 c5 06     .. :052d[3]
+    tay                                                               // 4d0b: a8          .   :0530[3]
+    jsr osbget                                                        // 4d0c: 20 d7 ff     .. :0531[3]
+    jmp c053a                                                         // 4d0f: 4c 3a 05    L:. :0534[3]
+
+sub_c0537
+    jsr osrdch                                                        // 4d12: 20 e0 ff     .. :0537[3]
+// $4d15 referenced 2 times by $0534, $05ef
+c053a
+    ror                                                               // 4d15: 6a          j   :053a[3]
+    jsr write_tube_r2_data                                            // 4d16: 20 95 06     .. :053b[3]
+    rol                                                               // 4d19: 2a          *   :053e[3]
+    jmp c059e                                                         // 4d1a: 4c 9e 05    L.. :053f[3]
+
+sub_c0542
+    jsr read_tube_r2_data                                             // 4d1d: 20 c5 06     .. :0542[3]
+    beq c0552                                                         // 4d20: f0 0b       ..  :0545[3]
+    pha                                                               // 4d22: 48          H   :0547[3]
+    jsr sub_c0582                                                     // 4d23: 20 82 05     .. :0548[3]
+    pla                                                               // 4d26: 68          h   :054b[3]
+    jsr osfind                                                        // 4d27: 20 ce ff     .. :054c[3]
+    jmp c059e                                                         // 4d2a: 4c 9e 05    L.. :054f[3]
+
+// $4d2d referenced 1 time by $0545
+c0552
+    jsr read_tube_r2_data                                             // 4d2d: 20 c5 06     .. :0552[3]
+    tay                                                               // 4d30: a8          .   :0555[3]
+    lda #0                                                            // 4d31: a9 00       ..  :0556[3]
+    jsr osfind                                                        // 4d33: 20 ce ff     .. :0558[3]
+    jmp c059c                                                         // 4d36: 4c 9c 05    L.. :055b[3]
+
+sub_c055e
+    jsr read_tube_r2_data                                             // 4d39: 20 c5 06     .. :055e[3]
+    tay                                                               // 4d3c: a8          .   :0561[3]
+    ldx #4                                                            // 4d3d: a2 04       ..  :0562[3]
+// $4d3f referenced 1 time by $056a
+loop_c0564
+    jsr read_tube_r2_data                                             // 4d3f: 20 c5 06     .. :0564[3]
+    sta l00ff,x                                                       // 4d42: 95 ff       ..  :0567[3]
+    dex                                                               // 4d44: ca          .   :0569[3]
+    bne loop_c0564                                                    // 4d45: d0 f8       ..  :056a[3]
+    jsr read_tube_r2_data                                             // 4d47: 20 c5 06     .. :056c[3]
+    jsr osargs                                                        // 4d4a: 20 da ff     .. :056f[3]
+    jsr write_tube_r2_data                                            // 4d4d: 20 95 06     .. :0572[3]
+    ldx #3                                                            // 4d50: a2 03       ..  :0575[3]
+// $4d52 referenced 1 time by $057d
+loop_c0577
+    lda l0000,x                                                       // 4d52: b5 00       ..  :0577[3]
+    jsr write_tube_r2_data                                            // 4d54: 20 95 06     .. :0579[3]
+    dex                                                               // 4d57: ca          .   :057c[3]
+    bpl loop_c0577                                                    // 4d58: 10 f8       ..  :057d[3]
+    jmp c0036                                                         // 4d5a: 4c 36 00    L6. :057f[3]
+
+// $4d5d referenced 3 times by $0548, $0596, $05b3
+sub_c0582
+    ldx #0                                                            // 4d5d: a2 00       ..  :0582[3]
+    ldy #0                                                            // 4d5f: a0 00       ..  :0584[3]
+// $4d61 referenced 1 time by $0591
+loop_c0586
+    jsr read_tube_r2_data                                             // 4d61: 20 c5 06     .. :0586[3]
+    sta l0700,y                                                       // 4d64: 99 00 07    ... :0589[3]
+    iny                                                               // 4d67: c8          .   :058c[3]
+    beq c0593                                                         // 4d68: f0 04       ..  :058d[3]
+    cmp #$0d                                                          // 4d6a: c9 0d       ..  :058f[3]
+    bne loop_c0586                                                    // 4d6c: d0 f3       ..  :0591[3]
+// $4d6e referenced 1 time by $058d
+c0593
+    ldy #7                                                            // 4d6e: a0 07       ..  :0593[3]
+    rts                                                               // 4d70: 60          `   :0595[3]
+
+sub_c0596
+    jsr sub_c0582                                                     // 4d71: 20 82 05     .. :0596[3]
+    jsr oscli                                                         // 4d74: 20 f7 ff     .. :0599[3]
+// $4d77 referenced 3 times by $0489, $052a, $055b
+c059c
+    lda #$7f                                                          // 4d77: a9 7f       ..  :059c[3]
+// $4d79 referenced 4 times by $053f, $054f, $05a1, $067d
+c059e
+    bit tube_host_r2_status                                           // 4d79: 2c e2 fe    ,.. :059e[3]
+    bvc c059e                                                         // 4d7c: 50 fb       P.  :05a1[3]
+    sta tube_host_r2_data                                             // 4d7e: 8d e3 fe    ... :05a3[3]
+// $4d81 referenced 1 time by $05cf
+c05a6
+    jmp c0036                                                         // 4d81: 4c 36 00    L6. :05a6[3]
+
+sub_c05a9
+    ldx #$10                                                          // 4d84: a2 10       ..  :05a9[3]
+// $4d86 referenced 1 time by $05b1
+loop_c05ab
+    jsr read_tube_r2_data                                             // 4d86: 20 c5 06     .. :05ab[3]
+    sta l0001,x                                                       // 4d89: 95 01       ..  :05ae[3]
+    dex                                                               // 4d8b: ca          .   :05b0[3]
+    bne loop_c05ab                                                    // 4d8c: d0 f8       ..  :05b1[3]
+    jsr sub_c0582                                                     // 4d8e: 20 82 05     .. :05b3[3]
+    stx l0000                                                         // 4d91: 86 00       ..  :05b6[3]
+    sty l0001                                                         // 4d93: 84 01       ..  :05b8[3]
+    ldy #0                                                            // 4d95: a0 00       ..  :05ba[3]
+    jsr read_tube_r2_data                                             // 4d97: 20 c5 06     .. :05bc[3]
+    jsr osfile                                                        // 4d9a: 20 dd ff     .. :05bf[3]
+    jsr write_tube_r2_data                                            // 4d9d: 20 95 06     .. :05c2[3]
+    ldx #$10                                                          // 4da0: a2 10       ..  :05c5[3]
+// $4da2 referenced 1 time by $05cd
+loop_c05c7
+    lda l0001,x                                                       // 4da2: b5 01       ..  :05c7[3]
+    jsr write_tube_r2_data                                            // 4da4: 20 95 06     .. :05c9[3]
+    dex                                                               // 4da7: ca          .   :05cc[3]
+    bne loop_c05c7                                                    // 4da8: d0 f8       ..  :05cd[3]
+    beq c05a6                                                         // 4daa: f0 d5       ..  :05cf[3]
+sub_c05d1
+    ldx #$0d                                                          // 4dac: a2 0d       ..  :05d1[3]
+// $4dae referenced 1 time by $05d9
+loop_c05d3
+    jsr read_tube_r2_data                                             // 4dae: 20 c5 06     .. :05d3[3]
+    sta l00ff,x                                                       // 4db1: 95 ff       ..  :05d6[3]
+    dex                                                               // 4db3: ca          .   :05d8[3]
+    bne loop_c05d3                                                    // 4db4: d0 f8       ..  :05d9[3]
+    jsr read_tube_r2_data                                             // 4db6: 20 c5 06     .. :05db[3]
+    ldy #0                                                            // 4db9: a0 00       ..  :05de[3]
+    jsr osgbpb                                                        // 4dbb: 20 d1 ff     .. :05e0[3]
+    pha                                                               // 4dbe: 48          H   :05e3[3]
+    ldx #$0c                                                          // 4dbf: a2 0c       ..  :05e4[3]
+// $4dc1 referenced 1 time by $05ec
+loop_c05e6
+    lda l0000,x                                                       // 4dc1: b5 00       ..  :05e6[3]
+    jsr write_tube_r2_data                                            // 4dc3: 20 95 06     .. :05e8[3]
+    dex                                                               // 4dc6: ca          .   :05eb[3]
+    bpl loop_c05e6                                                    // 4dc7: 10 f8       ..  :05ec[3]
+    pla                                                               // 4dc9: 68          h   :05ee[3]
+    jmp c053a                                                         // 4dca: 4c 3a 05    L:. :05ef[3]
+
+sub_c05f2
+    jsr read_tube_r2_data                                             // 4dcd: 20 c5 06     .. :05f2[3]
+    tax                                                               // 4dd0: aa          .   :05f5[3]
+    jsr read_tube_r2_data                                             // 4dd1: 20 c5 06     .. :05f6[3]
+    jsr osbyte                                                        // 4dd4: 20 f4 ff     .. :05f9[3]
+// $4dd7 referenced 2 times by $05ff, $0625
+c05fc
+    bit tube_host_r2_status                                           // 4dd7: 2c e2 fe    ,.. :05fc[3]
+sub_c05ff
+l0600 = sub_c05ff+1
+    bvc c05fc                                                         // 4dda: 50 fb       P.  :05ff[3]
+// $4ddb referenced 1 time by $af22
+    stx tube_host_r2_data                                             // 4ddc: 8e e3 fe    ... :0601[3]
+// $4ddf referenced 1 time by $0617
+loop_c0604
+    jmp c0036                                                         // 4ddf: 4c 36 00    L6. :0604[3]
+
+sub_c0607
+    jsr read_tube_r2_data                                             // 4de2: 20 c5 06     .. :0607[3]
+    tax                                                               // 4de5: aa          .   :060a[3]
+    jsr read_tube_r2_data                                             // 4de6: 20 c5 06     .. :060b[3]
+    tay                                                               // 4de9: a8          .   :060e[3]
+    jsr read_tube_r2_data                                             // 4dea: 20 c5 06     .. :060f[3]
+    jsr osbyte                                                        // 4ded: 20 f4 ff     .. :0612[3]
+    eor #$9d                                                          // 4df0: 49 9d       I.  :0615[3]
+    beq loop_c0604                                                    // 4df2: f0 eb       ..  :0617[3]
+    ror                                                               // 4df4: 6a          j   :0619[3]
+    jsr write_tube_r2_data                                            // 4df5: 20 95 06     .. :061a[3]
+// $4df8 referenced 1 time by $0620
+loop_c061d
+    bit tube_host_r2_status                                           // 4df8: 2c e2 fe    ,.. :061d[3]
+    bvc loop_c061d                                                    // 4dfb: 50 fb       P.  :0620[3]
+    sty tube_host_r2_data                                             // 4dfd: 8c e3 fe    ... :0622[3]
+    bvs c05fc                                                         // 4e00: 70 d5       p.  :0625[3]
+sub_c0627
+    jsr read_tube_r2_data                                             // 4e02: 20 c5 06     .. :0627[3]
+    tay                                                               // 4e05: a8          .   :062a[3]
+// $4e06 referenced 1 time by $062e
+loop_c062b
+    bit tube_host_r2_status                                           // 4e06: 2c e2 fe    ,.. :062b[3]
+    bpl loop_c062b                                                    // 4e09: 10 fb       ..  :062e[3]
+    ldx tube_host_r2_data                                             // 4e0b: ae e3 fe    ... :0630[3]
+    dex                                                               // 4e0e: ca          .   :0633[3]
+    bmi c0645                                                         // 4e0f: 30 0f       0.  :0634[3]
+// $4e11 referenced 2 times by $0639, $0642
+c0636
+    bit tube_host_r2_status                                           // 4e11: 2c e2 fe    ,.. :0636[3]
+    bpl c0636                                                         // 4e14: 10 fb       ..  :0639[3]
+    lda tube_host_r2_data                                             // 4e16: ad e3 fe    ... :063b[3]
+    sta l0128,x                                                       // 4e19: 9d 28 01    .(. :063e[3]
+    dex                                                               // 4e1c: ca          .   :0641[3]
+    bpl c0636                                                         // 4e1d: 10 f2       ..  :0642[3]
+    tya                                                               // 4e1f: 98          .   :0644[3]
+// $4e20 referenced 1 time by $0634
+c0645
+    ldx #<(l0128)                                                     // 4e20: a2 28       .(  :0645[3]
+    ldy #>(l0128)                                                     // 4e22: a0 01       ..  :0647[3]
+    jsr osword                                                        // 4e24: 20 f1 ff     .. :0649[3]
+// $4e27 referenced 1 time by $064f
+loop_c064c
+    bit tube_host_r2_status                                           // 4e27: 2c e2 fe    ,.. :064c[3]
+    bpl loop_c064c                                                    // 4e2a: 10 fb       ..  :064f[3]
+    ldx tube_host_r2_data                                             // 4e2c: ae e3 fe    ... :0651[3]
+    dex                                                               // 4e2f: ca          .   :0654[3]
+    bmi c0665                                                         // 4e30: 30 0e       0.  :0655[3]
+// $4e32 referenced 1 time by $0663
+loop_c0657
+    ldy l0128,x                                                       // 4e32: bc 28 01    .(. :0657[3]
+// $4e35 referenced 1 time by $065d
+loop_c065a
+    bit tube_host_r2_status                                           // 4e35: 2c e2 fe    ,.. :065a[3]
+    bvc loop_c065a                                                    // 4e38: 50 fb       P.  :065d[3]
+    sty tube_host_r2_data                                             // 4e3a: 8c e3 fe    ... :065f[3]
+    dex                                                               // 4e3d: ca          .   :0662[3]
+    bpl loop_c0657                                                    // 4e3e: 10 f2       ..  :0663[3]
+// $4e40 referenced 1 time by $0655
+c0665
+    jmp c0036                                                         // 4e40: 4c 36 00    L6. :0665[3]
+
+tube_host_osword_0
+    ldx #4                                                            // 4e43: a2 04       ..  :0668[3]
+// $4e45 referenced 1 time by $0670
+tube_host_osword_0_loop
+    jsr read_tube_r2_data                                             // 4e45: 20 c5 06     .. :066a[3]
+    sta l0000,x                                                       // 4e48: 95 00       ..  :066d[3]
+    dex                                                               // 4e4a: ca          .   :066f[3]
+    bpl tube_host_osword_0_loop                                       // 4e4b: 10 f8       ..  :0670[3]
+    inx                                                               // 4e4d: e8          .   :0672[3]
+    ldy #0                                                            // 4e4e: a0 00       ..  :0673[3]
+    txa                                                               // 4e50: 8a          .   :0675[3]
+    jsr osword                                                        // 4e51: 20 f1 ff     .. :0676[3]
+    bcc tube_host_osword_0_no_escape                                  // 4e54: 90 05       ..  :0679[3]
+    lda #$ff                                                          // 4e56: a9 ff       ..  :067b[3]
+    jmp c059e                                                         // 4e58: 4c 9e 05    L.. :067d[3]
+
+// $4e5b referenced 1 time by $0679
+tube_host_osword_0_no_escape
+    ldx #0                                                            // 4e5b: a2 00       ..  :0680[3]
+    lda #$7f                                                          // 4e5d: a9 7f       ..  :0682[3]
+    jsr write_tube_r2_data                                            // 4e5f: 20 95 06     .. :0684[3]
+// $4e62 referenced 1 time by $0690
+tube_host_osword_0_no_escape_loop
+    lda l0700,x                                                       // 4e62: bd 00 07    ... :0687[3]
+    jsr write_tube_r2_data                                            // 4e65: 20 95 06     .. :068a[3]
+    inx                                                               // 4e68: e8          .   :068d[3]
+    cmp #$0d                                                          // 4e69: c9 0d       ..  :068e[3]
+    bne tube_host_osword_0_no_escape_loop                             // 4e6b: d0 f5       ..  :0690[3]
+    jmp c0036                                                         // 4e6d: 4c 36 00    L6. :0692[3]
+
+// Wait for register 2 to have space and write A to it.
+// $4e70 referenced 14 times by $0020, $0026, $002c, $0474, $053b, $0572, $0579, $05c2, $05c9, $05e8, $061a, $0684, $068a, $0698
+write_tube_r2_data
+    bit tube_host_r2_status                                           // 4e70: 2c e2 fe    ,.. :0695[3]
+    bvc write_tube_r2_data                                            // 4e73: 50 fb       P.  :0698[3]
+    sta tube_host_r2_data                                             // 4e75: 8d e3 fe    ... :069a[3]
+    rts                                                               // 4e78: 60          `   :069d[3]
+
+// Wait for register 4 to have space and write A to it.
+// $4e79 referenced 8 times by $0018, $0418, $041d, $043b, $0443, $0448, $0463, $06a1
+write_tube_r4_data
+    bit tube_host_r4_status                                           // 4e79: 2c e6 fe    ,.. :069e[3]
+    bvc write_tube_r4_data                                            // 4e7c: 50 fb       P.  :06a1[3]
+    sta tube_host_r4_data                                             // 4e7e: 8d e7 fe    ... :06a3[3]
+    rts                                                               // 4e81: 60          `   :06a6[3]
+
+// $4e82 referenced 1 time by $0403
+c06a7
+    lda l00ff                                                         // 4e82: a5 ff       ..  :06a7[3]
+    sec                                                               // 4e84: 38          8   :06a9[3]
+    ror                                                               // 4e85: 6a          j   :06aa[3]
+    bmi write_tube_r1_data                                            // 4e86: 30 0f       0.  :06ab[3]
+tube_evntv_handler
+    pha                                                               // 4e88: 48          H   :06ad[3]
+    lda #0                                                            // 4e89: a9 00       ..  :06ae[3]
+    jsr write_tube_r1_data                                            // 4e8b: 20 bc 06     .. :06b0[3]
+    tya                                                               // 4e8e: 98          .   :06b3[3]
+    jsr write_tube_r1_data                                            // 4e8f: 20 bc 06     .. :06b4[3]
+    txa                                                               // 4e92: 8a          .   :06b7[3]
+    jsr write_tube_r1_data                                            // 4e93: 20 bc 06     .. :06b8[3]
+    pla                                                               // 4e96: 68          h   :06bb[3]
+// Wait for register 1 to have space and write A to it.
+// $4e97 referenced 5 times by $06ab, $06b0, $06b4, $06b8, $06bf
+write_tube_r1_data
+    bit tube_host_r1_status                                           // 4e97: 2c e0 fe    ,.. :06bc[3]
+    bvc write_tube_r1_data                                            // 4e9a: 50 fb       P.  :06bf[3]
+    sta tube_host_r1_data                                             // 4e9c: 8d e1 fe    ... :06c1[3]
+    rts                                                               // 4e9f: 60          `   :06c4[3]
+
+// Wait for register 2 to have data and read A from it.
+// $4ea0 referenced 21 times by $0520, $0524, $052d, $0542, $0552, $055e, $0564, $056c, $0586, $05ab, $05bc, $05d3, $05db, $05f2, $05f6, $0607, $060b, $060f, $0627, $066a, $06c8
+read_tube_r2_data
+    bit tube_host_r2_status                                           // 4ea0: 2c e2 fe    ,.. :06c5[3]
+    bpl read_tube_r2_data                                             // 4ea3: 10 fb       ..  :06c8[3]
+    lda tube_host_r2_data                                             // 4ea5: ad e3 fe    ... :06ca[3]
+    rts                                                               // 4ea8: 60          `   :06cd[3]
+
+// $4ea9 referenced 1 time by $965d
+* = $4ea9
+// $4ea9 referenced 1 time by $965d
+// $4ea9 referenced 1 time by $965d
+* = $aea9
+// $4ea9 referenced 1 time by $965d
+service_handler_help_and_tube
+    cmp #service_help                                                 // 4ea9: c9 09       ..  :aea9[1]
+    bne caed7                                                         // 4eab: d0 2a       .*  :aeab[1]
+    tya                                                               // 4ead: 98          .   :aead[1]
+    pha                                                               // 4eae: 48          H   :aeae[1]
+    lda (os_text_ptr),y                                               // 4eaf: b1 f2       ..  :aeaf[1]
+    cmp #$0d                                                          // 4eb1: c9 0d       ..  :aeb1[1]
+    bne caed3                                                         // 4eb3: d0 1e       ..  :aeb3[1]
+    lda #$e9                                                          // 4eb5: a9 e9       ..  :aeb5[1]
+    jsr osbyte_read                                                   // 4eb7: 20 e5 9a     .. :aeb7[1]
+    ldx romsel_copy                                                   // 4eba: a6 f4       ..  :aeba[1]
+    tya                                                               // 4ebc: 98          .   :aebc[1]
+    beq caed3                                                         // 4ebd: f0 14       ..  :aebd[1]
+    jsr print_inline_l809f_top_bit_clear                              // 4ebf: 20 77 80     w. :aebf[1]
+    .asc $0d, "TUBE HOST 2.30", $0d                                   // 4ec2: 0d 54 55... .TU :aec2[1]
+
+    nop                                                               // 4ed2: ea          .   :aed2[1]
+// $4ed3 referenced 2 times by $aeb3, $aebd
+caed3
+    pla                                                               // 4ed3: 68          h   :aed3[1]
+    tay                                                               // 4ed4: a8          .   :aed4[1]
+    lda #9                                                            // 4ed5: a9 09       ..  :aed5[1]
+// $4ed7 referenced 1 time by $aeab
+caed7
+    cmp #service_tube_post_init                                       // 4ed7: c9 fe       ..  :aed7[1]
+    bcc just_rts                                                      // 4ed9: 90 5c       .\  :aed9[1]
+    bne service_handler_tube_main_init                                // 4edb: d0 1b       ..  :aedb[1]
+    cpy #0                                                            // 4edd: c0 00       ..  :aedd[1]
+    beq just_rts                                                      // 4edf: f0 56       .V  :aedf[1]
+    ldx #6                                                            // 4ee1: a2 06       ..  :aee1[1]
+    lda #osbyte_explode_chars                                         // 4ee3: a9 14       ..  :aee3[1]
+    jsr osbyte                                                        // 4ee5: 20 f4 ff     .. :aee5[1]
+// $4ee8 referenced 2 times by $aeeb, $aef5
+tube_banner_loop
+    bit tube_host_r1_status                                           // 4ee8: 2c e0 fe    ,.. :aee8[1]
+    bpl tube_banner_loop                                              // 4eeb: 10 fb       ..  :aeeb[1]
+    lda tube_host_r1_data                                             // 4eed: ad e1 fe    ... :aeed[1]
+    beq lda_0_rts                                                     // 4ef0: f0 43       .C  :aef0[1]
+    jsr oswrch                                                        // 4ef2: 20 ee ff     .. :aef2[1]
+    jmp tube_banner_loop                                              // 4ef5: 4c e8 ae    L.. :aef5[1]
+
+// $4ef8 referenced 1 time by $aedb
+service_handler_tube_main_init
+    lda #<tube_evntv_handler                                          // 4ef8: a9 ad       ..  :aef8[1]
+    sta evntv                                                         // 4efa: 8d 20 02    . . :aefa[1]
+    lda #>tube_evntv_handler                                          // 4efd: a9 06       ..  :aefd[1]
+    sta evntv+1                                                       // 4eff: 8d 21 02    .!. :aeff[1]
+    lda #<tube_brkv_handler                                           // 4f02: a9 16       ..  :af02[1]
+    sta brkv                                                          // 4f04: 8d 02 02    ... :af04[1]
+    lda #>tube_brkv_handler                                           // 4f07: a9 00       ..  :af07[1]
+    sta brkv+1                                                        // 4f09: 8d 03 02    ... :af09[1]
+    lda #$8e                                                          // 4f0c: a9 8e       ..  :af0c[1]
+    sta tube_host_r1_status                                           // 4f0e: 8d e0 fe    ... :af0e[1]
+    ldy #0                                                            // 4f11: a0 00       ..  :af11[1]
+// $4f13 referenced 1 time by $af26
+loop_caf13
+    lda tube_host_code1,y                                             // 4f13: b9 79 af    .y. :af13[1]
+    sta c0400,y                                                       // 4f16: 99 00 04    ... :af16[1]
+    lda tube_host_code2,y                                             // 4f19: b9 db ac    ... :af19[1]
+    sta l0500,y                                                       // 4f1c: 99 00 05    ... :af1c[1]
+    lda tube_host_code2+256,y                                         // 4f1f: b9 db ad    ... :af1f[1]
+    sta l0600,y                                                       // 4f22: 99 00 06    ... :af22[1]
+    dey                                                               // 4f25: 88          .   :af25[1]
+    bne loop_caf13                                                    // 4f26: d0 eb       ..  :af26[1]
+    jsr sub_c0421                                                     // 4f28: 20 21 04     !. :af28[1]
+    ldx #$41 // 'A'                                                   // 4f2b: a2 41       .A  :af2b[1]
+// $4f2d referenced 1 time by $af33
+loop_caf2d
+    lda tube_host_code3,x                                             // 4f2d: bd 38 af    .8. :af2d[1]
+    sta tube_brkv_handler_fwd,x                                       // 4f30: 95 16       ..  :af30[1]
+    dex                                                               // 4f32: ca          .   :af32[1]
+    bpl loop_caf2d                                                    // 4f33: 10 f8       ..  :af33[1]
+// $4f35 referenced 1 time by $aef0
+lda_0_rts
+    lda #0                                                            // 4f35: a9 00       ..  :af35[1]
+// $4f37 referenced 2 times by $aed9, $aedf
+just_rts
+    rts                                                               // 4f37: 60          `   :af37[1]
+
+// $4f38 referenced 1 time by $af30
+tube_host_code3
+* = $4f38
+// $4f38 referenced 1 time by $af30
+// $4f38 referenced 1 time by $af30
+* = $16
+// $4f38 referenced 1 time by $af30
+tube_brkv_handler
+    lda #$ff                                                          // 4f38: a9 ff       ..  :0016[4]
+    jsr write_tube_r4_data                                            // 4f3a: 20 9e 06     .. :0018[4]
+    lda tube_host_r2_data                                             // 4f3d: ad e3 fe    ... :001b[4]
+    lda #0                                                            // 4f40: a9 00       ..  :001e[4]
+    jsr write_tube_r2_data                                            // 4f42: 20 95 06     .. :0020[4]
+    tay                                                               // 4f45: a8          .   :0023[4]
+    lda (l00fd),y                                                     // 4f46: b1 fd       ..  :0024[4]
+    jsr write_tube_r2_data                                            // 4f48: 20 95 06     .. :0026[4]
+// $4f4b referenced 1 time by $0030
+loop_c0029
+    iny                                                               // 4f4b: c8          .   :0029[4]
+    lda (l00fd),y                                                     // 4f4c: b1 fd       ..  :002a[4]
+    jsr write_tube_r2_data                                            // 4f4e: 20 95 06     .. :002c[4]
+    tax                                                               // 4f51: aa          .   :002f[4]
+    bne loop_c0029                                                    // 4f52: d0 f7       ..  :0030[4]
+// $4f54 referenced 1 time by $0477
+c0032
+    ldx #$ff                                                          // 4f54: a2 ff       ..  :0032[4]
+    txs                                                               // 4f56: 9a          .   :0034[4]
+    cli                                                               // 4f57: 58          X   :0035[4]
+// $4f58 referenced 6 times by $0044, $057f, $05a6, $0604, $0665, $0692
+c0036
+    bit tube_host_r1_status                                           // 4f58: 2c e0 fe    ,.. :0036[4]
+    bpl c0041                                                         // 4f5b: 10 06       ..  :0039[4]
+// $4f5d referenced 1 time by $0049
+loop_c003b
+    lda tube_host_r1_data                                             // 4f5d: ad e1 fe    ... :003b[4]
+    jsr oswrch                                                        // 4f60: 20 ee ff     .. :003e[4]
+// $4f63 referenced 1 time by $0039
+c0041
+    bit tube_host_r2_status                                           // 4f63: 2c e2 fe    ,.. :0041[4]
+    bpl c0036                                                         // 4f66: 10 f0       ..  :0044[4]
+    bit tube_host_r1_status                                           // 4f68: 2c e0 fe    ,.. :0046[4]
+    bmi loop_c003b                                                    // 4f6b: 30 f0       0.  :0049[4]
+    ldx tube_host_r2_data                                             // 4f6d: ae e3 fe    ... :004b[4]
+// Patch the following JMP so we effectively do JMP (&500,X)
+    stx `jump_address_low                                             // 4f70: 86 51       .Q  :004e[4]
+sub_c0050
+jump_address_low = sub_c0050+1
+    jmp (l0500)                                                       // 4f72: 6c 00 05    l.. :0050[4]
+
+// $4f73 referenced 1 time by $004e
+// $4f75 referenced 2 times by $04da, $04ea
+l0053
+    .byt 0                                                            // 4f75: 00          .   :0053[4]
+// $4f76 referenced 3 times by $04b2, $04d0, $04ef
+l0054
+    .byt $80                                                          // 4f76: 80          .   :0054[4]
+// $4f77 referenced 2 times by $04b6, $04f9
+l0055
+    .byt 0                                                            // 4f77: 00          .   :0055[4]
+// $4f78 referenced 2 times by $04ba, $04f7
+l0056
+    .byt 0                                                            // 4f78: 00          .   :0056[4]
+// $4f79 referenced 1 time by $af16
+* = $4f79
+// $4f79 referenced 1 time by $af16
+// $4f79 referenced 1 time by $af16
+* = $0400
+// $4f79 referenced 1 time by $af16
+c0400
+    jmp c0484                                                         // 4f79: 4c 84 04    L.. :0400[2]
+
+    jmp c06a7                                                         // 4f7c: 4c a7 06    L.. :0403[2]
+
+// $4f7f referenced 14 times by $0493, $04cb, $892a, $8cae, $8f6e, $8f7d, $9346, $982b, $bd64, $bd91, $be09, $be2c, $be7d, $be85
+tube_entry
+    cmp #$80                                                          // 4f7f: c9 80       ..  :0406[2]
+    bcc tube_entry_small_a                                            // 4f81: 90 2b       .+  :0408[2]
+    cmp #$c0                                                          // 4f83: c9 c0       ..  :040a[2]
+    bcs tube_entry_claim_tube                                         // 4f85: b0 1a       ..  :040c[2]
+// This is a call to release the tube.
+    ora #$40 // '@'                                                   // 4f87: 09 40       .@  :040e[2]
+    cmp l0015                                                         // 4f89: c5 15       ..  :0410[2]
+    bne c0434                                                         // 4f8b: d0 20       .   :0412[2]
+// $4f8d referenced 1 time by $0471
+sub_c0414
+    php                                                               // 4f8d: 08          .   :0414[2]
+    sei                                                               // 4f8e: 78          x   :0415[2]
+    lda #5                                                            // 4f8f: a9 05       ..  :0416[2]
+    jsr write_tube_r4_data                                            // 4f91: 20 9e 06     .. :0418[2]
+    lda l0015                                                         // 4f94: a5 15       ..  :041b[2]
+    jsr write_tube_r4_data                                            // 4f96: 20 9e 06     .. :041d[2]
+    plp                                                               // 4f99: 28          (   :0420[2]
+// $4f9a referenced 1 time by $af28
+sub_c0421
+    lda #$80                                                          // 4f9a: a9 80       ..  :0421[2]
+    sta l0015                                                         // 4f9c: 85 15       ..  :0423[2]
+    sta l0014                                                         // 4f9e: 85 14       ..  :0425[2]
+    rts                                                               // 4fa0: 60          `   :0427[2]
+
+// $4fa1 referenced 1 time by $040c
+tube_entry_claim_tube
+    asl l0014                                                         // 4fa1: 06 14       ..  :0428[2]
+    bcs c0432                                                         // 4fa3: b0 06       ..  :042a[2]
+    cmp l0015                                                         // 4fa5: c5 15       ..  :042c[2]
+    beq c0434                                                         // 4fa7: f0 04       ..  :042e[2]
+    clc                                                               // 4fa9: 18          .   :0430[2]
+    rts                                                               // 4faa: 60          `   :0431[2]
+
+// $4fab referenced 1 time by $042a
+c0432
+    sta l0015                                                         // 4fab: 85 15       ..  :0432[2]
+// $4fad referenced 2 times by $0412, $042e
+c0434
+    rts                                                               // 4fad: 60          `   :0434[2]
+
+// $4fae referenced 1 time by $0408
+tube_entry_small_a
+    php                                                               // 4fae: 08          .   :0435[2]
+    sei                                                               // 4faf: 78          x   :0436[2]
+    sty l0013                                                         // 4fb0: 84 13       ..  :0437[2]
+    stx l0012                                                         // 4fb2: 86 12       ..  :0439[2]
+    jsr write_tube_r4_data                                            // 4fb4: 20 9e 06     .. :043b[2]
+    tax                                                               // 4fb7: aa          .   :043e[2]
+    ldy #3                                                            // 4fb8: a0 03       ..  :043f[2]
+    lda l0015                                                         // 4fba: a5 15       ..  :0441[2]
+    jsr write_tube_r4_data                                            // 4fbc: 20 9e 06     .. :0443[2]
+// $4fbf referenced 1 time by $044c
+loop_c0446
+    lda (l0012),y                                                     // 4fbf: b1 12       ..  :0446[2]
+    jsr write_tube_r4_data                                            // 4fc1: 20 9e 06     .. :0448[2]
+    dey                                                               // 4fc4: 88          .   :044b[2]
+    bpl loop_c0446                                                    // 4fc5: 10 f8       ..  :044c[2]
+    ldy #$18                                                          // 4fc7: a0 18       ..  :044e[2]
+    sty tube_host_r1_status                                           // 4fc9: 8c e0 fe    ... :0450[2]
+    lda tube_entry_flags,x                                            // 4fcc: bd 18 05    ... :0453[2]
+    sta tube_host_r1_status                                           // 4fcf: 8d e0 fe    ... :0456[2]
+    lsr                                                               // 4fd2: 4a          J   :0459[2]
+    lsr                                                               // 4fd3: 4a          J   :045a[2]
+    bcc c0463                                                         // 4fd4: 90 06       ..  :045b[2]
+    bit tube_host_r3_data                                             // 4fd6: 2c e5 fe    ,.. :045d[2]
+    bit tube_host_r3_data                                             // 4fd9: 2c e5 fe    ,.. :0460[2]
+// $4fdc referenced 1 time by $045b
+c0463
+    jsr write_tube_r4_data                                            // 4fdc: 20 9e 06     .. :0463[2]
+// $4fdf referenced 1 time by $0469
+loop_c0466
+    bit tube_host_r4_status                                           // 4fdf: 2c e6 fe    ,.. :0466[2]
+    bvc loop_c0466                                                    // 4fe2: 50 fb       P.  :0469[2]
+    bcs c047a                                                         // 4fe4: b0 0d       ..  :046b[2]
+    cpx #4                                                            // 4fe6: e0 04       ..  :046d[2]
+    bne c0482                                                         // 4fe8: d0 11       ..  :046f[2]
+// $4fea referenced 1 time by $048f
+loop_c0471
+    jsr sub_c0414                                                     // 4fea: 20 14 04     .. :0471[2]
+    jsr write_tube_r2_data                                            // 4fed: 20 95 06     .. :0474[2]
+    jmp c0032                                                         // 4ff0: 4c 32 00    L2. :0477[2]
+
+// $4ff3 referenced 1 time by $046b
+c047a
+    lsr                                                               // 4ff3: 4a          J   :047a[2]
+    bcc c0482                                                         // 4ff4: 90 05       ..  :047b[2]
+    ldy #$88                                                          // 4ff6: a0 88       ..  :047d[2]
+    sty tube_host_r1_status                                           // 4ff8: 8c e0 fe    ... :047f[2]
+// $4ffb referenced 2 times by $046f, $047b
+c0482
+    plp                                                               // 4ffb: 28          (   :0482[2]
+    rts                                                               // 4ffc: 60          `   :0483[2]
+
+// $4ffd referenced 1 time by $0400
+c0484
+    cli                                                               // 4ffd: 58          X   :0484[2]
+    bcs c0491                                                         // 4ffe: b0 0a       ..  :0485[2]
+    bne c048c                                                         // 5000: d0 03       ..  :0487[2]
+    jmp c059c                                                         // 5002: 4c 9c 05    L.. :0489[2]
+
+// $5005 referenced 1 time by $0487
+c048c
+    ldx l028d                                                         // 5005: ae 8d 02    ... :048c[2]
+    beq loop_c0471                                                    // 5008: f0 e0       ..  :048f[2]
+// $500a referenced 2 times by $0485, $0496
+c0491
+    lda #$ff                                                          // 500a: a9 ff       ..  :0491[2]
+    jsr tube_entry                                                    // 500c: 20 06 04     .. :0493[2]
+    bcc c0491                                                         // 500f: 90 f9       ..  :0496[2]
+    jsr sub_c04ce                                                     // 5011: 20 ce 04     .. :0498[2]
+// $5014 referenced 1 time by $04c0
+c049b
+    php                                                               // 5014: 08          .   :049b[2]
+    sei                                                               // 5015: 78          x   :049c[2]
+    lda #7                                                            // 5016: a9 07       ..  :049d[2]
+    jsr sub_c04c7                                                     // 5018: 20 c7 04     .. :049f[2]
+    ldy #0                                                            // 501b: a0 00       ..  :04a2[2]
+    sty l0000                                                         // 501d: 84 00       ..  :04a4[2]
+// $501f referenced 1 time by $04af
+loop_c04a6
+    lda (l0000),y                                                     // 501f: b1 00       ..  :04a6[2]
+    sta tube_host_r3_data                                             // 5021: 8d e5 fe    ... :04a8[2]
+    nop                                                               // 5024: ea          .   :04ab[2]
+    nop                                                               // 5025: ea          .   :04ac[2]
+    nop                                                               // 5026: ea          .   :04ad[2]
+    iny                                                               // 5027: c8          .   :04ae[2]
+    bne loop_c04a6                                                    // 5028: d0 f5       ..  :04af[2]
+    plp                                                               // 502a: 28          (   :04b1[2]
+    inc l0054                                                         // 502b: e6 54       .T  :04b2[2]
+    bne c04bc                                                         // 502d: d0 06       ..  :04b4[2]
+    inc l0055                                                         // 502f: e6 55       .U  :04b6[2]
+    bne c04bc                                                         // 5031: d0 02       ..  :04b8[2]
+    inc l0056                                                         // 5033: e6 56       .V  :04ba[2]
+// $5035 referenced 2 times by $04b4, $04b8
+c04bc
+    inc l0001                                                         // 5035: e6 01       ..  :04bc[2]
+    bit l0001                                                         // 5037: 24 01       $.  :04be[2]
+    bvc c049b                                                         // 5039: 50 d9       P.  :04c0[2]
+    jsr sub_c04ce                                                     // 503b: 20 ce 04     .. :04c2[2]
+    lda #4                                                            // 503e: a9 04       ..  :04c5[2]
+// $5040 referenced 1 time by $049f
+sub_c04c7
+    ldy #0                                                            // 5040: a0 00       ..  :04c7[2]
+    ldx #$53 // 'S'                                                   // 5042: a2 53       .S  :04c9[2]
+    jmp tube_entry                                                    // 5044: 4c 06 04    L.. :04cb[2]
+
+// $5047 referenced 2 times by $0498, $04c2
+sub_c04ce
+    lda #$80                                                          // 5047: a9 80       ..  :04ce[2]
+    sta l0054                                                         // 5049: 85 54       .T  :04d0[2]
+    sta l0001                                                         // 504b: 85 01       ..  :04d2[2]
+    lda #$20 // ' '                                                   // 504d: a9 20       .   :04d4[2]
+    and rom_type                                                      // 504f: 2d 06 80    -.. :04d6[2]
+    tay                                                               // 5052: a8          .   :04d9[2]
+    sty l0053                                                         // 5053: 84 53       .S  :04da[2]
+    beq c04f7                                                         // 5055: f0 19       ..  :04dc[2]
+    ldx copyright_offset                                              // 5057: ae 07 80    ... :04de[2]
+// $505a referenced 1 time by $04e5
+loop_c04e1
+    inx                                                               // 505a: e8          .   :04e1[2]
+    lda rom_header,x                                                  // 505b: bd 00 80    ... :04e2[2]
+    bne loop_c04e1                                                    // 505e: d0 fa       ..  :04e5[2]
+    lda l8001,x                                                       // 5060: bd 01 80    ... :04e7[2]
+    sta l0053                                                         // 5063: 85 53       .S  :04ea[2]
+    lda l8002,x                                                       // 5065: bd 02 80    ... :04ec[2]
+    sta l0054                                                         // 5068: 85 54       .T  :04ef[2]
+    ldy service_entry,x                                               // 506a: bc 03 80    ... :04f1[2]
+    lda l8004,x                                                       // 506d: bd 04 80    ... :04f4[2]
+// $5070 referenced 1 time by $04dc
+c04f7
+    sta l0056                                                         // 5070: 85 56       .V  :04f7[2]
+    sty l0055                                                         // 5072: 84 55       .U  :04f9[2]
+    rts                                                               // 5074: 60          `   :04fb[2]
+
+// $5075 referenced 1 time by $b2b4
+* = $5075
+// $5075 referenced 1 time by $b2b4
+// $5075 referenced 1 time by $b2b4
+* = $b075
+// $5075 referenced 1 time by $b2b4
+lb075
+    .byt $0a                                                          // 5075: 0a          .   :b075[1]
+    .asc "SRAM 1.05"                                                  // 5076: 53 52 41... SRA :b076[1]
+    .byt $0d, $0a                                                     // 507f: 0d 0a       ..  :b07f[1]
+    .asc "  SRDATA  <id.>"                                            // 5081: 20 20 53...   S :b081[1]
+    .byt $0d, $0a                                                     // 5090: 0d 0a       ..  :b090[1]
+    .asc "  SRLOAD  <filename> <sram address> (<id.>) (Q)"            // 5092: 20 20 53...   S :b092[1]
+    .byt $0d, $0a                                                     // 50c1: 0d 0a       ..  :b0c1[1]
+    .asc "  SRREAD  <dest. start> <dest. end> <sram start> (<id.>)"   // 50c3: 20 20 53...   S :b0c3[1]
+    .byt $0d, $0a                                                     // 50fb: 0d 0a       ..  :b0fb[1]
+    .asc "  SRROM   <id.>"                                            // 50fd: 20 20 53...   S :b0fd[1]
+    .byt $0d, $0a                                                     // 510c: 0d 0a       ..  :b10c[1]
+    .asc "  SRSAVE  <filename> <sram start> <sram end> (<id.>) (Q)"   // 510e: 20 20 53...   S :b10e[1]
+    .byt $0d, $0a                                                     // 5146: 0d 0a       ..  :b146[1]
+    .asc "  SRWRITE <source start> <source end> <sram s"              // 5148: 20 20 53...   S :b148[1]
+// $5175 referenced 1 time by $b2bd
+lb175
+    .asc "tart> (<id.>)"                                              // 5175: 74 61 72... tar :b175[1]
+    .byt $0d, $0a                                                     // 5182: 0d 0a       ..  :b182[1]
+    .asc "End addresses may be replaced by +<length>"                 // 5184: 45 6e 64... End :b184[1]
+    .byt $0d, $0a,   0                                                // 51ae: 0d 0a 00    ... :b1ae[1]
+
+// $51b1 referenced 1 time by $bedd
+general_service_handler
+    jsr sub_c965d                                                     // 51b1: 20 5d 96     ]. :b1b1[1]
+    pha                                                               // 51b4: 48          H   :b1b4[1]
+    tax                                                               // 51b5: aa          .   :b1b5[1]
+    lda l00b8                                                         // 51b6: a5 b8       ..  :b1b6[1]
+    pha                                                               // 51b8: 48          H   :b1b8[1]
+    lda l00b9                                                         // 51b9: a5 b9       ..  :b1b9[1]
+    pha                                                               // 51bb: 48          H   :b1bb[1]
+    tya                                                               // 51bc: 98          .   :b1bc[1]
+    pha                                                               // 51bd: 48          H   :b1bd[1]
+    txa                                                               // 51be: 8a          .   :b1be[1]
+    ldx romsel_copy                                                   // 51bf: a6 f4       ..  :b1bf[1]
+    jsr cb82b                                                         // 51c1: 20 2b b8     +. :b1c1[1]
+    bit l00b9                                                         // 51c4: 24 b9       $.  :b1c4[1]
+    bmi cb203                                                         // 51c6: 30 3b       0;  :b1c6[1]
+    cmp #8                                                            // 51c8: c9 08       ..  :b1c8[1]
+    bne cb1fc                                                         // 51ca: d0 30       .0  :b1ca[1]
+    lda l00ef                                                         // 51cc: a5 ef       ..  :b1cc[1]
+    cmp #$43 // 'C'                                                   // 51ce: c9 43       .C  :b1ce[1]
+    bne cb1dd                                                         // 51d0: d0 0b       ..  :b1d0[1]
+    jsr sub_cb2c8                                                     // 51d2: 20 c8 b2     .. :b1d2[1]
+// $51d5 referenced 3 times by $b1f9, $b231, $b25d
+cb1d5
+    tsx                                                               // 51d5: ba          .   :b1d5[1]
+    lda #0                                                            // 51d6: a9 00       ..  :b1d6[1]
+    sta l0104,x                                                       // 51d8: 9d 04 01    ... :b1d8[1]
+    beq cb203                                                         // 51db: f0 26       .&  :b1db[1]
+// $51dd referenced 1 time by $b1d0
+cb1dd
+    cmp #$42 // 'B'                                                   // 51dd: c9 42       .B  :b1dd[1]
+    bne cb203                                                         // 51df: d0 22       ."  :b1df[1]
+    ldy #9                                                            // 51e1: a0 09       ..  :b1e1[1]
+// $51e3 referenced 1 time by $b1eb
+loop_cb1e3
+    lda (l00f0),y                                                     // 51e3: b1 f0       ..  :b1e3[1]
+    sta l00b4,y                                                       // 51e5: 99 b4 00    ... :b1e5[1]
+    dey                                                               // 51e8: 88          .   :b1e8[1]
+    cpy #8                                                            // 51e9: c0 08       ..  :b1e9[1]
+    bcs loop_cb1e3                                                    // 51eb: b0 f6       ..  :b1eb[1]
+// $51ed referenced 1 time by $b1f3
+loop_cb1ed
+    lda (l00f0),y                                                     // 51ed: b1 f0       ..  :b1ed[1]
+    sta l00b0,y                                                       // 51ef: 99 b0 00    ... :b1ef[1]
+    dey                                                               // 51f2: 88          .   :b1f2[1]
+    bpl loop_cb1ed                                                    // 51f3: 10 f8       ..  :b1f3[1]
+    cli                                                               // 51f5: 58          X   :b1f5[1]
+    jsr cbcb9                                                         // 51f6: 20 b9 bc     .. :b1f6[1]
+    jmp cb1d5                                                         // 51f9: 4c d5 b1    L.. :b1f9[1]
+
+// $51fc referenced 1 time by $b1ca
+cb1fc
+    cmp #2                                                            // 51fc: c9 02       ..  :b1fc[1]
+    bne cb20f                                                         // 51fe: d0 0f       ..  :b1fe[1]
+    jsr sub_cb882                                                     // 5200: 20 82 b8     .. :b200[1]
+// $5203 referenced 10 times by $b1c6, $b1db, $b1df, $b219, $b21e, $b228, $b22c, $b262, $b26a, $b280
+cb203
+    pla                                                               // 5203: 68          h   :b203[1]
+    tay                                                               // 5204: a8          .   :b204[1]
+    pla                                                               // 5205: 68          h   :b205[1]
+    sta l00b9                                                         // 5206: 85 b9       ..  :b206[1]
+    pla                                                               // 5208: 68          h   :b208[1]
+    sta l00b8                                                         // 5209: 85 b8       ..  :b209[1]
+    pla                                                               // 520b: 68          h   :b20b[1]
+    ldx romsel_copy                                                   // 520c: a6 f4       ..  :b20c[1]
+    rts                                                               // 520e: 60          `   :b20e[1]
+
+// $520f referenced 1 time by $b1fe
+cb20f
+    cmp #6                                                            // 520f: c9 06       ..  :b20f[1]
+    bne cb221                                                         // 5211: d0 0e       ..  :b211[1]
+    ldy #$ff                                                          // 5213: a0 ff       ..  :b213[1]
+    lda (l00b8),y                                                     // 5215: b1 b8       ..  :b215[1]
+    cmp #$4e // 'N'                                                   // 5217: c9 4e       .N  :b217[1]
+    bne cb203                                                         // 5219: d0 e8       ..  :b219[1]
+    jsr sub_cb5f2                                                     // 521b: 20 f2 b5     .. :b21b[1]
+    jmp cb203                                                         // 521e: 4c 03 b2    L.. :b21e[1]
+
+// $5221 referenced 1 time by $b211
+cb221
+    cmp #4                                                            // 5221: c9 04       ..  :b221[1]
+    bne cb23d                                                         // 5223: d0 18       ..  :b223[1]
+    jsr sub_cb9f5                                                     // 5225: 20 f5 b9     .. :b225[1]
+    bcs cb203                                                         // 5228: b0 d9       ..  :b228[1]
+    cpx #4                                                            // 522a: e0 04       ..  :b22a[1]
+    beq cb203                                                         // 522c: f0 d5       ..  :b22c[1]
+    jsr sub_cb234                                                     // 522e: 20 34 b2     4. :b22e[1]
+    jmp cb1d5                                                         // 5231: 4c d5 b1    L.. :b231[1]
+
+// $5234 referenced 1 time by $b22e
+sub_cb234
+    lda sram_table,x                                                  // 5234: bd 30 ba    .0. :b234[1]
+    pha                                                               // 5237: 48          H   :b237[1]
+    lda sram_table+1,x                                                // 5238: bd 31 ba    .1. :b238[1]
+    pha                                                               // 523b: 48          H   :b23b[1]
+    rts                                                               // 523c: 60          `   :b23c[1]
+
+// $523d referenced 1 time by $b223
+cb23d
+    cmp #7                                                            // 523d: c9 07       ..  :b23d[1]
+    bne cb268                                                         // 523f: d0 27       .'  :b23f[1]
+    lda l00ef                                                         // 5241: a5 ef       ..  :b241[1]
+    cmp #$44 // 'D'                                                   // 5243: c9 44       .D  :b243[1]
+    bne cb260                                                         // 5245: d0 19       ..  :b245[1]
+    ldy #$ee                                                          // 5247: a0 ee       ..  :b247[1]
+// $5249 referenced 1 time by $b266
+loop_cb249
+    lda (l00b8),y                                                     // 5249: b1 b8       ..  :b249[1]
+    and #$3f // '?'                                                   // 524b: 29 3f       )?  :b24b[1]
+    sta l00b0                                                         // 524d: 85 b0       ..  :b24d[1]
+    ldy #$fe                                                          // 524f: a0 fe       ..  :b24f[1]
+    lda (l00b8),y                                                     // 5251: b1 b8       ..  :b251[1]
+    and #8                                                            // 5253: 29 08       ).  :b253[1]
+    asl                                                               // 5255: 0a          .   :b255[1]
+    asl                                                               // 5256: 0a          .   :b256[1]
+    asl                                                               // 5257: 0a          .   :b257[1]
+    asl                                                               // 5258: 0a          .   :b258[1]
+    ora l00b0                                                         // 5259: 05 b0       ..  :b259[1]
+    sta l00f0                                                         // 525b: 85 f0       ..  :b25b[1]
+    jmp cb1d5                                                         // 525d: 4c d5 b1    L.. :b25d[1]
+
+// $5260 referenced 1 time by $b245
+cb260
+    cmp #$45 // 'E'                                                   // 5260: c9 45       .E  :b260[1]
+    bne cb203                                                         // 5262: d0 9f       ..  :b262[1]
+    ldy #$fd                                                          // 5264: a0 fd       ..  :b264[1]
+    bne loop_cb249                                                    // 5266: d0 e1       ..  :b266[1]
+// $5268 referenced 1 time by $b23f
+cb268
+    cmp #9                                                            // 5268: c9 09       ..  :b268[1]
+    bne cb203                                                         // 526a: d0 97       ..  :b26a[1]
+    lda #$0d                                                          // 526c: a9 0d       ..  :b26c[1]
+    jsr sub_cbac4                                                     // 526e: 20 c4 ba     .. :b26e[1]
+    bcs cb297                                                         // 5271: b0 24       .$  :b271[1]
+    ldx #0                                                            // 5273: a2 00       ..  :b273[1]
+// $5275 referenced 1 time by $b27e
+loop_cb275
+    lda lb283,x                                                       // 5275: bd 83 b2    ... :b275[1]
+    jsr oswrch                                                        // 5278: 20 ee ff     .. :b278[1]
+    inx                                                               // 527b: e8          .   :b27b[1]
+    cpx #$14                                                          // 527c: e0 14       ..  :b27c[1]
+    bne loop_cb275                                                    // 527e: d0 f5       ..  :b27e[1]
+// $5280 referenced 2 times by $b2a6, $b2c0
+cb280
+    jmp cb203                                                         // 5280: 4c 03 b2    L.. :b280[1]
+
+// $5283 referenced 1 time by $b275
+lb283
+    .byt $0a                                                          // 5283: 0a          .   :b283[1]
+    .asc "SRAM 1.05"                                                  // 5284: 53 52 41... SRA :b284[1]
+    .byt $0d, $0a                                                     // 528d: 0d 0a       ..  :b28d[1]
+    .asc "  SRAM"                                                     // 528f: 20 20 53...   S :b28f[1]
+    .byt $0d, $0a                                                     // 5295: 0d 0a       ..  :b295[1]
+
+// $5297 referenced 2 times by $b271, $b2b0
+cb297
+    jsr sub_cb9f5                                                     // 5297: 20 f5 b9     .. :b297[1]
+    cpx #4                                                            // 529a: e0 04       ..  :b29a[1]
+    beq cb2b2                                                         // 529c: f0 14       ..  :b29c[1]
+    lda #0                                                            // 529e: a9 00       ..  :b29e[1]
+// $52a0 referenced 2 times by $b2aa, $b2ae
+cb2a0
+    tax                                                               // 52a0: aa          .   :b2a0[1]
+    iny                                                               // 52a1: c8          .   :b2a1[1]
+    lda (os_text_ptr),y                                               // 52a2: b1 f2       ..  :b2a2[1]
+    cmp #$0d                                                          // 52a4: c9 0d       ..  :b2a4[1]
+    beq cb280                                                         // 52a6: f0 d8       ..  :b2a6[1]
+    cmp #$20 // ' '                                                   // 52a8: c9 20       .   :b2a8[1]
+    beq cb2a0                                                         // 52aa: f0 f4       ..  :b2aa[1]
+    cpx #$20 // ' '                                                   // 52ac: e0 20       .   :b2ac[1]
+    bne cb2a0                                                         // 52ae: d0 f0       ..  :b2ae[1]
+    beq cb297                                                         // 52b0: f0 e5       ..  :b2b0[1]
+// $52b2 referenced 1 time by $b29c
+cb2b2
+    ldy #0                                                            // 52b2: a0 00       ..  :b2b2[1]
+// $52b4 referenced 1 time by $b2bb
+loop_cb2b4
+    lda lb075,y                                                       // 52b4: b9 75 b0    .u. :b2b4[1]
+    jsr oswrch                                                        // 52b7: 20 ee ff     .. :b2b7[1]
+    iny                                                               // 52ba: c8          .   :b2ba[1]
+    bne loop_cb2b4                                                    // 52bb: d0 f7       ..  :b2bb[1]
+// $52bd referenced 1 time by $b2c6
+loop_cb2bd
+    lda lb175,y                                                       // 52bd: b9 75 b1    .u. :b2bd[1]
+    beq cb280                                                         // 52c0: f0 be       ..  :b2c0[1]
+    jsr oswrch                                                        // 52c2: 20 ee ff     .. :b2c2[1]
+    iny                                                               // 52c5: c8          .   :b2c5[1]
+    bne loop_cb2bd                                                    // 52c6: d0 f5       ..  :b2c6[1]
+// $52c8 referenced 1 time by $b1d2
+sub_cb2c8
+    jsr cb82b                                                         // 52c8: 20 2b b8     +. :b2c8[1]
+    lda #$ee                                                          // 52cb: a9 ee       ..  :b2cb[1]
+    sta l00b8                                                         // 52cd: 85 b8       ..  :b2cd[1]
+    ldy #$0b                                                          // 52cf: a0 0b       ..  :b2cf[1]
+// $52d1 referenced 1 time by $b2e4
+loop_cb2d1
+    lda (l00f0),y                                                     // 52d1: b1 f0       ..  :b2d1[1]
+    cpy #0                                                            // 52d3: c0 00       ..  :b2d3[1]
+    bne cb2e1                                                         // 52d5: d0 0a       ..  :b2d5[1]
+    and #$c0                                                          // 52d7: 29 c0       ).  :b2d7[1]
+    sta l00bc                                                         // 52d9: 85 bc       ..  :b2d9[1]
+    lda (l00b8),y                                                     // 52db: b1 b8       ..  :b2db[1]
+    and #$3f // '?'                                                   // 52dd: 29 3f       )?  :b2dd[1]
+    ora l00bc                                                         // 52df: 05 bc       ..  :b2df[1]
+// $52e1 referenced 1 time by $b2d5
+cb2e1
+    sta (l00b8),y                                                     // 52e1: 91 b8       ..  :b2e1[1]
+    dey                                                               // 52e3: 88          .   :b2e3[1]
+    bpl loop_cb2d1                                                    // 52e4: 10 eb       ..  :b2e4[1]
+    cli                                                               // 52e6: 58          X   :b2e6[1]
+// $52e7 referenced 1 time by $bbcd
+cb2e7
+    jsr cb82b                                                         // 52e7: 20 2b b8     +. :b2e7[1]
+    ldy #$f2                                                          // 52ea: a0 f2       ..  :b2ea[1]
+    lda (l00b8),y                                                     // 52ec: b1 b8       ..  :b2ec[1]
+    tax                                                               // 52ee: aa          .   :b2ee[1]
+    iny                                                               // 52ef: c8          .   :b2ef[1]
+    lda (l00b8),y                                                     // 52f0: b1 b8       ..  :b2f0[1]
+    jsr sub_cb85d                                                     // 52f2: 20 5d b8     ]. :b2f2[1]
+    bvs cb305                                                         // 52f5: 70 0e       p.  :b2f5[1]
+    ldy #$f1                                                          // 52f7: a0 f1       ..  :b2f7[1]
+    lda (l00b8),y                                                     // 52f9: b1 b8       ..  :b2f9[1]
+    tay                                                               // 52fb: a8          .   :b2fb[1]
+    cpy #$14                                                          // 52fc: c0 14       ..  :b2fc[1]
+    bcc cb314                                                         // 52fe: 90 14       ..  :b2fe[1]
+// $5300 referenced 2 times by $b324, $bcd3
+cb300
+    ldx #0                                                            // 5300: a2 00       ..  :b300[1]
+    jmp cb8fb                                                         // 5302: 4c fb b8    L.. :b302[1]
+
+// $5305 referenced 1 time by $b2f5
+cb305
+    jsr sub_cb6b1                                                     // 5305: 20 b1 b6     .. :b305[1]
+    sty l00ba                                                         // 5308: 84 ba       ..  :b308[1]
+    ldy #$f3                                                          // 530a: a0 f3       ..  :b30a[1]
+    sta (l00b8),y                                                     // 530c: 91 b8       ..  :b30c[1]
+    txa                                                               // 530e: 8a          .   :b30e[1]
+    dey                                                               // 530f: 88          .   :b30f[1]
+    sta (l00b8),y                                                     // 5310: 91 b8       ..  :b310[1]
+    ldy l00ba                                                         // 5312: a4 ba       ..  :b312[1]
+// $5314 referenced 1 time by $b2fe
+cb314
+    jsr sub_cb6fe                                                     // 5314: 20 fe b6     .. :b314[1]
+    tax                                                               // 5317: aa          .   :b317[1]
+    tya                                                               // 5318: 98          .   :b318[1]
+    ldy #$f1                                                          // 5319: a0 f1       ..  :b319[1]
+    sta (l00b8),y                                                     // 531b: 91 b8       ..  :b31b[1]
+    txa                                                               // 531d: 8a          .   :b31d[1]
+    ldy #$ee                                                          // 531e: a0 ee       ..  :b31e[1]
+    eor (l00b8),y                                                     // 5320: 51 b8       Q.  :b320[1]
+    and #$40 // '@'                                                   // 5322: 29 40       )@  :b322[1]
+    bne cb300                                                         // 5324: d0 da       ..  :b324[1]
+    tay                                                               // 5326: a8          .   :b326[1]
+    ldx #$ba                                                          // 5327: a2 ba       ..  :b327[1]
+    jsr osargs                                                        // 5329: 20 da ff     .. :b329[1]
+    jsr cb82b                                                         // 532c: 20 2b b8     +. :b32c[1]
+    tax                                                               // 532f: aa          .   :b32f[1]
+    bne cb337                                                         // 5330: d0 05       ..  :b330[1]
+    ldx #2                                                            // 5332: a2 02       ..  :b332[1]
+    jmp cb8fb                                                         // 5334: 4c fb b8    L.. :b334[1]
+
+// $5337 referenced 1 time by $b330
+cb337
+    pha                                                               // 5337: 48          H   :b337[1]
+    jsr sub_cbe9d                                                     // 5338: 20 9d be     .. :b338[1]
+    pla                                                               // 533b: 68          h   :b33b[1]
+    cmp #4                                                            // 533c: c9 04       ..  :b33c[1]
+    bcs cb3ba                                                         // 533e: b0 7a       .z  :b33e[1]
+    jsr sub_cb85d                                                     // 5340: 20 5d b8     ]. :b340[1]
+    bpl cb375                                                         // 5343: 10 30       .0  :b343[1]
+    jsr sub_cb5ce                                                     // 5345: 20 ce b5     .. :b345[1]
+    jsr sub_cb607                                                     // 5348: 20 07 b6     .. :b348[1]
+    bne cb371                                                         // 534b: d0 24       .$  :b34b[1]
+    beq cb352                                                         // 534d: f0 03       ..  :b34d[1]
+// $534f referenced 1 time by $b36f
+cb34f
+    jsr sub_cb65f                                                     // 534f: 20 5f b6     _. :b34f[1]
+// $5352 referenced 1 time by $b34d
+cb352
+    ldy #$fa                                                          // 5352: a0 fa       ..  :b352[1]
+    lda (l00b8),y                                                     // 5354: b1 b8       ..  :b354[1]
+    tay                                                               // 5356: a8          .   :b356[1]
+    jsr osbget                                                        // 5357: 20 d7 ff     .. :b357[1]
+    jsr cb82b                                                         // 535a: 20 2b b8     +. :b35a[1]
+    ldy #$f2                                                          // 535d: a0 f2       ..  :b35d[1]
+    jsr sub_cb83f                                                     // 535f: 20 3f b8     ?. :b35f[1]
+    tax                                                               // 5362: aa          .   :b362[1]
+    ldy #$f1                                                          // 5363: a0 f1       ..  :b363[1]
+    lda (l00b8),y                                                     // 5365: b1 b8       ..  :b365[1]
+    tay                                                               // 5367: a8          .   :b367[1]
+    txa                                                               // 5368: 8a          .   :b368[1]
+    jsr sub_cb745                                                     // 5369: 20 45 b7     E. :b369[1]
+    jsr sub_cb607                                                     // 536c: 20 07 b6     .. :b36c[1]
+    beq cb34f                                                         // 536f: f0 de       ..  :b36f[1]
+// $5371 referenced 3 times by $b34b, $b37b, $b3b8
+cb371
+    jsr sub_cb5f2                                                     // 5371: 20 f2 b5     .. :b371[1]
+    rts                                                               // 5374: 60          `   :b374[1]
+
+// $5375 referenced 1 time by $b343
+cb375
+    jsr sub_cb5ee                                                     // 5375: 20 ee b5     .. :b375[1]
+    jsr sub_cb616                                                     // 5378: 20 16 b6     .. :b378[1]
+    beq cb371                                                         // 537b: f0 f4       ..  :b37b[1]
+    bne cb382                                                         // 537d: d0 03       ..  :b37d[1]
+// $537f referenced 1 time by $b3b6
+cb37f
+    jsr sub_cb65f                                                     // 537f: 20 5f b6     _. :b37f[1]
+// $5382 referenced 1 time by $b37d
+cb382
+    ldy #$f4                                                          // 5382: a0 f4       ..  :b382[1]
+    lda (l00b8),y                                                     // 5384: b1 b8       ..  :b384[1]
+    sec                                                               // 5386: 38          8   :b386[1]
+    sbc #1                                                            // 5387: e9 01       ..  :b387[1]
+    sta (l00b8),y                                                     // 5389: 91 b8       ..  :b389[1]
+    cmp #$ff                                                          // 538b: c9 ff       ..  :b38b[1]
+    bne cb397                                                         // 538d: d0 08       ..  :b38d[1]
+    iny                                                               // 538f: c8          .   :b38f[1]
+    lda (l00b8),y                                                     // 5390: b1 b8       ..  :b390[1]
+    sec                                                               // 5392: 38          8   :b392[1]
+    sbc #1                                                            // 5393: e9 01       ..  :b393[1]
+    sta (l00b8),y                                                     // 5395: 91 b8       ..  :b395[1]
+// $5397 referenced 1 time by $b38d
+cb397
+    ldx #$f6                                                          // 5397: a2 f6       ..  :b397[1]
+    ldy #$f2                                                          // 5399: a0 f2       ..  :b399[1]
+    jsr sub_cb841                                                     // 539b: 20 41 b8     A. :b39b[1]
+    ldy #$f1                                                          // 539e: a0 f1       ..  :b39e[1]
+    lda (l00b8),y                                                     // 53a0: b1 b8       ..  :b3a0[1]
+    tay                                                               // 53a2: a8          .   :b3a2[1]
+    jsr osrdsc                                                        // 53a3: 20 b9 ff     .. :b3a3[1]
+    tax                                                               // 53a6: aa          .   :b3a6[1]
+    ldy #$fa                                                          // 53a7: a0 fa       ..  :b3a7[1]
+    lda (l00b8),y                                                     // 53a9: b1 b8       ..  :b3a9[1]
+    tay                                                               // 53ab: a8          .   :b3ab[1]
+    txa                                                               // 53ac: 8a          .   :b3ac[1]
+    jsr osbput                                                        // 53ad: 20 d4 ff     .. :b3ad[1]
+    jsr cb82b                                                         // 53b0: 20 2b b8     +. :b3b0[1]
+    jsr sub_cb616                                                     // 53b3: 20 16 b6     .. :b3b3[1]
+    bne cb37f                                                         // 53b6: d0 c7       ..  :b3b6[1]
+    beq cb371                                                         // 53b8: f0 b7       ..  :b3b8[1]
+// $53ba referenced 1 time by $b33e
+cb3ba
+    ldy #$f9                                                          // 53ba: a0 f9       ..  :b3ba[1]
+    lda (l00b8),y                                                     // 53bc: b1 b8       ..  :b3bc[1]
+    bmi cb3de                                                         // 53be: 30 1e       0.  :b3be[1]
+    dey                                                               // 53c0: 88          .   :b3c0[1]
+    ora (l00b8),y                                                     // 53c1: 11 b8       ..  :b3c1[1]
+    bne cb406                                                         // 53c3: d0 41       .A  :b3c3[1]
+    lda #0                                                            // 53c5: a9 00       ..  :b3c5[1]
+    sta (l00b8),y                                                     // 53c7: 91 b8       ..  :b3c7[1]
+    lda #1                                                            // 53c9: a9 01       ..  :b3c9[1]
+    iny                                                               // 53cb: c8          .   :b3cb[1]
+    sta (l00b8),y                                                     // 53cc: 91 b8       ..  :b3cc[1]
+    ldy #$f6                                                          // 53ce: a0 f6       ..  :b3ce[1]
+    lda #0                                                            // 53d0: a9 00       ..  :b3d0[1]
+    sta (l00b8),y                                                     // 53d2: 91 b8       ..  :b3d2[1]
+    ldx l00b9                                                         // 53d4: a6 b9       ..  :b3d4[1]
+    inx                                                               // 53d6: e8          .   :b3d6[1]
+    txa                                                               // 53d7: 8a          .   :b3d7[1]
+    iny                                                               // 53d8: c8          .   :b3d8[1]
+    sta (l00b8),y                                                     // 53d9: 91 b8       ..  :b3d9[1]
+    jmp cb406                                                         // 53db: 4c 06 b4    L.. :b3db[1]
+
+// $53de referenced 1 time by $b3be
+cb3de
+    lda #osbyte_read_himem                                            // 53de: a9 84       ..  :b3de[1]
+    jsr osbyte                                                        // 53e0: 20 f4 ff     .. :b3e0[1]
+    tya                                                               // 53e3: 98          .   :b3e3[1]
+    pha                                                               // 53e4: 48          H   :b3e4[1]
+    txa                                                               // 53e5: 8a          .   :b3e5[1]
+    pha                                                               // 53e6: 48          H   :b3e6[1]
+    lda #osbyte_read_oshwm                                            // 53e7: a9 83       ..  :b3e7[1]
+    jsr osbyte                                                        // 53e9: 20 f4 ff     .. :b3e9[1]
+    jsr cb82b                                                         // 53ec: 20 2b b8     +. :b3ec[1]
+    stx l00ba                                                         // 53ef: 86 ba       ..  :b3ef[1]
+    sty l00bb                                                         // 53f1: 84 bb       ..  :b3f1[1]
+    ldy #$f6                                                          // 53f3: a0 f6       ..  :b3f3[1]
+    jsr sub_cb84e                                                     // 53f5: 20 4e b8     N. :b3f5[1]
+    pla                                                               // 53f8: 68          h   :b3f8[1]
+    sec                                                               // 53f9: 38          8   :b3f9[1]
+    sbc l00ba                                                         // 53fa: e5 ba       ..  :b3fa[1]
+    ldy #$f8                                                          // 53fc: a0 f8       ..  :b3fc[1]
+    sta (l00b8),y                                                     // 53fe: 91 b8       ..  :b3fe[1]
+    pla                                                               // 5400: 68          h   :b400[1]
+    sbc l00bb                                                         // 5401: e5 bb       ..  :b401[1]
+    iny                                                               // 5403: c8          .   :b403[1]
+    sta (l00b8),y                                                     // 5404: 91 b8       ..  :b404[1]
+// $5406 referenced 2 times by $b3c3, $b3db
+cb406
+    jsr sub_cb85d                                                     // 5406: 20 5d b8     ]. :b406[1]
+    bmi cb40e                                                         // 5409: 30 03       0.  :b409[1]
+    jmp cb4d8                                                         // 540b: 4c d8 b4    L.. :b40b[1]
+
+// $540e referenced 1 time by $b409
+cb40e
+    jsr sub_cb5ce                                                     // 540e: 20 ce b5     .. :b40e[1]
+    tsx                                                               // 5411: ba          .   :b411[1]
+    txa                                                               // 5412: 8a          .   :b412[1]
+    sec                                                               // 5413: 38          8   :b413[1]
+    sbc #$10                                                          // 5414: e9 10       ..  :b414[1]
+    tax                                                               // 5416: aa          .   :b416[1]
+    txs                                                               // 5417: 9a          .   :b417[1]
+    ldy #$f0                                                          // 5418: a0 f0       ..  :b418[1]
+    lda (l00b8),y                                                     // 541a: b1 b8       ..  :b41a[1]
+    pha                                                               // 541c: 48          H   :b41c[1]
+    dey                                                               // 541d: 88          .   :b41d[1]
+    lda (l00b8),y                                                     // 541e: b1 b8       ..  :b41e[1]
+    pha                                                               // 5420: 48          H   :b420[1]
+    dex                                                               // 5421: ca          .   :b421[1]
+    ldy #1                                                            // 5422: a0 01       ..  :b422[1]
+    lda #osfile_read_catalogue_info                                   // 5424: a9 05       ..  :b424[1]
+    jsr osfile                                                        // 5426: 20 dd ff     .. :b426[1]
+    jsr cb82b                                                         // 5429: 20 2b b8     +. :b429[1]
+    tsx                                                               // 542c: ba          .   :b42c[1]
+    lda l010b,x                                                       // 542d: bd 0b 01    ... :b42d[1]
+    ldy #$f4                                                          // 5430: a0 f4       ..  :b430[1]
+    sta (l00b8),y                                                     // 5432: 91 b8       ..  :b432[1]
+    sta l00ba                                                         // 5434: 85 ba       ..  :b434[1]
+    lda l010c,x                                                       // 5436: bd 0c 01    ... :b436[1]
+    iny                                                               // 5439: c8          .   :b439[1]
+    sta (l00b8),y                                                     // 543a: 91 b8       ..  :b43a[1]
+    sta l00bb                                                         // 543c: 85 bb       ..  :b43c[1]
+    lda l010d,x                                                       // 543e: bd 0d 01    ... :b43e[1]
+    ora l010e,x                                                       // 5441: 1d 0e 01    ... :b441[1]
+    beq cb44b                                                         // 5444: f0 05       ..  :b444[1]
+// $5446 referenced 4 times by $b68c, $b6c7, $b715, $bc10
+cb446
+    ldx #1                                                            // 5446: a2 01       ..  :b446[1]
+    jmp cb8fb                                                         // 5448: 4c fb b8    L.. :b448[1]
+
+// $544b referenced 1 time by $b444
+cb44b
+    ldx #$12                                                          // 544b: a2 12       ..  :b44b[1]
+// $544d referenced 1 time by $b44f
+loop_cb44d
+    pla                                                               // 544d: 68          h   :b44d[1]
+    dex                                                               // 544e: ca          .   :b44e[1]
+    bne loop_cb44d                                                    // 544f: d0 fc       ..  :b44f[1]
+    bit lb57f                                                         // 5451: 2c 7f b5    ,.. :b451[1]
+    lda l00ba                                                         // 5454: a5 ba       ..  :b454[1]
+    ora l00bb                                                         // 5456: 05 bb       ..  :b456[1]
+    bne cb45e                                                         // 5458: d0 04       ..  :b458[1]
+// $545a referenced 1 time by $b4d2
+cb45a
+    jsr sub_cb5f2                                                     // 545a: 20 f2 b5     .. :b45a[1]
+    rts                                                               // 545d: 60          `   :b45d[1]
+
+// $545e referenced 2 times by $b458, $b4d5
+cb45e
+    ldx #$bc                                                          // 545e: a2 bc       ..  :b45e[1]
+    ldy #$f8                                                          // 5460: a0 f8       ..  :b460[1]
+    jsr sub_cb841                                                     // 5462: 20 41 b8     A. :b462[1]
+    ldy #$ba                                                          // 5465: a0 ba       ..  :b465[1]
+    jsr sub_cb58b                                                     // 5467: 20 8b b5     .. :b467[1]
+    bcs cb470                                                         // 546a: b0 04       ..  :b46a[1]
+    jsr sub_cb580                                                     // 546c: 20 80 b5     .. :b46c[1]
+    clv                                                               // 546f: b8          .   :b46f[1]
+// $5470 referenced 1 time by $b46a
+cb470
+    ldy #$fb                                                          // 5470: a0 fb       ..  :b470[1]
+    jsr sub_cb84e                                                     // 5472: 20 4e b8     N. :b472[1]
+    bvc cb4af                                                         // 5475: 50 38       P8  :b475[1]
+    jsr sub_cb5f2                                                     // 5477: 20 f2 b5     .. :b477[1]
+    tsx                                                               // 547a: ba          .   :b47a[1]
+    txa                                                               // 547b: 8a          .   :b47b[1]
+    sec                                                               // 547c: 38          8   :b47c[1]
+    sbc #$0b                                                          // 547d: e9 0b       ..  :b47d[1]
+    tax                                                               // 547f: aa          .   :b47f[1]
+    txs                                                               // 5480: 9a          .   :b480[1]
+    lda #0                                                            // 5481: a9 00       ..  :b481[1]
+    pha                                                               // 5483: 48          H   :b483[1]
+    lda #$ff                                                          // 5484: a9 ff       ..  :b484[1]
+    pha                                                               // 5486: 48          H   :b486[1]
+    pha                                                               // 5487: 48          H   :b487[1]
+    ldy #$f7                                                          // 5488: a0 f7       ..  :b488[1]
+    lda (l00b8),y                                                     // 548a: b1 b8       ..  :b48a[1]
+    pha                                                               // 548c: 48          H   :b48c[1]
+    dey                                                               // 548d: 88          .   :b48d[1]
+    lda (l00b8),y                                                     // 548e: b1 b8       ..  :b48e[1]
+    pha                                                               // 5490: 48          H   :b490[1]
+    ldy #$f0                                                          // 5491: a0 f0       ..  :b491[1]
+    lda (l00b8),y                                                     // 5493: b1 b8       ..  :b493[1]
+    pha                                                               // 5495: 48          H   :b495[1]
+    dey                                                               // 5496: 88          .   :b496[1]
+    lda (l00b8),y                                                     // 5497: b1 b8       ..  :b497[1]
+    pha                                                               // 5499: 48          H   :b499[1]
+    tsx                                                               // 549a: ba          .   :b49a[1]
+    inx                                                               // 549b: e8          .   :b49b[1]
+    ldy #1                                                            // 549c: a0 01       ..  :b49c[1]
+    lda #osfile_load                                                  // 549e: a9 ff       ..  :b49e[1]
+    jsr osfile                                                        // 54a0: 20 dd ff     .. :b4a0[1]
+    jsr cb82b                                                         // 54a3: 20 2b b8     +. :b4a3[1]
+    ldx #$12                                                          // 54a6: a2 12       ..  :b4a6[1]
+// $54a8 referenced 1 time by $b4aa
+loop_cb4a8
+    pla                                                               // 54a8: 68          h   :b4a8[1]
+    dex                                                               // 54a9: ca          .   :b4a9[1]
+    bne loop_cb4a8                                                    // 54aa: d0 fc       ..  :b4aa[1]
+    jmp cb4b4                                                         // 54ac: 4c b4 b4    L.. :b4ac[1]
+
+// $54af referenced 1 time by $b475
+cb4af
+    lda #4                                                            // 54af: a9 04       ..  :b4af[1]
+    jsr sub_cb598                                                     // 54b1: 20 98 b5     .. :b4b1[1]
+// $54b4 referenced 1 time by $b4ac
+cb4b4
+    ldx #$b1                                                          // 54b4: a2 b1       ..  :b4b4[1]
+    ldy #$f6                                                          // 54b6: a0 f6       ..  :b4b6[1]
+    jsr sub_cb841                                                     // 54b8: 20 41 b8     A. :b4b8[1]
+    ldx #$b3                                                          // 54bb: a2 b3       ..  :b4bb[1]
+    ldy #$f2                                                          // 54bd: a0 f2       ..  :b4bd[1]
+    jsr sub_cb841                                                     // 54bf: 20 41 b8     A. :b4bf[1]
+    ldx #$be                                                          // 54c2: a2 be       ..  :b4c2[1]
+    ldy #$fb                                                          // 54c4: a0 fb       ..  :b4c4[1]
+    jsr sub_cb841                                                     // 54c6: 20 41 b8     A. :b4c6[1]
+    sec                                                               // 54c9: 38          8   :b4c9[1]
+    jsr cb795                                                         // 54ca: 20 95 b7     .. :b4ca[1]
+    ldx #$b3                                                          // 54cd: a2 b3       ..  :b4cd[1]
+    jsr sub_cb61e                                                     // 54cf: 20 1e b6     .. :b4cf[1]
+    beq cb45a                                                         // 54d2: f0 86       ..  :b4d2[1]
+    clv                                                               // 54d4: b8          .   :b4d4[1]
+    jmp cb45e                                                         // 54d5: 4c 5e b4    L^. :b4d5[1]
+
+// $54d8 referenced 1 time by $b40b
+cb4d8
+    jsr sub_cb5ee                                                     // 54d8: 20 ee b5     .. :b4d8[1]
+    bit lb57f                                                         // 54db: 2c 7f b5    ,.. :b4db[1]
+    php                                                               // 54de: 08          .   :b4de[1]
+// $54df referenced 1 time by $b531
+cb4df
+    ldy #$f4                                                          // 54df: a0 f4       ..  :b4df[1]
+    jsr sub_cb83f                                                     // 54e1: 20 3f b8     ?. :b4e1[1]
+    jsr sub_cb616                                                     // 54e4: 20 16 b6     .. :b4e4[1]
+    bne cb4ee                                                         // 54e7: d0 05       ..  :b4e7[1]
+// $54e9 referenced 1 time by $b57c
+cb4e9
+    plp                                                               // 54e9: 28          (   :b4e9[1]
+    jsr sub_cb5f2                                                     // 54ea: 20 f2 b5     .. :b4ea[1]
+    rts                                                               // 54ed: 60          `   :b4ed[1]
+
+// $54ee referenced 1 time by $b4e7
+cb4ee
+    ldx #$bc                                                          // 54ee: a2 bc       ..  :b4ee[1]
+    ldy #$f8                                                          // 54f0: a0 f8       ..  :b4f0[1]
+    jsr sub_cb841                                                     // 54f2: 20 41 b8     A. :b4f2[1]
+    ldy #$ba                                                          // 54f5: a0 ba       ..  :b4f5[1]
+    jsr sub_cb58b                                                     // 54f7: 20 8b b5     .. :b4f7[1]
+    bcs cb502                                                         // 54fa: b0 06       ..  :b4fa[1]
+    jsr sub_cb580                                                     // 54fc: 20 80 b5     .. :b4fc[1]
+    plp                                                               // 54ff: 28          (   :b4ff[1]
+    clv                                                               // 5500: b8          .   :b500[1]
+    php                                                               // 5501: 08          .   :b501[1]
+// $5502 referenced 1 time by $b4fa
+cb502
+    ldy #$fb                                                          // 5502: a0 fb       ..  :b502[1]
+    jsr sub_cb84e                                                     // 5504: 20 4e b8     N. :b504[1]
+    ldx #$b1                                                          // 5507: a2 b1       ..  :b507[1]
+    ldy #$f2                                                          // 5509: a0 f2       ..  :b509[1]
+    jsr sub_cb841                                                     // 550b: 20 41 b8     A. :b50b[1]
+    ldx #$b3                                                          // 550e: a2 b3       ..  :b50e[1]
+    ldy #$f6                                                          // 5510: a0 f6       ..  :b510[1]
+    jsr sub_cb841                                                     // 5512: 20 41 b8     A. :b512[1]
+    ldx #$be                                                          // 5515: a2 be       ..  :b515[1]
+    ldy #$fb                                                          // 5517: a0 fb       ..  :b517[1]
+    jsr sub_cb841                                                     // 5519: 20 41 b8     A. :b519[1]
+    clc                                                               // 551c: 18          .   :b51c[1]
+    jsr cb795                                                         // 551d: 20 95 b7     .. :b51d[1]
+    ldx #$b1                                                          // 5520: a2 b1       ..  :b520[1]
+    jsr sub_cb61e                                                     // 5522: 20 1e b6     .. :b522[1]
+    plp                                                               // 5525: 28          (   :b525[1]
+    php                                                               // 5526: 08          .   :b526[1]
+    bvs cb534                                                         // 5527: 70 0b       p.  :b527[1]
+    lda #2                                                            // 5529: a9 02       ..  :b529[1]
+    jsr sub_cb598                                                     // 552b: 20 98 b5     .. :b52b[1]
+    plp                                                               // 552e: 28          (   :b52e[1]
+    clv                                                               // 552f: b8          .   :b52f[1]
+    php                                                               // 5530: 08          .   :b530[1]
+    jmp cb4df                                                         // 5531: 4c df b4    L.. :b531[1]
+
+// $5534 referenced 1 time by $b527
+cb534
+    jsr sub_cb5f2                                                     // 5534: 20 f2 b5     .. :b534[1]
+    lda #$ff                                                          // 5537: a9 ff       ..  :b537[1]
+    pha                                                               // 5539: 48          H   :b539[1]
+    pha                                                               // 553a: 48          H   :b53a[1]
+    ldy #$f6                                                          // 553b: a0 f6       ..  :b53b[1]
+    jsr sub_cb83f                                                     // 553d: 20 3f b8     ?. :b53d[1]
+    ldy #$fb                                                          // 5540: a0 fb       ..  :b540[1]
+    lda l00ba                                                         // 5542: a5 ba       ..  :b542[1]
+    clc                                                               // 5544: 18          .   :b544[1]
+    adc (l00b8),y                                                     // 5545: 71 b8       q.  :b545[1]
+    tax                                                               // 5547: aa          .   :b547[1]
+    lda l00bb                                                         // 5548: a5 bb       ..  :b548[1]
+    iny                                                               // 554a: c8          .   :b54a[1]
+    adc (l00b8),y                                                     // 554b: 71 b8       q.  :b54b[1]
+    pha                                                               // 554d: 48          H   :b54d[1]
+    txa                                                               // 554e: 8a          .   :b54e[1]
+    pha                                                               // 554f: 48          H   :b54f[1]
+    lda #$ff                                                          // 5550: a9 ff       ..  :b550[1]
+    pha                                                               // 5552: 48          H   :b552[1]
+    pha                                                               // 5553: 48          H   :b553[1]
+    lda l00bb                                                         // 5554: a5 bb       ..  :b554[1]
+    pha                                                               // 5556: 48          H   :b556[1]
+    lda l00ba                                                         // 5557: a5 ba       ..  :b557[1]
+    pha                                                               // 5559: 48          H   :b559[1]
+    lda #$ff                                                          // 555a: a9 ff       ..  :b55a[1]
+    ldx #8                                                            // 555c: a2 08       ..  :b55c[1]
+// $555e referenced 1 time by $b560
+loop_cb55e
+    pha                                                               // 555e: 48          H   :b55e[1]
+    dex                                                               // 555f: ca          .   :b55f[1]
+    bne loop_cb55e                                                    // 5560: d0 fc       ..  :b560[1]
+    ldy #$f0                                                          // 5562: a0 f0       ..  :b562[1]
+    lda (l00b8),y                                                     // 5564: b1 b8       ..  :b564[1]
+    pha                                                               // 5566: 48          H   :b566[1]
+    dey                                                               // 5567: 88          .   :b567[1]
+    tsx                                                               // 5568: ba          .   :b568[1]
+    lda (l00b8),y                                                     // 5569: b1 b8       ..  :b569[1]
+    pha                                                               // 556b: 48          H   :b56b[1]
+    ldy #1                                                            // 556c: a0 01       ..  :b56c[1]
+    lda #osfile_save                                                  // 556e: a9 00       ..  :b56e[1]
+    jsr osfile                                                        // 5570: 20 dd ff     .. :b570[1]
+    jsr cb82b                                                         // 5573: 20 2b b8     +. :b573[1]
+    ldx #$12                                                          // 5576: a2 12       ..  :b576[1]
+// $5578 referenced 1 time by $b57a
+loop_cb578
+    pla                                                               // 5578: 68          h   :b578[1]
+    dex                                                               // 5579: ca          .   :b579[1]
+    bne loop_cb578                                                    // 557a: d0 fc       ..  :b57a[1]
+    jmp cb4e9                                                         // 557c: 4c e9 b4    L.. :b57c[1]
+
+// $557f referenced 4 times by $b451, $b4db, $bae7, $bbda
+lb57f
+    .byt $40                                                          // 557f: 40          @   :b57f[1]
+
+// $5580 referenced 7 times by $b46c, $b4fc, $bcfd, $bd08, $bd12, $bdaa, $bde4
+sub_cb580
+    lda l0000,x                                                       // 5580: b5 00       ..  :b580[1]
+    sta l0000,y                                                       // 5582: 99 00 00    ... :b582[1]
+    lda l0001,x                                                       // 5585: b5 01       ..  :b585[1]
+    sta l0001,y                                                       // 5587: 99 01 00    ... :b587[1]
+    rts                                                               // 558a: 60          `   :b58a[1]
+
+// $558b referenced 3 times by $b467, $b4f7, $b800
+sub_cb58b
+    lda l0001,x                                                       // 558b: b5 01       ..  :b58b[1]
+    cmp l0001,y                                                       // 558d: d9 01 00    ... :b58d[1]
+    bne cb597                                                         // 5590: d0 05       ..  :b590[1]
+    lda l0000,x                                                       // 5592: b5 00       ..  :b592[1]
+    cmp l0000,y                                                       // 5594: d9 00 00    ... :b594[1]
+// $5597 referenced 1 time by $b590
+cb597
+    rts                                                               // 5597: 60          `   :b597[1]
+
+// $5598 referenced 2 times by $b4b1, $b52b
+sub_cb598
+    pha                                                               // 5598: 48          H   :b598[1]
+    pha                                                               // 5599: 48          H   :b599[1]
+    pha                                                               // 559a: 48          H   :b59a[1]
+    pha                                                               // 559b: 48          H   :b59b[1]
+    lda #0                                                            // 559c: a9 00       ..  :b59c[1]
+    pha                                                               // 559e: 48          H   :b59e[1]
+    pha                                                               // 559f: 48          H   :b59f[1]
+    ldy #$fc                                                          // 55a0: a0 fc       ..  :b5a0[1]
+    lda (l00b8),y                                                     // 55a2: b1 b8       ..  :b5a2[1]
+    pha                                                               // 55a4: 48          H   :b5a4[1]
+    dey                                                               // 55a5: 88          .   :b5a5[1]
+    lda (l00b8),y                                                     // 55a6: b1 b8       ..  :b5a6[1]
+    pha                                                               // 55a8: 48          H   :b5a8[1]
+    lda #$ff                                                          // 55a9: a9 ff       ..  :b5a9[1]
+    pha                                                               // 55ab: 48          H   :b5ab[1]
+    pha                                                               // 55ac: 48          H   :b5ac[1]
+    ldy #$f7                                                          // 55ad: a0 f7       ..  :b5ad[1]
+    lda (l00b8),y                                                     // 55af: b1 b8       ..  :b5af[1]
+    pha                                                               // 55b1: 48          H   :b5b1[1]
+    dey                                                               // 55b2: 88          .   :b5b2[1]
+    lda (l00b8),y                                                     // 55b3: b1 b8       ..  :b5b3[1]
+    pha                                                               // 55b5: 48          H   :b5b5[1]
+    tsx                                                               // 55b6: ba          .   :b5b6[1]
+    ldy #$fa                                                          // 55b7: a0 fa       ..  :b5b7[1]
+    lda (l00b8),y                                                     // 55b9: b1 b8       ..  :b5b9[1]
+    pha                                                               // 55bb: 48          H   :b5bb[1]
+    lda l0109,x                                                       // 55bc: bd 09 01    ... :b5bc[1]
+    ldy #1                                                            // 55bf: a0 01       ..  :b5bf[1]
+    jsr osgbpb                                                        // 55c1: 20 d1 ff     .. :b5c1[1]
+    ldx #$0d                                                          // 55c4: a2 0d       ..  :b5c4[1]
+// $55c6 referenced 1 time by $b5c8
+loop_cb5c6
+    pla                                                               // 55c6: 68          h   :b5c6[1]
+    dex                                                               // 55c7: ca          .   :b5c7[1]
+    bne loop_cb5c6                                                    // 55c8: d0 fc       ..  :b5c8[1]
+    jsr cb82b                                                         // 55ca: 20 2b b8     +. :b5ca[1]
+    rts                                                               // 55cd: 60          `   :b5cd[1]
+
+// $55ce referenced 2 times by $b345, $b40e
+sub_cb5ce
+    lda #$40 // '@'                                                   // 55ce: a9 40       .@  :b5ce[1]
+// $55d0 referenced 1 time by $b5f0
+cb5d0
+    pha                                                               // 55d0: 48          H   :b5d0[1]
+    ldy #$ef                                                          // 55d1: a0 ef       ..  :b5d1[1]
+    lda (l00b8),y                                                     // 55d3: b1 b8       ..  :b5d3[1]
+    tax                                                               // 55d5: aa          .   :b5d5[1]
+    iny                                                               // 55d6: c8          .   :b5d6[1]
+    lda (l00b8),y                                                     // 55d7: b1 b8       ..  :b5d7[1]
+    tay                                                               // 55d9: a8          .   :b5d9[1]
+    pla                                                               // 55da: 68          h   :b5da[1]
+    jsr osfind                                                        // 55db: 20 ce ff     .. :b5db[1]
+    tax                                                               // 55de: aa          .   :b5de[1]
+    bne cb5e6                                                         // 55df: d0 05       ..  :b5df[1]
+    ldx #4                                                            // 55e1: a2 04       ..  :b5e1[1]
+    jmp cb8fb                                                         // 55e3: 4c fb b8    L.. :b5e3[1]
+
+// $55e6 referenced 1 time by $b5df
+cb5e6
+    ldy #$fa                                                          // 55e6: a0 fa       ..  :b5e6[1]
+    jsr cb82b                                                         // 55e8: 20 2b b8     +. :b5e8[1]
+    sta (l00b8),y                                                     // 55eb: 91 b8       ..  :b5eb[1]
+// $55ed referenced 1 time by $b5f6
+loop_cb5ed
+    rts                                                               // 55ed: 60          `   :b5ed[1]
+
+// $55ee referenced 2 times by $b375, $b4d8
+sub_cb5ee
+    lda #$80                                                          // 55ee: a9 80       ..  :b5ee[1]
+    bne cb5d0                                                         // 55f0: d0 de       ..  :b5f0[1]
+// $55f2 referenced 6 times by $b21b, $b371, $b45a, $b477, $b4ea, $b534
+sub_cb5f2
+    ldy #$fa                                                          // 55f2: a0 fa       ..  :b5f2[1]
+    lda (l00b8),y                                                     // 55f4: b1 b8       ..  :b5f4[1]
+    beq loop_cb5ed                                                    // 55f6: f0 f5       ..  :b5f6[1]
+    pha                                                               // 55f8: 48          H   :b5f8[1]
+    lda #0                                                            // 55f9: a9 00       ..  :b5f9[1]
+    sta (l00b8),y                                                     // 55fb: 91 b8       ..  :b5fb[1]
+    pla                                                               // 55fd: 68          h   :b5fd[1]
+    tay                                                               // 55fe: a8          .   :b5fe[1]
+    lda #0                                                            // 55ff: a9 00       ..  :b5ff[1]
+    jsr osfind                                                        // 5601: 20 ce ff     .. :b601[1]
+    jmp cb82b                                                         // 5604: 4c 2b b8    L+. :b604[1]
+
+// $5607 referenced 2 times by $b348, $b36c
+sub_cb607
+    ldy #$fa                                                          // 5607: a0 fa       ..  :b607[1]
+    lda (l00b8),y                                                     // 5609: b1 b8       ..  :b609[1]
+    tax                                                               // 560b: aa          .   :b60b[1]
+    lda #1                                                            // 560c: a9 01       ..  :b60c[1]
+    jsr sub_cb86f                                                     // 560e: 20 6f b8     o. :b60e[1]
+    jsr cb82b                                                         // 5611: 20 2b b8     +. :b611[1]
+    txa                                                               // 5614: 8a          .   :b614[1]
+    rts                                                               // 5615: 60          `   :b615[1]
+
+// $5616 referenced 4 times by $b378, $b3b3, $b4e4, $be5d
+sub_cb616
+    ldy #$f4                                                          // 5616: a0 f4       ..  :b616[1]
+    lda (l00b8),y                                                     // 5618: b1 b8       ..  :b618[1]
+    iny                                                               // 561a: c8          .   :b61a[1]
+    ora (l00b8),y                                                     // 561b: 11 b8       ..  :b61b[1]
+    rts                                                               // 561d: 60          `   :b61d[1]
+
+// $561e referenced 2 times by $b4cf, $b522
+sub_cb61e
+    stx l00bc                                                         // 561e: 86 bc       ..  :b61e[1]
+    ldy #$fb                                                          // 5620: a0 fb       ..  :b620[1]
+    jsr sub_cb83f                                                     // 5622: 20 3f b8     ?. :b622[1]
+    ldy #$f4                                                          // 5625: a0 f4       ..  :b625[1]
+    lda (l00b8),y                                                     // 5627: b1 b8       ..  :b627[1]
+    sec                                                               // 5629: 38          8   :b629[1]
+    sbc l00ba                                                         // 562a: e5 ba       ..  :b62a[1]
+    sta (l00b8),y                                                     // 562c: 91 b8       ..  :b62c[1]
+    sta l00ba                                                         // 562e: 85 ba       ..  :b62e[1]
+    iny                                                               // 5630: c8          .   :b630[1]
+    lda (l00b8),y                                                     // 5631: b1 b8       ..  :b631[1]
+    sbc l00bb                                                         // 5633: e5 bb       ..  :b633[1]
+    sta (l00b8),y                                                     // 5635: 91 b8       ..  :b635[1]
+    sta l00bb                                                         // 5637: 85 bb       ..  :b637[1]
+    ora l00ba                                                         // 5639: 05 ba       ..  :b639[1]
+    beq cb65e                                                         // 563b: f0 21       .!  :b63b[1]
+    ldx l00bc                                                         // 563d: a6 bc       ..  :b63d[1]
+    jsr sub_cb85d                                                     // 563f: 20 5d b8     ]. :b63f[1]
+    bvc cb655                                                         // 5642: 50 11       P.  :b642[1]
+    lda l0001,x                                                       // 5644: b5 01       ..  :b644[1]
+    cmp #$c0                                                          // 5646: c9 c0       ..  :b646[1]
+    bcc cb655                                                         // 5648: 90 0b       ..  :b648[1]
+    lda #$10                                                          // 564a: a9 10       ..  :b64a[1]
+    sta l0000,x                                                       // 564c: 95 00       ..  :b64c[1]
+    lda #$80                                                          // 564e: a9 80       ..  :b64e[1]
+    sta l0001,x                                                       // 5650: 95 01       ..  :b650[1]
+    jsr sub_cb68f                                                     // 5652: 20 8f b6     .. :b652[1]
+// $5655 referenced 2 times by $b642, $b648
+cb655
+    ldx l00bc                                                         // 5655: a6 bc       ..  :b655[1]
+    ldy #$f2                                                          // 5657: a0 f2       ..  :b657[1]
+    jsr sub_cb850                                                     // 5659: 20 50 b8     P. :b659[1]
+    lda #$ff                                                          // 565c: a9 ff       ..  :b65c[1]
+// $565e referenced 1 time by $b63b
+cb65e
+    rts                                                               // 565e: 60          `   :b65e[1]
+
+// $565f referenced 2 times by $b34f, $b37f
+sub_cb65f
+    ldx #$bd                                                          // 565f: a2 bd       ..  :b65f[1]
+    ldy #$f2                                                          // 5661: a0 f2       ..  :b661[1]
+    jsr sub_cb841                                                     // 5663: 20 41 b8     A. :b663[1]
+    inc l00bd                                                         // 5666: e6 bd       ..  :b666[1]
+    bne cb684                                                         // 5668: d0 1a       ..  :b668[1]
+    inc l00be                                                         // 566a: e6 be       ..  :b66a[1]
+    beq cb68c                                                         // 566c: f0 1e       ..  :b66c[1]
+    jsr sub_cb85d                                                     // 566e: 20 5d b8     ]. :b66e[1]
+    bvc cb684                                                         // 5671: 50 11       P.  :b671[1]
+    lda l00be                                                         // 5673: a5 be       ..  :b673[1]
+    cmp #$c0                                                          // 5675: c9 c0       ..  :b675[1]
+    bne cb684                                                         // 5677: d0 0b       ..  :b677[1]
+    jsr sub_cb68f                                                     // 5679: 20 8f b6     .. :b679[1]
+    lda #$10                                                          // 567c: a9 10       ..  :b67c[1]
+    sta l00bd                                                         // 567e: 85 bd       ..  :b67e[1]
+    lda #$80                                                          // 5680: a9 80       ..  :b680[1]
+    sta l00be                                                         // 5682: 85 be       ..  :b682[1]
+// $5684 referenced 3 times by $b668, $b671, $b677
+cb684
+    ldx #$bd                                                          // 5684: a2 bd       ..  :b684[1]
+    ldy #$f2                                                          // 5686: a0 f2       ..  :b686[1]
+    jsr sub_cb850                                                     // 5688: 20 50 b8     P. :b688[1]
+    rts                                                               // 568b: 60          `   :b68b[1]
+
+// $568c referenced 4 times by $b66c, $b698, $b69c, $b6ae
+cb68c
+    jmp cb446                                                         // 568c: 4c 46 b4    LF. :b68c[1]
+
+// $568f referenced 4 times by $b652, $b679, $b81f, $be77
+sub_cb68f
+    ldy #$f1                                                          // 568f: a0 f1       ..  :b68f[1]
+    lda (l00b8),y                                                     // 5691: b1 b8       ..  :b691[1]
+    clc                                                               // 5693: 18          .   :b693[1]
+    adc #1                                                            // 5694: 69 01       i.  :b694[1]
+    cmp #$10                                                          // 5696: c9 10       ..  :b696[1]
+    bcs cb68c                                                         // 5698: b0 f2       ..  :b698[1]
+    cmp #2                                                            // 569a: c9 02       ..  :b69a[1]
+    beq cb68c                                                         // 569c: f0 ee       ..  :b69c[1]
+    cmp #$0e                                                          // 569e: c9 0e       ..  :b69e[1]
+    bne cb6a6                                                         // 56a0: d0 04       ..  :b6a0[1]
+    ldy #$fe                                                          // 56a2: a0 fe       ..  :b6a2[1]
+    and (l00b8),y                                                     // 56a4: 31 b8       1.  :b6a4[1]
+// $56a6 referenced 1 time by $b6a0
+cb6a6
+    ldy #$f1                                                          // 56a6: a0 f1       ..  :b6a6[1]
+    sta (l00b8),y                                                     // 56a8: 91 b8       ..  :b6a8[1]
+    tay                                                               // 56aa: a8          .   :b6aa[1]
+    jsr sub_cb6fe                                                     // 56ab: 20 fe b6     .. :b6ab[1]
+    beq cb68c                                                         // 56ae: f0 dc       ..  :b6ae[1]
+    rts                                                               // 56b0: 60          `   :b6b0[1]
+
+// $56b1 referenced 2 times by $b305, $bcda
+sub_cb6b1
+    ldy #$10                                                          // 56b1: a0 10       ..  :b6b1[1]
+// $56b3 referenced 1 time by $b6c5
+loop_cb6b3
+    cmp cb6ca,y                                                       // 56b3: d9 ca b6    ... :b6b3[1]
+    bcc cb6ca                                                         // 56b6: 90 12       ..  :b6b6[1]
+    bne cb6c2                                                         // 56b8: d0 08       ..  :b6b8[1]
+    pha                                                               // 56ba: 48          H   :b6ba[1]
+    txa                                                               // 56bb: 8a          .   :b6bb[1]
+    cmp lb6c6,y                                                       // 56bc: d9 c6 b6    ... :b6bc[1]
+    pla                                                               // 56bf: 68          h   :b6bf[1]
+    bcc cb6ca                                                         // 56c0: 90 08       ..  :b6c0[1]
+// $56c2 referenced 1 time by $b6b8
+cb6c2
+    iny                                                               // 56c2: c8          .   :b6c2[1]
+    cpy #$14                                                          // 56c3: c0 14       ..  :b6c3[1]
+sub_cb6c5
+lb6c6 = sub_cb6c5+1
+    bcc loop_cb6b3                                                    // 56c5: 90 ec       ..  :b6c5[1]
+// $56c6 referenced 1 time by $b6bc
+    jmp cb446                                                         // 56c7: 4c 46 b4    LF. :b6c7[1]
+
+// $56ca referenced 3 times by $b6b3, $b6b6, $b6c0
+cb6ca
+    pha                                                               // 56ca: 48          H   :b6ca[1]
+    txa                                                               // 56cb: 8a          .   :b6cb[1]
+    clc                                                               // 56cc: 18          .   :b6cc[1]
+sub_cb6cd
+lb6ce = sub_cb6cd+1
+    adc lb6ce,y                                                       // 56cd: 79 ce b6    y.. :b6cd[1]
+// $56ce referenced 1 time by $b6cd
+    tax                                                               // 56d0: aa          .   :b6d0[1]
+    pla                                                               // 56d1: 68          h   :b6d1[1]
+// $56d2 referenced 1 time by $b6d2
+cb6d2
+    adc cb6d2,y                                                       // 56d2: 79 d2 b6    y.. :b6d2[1]
+    rts                                                               // 56d5: 60          `   :b6d5[1]
+
+    .byt $f0, $e0, $d0, $c0, $3f, $7f, $bf, $ff, $10                  // 56d6: f0 e0 d0... ... :b6d6[1]
+    .asc " 0@"                                                        // 56df: 20 30 40     0@ :b6df[1]
+    .byt $80, $40,   0, $c0                                           // 56e2: 80 40 00... .@. :b6e2[1]
+
+// $56e6 referenced 1 time by $b6fe
+sub_cb6e6
+    cpy #$10                                                          // 56e6: c0 10       ..  :b6e6[1]
+    bcs cb6eb                                                         // 56e8: b0 01       ..  :b6e8[1]
+    rts                                                               // 56ea: 60          `   :b6ea[1]
+
+// $56eb referenced 1 time by $b6e8
+cb6eb
+    tya                                                               // 56eb: 98          .   :b6eb[1]
+    sec                                                               // 56ec: 38          8   :b6ec[1]
+    sbc #4                                                            // 56ed: e9 04       ..  :b6ed[1]
+    tay                                                               // 56ef: a8          .   :b6ef[1]
+    cpy #$0e                                                          // 56f0: c0 0e       ..  :b6f0[1]
+    bcs cb6f5                                                         // 56f2: b0 01       ..  :b6f2[1]
+    rts                                                               // 56f4: 60          `   :b6f4[1]
+
+// $56f5 referenced 1 time by $b6f2
+cb6f5
+    tya                                                               // 56f5: 98          .   :b6f5[1]
+    and #1                                                            // 56f6: 29 01       ).  :b6f6[1]
+    ldy #$fe                                                          // 56f8: a0 fe       ..  :b6f8[1]
+    ora (l00b8),y                                                     // 56fa: 11 b8       ..  :b6fa[1]
+    tay                                                               // 56fc: a8          .   :b6fc[1]
+    rts                                                               // 56fd: 60          `   :b6fd[1]
+
+// $56fe referenced 5 times by $b314, $b6ab, $bc44, $bc8e, $bce1
+sub_cb6fe
+    jsr sub_cb6e6                                                     // 56fe: 20 e6 b6     .. :b6fe[1]
+    tya                                                               // 5701: 98          .   :b701[1]
+    tax                                                               // 5702: aa          .   :b702[1]
+    lda lb726,y                                                       // 5703: b9 26 b7    .&. :b703[1]
+    pha                                                               // 5706: 48          H   :b706[1]
+    ldy #$ee                                                          // 5707: a0 ee       ..  :b707[1]
+    and (l00b8),y                                                     // 5709: 31 b8       1.  :b709[1]
+    bne cb718                                                         // 570b: d0 0b       ..  :b70b[1]
+    lda (l00b8),y                                                     // 570d: b1 b8       ..  :b70d[1]
+    and #$c0                                                          // 570f: 29 c0       ).  :b70f[1]
+    cmp #$80                                                          // 5711: c9 80       ..  :b711[1]
+    beq cb718                                                         // 5713: f0 03       ..  :b713[1]
+    jmp cb446                                                         // 5715: 4c 46 b4    LF. :b715[1]
+
+// $5718 referenced 2 times by $b70b, $b713
+cb718
+    pla                                                               // 5718: 68          h   :b718[1]
+    ldy #$fd                                                          // 5719: a0 fd       ..  :b719[1]
+    and (l00b8),y                                                     // 571b: 31 b8       1.  :b71b[1]
+    pha                                                               // 571d: 48          H   :b71d[1]
+    txa                                                               // 571e: 8a          .   :b71e[1]
+    tay                                                               // 571f: a8          .   :b71f[1]
+    pla                                                               // 5720: 68          h   :b720[1]
+    beq cb725                                                         // 5721: f0 02       ..  :b721[1]
+    lda #$ff                                                          // 5723: a9 ff       ..  :b723[1]
+// $5725 referenced 1 time by $b721
+cb725
+    rts                                                               // 5725: 60          `   :b725[1]
+
+// $5726 referenced 6 times by $b703, $b898, $b8c8, $b8db, $bc56, $bca1
+lb726
+    .byt   4,   8,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0   // 5726: 04 08 00... ... :b726[1]
+    .byt   1,   2, $10, $20                                           // 5732: 01 02 10... ... :b732[1]
+
+// $5736 referenced 1 time by $b75a
+cb736
+    sty romsel_copy                                                   // 5736: 84 f4       ..  :b736[1]
+    sty romsel                                                        // 5738: 8c 30 fe    .0. :b738[1]
+    ldy #0                                                            // 573b: a0 00       ..  :b73b[1]
+    sta (l00ba),y                                                     // 573d: 91 ba       ..  :b73d[1]
+    stx romsel_copy                                                   // 573f: 86 f4       ..  :b73f[1]
+    stx romsel                                                        // 5741: 8e 30 fe    .0. :b741[1]
+    rts                                                               // 5744: 60          `   :b744[1]
+
+// $5745 referenced 5 times by $b369, $b8b7, $b8d1, $bc78, $bc9e
+sub_cb745
+    sta l00bf                                                         // 5745: 85 bf       ..  :b745[1]
+    txa                                                               // 5747: 8a          .   :b747[1]
+    pha                                                               // 5748: 48          H   :b748[1]
+    tya                                                               // 5749: 98          .   :b749[1]
+    pha                                                               // 574a: 48          H   :b74a[1]
+    ldx romsel_copy                                                   // 574b: a6 f4       ..  :b74b[1]
+    lda l0df0,x                                                       // 574d: bd f0 0d    ... :b74d[1]
+    sta l00b1                                                         // 5750: 85 b1       ..  :b750[1]
+    inc l00b1                                                         // 5752: e6 b1       ..  :b752[1]
+    lda #0                                                            // 5754: a9 00       ..  :b754[1]
+    sta l00b0                                                         // 5756: 85 b0       ..  :b756[1]
+    ldy #$0e                                                          // 5758: a0 0e       ..  :b758[1]
+// $575a referenced 1 time by $b760
+loop_cb75a
+    lda cb736,y                                                       // 575a: b9 36 b7    .6. :b75a[1]
+    sta (l00b0),y                                                     // 575d: 91 b0       ..  :b75d[1]
+    dey                                                               // 575f: 88          .   :b75f[1]
+    bpl loop_cb75a                                                    // 5760: 10 f8       ..  :b760[1]
+    pla                                                               // 5762: 68          h   :b762[1]
+    pha                                                               // 5763: 48          H   :b763[1]
+    tay                                                               // 5764: a8          .   :b764[1]
+    lda l00bf                                                         // 5765: a5 bf       ..  :b765[1]
+    jsr sub_cb771                                                     // 5767: 20 71 b7     q. :b767[1]
+    pla                                                               // 576a: 68          h   :b76a[1]
+    tay                                                               // 576b: a8          .   :b76b[1]
+    pla                                                               // 576c: 68          h   :b76c[1]
+    tax                                                               // 576d: aa          .   :b76d[1]
+    lda l00bf                                                         // 576e: a5 bf       ..  :b76e[1]
+    rts                                                               // 5770: 60          `   :b770[1]
+
+// $5771 referenced 1 time by $b767
+sub_cb771
+    jmp (l00b0)                                                       // 5771: 6c b0 00    l.. :b771[1]
+
+// $5774 referenced 1 time by $b7be
+lb774
+    .byt $85, $f4, $8d, $30, $fe, $b1, $b1, $91, $b3, $c8, $d0,   5   // 5774: 85 f4 8d... ... :b774[1]
+    .byt $e6, $b2, $e6, $b4, $ca, $c4, $b5, $d0, $f0, $8a, $d0, $ed   // 5780: e6 b2 e6... ... :b780[1]
+    .byt $68, $85, $f4, $8d, $30, $fe, $4c, $d5, $b7                  // 578c: 68 85 f4... h.. :b78c[1]
+
+// $5795 referenced 5 times by $b4ca, $b51d, $bd0b, $bdb0, $bded
+cb795
+    ldy #$f1                                                          // 5795: a0 f1       ..  :b795[1]
+    lda (l00b8),y                                                     // 5797: b1 b8       ..  :b797[1]
+    sta l00b0                                                         // 5799: 85 b0       ..  :b799[1]
+    ldx l00be                                                         // 579b: a6 be       ..  :b79b[1]
+    ldy l00bf                                                         // 579d: a4 bf       ..  :b79d[1]
+    lda #0                                                            // 579f: a9 00       ..  :b79f[1]
+    rol                                                               // 57a1: 2a          *   :b7a1[1]
+    asl                                                               // 57a2: 0a          .   :b7a2[1]
+    sta l00b7                                                         // 57a3: 85 b7       ..  :b7a3[1]
+    inc l00b7                                                         // 57a5: e6 b7       ..  :b7a5[1]
+    jsr sub_cb85d                                                     // 57a7: 20 5d b8     ]. :b7a7[1]
+    bvs cb7ed                                                         // 57aa: 70 41       pA  :b7aa[1]
+    bvc cb7b2                                                         // 57ac: 50 04       P.  :b7ac[1]
+// $57ae referenced 1 time by $b803
+cb7ae
+    ldx l00be                                                         // 57ae: a6 be       ..  :b7ae[1]
+    ldy l00bf                                                         // 57b0: a4 bf       ..  :b7b0[1]
+// $57b2 referenced 1 time by $b7ac
+cb7b2
+    stx l00b5                                                         // 57b2: 86 b5       ..  :b7b2[1]
+    sty l00b6                                                         // 57b4: 84 b6       ..  :b7b4[1]
+// $57b6 referenced 1 time by $b812
+sub_cb7b6
+    lda l00b5                                                         // 57b6: a5 b5       ..  :b7b6[1]
+    ora l00b6                                                         // 57b8: 05 b6       ..  :b7b8[1]
+    beq cb7ec                                                         // 57ba: f0 30       .0  :b7ba[1]
+    ldx #$20 // ' '                                                   // 57bc: a2 20       .   :b7bc[1]
+// $57be referenced 1 time by $b7c3
+loop_cb7be
+    lda lb774,x                                                       // 57be: bd 74 b7    .t. :b7be[1]
+    pha                                                               // 57c1: 48          H   :b7c1[1]
+    dex                                                               // 57c2: ca          .   :b7c2[1]
+    bpl loop_cb7be                                                    // 57c3: 10 f9       ..  :b7c3[1]
+    tsx                                                               // 57c5: ba          .   :b7c5[1]
+    lda romsel_copy                                                   // 57c6: a5 f4       ..  :b7c6[1]
+    pha                                                               // 57c8: 48          H   :b7c8[1]
+    lda #1                                                            // 57c9: a9 01       ..  :b7c9[1]
+    pha                                                               // 57cb: 48          H   :b7cb[1]
+    txa                                                               // 57cc: 8a          .   :b7cc[1]
+    pha                                                               // 57cd: 48          H   :b7cd[1]
+    lda l00b0                                                         // 57ce: a5 b0       ..  :b7ce[1]
+    ldx l00b6                                                         // 57d0: a6 b6       ..  :b7d0[1]
+    ldy #0                                                            // 57d2: a0 00       ..  :b7d2[1]
+    rts                                                               // 57d4: 60          `   :b7d4[1]
+
+    ldx #$21 // '!'                                                   // 57d5: a2 21       .!  :b7d5[1]
+// $57d7 referenced 1 time by $b7d9
+loop_cb7d7
+    pla                                                               // 57d7: 68          h   :b7d7[1]
+    dex                                                               // 57d8: ca          .   :b7d8[1]
+    bne loop_cb7d7                                                    // 57d9: d0 fc       ..  :b7d9[1]
+    ldx #2                                                            // 57db: a2 02       ..  :b7db[1]
+// $57dd referenced 1 time by $b7ea
+loop_cb7dd
+    lda l00b1,x                                                       // 57dd: b5 b1       ..  :b7dd[1]
+    clc                                                               // 57df: 18          .   :b7df[1]
+    adc l00b5                                                         // 57e0: 65 b5       e.  :b7e0[1]
+    sta l00b1,x                                                       // 57e2: 95 b1       ..  :b7e2[1]
+    bcc cb7e8                                                         // 57e4: 90 02       ..  :b7e4[1]
+    inc l00b2,x                                                       // 57e6: f6 b2       ..  :b7e6[1]
+// $57e8 referenced 1 time by $b7e4
+cb7e8
+    dex                                                               // 57e8: ca          .   :b7e8[1]
+    dex                                                               // 57e9: ca          .   :b7e9[1]
+    bpl loop_cb7dd                                                    // 57ea: 10 f1       ..  :b7ea[1]
+// $57ec referenced 1 time by $b7ba
+cb7ec
+    rts                                                               // 57ec: 60          `   :b7ec[1]
+
+// $57ed referenced 2 times by $b7aa, $b828
+cb7ed
+    lda #0                                                            // 57ed: a9 00       ..  :b7ed[1]
+    sec                                                               // 57ef: 38          8   :b7ef[1]
+    ldx l00b7                                                         // 57f0: a6 b7       ..  :b7f0[1]
+    sbc l00b0,x                                                       // 57f2: f5 b0       ..  :b7f2[1]
+    sta l00b5                                                         // 57f4: 85 b5       ..  :b7f4[1]
+    lda #$c0                                                          // 57f6: a9 c0       ..  :b7f6[1]
+    sbc l00b1,x                                                       // 57f8: f5 b1       ..  :b7f8[1]
+    sta l00b6                                                         // 57fa: 85 b6       ..  :b7fa[1]
+    ldx #$b5                                                          // 57fc: a2 b5       ..  :b7fc[1]
+    ldy #$be                                                          // 57fe: a0 be       ..  :b7fe[1]
+    jsr sub_cb58b                                                     // 5800: 20 8b b5     .. :b800[1]
+    bcs cb7ae                                                         // 5803: b0 a9       ..  :b803[1]
+    lda l00be                                                         // 5805: a5 be       ..  :b805[1]
+    sec                                                               // 5807: 38          8   :b807[1]
+    sbc l00b5                                                         // 5808: e5 b5       ..  :b808[1]
+    sta l00be                                                         // 580a: 85 be       ..  :b80a[1]
+    lda l00bf                                                         // 580c: a5 bf       ..  :b80c[1]
+    sbc l00b6                                                         // 580e: e5 b6       ..  :b80e[1]
+    sta l00bf                                                         // 5810: 85 bf       ..  :b810[1]
+    jsr sub_cb7b6                                                     // 5812: 20 b6 b7     .. :b812[1]
+    lda #$10                                                          // 5815: a9 10       ..  :b815[1]
+    ldx l00b7                                                         // 5817: a6 b7       ..  :b817[1]
+    sta l00b0,x                                                       // 5819: 95 b0       ..  :b819[1]
+    lda #$80                                                          // 581b: a9 80       ..  :b81b[1]
+    sta l00b1,x                                                       // 581d: 95 b1       ..  :b81d[1]
+    jsr sub_cb68f                                                     // 581f: 20 8f b6     .. :b81f[1]
+    ldy #$f1                                                          // 5822: a0 f1       ..  :b822[1]
+    lda (l00b8),y                                                     // 5824: b1 b8       ..  :b824[1]
+    sta l00b0                                                         // 5826: 85 b0       ..  :b826[1]
+    jmp cb7ed                                                         // 5828: 4c ed b7    L.. :b828[1]
+
+// $582b referenced 16 times by $b1c1, $b2c8, $b2e7, $b32c, $b35a, $b3b0, $b3ec, $b429, $b4a3, $b573, $b5ca, $b5e8, $b604, $b611, $b86b, $beb5
+cb82b
+    php                                                               // 582b: 08          .   :b82b[1]
+    pha                                                               // 582c: 48          H   :b82c[1]
+    txa                                                               // 582d: 8a          .   :b82d[1]
+    pha                                                               // 582e: 48          H   :b82e[1]
+    lda #0                                                            // 582f: a9 00       ..  :b82f[1]
+    sta l00b8                                                         // 5831: 85 b8       ..  :b831[1]
+    ldx romsel_copy                                                   // 5833: a6 f4       ..  :b833[1]
+    lda l0df0,x                                                       // 5835: bd f0 0d    ... :b835[1]
+    sta l00b9                                                         // 5838: 85 b9       ..  :b838[1]
+    pla                                                               // 583a: 68          h   :b83a[1]
+    tax                                                               // 583b: aa          .   :b83b[1]
+    pla                                                               // 583c: 68          h   :b83c[1]
+    plp                                                               // 583d: 28          (   :b83d[1]
+    rts                                                               // 583e: 60          `   :b83e[1]
+
+// $583f referenced 4 times by $b35f, $b4e1, $b53d, $b622
+sub_cb83f
+    ldx #$ba                                                          // 583f: a2 ba       ..  :b83f[1]
+// $5841 referenced 12 times by $b39b, $b462, $b4b8, $b4bf, $b4c6, $b4f2, $b50b, $b512, $b519, $b663, $bd4a, $bdc4
+sub_cb841
+    pha                                                               // 5841: 48          H   :b841[1]
+    lda (l00b8),y                                                     // 5842: b1 b8       ..  :b842[1]
+    sta l0000,x                                                       // 5844: 95 00       ..  :b844[1]
+    iny                                                               // 5846: c8          .   :b846[1]
+    lda (l00b8),y                                                     // 5847: b1 b8       ..  :b847[1]
+    sta l0001,x                                                       // 5849: 95 01       ..  :b849[1]
+    dey                                                               // 584b: 88          .   :b84b[1]
+    pla                                                               // 584c: 68          h   :b84c[1]
+    rts                                                               // 584d: 60          `   :b84d[1]
+
+// $584e referenced 3 times by $b3f5, $b472, $b504
+sub_cb84e
+    ldx #$ba                                                          // 584e: a2 ba       ..  :b84e[1]
+// $5850 referenced 5 times by $b659, $b688, $bb5c, $bb8d, $bd36
+sub_cb850
+    pha                                                               // 5850: 48          H   :b850[1]
+    lda l0000,x                                                       // 5851: b5 00       ..  :b851[1]
+    sta (l00b8),y                                                     // 5853: 91 b8       ..  :b853[1]
+    iny                                                               // 5855: c8          .   :b855[1]
+    lda l0001,x                                                       // 5856: b5 01       ..  :b856[1]
+    sta (l00b8),y                                                     // 5858: 91 b8       ..  :b858[1]
+    dey                                                               // 585a: 88          .   :b85a[1]
+    pla                                                               // 585b: 68          h   :b85b[1]
+    rts                                                               // 585c: 60          `   :b85c[1]
+
+// $585d referenced 8 times by $b2f2, $b340, $b406, $b63f, $b66e, $b7a7, $be64, $be9d
+sub_cb85d
+    pha                                                               // 585d: 48          H   :b85d[1]
+    tya                                                               // 585e: 98          .   :b85e[1]
+    pha                                                               // 585f: 48          H   :b85f[1]
+    ldy #$ee                                                          // 5860: a0 ee       ..  :b860[1]
+    lda (l00b8),y                                                     // 5862: b1 b8       ..  :b862[1]
+    sta l00b8                                                         // 5864: 85 b8       ..  :b864[1]
+    pla                                                               // 5866: 68          h   :b866[1]
+    tay                                                               // 5867: a8          .   :b867[1]
+    pla                                                               // 5868: 68          h   :b868[1]
+    bit l00b8                                                         // 5869: 24 b8       $.  :b869[1]
+    jsr cb82b                                                         // 586b: 20 2b b8     +. :b86b[1]
+    rts                                                               // 586e: 60          `   :b86e[1]
+
+// $586f referenced 1 time by $b60e
+sub_cb86f
+    jmp (fscv)                                                        // 586f: 6c 1e 02    l.. :b86f[1]
+
+// $5872 referenced 2 times by $b9c7, $bc70
+lb872
+    .byt $60,   0,   0, $60,   0,   0,   2, $0c, $ff                  // 5872: 60 00 00... `.. :b872[1]
+    .asc "RAM"                                                        // 587b: 52 41 4d    RAM :b87b[1]
+// $587e referenced 1 time by $b9a3
+lb87e
+    .byt 0                                                            // 587e: 00          .   :b87e[1]
+    .asc "(C)"                                                        // 587f: 28 43 29    (C) :b87f[1]
+
+// $5882 referenced 1 time by $b200
+sub_cb882
+    lda #0                                                            // 5882: a9 00       ..  :b882[1]
+    ldy #$fd                                                          // 5884: a0 fd       ..  :b884[1]
+    sta (l00b8),y                                                     // 5886: 91 b8       ..  :b886[1]
+    ldy #$ee                                                          // 5888: a0 ee       ..  :b888[1]
+    sta (l00b8),y                                                     // 588a: 91 b8       ..  :b88a[1]
+    ldy #$fa                                                          // 588c: a0 fa       ..  :b88c[1]
+    sta (l00b8),y                                                     // 588e: 91 b8       ..  :b88e[1]
+    ldy #$ff                                                          // 5890: a0 ff       ..  :b890[1]
+    lda #$4e // 'N'                                                   // 5892: a9 4e       .N  :b892[1]
+    sta (l00b8),y                                                     // 5894: 91 b8       ..  :b894[1]
+    ldy #$0f                                                          // 5896: a0 0f       ..  :b896[1]
+// $5898 referenced 1 time by $b8e7
+cb898
+    lda lb726,y                                                       // 5898: b9 26 b7    .&. :b898[1]
+    beq cb8e6                                                         // 589b: f0 49       .I  :b89b[1]
+    tya                                                               // 589d: 98          .   :b89d[1]
+    pha                                                               // 589e: 48          H   :b89e[1]
+    lda #8                                                            // 589f: a9 08       ..  :b89f[1]
+    sta osrdsc_ptr                                                    // 58a1: 85 f6       ..  :b8a1[1]
+    sta l00ba                                                         // 58a3: 85 ba       ..  :b8a3[1]
+    lda #$80                                                          // 58a5: a9 80       ..  :b8a5[1]
+    sta l00f7                                                         // 58a7: 85 f7       ..  :b8a7[1]
+    sta l00bb                                                         // 58a9: 85 bb       ..  :b8a9[1]
+    jsr osrdsc                                                        // 58ab: 20 b9 ff     .. :b8ab[1]
+    sta l00bd                                                         // 58ae: 85 bd       ..  :b8ae[1]
+    pla                                                               // 58b0: 68          h   :b8b0[1]
+    pha                                                               // 58b1: 48          H   :b8b1[1]
+    tay                                                               // 58b2: a8          .   :b8b2[1]
+    lda l00bd                                                         // 58b3: a5 bd       ..  :b8b3[1]
+    eor #$ff                                                          // 58b5: 49 ff       I.  :b8b5[1]
+    jsr sub_cb745                                                     // 58b7: 20 45 b7     E. :b8b7[1]
+    jsr osrdsc                                                        // 58ba: 20 b9 ff     .. :b8ba[1]
+    cmp l00bd                                                         // 58bd: c5 bd       ..  :b8bd[1]
+    beq cb8e4                                                         // 58bf: f0 23       .#  :b8bf[1]
+    pla                                                               // 58c1: 68          h   :b8c1[1]
+    pha                                                               // 58c2: 48          H   :b8c2[1]
+    tax                                                               // 58c3: aa          .   :b8c3[1]
+    ldy #$ee                                                          // 58c4: a0 ee       ..  :b8c4[1]
+    lda (l00b8),y                                                     // 58c6: b1 b8       ..  :b8c6[1]
+    ora lb726,x                                                       // 58c8: 1d 26 b7    .&. :b8c8[1]
+    sta (l00b8),y                                                     // 58cb: 91 b8       ..  :b8cb[1]
+    txa                                                               // 58cd: 8a          .   :b8cd[1]
+    tay                                                               // 58ce: a8          .   :b8ce[1]
+    lda l00bd                                                         // 58cf: a5 bd       ..  :b8cf[1]
+    jsr sub_cb745                                                     // 58d1: 20 45 b7     E. :b8d1[1]
+    jsr sub_cb986                                                     // 58d4: 20 86 b9     .. :b8d4[1]
+    cmp #2                                                            // 58d7: c9 02       ..  :b8d7[1]
+    bne cb8e4                                                         // 58d9: d0 09       ..  :b8d9[1]
+    lda lb726,y                                                       // 58db: b9 26 b7    .&. :b8db[1]
+    ldy #$fd                                                          // 58de: a0 fd       ..  :b8de[1]
+    ora (l00b8),y                                                     // 58e0: 11 b8       ..  :b8e0[1]
+    sta (l00b8),y                                                     // 58e2: 91 b8       ..  :b8e2[1]
+// $58e4 referenced 2 times by $b8bf, $b8d9
+cb8e4
+    pla                                                               // 58e4: 68          h   :b8e4[1]
+    tay                                                               // 58e5: a8          .   :b8e5[1]
+// $58e6 referenced 1 time by $b89b
+cb8e6
+    dey                                                               // 58e6: 88          .   :b8e6[1]
+    bpl cb898                                                         // 58e7: 10 af       ..  :b8e7[1]
+    ldy #$ee                                                          // 58e9: a0 ee       ..  :b8e9[1]
+    lda (l00b8),y                                                     // 58eb: b1 b8       ..  :b8eb[1]
+    ldx #0                                                            // 58ed: a2 00       ..  :b8ed[1]
+    and #$0c                                                          // 58ef: 29 0c       ).  :b8ef[1]
+    bne cb8f5                                                         // 58f1: d0 02       ..  :b8f1[1]
+    ldx #$0e                                                          // 58f3: a2 0e       ..  :b8f3[1]
+// $58f5 referenced 1 time by $b8f1
+cb8f5
+    txa                                                               // 58f5: 8a          .   :b8f5[1]
+    ldy #$fe                                                          // 58f6: a0 fe       ..  :b8f6[1]
+    sta (l00b8),y                                                     // 58f8: 91 b8       ..  :b8f8[1]
+    rts                                                               // 58fa: 60          `   :b8fa[1]
+
+// $58fb referenced 6 times by $b302, $b334, $b448, $b5e3, $bafa, $bc51
+cb8fb
+    lda #0                                                            // 58fb: a9 00       ..  :b8fb[1]
+    sta l0100                                                         // 58fd: 8d 00 01    ... :b8fd[1]
+    lda lb980,x                                                       // 5900: bd 80 b9    ... :b900[1]
+    sta l0101                                                         // 5903: 8d 01 01    ... :b903[1]
+    lda lb97a,x                                                       // 5906: bd 7a b9    .z. :b906[1]
+    sta l00bf                                                         // 5909: 85 bf       ..  :b909[1]
+    ldy lb979,x                                                       // 590b: bc 79 b9    .y. :b90b[1]
+    ldx #0                                                            // 590e: a2 00       ..  :b90e[1]
+// $5910 referenced 1 time by $b91a
+loop_cb910
+    lda lb924,y                                                       // 5910: b9 24 b9    .$. :b910[1]
+    sta l0102,x                                                       // 5913: 9d 02 01    ... :b913[1]
+    inx                                                               // 5916: e8          .   :b916[1]
+    iny                                                               // 5917: c8          .   :b917[1]
+    cpy l00bf                                                         // 5918: c4 bf       ..  :b918[1]
+    bcc loop_cb910                                                    // 591a: 90 f4       ..  :b91a[1]
+    lda #0                                                            // 591c: a9 00       ..  :b91c[1]
+    sta l0102,x                                                       // 591e: 9d 02 01    ... :b91e[1]
+    jmp l0100                                                         // 5921: 4c 00 01    L.. :b921[1]
+
+// $5924 referenced 1 time by $b910
+lb924
+    .asc "Illegal parameterIllegal addressNo filing systemBad comm"   // 5924: 49 6c 6c... Ill :b924[1]
+    .asc "andFile not foundRAM occupied"                              // 595c: 61 6e 64... and :b95c[1]
+// $5979 referenced 1 time by $b90b
+lb979
+    .byt 0                                                            // 5979: 00          .   :b979[1]
+// $597a referenced 1 time by $b906
+lb97a
+    .byt $11                                                          // 597a: 11          .   :b97a[1]
+    .asc " 0;IU"                                                      // 597b: 20 30 3b...  0; :b97b[1]
+// $5980 referenced 1 time by $b900
+lb980
+    .byt $80, $81, $82, $fe, $d6, $83                                 // 5980: 80 81 82... ... :b980[1]
+
+// $5986 referenced 3 times by $b8d4, $bc49, $bcb2
+sub_cb986
+    txa                                                               // 5986: 8a          .   :b986[1]
+    pha                                                               // 5987: 48          H   :b987[1]
+    tya                                                               // 5988: 98          .   :b988[1]
+    pha                                                               // 5989: 48          H   :b989[1]
+    ldx #7                                                            // 598a: a2 07       ..  :b98a[1]
+    stx osrdsc_ptr                                                    // 598c: 86 f6       ..  :b98c[1]
+    lda #$80                                                          // 598e: a9 80       ..  :b98e[1]
+    sta l00f7                                                         // 5990: 85 f7       ..  :b990[1]
+    jsr osrdsc                                                        // 5992: 20 b9 ff     .. :b992[1]
+    sta osrdsc_ptr                                                    // 5995: 85 f6       ..  :b995[1]
+    ldx #0                                                            // 5997: a2 00       ..  :b997[1]
+// $5999 referenced 1 time by $b9b1
+loop_cb999
+    stx l00bf                                                         // 5999: 86 bf       ..  :b999[1]
+    pla                                                               // 599b: 68          h   :b99b[1]
+    pha                                                               // 599c: 48          H   :b99c[1]
+    tay                                                               // 599d: a8          .   :b99d[1]
+    jsr osrdsc                                                        // 599e: 20 b9 ff     .. :b99e[1]
+    ldx l00bf                                                         // 59a1: a6 bf       ..  :b9a1[1]
+    cmp lb87e,x                                                       // 59a3: dd 7e b8    .~. :b9a3[1]
+    bne cb9ee                                                         // 59a6: d0 46       .F  :b9a6[1]
+    inc osrdsc_ptr                                                    // 59a8: e6 f6       ..  :b9a8[1]
+    bne cb9ae                                                         // 59aa: d0 02       ..  :b9aa[1]
+    inc l00f7                                                         // 59ac: e6 f7       ..  :b9ac[1]
+// $59ae referenced 1 time by $b9aa
+cb9ae
+    inx                                                               // 59ae: e8          .   :b9ae[1]
+    cpx #4                                                            // 59af: e0 04       ..  :b9af[1]
+    bcc loop_cb999                                                    // 59b1: 90 e6       ..  :b9b1[1]
+    lda #2                                                            // 59b3: a9 02       ..  :b9b3[1]
+    sta l00bf                                                         // 59b5: 85 bf       ..  :b9b5[1]
+    ldx #$0f                                                          // 59b7: a2 0f       ..  :b9b7[1]
+    lda #$80                                                          // 59b9: a9 80       ..  :b9b9[1]
+    sta l00f7                                                         // 59bb: 85 f7       ..  :b9bb[1]
+// $59bd referenced 1 time by $b9cf
+loop_cb9bd
+    stx osrdsc_ptr                                                    // 59bd: 86 f6       ..  :b9bd[1]
+    pla                                                               // 59bf: 68          h   :b9bf[1]
+    pha                                                               // 59c0: 48          H   :b9c0[1]
+    tay                                                               // 59c1: a8          .   :b9c1[1]
+    jsr osrdsc                                                        // 59c2: 20 b9 ff     .. :b9c2[1]
+    ldx osrdsc_ptr                                                    // 59c5: a6 f6       ..  :b9c5[1]
+    cmp lb872,x                                                       // 59c7: dd 72 b8    .r. :b9c7[1]
+    bne cb9d9                                                         // 59ca: d0 0d       ..  :b9ca[1]
+// $59cc referenced 1 time by $b9e5
+loop_cb9cc
+    dex                                                               // 59cc: ca          .   :b9cc[1]
+    cpx #6                                                            // 59cd: e0 06       ..  :b9cd[1]
+    bcs loop_cb9bd                                                    // 59cf: b0 ec       ..  :b9cf[1]
+// $59d1 referenced 1 time by $b9ec
+loop_cb9d1
+    clc                                                               // 59d1: 18          .   :b9d1[1]
+// $59d2 referenced 1 time by $b9f3
+cb9d2
+    pla                                                               // 59d2: 68          h   :b9d2[1]
+    tay                                                               // 59d3: a8          .   :b9d3[1]
+    pla                                                               // 59d4: 68          h   :b9d4[1]
+    tax                                                               // 59d5: aa          .   :b9d5[1]
+    lda l00bf                                                         // 59d6: a5 bf       ..  :b9d6[1]
+    rts                                                               // 59d8: 60          `   :b9d8[1]
+
+// $59d9 referenced 1 time by $b9ca
+cb9d9
+    cpx #$0a                                                          // 59d9: e0 0a       ..  :b9d9[1]
+    bne cb9e8                                                         // 59db: d0 0b       ..  :b9db[1]
+    cmp #$4f // 'O'                                                   // 59dd: c9 4f       .O  :b9dd[1]
+    bne cb9e8                                                         // 59df: d0 07       ..  :b9df[1]
+    lda #1                                                            // 59e1: a9 01       ..  :b9e1[1]
+    sta l00bf                                                         // 59e3: 85 bf       ..  :b9e3[1]
+    jmp loop_cb9cc                                                    // 59e5: 4c cc b9    L.. :b9e5[1]
+
+// $59e8 referenced 2 times by $b9db, $b9df
+cb9e8
+    lda #0                                                            // 59e8: a9 00       ..  :b9e8[1]
+    sta l00bf                                                         // 59ea: 85 bf       ..  :b9ea[1]
+    beq loop_cb9d1                                                    // 59ec: f0 e3       ..  :b9ec[1]
+// $59ee referenced 1 time by $b9a6
+cb9ee
+    lda #$ff                                                          // 59ee: a9 ff       ..  :b9ee[1]
+    sta l00bf                                                         // 59f0: 85 bf       ..  :b9f0[1]
+    sec                                                               // 59f2: 38          8   :b9f2[1]
+    bcs cb9d2                                                         // 59f3: b0 dd       ..  :b9f3[1]
+// $59f5 referenced 2 times by $b225, $b297
+sub_cb9f5
+    ldx #0                                                            // 59f5: a2 00       ..  :b9f5[1]
+// $59f7 referenced 1 time by $ba25
+cb9f7
+    tya                                                               // 59f7: 98          .   :b9f7[1]
+    pha                                                               // 59f8: 48          H   :b9f8[1]
+// $59f9 referenced 1 time by $ba0e
+loop_cb9f9
+    lda (os_text_ptr),y                                               // 59f9: b1 f2       ..  :b9f9[1]
+    bmi cba10                                                         // 59fb: 30 13       0.  :b9fb[1]
+    cmp #$2e // '.'                                                   // 59fd: c9 2e       ..  :b9fd[1]
+    beq cba19                                                         // 59ff: f0 18       ..  :b9ff[1]
+    cmp #$41 // 'A'                                                   // 5a01: c9 41       .A  :ba01[1]
+    bcc cba10                                                         // 5a03: 90 0b       ..  :ba03[1]
+    eor sram_table,x                                                  // 5a05: 5d 30 ba    ]0. :ba05[1]
+    and #$df                                                          // 5a08: 29 df       ).  :ba08[1]
+    bne cba15                                                         // 5a0a: d0 09       ..  :ba0a[1]
+    iny                                                               // 5a0c: c8          .   :ba0c[1]
+    inx                                                               // 5a0d: e8          .   :ba0d[1]
+    bne loop_cb9f9                                                    // 5a0e: d0 e9       ..  :ba0e[1]
+// $5a10 referenced 2 times by $b9fb, $ba03
+cba10
+    lda sram_table,x                                                  // 5a10: bd 30 ba    .0. :ba10[1]
+    bmi cba28                                                         // 5a13: 30 13       0.  :ba13[1]
+// $5a15 referenced 1 time by $ba0a
+cba15
+    clc                                                               // 5a15: 18          .   :ba15[1]
+    pla                                                               // 5a16: 68          h   :ba16[1]
+    tay                                                               // 5a17: a8          .   :ba17[1]
+    dey                                                               // 5a18: 88          .   :ba18[1]
+// $5a19 referenced 1 time by $b9ff
+cba19
+    iny                                                               // 5a19: c8          .   :ba19[1]
+// $5a1a referenced 1 time by $ba20
+loop_cba1a
+    inx                                                               // 5a1a: e8          .   :ba1a[1]
+    lda cba2f,x                                                       // 5a1b: bd 2f ba    ./. :ba1b[1]
+    beq cba2e                                                         // 5a1e: f0 0e       ..  :ba1e[1]
+    bpl loop_cba1a                                                    // 5a20: 10 f8       ..  :ba20[1]
+    bcs cba27                                                         // 5a22: b0 03       ..  :ba22[1]
+    inx                                                               // 5a24: e8          .   :ba24[1]
+    bcc cb9f7                                                         // 5a25: 90 d0       ..  :ba25[1]
+// $5a27 referenced 1 time by $ba22
+cba27
+    dex                                                               // 5a27: ca          .   :ba27[1]
+// $5a28 referenced 1 time by $ba13
+cba28
+    pla                                                               // 5a28: 68          h   :ba28[1]
+    jsr sub_cbab9                                                     // 5a29: 20 b9 ba     .. :ba29[1]
+    clc                                                               // 5a2c: 18          .   :ba2c[1]
+    rts                                                               // 5a2d: 60          `   :ba2d[1]
+
+// $5a2e referenced 1 time by $ba1e
+cba2e
+    sec                                                               // 5a2e: 38          8   :ba2e[1]
+// $5a2f referenced 1 time by $ba1b
+cba2f
+    rts                                                               // 5a2f: 60          `   :ba2f[1]
+
+// $5a30 referenced 3 times by $b234, $ba05, $ba10
+sram_table
+    .asc "SRAM"                                                       // 5a30: 53 52 41... SRA :ba30[1]
+// $5a31 referenced 1 time by $b238
+    .byt $ff, $ff                                                     // 5a34: ff ff       ..  :ba34[1]
+    .asc "SRLOAD"                                                     // 5a36: 53 52 4c... SRL :ba36[1]
+    .byt >(sub_cbb46-1)                                               // 5a3c: bb          .   :ba3c[1]
+    .byt <(sub_cbb46-1)                                               // 5a3d: 45          E   :ba3d[1]
+    .asc "SRSAVE"                                                     // 5a3e: 53 52 53... SRS :ba3e[1]
+    .byt >(sub_cbb4a-1)                                               // 5a44: bb          .   :ba44[1]
+    .byt <(sub_cbb4a-1)                                               // 5a45: 49          I   :ba45[1]
+    .asc "SRWRITE"                                                    // 5a46: 53 52 57... SRW :ba46[1]
+    .byt >(sub_cbbd3-1)                                               // 5a4d: bb          .   :ba4d[1]
+    .byt <(sub_cbbd3-1)                                               // 5a4e: d2          .   :ba4e[1]
+    .asc "SRREAD"                                                     // 5a4f: 53 52 52... SRR :ba4f[1]
+    .byt >(sub_cbbd7-1)                                               // 5a55: bb          .   :ba55[1]
+    .byt <(sub_cbbd7-1)                                               // 5a56: d6          .   :ba56[1]
+    .asc "SRDATA"                                                     // 5a57: 53 52 44... SRD :ba57[1]
+    .byt >(sub_cbc37-1)                                               // 5a5d: bc          .   :ba5d[1]
+    .byt <(sub_cbc37-1)                                               // 5a5e: 36          6   :ba5e[1]
+    .asc "SRROM"                                                      // 5a5f: 53 52 52... SRR :ba5f[1]
+    .byt >(sub_cbc81-1)                                               // 5a64: bc          .   :ba64[1]
+    .byt <(sub_cbc81-1)                                               // 5a65: 80          .   :ba65[1]
+    .byt 0                                                            // 5a66: 00          .   :ba66[1]
+
+// $5a67 referenced 5 times by $bb51, $bb6c, $bbdd, $bbf3, $bc1c
+sub_cba67
+    txa                                                               // 5a67: 8a          .   :ba67[1]
+    pha                                                               // 5a68: 48          H   :ba68[1]
+    jsr sub_cbab9                                                     // 5a69: 20 b9 ba     .. :ba69[1]
+    lda #0                                                            // 5a6c: a9 00       ..  :ba6c[1]
+    sta l00bc                                                         // 5a6e: 85 bc       ..  :ba6e[1]
+    sta l00bd                                                         // 5a70: 85 bd       ..  :ba70[1]
+    sta l00be                                                         // 5a72: 85 be       ..  :ba72[1]
+    sta l00bf                                                         // 5a74: 85 bf       ..  :ba74[1]
+    sec                                                               // 5a76: 38          8   :ba76[1]
+    php                                                               // 5a77: 08          .   :ba77[1]
+// $5a78 referenced 1 time by $baae
+cba78
+    lda (os_text_ptr),y                                               // 5a78: b1 f2       ..  :ba78[1]
+    cmp #$30 // '0'                                                   // 5a7a: c9 30       .0  :ba7a[1]
+    bcc cbab4                                                         // 5a7c: 90 36       .6  :ba7c[1]
+    cmp #$3a // ':'                                                   // 5a7e: c9 3a       .:  :ba7e[1]
+    bcc cba8c                                                         // 5a80: 90 0a       ..  :ba80[1]
+    cmp #$47 // 'G'                                                   // 5a82: c9 47       .G  :ba82[1]
+    bcs cbab4                                                         // 5a84: b0 2e       ..  :ba84[1]
+    cmp #$41 // 'A'                                                   // 5a86: c9 41       .A  :ba86[1]
+    bcc cbab4                                                         // 5a88: 90 2a       .*  :ba88[1]
+    sbc #7                                                            // 5a8a: e9 07       ..  :ba8a[1]
+// $5a8c referenced 1 time by $ba80
+cba8c
+    sec                                                               // 5a8c: 38          8   :ba8c[1]
+    sbc #$30 // '0'                                                   // 5a8d: e9 30       .0  :ba8d[1]
+    plp                                                               // 5a8f: 28          (   :ba8f[1]
+    php                                                               // 5a90: 08          .   :ba90[1]
+    pha                                                               // 5a91: 48          H   :ba91[1]
+    ldx #4                                                            // 5a92: a2 04       ..  :ba92[1]
+// $5a94 referenced 1 time by $baa1
+loop_cba94
+    asl l00bc                                                         // 5a94: 06 bc       ..  :ba94[1]
+    rol l00bd                                                         // 5a96: 26 bd       &.  :ba96[1]
+    bvc cba9e                                                         // 5a98: 50 04       P.  :ba98[1]
+    rol l00be                                                         // 5a9a: 26 be       &.  :ba9a[1]
+    rol l00bf                                                         // 5a9c: 26 bf       &.  :ba9c[1]
+// $5a9e referenced 1 time by $ba98
+cba9e
+    bcs cbab0                                                         // 5a9e: b0 10       ..  :ba9e[1]
+    dex                                                               // 5aa0: ca          .   :baa0[1]
+    bne loop_cba94                                                    // 5aa1: d0 f1       ..  :baa1[1]
+    pla                                                               // 5aa3: 68          h   :baa3[1]
+    ora l00bc                                                         // 5aa4: 05 bc       ..  :baa4[1]
+    sta l00bc                                                         // 5aa6: 85 bc       ..  :baa6[1]
+    plp                                                               // 5aa8: 28          (   :baa8[1]
+    clc                                                               // 5aa9: 18          .   :baa9[1]
+    php                                                               // 5aaa: 08          .   :baaa[1]
+    iny                                                               // 5aab: c8          .   :baab[1]
+    beq cbab1                                                         // 5aac: f0 03       ..  :baac[1]
+    bcc cba78                                                         // 5aae: 90 c8       ..  :baae[1]
+// $5ab0 referenced 1 time by $ba9e
+cbab0
+    pla                                                               // 5ab0: 68          h   :bab0[1]
+// $5ab1 referenced 1 time by $baac
+cbab1
+    plp                                                               // 5ab1: 28          (   :bab1[1]
+    sec                                                               // 5ab2: 38          8   :bab2[1]
+    php                                                               // 5ab3: 08          .   :bab3[1]
+// $5ab4 referenced 3 times by $ba7c, $ba84, $ba88
+cbab4
+    plp                                                               // 5ab4: 28          (   :bab4[1]
+    pla                                                               // 5ab5: 68          h   :bab5[1]
+    tax                                                               // 5ab6: aa          .   :bab6[1]
+    rts                                                               // 5ab7: 60          `   :bab7[1]
+
+// $5ab8 referenced 1 time by $babd
+loop_cbab8
+    iny                                                               // 5ab8: c8          .   :bab8[1]
+// $5ab9 referenced 7 times by $ba29, $ba69, $bac5, $bad2, $bb02, $bb2b, $bbb0
+sub_cbab9
+    lda (os_text_ptr),y                                               // 5ab9: b1 f2       ..  :bab9[1]
+    cmp #$20 // ' '                                                   // 5abb: c9 20       .   :babb[1]
+    beq loop_cbab8                                                    // 5abd: f0 f9       ..  :babd[1]
+    cmp #$0d                                                          // 5abf: c9 0d       ..  :babf[1]
+    rts                                                               // 5ac1: 60          `   :bac1[1]
+
+// $5ac2 referenced 4 times by $bbbe, $bc2c, $bc3d, $bc87
+sub_cbac2
+    lda #$0d                                                          // 5ac2: a9 0d       ..  :bac2[1]
+// $5ac4 referenced 3 times by $b26e, $bb67, $bbed
+sub_cbac4
+    pha                                                               // 5ac4: 48          H   :bac4[1]
+    jsr sub_cbab9                                                     // 5ac5: 20 b9 ba     .. :bac5[1]
+    pla                                                               // 5ac8: 68          h   :bac8[1]
+    cmp (os_text_ptr),y                                               // 5ac9: d1 f2       ..  :bac9[1]
+    bne cbad0                                                         // 5acb: d0 03       ..  :bacb[1]
+    clc                                                               // 5acd: 18          .   :bacd[1]
+    iny                                                               // 5ace: c8          .   :bace[1]
+    rts                                                               // 5acf: 60          `   :bacf[1]
+
+// $5ad0 referenced 1 time by $bacb
+cbad0
+    sec                                                               // 5ad0: 38          8   :bad0[1]
+    rts                                                               // 5ad1: 60          `   :bad1[1]
+
+// $5ad2 referenced 1 time by $bb4d
+sub_cbad2
+    jsr sub_cbab9                                                     // 5ad2: 20 b9 ba     .. :bad2[1]
+    tya                                                               // 5ad5: 98          .   :bad5[1]
+    pha                                                               // 5ad6: 48          H   :bad6[1]
+    clc                                                               // 5ad7: 18          .   :bad7[1]
+    adc os_text_ptr                                                   // 5ad8: 65 f2       e.  :bad8[1]
+    ldy #$ef                                                          // 5ada: a0 ef       ..  :bada[1]
+    sta (l00b8),y                                                     // 5adc: 91 b8       ..  :badc[1]
+    lda l00f3                                                         // 5ade: a5 f3       ..  :bade[1]
+    adc #0                                                            // 5ae0: 69 00       i.  :bae0[1]
+    iny                                                               // 5ae2: c8          .   :bae2[1]
+    sta (l00b8),y                                                     // 5ae3: 91 b8       ..  :bae3[1]
+    pla                                                               // 5ae5: 68          h   :bae5[1]
+    tay                                                               // 5ae6: a8          .   :bae6[1]
+    bit lb57f                                                         // 5ae7: 2c 7f b5    ,.. :bae7[1]
+// $5aea referenced 1 time by $baf6
+loop_cbaea
+    lda (os_text_ptr),y                                               // 5aea: b1 f2       ..  :baea[1]
+    cmp #$20 // ' '                                                   // 5aec: c9 20       .   :baec[1]
+    beq cbafd                                                         // 5aee: f0 0d       ..  :baee[1]
+    cmp #$0d                                                          // 5af0: c9 0d       ..  :baf0[1]
+    beq cbafd                                                         // 5af2: f0 09       ..  :baf2[1]
+    clv                                                               // 5af4: b8          .   :baf4[1]
+    iny                                                               // 5af5: c8          .   :baf5[1]
+    bne loop_cbaea                                                    // 5af6: d0 f2       ..  :baf6[1]
+// $5af8 referenced 2 times by $bafd, $bbd0
+cbaf8
+    ldx #3                                                            // 5af8: a2 03       ..  :baf8[1]
+    jmp cb8fb                                                         // 5afa: 4c fb b8    L.. :bafa[1]
+
+// $5afd referenced 2 times by $baee, $baf2
+cbafd
+    bvs cbaf8                                                         // 5afd: 70 f9       p.  :bafd[1]
+    rts                                                               // 5aff: 60          `   :baff[1]
+
+// $5b00 referenced 4 times by $bb92, $bc21, $bc37, $bc81
+sub_cbb00
+    stx l00bf                                                         // 5b00: 86 bf       ..  :bb00[1]
+    jsr sub_cbab9                                                     // 5b02: 20 b9 ba     .. :bb02[1]
+    ldx #3                                                            // 5b05: a2 03       ..  :bb05[1]
+// $5b07 referenced 1 time by $bb34
+cbb07
+    cmp lbb3e,x                                                       // 5b07: dd 3e bb    .>. :bb07[1]
+    bcs cbb36                                                         // 5b0a: b0 2a       .*  :bb0a[1]
+    cmp lbb3a,x                                                       // 5b0c: dd 3a bb    .:. :bb0c[1]
+    bcc cbb33                                                         // 5b0f: 90 22       ."  :bb0f[1]
+    sbc lbb42,x                                                       // 5b11: fd 42 bb    .B. :bb11[1]
+    iny                                                               // 5b14: c8          .   :bb14[1]
+    cmp #1                                                            // 5b15: c9 01       ..  :bb15[1]
+    bne cbb2a                                                         // 5b17: d0 11       ..  :bb17[1]
+    lda (os_text_ptr),y                                               // 5b19: b1 f2       ..  :bb19[1]
+    cmp #$36 // '6'                                                   // 5b1b: c9 36       .6  :bb1b[1]
+    bcs cbb28                                                         // 5b1d: b0 09       ..  :bb1d[1]
+    cmp #$30 // '0'                                                   // 5b1f: c9 30       .0  :bb1f[1]
+    bcc cbb28                                                         // 5b21: 90 05       ..  :bb21[1]
+    sbc #$26 // '&'                                                   // 5b23: e9 26       .&  :bb23[1]
+    iny                                                               // 5b25: c8          .   :bb25[1]
+    bne cbb2a                                                         // 5b26: d0 02       ..  :bb26[1]
+// $5b28 referenced 2 times by $bb1d, $bb21
+cbb28
+    lda #1                                                            // 5b28: a9 01       ..  :bb28[1]
+// $5b2a referenced 2 times by $bb17, $bb26
+cbb2a
+    pha                                                               // 5b2a: 48          H   :bb2a[1]
+    jsr sub_cbab9                                                     // 5b2b: 20 b9 ba     .. :bb2b[1]
+    pla                                                               // 5b2e: 68          h   :bb2e[1]
+    ldx l00bf                                                         // 5b2f: a6 bf       ..  :bb2f[1]
+    clc                                                               // 5b31: 18          .   :bb31[1]
+    rts                                                               // 5b32: 60          `   :bb32[1]
+
+// $5b33 referenced 1 time by $bb0f
+cbb33
+    dex                                                               // 5b33: ca          .   :bb33[1]
+    bpl cbb07                                                         // 5b34: 10 d1       ..  :bb34[1]
+// $5b36 referenced 1 time by $bb0a
+cbb36
+    ldx l00bf                                                         // 5b36: a6 bf       ..  :bb36[1]
+    sec                                                               // 5b38: 38          8   :bb38[1]
+    rts                                                               // 5b39: 60          `   :bb39[1]
+
+// $5b3a referenced 1 time by $bb0c
+lbb3a
+    .asc "0AWw"                                                       // 5b3a: 30 41 57... 0AW :bb3a[1]
+// $5b3e referenced 1 time by $bb07
+lbb3e
+    .asc ":G[{"                                                       // 5b3e: 3a 47 5b... :G[ :bb3e[1]
+// $5b42 referenced 1 time by $bb11
+lbb42
+    .asc "07Gg"                                                       // 5b42: 30 37 47... 07G :bb42[1]
+
+sub_cbb46
+    lda #$c0                                                          // 5b46: a9 c0       ..  :bb46[1]
+    bne cbb4c                                                         // 5b48: d0 02       ..  :bb48[1]
+sub_cbb4a
+    lda #$40 // '@'                                                   // 5b4a: a9 40       .@  :bb4a[1]
+// $5b4c referenced 1 time by $bb48
+cbb4c
+    pha                                                               // 5b4c: 48          H   :bb4c[1]
+    jsr sub_cbad2                                                     // 5b4d: 20 d2 ba     .. :bb4d[1]
+    clv                                                               // 5b50: b8          .   :bb50[1]
+    jsr sub_cba67                                                     // 5b51: 20 67 ba     g. :bb51[1]
+    bcs cbb6f                                                         // 5b54: b0 19       ..  :bb54[1]
+    sty l00ba                                                         // 5b56: 84 ba       ..  :bb56[1]
+    ldx #$bc                                                          // 5b58: a2 bc       ..  :bb58[1]
+    ldy #$f2                                                          // 5b5a: a0 f2       ..  :bb5a[1]
+    jsr sub_cb850                                                     // 5b5c: 20 50 b8     P. :bb5c[1]
+    ldy l00ba                                                         // 5b5f: a4 ba       ..  :bb5f[1]
+    pla                                                               // 5b61: 68          h   :bb61[1]
+    pha                                                               // 5b62: 48          H   :bb62[1]
+    bmi cbb90                                                         // 5b63: 30 2b       0+  :bb63[1]
+    lda #$2b // '+'                                                   // 5b65: a9 2b       .+  :bb65[1]
+    jsr sub_cbac4                                                     // 5b67: 20 c4 ba     .. :bb67[1]
+    php                                                               // 5b6a: 08          .   :bb6a[1]
+    clv                                                               // 5b6b: b8          .   :bb6b[1]
+    jsr sub_cba67                                                     // 5b6c: 20 67 ba     g. :bb6c[1]
+// $5b6f referenced 1 time by $bb54
+cbb6f
+    bcs cbbd0                                                         // 5b6f: b0 5f       ._  :bb6f[1]
+    sty l00ba                                                         // 5b71: 84 ba       ..  :bb71[1]
+    plp                                                               // 5b73: 28          (   :bb73[1]
+    bcc cbb89                                                         // 5b74: 90 13       ..  :bb74[1]
+    ldy #$f2                                                          // 5b76: a0 f2       ..  :bb76[1]
+    sec                                                               // 5b78: 38          8   :bb78[1]
+    lda l00bc                                                         // 5b79: a5 bc       ..  :bb79[1]
+    sec                                                               // 5b7b: 38          8   :bb7b[1]
+    sbc (l00b8),y                                                     // 5b7c: f1 b8       ..  :bb7c[1]
+    sta l00bc                                                         // 5b7e: 85 bc       ..  :bb7e[1]
+    iny                                                               // 5b80: c8          .   :bb80[1]
+    lda l00bd                                                         // 5b81: a5 bd       ..  :bb81[1]
+    sbc (l00b8),y                                                     // 5b83: f1 b8       ..  :bb83[1]
+    bcc cbbd0                                                         // 5b85: 90 49       .I  :bb85[1]
+    sta l00bd                                                         // 5b87: 85 bd       ..  :bb87[1]
+// $5b89 referenced 1 time by $bb74
+cbb89
+    ldx #$bc                                                          // 5b89: a2 bc       ..  :bb89[1]
+    ldy #$f4                                                          // 5b8b: a0 f4       ..  :bb8b[1]
+    jsr sub_cb850                                                     // 5b8d: 20 50 b8     P. :bb8d[1]
+// $5b90 referenced 1 time by $bb63
+cbb90
+    ldy l00ba                                                         // 5b90: a4 ba       ..  :bb90[1]
+    jsr sub_cbb00                                                     // 5b92: 20 00 bb     .. :bb92[1]
+    sty l00ba                                                         // 5b95: 84 ba       ..  :bb95[1]
+    bcs cbba1                                                         // 5b97: b0 08       ..  :bb97[1]
+    ldy #$f1                                                          // 5b99: a0 f1       ..  :bb99[1]
+    sta (l00b8),y                                                     // 5b9b: 91 b8       ..  :bb9b[1]
+    pla                                                               // 5b9d: 68          h   :bb9d[1]
+    and #$80                                                          // 5b9e: 29 80       ).  :bb9e[1]
+    pha                                                               // 5ba0: 48          H   :bba0[1]
+// $5ba1 referenced 1 time by $bb97
+cbba1
+    pla                                                               // 5ba1: 68          h   :bba1[1]
+    sta l00bb                                                         // 5ba2: 85 bb       ..  :bba2[1]
+    ldy #$ee                                                          // 5ba4: a0 ee       ..  :bba4[1]
+    lda (l00b8),y                                                     // 5ba6: b1 b8       ..  :bba6[1]
+    and #$3f // '?'                                                   // 5ba8: 29 3f       )?  :bba8[1]
+    ora l00bb                                                         // 5baa: 05 bb       ..  :bbaa[1]
+    sta (l00b8),y                                                     // 5bac: 91 b8       ..  :bbac[1]
+    ldy l00ba                                                         // 5bae: a4 ba       ..  :bbae[1]
+    jsr sub_cbab9                                                     // 5bb0: 20 b9 ba     .. :bbb0[1]
+    and #$df                                                          // 5bb3: 29 df       ).  :bbb3[1]
+    ldx #0                                                            // 5bb5: a2 00       ..  :bbb5[1]
+    cmp #$51 // 'Q'                                                   // 5bb7: c9 51       .Q  :bbb7[1]
+    bne cbbbe                                                         // 5bb9: d0 03       ..  :bbb9[1]
+    iny                                                               // 5bbb: c8          .   :bbbb[1]
+    ldx #$ff                                                          // 5bbc: a2 ff       ..  :bbbc[1]
+// $5bbe referenced 1 time by $bbb9
+cbbbe
+    jsr sub_cbac2                                                     // 5bbe: 20 c2 ba     .. :bbbe[1]
+    bcs cbbd0                                                         // 5bc1: b0 0d       ..  :bbc1[1]
+    ldy #$f8                                                          // 5bc3: a0 f8       ..  :bbc3[1]
+    lda #0                                                            // 5bc5: a9 00       ..  :bbc5[1]
+    sta (l00b8),y                                                     // 5bc7: 91 b8       ..  :bbc7[1]
+    iny                                                               // 5bc9: c8          .   :bbc9[1]
+    txa                                                               // 5bca: 8a          .   :bbca[1]
+    sta (l00b8),y                                                     // 5bcb: 91 b8       ..  :bbcb[1]
+    jmp cb2e7                                                         // 5bcd: 4c e7 b2    L.. :bbcd[1]
+
+// $5bd0 referenced 9 times by $bb6f, $bb85, $bbc1, $bbe0, $bbf6, $bc1f, $bc2f, $bc3a, $bc40
+cbbd0
+    jmp cbaf8                                                         // 5bd0: 4c f8 ba    L.. :bbd0[1]
+
+sub_cbbd3
+    lda #$c0                                                          // 5bd3: a9 c0       ..  :bbd3[1]
+    bne cbbd9                                                         // 5bd5: d0 02       ..  :bbd5[1]
+sub_cbbd7
+    lda #$40 // '@'                                                   // 5bd7: a9 40       .@  :bbd7[1]
+// $5bd9 referenced 1 time by $bbd5
+cbbd9
+    pha                                                               // 5bd9: 48          H   :bbd9[1]
+    bit lb57f                                                         // 5bda: 2c 7f b5    ,.. :bbda[1]
+    jsr sub_cba67                                                     // 5bdd: 20 67 ba     g. :bbdd[1]
+    bcs cbbd0                                                         // 5be0: b0 ee       ..  :bbe0[1]
+    ldx #3                                                            // 5be2: a2 03       ..  :bbe2[1]
+// $5be4 referenced 1 time by $bbe9
+loop_cbbe4
+    lda l00bc,x                                                       // 5be4: b5 bc       ..  :bbe4[1]
+    sta l00b1,x                                                       // 5be6: 95 b1       ..  :bbe6[1]
+    dex                                                               // 5be8: ca          .   :bbe8[1]
+    bpl loop_cbbe4                                                    // 5be9: 10 f9       ..  :bbe9[1]
+    lda #$2b // '+'                                                   // 5beb: a9 2b       .+  :bbeb[1]
+    jsr sub_cbac4                                                     // 5bed: 20 c4 ba     .. :bbed[1]
+    bcs cbbf3                                                         // 5bf0: b0 01       ..  :bbf0[1]
+    clv                                                               // 5bf2: b8          .   :bbf2[1]
+// $5bf3 referenced 1 time by $bbf0
+cbbf3
+    jsr sub_cba67                                                     // 5bf3: 20 67 ba     g. :bbf3[1]
+    bcs cbbd0                                                         // 5bf6: b0 d8       ..  :bbf6[1]
+    bvc cbc13                                                         // 5bf8: 50 19       P.  :bbf8[1]
+    sec                                                               // 5bfa: 38          8   :bbfa[1]
+    ldx #0                                                            // 5bfb: a2 00       ..  :bbfb[1]
+    sec                                                               // 5bfd: 38          8   :bbfd[1]
+// $5bfe referenced 1 time by $bc08
+loop_cbbfe
+    lda l00bc,x                                                       // 5bfe: b5 bc       ..  :bbfe[1]
+    sbc l00b1,x                                                       // 5c00: f5 b1       ..  :bc00[1]
+    sta l00bc,x                                                       // 5c02: 95 bc       ..  :bc02[1]
+    inx                                                               // 5c04: e8          .   :bc04[1]
+    txa                                                               // 5c05: 8a          .   :bc05[1]
+    and #4                                                            // 5c06: 29 04       ).  :bc06[1]
+    beq loop_cbbfe                                                    // 5c08: f0 f4       ..  :bc08[1]
+    lda l00be                                                         // 5c0a: a5 be       ..  :bc0a[1]
+    ora l00bf                                                         // 5c0c: 05 bf       ..  :bc0c[1]
+    beq cbc13                                                         // 5c0e: f0 03       ..  :bc0e[1]
+    jmp cb446                                                         // 5c10: 4c 46 b4    LF. :bc10[1]
+
+// $5c13 referenced 2 times by $bbf8, $bc0e
+cbc13
+    lda l00bc                                                         // 5c13: a5 bc       ..  :bc13[1]
+    sta l00b5                                                         // 5c15: 85 b5       ..  :bc15[1]
+    lda l00bd                                                         // 5c17: a5 bd       ..  :bc17[1]
+    sta l00b6                                                         // 5c19: 85 b6       ..  :bc19[1]
+    clv                                                               // 5c1b: b8          .   :bc1b[1]
+    jsr sub_cba67                                                     // 5c1c: 20 67 ba     g. :bc1c[1]
+    bcs cbbd0                                                         // 5c1f: b0 af       ..  :bc1f[1]
+    jsr sub_cbb00                                                     // 5c21: 20 00 bb     .. :bc21[1]
+    bcs cbc2c                                                         // 5c24: b0 06       ..  :bc24[1]
+    sta l00b7                                                         // 5c26: 85 b7       ..  :bc26[1]
+    pla                                                               // 5c28: 68          h   :bc28[1]
+    and #$bf                                                          // 5c29: 29 bf       ).  :bc29[1]
+    pha                                                               // 5c2b: 48          H   :bc2b[1]
+// $5c2c referenced 1 time by $bc24
+cbc2c
+    jsr sub_cbac2                                                     // 5c2c: 20 c2 ba     .. :bc2c[1]
+    bcs cbbd0                                                         // 5c2f: b0 9f       ..  :bc2f[1]
+    pla                                                               // 5c31: 68          h   :bc31[1]
+    sta l00b0                                                         // 5c32: 85 b0       ..  :bc32[1]
+    jmp cbcb9                                                         // 5c34: 4c b9 bc    L.. :bc34[1]
+
+sub_cbc37
+    jsr sub_cbb00                                                     // 5c37: 20 00 bb     .. :bc37[1]
+// $5c3a referenced 2 times by $bc84, $bc8a
+cbc3a
+    bcs cbbd0                                                         // 5c3a: b0 94       ..  :bc3a[1]
+    pha                                                               // 5c3c: 48          H   :bc3c[1]
+    jsr sub_cbac2                                                     // 5c3d: 20 c2 ba     .. :bc3d[1]
+    bcs cbbd0                                                         // 5c40: b0 8e       ..  :bc40[1]
+    pla                                                               // 5c42: 68          h   :bc42[1]
+    tay                                                               // 5c43: a8          .   :bc43[1]
+    jsr sub_cb6fe                                                     // 5c44: 20 fe b6     .. :bc44[1]
+    bne cbc64                                                         // 5c47: d0 1b       ..  :bc47[1]
+    jsr sub_cb986                                                     // 5c49: 20 86 b9     .. :bc49[1]
+    tax                                                               // 5c4c: aa          .   :bc4c[1]
+    bne cbc54                                                         // 5c4d: d0 05       ..  :bc4d[1]
+    ldx #5                                                            // 5c4f: a2 05       ..  :bc4f[1]
+    jmp cb8fb                                                         // 5c51: 4c fb b8    L.. :bc51[1]
+
+// $5c54 referenced 1 time by $bc4d
+cbc54
+    sty l00bf                                                         // 5c54: 84 bf       ..  :bc54[1]
+    lda lb726,y                                                       // 5c56: b9 26 b7    .&. :bc56[1]
+    ldy #$fd                                                          // 5c59: a0 fd       ..  :bc59[1]
+    ora (l00b8),y                                                     // 5c5b: 11 b8       ..  :bc5b[1]
+    sta (l00b8),y                                                     // 5c5d: 91 b8       ..  :bc5d[1]
+    ldy l00bf                                                         // 5c5f: a4 bf       ..  :bc5f[1]
+    jsr sub_cbc68                                                     // 5c61: 20 68 bc     h. :bc61[1]
+// $5c64 referenced 1 time by $bc47
+cbc64
+    jsr sub_cbec2                                                     // 5c64: 20 c2 be     .. :bc64[1]
+    rts                                                               // 5c67: 60          `   :bc67[1]
+
+// $5c68 referenced 2 times by $bc61, $bc95
+sub_cbc68
+    ldx #$0f                                                          // 5c68: a2 0f       ..  :bc68[1]
+    stx l00ba                                                         // 5c6a: 86 ba       ..  :bc6a[1]
+    lda #$80                                                          // 5c6c: a9 80       ..  :bc6c[1]
+    sta l00bb                                                         // 5c6e: 85 bb       ..  :bc6e[1]
+// $5c70 referenced 1 time by $bc7e
+loop_cbc70
+    lda lb872,x                                                       // 5c70: bd 72 b8    .r. :bc70[1]
+    cpx #1                                                            // 5c73: e0 01       ..  :bc73[1]
+    bne cbc78                                                         // 5c75: d0 01       ..  :bc75[1]
+    tya                                                               // 5c77: 98          .   :bc77[1]
+// $5c78 referenced 1 time by $bc75
+cbc78
+    jsr sub_cb745                                                     // 5c78: 20 45 b7     E. :bc78[1]
+    dex                                                               // 5c7b: ca          .   :bc7b[1]
+    stx l00ba                                                         // 5c7c: 86 ba       ..  :bc7c[1]
+    bpl loop_cbc70                                                    // 5c7e: 10 f0       ..  :bc7e[1]
+    rts                                                               // 5c80: 60          `   :bc80[1]
+
+sub_cbc81
+    jsr sub_cbb00                                                     // 5c81: 20 00 bb     .. :bc81[1]
+    bcs cbc3a                                                         // 5c84: b0 b4       ..  :bc84[1]
+    pha                                                               // 5c86: 48          H   :bc86[1]
+    jsr sub_cbac2                                                     // 5c87: 20 c2 ba     .. :bc87[1]
+    bcs cbc3a                                                         // 5c8a: b0 ae       ..  :bc8a[1]
+    pla                                                               // 5c8c: 68          h   :bc8c[1]
+    tay                                                               // 5c8d: a8          .   :bc8d[1]
+    jsr sub_cb6fe                                                     // 5c8e: 20 fe b6     .. :bc8e[1]
+    beq cbcb2                                                         // 5c91: f0 1f       ..  :bc91[1]
+// $5c93 referenced 1 time by $bcb6
+cbc93
+    sty l00bc                                                         // 5c93: 84 bc       ..  :bc93[1]
+    jsr sub_cbc68                                                     // 5c95: 20 68 bc     h. :bc95[1]
+    lda #$0a                                                          // 5c98: a9 0a       ..  :bc98[1]
+    sta l00ba                                                         // 5c9a: 85 ba       ..  :bc9a[1]
+    lda #$4f // 'O'                                                   // 5c9c: a9 4f       .O  :bc9c[1]
+    jsr sub_cb745                                                     // 5c9e: 20 45 b7     E. :bc9e[1]
+    lda lb726,y                                                       // 5ca1: b9 26 b7    .&. :bca1[1]
+    eor #$ff                                                          // 5ca4: 49 ff       I.  :bca4[1]
+    ldy #$fd                                                          // 5ca6: a0 fd       ..  :bca6[1]
+    and (l00b8),y                                                     // 5ca8: 31 b8       1.  :bca8[1]
+    sta (l00b8),y                                                     // 5caa: 91 b8       ..  :bcaa[1]
+    ldy l00bc                                                         // 5cac: a4 bc       ..  :bcac[1]
+    jsr sub_cbec2                                                     // 5cae: 20 c2 be     .. :bcae[1]
+    rts                                                               // 5cb1: 60          `   :bcb1[1]
+
+// $5cb2 referenced 1 time by $bc91
+cbcb2
+    jsr sub_cb986                                                     // 5cb2: 20 86 b9     .. :bcb2[1]
+    tax                                                               // 5cb5: aa          .   :bcb5[1]
+    bne cbc93                                                         // 5cb6: d0 db       ..  :bcb6[1]
+    rts                                                               // 5cb8: 60          `   :bcb8[1]
+
+// $5cb9 referenced 2 times by $b1f6, $bc34
+cbcb9
+    lda l00b0                                                         // 5cb9: a5 b0       ..  :bcb9[1]
+    and #$c0                                                          // 5cbb: 29 c0       ).  :bcbb[1]
+    sta l00be                                                         // 5cbd: 85 be       ..  :bcbd[1]
+    ldy #$ee                                                          // 5cbf: a0 ee       ..  :bcbf[1]
+    lda (l00b8),y                                                     // 5cc1: b1 b8       ..  :bcc1[1]
+    and #$3f // '?'                                                   // 5cc3: 29 3f       )?  :bcc3[1]
+    ora l00be                                                         // 5cc5: 05 be       ..  :bcc5[1]
+    sta (l00b8),y                                                     // 5cc7: 91 b8       ..  :bcc7[1]
+    bit l00b0                                                         // 5cc9: 24 b0       $.  :bcc9[1]
+    bvs cbcd6                                                         // 5ccb: 70 09       p.  :bccb[1]
+    ldy l00b7                                                         // 5ccd: a4 b7       ..  :bccd[1]
+    cpy #$14                                                          // 5ccf: c0 14       ..  :bccf[1]
+    bcc cbce1                                                         // 5cd1: 90 0e       ..  :bcd1[1]
+// $5cd3 referenced 1 time by $bcef
+loop_cbcd3
+    jmp cb300                                                         // 5cd3: 4c 00 b3    L.. :bcd3[1]
+
+// $5cd6 referenced 1 time by $bccb
+cbcd6
+    ldx l00bc                                                         // 5cd6: a6 bc       ..  :bcd6[1]
+    lda l00bd                                                         // 5cd8: a5 bd       ..  :bcd8[1]
+    jsr sub_cb6b1                                                     // 5cda: 20 b1 b6     .. :bcda[1]
+    stx l00bc                                                         // 5cdd: 86 bc       ..  :bcdd[1]
+    sta l00bd                                                         // 5cdf: 85 bd       ..  :bcdf[1]
+// $5ce1 referenced 1 time by $bcd1
+cbce1
+    jsr sub_cb6fe                                                     // 5ce1: 20 fe b6     .. :bce1[1]
+    pha                                                               // 5ce4: 48          H   :bce4[1]
+    tya                                                               // 5ce5: 98          .   :bce5[1]
+    ldy #$f1                                                          // 5ce6: a0 f1       ..  :bce6[1]
+    sta (l00b8),y                                                     // 5ce8: 91 b8       ..  :bce8[1]
+    pla                                                               // 5cea: 68          h   :bcea[1]
+    eor l00b0                                                         // 5ceb: 45 b0       E.  :bceb[1]
+    and #$40 // '@'                                                   // 5ced: 29 40       )@  :bced[1]
+    bne loop_cbcd3                                                    // 5cef: d0 e2       ..  :bcef[1]
+    jsr sub_cbe9d                                                     // 5cf1: 20 9d be     .. :bcf1[1]
+    jsr sub_cbe91                                                     // 5cf4: 20 91 be     .. :bcf4[1]
+    bcs cbd1b                                                         // 5cf7: b0 22       ."  :bcf7[1]
+// $5cf9 referenced 1 time by $bd21
+cbcf9
+    ldx #$b5                                                          // 5cf9: a2 b5       ..  :bcf9[1]
+    ldy #$be                                                          // 5cfb: a0 be       ..  :bcfb[1]
+    jsr sub_cb580                                                     // 5cfd: 20 80 b5     .. :bcfd[1]
+    rol l00b0                                                         // 5d00: 26 b0       &.  :bd00[1]
+    bcc cbd0e                                                         // 5d02: 90 0a       ..  :bd02[1]
+    ldx #$bc                                                          // 5d04: a2 bc       ..  :bd04[1]
+    ldy #$b3                                                          // 5d06: a0 b3       ..  :bd06[1]
+// $5d08 referenced 1 time by $bd19
+loop_cbd08
+    jsr sub_cb580                                                     // 5d08: 20 80 b5     .. :bd08[1]
+    jmp cb795                                                         // 5d0b: 4c 95 b7    L.. :bd0b[1]
+
+// $5d0e referenced 1 time by $bd02
+cbd0e
+    ldx #$b1                                                          // 5d0e: a2 b1       ..  :bd0e[1]
+    ldy #$b3                                                          // 5d10: a0 b3       ..  :bd10[1]
+    jsr sub_cb580                                                     // 5d12: 20 80 b5     .. :bd12[1]
+    ldx #$bc                                                          // 5d15: a2 bc       ..  :bd15[1]
+    ldy #$b1                                                          // 5d17: a0 b1       ..  :bd17[1]
+    bne loop_cbd08                                                    // 5d19: d0 ed       ..  :bd19[1]
+// $5d1b referenced 1 time by $bcf7
+cbd1b
+    lda l00b3                                                         // 5d1b: a5 b3       ..  :bd1b[1]
+    and l00b4                                                         // 5d1d: 25 b4       %.  :bd1d[1]
+    cmp #$ff                                                          // 5d1f: c9 ff       ..  :bd1f[1]
+    beq cbcf9                                                         // 5d21: f0 d6       ..  :bd21[1]
+    lda l00bc                                                         // 5d23: a5 bc       ..  :bd23[1]
+    pha                                                               // 5d25: 48          H   :bd25[1]
+    lda l00bd                                                         // 5d26: a5 bd       ..  :bd26[1]
+    pha                                                               // 5d28: 48          H   :bd28[1]
+    ldx #3                                                            // 5d29: a2 03       ..  :bd29[1]
+// $5d2b referenced 1 time by $bd30
+loop_cbd2b
+    lda l00b1,x                                                       // 5d2b: b5 b1       ..  :bd2b[1]
+    sta l00ba,x                                                       // 5d2d: 95 ba       ..  :bd2d[1]
+    dex                                                               // 5d2f: ca          .   :bd2f[1]
+    bpl loop_cbd2b                                                    // 5d30: 10 f9       ..  :bd30[1]
+    ldx #$b5                                                          // 5d32: a2 b5       ..  :bd32[1]
+    ldy #$f4                                                          // 5d34: a0 f4       ..  :bd34[1]
+    jsr sub_cb850                                                     // 5d36: 20 50 b8     P. :bd36[1]
+    bit l00b0                                                         // 5d39: 24 b0       $.  :bd39[1]
+    bmi cbd40                                                         // 5d3b: 30 03       0.  :bd3b[1]
+    jmp cbdba                                                         // 5d3d: 4c ba bd    L.. :bd3d[1]
+
+// $5d40 referenced 1 time by $bd3b
+cbd40
+    pla                                                               // 5d40: 68          h   :bd40[1]
+    sta l00b4                                                         // 5d41: 85 b4       ..  :bd41[1]
+    pla                                                               // 5d43: 68          h   :bd43[1]
+    sta l00b3                                                         // 5d44: 85 b3       ..  :bd44[1]
+// $5d46 referenced 1 time by $bdb6
+cbd46
+    ldx #$be                                                          // 5d46: a2 be       ..  :bd46[1]
+    ldy #$f4                                                          // 5d48: a0 f4       ..  :bd48[1]
+    jsr sub_cb841                                                     // 5d4a: 20 41 b8     A. :bd4a[1]
+    lda l00bf                                                         // 5d4d: a5 bf       ..  :bd4d[1]
+    bne cbd7e                                                         // 5d4f: d0 2d       .-  :bd4f[1]
+    ldx l00be                                                         // 5d51: a6 be       ..  :bd51[1]
+    beq cbdb9                                                         // 5d53: f0 64       .d  :bd53[1]
+    lda #0                                                            // 5d55: a9 00       ..  :bd55[1]
+    sta (l00b8),y                                                     // 5d57: 91 b8       ..  :bd57[1]
+    inc l00b9                                                         // 5d59: e6 b9       ..  :bd59[1]
+    jsr cbe7b                                                         // 5d5b: 20 7b be     {. :bd5b[1]
+    lda #0                                                            // 5d5e: a9 00       ..  :bd5e[1]
+    ldx #$ba                                                          // 5d60: a2 ba       ..  :bd60[1]
+    ldy #0                                                            // 5d62: a0 00       ..  :bd62[1]
+    jsr tube_entry                                                    // 5d64: 20 06 04     .. :bd64[1]
+    ldy #7                                                            // 5d67: a0 07       ..  :bd67[1]
+    jsr cbe89                                                         // 5d69: 20 89 be     .. :bd69[1]
+// $5d6c referenced 1 time by $bd7a
+loop_cbd6c
+    lda tube_host_r3_data                                             // 5d6c: ad e5 fe    ... :bd6c[1]
+    sta (l00b8),y                                                     // 5d6f: 91 b8       ..  :bd6f[1]
+    ldx #3                                                            // 5d71: a2 03       ..  :bd71[1]
+    jsr cbe8d                                                         // 5d73: 20 8d be     .. :bd73[1]
+    nop                                                               // 5d76: ea          .   :bd76[1]
+    iny                                                               // 5d77: c8          .   :bd77[1]
+    cpy l00be                                                         // 5d78: c4 be       ..  :bd78[1]
+    bne loop_cbd6c                                                    // 5d7a: d0 f0       ..  :bd7a[1]
+    beq cbda3                                                         // 5d7c: f0 25       .%  :bd7c[1]
+// $5d7e referenced 1 time by $bd4f
+cbd7e
+    lda #0                                                            // 5d7e: a9 00       ..  :bd7e[1]
+    sta l00be                                                         // 5d80: 85 be       ..  :bd80[1]
+    lda #1                                                            // 5d82: a9 01       ..  :bd82[1]
+    sta l00bf                                                         // 5d84: 85 bf       ..  :bd84[1]
+    inc l00b9                                                         // 5d86: e6 b9       ..  :bd86[1]
+    jsr cbe7b                                                         // 5d88: 20 7b be     {. :bd88[1]
+    lda #6                                                            // 5d8b: a9 06       ..  :bd8b[1]
+    ldx #$ba                                                          // 5d8d: a2 ba       ..  :bd8d[1]
+    ldy #0                                                            // 5d8f: a0 00       ..  :bd8f[1]
+    jsr tube_entry                                                    // 5d91: 20 06 04     .. :bd91[1]
+    ldy #5                                                            // 5d94: a0 05       ..  :bd94[1]
+    jsr cbe89                                                         // 5d96: 20 89 be     .. :bd96[1]
+// $5d99 referenced 1 time by $bda1
+loop_cbd99
+    lda tube_host_r3_data                                             // 5d99: ad e5 fe    ... :bd99[1]
+    sta (l00b8),y                                                     // 5d9c: 91 b8       ..  :bd9c[1]
+    lda (l00b8),y                                                     // 5d9e: b1 b8       ..  :bd9e[1]
+    iny                                                               // 5da0: c8          .   :bda0[1]
+    bne loop_cbd99                                                    // 5da1: d0 f6       ..  :bda1[1]
+// $5da3 referenced 1 time by $bd7c
+cbda3
+    jsr sub_cbe83                                                     // 5da3: 20 83 be     .. :bda3[1]
+    ldx #$b8                                                          // 5da6: a2 b8       ..  :bda6[1]
+    ldy #$b1                                                          // 5da8: a0 b1       ..  :bda8[1]
+    jsr sub_cb580                                                     // 5daa: 20 80 b5     .. :bdaa[1]
+    dec l00b9                                                         // 5dad: c6 b9       ..  :bdad[1]
+    sec                                                               // 5daf: 38          8   :bdaf[1]
+    jsr cb795                                                         // 5db0: 20 95 b7     .. :bdb0[1]
+    jsr cbe47                                                         // 5db3: 20 47 be     G. :bdb3[1]
+    jmp cbd46                                                         // 5db6: 4c 46 bd    LF. :bdb6[1]
+
+// $5db9 referenced 2 times by $bd53, $bdcd
+cbdb9
+    rts                                                               // 5db9: 60          `   :bdb9[1]
+
+// $5dba referenced 1 time by $bd3d
+cbdba
+    pla                                                               // 5dba: 68          h   :bdba[1]
+    sta l00b2                                                         // 5dbb: 85 b2       ..  :bdbb[1]
+    pla                                                               // 5dbd: 68          h   :bdbd[1]
+    sta l00b1                                                         // 5dbe: 85 b1       ..  :bdbe[1]
+// $5dc0 referenced 1 time by $be44
+cbdc0
+    ldx #$be                                                          // 5dc0: a2 be       ..  :bdc0[1]
+    ldy #$f4                                                          // 5dc2: a0 f4       ..  :bdc2[1]
+    jsr sub_cb841                                                     // 5dc4: 20 41 b8     A. :bdc4[1]
+    lda l00bf                                                         // 5dc7: a5 bf       ..  :bdc7[1]
+    bne cbdd3                                                         // 5dc9: d0 08       ..  :bdc9[1]
+    ldx l00be                                                         // 5dcb: a6 be       ..  :bdcb[1]
+    beq cbdb9                                                         // 5dcd: f0 ea       ..  :bdcd[1]
+    lda #1                                                            // 5dcf: a9 01       ..  :bdcf[1]
+    bne cbddd                                                         // 5dd1: d0 0a       ..  :bdd1[1]
+// $5dd3 referenced 1 time by $bdc9
+cbdd3
+    lda #0                                                            // 5dd3: a9 00       ..  :bdd3[1]
+    sta l00be                                                         // 5dd5: 85 be       ..  :bdd5[1]
+    lda #1                                                            // 5dd7: a9 01       ..  :bdd7[1]
+    sta l00bf                                                         // 5dd9: 85 bf       ..  :bdd9[1]
+    lda #7                                                            // 5ddb: a9 07       ..  :bddb[1]
+// $5ddd referenced 1 time by $bdd1
+cbddd
+    pha                                                               // 5ddd: 48          H   :bddd[1]
+    inc l00b9                                                         // 5dde: e6 b9       ..  :bdde[1]
+    ldx #$b8                                                          // 5de0: a2 b8       ..  :bde0[1]
+    ldy #$b3                                                          // 5de2: a0 b3       ..  :bde2[1]
+    jsr sub_cb580                                                     // 5de4: 20 80 b5     .. :bde4[1]
+    lda l00be                                                         // 5de7: a5 be       ..  :bde7[1]
+    pha                                                               // 5de9: 48          H   :bde9[1]
+    dec l00b9                                                         // 5dea: c6 b9       ..  :bdea[1]
+    clc                                                               // 5dec: 18          .   :bdec[1]
+    jsr cb795                                                         // 5ded: 20 95 b7     .. :bded[1]
+    pla                                                               // 5df0: 68          h   :bdf0[1]
+    sta l00be                                                         // 5df1: 85 be       ..  :bdf1[1]
+    pla                                                               // 5df3: 68          h   :bdf3[1]
+    cmp #1                                                            // 5df4: c9 01       ..  :bdf4[1]
+    bne cbe21                                                         // 5df6: d0 29       .)  :bdf6[1]
+    lda #0                                                            // 5df8: a9 00       ..  :bdf8[1]
+    ldy #$f4                                                          // 5dfa: a0 f4       ..  :bdfa[1]
+    sta (l00b8),y                                                     // 5dfc: 91 b8       ..  :bdfc[1]
+    inc l00b9                                                         // 5dfe: e6 b9       ..  :bdfe[1]
+    jsr cbe7b                                                         // 5e00: 20 7b be     {. :be00[1]
+    lda #1                                                            // 5e03: a9 01       ..  :be03[1]
+    ldx #$ba                                                          // 5e05: a2 ba       ..  :be05[1]
+    ldy #0                                                            // 5e07: a0 00       ..  :be07[1]
+    jsr tube_entry                                                    // 5e09: 20 06 04     .. :be09[1]
+    ldy #0                                                            // 5e0c: a0 00       ..  :be0c[1]
+// $5e0e referenced 1 time by $be1d
+loop_cbe0e
+    lda (l00b8),y                                                     // 5e0e: b1 b8       ..  :be0e[1]
+    sta tube_host_r3_data                                             // 5e10: 8d e5 fe    ... :be10[1]
+    ldx #3                                                            // 5e13: a2 03       ..  :be13[1]
+    jsr cbe8d                                                         // 5e15: 20 8d be     .. :be15[1]
+    iny                                                               // 5e18: c8          .   :be18[1]
+    cpy l00be                                                         // 5e19: c4 be       ..  :be19[1]
+    cpy l00be                                                         // 5e1b: c4 be       ..  :be1b[1]
+    bne loop_cbe0e                                                    // 5e1d: d0 ef       ..  :be1d[1]
+    beq cbe3c                                                         // 5e1f: f0 1b       ..  :be1f[1]
+// $5e21 referenced 1 time by $bdf6
+cbe21
+    inc l00b9                                                         // 5e21: e6 b9       ..  :be21[1]
+    jsr cbe7b                                                         // 5e23: 20 7b be     {. :be23[1]
+    lda #7                                                            // 5e26: a9 07       ..  :be26[1]
+    ldx #$ba                                                          // 5e28: a2 ba       ..  :be28[1]
+    ldy #0                                                            // 5e2a: a0 00       ..  :be2a[1]
+    jsr tube_entry                                                    // 5e2c: 20 06 04     .. :be2c[1]
+    ldy #0                                                            // 5e2f: a0 00       ..  :be2f[1]
+// $5e31 referenced 1 time by $be3a
+loop_cbe31
+    lda (l00b8),y                                                     // 5e31: b1 b8       ..  :be31[1]
+    sta tube_host_r3_data                                             // 5e33: 8d e5 fe    ... :be33[1]
+    nop                                                               // 5e36: ea          .   :be36[1]
+    nop                                                               // 5e37: ea          .   :be37[1]
+    nop                                                               // 5e38: ea          .   :be38[1]
+    iny                                                               // 5e39: c8          .   :be39[1]
+    bne loop_cbe31                                                    // 5e3a: d0 f5       ..  :be3a[1]
+// $5e3c referenced 1 time by $be1f
+cbe3c
+    jsr sub_cbe83                                                     // 5e3c: 20 83 be     .. :be3c[1]
+    dec l00b9                                                         // 5e3f: c6 b9       ..  :be3f[1]
+    jsr cbe47                                                         // 5e41: 20 47 be     G. :be41[1]
+    jmp cbdc0                                                         // 5e44: 4c c0 bd    L.. :be44[1]
+
+// $5e47 referenced 3 times by $bdb3, $be41, $be50
+cbe47
+    ldx #1                                                            // 5e47: a2 01       ..  :be47[1]
+    inc l00ba,x                                                       // 5e49: f6 ba       ..  :be49[1]
+    bne cbe52                                                         // 5e4b: d0 05       ..  :be4b[1]
+    inx                                                               // 5e4d: e8          .   :be4d[1]
+    cpx #4                                                            // 5e4e: e0 04       ..  :be4e[1]
+    bcc cbe47                                                         // 5e50: 90 f5       ..  :be50[1]
+// $5e52 referenced 1 time by $be4b
+cbe52
+    ldy #$f5                                                          // 5e52: a0 f5       ..  :be52[1]
+    lda (l00b8),y                                                     // 5e54: b1 b8       ..  :be54[1]
+    sec                                                               // 5e56: 38          8   :be56[1]
+    sbc #1                                                            // 5e57: e9 01       ..  :be57[1]
+    bcc cbe7a                                                         // 5e59: 90 1f       ..  :be59[1]
+    sta (l00b8),y                                                     // 5e5b: 91 b8       ..  :be5b[1]
+    jsr sub_cb616                                                     // 5e5d: 20 16 b6     .. :be5d[1]
+    beq cbe7a                                                         // 5e60: f0 18       ..  :be60[1]
+    ldx l00b7                                                         // 5e62: a6 b7       ..  :be62[1]
+    jsr sub_cb85d                                                     // 5e64: 20 5d b8     ]. :be64[1]
+    bvc cbe7a                                                         // 5e67: 50 11       P.  :be67[1]
+    lda l00b1,x                                                       // 5e69: b5 b1       ..  :be69[1]
+    cmp #$c0                                                          // 5e6b: c9 c0       ..  :be6b[1]
+    bcc cbe7a                                                         // 5e6d: 90 0b       ..  :be6d[1]
+    lda #$10                                                          // 5e6f: a9 10       ..  :be6f[1]
+    sta l00b0,x                                                       // 5e71: 95 b0       ..  :be71[1]
+    lda #$80                                                          // 5e73: a9 80       ..  :be73[1]
+    sta l00b1,x                                                       // 5e75: 95 b1       ..  :be75[1]
+    jsr sub_cb68f                                                     // 5e77: 20 8f b6     .. :be77[1]
+// $5e7a referenced 4 times by $be59, $be60, $be67, $be6d
+cbe7a
+    rts                                                               // 5e7a: 60          `   :be7a[1]
+
+// $5e7b referenced 5 times by $bd5b, $bd88, $be00, $be23, $be80
+cbe7b
+    lda #$c8                                                          // 5e7b: a9 c8       ..  :be7b[1]
+    jsr tube_entry                                                    // 5e7d: 20 06 04     .. :be7d[1]
+    bcc cbe7b                                                         // 5e80: 90 f9       ..  :be80[1]
+    rts                                                               // 5e82: 60          `   :be82[1]
+
+// $5e83 referenced 2 times by $bda3, $be3c
+sub_cbe83
+    lda #$88                                                          // 5e83: a9 88       ..  :be83[1]
+    jsr tube_entry                                                    // 5e85: 20 06 04     .. :be85[1]
+    rts                                                               // 5e88: 60          `   :be88[1]
+
+// $5e89 referenced 3 times by $bd69, $bd96, $be8a
+cbe89
+    dey                                                               // 5e89: 88          .   :be89[1]
+    bne cbe89                                                         // 5e8a: d0 fd       ..  :be8a[1]
+    rts                                                               // 5e8c: 60          `   :be8c[1]
+
+// $5e8d referenced 3 times by $bd73, $be15, $be8e
+cbe8d
+    dex                                                               // 5e8d: ca          .   :be8d[1]
+    bne cbe8d                                                         // 5e8e: d0 fd       ..  :be8e[1]
+    rts                                                               // 5e90: 60          `   :be90[1]
+
+// $5e91 referenced 1 time by $bcf4
+sub_cbe91
+    lda #osbyte_read_tube_presence                                    // 5e91: a9 ea       ..  :be91[1]
+    ldx #0                                                            // 5e93: a2 00       ..  :be93[1]
+    ldy #$ff                                                          // 5e95: a0 ff       ..  :be95[1]
+    jsr osbyte                                                        // 5e97: 20 f4 ff     .. :be97[1]
+    cpx #$ff                                                          // 5e9a: e0 ff       ..  :be9a[1]
+    rts                                                               // 5e9c: 60          `   :be9c[1]
+
+// $5e9d referenced 2 times by $b338, $bcf1
+sub_cbe9d
+    jsr sub_cb85d                                                     // 5e9d: 20 5d b8     ]. :be9d[1]
+    bpl cbec1                                                         // 5ea0: 10 1f       ..  :bea0[1]
+    bvs cbec1                                                         // 5ea2: 70 1d       p.  :bea2[1]
+    lda #0                                                            // 5ea4: a9 00       ..  :bea4[1]
+    pha                                                               // 5ea6: 48          H   :bea6[1]
+    ldy #$f1                                                          // 5ea7: a0 f1       ..  :bea7[1]
+    lda (l00b8),y                                                     // 5ea9: b1 b8       ..  :bea9[1]
+// $5eab referenced 1 time by $bec6
+loop_cbeab
+    pha                                                               // 5eab: 48          H   :beab[1]
+    lda #osbyte_read_rom_info_table_low                               // 5eac: a9 aa       ..  :beac[1]
+    ldx #0                                                            // 5eae: a2 00       ..  :beae[1]
+    ldy #$ff                                                          // 5eb0: a0 ff       ..  :beb0[1]
+    jsr osbyte                                                        // 5eb2: 20 f4 ff     .. :beb2[1]
+    jsr cb82b                                                         // 5eb5: 20 2b b8     +. :beb5[1]
+    stx l00ba                                                         // 5eb8: 86 ba       ..  :beb8[1]
+    sty l00bb                                                         // 5eba: 84 bb       ..  :beba[1]
+    pla                                                               // 5ebc: 68          h   :bebc[1]
+    tay                                                               // 5ebd: a8          .   :bebd[1]
+    pla                                                               // 5ebe: 68          h   :bebe[1]
+    sta (l00ba),y                                                     // 5ebf: 91 ba       ..  :bebf[1]
+// $5ec1 referenced 2 times by $bea0, $bea2
+cbec1
+    rts                                                               // 5ec1: 60          `   :bec1[1]
+
+// $5ec2 referenced 2 times by $bc64, $bcae
+sub_cbec2
+    lda #2                                                            // 5ec2: a9 02       ..  :bec2[1]
+    pha                                                               // 5ec4: 48          H   :bec4[1]
+    tya                                                               // 5ec5: 98          .   :bec5[1]
+    bpl loop_cbeab                                                    // 5ec6: 10 e3       ..  :bec6[1]
+// $5ec8 referenced 1 time by $8003
+service_handler
+    cmp #service_claim_absolute_workspace                             // 5ec8: c9 01       ..  :bec8[1]
+    bne cbee0                                                         // 5eca: d0 14       ..  :beca[1]
+    pha                                                               // 5ecc: 48          H   :becc[1]
+    tya                                                               // 5ecd: 98          .   :becd[1]
+    pha                                                               // 5ece: 48          H   :bece[1]
+    lda #osbyte_issue_service_request                                 // 5ecf: a9 8f       ..  :becf[1]
+    ldx #service_check_swr_presence                                   // 5ed1: a2 2b       .+  :bed1[1]
+    ldy romsel_copy                                                   // 5ed3: a4 f4       ..  :bed3[1]
+    jsr osbyte                                                        // 5ed5: 20 f4 ff     .. :bed5[1]
+    pla                                                               // 5ed8: 68          h   :bed8[1]
+    tay                                                               // 5ed9: a8          .   :bed9[1]
+    ldx romsel_copy                                                   // 5eda: a6 f4       ..  :beda[1]
+    pla                                                               // 5edc: 68          h   :bedc[1]
+// $5edd referenced 2 times by $bee2, $beec
+general_service_handler_indirect
+    jmp general_service_handler                                       // 5edd: 4c b1 b1    L.. :bedd[1]
+
+// $5ee0 referenced 1 time by $beca
+cbee0
+    cmp #service_check_swr_presence                                   // 5ee0: c9 2b       .+  :bee0[1]
+    bne general_service_handler_indirect                              // 5ee2: d0 f9       ..  :bee2[1]
+    cpy romsel_copy                                                   // 5ee4: c4 f4       ..  :bee4[1]
+    beq cbeee                                                         // 5ee6: f0 06       ..  :bee6[1]
+// $5ee8 referenced 4 times by $bef8, $beff, $bf08, $bf4c
+cbee8
+    ldx romsel_copy                                                   // 5ee8: a6 f4       ..  :bee8[1]
+    lda #0                                                            // 5eea: a9 00       ..  :beea[1]
+    beq general_service_handler_indirect                              // 5eec: f0 ef       ..  :beec[1]
+// $5eee referenced 1 time by $bee6
+cbeee
+    lda #$72 // 'r'                                                   // 5eee: a9 72       .r  :beee[1]
+    ldx #0                                                            // 5ef0: a2 00       ..  :bef0[1]
+    jsr osbyte                                                        // 5ef2: 20 f4 ff     .. :bef2[1]
+    jsr osbyte                                                        // 5ef5: 20 f4 ff     .. :bef5[1]
+    bvs cbee8                                                         // 5ef8: 70 ee       p.  :bef8[1]
+    lda #$ea                                                          // 5efa: a9 ea       ..  :befa[1]
+    jsr sub_cbf82                                                     // 5efc: 20 82 bf     .. :befc[1]
+    bne cbee8                                                         // 5eff: d0 e7       ..  :beff[1]
+    lda #$d7                                                          // 5f01: a9 d7       ..  :bf01[1]
+    ldy #$7f                                                          // 5f03: a0 7f       ..  :bf03[1]
+    jsr sub_cbf84                                                     // 5f05: 20 84 bf     .. :bf05[1]
+    bpl cbee8                                                         // 5f08: 10 de       ..  :bf08[1]
+    jsr osnewl                                                        // 5f0a: 20 e7 ff     .. :bf0a[1]
+    ldx #0                                                            // 5f0d: a2 00       ..  :bf0d[1]
+    jsr sub_cbf7c                                                     // 5f0f: 20 7c bf     |. :bf0f[1]
+    lda #$fd                                                          // 5f12: a9 fd       ..  :bf12[1]
+    jsr sub_cbf82                                                     // 5f14: 20 82 bf     .. :bf14[1]
+    beq cbf46                                                         // 5f17: f0 2d       .-  :bf17[1]
+    tsx                                                               // 5f19: ba          .   :bf19[1]
+    ldy #$30 // '0'                                                   // 5f1a: a0 30       .0  :bf1a[1]
+// $5f1c referenced 1 time by $bf21
+loop_cbf1c
+    lda cbf8a,y                                                       // 5f1c: b9 8a bf    ... :bf1c[1]
+    pha                                                               // 5f1f: 48          H   :bf1f[1]
+    dey                                                               // 5f20: 88          .   :bf20[1]
+    bne loop_cbf1c                                                    // 5f21: d0 f9       ..  :bf21[1]
+    txa                                                               // 5f23: 8a          .   :bf23[1]
+    tay                                                               // 5f24: a8          .   :bf24[1]
+    lda #1                                                            // 5f25: a9 01       ..  :bf25[1]
+    pha                                                               // 5f27: 48          H   :bf27[1]
+    tsx                                                               // 5f28: ba          .   :bf28[1]
+    inx                                                               // 5f29: e8          .   :bf29[1]
+    txa                                                               // 5f2a: 8a          .   :bf2a[1]
+    pha                                                               // 5f2b: 48          H   :bf2b[1]
+    ldx #$0f                                                          // 5f2c: a2 0f       ..  :bf2c[1]
+    lda #0                                                            // 5f2e: a9 00       ..  :bf2e[1]
+    sta l00b0                                                         // 5f30: 85 b0       ..  :bf30[1]
+    rts                                                               // 5f32: 60          `   :bf32[1]
+
+// $5f33 referenced 1 time by $bfb8
+cbf33
+    tya                                                               // 5f33: 98          .   :bf33[1]
+    tax                                                               // 5f34: aa          .   :bf34[1]
+    txs                                                               // 5f35: 9a          .   :bf35[1]
+    lda l00b0                                                         // 5f36: a5 b0       ..  :bf36[1]
+    asl                                                               // 5f38: 0a          .   :bf38[1]
+    asl                                                               // 5f39: 0a          .   :bf39[1]
+    clc                                                               // 5f3a: 18          .   :bf3a[1]
+    adc #$0d                                                          // 5f3b: 69 0d       i.  :bf3b[1]
+    tax                                                               // 5f3d: aa          .   :bf3d[1]
+    jsr sub_cbf7c                                                     // 5f3e: 20 7c bf     |. :bf3e[1]
+    ldx #$0a                                                          // 5f41: a2 0a       ..  :bf41[1]
+    jsr sub_cbf7c                                                     // 5f43: 20 7c bf     |. :bf43[1]
+// $5f46 referenced 1 time by $bf17
+cbf46
+    jsr osnewl                                                        // 5f46: 20 e7 ff     .. :bf46[1]
+    jsr osnewl                                                        // 5f49: 20 e7 ff     .. :bf49[1]
+    jmp cbee8                                                         // 5f4c: 4c e8 be    L.. :bf4c[1]
+
+// $5f4f referenced 1 time by $bf7c
+lbf4f
+    .asc "Acorn OS "                                                  // 5f4f: 41 63 6f... Aco :bf4f[1]
+    .byt   0, $4b,   7,   0, $36, $34,   0,   0, $38, $30,   0,   0   // 5f58: 00 4b 07... .K. :bf58[1]
+    .byt $39, $36,   0,   0                                           // 5f64: 39 36 00... 96. :bf64[1]
+    .asc "112"                                                        // 5f68: 31 31 32    112 :bf68[1]
+    .byt 0                                                            // 5f6b: 00          .   :bf6b[1]
+    .asc "128"                                                        // 5f6c: 31 32 38    128 :bf6c[1]
+    .byt 0                                                            // 5f6f: 00          .   :bf6f[1]
+    .asc "144"                                                        // 5f70: 31 34 34    144 :bf70[1]
+    .byt 0                                                            // 5f73: 00          .   :bf73[1]
+    .asc "160"                                                        // 5f74: 31 36 30    160 :bf74[1]
+    .byt 0                                                            // 5f77: 00          .   :bf77[1]
+
+// $5f78 referenced 1 time by $bf7f
+loop_cbf78
+    jsr oswrch                                                        // 5f78: 20 ee ff     .. :bf78[1]
+    inx                                                               // 5f7b: e8          .   :bf7b[1]
+// $5f7c referenced 3 times by $bf0f, $bf3e, $bf43
+sub_cbf7c
+    lda lbf4f,x                                                       // 5f7c: bd 4f bf    .O. :bf7c[1]
+    bne loop_cbf78                                                    // 5f7f: d0 f7       ..  :bf7f[1]
+    rts                                                               // 5f81: 60          `   :bf81[1]
+
+// $5f82 referenced 2 times by $befc, $bf14
+sub_cbf82
+    ldy #$ff                                                          // 5f82: a0 ff       ..  :bf82[1]
+// $5f84 referenced 1 time by $bf05
+sub_cbf84
+    ldx #0                                                            // 5f84: a2 00       ..  :bf84[1]
+    jsr osbyte                                                        // 5f86: 20 f4 ff     .. :bf86[1]
+    txa                                                               // 5f89: 8a          .   :bf89[1]
+// $5f8a referenced 1 time by $bf1c
+cbf8a
+    rts                                                               // 5f8a: 60          `   :bf8a[1]
+
+    lda romsel_copy                                                   // 5f8b: a5 f4       ..  :bf8b[1]
+    pha                                                               // 5f8d: 48          H   :bf8d[1]
+// $5f8e referenced 2 times by $bfac, $bfb0
+cbf8e
+    stx romsel_copy                                                   // 5f8e: 86 f4       ..  :bf8e[1]
+    stx romsel                                                        // 5f90: 8e 30 fe    .0. :bf90[1]
+    lda lbfff                                                         // 5f93: ad ff bf    ... :bf93[1]
+    pha                                                               // 5f96: 48          H   :bf96[1]
+    eor #$a5                                                          // 5f97: 49 a5       I.  :bf97[1]
+    sta lbfff                                                         // 5f99: 8d ff bf    ... :bf99[1]
+    cmp lbfff                                                         // 5f9c: cd ff bf    ... :bf9c[1]
+    bne cbfa3                                                         // 5f9f: d0 02       ..  :bf9f[1]
+    inc l00b0                                                         // 5fa1: e6 b0       ..  :bfa1[1]
+// $5fa3 referenced 1 time by $bf9f
+cbfa3
+    pla                                                               // 5fa3: 68          h   :bfa3[1]
+    sta lbfff                                                         // 5fa4: 8d ff bf    ... :bfa4[1]
+    dex                                                               // 5fa7: ca          .   :bfa7[1]
+    bmi cbfb2                                                         // 5fa8: 30 08       0.  :bfa8[1]
+    cpx #$0b                                                          // 5faa: e0 0b       ..  :bfaa[1]
+    bne cbf8e                                                         // 5fac: d0 e0       ..  :bfac[1]
+    ldx #1                                                            // 5fae: a2 01       ..  :bfae[1]
+    bne cbf8e                                                         // 5fb0: d0 dc       ..  :bfb0[1]
+// $5fb2 referenced 1 time by $bfa8
+cbfb2
+    pla                                                               // 5fb2: 68          h   :bfb2[1]
+    sta romsel_copy                                                   // 5fb3: 85 f4       ..  :bfb3[1]
+    sta romsel                                                        // 5fb5: 8d 30 fe    .0. :bfb5[1]
+    jmp cbf33                                                         // 5fb8: 4c 33 bf    L3. :bfb8[1]
+
+    .byt $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff   // 5fbb: ff ff ff... ... :bfbb[1]
+    .byt $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff   // 5fc7: ff ff ff... ... :bfc7[1]
+    .byt $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff   // 5fd3: ff ff ff... ... :bfd3[1]
+    .byt $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff   // 5fdf: ff ff ff... ... :bfdf[1]
+    .byt $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff   // 5feb: ff ff ff... ... :bfeb[1]
+    .byt $ff, $ff, $ff, $ff, $ff, $ff, $ff, $ff                       // 5ff7: ff ff ff... ... :bff7[1]
+// $5fff referenced 4 times by $bf93, $bf99, $bf9c, $bfa4
+lbfff
+    .byt $ff                                                          // 5fff: ff          .   :bfff[1]
+* = $6000
+pydis_end
+
+// Label references by decreasing frequency:
+//     l00b8:                    125
+//     l00b0:                    105
+//     l00ba:                     44
+//     l00bf:                     42
+//     l00bc:                     41
+//     l00b6:                     35
+//     l00be:                     31
+//     l00cd:                     31
+//     sub_c2077:                 31
+//     l00c2:                     30
+//     l00b1:                     29
+//     sub_c23e3:                 29
+//     l00b9:                     28
+//     l00bb:                     28
+//     l00b5:                     26
+//     l00bd:                     26
+//     l00b4:                     25
+//     l00b3:                     23
+//     l00c1:                     23
+//     os_text_ptr:               23
+//     osbyte:                    22
+//     romsel_copy:               21
+//     l0f0e:                     21
+//     c4ea0:                     21
+//     l00c4:                     20
+//     c209f:                     20
+//     l00b2:                     19
+//     l10c2:                     19
+//     l0001:                     18
+//     l00a8:                     18
+//     l00aa:                     18
+//     l00c5:                     18
+//     l00c9:                     18
+//     l10de:                     18
+//     l0000:                     17
+//     l00b7:                     17
+//     l0e0f:                     17
+//     l0f06:                     17
+//     l1000:                     17
+//     l00a2:                     16
+//     l00ab:                     16
+//     l00ae:                     16
+//     c43dc:                     16
+//     c582b:                     16
+//     l00c0:                     15
+//     l00c3:                     15
+//     l00c7:                     15
+//     l0f05:                     15
+//     l00cc:                     14
+//     l1117:                     14
+//     c4e70:                     14
+//     c4f7f:                     14
+//     l00a1:                     13
+//     l00a5:                     13
+//     l00c8:                     13
+//     l0f07:                     13
+//     sub_c414a:                 13
+//     tube_host_r3_data:         13
+//     l00ac:                     12
+//     sub_c274c:                 12
+//     sub_c5841:                 12
+//     osasci:                    12
+//     l00c6:                     11
+//     osrdsc_ptr:                11
+//     l0e08:                     11
+//     sub_c2038:                 11
+//     sub_c2149:                 11
+//     c396e:                     11
+//     c4c0f:                     11
+//     lfe84:                     11
+//     tube_host_r2_data:         11
+//     l00a9:                     10
+//     l1111:                     10
+//     l1112:                     10
+//     sub_c20c3:                 10
+//     c33e6:                     10
+//     c5203:                     10
+//     lfe87:                     10
+//     tube_host_r2_status:       10
+//     l00ca:                      9
+//     l1074:                      9
+//     l108a:                      9
+//     l1097:                      9
+//     l10c0:                      9
+//     l1110:                      9
+//     c5bd0:                      9
+//     l00ce:                      8
+//     l00ff:                      8
+//     l0100:                      8
+//     l0df0:                      8
+//     l0f04:                      8
+//     l1060:                      8
+//     l1082:                      8
+//     l108b:                      8
+//     l1090:                      8
+//     l1096:                      8
+//     l10ca:                      8
+//     l10cf:                      8
+//     l10d1:                      8
+//     sub_c21b0:                  8
+//     sub_c21bf:                  8
+//     c2816:                      8
+//     sub_c2b7b:                  8
+//     sub_c3ae5:                  8
+//     c4e79:                      8
+//     sub_c585d:                  8
+//     tube_host_r1_status:        8
+//     osfind:                     8
+//     l00a7:                      7
+//     l00cf:                      7
+//     l0f08:                      7
+//     l1075:                      7
+//     l10c9:                      7
+//     l10d2:                      7
+//     l1114:                      7
+//     c204f:                      7
+//     sub_c2284:                  7
+//     sub_c2380:                  7
+//     c2b8b:                      7
+//     sub_c499c:                  7
+//     sub_c5580:                  7
+//     sub_c5ab9:                  7
+//     osrdsc:                     7
+//     l0015:                      6
+//     l00f3:                      6
+//     l00f7:                      6
+//     l0f0f:                      6
+//     l1100:                      6
+//     sub_c202e:                  6
+//     sub_c2280:                  6
+//     sub_c22fe:                  6
+//     l261c:                      6
+//     sub_c27da:                  6
+//     c340c:                      6
+//     sub_c39ac:                  6
+//     sub_c3d8e:                  6
+//     sub_c3e75:                  6
+//     c4f58:                      6
+//     sub_c55f2:                  6
+//     l5726:                      6
+//     c58fb:                      6
+//     oswrch:                     6
+//     l00a6:                      5
+//     l00af:                      5
+//     l00f0:                      5
+//     l1087:                      5
+//     l1088:                      5
+//     l1099:                      5
+//     l10c7:                      5
+//     l10dd:                      5
+//     l110c:                      5
+//     l1115:                      5
+//     l1116:                      5
+//     sub_c20bb:                  5
+//     sub_c20ed:                  5
+//     sub_c20f3:                  5
+//     c2125:                      5
+//     sub_c230a:                  5
+//     sub_c2335:                  5
+//     sub_c2386:                  5
+//     sub_c240c:                  5
+//     c2ba2:                      5
+//     sub_c2f3f:                  5
+//     c3257:                      5
+//     c39a3:                      5
+//     sub_c3a6e:                  5
+//     sub_c3ab8:                  5
+//     sub_c40de:                  5
+//     sub_c41b4:                  5
+//     c4e97:                      5
+//     sub_c56fe:                  5
+//     sub_c5745:                  5
+//     c5795:                      5
+//     sub_c5850:                  5
+//     sub_c5a67:                  5
+//     c5e7b:                      5
+//     osnewl:                     5
+//     l0002:                      4
+//     l0e00:                      4
+//     l0f0c:                      4
+//     l0f0d:                      4
+//     l1069:                      4
+//     l1076:                      4
+//     l1077:                      4
+//     l1081:                      4
+//     l1086:                      4
+//     l1095:                      4
+//     l10c4:                      4
+//     l10cb:                      4
+//     l10cc:                      4
+//     l10ce:                      4
+//     l10d9:                      4
+//     l10da:                      4
+//     l110d:                      4
+//     l1113:                      4
+//     l111a:                      4
+//     l111d:                      4
+//     sub_c2023:                  4
+//     sub_c2048:                  4
+//     sub_c20c8:                  4
+//     sub_c2174:                  4
+//     c21a7:                      4
+//     sub_c221d:                  4
+//     c2225:                      4
+//     sub_c22b2:                  4
+//     sub_c2327:                  4
+//     sub_c23dc:                  4
+//     c2d74:                      4
+//     c2d91:                      4
+//     c2e0e:                      4
+//     c2e12:                      4
+//     c2e64:                      4
+//     sub_c2f6b:                  4
+//     c340e:                      4
+//     c3436:                      4
+//     c393b:                      4
+//     sub_c3965:                  4
+//     sub_c3a8d:                  4
+//     c3adf:                      4
+//     c3ae9:                      4
+//     sub_c4379:                  4
+//     c45e5:                      4
+//     sub_c49ca:                  4
+//     sub_c4acf:                  4
+//     sub_c4c18:                  4
+//     sub_c4c62:                  4
+//     c4d79:                      4
+//     c5446:                      4
+//     l557f:                      4
+//     sub_c5616:                  4
+//     c568c:                      4
+//     sub_c568f:                  4
+//     sub_c583f:                  4
+//     sub_c5ac2:                  4
+//     sub_c5b00:                  4
+//     c5e7a:                      4
+//     c5ee8:                      4
+//     l5fff:                      4
+//     romsel:                     4
+//     lfe85:                      4
+//     lfe86:                      4
+//     osbput:                     4
+//     osbget:                     4
+//     osfile:                     4
+//     osrdch:                     4
+//     l00ef:                      3
+//     l0107:                      3
+//     l0109:                      3
+//     bytev:                      3
+//     bytev+1:                    3
+//     l0ef8:                      3
+//     l1092:                      3
+//     l1093:                      3
+//     l1094:                      3
+//     l1098:                      3
+//     l109d:                      3
+//     l109f:                      3
+//     l10c3:                      3
+//     l10c5:                      3
+//     l10c6:                      3
+//     l10d0:                      3
+//     l10d3:                      3
+//     l10d6:                      3
+//     l10d7:                      3
+//     l1119:                      3
+//     l111c:                      3
+//     c2103:                      3
+//     sub_c21be:                  3
+//     c2290:                      3
+//     c22e6:                      3
+//     sub_c233a:                  3
+//     sub_c236e:                  3
+//     c2454:                      3
+//     sub_c2456:                  3
+//     c29d7:                      3
+//     sub_c2b86:                  3
+//     c2d41:                      3
+//     c2e53:                      3
+//     c2ecc:                      3
+//     c2f2a:                      3
+//     sub_c2f7a:                  3
+//     c30fb:                      3
+//     c31af:                      3
+//     c3214:                      3
+//     sub_c33fd:                  3
+//     c3444:                      3
+//     c34bc:                      3
+//     sub_c3526:                  3
+//     c3738:                      3
+//     sub_c3940:                  3
+//     c39ed:                      3
+//     c3a8c:                      3
+//     sub_c3be5:                  3
+//     c3c82:                      3
+//     c3d5d:                      3
+//     sub_c3e30:                  3
+//     sub_c3f0f:                  3
+//     sub_c3f16:                  3
+//     sub_c3f1e:                  3
+//     c406b:                      3
+//     c414f:                      3
+//     c41c0:                      3
+//     sub_c4315:                  3
+//     sub_c4384:                  3
+//     sub_c4530:                  3
+//     c4660:                      3
+//     sub_c49c2:                  3
+//     c4a42:                      3
+//     c4a44:                      3
+//     sub_c4c0c:                  3
+//     c4cc4:                      3
+//     sub_c4d5d:                  3
+//     c4d77:                      3
+//     l4f76:                      3
+//     c51d5:                      3
+//     c5371:                      3
+//     sub_c558b:                  3
+//     c5684:                      3
+//     c56ca:                      3
+//     sub_c584e:                  3
+//     sub_c5986:                  3
+//     l5a30:                      3
+//     c5ab4:                      3
+//     sub_c5ac4:                  3
+//     c5e47:                      3
+//     c5e89:                      3
+//     c5e8d:                      3
+//     sub_c5f7c:                  3
+//     lfe80:                      3
+//     tube_host_r1_data:          3
+//     osword:                     3
+//     oscli:                      3
+//     l0003:                      2
+//     l0012:                      2
+//     l0014:                      2
+//     l00a0:                      2
+//     l00a3:                      2
+//     l00a4:                      2
+//     l00ad:                      2
+//     l00fd:                      2
+//     l0101:                      2
+//     l0102:                      2
+//     l0105:                      2
+//     l010b:                      2
+//     l0128:                      2
+//     fscv:                       2
+//     l0700:                      2
+//     l0e07:                      2
+//     l0f0a:                      2
+//     l0f0b:                      2
+//     l1045:                      2
+//     l1062:                      2
+//     l1065:                      2
+//     l1067:                      2
+//     l1078:                      2
+//     l107d:                      2
+//     l107e:                      2
+//     l107f:                      2
+//     l1089:                      2
+//     l108c:                      2
+//     l1091:                      2
+//     l109a:                      2
+//     l109b:                      2
+//     l109e:                      2
+//     l10c1:                      2
+//     l10cd:                      2
+//     l10d8:                      2
+//     l10db:                      2
+//     l10dc:                      2
+//     l10e2:                      2
+//     l10e3:                      2
+//     l10e4:                      2
+//     l1109:                      2
+//     l110b:                      2
+//     l110e:                      2
+//     l110f:                      2
+//     l111b:                      2
+//     sub_c209a:                  2
+//     sub_c20e3:                  2
+//     c215d:                      2
+//     sub_c21ae:                  2
+//     sub_c21c5:                  2
+//     c222a:                      2
+//     c225d:                      2
+//     sub_c2266:                  2
+//     sub_c226d:                  2
+//     sub_c22bb:                  2
+//     sub_c22e8:                  2
+//     c22fd:                      2
+//     sub_c241b:                  2
+//     sub_c2439:                  2
+//     c2543:                      2
+//     sub_c2555:                  2
+//     c2560:                      2
+//     c25bc:                      2
+//     c2703:                      2
+//     c2705:                      2
+//     c273b:                      2
+//     sub_c2745:                  2
+//     sub_c27db:                  2
+//     sub_c27e3:                  2
+//     c2808:                      2
+//     c283f:                      2
+//     sub_c2855:                  2
+//     sub_c2862:                  2
+//     c28a6:                      2
+//     c28f4:                      2
+//     sub_c2951:                  2
+//     c298a:                      2
+//     c29a5:                      2
+//     c29b4:                      2
+//     sub_c29da:                  2
+//     c2a00:                      2
+//     c2a6e:                      2
+//     sub_c2a77:                  2
+//     sub_c2ab3:                  2
+//     sub_c2b4d:                  2
+//     sub_c2b64:                  2
+//     c2be3:                      2
+//     c2c12:                      2
+//     c2cb2:                      2
+//     c2d0d:                      2
+//     c2d13:                      2
+//     c2e0d:                      2
+//     c2e32:                      2
+//     c2e9f:                      2
+//     c2ea5:                      2
+//     c2eb7:                      2
+//     c2eeb:                      2
+//     c2f3e:                      2
+//     c30c7:                      2
+//     c31df:                      2
+//     sub_c3279:                  2
+//     c3289:                      2
+//     sub_c328a:                  2
+//     c3367:                      2
+//     sub_c33c5:                  2
+//     sub_c33d3:                  2
+//     sub_c33f5:                  2
+//     sub_c3432:                  2
+//     sub_c3445:                  2
+//     c34a9:                      2
+//     c34c6:                      2
+//     sub_c3516:                  2
+//     sub_c352e:                  2
+//     c35fd:                      2
+//     c3628:                      2
+//     c365a:                      2
+//     c36b7:                      2
+//     c37b3:                      2
+//     sub_c392c:                  2
+//     sub_c394c:                  2
+//     sub_c395a:                  2
+//     sub_c39f3:                  2
+//     sub_c3a0f:                  2
+//     sub_c3a50:                  2
+//     sub_c3a60:                  2
+//     sub_c3a63:                  2
+//     sub_c3a78:                  2
+//     sub_c3a82:                  2
+//     sub_c3aa3:                  2
+//     sub_c3ac8:                  2
+//     sub_c3ad8:                  2
+//     c3b6e:                      2
+//     sub_c3b79:                  2
+//     c3bc5:                      2
+//     sub_c3bf2:                  2
+//     sub_c3d1e:                  2
+//     c3dcd:                      2
+//     c3dd5:                      2
+//     sub_c3df4:                  2
+//     sub_c3e1e:                  2
+//     c3e41:                      2
+//     sub_c3e54:                  2
+//     sub_c3ef4:                  2
+//     sub_c3f14:                  2
+//     sub_c3f26:                  2
+//     c401d:                      2
+//     c4021:                      2
+//     c406c:                      2
+//     c40f5:                      2
+//     c410b:                      2
+//     sub_c4168:                  2
+//     c419f:                      2
+//     sub_c41c6:                  2
+//     l41d3:                      2
+//     c42f2:                      2
+//     sub_c4324:                  2
+//     c438b:                      2
+//     sub_c43ec:                  2
+//     c4411:                      2
+//     c4414:                      2
+//     sub_c451f:                  2
+//     c45ab:                      2
+//     sub_c45b2:                  2
+//     c4637:                      2
+//     c4845:                      2
+//     c486b:                      2
+//     c487a:                      2
+//     sub_c490d:                  2
+//     c497d:                      2
+//     c49ff:                      2
+//     c4a1c:                      2
+//     c4a51:                      2
+//     sub_c4a53:                  2
+//     sub_c4ac2:                  2
+//     sub_c4af1:                  2
+//     c4b1a:                      2
+//     c4b41:                      2
+//     c4b54:                      2
+//     c4bbc:                      2
+//     sub_c4c4e:                  2
+//     l4cdb:                      2
+//     c4d15:                      2
+//     c4dd7:                      2
+//     c4e11:                      2
+//     c4ed3:                      2
+//     c4ee8:                      2
+//     c4f37:                      2
+//     l4f75:                      2
+//     l4f77:                      2
+//     l4f78:                      2
+//     c4fad:                      2
+//     c4ffb:                      2
+//     c500a:                      2
+//     c5035:                      2
+//     sub_c5047:                  2
+//     c5280:                      2
+//     c5297:                      2
+//     c52a0:                      2
+//     c5300:                      2
+//     c5406:                      2
+//     c545e:                      2
+//     sub_c5598:                  2
+//     sub_c55ce:                  2
+//     sub_c55ee:                  2
+//     sub_c5607:                  2
+//     sub_c561e:                  2
+//     c5655:                      2
+//     sub_c565f:                  2
+//     sub_c56b1:                  2
+//     c5718:                      2
+//     c57ed:                      2
+//     l5872:                      2
+//     c58e4:                      2
+//     c59e8:                      2
+//     sub_c59f5:                  2
+//     c5a10:                      2
+//     c5af8:                      2
+//     c5afd:                      2
+//     c5b28:                      2
+//     c5b2a:                      2
+//     c5c13:                      2
+//     c5c3a:                      2
+//     sub_c5c68:                  2
+//     c5cb9:                      2
+//     c5db9:                      2
+//     sub_c5e83:                  2
+//     sub_c5e9d:                  2
+//     c5ec1:                      2
+//     sub_c5ec2:                  2
+//     c5edd:                      2
+//     sub_c5f82:                  2
+//     c5f8e:                      2
+//     tube_host_r4_status:        2
+//     gsinit:                     2
+//     gsread:                     2
+//     osgbpb:                     2
+//     osargs:                     2
+//     l0013:                      1
+//     l00f1:                      1
+//     l0103:                      1
+//     l0104:                      1
+//     l010c:                      1
+//     l010d:                      1
+//     l010e:                      1
+//     brkv:                       1
+//     brkv+1:                     1
+//     filev:                      1
+//     evntv:                      1
+//     evntv+1:                    1
+//     l028d:                      1
+//     l0cff:                      1
+//     l0e0e:                      1
+//     l0e10:                      1
+//     l0f00:                      1
+//     l0f09:                      1
+//     l0f10:                      1
+//     l1001:                      1
+//     l1002:                      1
+//     l1003:                      1
+//     l1004:                      1
+//     l1005:                      1
+//     l1006:                      1
+//     l1007:                      1
+//     l100e:                      1
+//     l1047:                      1
+//     l104d:                      1
+//     l104e:                      1
+//     l1050:                      1
+//     l1058:                      1
+//     l105f:                      1
+//     l1061:                      1
+//     l1063:                      1
+//     l1064:                      1
+//     l1072:                      1
+//     l1079:                      1
+//     l107a:                      1
+//     l1083:                      1
+//     l108f:                      1
+//     pydis_start:                1
+//     l2001:                      1
+//     l2002:                      1
+//     c2003:                      1
+//     l2004:                      1
+//     l2006:                      1
+//     l2007:                      1
+//     sub_c2020:                  1
+//     c2040:                      1
+//     c2064:                      1
+//     c2086:                      1
+//     c2093:                      1
+//     c2096:                      1
+//     sub_c209d:                  1
+//     sub_c20b8:                  1
+//     c20d0:                      1
+//     sub_c20d3:                  1
+//     sub_c20db:                  1
+//     sub_c20e6:                  1
+//     sub_c20f6:                  1
+//     c2111:                      1
+//     c2115:                      1
+//     c212e:                      1
+//     c213a:                      1
+//     c215b:                      1
+//     c215f:                      1
+//     c2161:                      1
+//     c216b:                      1
+//     c2184:                      1
+//     c218a:                      1
+//     c218c:                      1
+//     c21a2:                      1
+//     sub_c21b7:                  1
+//     c21bd:                      1
+//     sub_c21c0:                  1
+//     sub_c21c4:                  1
+//     sub_c21ca:                  1
+//     c220c:                      1
+//     c220d:                      1
+//     c221c:                      1
+//     sub_c2222:                  1
+//     c2243:                      1
+//     c226f:                      1
+//     c2286:                      1
+//     c228b:                      1
+//     c22be:                      1
+//     c22c7:                      1
+//     c22d1:                      1
+//     c22d9:                      1
+//     c22e7:                      1
+//     c22fb:                      1
+//     c2306:                      1
+//     c230d:                      1
+//     c2326:                      1
+//     c2332:                      1
+//     c2333:                      1
+//     c2370:                      1
+//     c2390:                      1
+//     c2397:                      1
+//     c23ab:                      1
+//     sub_c23bf:                  1
+//     c23cd:                      1
+//     sub_c23d1:                  1
+//     sub_c23d4:                  1
+//     c23e2:                      1
+//     sub_c23ee:                  1
+//     c23f0:                      1
+//     c23fa:                      1
+//     c2406:                      1
+//     c2425:                      1
+//     c242b:                      1
+//     sub_c242c:                  1
+//     c2436:                      1
+//     c2438:                      1
+//     c2453:                      1
+//     c2463:                      1
+//     c2477:                      1
+//     c2481:                      1
+//     c2482:                      1
+//     c2493:                      1
+//     c249d:                      1
+//     c24e7:                      1
+//     c2527:                      1
+//     c253e:                      1
+//     c2552:                      1
+//     c255f:                      1
+//     c2564:                      1
+//     c2573:                      1
+//     c257b:                      1
+//     c259b:                      1
+//     c25b5:                      1
+//     c25c5:                      1
+//     l25d3:                      1
+//     sub_c25e3:                  1
+//     sub_c2602:                  1
+//     l261d:                      1
+//     c2717:                      1
+//     c2725:                      1
+//     c2734:                      1
+//     c2759:                      1
+//     c2779:                      1
+//     c277c:                      1
+//     c27a0:                      1
+//     c27ab:                      1
+//     c27b8:                      1
+//     c27be:                      1
+//     c27c6:                      1
+//     c2815:                      1
+//     sub_c2826:                  1
+//     c2837:                      1
+//     c2864:                      1
+//     c2867:                      1
+//     c28bc:                      1
+//     c292d:                      1
+//     sub_c2932:                  1
+//     c2945:                      1
+//     c295f:                      1
+//     c2968:                      1
+//     c296b:                      1
+//     sub_c2979:                  1
+//     c2990:                      1
+//     c29ad:                      1
+//     c29c4:                      1
+//     c29ca:                      1
+//     c29e2:                      1
+//     c29f6:                      1
+//     c2a17:                      1
+//     c2a19:                      1
+//     c2a49:                      1
+//     c2a50:                      1
+//     c2a54:                      1
+//     c2a82:                      1
+//     c2ac8:                      1
+//     c2ad0:                      1
+//     c2ad8:                      1
+//     c2aeb:                      1
+//     c2af0:                      1
+//     c2afb:                      1
+//     c2b18:                      1
+//     sub_c2b25:                  1
+//     c2b60:                      1
+//     c2b77:                      1
+//     c2b80:                      1
+//     c2bea:                      1
+//     sub_c2bf6:                  1
+//     sub_c2bf9:                  1
+//     c2bfb:                      1
+//     c2c2e:                      1
+//     c2c3a:                      1
+//     c2c4e:                      1
+//     sub_c2c56:                  1
+//     c2c58:                      1
+//     c2c61:                      1
+//     sub_c2c65:                  1
+//     c2c71:                      1
+//     c2c87:                      1
+//     c2cae:                      1
+//     c2cc1:                      1
+//     c2cd6:                      1
+//     c2ce7:                      1
+//     c2cfc:                      1
+//     c2d03:                      1
+//     c2d14:                      1
+//     c2d17:                      1
+//     sub_c2d1a:                  1
+//     c2d5d:                      1
+//     c2d92:                      1
+//     c2dac:                      1
+//     c2dba:                      1
+//     sub_c2dc6:                  1
+//     c2dd2:                      1
+//     c2de2:                      1
+//     c2de9:                      1
+//     c2df0:                      1
+//     c2e03:                      1
+//     c2e14:                      1
+//     c2e4d:                      1
+//     c2e6f:                      1
+//     c2e72:                      1
+//     c2e85:                      1
+//     c2e9e:                      1
+//     c2eaf:                      1
+//     c2ecb:                      1
+//     c2edf:                      1
+//     sub_c2eec:                  1
+//     c2ef8:                      1
+//     sub_c2efa:                  1
+//     sub_c2eff:                  1
+//     c2f12:                      1
+//     c2f17:                      1
+//     c2f21:                      1
+//     sub_c2f33:                  1
+//     sub_c2f37:                  1
+//     sub_c2f4f:                  1
+//     sub_c2f5e:                  1
+//     c2f6c:                      1
+//     sub_c2f75:                  1
+//     c2f81:                      1
+//     sub_c2f82:                  1
+//     sub_c2f94:                  1
+//     c2f96:                      1
+//     c2fac:                      1
+//     c2fb5:                      1
+//     c2fc7:                      1
+//     sub_c303e:                  1
+//     c3047:                      1
+//     c3060:                      1
+//     c3066:                      1
+//     c30db:                      1
+//     c30e7:                      1
+//     sub_c3104:                  1
+//     c3108:                      1
+//     c3113:                      1
+//     c3115:                      1
+//     l311d:                      1
+//     l3121:                      1
+//     l312d:                      1
+//     l3139:                      1
+//     l313f:                      1
+//     l3145:                      1
+//     l3146:                      1
+//     l3191:                      1
+//     l31a0:                      1
+//     c31ba:                      1
+//     c31cc:                      1
+//     c31e7:                      1
+//     c31eb:                      1
+//     c31f3:                      1
+//     c31f9:                      1
+//     c3201:                      1
+//     c320d:                      1
+//     c321f:                      1
+//     c322b:                      1
+//     c3238:                      1
+//     c323b:                      1
+//     c323f:                      1
+//     c3249:                      1
+//     c325a:                      1
+//     c326a:                      1
+//     c3276:                      1
+//     c329c:                      1
+//     sub_c329d:                  1
+//     c32bd:                      1
+//     c32c4:                      1
+//     c32c7:                      1
+//     c32d6:                      1
+//     c32e3:                      1
+//     c32ef:                      1
+//     c3302:                      1
+//     c3355:                      1
+//     c3357:                      1
+//     c336b:                      1
+//     c336f:                      1
+//     c3379:                      1
+//     c3382:                      1
+//     c338d:                      1
+//     c3390:                      1
+//     c33a8:                      1
+//     c33b1:                      1
+//     sub_c33b4:                  1
+//     c33bd:                      1
+//     c33c4:                      1
+//     sub_c33d8:                  1
+//     c33da:                      1
+//     c33e2:                      1
+//     c33e5:                      1
+//     sub_c33f1:                  1
+//     sub_c33f9:                  1
+//     c33ff:                      1
+//     c3450:                      1
+//     c345c:                      1
+//     c348d:                      1
+//     c34c1:                      1
+//     c34c2:                      1
+//     c34d4:                      1
+//     c3504:                      1
+//     c3535:                      1
+//     sub_c3536:                  1
+//     c353a:                      1
+//     c3556:                      1
+//     c356d:                      1
+//     c356f:                      1
+//     c357d:                      1
+//     c3593:                      1
+//     c35b6:                      1
+//     c35d9:                      1
+//     c35e4:                      1
+//     c35e7:                      1
+//     c35ec:                      1
+//     c3618:                      1
+//     c3649:                      1
+//     c364a:                      1
+//     c3658:                      1
+//     sub_c365d:                  1
+//     c367a:                      1
+//     c3682:                      1
+//     c3683:                      1
+//     c369e:                      1
+//     c36c1:                      1
+//     c36c2:                      1
+//     c36c3:                      1
+//     c36e4:                      1
+//     c36e9:                      1
+//     c36ec:                      1
+//     c36f2:                      1
+//     c36f5:                      1
+//     c3700:                      1
+//     c3714:                      1
+//     c3736:                      1
+//     c373c:                      1
+//     c373d:                      1
+//     c375b:                      1
+//     c376c:                      1
+//     c379d:                      1
+//     c37c8:                      1
+//     c37e6:                      1
+//     sub_c37e8:                  1
+//     c3803:                      1
+//     c381f:                      1
+//     c382e:                      1
+//     sub_c3832:                  1
+//     c3835:                      1
+//     c3837:                      1
+//     c384c:                      1
+//     c3851:                      1
+//     c3859:                      1
+//     c385e:                      1
+//     c386b:                      1
+//     c3873:                      1
+//     c3881:                      1
+//     c38a0:                      1
+//     c38b1:                      1
+//     c38ba:                      1
+//     c38c1:                      1
+//     c38cd:                      1
+//     c38e4:                      1
+//     c38ed:                      1
+//     c38f0:                      1
+//     c3942:                      1
+//     c394b:                      1
+//     c394e:                      1
+//     c3964:                      1
+//     c3978:                      1
+//     sub_c3988:                  1
+//     c3993:                      1
+//     c39a8:                      1
+//     c39ea:                      1
+//     c3a2a:                      1
+//     sub_c3a32:                  1
+//     c3a3f:                      1
+//     sub_c3a4b:                  1
+//     c3a55:                      1
+//     c3a73:                      1
+//     c3a77:                      1
+//     sub_c3ad3:                  1
+//     c3ad4:                      1
+//     l3aec:                      1
+//     l3b0f:                      1
+//     l3b18:                      1
+//     l3b21:                      1
+//     l3b29:                      1
+//     l3b31:                      1
+//     l3b3a:                      1
+//     l3b43:                      1
+//     c3b50:                      1
+//     sub_c3b51:                  1
+//     c3b5e:                      1
+//     sub_c3b61:                  1
+//     c3b63:                      1
+//     c3bc2:                      1
+//     sub_c3bca:                  1
+//     sub_c3bcd:                  1
+//     c3bcf:                      1
+//     c3be4:                      1
+//     c3c00:                      1
+//     c3c16:                      1
+//     c3c33:                      1
+//     c3c38:                      1
+//     c3c51:                      1
+//     c3c58:                      1
+//     c3c5d:                      1
+//     c3c6b:                      1
+//     c3c8b:                      1
+//     c3c90:                      1
+//     c3ca8:                      1
+//     c3cee:                      1
+//     c3d03:                      1
+//     c3d12:                      1
+//     sub_c3d19:                  1
+//     c3d2b:                      1
+//     c3d43:                      1
+//     c3d57:                      1
+//     c3d67:                      1
+//     c3d71:                      1
+//     c3d72:                      1
+//     sub_c3d75:                  1
+//     c3d86:                      1
+//     c3d89:                      1
+//     c3db4:                      1
+//     c3dce:                      1
+//     c3e07:                      1
+//     c3e13:                      1
+//     c3e16:                      1
+//     c3e28:                      1
+//     c3e2a:                      1
+//     c3e4d:                      1
+//     c3e5c:                      1
+//     c3e6f:                      1
+//     c3e71:                      1
+//     c3e74:                      1
+//     c3e8c:                      1
+//     sub_c3e94:                  1
+//     c3eb3:                      1
+//     c3ec2:                      1
+//     c3ef1:                      1
+//     c3f0d:                      1
+//     c3f19:                      1
+//     c3f5e:                      1
+//     c3f64:                      1
+//     c3f6a:                      1
+//     c3f6b:                      1
+//     c3f6e:                      1
+//     sub_c3f7c:                  1
+//     sub_c3f82:                  1
+//     c3f88:                      1
+//     c3fd9:                      1
+//     c3ff4:                      1
+//     c4005:                      1
+//     c4054:                      1
+//     c4061:                      1
+//     c4075:                      1
+//     c40a9:                      1
+//     sub_c40b8:                  1
+//     sub_c40f6:                  1
+//     c411d:                      1
+//     c4132:                      1
+//     c4143:                      1
+//     c416e:                      1
+//     c417a:                      1
+//     c4183:                      1
+//     sub_c4190:                  1
+//     c41aa:                      1
+//     c41c1:                      1
+//     c41cc:                      1
+//     c41d2:                      1
+//     c427a:                      1
+//     c42ab:                      1
+//     c430d:                      1
+//     c4321:                      1
+//     c434a:                      1
+//     c4378:                      1
+//     c438c:                      1
+//     c438e:                      1
+//     c43ae:                      1
+//     c43bd:                      1
+//     sub_c43e4:                  1
+//     c43fb:                      1
+//     c440c:                      1
+//     c445d:                      1
+//     c447b:                      1
+//     c4487:                      1
+//     sub_c44e1:                  1
+//     c44fa:                      1
+//     c4521:                      1
+//     c4538:                      1
+//     c4547:                      1
+//     c4574:                      1
+//     c4595:                      1
+//     c45a0:                      1
+//     c45c4:                      1
+//     c45e2:                      1
+//     c45fb:                      1
+//     c4605:                      1
+//     c463a:                      1
+//     c4647:                      1
+//     c4652:                      1
+//     c465d:                      1
+//     sub_c4663:                  1
+//     c4675:                      1
+//     c468a:                      1
+//     c46b3:                      1
+//     c46b6:                      1
+//     c46bb:                      1
+//     c46ce:                      1
+//     c46e2:                      1
+//     c470a:                      1
+//     c4712:                      1
+//     c4721:                      1
+//     c4728:                      1
+//     c473a:                      1
+//     sub_c473d:                  1
+//     sub_c476c:                  1
+//     c476f:                      1
+//     sub_c4779:                  1
+//     c4787:                      1
+//     sub_c4788:                  1
+//     c47a4:                      1
+//     c47a7:                      1
+//     sub_c47c4:                  1
+//     sub_c47c5:                  1
+//     c47c6:                      1
+//     sub_c47ce:                  1
+//     c47e0:                      1
+//     c47e1:                      1
+//     c47f2:                      1
+//     c47f7:                      1
+//     c4818:                      1
+//     c482f:                      1
+//     c4856:                      1
+//     c48bd:                      1
+//     sub_c48be:                  1
+//     sub_c48e2:                  1
+//     c48fa:                      1
+//     c4902:                      1
+//     c490c:                      1
+//     c4941:                      1
+//     c4947:                      1
+//     c4953:                      1
+//     c495d:                      1
+//     c496c:                      1
+//     c4970:                      1
+//     c4982:                      1
+//     c498d:                      1
+//     c49ab:                      1
+//     c49b8:                      1
+//     sub_c49bf:                  1
+//     c49e7:                      1
+//     c4a01:                      1
+//     c4a0a:                      1
+//     c4a0d:                      1
+//     sub_c4a12:                  1
+//     c4a78:                      1
+//     c4a7a:                      1
+//     c4a86:                      1
+//     sub_c4a9a:                  1
+//     c4ab7:                      1
+//     c4ab8:                      1
+//     c4abe:                      1
+//     c4ace:                      1
+//     sub_c4add:                  1
+//     sub_c4aea:                  1
+//     c4b09:                      1
+//     c4b17:                      1
+//     c4b2e:                      1
+//     c4b35:                      1
+//     c4b3d:                      1
+//     c4b6b:                      1
+//     c4b7d:                      1
+//     c4b80:                      1
+//     c4b93:                      1
+//     c4ba4:                      1
+//     sub_c4ba9:                  1
+//     c4bad:                      1
+//     c4bcf:                      1
+//     c4bf4:                      1
+//     c4bfb:                      1
+//     c4c28:                      1
+//     c4c45:                      1
+//     c4c46:                      1
+//     sub_c4c47:                  1
+//     sub_c4c6a:                  1
+//     sub_c4c72:                  1
+//     c4cc7:                      1
+//     l4cf3:                      1
+//     c4d2d:                      1
+//     c4d3f:                      1
+//     c4d52:                      1
+//     c4d61:                      1
+//     c4d6e:                      1
+//     c4d81:                      1
+//     c4d86:                      1
+//     c4da2:                      1
+//     c4dae:                      1
+//     c4dc1:                      1
+//     l4ddb:                      1
+//     c4ddf:                      1
+//     c4df8:                      1
+//     c4e06:                      1
+//     c4e20:                      1
+//     c4e27:                      1
+//     c4e32:                      1
+//     c4e35:                      1
+//     c4e40:                      1
+//     c4e45:                      1
+//     c4e5b:                      1
+//     c4e62:                      1
+//     c4e82:                      1
+//     sub_c4ea9:                  1
+//     c4ed7:                      1
+//     c4ef8:                      1
+//     c4f13:                      1
+//     c4f2d:                      1
+//     c4f35:                      1
+//     c4f38:                      1
+//     c4f4b:                      1
+//     c4f54:                      1
+//     c4f5d:                      1
+//     c4f63:                      1
+//     l4f73:                      1
+//     c4f79:                      1
+//     sub_c4f8d:                  1
+//     sub_c4f9a:                  1
+//     c4fa1:                      1
+//     c4fab:                      1
+//     c4fae:                      1
+//     c4fbf:                      1
+//     c4fdc:                      1
+//     c4fdf:                      1
+//     c4fea:                      1
+//     c4ff3:                      1
+//     c4ffd:                      1
+//     c5005:                      1
+//     c5014:                      1
+//     c501f:                      1
+//     sub_c5040:                  1
+//     c505a:                      1
+//     c5070:                      1
+//     l5075:                      1
+//     l5175:                      1
+//     c51b1:                      1
+//     c51dd:                      1
+//     c51e3:                      1
+//     c51ed:                      1
+//     c51fc:                      1
+//     c520f:                      1
+//     c5221:                      1
+//     sub_c5234:                  1
+//     c523d:                      1
+//     c5249:                      1
+//     c5260:                      1
+//     c5268:                      1
+//     c5275:                      1
+//     l5283:                      1
+//     c52b2:                      1
+//     c52b4:                      1
+//     c52bd:                      1
+//     sub_c52c8:                  1
+//     c52d1:                      1
+//     c52e1:                      1
+//     c52e7:                      1
+//     c5305:                      1
+//     c5314:                      1
+//     c5337:                      1
+//     c534f:                      1
+//     c5352:                      1
+//     c5375:                      1
+//     c537f:                      1
+//     c5382:                      1
+//     c5397:                      1
+//     c53ba:                      1
+//     c53de:                      1
+//     c540e:                      1
+//     c544b:                      1
+//     c544d:                      1
+//     c545a:                      1
+//     c5470:                      1
+//     c54a8:                      1
+//     c54af:                      1
+//     c54b4:                      1
+//     c54d8:                      1
+//     c54df:                      1
+//     c54e9:                      1
+//     c54ee:                      1
+//     c5502:                      1
+//     c5534:                      1
+//     c555e:                      1
+//     c5578:                      1
+//     c5597:                      1
+//     c55c6:                      1
+//     c55d0:                      1
+//     c55e6:                      1
+//     c55ed:                      1
+//     c565e:                      1
+//     c56a6:                      1
+//     c56b3:                      1
+//     c56c2:                      1
+//     l56c6:                      1
+//     l56ce:                      1
+//     c56d2:                      1
+//     sub_c56e6:                  1
+//     c56eb:                      1
+//     c56f5:                      1
+//     c5725:                      1
+//     c5736:                      1
+//     c575a:                      1
+//     sub_c5771:                  1
+//     l5774:                      1
+//     c57ae:                      1
+//     c57b2:                      1
+//     sub_c57b6:                  1
+//     c57be:                      1
+//     c57d7:                      1
+//     c57dd:                      1
+//     c57e8:                      1
+//     c57ec:                      1
+//     sub_c586f:                  1
+//     l587e:                      1
+//     sub_c5882:                  1
+//     c5898:                      1
+//     c58e6:                      1
+//     c58f5:                      1
+//     c5910:                      1
+//     l5924:                      1
+//     l5979:                      1
+//     l597a:                      1
+//     l5980:                      1
+//     c5999:                      1
+//     c59ae:                      1
+//     c59bd:                      1
+//     c59cc:                      1
+//     c59d1:                      1
+//     c59d2:                      1
+//     c59d9:                      1
+//     c59ee:                      1
+//     c59f7:                      1
+//     c59f9:                      1
+//     c5a15:                      1
+//     c5a19:                      1
+//     c5a1a:                      1
+//     c5a27:                      1
+//     c5a28:                      1
+//     c5a2e:                      1
+//     c5a2f:                      1
+//     l5a31:                      1
+//     c5a78:                      1
+//     c5a8c:                      1
+//     c5a94:                      1
+//     c5a9e:                      1
+//     c5ab0:                      1
+//     c5ab1:                      1
+//     c5ab8:                      1
+//     c5ad0:                      1
+//     sub_c5ad2:                  1
+//     c5aea:                      1
+//     c5b07:                      1
+//     c5b33:                      1
+//     c5b36:                      1
+//     l5b3a:                      1
+//     l5b3e:                      1
+//     l5b42:                      1
+//     c5b4c:                      1
+//     c5b6f:                      1
+//     c5b89:                      1
+//     c5b90:                      1
+//     c5ba1:                      1
+//     c5bbe:                      1
+//     c5bd9:                      1
+//     c5be4:                      1
+//     c5bf3:                      1
+//     c5bfe:                      1
+//     c5c2c:                      1
+//     c5c54:                      1
+//     c5c64:                      1
+//     c5c70:                      1
+//     c5c78:                      1
+//     c5c93:                      1
+//     c5cb2:                      1
+//     c5cd3:                      1
+//     c5cd6:                      1
+//     c5ce1:                      1
+//     c5cf9:                      1
+//     c5d08:                      1
+//     c5d0e:                      1
+//     c5d1b:                      1
+//     c5d2b:                      1
+//     c5d40:                      1
+//     c5d46:                      1
+//     c5d6c:                      1
+//     c5d7e:                      1
+//     c5d99:                      1
+//     c5da3:                      1
+//     c5dba:                      1
+//     c5dc0:                      1
+//     c5dd3:                      1
+//     c5ddd:                      1
+//     c5e0e:                      1
+//     c5e21:                      1
+//     c5e31:                      1
+//     c5e3c:                      1
+//     c5e52:                      1
+//     sub_c5e91:                  1
+//     c5eab:                      1
+//     c5ec8:                      1
+//     c5ee0:                      1
+//     c5eee:                      1
+//     c5f1c:                      1
+//     c5f33:                      1
+//     c5f46:                      1
+//     l5f4f:                      1
+//     c5f78:                      1
+//     sub_c5f84:                  1
+//     c5f8a:                      1
+//     c5fa3:                      1
+//     c5fb2:                      1
+//     nmi_handler_rom_start:      1
+//     nmi3_handler_rom_start-1:   1
+//     tube_host_code2:            1
+//     tube_host_code2+256:        1
+//     tube_host_code3:            1
+//     tube_host_code1:            1
+//     tube_host_r4_data:          1
+
+// Automatically generated labels:
+//     c0032
+//     c0036
+//     c0041
+//     c0400
+//     c0432
+//     c0434
+//     c0463
+//     c047a
+//     c0482
+//     c0484
+//     c048c
+//     c0491
+//     c049b
+//     c04bc
+//     c04f7
+//     c053a
+//     c0552
+//     c0593
+//     c059c
+//     c059e
+//     c05a6
+//     c05fc
+//     c0636
+//     c0645
+//     c0665
+//     c06a7
+//     c0d60
+//     c0d74
+//     c0d80
+//     c2003
+//     c2040
+//     c204f
+//     c2064
+//     c2086
+//     c2093
+//     c2096
+//     c209f
+//     c20d0
+//     c2103
+//     c2111
+//     c2115
+//     c2125
+//     c212e
+//     c213a
+//     c215b
+//     c215d
+//     c215f
+//     c2161
+//     c216b
+//     c2184
+//     c218a
+//     c218c
+//     c21a2
+//     c21a7
+//     c21bd
+//     c220c
+//     c220d
+//     c221c
+//     c2225
+//     c222a
+//     c2243
+//     c225d
+//     c226f
+//     c2286
+//     c228b
+//     c2290
+//     c22be
+//     c22c7
+//     c22d1
+//     c22d9
+//     c22e6
+//     c22e7
+//     c22fb
+//     c22fd
+//     c2306
+//     c230d
+//     c2326
+//     c2332
+//     c2333
+//     c2370
+//     c2390
+//     c2397
+//     c23ab
+//     c23cd
+//     c23e2
+//     c23f0
+//     c23fa
+//     c2406
+//     c2425
+//     c242b
+//     c2436
+//     c2438
+//     c2453
+//     c2454
+//     c2463
+//     c2477
+//     c2481
+//     c2482
+//     c2493
+//     c249d
+//     c24e7
+//     c2527
+//     c253e
+//     c2543
+//     c2552
+//     c255f
+//     c2560
+//     c2564
+//     c2573
+//     c257b
+//     c259b
+//     c25b5
+//     c25bc
+//     c25c5
+//     c2703
+//     c2705
+//     c2717
+//     c2725
+//     c2734
+//     c273b
+//     c2759
+//     c2779
+//     c277c
+//     c27a0
+//     c27ab
+//     c27b8
+//     c27be
+//     c27c6
+//     c2808
+//     c2815
+//     c2816
+//     c2837
+//     c283f
+//     c2864
+//     c2867
+//     c28a6
+//     c28bc
+//     c28f4
+//     c292d
+//     c2945
+//     c295f
+//     c2968
+//     c296b
+//     c298a
+//     c2990
+//     c29a5
+//     c29ad
+//     c29b4
+//     c29c4
+//     c29ca
+//     c29d7
+//     c29e2
+//     c29f6
+//     c2a00
+//     c2a17
+//     c2a19
+//     c2a49
+//     c2a50
+//     c2a54
+//     c2a6e
+//     c2a82
+//     c2ac8
+//     c2ad0
+//     c2ad8
+//     c2aeb
+//     c2af0
+//     c2afb
+//     c2b18
+//     c2b60
+//     c2b77
+//     c2b80
+//     c2b8b
+//     c2ba2
+//     c2be3
+//     c2bea
+//     c2bfb
+//     c2c12
+//     c2c2e
+//     c2c3a
+//     c2c4e
+//     c2c58
+//     c2c61
+//     c2c71
+//     c2c87
+//     c2cae
+//     c2cb2
+//     c2cc1
+//     c2cd6
+//     c2ce7
+//     c2cfc
+//     c2d03
+//     c2d0d
+//     c2d13
+//     c2d14
+//     c2d17
+//     c2d41
+//     c2d5d
+//     c2d74
+//     c2d91
+//     c2d92
+//     c2dac
+//     c2dba
+//     c2dd2
+//     c2de2
+//     c2de9
+//     c2df0
+//     c2e03
+//     c2e0d
+//     c2e0e
+//     c2e12
+//     c2e14
+//     c2e32
+//     c2e4d
+//     c2e53
+//     c2e64
+//     c2e6f
+//     c2e72
+//     c2e85
+//     c2e9e
+//     c2e9f
+//     c2ea5
+//     c2eaf
+//     c2eb7
+//     c2ecb
+//     c2ecc
+//     c2edf
+//     c2eeb
+//     c2ef8
+//     c2f12
+//     c2f17
+//     c2f21
+//     c2f2a
+//     c2f3e
+//     c2f6c
+//     c2f81
+//     c2f96
+//     c2fac
+//     c2fb5
+//     c2fc7
+//     c3047
+//     c3060
+//     c3066
+//     c30c7
+//     c30db
+//     c30e7
+//     c30fb
+//     c3108
+//     c3113
+//     c3115
+//     c31af
+//     c31ba
+//     c31cc
+//     c31df
+//     c31e7
+//     c31eb
+//     c31f3
+//     c31f9
+//     c3201
+//     c320d
+//     c3214
+//     c321f
+//     c322b
+//     c3238
+//     c323b
+//     c323f
+//     c3249
+//     c3257
+//     c325a
+//     c326a
+//     c3276
+//     c3289
+//     c329c
+//     c32bd
+//     c32c4
+//     c32c7
+//     c32d6
+//     c32e3
+//     c32ef
+//     c3302
+//     c3355
+//     c3357
+//     c3367
+//     c336b
+//     c336f
+//     c3379
+//     c3382
+//     c338d
+//     c3390
+//     c33a8
+//     c33b1
+//     c33bd
+//     c33c4
+//     c33da
+//     c33e2
+//     c33e5
+//     c33e6
+//     c33ff
+//     c340c
+//     c340e
+//     c3436
+//     c3444
+//     c3450
+//     c345c
+//     c348d
+//     c34a9
+//     c34bc
+//     c34c1
+//     c34c2
+//     c34c6
+//     c34d4
+//     c3504
+//     c3535
+//     c353a
+//     c3556
+//     c356d
+//     c356f
+//     c357d
+//     c3593
+//     c35b6
+//     c35d9
+//     c35e4
+//     c35e7
+//     c35ec
+//     c35fd
+//     c3618
+//     c3628
+//     c3649
+//     c364a
+//     c3658
+//     c365a
+//     c367a
+//     c3682
+//     c3683
+//     c369e
+//     c36b7
+//     c36c1
+//     c36c2
+//     c36c3
+//     c36e4
+//     c36e9
+//     c36ec
+//     c36f2
+//     c36f5
+//     c3700
+//     c3714
+//     c3736
+//     c3738
+//     c373c
+//     c373d
+//     c375b
+//     c376c
+//     c379d
+//     c37b3
+//     c37c8
+//     c37e6
+//     c3803
+//     c381f
+//     c382e
+//     c3835
+//     c3837
+//     c384c
+//     c3851
+//     c3859
+//     c385e
+//     c386b
+//     c3873
+//     c3881
+//     c38a0
+//     c38b1
+//     c38ba
+//     c38c1
+//     c38cd
+//     c38e4
+//     c38ed
+//     c38f0
+//     c393b
+//     c3942
+//     c394b
+//     c394e
+//     c3964
+//     c396e
+//     c3978
+//     c3993
+//     c39a3
+//     c39a8
+//     c39ea
+//     c39ed
+//     c3a2a
+//     c3a3f
+//     c3a55
+//     c3a73
+//     c3a77
+//     c3a8c
+//     c3ad4
+//     c3adf
+//     c3ae9
+//     c3b50
+//     c3b5e
+//     c3b63
+//     c3b6e
+//     c3bc2
+//     c3bc5
+//     c3bcf
+//     c3be4
+//     c3c00
+//     c3c16
+//     c3c33
+//     c3c38
+//     c3c51
+//     c3c58
+//     c3c5d
+//     c3c6b
+//     c3c82
+//     c3c8b
+//     c3c90
+//     c3ca8
+//     c3cee
+//     c3d03
+//     c3d12
+//     c3d2b
+//     c3d43
+//     c3d57
+//     c3d5d
+//     c3d67
+//     c3d71
+//     c3d72
+//     c3d86
+//     c3d89
+//     c3db4
+//     c3dcd
+//     c3dce
+//     c3dd5
+//     c3e07
+//     c3e13
+//     c3e16
+//     c3e28
+//     c3e2a
+//     c3e41
+//     c3e4d
+//     c3e5c
+//     c3e6f
+//     c3e71
+//     c3e74
+//     c3e8c
+//     c3eb3
+//     c3ec2
+//     c3ef1
+//     c3f0d
+//     c3f19
+//     c3f5e
+//     c3f64
+//     c3f6a
+//     c3f6b
+//     c3f6e
+//     c3f88
+//     c3fd9
+//     c3ff4
+//     c4005
+//     c401d
+//     c4021
+//     c4054
+//     c4061
+//     c406b
+//     c406c
+//     c4075
+//     c40a9
+//     c40f5
+//     c410b
+//     c411d
+//     c4132
+//     c4143
+//     c414f
+//     c416e
+//     c417a
+//     c4183
+//     c419f
+//     c41aa
+//     c41c0
+//     c41c1
+//     c41cc
+//     c41d2
+//     c427a
+//     c42ab
+//     c42f2
+//     c430d
+//     c4321
+//     c434a
+//     c4378
+//     c438b
+//     c438c
+//     c438e
+//     c43ae
+//     c43bd
+//     c43dc
+//     c43fb
+//     c440c
+//     c4411
+//     c4414
+//     c445d
+//     c447b
+//     c4487
+//     c44fa
+//     c4521
+//     c4538
+//     c4547
+//     c4574
+//     c4595
+//     c45a0
+//     c45ab
+//     c45c4
+//     c45e2
+//     c45e5
+//     c45fb
+//     c4605
+//     c4637
+//     c463a
+//     c4647
+//     c4652
+//     c465d
+//     c4660
+//     c4675
+//     c468a
+//     c46b3
+//     c46b6
+//     c46bb
+//     c46ce
+//     c46e2
+//     c470a
+//     c4712
+//     c4721
+//     c4728
+//     c473a
+//     c476f
+//     c4787
+//     c47a4
+//     c47a7
+//     c47c6
+//     c47e0
+//     c47e1
+//     c47f2
+//     c47f7
+//     c4818
+//     c482f
+//     c4845
+//     c4856
+//     c486b
+//     c487a
+//     c48bd
+//     c48fa
+//     c4902
+//     c490c
+//     c4941
+//     c4947
+//     c4953
+//     c495d
+//     c496c
+//     c4970
+//     c497d
+//     c4982
+//     c498d
+//     c49ab
+//     c49b8
+//     c49e7
+//     c49ff
+//     c4a01
+//     c4a0a
+//     c4a0d
+//     c4a1c
+//     c4a42
+//     c4a44
+//     c4a51
+//     c4a78
+//     c4a7a
+//     c4a86
+//     c4ab7
+//     c4ab8
+//     c4abe
+//     c4ace
+//     c4b09
+//     c4b17
+//     c4b1a
+//     c4b2e
+//     c4b35
+//     c4b3d
+//     c4b41
+//     c4b54
+//     c4b6b
+//     c4b7d
+//     c4b80
+//     c4b93
+//     c4ba4
+//     c4bad
+//     c4bbc
+//     c4bcf
+//     c4bf4
+//     c4bfb
+//     c4c0f
+//     c4c28
+//     c4c45
+//     c4c46
+//     c4cc4
+//     c4cc7
+//     c4d15
+//     c4d2d
+//     c4d3f
+//     c4d52
+//     c4d61
+//     c4d6e
+//     c4d77
+//     c4d79
+//     c4d81
+//     c4d86
+//     c4da2
+//     c4dae
+//     c4dc1
+//     c4dd7
+//     c4ddf
+//     c4df8
+//     c4e06
+//     c4e11
+//     c4e20
+//     c4e27
+//     c4e32
+//     c4e35
+//     c4e40
+//     c4e45
+//     c4e5b
+//     c4e62
+//     c4e70
+//     c4e79
+//     c4e82
+//     c4e97
+//     c4ea0
+//     c4ed3
+//     c4ed7
+//     c4ee8
+//     c4ef8
+//     c4f13
+//     c4f2d
+//     c4f35
+//     c4f37
+//     c4f38
+//     c4f4b
+//     c4f54
+//     c4f58
+//     c4f5d
+//     c4f63
+//     c4f79
+//     c4f7f
+//     c4fa1
+//     c4fab
+//     c4fad
+//     c4fae
+//     c4fbf
+//     c4fdc
+//     c4fdf
+//     c4fea
+//     c4ff3
+//     c4ffb
+//     c4ffd
+//     c5005
+//     c500a
+//     c5014
+//     c501f
+//     c5035
+//     c505a
+//     c5070
+//     c51b1
+//     c51d5
+//     c51dd
+//     c51e3
+//     c51ed
+//     c51fc
+//     c5203
+//     c520f
+//     c5221
+//     c523d
+//     c5249
+//     c5260
+//     c5268
+//     c5275
+//     c5280
+//     c5297
+//     c52a0
+//     c52b2
+//     c52b4
+//     c52bd
+//     c52d1
+//     c52e1
+//     c52e7
+//     c5300
+//     c5305
+//     c5314
+//     c5337
+//     c534f
+//     c5352
+//     c5371
+//     c5375
+//     c537f
+//     c5382
+//     c5397
+//     c53ba
+//     c53de
+//     c5406
+//     c540e
+//     c5446
+//     c544b
+//     c544d
+//     c545a
+//     c545e
+//     c5470
+//     c54a8
+//     c54af
+//     c54b4
+//     c54d8
+//     c54df
+//     c54e9
+//     c54ee
+//     c5502
+//     c5534
+//     c555e
+//     c5578
+//     c5597
+//     c55c6
+//     c55d0
+//     c55e6
+//     c55ed
+//     c5655
+//     c565e
+//     c5684
+//     c568c
+//     c56a6
+//     c56b3
+//     c56c2
+//     c56ca
+//     c56d2
+//     c56eb
+//     c56f5
+//     c5718
+//     c5725
+//     c5736
+//     c575a
+//     c5795
+//     c57ae
+//     c57b2
+//     c57be
+//     c57d7
+//     c57dd
+//     c57e8
+//     c57ec
+//     c57ed
+//     c582b
+//     c5898
+//     c58e4
+//     c58e6
+//     c58f5
+//     c58fb
+//     c5910
+//     c5999
+//     c59ae
+//     c59bd
+//     c59cc
+//     c59d1
+//     c59d2
+//     c59d9
+//     c59e8
+//     c59ee
+//     c59f7
+//     c59f9
+//     c5a10
+//     c5a15
+//     c5a19
+//     c5a1a
+//     c5a27
+//     c5a28
+//     c5a2e
+//     c5a2f
+//     c5a78
+//     c5a8c
+//     c5a94
+//     c5a9e
+//     c5ab0
+//     c5ab1
+//     c5ab4
+//     c5ab8
+//     c5ad0
+//     c5aea
+//     c5af8
+//     c5afd
+//     c5b07
+//     c5b28
+//     c5b2a
+//     c5b33
+//     c5b36
+//     c5b4c
+//     c5b6f
+//     c5b89
+//     c5b90
+//     c5ba1
+//     c5bbe
+//     c5bd0
+//     c5bd9
+//     c5be4
+//     c5bf3
+//     c5bfe
+//     c5c13
+//     c5c2c
+//     c5c3a
+//     c5c54
+//     c5c64
+//     c5c70
+//     c5c78
+//     c5c93
+//     c5cb2
+//     c5cb9
+//     c5cd3
+//     c5cd6
+//     c5ce1
+//     c5cf9
+//     c5d08
+//     c5d0e
+//     c5d1b
+//     c5d2b
+//     c5d40
+//     c5d46
+//     c5d6c
+//     c5d7e
+//     c5d99
+//     c5da3
+//     c5db9
+//     c5dba
+//     c5dc0
+//     c5dd3
+//     c5ddd
+//     c5e0e
+//     c5e21
+//     c5e31
+//     c5e3c
+//     c5e47
+//     c5e52
+//     c5e7a
+//     c5e7b
+//     c5e89
+//     c5e8d
+//     c5eab
+//     c5ec1
+//     c5ec8
+//     c5edd
+//     c5ee0
+//     c5ee8
+//     c5eee
+//     c5f1c
+//     c5f33
+//     c5f46
+//     c5f78
+//     c5f8a
+//     c5f8e
+//     c5fa3
+//     c5fb2
+//     c8040
+//     c8093
+//     c8096
+//     c809f
+//     c80d0
+//     c8103
+//     c8111
+//     c8115
+//     c8125
+//     c812e
+//     c815b
+//     c815d
+//     c815f
+//     c8184
+//     c818a
+//     c81a2
+//     c81a7
+//     c81bd
+//     c8225
+//     c822a
+//     c8243
+//     c825d
+//     c8286
+//     c828b
+//     c8290
+//     c82be
+//     c82d9
+//     c82e6
+//     c82e7
+//     c82fb
+//     c82fd
+//     c8306
+//     c8332
+//     c8333
+//     c83ab
+//     c83cd
+//     c83e2
+//     c842b
+//     c8436
+//     c8438
+//     c8453
+//     c8454
+//     c8477
+//     c8481
+//     c8482
+//     c849d
+//     c853e
+//     c8543
+//     c855f
+//     c8560
+//     c8573
+//     c859b
+//     c85bc
+//     c85c5
+//     c8703
+//     c8705
+//     c8734
+//     c873b
+//     c8759
+//     c8779
+//     c877c
+//     c87ab
+//     c87b8
+//     c87c6
+//     c8808
+//     c8815
+//     c8816
+//     c8837
+//     c883f
+//     c8864
+//     c8867
+//     c88a6
+//     c88f4
+//     c892d
+//     c8945
+//     c8968
+//     c896b
+//     c898a
+//     c89a5
+//     c89ad
+//     c89b4
+//     c89d7
+//     c89e2
+//     c89f6
+//     c8a00
+//     c8a19
+//     c8a49
+//     c8a50
+//     c8a54
+//     c8a6e
+//     c8a82
+//     c8ad0
+//     c8aeb
+//     c8b18
+//     c8b60
+//     c8b77
+//     c8b8b
+//     c8ba2
+//     c8be3
+//     c8bfb
+//     c8c12
+//     c8c2e
+//     c8c3a
+//     c8c4e
+//     c8c61
+//     c8c87
+//     c8cae
+//     c8cb2
+//     c8cc1
+//     c8cd6
+//     c8ce7
+//     c8cfc
+//     c8d03
+//     c8d0d
+//     c8d13
+//     c8d41
+//     c8d5d
+//     c8d74
+//     c8d91
+//     c8d92
+//     c8dd2
+//     c8de2
+//     c8e03
+//     c8e0d
+//     c8e0e
+//     c8e12
+//     c8e32
+//     c8e4d
+//     c8e53
+//     c8e64
+//     c8e6f
+//     c8e72
+//     c8e9e
+//     c8e9f
+//     c8ea5
+//     c8eaf
+//     c8eb7
+//     c8ecb
+//     c8ecc
+//     c8edf
+//     c8eeb
+//     c8ef8
+//     c8f12
+//     c8f21
+//     c8f2a
+//     c8f3e
+//     c8f81
+//     c8fb5
+//     c8fc7
+//     c9060
+//     c9115
+//     c91af
+//     c91cc
+//     c91df
+//     c91eb
+//     c91f3
+//     c91f9
+//     c9201
+//     c920d
+//     c9214
+//     c921f
+//     c922b
+//     c9238
+//     c923b
+//     c923f
+//     c9249
+//     c9257
+//     c925a
+//     c926a
+//     c9276
+//     c9289
+//     c929c
+//     c92bd
+//     c92c4
+//     c92c7
+//     c92d6
+//     c92e3
+//     c9302
+//     c9367
+//     c936b
+//     c9379
+//     c938d
+//     c9390
+//     c93a8
+//     c93b1
+//     c93c4
+//     c93e2
+//     c93e5
+//     c93e6
+//     c93ff
+//     c940c
+//     c940e
+//     c9436
+//     c9444
+//     c9450
+//     c945c
+//     c948d
+//     c94a9
+//     c94bc
+//     c94c1
+//     c94c2
+//     c94c6
+//     c94d4
+//     c9504
+//     c9535
+//     c9556
+//     c956d
+//     c956f
+//     c95e4
+//     c95e7
+//     c95fd
+//     c9628
+//     c9649
+//     c964a
+//     c9658
+//     c965a
+//     c967a
+//     c9682
+//     c9683
+//     c969e
+//     c96b7
+//     c96c3
+//     c96e4
+//     c96e9
+//     c96ec
+//     c96f5
+//     c9700
+//     c9714
+//     c9736
+//     c9738
+//     c973c
+//     c973d
+//     c975b
+//     c976c
+//     c97b3
+//     c97e6
+//     c981f
+//     c982e
+//     c9835
+//     c984c
+//     c9859
+//     c986b
+//     c9873
+//     c98b1
+//     c98ba
+//     c98cd
+//     c98ed
+//     c98f0
+//     c993b
+//     c994b
+//     c996e
+//     c9978
+//     c9993
+//     c99a3
+//     c99ea
+//     c99ed
+//     c9a2a
+//     c9a3f
+//     c9a73
+//     c9a77
+//     c9a8c
+//     c9ad4
+//     c9adf
+//     c9ae9
+//     c9b6e
+//     c9bc2
+//     c9bc5
+//     c9c16
+//     c9c33
+//     c9c51
+//     c9c58
+//     c9c6b
+//     c9c8b
+//     c9cee
+//     c9d12
+//     c9d2b
+//     c9d57
+//     c9d5d
+//     c9d67
+//     c9d71
+//     c9d72
+//     c9d86
+//     c9d89
+//     c9db4
+//     c9dcd
+//     c9dce
+//     c9dd5
+//     c9e13
+//     c9e16
+//     c9e28
+//     c9e2a
+//     c9e41
+//     c9e5c
+//     c9e6f
+//     c9e71
+//     c9eb3
+//     c9ec2
+//     c9ef1
+//     c9f0d
+//     c9f19
+//     c9f5e
+//     c9f64
+//     c9f6a
+//     c9f6b
+//     c9f88
+//     c9fd9
+//     c9ff4
+//     ca005
+//     ca01d
+//     ca021
+//     ca054
+//     ca06b
+//     ca06c
+//     ca075
+//     ca0a9
+//     ca0f5
+//     ca10b
+//     ca14f
+//     ca17a
+//     ca183
+//     ca19f
+//     ca1c0
+//     ca1c1
+//     ca1d2
+//     ca27a
+//     ca2ab
+//     ca2f2
+//     ca30d
+//     ca321
+//     ca34a
+//     ca378
+//     ca38b
+//     ca38c
+//     ca38e
+//     ca3ae
+//     ca3bd
+//     ca3dc
+//     ca3fb
+//     ca40c
+//     ca411
+//     ca414
+//     ca45d
+//     ca47b
+//     ca4fa
+//     ca538
+//     ca547
+//     ca574
+//     ca595
+//     ca5a0
+//     ca5ab
+//     ca5c4
+//     ca5e2
+//     ca5e5
+//     ca5fb
+//     ca605
+//     ca637
+//     ca63a
+//     ca647
+//     ca652
+//     ca65d
+//     ca660
+//     ca675
+//     ca68a
+//     ca6b3
+//     ca6b6
+//     ca6bb
+//     ca6ce
+//     ca6e2
+//     ca70a
+//     ca712
+//     ca721
+//     ca728
+//     ca73a
+//     ca787
+//     ca7a4
+//     ca7f2
+//     ca7f7
+//     ca818
+//     ca82f
+//     ca845
+//     ca856
+//     ca86b
+//     ca87a
+//     ca8bd
+//     ca8fa
+//     ca902
+//     ca90c
+//     ca95d
+//     ca96c
+//     ca970
+//     ca97d
+//     ca982
+//     ca98d
+//     ca9b8
+//     ca9ff
+//     caa0a
+//     caa0d
+//     caa1c
+//     caa42
+//     caa44
+//     caa51
+//     caa78
+//     caa7a
+//     caa86
+//     caab7
+//     caabe
+//     caace
+//     cab09
+//     cab17
+//     cab1a
+//     cab2e
+//     cab35
+//     cab3d
+//     cab41
+//     cab54
+//     cab7d
+//     cab93
+//     caba4
+//     cabbc
+//     cabcf
+//     cabfb
+//     cac0f
+//     cac28
+//     cac45
+//     cacc4
+//     cacc7
+//     caed3
+//     caed7
+//     cb1d5
+//     cb1dd
+//     cb1fc
+//     cb203
+//     cb20f
+//     cb221
+//     cb23d
+//     cb260
+//     cb268
+//     cb280
+//     cb297
+//     cb2a0
+//     cb2b2
+//     cb2e1
+//     cb2e7
+//     cb300
+//     cb305
+//     cb314
+//     cb337
+//     cb34f
+//     cb352
+//     cb371
+//     cb375
+//     cb37f
+//     cb382
+//     cb397
+//     cb3ba
+//     cb3de
+//     cb406
+//     cb40e
+//     cb446
+//     cb44b
+//     cb45a
+//     cb45e
+//     cb470
+//     cb4af
+//     cb4b4
+//     cb4d8
+//     cb4df
+//     cb4e9
+//     cb4ee
+//     cb502
+//     cb534
+//     cb597
+//     cb5d0
+//     cb5e6
+//     cb655
+//     cb65e
+//     cb684
+//     cb68c
+//     cb6a6
+//     cb6c2
+//     cb6ca
+//     cb6d2
+//     cb6eb
+//     cb6f5
+//     cb718
+//     cb725
+//     cb736
+//     cb795
+//     cb7ae
+//     cb7b2
+//     cb7e8
+//     cb7ec
+//     cb7ed
+//     cb82b
+//     cb898
+//     cb8e4
+//     cb8e6
+//     cb8f5
+//     cb8fb
+//     cb9ae
+//     cb9d2
+//     cb9d9
+//     cb9e8
+//     cb9ee
+//     cb9f7
+//     cba10
+//     cba15
+//     cba19
+//     cba27
+//     cba28
+//     cba2e
+//     cba2f
+//     cba78
+//     cba8c
+//     cba9e
+//     cbab0
+//     cbab1
+//     cbab4
+//     cbad0
+//     cbaf8
+//     cbafd
+//     cbb07
+//     cbb28
+//     cbb2a
+//     cbb33
+//     cbb36
+//     cbb4c
+//     cbb6f
+//     cbb89
+//     cbb90
+//     cbba1
+//     cbbbe
+//     cbbd0
+//     cbbd9
+//     cbbf3
+//     cbc13
+//     cbc2c
+//     cbc3a
+//     cbc54
+//     cbc64
+//     cbc78
+//     cbc93
+//     cbcb2
+//     cbcb9
+//     cbcd6
+//     cbce1
+//     cbcf9
+//     cbd0e
+//     cbd1b
+//     cbd40
+//     cbd46
+//     cbd7e
+//     cbda3
+//     cbdb9
+//     cbdba
+//     cbdc0
+//     cbdd3
+//     cbddd
+//     cbe21
+//     cbe3c
+//     cbe47
+//     cbe52
+//     cbe7a
+//     cbe7b
+//     cbe89
+//     cbe8d
+//     cbec1
+//     cbee0
+//     cbee8
+//     cbeee
+//     cbf33
+//     cbf46
+//     cbf8a
+//     cbf8e
+//     cbfa3
+//     cbfb2
+//     l0000
+//     l0001
+//     l0002
+//     l0003
+//     l0012
+//     l0013
+//     l0014
+//     l0015
+//     l0053
+//     l0054
+//     l0055
+//     l0056
+//     l00a0
+//     l00a1
+//     l00a2
+//     l00a3
+//     l00a4
+//     l00a5
+//     l00a6
+//     l00a7
+//     l00a8
+//     l00a9
+//     l00aa
+//     l00ab
+//     l00ac
+//     l00ad
+//     l00ae
+//     l00af
+//     l00b0
+//     l00b1
+//     l00b2
+//     l00b3
+//     l00b4
+//     l00b5
+//     l00b6
+//     l00b7
+//     l00b8
+//     l00b9
+//     l00ba
+//     l00bb
+//     l00bc
+//     l00bd
+//     l00be
+//     l00bf
+//     l00c0
+//     l00c1
+//     l00c2
+//     l00c3
+//     l00c4
+//     l00c5
+//     l00c6
+//     l00c7
+//     l00c8
+//     l00c9
+//     l00ca
+//     l00cc
+//     l00cd
+//     l00ce
+//     l00cf
+//     l00ef
+//     l00f0
+//     l00f1
+//     l00f3
+//     l00f7
+//     l00fd
+//     l00ff
+//     l0100
+//     l0101
+//     l0102
+//     l0103
+//     l0104
+//     l0105
+//     l0107
+//     l0109
+//     l010b
+//     l010c
+//     l010d
+//     l010e
+//     l0128
+//     l028d
+//     l0500
+//     l0600
+//     l0700
+//     l0cff
+//     l0d0f
+//     l0d12
+//     l0d1f
+//     l0d26
+//     l0d2a
+//     l0d30
+//     l0d3d
+//     l0d50
+//     l0df0
+//     l0e00
+//     l0e07
+//     l0e08
+//     l0e0e
+//     l0e0f
+//     l0e10
+//     l0ef8
+//     l0f00
+//     l0f04
+//     l0f05
+//     l0f06
+//     l0f07
+//     l0f08
+//     l0f09
+//     l0f0a
+//     l0f0b
+//     l0f0c
+//     l0f0d
+//     l0f0e
+//     l0f0f
+//     l0f10
+//     l1000
+//     l1001
+//     l1002
+//     l1003
+//     l1004
+//     l1005
+//     l1006
+//     l1007
+//     l100e
+//     l1045
+//     l1047
+//     l104d
+//     l104e
+//     l1050
+//     l1058
+//     l105f
+//     l1060
+//     l1061
+//     l1062
+//     l1063
+//     l1064
+//     l1065
+//     l1067
+//     l1069
+//     l1072
+//     l1074
+//     l1075
+//     l1076
+//     l1077
+//     l1078
+//     l1079
+//     l107a
+//     l107d
+//     l107e
+//     l107f
+//     l1081
+//     l1082
+//     l1083
+//     l1086
+//     l1087
+//     l1088
+//     l1089
+//     l108a
+//     l108b
+//     l108c
+//     l108f
+//     l1090
+//     l1091
+//     l1092
+//     l1093
+//     l1094
+//     l1095
+//     l1096
+//     l1097
+//     l1098
+//     l1099
+//     l109a
+//     l109b
+//     l109d
+//     l109e
+//     l109f
+//     l10c0
+//     l10c1
+//     l10c2
+//     l10c3
+//     l10c4
+//     l10c5
+//     l10c6
+//     l10c7
+//     l10c9
+//     l10ca
+//     l10cb
+//     l10cc
+//     l10cd
+//     l10ce
+//     l10cf
+//     l10d0
+//     l10d1
+//     l10d2
+//     l10d3
+//     l10d6
+//     l10d7
+//     l10d8
+//     l10d9
+//     l10da
+//     l10db
+//     l10dc
+//     l10dd
+//     l10de
+//     l10e2
+//     l10e3
+//     l10e4
+//     l1100
+//     l1109
+//     l110b
+//     l110c
+//     l110d
+//     l110e
+//     l110f
+//     l1110
+//     l1111
+//     l1112
+//     l1113
+//     l1114
+//     l1115
+//     l1116
+//     l1117
+//     l1119
+//     l111a
+//     l111b
+//     l111c
+//     l111d
+//     l2001
+//     l2002
+//     l2004
+//     l2006
+//     l2007
+//     l25d3
+//     l261c
+//     l261d
+//     l311d
+//     l3121
+//     l312d
+//     l3139
+//     l313f
+//     l3145
+//     l3146
+//     l3191
+//     l31a0
+//     l3aec
+//     l3b0f
+//     l3b18
+//     l3b21
+//     l3b29
+//     l3b31
+//     l3b3a
+//     l3b43
+//     l41d3
+//     l4cdb
+//     l4cf3
+//     l4ddb
+//     l4f73
+//     l4f75
+//     l4f76
+//     l4f77
+//     l4f78
+//     l5075
+//     l5175
+//     l5283
+//     l557f
+//     l56c6
+//     l56ce
+//     l5726
+//     l5774
+//     l5872
+//     l587e
+//     l5924
+//     l5979
+//     l597a
+//     l5980
+//     l5a30
+//     l5a31
+//     l5b3a
+//     l5b3e
+//     l5b42
+//     l5f4f
+//     l5fff
+//     l8001
+//     l8002
+//     l8004
+//     l911d
+//     l9121
+//     l9139
+//     l913f
+//     l9145
+//     l9146
+//     l9191
+//     l91a0
+//     l9aec
+//     l9b0f
+//     l9b18
+//     l9b21
+//     l9b29
+//     l9b31
+//     l9b3a
+//     l9b43
+//     la1d3
+//     lb075
+//     lb175
+//     lb283
+//     lb57f
+//     lb6c6
+//     lb6ce
+//     lb726
+//     lb774
+//     lb872
+//     lb87e
+//     lb924
+//     lb979
+//     lb97a
+//     lb980
+//     lbb3a
+//     lbb3e
+//     lbb42
+//     lbf4f
+//     lbfff
+//     lfe80
+//     lfe84
+//     lfe85
+//     lfe86
+//     lfe87
+//     loop_c0029
+//     loop_c003b
+//     loop_c0446
+//     loop_c0466
+//     loop_c0471
+//     loop_c04a6
+//     loop_c04e1
+//     loop_c0564
+//     loop_c0577
+//     loop_c0586
+//     loop_c05ab
+//     loop_c05c7
+//     loop_c05d3
+//     loop_c05e6
+//     loop_c0604
+//     loop_c061d
+//     loop_c062b
+//     loop_c064c
+//     loop_c0657
+//     loop_c065a
+//     loop_c8064
+//     loop_c8086
+//     loop_c813a
+//     loop_c8161
+//     loop_c816b
+//     loop_c818c
+//     loop_c820c
+//     loop_c820d
+//     loop_c821c
+//     loop_c826f
+//     loop_c82c7
+//     loop_c82d1
+//     loop_c830d
+//     loop_c8326
+//     loop_c8370
+//     loop_c8390
+//     loop_c8397
+//     loop_c83f0
+//     loop_c83fa
+//     loop_c8406
+//     loop_c8425
+//     loop_c8463
+//     loop_c8493
+//     loop_c84e7
+//     loop_c8527
+//     loop_c8552
+//     loop_c8564
+//     loop_c857b
+//     loop_c85b5
+//     loop_c8717
+//     loop_c8725
+//     loop_c87a0
+//     loop_c87be
+//     loop_c88bc
+//     loop_c895f
+//     loop_c8990
+//     loop_c89c4
+//     loop_c89ca
+//     loop_c8a17
+//     loop_c8ac8
+//     loop_c8ad8
+//     loop_c8af0
+//     loop_c8afb
+//     loop_c8b80
+//     loop_c8bea
+//     loop_c8c58
+//     loop_c8c71
+//     loop_c8d14
+//     loop_c8d17
+//     loop_c8dac
+//     loop_c8dba
+//     loop_c8de9
+//     loop_c8df0
+//     loop_c8e14
+//     loop_c8e85
+//     loop_c8f17
+//     loop_c8f6c
+//     loop_c8f96
+//     loop_c8fac
+//     loop_c9047
+//     loop_c9108
+//     loop_c9113
+//     loop_c91ba
+//     loop_c91e7
+//     loop_c92ef
+//     loop_c9355
+//     loop_c9357
+//     loop_c936f
+//     loop_c9382
+//     loop_c93bd
+//     loop_c93da
+//     loop_c953a
+//     loop_c957d
+//     loop_c9593
+//     loop_c95b6
+//     loop_c95d9
+//     loop_c95ec
+//     loop_c9618
+//     loop_c96c2
+//     loop_c96f2
+//     loop_c979d
+//     loop_c97c8
+//     loop_c9803
+//     loop_c9837
+//     loop_c9851
+//     loop_c985e
+//     loop_c9881
+//     loop_c98a0
+//     loop_c98c1
+//     loop_c98e4
+//     loop_c9942
+//     loop_c994e
+//     loop_c9964
+//     loop_c99a8
+//     loop_c9b50
+//     loop_c9b5e
+//     loop_c9b63
+//     loop_c9bcf
+//     loop_c9be4
+//     loop_c9c38
+//     loop_c9c5d
+//     loop_c9c90
+//     loop_c9ca8
+//     loop_c9d03
+//     loop_c9d43
+//     loop_c9e07
+//     loop_c9e74
+//     loop_c9e8c
+//     loop_c9f6e
+//     loop_ca061
+//     loop_ca11d
+//     loop_ca132
+//     loop_ca143
+//     loop_ca16e
+//     loop_ca1aa
+//     loop_ca1cc
+//     loop_ca487
+//     loop_ca521
+//     loop_ca76f
+//     loop_ca7a7
+//     loop_ca7c6
+//     loop_ca7e0
+//     loop_ca7e1
+//     loop_ca941
+//     loop_ca947
+//     loop_ca953
+//     loop_ca9ab
+//     loop_ca9e7
+//     loop_caa01
+//     loop_caab8
+//     loop_cab6b
+//     loop_cab80
+//     loop_cabad
+//     loop_cabf4
+//     loop_cac46
+//     loop_caf13
+//     loop_caf2d
+//     loop_cb1e3
+//     loop_cb1ed
+//     loop_cb249
+//     loop_cb275
+//     loop_cb2b4
+//     loop_cb2bd
+//     loop_cb2d1
+//     loop_cb44d
+//     loop_cb4a8
+//     loop_cb55e
+//     loop_cb578
+//     loop_cb5c6
+//     loop_cb5ed
+//     loop_cb6b3
+//     loop_cb75a
+//     loop_cb7be
+//     loop_cb7d7
+//     loop_cb7dd
+//     loop_cb910
+//     loop_cb999
+//     loop_cb9bd
+//     loop_cb9cc
+//     loop_cb9d1
+//     loop_cb9f9
+//     loop_cba1a
+//     loop_cba94
+//     loop_cbab8
+//     loop_cbaea
+//     loop_cbbe4
+//     loop_cbbfe
+//     loop_cbc70
+//     loop_cbcd3
+//     loop_cbd08
+//     loop_cbd2b
+//     loop_cbd6c
+//     loop_cbd99
+//     loop_cbe0e
+//     loop_cbe31
+//     loop_cbeab
+//     loop_cbf1c
+//     loop_cbf78
+//     sub_c0050
+//     sub_c0414
+//     sub_c0421
+//     sub_c04c7
+//     sub_c04ce
+//     sub_c0520
+//     sub_c052d
+//     sub_c0537
+//     sub_c0542
+//     sub_c055e
+//     sub_c0582
+//     sub_c0596
+//     sub_c05a9
+//     sub_c05d1
+//     sub_c05f2
+//     sub_c05ff
+//     sub_c0607
+//     sub_c0627
+//     sub_c2020
+//     sub_c2023
+//     sub_c202e
+//     sub_c2038
+//     sub_c2048
+//     sub_c2077
+//     sub_c209a
+//     sub_c209d
+//     sub_c20b8
+//     sub_c20bb
+//     sub_c20c3
+//     sub_c20c8
+//     sub_c20d3
+//     sub_c20db
+//     sub_c20e3
+//     sub_c20e6
+//     sub_c20ed
+//     sub_c20f3
+//     sub_c20f6
+//     sub_c2149
+//     sub_c2174
+//     sub_c21ae
+//     sub_c21b0
+//     sub_c21b7
+//     sub_c21be
+//     sub_c21bf
+//     sub_c21c0
+//     sub_c21c4
+//     sub_c21c5
+//     sub_c21ca
+//     sub_c221d
+//     sub_c2222
+//     sub_c2266
+//     sub_c226d
+//     sub_c2280
+//     sub_c2284
+//     sub_c22b2
+//     sub_c22bb
+//     sub_c22e8
+//     sub_c22fe
+//     sub_c230a
+//     sub_c2327
+//     sub_c2335
+//     sub_c233a
+//     sub_c236e
+//     sub_c2380
+//     sub_c2386
+//     sub_c23bf
+//     sub_c23d1
+//     sub_c23d4
+//     sub_c23dc
+//     sub_c23e3
+//     sub_c23ee
+//     sub_c240c
+//     sub_c241b
+//     sub_c242c
+//     sub_c2439
+//     sub_c2456
+//     sub_c2555
+//     sub_c25e3
+//     sub_c2602
+//     sub_c2745
+//     sub_c274c
+//     sub_c27da
+//     sub_c27db
+//     sub_c27e3
+//     sub_c2826
+//     sub_c2855
+//     sub_c2862
+//     sub_c2932
+//     sub_c2951
+//     sub_c2979
+//     sub_c29da
+//     sub_c2a77
+//     sub_c2ab3
+//     sub_c2b25
+//     sub_c2b4d
+//     sub_c2b64
+//     sub_c2b7b
+//     sub_c2b86
+//     sub_c2bf6
+//     sub_c2bf9
+//     sub_c2c56
+//     sub_c2c65
+//     sub_c2d1a
+//     sub_c2dc6
+//     sub_c2eec
+//     sub_c2efa
+//     sub_c2eff
+//     sub_c2f33
+//     sub_c2f37
+//     sub_c2f3f
+//     sub_c2f4f
+//     sub_c2f5e
+//     sub_c2f6b
+//     sub_c2f75
+//     sub_c2f7a
+//     sub_c2f82
+//     sub_c2f94
+//     sub_c303e
+//     sub_c3104
+//     sub_c3279
+//     sub_c328a
+//     sub_c329d
+//     sub_c33b4
+//     sub_c33c5
+//     sub_c33d3
+//     sub_c33d8
+//     sub_c33f1
+//     sub_c33f5
+//     sub_c33f9
+//     sub_c33fd
+//     sub_c3432
+//     sub_c3445
+//     sub_c3516
+//     sub_c3526
+//     sub_c352e
+//     sub_c3536
+//     sub_c365d
+//     sub_c37e8
+//     sub_c3832
+//     sub_c392c
+//     sub_c3940
+//     sub_c394c
+//     sub_c395a
+//     sub_c3965
+//     sub_c3988
+//     sub_c39ac
+//     sub_c39f3
+//     sub_c3a0f
+//     sub_c3a32
+//     sub_c3a4b
+//     sub_c3a50
+//     sub_c3a60
+//     sub_c3a63
+//     sub_c3a6e
+//     sub_c3a78
+//     sub_c3a82
+//     sub_c3a8d
+//     sub_c3aa3
+//     sub_c3ab8
+//     sub_c3ac8
+//     sub_c3ad3
+//     sub_c3ad8
+//     sub_c3ae5
+//     sub_c3b51
+//     sub_c3b61
+//     sub_c3b79
+//     sub_c3bca
+//     sub_c3bcd
+//     sub_c3be5
+//     sub_c3bf2
+//     sub_c3d19
+//     sub_c3d1e
+//     sub_c3d75
+//     sub_c3d8e
+//     sub_c3df4
+//     sub_c3e1e
+//     sub_c3e30
+//     sub_c3e54
+//     sub_c3e75
+//     sub_c3e94
+//     sub_c3ef4
+//     sub_c3f0f
+//     sub_c3f14
+//     sub_c3f16
+//     sub_c3f1e
+//     sub_c3f26
+//     sub_c3f7c
+//     sub_c3f82
+//     sub_c40b8
+//     sub_c40de
+//     sub_c40f6
+//     sub_c414a
+//     sub_c4168
+//     sub_c4190
+//     sub_c41b4
+//     sub_c41c6
+//     sub_c4315
+//     sub_c4324
+//     sub_c4379
+//     sub_c4384
+//     sub_c43e4
+//     sub_c43ec
+//     sub_c44e1
+//     sub_c451f
+//     sub_c4530
+//     sub_c45b2
+//     sub_c4663
+//     sub_c473d
+//     sub_c476c
+//     sub_c4779
+//     sub_c4788
+//     sub_c47c4
+//     sub_c47c5
+//     sub_c47ce
+//     sub_c48be
+//     sub_c48e2
+//     sub_c490d
+//     sub_c499c
+//     sub_c49bf
+//     sub_c49c2
+//     sub_c49ca
+//     sub_c4a12
+//     sub_c4a53
+//     sub_c4a9a
+//     sub_c4ac2
+//     sub_c4acf
+//     sub_c4add
+//     sub_c4aea
+//     sub_c4af1
+//     sub_c4ba9
+//     sub_c4c0c
+//     sub_c4c18
+//     sub_c4c47
+//     sub_c4c4e
+//     sub_c4c62
+//     sub_c4c6a
+//     sub_c4c72
+//     sub_c4d5d
+//     sub_c4ea9
+//     sub_c4f8d
+//     sub_c4f9a
+//     sub_c5040
+//     sub_c5047
+//     sub_c5234
+//     sub_c52c8
+//     sub_c5580
+//     sub_c558b
+//     sub_c5598
+//     sub_c55ce
+//     sub_c55ee
+//     sub_c55f2
+//     sub_c5607
+//     sub_c5616
+//     sub_c561e
+//     sub_c565f
+//     sub_c568f
+//     sub_c56b1
+//     sub_c56e6
+//     sub_c56fe
+//     sub_c5745
+//     sub_c5771
+//     sub_c57b6
+//     sub_c583f
+//     sub_c5841
+//     sub_c584e
+//     sub_c5850
+//     sub_c585d
+//     sub_c586f
+//     sub_c5882
+//     sub_c5986
+//     sub_c59f5
+//     sub_c5a67
+//     sub_c5ab9
+//     sub_c5ac2
+//     sub_c5ac4
+//     sub_c5ad2
+//     sub_c5b00
+//     sub_c5c68
+//     sub_c5e83
+//     sub_c5e91
+//     sub_c5e9d
+//     sub_c5ec2
+//     sub_c5f7c
+//     sub_c5f82
+//     sub_c5f84
+//     sub_c8020
+//     sub_c809a
+//     sub_c809d
+//     sub_c80b8
+//     sub_c80bb
+//     sub_c80c3
+//     sub_c80c8
+//     sub_c80d3
+//     sub_c80db
+//     sub_c80e3
+//     sub_c80e6
+//     sub_c80ed
+//     sub_c80f3
+//     sub_c80f6
+//     sub_c8149
+//     sub_c8174
+//     sub_c81ae
+//     sub_c81b0
+//     sub_c81b7
+//     sub_c81be
+//     sub_c81bf
+//     sub_c81c0
+//     sub_c81c4
+//     sub_c81c5
+//     sub_c81ca
+//     sub_c821d
+//     sub_c8222
+//     sub_c8238
+//     sub_c8254
+//     sub_c8266
+//     sub_c826d
+//     sub_c8280
+//     sub_c8284
+//     sub_c82b2
+//     sub_c82bb
+//     sub_c82e8
+//     sub_c82fe
+//     sub_c830a
+//     sub_c8327
+//     sub_c8335
+//     sub_c833a
+//     sub_c836e
+//     sub_c8380
+//     sub_c8386
+//     sub_c83bf
+//     sub_c83d1
+//     sub_c83d4
+//     sub_c83e3
+//     sub_c83ee
+//     sub_c840c
+//     sub_c841b
+//     sub_c842c
+//     sub_c8439
+//     sub_c8456
+//     sub_c8555
+//     sub_c85e3
+//     sub_c8602
+//     sub_c8745
+//     sub_c8750
+//     sub_c8782
+//     sub_c8794
+//     sub_c87da
+//     sub_c87db
+//     sub_c87e3
+//     sub_c87ee
+//     sub_c8826
+//     sub_c8855
+//     sub_c8862
+//     sub_c8932
+//     sub_c893f
+//     sub_c8943
+//     sub_c8951
+//     sub_c8979
+//     sub_c89b7
+//     sub_c89da
+//     sub_c89e6
+//     sub_c8a77
+//     sub_c8ab3
+//     sub_c8b25
+//     sub_c8b47
+//     sub_c8b4d
+//     sub_c8b64
+//     sub_c8b7b
+//     sub_c8b86
+//     sub_c8bac
+//     sub_c8bf6
+//     sub_c8bf9
+//     sub_c8c56
+//     sub_c8c65
+//     sub_c8d1a
+//     sub_c8dc6
+//     sub_c8eec
+//     sub_c8efa
+//     sub_c8eff
+//     sub_c8f33
+//     sub_c8f37
+//     sub_c8f3f
+//     sub_c8f4f
+//     sub_c8f5e
+//     sub_c8f6b
+//     sub_c8f75
+//     sub_c8f7a
+//     sub_c8f82
+//     sub_c8f94
+//     sub_c9279
+//     sub_c928a
+//     sub_c929d
+//     sub_c93b4
+//     sub_c93c5
+//     sub_c93d3
+//     sub_c93d8
+//     sub_c93f1
+//     sub_c93f5
+//     sub_c93f9
+//     sub_c93fd
+//     sub_c9432
+//     sub_c9445
+//     sub_c9516
+//     sub_c9526
+//     sub_c952e
+//     sub_c9536
+//     sub_c965d
+//     sub_c9785
+//     sub_c97b6
+//     sub_c97c9
+//     sub_c97e8
+//     sub_c9832
+//     sub_c992c
+//     sub_c9940
+//     sub_c995a
+//     sub_c9965
+//     sub_c9988
+//     sub_c99ac
+//     sub_c99f3
+//     sub_c9a0f
+//     sub_c9a32
+//     sub_c9a4b
+//     sub_c9a50
+//     sub_c9a60
+//     sub_c9a63
+//     sub_c9a6e
+//     sub_c9a78
+//     sub_c9a82
+//     sub_c9a8d
+//     sub_c9aa3
+//     sub_c9ab8
+//     sub_c9ac8
+//     sub_c9ad3
+//     sub_c9ad8
+//     sub_c9b51
+//     sub_c9b59
+//     sub_c9b61
+//     sub_c9b79
+//     sub_c9bca
+//     sub_c9bcd
+//     sub_c9be5
+//     sub_c9bf2
+//     sub_c9c0c
+//     sub_c9d19
+//     sub_c9d1e
+//     sub_c9d75
+//     sub_c9d9b
+//     sub_c9df4
+//     sub_c9e1e
+//     sub_c9e30
+//     sub_c9e54
+//     sub_c9e75
+//     sub_c9e94
+//     sub_c9ef4
+//     sub_c9f0f
+//     sub_c9f14
+//     sub_c9f16
+//     sub_c9f1e
+//     sub_c9f26
+//     sub_c9f7c
+//     sub_c9f82
+//     sub_ca0b8
+//     sub_ca0de
+//     sub_ca0f6
+//     sub_ca106
+//     sub_ca137
+//     sub_ca14a
+//     sub_ca168
+//     sub_ca190
+//     sub_ca1b4
+//     sub_ca1c6
+//     sub_ca244
+//     sub_ca315
+//     sub_ca324
+//     sub_ca379
+//     sub_ca384
+//     sub_ca3e4
+//     sub_ca3ec
+//     sub_ca417
+//     sub_ca463
+//     sub_ca4e1
+//     sub_ca51f
+//     sub_ca530
+//     sub_ca5b2
+//     sub_ca5bb
+//     sub_ca5bf
+//     sub_ca663
+//     sub_ca73d
+//     sub_ca76c
+//     sub_ca779
+//     sub_ca788
+//     sub_ca7c4
+//     sub_ca7c5
+//     sub_ca7ce
+//     sub_ca7f3
+//     sub_ca7f6
+//     sub_ca8be
+//     sub_ca8e2
+//     sub_ca90d
+//     sub_ca9bf
+//     sub_ca9c2
+//     sub_ca9ca
+//     sub_ca9d0
+//     sub_caa12
+//     sub_caa53
+//     sub_caa9a
+//     sub_caac2
+//     sub_caacf
+//     sub_caadd
+//     sub_caaea
+//     sub_caaf1
+//     sub_caafd
+//     sub_cab04
+//     sub_cab46
+//     sub_caba9
+//     sub_cabc5
+//     sub_cac0c
+//     sub_cac18
+//     sub_cac47
+//     sub_cac4e
+//     sub_cac62
+//     sub_cac6a
+//     sub_cac72
+//     sub_cb234
+//     sub_cb2c8
+//     sub_cb580
+//     sub_cb58b
+//     sub_cb598
+//     sub_cb5ce
+//     sub_cb5ee
+//     sub_cb5f2
+//     sub_cb607
+//     sub_cb616
+//     sub_cb61e
+//     sub_cb65f
+//     sub_cb68f
+//     sub_cb6b1
+//     sub_cb6c5
+//     sub_cb6cd
+//     sub_cb6e6
+//     sub_cb6fe
+//     sub_cb745
+//     sub_cb771
+//     sub_cb7b6
+//     sub_cb83f
+//     sub_cb841
+//     sub_cb84e
+//     sub_cb850
+//     sub_cb85d
+//     sub_cb86f
+//     sub_cb882
+//     sub_cb986
+//     sub_cb9f5
+//     sub_cba67
+//     sub_cbab9
+//     sub_cbac2
+//     sub_cbac4
+//     sub_cbad2
+//     sub_cbb00
+//     sub_cbb46
+//     sub_cbb4a
+//     sub_cbbd3
+//     sub_cbbd7
+//     sub_cbc37
+//     sub_cbc68
+//     sub_cbc81
+//     sub_cbe83
+//     sub_cbe91
+//     sub_cbe9d
+//     sub_cbec2
+//     sub_cbf7c
+//     sub_cbf82
+//     sub_cbf84

--- a/examples/known_good/example8080_8080.asm
+++ b/examples/known_good/example8080_8080.asm
@@ -1,0 +1,27 @@
+; Memory locations
+
+    ORG $1000
+
+pydis_start:
+    mov a, b                                                          ; 1000: 78          x
+    ora c                                                             ; 1001: b1          .
+    rz                                                                ; 1002: c8          .
+; $1003 referenced 1 time by $100a
+loop_c1003:
+    ldax d                                                            ; 1003: 1a          .
+    mov m, a                                                          ; 1004: 77          w
+    inx d                                                             ; 1005: 13          .
+    inx h                                                             ; 1006: 23          #
+    dcx b                                                             ; 1007: 0b          .
+    mov a, b                                                          ; 1008: 78          x
+    ora c                                                             ; 1009: b1          .
+    jnz loop_c1003                                                    ; 100a: c2 03 10    ...
+    ret                                                               ; 100d: c9          .
+
+pydis_end:
+
+; Label references by decreasing frequency:
+;     loop_c1003:   1
+
+; Automatically generated labels:
+;     loop_c1003

--- a/examples/known_good/helloworld_acme.asm
+++ b/examples/known_good/helloworld_acme.asm
@@ -1,0 +1,31 @@
+; Memory locations
+lffe3   = $ffe3
+
+    * = $2000
+
+pydis_start
+    ldx #0                                                            ; 2000: a2 00       ..
+; $2002 referenced 1 time by $200b
+loop_c2002
+    lda l200e,x                                                       ; 2002: bd 0e 20    ..
+    jsr lffe3                                                         ; 2005: 20 e3 ff     ..
+    inx                                                               ; 2008: e8          .
+    cpx #$0e                                                          ; 2009: e0 0e       ..
+    bne loop_c2002                                                    ; 200b: d0 f5       ..
+    rts                                                               ; 200d: 60          `
+
+; $200e referenced 1 time by $2002
+l200e
+    !text "Hello, world!"                                             ; 200e: 48 65 6c... Hel
+    !byte $0d                                                         ; 201b: 0d          .
+pydis_end
+
+; Label references by decreasing frequency:
+;     loop_c2002:   1
+;     l200e:        1
+;     lffe3:        1
+
+; Automatically generated labels:
+;     l200e
+;     lffe3
+;     loop_c2002

--- a/examples/known_good/helloworld_beebasm.asm
+++ b/examples/known_good/helloworld_beebasm.asm
@@ -1,0 +1,33 @@
+; Memory locations
+lffe3   = &ffe3
+
+    org &2000
+
+.pydis_start
+    ldx #0                                                            ; 2000: a2 00       ..
+; &2002 referenced 1 time by &200b
+.loop_c2002
+    lda l200e,x                                                       ; 2002: bd 0e 20    ..
+    jsr lffe3                                                         ; 2005: 20 e3 ff     ..
+    inx                                                               ; 2008: e8          .
+    cpx #&0e                                                          ; 2009: e0 0e       ..
+    bne loop_c2002                                                    ; 200b: d0 f5       ..
+    rts                                                               ; 200d: 60          `
+
+; &200e referenced 1 time by &2002
+.l200e
+    equs "Hello, world!"                                              ; 200e: 48 65 6c... Hel
+    equb &0d                                                          ; 201b: 0d          .
+.pydis_end
+
+; Label references by decreasing frequency:
+;     loop_c2002:   1
+;     l200e:        1
+;     lffe3:        1
+
+; Automatically generated labels:
+;     l200e
+;     lffe3
+;     loop_c2002
+
+save pydis_start, pydis_end

--- a/examples/known_good/helloworld_xa.asm
+++ b/examples/known_good/helloworld_xa.asm
@@ -1,0 +1,31 @@
+// Memory locations
+lffe3   = $ffe3
+
+    * = $2000
+
+pydis_start
+    ldx #0                                                            // 2000: a2 00       ..
+// $2002 referenced 1 time by $200b
+loop_c2002
+    lda l200e,x                                                       // 2002: bd 0e 20    ..
+    jsr lffe3                                                         // 2005: 20 e3 ff     ..
+    inx                                                               // 2008: e8          .
+    cpx #$0e                                                          // 2009: e0 0e       ..
+    bne loop_c2002                                                    // 200b: d0 f5       ..
+    rts                                                               // 200d: 60          `
+
+// $200e referenced 1 time by $2002
+l200e
+    .asc "Hello, world!"                                              // 200e: 48 65 6c... Hel
+    .byt $0d                                                          // 201b: 0d          .
+pydis_end
+
+// Label references by decreasing frequency:
+//     loop_c2002:   1
+//     l200e:        1
+//     lffe3:        1
+
+// Automatically generated labels:
+//     l200e
+//     lffe3
+//     loop_c2002

--- a/examples/known_good/move2_acme.asm
+++ b/examples/known_good/move2_acme.asm
@@ -1,0 +1,88 @@
+; Memory locations
+lffee   = $ffee
+
+    * = $2000
+
+pydis_start
+    lda #$41 ; 'A'                                                    ; 2000: a9 41       .A
+    jsr lffee                                                         ; 2002: 20 ee ff     ..
+    jsr sub_c2022                                                     ; 2005: 20 22 20     "
+    jsr low_a                                                         ; 2008: 20 00 09     ..
+    lda #$42 ; 'B'                                                    ; 200b: a9 42       .B
+    jmp lffee                                                         ; 200d: 4c ee ff    L..
+
+; $2010 referenced 3 times by $2008, $2022, $2025
+; $2010 referenced 3 times by $2008, $2022, $2025
+
+!pseudopc $0900 {
+; $2010 referenced 3 times by $2008, $2022, $2025
+low_a
+    ldx #$46 ; 'F'                                                    ; 2010: a2 46       .F  :0900[1]
+    jmp l0909                                                         ; 2012: 4c 09 09    L.. :0902[1]
+
+l0905
+    txa                                                               ; 2015: 8a          .   :0905[1]
+    jsr lffee                                                         ; 2016: 20 ee ff     .. :0906[1]
+l0909
+    dex                                                               ; 2019: ca          .   :0909[1]
+    bne l0905                                                         ; 201a: d0 f9       ..  :090a[1]
+l090c
+l090d = l090c+1
+    jsr sub_c2039                                                     ; 201c: 20 39 20     9  :090c[1]
+    jmp l090d                                                         ; 201f: 4c 0d 09    L.. :090f[1]
+
+; $2022 referenced 1 time by $2005
+}
+
+; $2022 referenced 1 time by $2005
+sub_c2022
+; $2022 referenced 1 time by $2005
+    lda low_a,y                                                       ; 2022: b9 00 09    ...
+    sta low_a,y                                                       ; 2025: 99 00 09    ...
+    rts                                                               ; 2028: 60          `
+
+
+!pseudopc $0901 {
+low_b
+    ldx #6                                                            ; 2029: a2 06       ..  :0901[2]
+l0903
+    lda l090a,x                                                       ; 202b: bd 0a 09    ... :0903[2]
+    dex                                                               ; 202e: ca          .   :0906[2]
+    bne l0903                                                         ; 202f: d0 fa       ..  :0907[2]
+    rts                                                               ; 2031: 60          `   :0909[2]
+
+l090a
+    !text "foo"                                                       ; 2032: 66 6f 6f    foo :090a[2]
+
+low_b_baz
+    ldx #2                                                            ; 2035: a2 02       ..  :090d[2]
+    bne l0903                                                         ; 2037: d0 f2       ..  :090f[2]
+; $2039 referenced 1 time by $090c
+}
+
+; $2039 referenced 1 time by $090c
+sub_c2039
+; $2039 referenced 1 time by $090c
+    lda low_b,x                                                       ; 2039: bd 01 09    ...
+    sta low_b,x                                                       ; 203c: 9d 01 09    ...
+    rts                                                               ; 203f: 60          `
+
+pydis_end
+
+; Label references by decreasing frequency:
+;     c2010:       3
+;     lffee:       3
+;     sub_c2022:   1
+;     sub_c2039:   1
+
+; Automatically generated labels:
+;     c2010
+;     l0903
+;     l0905
+;     l0909
+;     l090a
+;     l090c
+;     l090d
+;     lffee
+;     sub_c2022
+;     sub_c2039

--- a/examples/known_good/move2_beebasm.asm
+++ b/examples/known_good/move2_beebasm.asm
@@ -1,0 +1,101 @@
+; Memory locations
+l0911       = &0911
+l0912       = &0912
+c2010       = &2010
+sub_c2029   = &2029
+lffee       = &ffee
+
+    org &2000
+
+.pydis_start
+    lda #&41 ; 'A'                                                    ; 2000: a9 41       .A
+    jsr lffee                                                         ; 2002: 20 ee ff     ..
+    jsr sub_c2022                                                     ; 2005: 20 22 20     "
+    jsr low_a                                                         ; 2008: 20 00 09     ..
+    lda #&42 ; 'B'                                                    ; 200b: a9 42       .B
+    jmp lffee                                                         ; 200d: 4c ee ff    L..
+
+; &2010 referenced 3 times by &2008, &2022, &2025
+; &2010 referenced 3 times by &2008, &2022, &2025
+
+    org &0900
+; &2010 referenced 3 times by &2008, &2022, &2025
+.low_a
+    ldx #&46 ; 'F'                                                    ; 2010: a2 46       .F  :0900[1]
+    jmp l0909                                                         ; 2012: 4c 09 09    L.. :0902[1]
+
+.l0905
+    txa                                                               ; 2015: 8a          .   :0905[1]
+    jsr lffee                                                         ; 2016: 20 ee ff     .. :0906[1]
+.l0909
+    dex                                                               ; 2019: ca          .   :0909[1]
+    bne l0905                                                         ; 201a: d0 f9       ..  :090a[1]
+.l090c
+l090d = l090c+1
+    jsr sub_c2039                                                     ; 201c: 20 39 20     9  :090c[1]
+    jmp l090d                                                         ; 201f: 4c 0d 09    L.. :090f[1]
+
+; &2022 referenced 1 time by &2005
+    org c2010 + (l0912 - low_a)
+    copyblock low_a, l0912, c2010
+    clear low_a, l0912
+
+; &2022 referenced 1 time by &2005
+.sub_c2022
+; &2022 referenced 1 time by &2005
+    lda low_a,y                                                       ; 2022: b9 00 09    ...
+    sta low_a,y                                                       ; 2025: 99 00 09    ...
+    rts                                                               ; 2028: 60          `
+
+
+    org &0901
+.low_b
+    ldx #6                                                            ; 2029: a2 06       ..  :0901[2]
+.l0903
+    lda l090a,x                                                       ; 202b: bd 0a 09    ... :0903[2]
+    dex                                                               ; 202e: ca          .   :0906[2]
+    bne l0903                                                         ; 202f: d0 fa       ..  :0907[2]
+    rts                                                               ; 2031: 60          `   :0909[2]
+
+.l090a
+    equs "foo"                                                        ; 2032: 66 6f 6f    foo :090a[2]
+
+.low_b_baz
+    ldx #2                                                            ; 2035: a2 02       ..  :090d[2]
+    bne l0903                                                         ; 2037: d0 f2       ..  :090f[2]
+; &2039 referenced 1 time by &090c
+    org sub_c2029 + (l0911 - low_b)
+    copyblock low_b, l0911, sub_c2029
+    clear low_b, l0911
+
+; &2039 referenced 1 time by &090c
+.sub_c2039
+; &2039 referenced 1 time by &090c
+    lda low_b,x                                                       ; 2039: bd 01 09    ...
+    sta low_b,x                                                       ; 203c: 9d 01 09    ...
+    rts                                                               ; 203f: 60          `
+
+.pydis_end
+
+; Label references by decreasing frequency:
+;     c2010:       3
+;     lffee:       3
+;     sub_c2022:   1
+;     sub_c2039:   1
+
+; Automatically generated labels:
+;     c2010
+;     l0903
+;     l0905
+;     l0909
+;     l090a
+;     l090c
+;     l090d
+;     l0911
+;     l0912
+;     lffee
+;     sub_c2022
+;     sub_c2029
+;     sub_c2039
+
+save pydis_start, pydis_end

--- a/examples/known_good/move2_xa.asm
+++ b/examples/known_good/move2_xa.asm
@@ -1,0 +1,84 @@
+// Memory locations
+lffee   = $ffee
+
+    * = $2000
+
+pydis_start
+    lda #$41 // 'A'                                                   // 2000: a9 41       .A
+    jsr lffee                                                         // 2002: 20 ee ff     ..
+    jsr sub_c2022                                                     // 2005: 20 22 20     "
+    jsr low_a                                                         // 2008: 20 00 09     ..
+    lda #$42 // 'B'                                                   // 200b: a9 42       .B
+    jmp lffee                                                         // 200d: 4c ee ff    L..
+
+// $2010 referenced 3 times by $2008, $2022, $2025
+// $2010 referenced 3 times by $2008, $2022, $2025
+* = $0900
+// $2010 referenced 3 times by $2008, $2022, $2025
+low_a
+    ldx #$46 // 'F'                                                   // 2010: a2 46       .F  :0900[1]
+    jmp l0909                                                         // 2012: 4c 09 09    L.. :0902[1]
+
+l0905
+    txa                                                               // 2015: 8a          .   :0905[1]
+    jsr lffee                                                         // 2016: 20 ee ff     .. :0906[1]
+l0909
+    dex                                                               // 2019: ca          .   :0909[1]
+    bne l0905                                                         // 201a: d0 f9       ..  :090a[1]
+l090c
+l090d = l090c+1
+    jsr sub_c2039                                                     // 201c: 20 39 20     9  :090c[1]
+    jmp l090d                                                         // 201f: 4c 0d 09    L.. :090f[1]
+
+// $2022 referenced 1 time by $2005
+* = $2022
+// $2022 referenced 1 time by $2005
+sub_c2022
+// $2022 referenced 1 time by $2005
+    lda low_a,y                                                       // 2022: b9 00 09    ...
+    sta low_a,y                                                       // 2025: 99 00 09    ...
+    rts                                                               // 2028: 60          `
+
+* = $0901
+low_b
+    ldx #6                                                            // 2029: a2 06       ..  :0901[2]
+l0903
+    lda l090a,x                                                       // 202b: bd 0a 09    ... :0903[2]
+    dex                                                               // 202e: ca          .   :0906[2]
+    bne l0903                                                         // 202f: d0 fa       ..  :0907[2]
+    rts                                                               // 2031: 60          `   :0909[2]
+
+l090a
+    .asc "foo"                                                        // 2032: 66 6f 6f    foo :090a[2]
+
+low_b_baz
+    ldx #2                                                            // 2035: a2 02       ..  :090d[2]
+    bne l0903                                                         // 2037: d0 f2       ..  :090f[2]
+// $2039 referenced 1 time by $090c
+* = $2039
+// $2039 referenced 1 time by $090c
+sub_c2039
+// $2039 referenced 1 time by $090c
+    lda low_b,x                                                       // 2039: bd 01 09    ...
+    sta low_b,x                                                       // 203c: 9d 01 09    ...
+    rts                                                               // 203f: 60          `
+
+pydis_end
+
+// Label references by decreasing frequency:
+//     c2010:       3
+//     lffee:       3
+//     sub_c2022:   1
+//     sub_c2039:   1
+
+// Automatically generated labels:
+//     c2010
+//     l0903
+//     l0905
+//     l0909
+//     l090a
+//     l090c
+//     l090d
+//     lffee
+//     sub_c2022
+//     sub_c2039

--- a/examples/known_good/move_acme.asm
+++ b/examples/known_good/move_acme.asm
@@ -1,0 +1,65 @@
+; Memory locations
+l0070   = $70
+lffe3   = $ffe3
+
+    * = $2000
+
+pydis_start
+    ldx #0                                                            ; 2000: a2 00       ..
+; $2002 referenced 1 time by $200b
+loop_c2002
+    lda c201e,x                                                       ; 2002: bd 1e 20    ..
+    sta print_and_inc_zp,x                                            ; 2005: 9d 00 09    ...
+    inx                                                               ; 2008: e8          .
+    cpx #$0f                                                          ; 2009: e0 0f       ..
+    bne loop_c2002                                                    ; 200b: d0 f5       ..
+    lda #$61 ; 'a'                                                    ; 200d: a9 61       .a
+    ldx #$0a                                                          ; 200f: a2 0a       ..
+    sta l0070                                                         ; 2011: 85 70       .p
+; $2013 referenced 1 time by $2017
+loop_c2013
+    jsr print_and_inc_zp                                              ; 2013: 20 00 09     ..
+    dex                                                               ; 2016: ca          .
+    bne loop_c2013                                                    ; 2017: d0 fa       ..
+    lda #$0d                                                          ; 2019: a9 0d       ..
+    jmp lffe3                                                         ; 201b: 4c e3 ff    L..
+
+; $201e referenced 3 times by $2002, $2005, $2013
+c201e
+; $201e referenced 3 times by $2002, $2005, $2013
+
+!pseudopc $0900 {
+; $201e referenced 3 times by $2002, $2005, $2013
+print_and_inc_zp
+    lda l0070                                                         ; 201e: a5 70       .p  :0900[1]
+    jsr sub_c0908                                                     ; 2020: 20 08 09     .. :0902[1]
+    sta l0070                                                         ; 2023: 85 70       .p  :0905[1]
+    rts                                                               ; 2025: 60          `   :0907[1]
+
+; $2026 referenced 1 time by $0902
+sub_c0908
+    jsr lffe3                                                         ; 2026: 20 e3 ff     .. :0908[1]
+    clc                                                               ; 2029: 18          .   :090b[1]
+    adc #1                                                            ; 202a: 69 01       i.  :090c[1]
+    rts                                                               ; 202c: 60          `   :090e[1]
+
+}
+
+pydis_end
+
+; Label references by decreasing frequency:
+;     l0070:        3
+;     c201e:        3
+;     lffe3:        2
+;     loop_c2002:   1
+;     loop_c2013:   1
+;     sub_c2026:    1
+
+; Automatically generated labels:
+;     c201e
+;     l0070
+;     lffe3
+;     loop_c2002
+;     loop_c2013
+;     sub_c0908
+;     sub_c2026

--- a/examples/known_good/move_beebasm.asm
+++ b/examples/known_good/move_beebasm.asm
@@ -1,0 +1,71 @@
+; Memory locations
+l0070   = &0070
+l090f   = &090f
+lffe3   = &ffe3
+
+    org &2000
+
+.pydis_start
+    ldx #0                                                            ; 2000: a2 00       ..
+; &2002 referenced 1 time by &200b
+.loop_c2002
+    lda c201e,x                                                       ; 2002: bd 1e 20    ..
+    sta print_and_inc_zp,x                                            ; 2005: 9d 00 09    ...
+    inx                                                               ; 2008: e8          .
+    cpx #&0f                                                          ; 2009: e0 0f       ..
+    bne loop_c2002                                                    ; 200b: d0 f5       ..
+    lda #&61 ; 'a'                                                    ; 200d: a9 61       .a
+    ldx #&0a                                                          ; 200f: a2 0a       ..
+    sta l0070                                                         ; 2011: 85 70       .p
+; &2013 referenced 1 time by &2017
+.loop_c2013
+    jsr print_and_inc_zp                                              ; 2013: 20 00 09     ..
+    dex                                                               ; 2016: ca          .
+    bne loop_c2013                                                    ; 2017: d0 fa       ..
+    lda #&0d                                                          ; 2019: a9 0d       ..
+    jmp lffe3                                                         ; 201b: 4c e3 ff    L..
+
+; &201e referenced 3 times by &2002, &2005, &2013
+.c201e
+; &201e referenced 3 times by &2002, &2005, &2013
+
+    org &0900
+; &201e referenced 3 times by &2002, &2005, &2013
+.print_and_inc_zp
+    lda l0070                                                         ; 201e: a5 70       .p  :0900[1]
+    jsr sub_c0908                                                     ; 2020: 20 08 09     .. :0902[1]
+    sta l0070                                                         ; 2023: 85 70       .p  :0905[1]
+    rts                                                               ; 2025: 60          `   :0907[1]
+
+; &2026 referenced 1 time by &0902
+.sub_c0908
+    jsr lffe3                                                         ; 2026: 20 e3 ff     .. :0908[1]
+    clc                                                               ; 2029: 18          .   :090b[1]
+    adc #1                                                            ; 202a: 69 01       i.  :090c[1]
+    rts                                                               ; 202c: 60          `   :090e[1]
+
+    org c201e + (l090f - print_and_inc_zp)
+    copyblock print_and_inc_zp, l090f, c201e
+    clear print_and_inc_zp, l090f
+
+.pydis_end
+
+; Label references by decreasing frequency:
+;     l0070:        3
+;     c201e:        3
+;     lffe3:        2
+;     loop_c2002:   1
+;     loop_c2013:   1
+;     sub_c2026:    1
+
+; Automatically generated labels:
+;     c201e
+;     l0070
+;     l090f
+;     lffe3
+;     loop_c2002
+;     loop_c2013
+;     sub_c0908
+;     sub_c2026
+
+save pydis_start, pydis_end

--- a/examples/known_good/move_xa.asm
+++ b/examples/known_good/move_xa.asm
@@ -1,0 +1,63 @@
+// Memory locations
+l0070   = $0070
+lffe3   = $ffe3
+
+    * = $2000
+
+pydis_start
+    ldx #0                                                            // 2000: a2 00       ..
+// $2002 referenced 1 time by $200b
+loop_c2002
+    lda c201e,x                                                       // 2002: bd 1e 20    ..
+    sta print_and_inc_zp,x                                            // 2005: 9d 00 09    ...
+    inx                                                               // 2008: e8          .
+    cpx #$0f                                                          // 2009: e0 0f       ..
+    bne loop_c2002                                                    // 200b: d0 f5       ..
+    lda #$61 // 'a'                                                   // 200d: a9 61       .a
+    ldx #$0a                                                          // 200f: a2 0a       ..
+    sta l0070                                                         // 2011: 85 70       .p
+// $2013 referenced 1 time by $2017
+loop_c2013
+    jsr print_and_inc_zp                                              // 2013: 20 00 09     ..
+    dex                                                               // 2016: ca          .
+    bne loop_c2013                                                    // 2017: d0 fa       ..
+    lda #$0d                                                          // 2019: a9 0d       ..
+    jmp lffe3                                                         // 201b: 4c e3 ff    L..
+
+// $201e referenced 3 times by $2002, $2005, $2013
+c201e
+// $201e referenced 3 times by $2002, $2005, $2013
+* = $0900
+// $201e referenced 3 times by $2002, $2005, $2013
+print_and_inc_zp
+    lda l0070                                                         // 201e: a5 70       .p  :0900[1]
+    jsr sub_c0908                                                     // 2020: 20 08 09     .. :0902[1]
+    sta l0070                                                         // 2023: 85 70       .p  :0905[1]
+    rts                                                               // 2025: 60          `   :0907[1]
+
+// $2026 referenced 1 time by $0902
+sub_c0908
+    jsr lffe3                                                         // 2026: 20 e3 ff     .. :0908[1]
+    clc                                                               // 2029: 18          .   :090b[1]
+    adc #1                                                            // 202a: 69 01       i.  :090c[1]
+    rts                                                               // 202c: 60          `   :090e[1]
+
+* = $202d
+pydis_end
+
+// Label references by decreasing frequency:
+//     l0070:        3
+//     c201e:        3
+//     lffe3:        2
+//     loop_c2002:   1
+//     loop_c2013:   1
+//     sub_c2026:    1
+
+// Automatically generated labels:
+//     c201e
+//     l0070
+//     lffe3
+//     loop_c2002
+//     loop_c2013
+//     sub_c0908
+//     sub_c2026

--- a/examples/known_good/split_acme.asm
+++ b/examples/known_good/split_acme.asm
@@ -1,0 +1,48 @@
+; Memory locations
+l0070   = $70
+osasci  = $ffe3
+
+    * = $0900
+
+; $0900 referenced 1 time by $2006
+print_and_inc_zp
+pydis_start
+    lda l0070                                                         ; 0900: a5 70       .p
+    jsr sub_c0908                                                     ; 0902: 20 08 09     ..
+    sta l0070                                                         ; 0905: 85 70       .p
+    rts                                                               ; 0907: 60          `
+
+; $0908 referenced 1 time by $0902
+sub_c0908
+    jsr osasci                                                        ; 0908: 20 e3 ff     ..
+    clc                                                               ; 090b: 18          .
+    adc #1                                                            ; 090c: 69 01       i.
+    rts                                                               ; 090e: 60          `
+
+
+    * = $2000
+
+    lda #$61 ; 'a'                                                    ; 2000: a9 61       .a
+    ldx #$0a                                                          ; 2002: a2 0a       ..
+    sta l0070                                                         ; 2004: 85 70       .p
+; $2006 referenced 1 time by $200a
+loop_c2006
+    jsr print_and_inc_zp                                              ; 2006: 20 00 09     ..
+    dex                                                               ; 2009: ca          .
+    bne loop_c2006                                                    ; 200a: d0 fa       ..
+    lda #$0d                                                          ; 200c: a9 0d       ..
+    jmp osasci                                                        ; 200e: 4c e3 ff    L..
+
+pydis_end
+
+; Label references by decreasing frequency:
+;     l0070:              3
+;     osasci:             2
+;     print_and_inc_zp:   1
+;     sub_c0908:          1
+;     loop_c2006:         1
+
+; Automatically generated labels:
+;     l0070
+;     loop_c2006
+;     sub_c0908

--- a/examples/known_good/split_beebasm.asm
+++ b/examples/known_good/split_beebasm.asm
@@ -1,0 +1,50 @@
+; Memory locations
+l0070   = &0070
+osasci  = &ffe3
+
+    org &0900
+
+; &0900 referenced 1 time by &2006
+.print_and_inc_zp
+.pydis_start
+    lda l0070                                                         ; 0900: a5 70       .p
+    jsr sub_c0908                                                     ; 0902: 20 08 09     ..
+    sta l0070                                                         ; 0905: 85 70       .p
+    rts                                                               ; 0907: 60          `
+
+; &0908 referenced 1 time by &0902
+.sub_c0908
+    jsr osasci                                                        ; 0908: 20 e3 ff     ..
+    clc                                                               ; 090b: 18          .
+    adc #1                                                            ; 090c: 69 01       i.
+    rts                                                               ; 090e: 60          `
+
+
+    org &2000
+
+    lda #&61 ; 'a'                                                    ; 2000: a9 61       .a
+    ldx #&0a                                                          ; 2002: a2 0a       ..
+    sta l0070                                                         ; 2004: 85 70       .p
+; &2006 referenced 1 time by &200a
+.loop_c2006
+    jsr print_and_inc_zp                                              ; 2006: 20 00 09     ..
+    dex                                                               ; 2009: ca          .
+    bne loop_c2006                                                    ; 200a: d0 fa       ..
+    lda #&0d                                                          ; 200c: a9 0d       ..
+    jmp osasci                                                        ; 200e: 4c e3 ff    L..
+
+.pydis_end
+
+; Label references by decreasing frequency:
+;     l0070:              3
+;     osasci:             2
+;     print_and_inc_zp:   1
+;     sub_c0908:          1
+;     loop_c2006:         1
+
+; Automatically generated labels:
+;     l0070
+;     loop_c2006
+;     sub_c0908
+
+save pydis_start, pydis_end

--- a/examples/known_good/split_xa.asm
+++ b/examples/known_good/split_xa.asm
@@ -1,0 +1,50 @@
+// Memory locations
+l0070   = $0070
+osasci  = $ffe3
+
+    * = $0900
+
+// $0900 referenced 1 time by $2006
+print_and_inc_zp
+pydis_start
+    lda l0070                                                         // 0900: a5 70       .p
+    jsr sub_c0908                                                     // 0902: 20 08 09     ..
+    sta l0070                                                         // 0905: 85 70       .p
+    rts                                                               // 0907: 60          `
+
+// $0908 referenced 1 time by $0902
+sub_c0908
+    jsr osasci                                                        // 0908: 20 e3 ff     ..
+    clc                                                               // 090b: 18          .
+    adc #1                                                            // 090c: 69 01       i.
+    rts                                                               // 090e: 60          `
+
+end_of_part_1
+    * = $2000
+.dsb (*-end_of_part_1), 0
+    * = $2000
+
+    lda #$61 // 'a'                                                   // 2000: a9 61       .a
+    ldx #$0a                                                          // 2002: a2 0a       ..
+    sta l0070                                                         // 2004: 85 70       .p
+// $2006 referenced 1 time by $200a
+loop_c2006
+    jsr print_and_inc_zp                                              // 2006: 20 00 09     ..
+    dex                                                               // 2009: ca          .
+    bne loop_c2006                                                    // 200a: d0 fa       ..
+    lda #$0d                                                          // 200c: a9 0d       ..
+    jmp osasci                                                        // 200e: 4c e3 ff    L..
+
+pydis_end
+
+// Label references by decreasing frequency:
+//     l0070:              3
+//     osasci:             2
+//     print_and_inc_zp:   1
+//     sub_c0908:          1
+//     loop_c2006:         1
+
+// Automatically generated labels:
+//     l0070
+//     loop_c2006
+//     sub_c0908

--- a/examples/known_good/test8080_8080.asm
+++ b/examples/known_good/test8080_8080.asm
@@ -1,0 +1,808 @@
+;
+; Microcosm Associates  8080/8085 CPU Diagnostic Version 1.0  (C) 1980
+;
+
+; Memory locations
+wboot   EQU $00
+bdos    EQU $05
+stack   EQU $07ad
+
+    ORG $0100
+
+pydis_start:
+    jmp cpu                                                           ; 0100: c3 ab 01    ...            ; jump to 8080 CPU diagnostic
+
+    db "MICROCOSM ASSOCIATES 8080/8085 CPU DIAGNOSTIC VERSION 1.0 "   ; 0103: 4d 49 43... MIC
+    db "(C) 1980"                                                     ; 013d: 28 43 29... (C)
+
+
+; 
+; message output routine
+; 
+msg:
+    push d                                                            ; 0145: d5          .
+    xchg                                                              ; 0146: eb          .
+    mvi c, 9                                                          ; 0147: 0e 09       ..
+    call bdos                                                         ; 0149: cd 05 00    ...
+    pop d                                                             ; 014c: d1          .
+    ret                                                               ; 014d: c9          .
+
+pchar:
+    mvi c, 2                                                          ; 014e: 0e 02       ..
+    call bdos                                                         ; 0150: cd 05 00    ...
+    ret                                                               ; 0153: c9          .
+
+byte0:
+    push psw                                                          ; 0154: f5          .
+    call byto1                                                        ; 0155: cd 64 01    .d.
+    mov e, a                                                          ; 0158: 5f          _
+    call pchar                                                        ; 0159: cd 4e 01    .N.
+    pop psw                                                           ; 015c: f1          .
+    call byto2                                                        ; 015d: cd 68 01    .h.
+    mov e, a                                                          ; 0160: 5f          _
+    jmp pchar                                                         ; 0161: c3 4e 01    .N.
+
+byto1:
+    rrc                                                               ; 0164: 0f          .
+    rrc                                                               ; 0165: 0f          .
+    rrc                                                               ; 0166: 0f          .
+    rrc                                                               ; 0167: 0f          .
+byto2:
+    ani $0f                                                           ; 0168: e6 0f       ..
+    cpi $0a                                                           ; 016a: fe 0a       ..
+    jm byto3                                                          ; 016c: fa 71 01    .q.
+    adi 7                                                             ; 016f: c6 07       ..
+byto3:
+    adi $30                                                           ; 0171: c6 30       .0
+    ret                                                               ; 0173: c9          .
+
+cpu_ok_message:
+    db %"----##--", %"----##-#", %"----#-#-"                          ; 0174: 0c 0d 0a    ...
+    db " CPU IS OPERATIONAL$"                                         ; 0177: 20 43 50...  CP
+
+cpu_error_message:
+    db $0c, $0d, $0a                                                  ; 018b: 0c 0d 0a    ...
+    db " CPU HAS FAILED! ERROR EXIT=$"                                ; 018e: 20 43 50...  CP
+
+cpu:
+    lxi sp, $07ad                                                     ; 01ab: 31 ad 07    1..
+    ani 0                                                             ; 01ae: e6 00       ..
+    jz j010                                                           ; 01b0: ca b6 01    ...            ; test "jz"
+    call cpuer                                                        ; 01b3: cd 89 06    ...
+j010:
+    jnc j020                                                          ; 01b6: d2 bc 01    ...            ; test "jnc"
+    call cpuer                                                        ; 01b9: cd 89 06    ...
+j020:
+    jpe j030                                                          ; 01bc: ea c2 01    ...            ; test "jpe"
+    call cpuer                                                        ; 01bf: cd 89 06    ...
+j030:
+    jp p, j040                                                        ; 01c2: f2 c8 01    ...            ; test "jp"
+    call cpuer                                                        ; 01c5: cd 89 06    ...
+j040:
+    jnz j050                                                          ; 01c8: c2 d7 01    ...            ; test "jnz"
+    jc j050                                                           ; 01cb: da d7 01    ...
+    jpo j050                                                          ; 01ce: e2 d7 01    ...
+    jm j050                                                           ; 01d1: fa d7 01    ...
+    jmp j060                                                          ; 01d4: c3 da 01    ...
+
+j050:
+    call cpuer                                                        ; 01d7: cd 89 06    ...
+j060:
+    adi 6                                                             ; 01da: c6 06       ..
+    jnz j070                                                          ; 01dc: c2 e2 01    ...
+    call cpuer                                                        ; 01df: cd 89 06    ...
+j070:
+    jc j080                                                           ; 01e2: da eb 01    ...
+    jpo j080                                                          ; 01e5: e2 eb 01    ...
+    jp p, j090                                                        ; 01e8: f2 ee 01    ...
+j080:
+    call cpuer                                                        ; 01eb: cd 89 06    ...
+j090:
+    adi $70                                                           ; 01ee: c6 70       .p
+    jpo j100                                                          ; 01f0: e2 f6 01    ...
+    call cpuer                                                        ; 01f3: cd 89 06    ...
+j100:
+    jm j110                                                           ; 01f6: fa ff 01    ...
+    jz j110                                                           ; 01f9: ca ff 01    ...
+    jnc j120                                                          ; 01fc: d2 02 02    ...
+j110:
+    call cpuer                                                        ; 01ff: cd 89 06    ...
+j120:
+    adi $81                                                           ; 0202: c6 81       ..
+    jm j130                                                           ; 0204: fa 0a 02    ...
+    call cpuer                                                        ; 0207: cd 89 06    ...
+j130:
+    jz j140                                                           ; 020a: ca 13 02    ...
+    jc j140                                                           ; 020d: da 13 02    ...
+    jpo j150                                                          ; 0210: e2 16 02    ...
+j140:
+    call cpuer                                                        ; 0213: cd 89 06    ...
+j150:
+    adi $fe                                                           ; 0216: c6 fe       ..
+    jc j160                                                           ; 0218: da 1e 02    ...
+    call cpuer                                                        ; 021b: cd 89 06    ...
+j160:
+    jz j170                                                           ; 021e: ca 27 02    .'.
+    jpo j170                                                          ; 0221: e2 27 02    .'.
+    jm aimm                                                           ; 0224: fa 2a 02    .*.
+j170:
+    call cpuer                                                        ; 0227: cd 89 06    ...
+
+; 
+; test accumulator immediate instructions
+; 
+aimm:
+    cpi 0                                                             ; 022a: fe 00       ..
+    jc cpie                                                           ; 022c: da 42 02    .B.
+    jz cpie                                                           ; 022f: ca 42 02    .B.
+    cpi $f5                                                           ; 0232: fe f5       ..
+    jc cpie                                                           ; 0234: da 42 02    .B.
+    jnz cpie                                                          ; 0237: c2 42 02    .B.
+    cpi $ff                                                           ; 023a: fe ff       ..
+    jz cpie                                                           ; 023c: ca 42 02    .B.
+    jc acii                                                           ; 023f: da 45 02    .E.
+cpie:
+    call cpuer                                                        ; 0242: cd 89 06    ...
+acii:
+    aci $0a                                                           ; 0245: ce 0a       ..
+    aci $0a                                                           ; 0247: ce 0a       ..
+    cpi $0b                                                           ; 0249: fe 0b       ..
+    jz suii                                                           ; 024b: ca 51 02    .Q.
+    call cpuer                                                        ; 024e: cd 89 06    ...
+suii:
+    sui $0c                                                           ; 0251: d6 0c       ..
+    sui $0f                                                           ; 0253: d6 0f       ..
+    cpi $f0                                                           ; 0255: fe f0       ..
+    jz sbii                                                           ; 0257: ca 5d 02    .].
+    call cpuer                                                        ; 025a: cd 89 06    ...
+sbii:
+    sbi $f1                                                           ; 025d: de f1       ..
+    sbi $0e                                                           ; 025f: de 0e       ..
+    cpi $f0                                                           ; 0261: fe f0       ..
+    jz anii                                                           ; 0263: ca 69 02    .i.
+    call cpuer                                                        ; 0266: cd 89 06    ...
+anii:
+    ani $55                                                           ; 0269: e6 55       .U
+    cpi $50                                                           ; 026b: fe 50       .P
+    jz orii                                                           ; 026d: ca 73 02    .s.
+    call cpuer                                                        ; 0270: cd 89 06    ...
+orii:
+    ori $3a                                                           ; 0273: f6 3a       .:
+    cpi $7a                                                           ; 0275: fe 7a       .z
+    jz xrii                                                           ; 0277: ca 7d 02    .}.
+    call cpuer                                                        ; 027a: cd 89 06    ...
+xrii:
+    xri $0f                                                           ; 027d: ee 0f       ..
+    cpi $75                                                           ; 027f: fe 75       .u
+    jz c010                                                           ; 0281: ca 87 02    ...
+    call cpuer                                                        ; 0284: cd 89 06    ...
+
+; 
+; test calls and returns
+; 
+c010:
+    ani 0                                                             ; 0287: e6 00       ..
+    cc cpuer                                                          ; 0289: dc 89 06    ...
+    cpo cpuer                                                         ; 028c: e4 89 06    ...
+    cm cpuer                                                          ; 028f: fc 89 06    ...
+    cnz cpuer                                                         ; 0292: c4 89 06    ...
+    cpi 0                                                             ; 0295: fe 00       ..
+    jz c020                                                           ; 0297: ca 9d 02    ...
+    call cpuer                                                        ; 029a: cd 89 06    ...
+c020:
+    sui $77                                                           ; 029d: d6 77       .w
+    cnc cpuer                                                         ; 029f: d4 89 06    ...
+    cpe cpuer                                                         ; 02a2: ec 89 06    ...
+    call p, cpuer                                                     ; 02a5: f4 89 06    ...
+    cz cpuer                                                          ; 02a8: cc 89 06    ...
+    cpi $89                                                           ; 02ab: fe 89       ..
+    jz c030                                                           ; 02ad: ca b3 02    ...
+    call cpuer                                                        ; 02b0: cd 89 06    ...
+c030:
+    ani $ff                                                           ; 02b3: e6 ff       ..
+    cpo cpoi                                                          ; 02b5: e4 c0 02    ...
+    cpi $d9                                                           ; 02b8: fe d9       ..
+    jz movi                                                           ; 02ba: ca 1d 03    ...
+    call cpuer                                                        ; 02bd: cd 89 06    ...
+cpoi:
+    rpe                                                               ; 02c0: e8          .
+    adi $10                                                           ; 02c1: c6 10       ..
+    cpe cpei                                                          ; 02c3: ec cc 02    ...
+    adi 2                                                             ; 02c6: c6 02       ..
+    rpo                                                               ; 02c8: e0          .
+    call cpuer                                                        ; 02c9: cd 89 06    ...
+cpei:
+    rpo                                                               ; 02cc: e0          .
+    adi $20                                                           ; 02cd: c6 20       .
+    cm cmi                                                            ; 02cf: fc d8 02    ...
+    adi 4                                                             ; 02d2: c6 04       ..
+    rpe                                                               ; 02d4: e8          .
+    call cpuer                                                        ; 02d5: cd 89 06    ...
+cmi:
+    rp                                                                ; 02d8: f0          .
+    adi $80                                                           ; 02d9: c6 80       ..
+    call p, tcpi                                                      ; 02db: f4 e4 02    ...
+    adi $80                                                           ; 02de: c6 80       ..
+    rm                                                                ; 02e0: f8          .
+    call cpuer                                                        ; 02e1: cd 89 06    ...
+tcpi:
+    rm                                                                ; 02e4: f8          .
+    adi $40                                                           ; 02e5: c6 40       .@
+    cnc cnci                                                          ; 02e7: d4 f0 02    ...
+    adi $40                                                           ; 02ea: c6 40       .@
+    rp                                                                ; 02ec: f0          .
+    call cpuer                                                        ; 02ed: cd 89 06    ...
+cnci:
+    rc                                                                ; 02f0: d8          .
+    adi $8f                                                           ; 02f1: c6 8f       ..
+    cc cci                                                            ; 02f3: dc fc 02    ...
+    sui 2                                                             ; 02f6: d6 02       ..
+    rnc                                                               ; 02f8: d0          .
+    call cpuer                                                        ; 02f9: cd 89 06    ...
+cci:
+    rnc                                                               ; 02fc: d0          .
+    adi $f7                                                           ; 02fd: c6 f7       ..
+    cnz cnzi                                                          ; 02ff: c4 08 03    ...
+    adi $fe                                                           ; 0302: c6 fe       ..
+    rc                                                                ; 0304: d8          .
+    call cpuer                                                        ; 0305: cd 89 06    ...
+cnzi:
+    rz                                                                ; 0308: c8          .
+    adi 1                                                             ; 0309: c6 01       ..
+    cz czi                                                            ; 030b: cc 14 03    ...
+    adi $d0                                                           ; 030e: c6 d0       ..
+    rnz                                                               ; 0310: c0          .
+    call cpuer                                                        ; 0311: cd 89 06    ...
+czi:
+    rnz                                                               ; 0314: c0          .
+    adi $47                                                           ; 0315: c6 47       .G
+    cpi $47                                                           ; 0317: fe 47       .G
+    rz                                                                ; 0319: c8          .
+    call cpuer                                                        ; 031a: cd 89 06    ...
+
+; 
+; test "mov","inr",and "dcr" instructions
+; 
+movi:
+    mvi a, $77                                                        ; 031d: 3e 77       >w
+    inr a                                                             ; 031f: 3c          <
+    mov b, a                                                          ; 0320: 47          G
+    inr b                                                             ; 0321: 04          .
+    mov c, b                                                          ; 0322: 48          H
+    dcr c                                                             ; 0323: 0d          .
+    mov d, c                                                          ; 0324: 51          Q
+    mov e, d                                                          ; 0325: 5a          Z
+    mov h, e                                                          ; 0326: 63          c
+    mov l, h                                                          ; 0327: 6c          l
+    mov a, l                                                          ; 0328: 7d          }
+    dcr a                                                             ; 0329: 3d          =
+    mov c, a                                                          ; 032a: 4f          O
+    mov e, c                                                          ; 032b: 59          Y
+    mov l, e                                                          ; 032c: 6b          k
+    mov b, l                                                          ; 032d: 45          E
+    mov d, b                                                          ; 032e: 50          P
+    mov h, d                                                          ; 032f: 62          b
+    mov a, h                                                          ; 0330: 7c          |
+    mov d, a                                                          ; 0331: 57          W
+    inr d                                                             ; 0332: 14          .
+    mov l, d                                                          ; 0333: 6a          j
+    mov c, l                                                          ; 0334: 4d          M
+    inr c                                                             ; 0335: 0c          .
+    mov h, c                                                          ; 0336: 61          a
+    mov b, h                                                          ; 0337: 44          D
+    dcr b                                                             ; 0338: 05          .
+    mov e, b                                                          ; 0339: 58          X
+    mov a, e                                                          ; 033a: 7b          {
+    mov e, a                                                          ; 033b: 5f          _
+    inr e                                                             ; 033c: 1c          .
+    mov b, e                                                          ; 033d: 43          C
+    mov h, b                                                          ; 033e: 60          `
+    inr h                                                             ; 033f: 24          $
+    mov c, h                                                          ; 0340: 4c          L
+    mov l, c                                                          ; 0341: 69          i
+    mov d, l                                                          ; 0342: 55          U
+    dcr d                                                             ; 0343: 15          .
+    mov a, d                                                          ; 0344: 7a          z
+    mov h, a                                                          ; 0345: 67          g
+    dcr h                                                             ; 0346: 25          %
+    mov d, h                                                          ; 0347: 54          T
+    mov b, d                                                          ; 0348: 42          B
+    mov l, b                                                          ; 0349: 68          h
+    inr l                                                             ; 034a: 2c          ,
+    mov e, l                                                          ; 034b: 5d          ]
+    dcr e                                                             ; 034c: 1d          .
+    mov c, e                                                          ; 034d: 4b          K
+    mov a, c                                                          ; 034e: 79          y
+    mov l, a                                                          ; 034f: 6f          o
+    dcr l                                                             ; 0350: 2d          -
+    mov h, l                                                          ; 0351: 65          e
+    mov e, h                                                          ; 0352: 5c          \
+    mov d, e                                                          ; 0353: 53          S
+    mov c, d                                                          ; 0354: 4a          J
+    mov b, c                                                          ; 0355: 41          A
+    mov a, b                                                          ; 0356: 78          x
+    cpi $77                                                           ; 0357: fe 77       .w
+    cnz cpuer                                                         ; 0359: c4 89 06    ...
+
+; 
+; test arithmetic and logic instructions
+; 
+    xra a                                                             ; 035c: af          .
+    mvi b, 1                                                          ; 035d: 06 01       ..
+    mvi c, 3                                                          ; 035f: 0e 03       ..
+    mvi d, 7                                                          ; 0361: 16 07       ..
+    mvi e, $0f                                                        ; 0363: 1e 0f       ..
+    mvi h, $1f                                                        ; 0365: 26 1f       &.
+    mvi l, $3f                                                        ; 0367: 2e 3f       .?
+    add b                                                             ; 0369: 80          .
+    add c                                                             ; 036a: 81          .
+    add d                                                             ; 036b: 82          .
+    add e                                                             ; 036c: 83          .
+    add h                                                             ; 036d: 84          .
+    add l                                                             ; 036e: 85          .
+    add a                                                             ; 036f: 87          .
+    cpi $f0                                                           ; 0370: fe f0       ..
+    cnz cpuer                                                         ; 0372: c4 89 06    ...
+    sub b                                                             ; 0375: 90          .
+    sub c                                                             ; 0376: 91          .
+    sub d                                                             ; 0377: 92          .
+    sub e                                                             ; 0378: 93          .
+    sub h                                                             ; 0379: 94          .
+    sub l                                                             ; 037a: 95          .
+    cpi $78                                                           ; 037b: fe 78       .x
+    cnz cpuer                                                         ; 037d: c4 89 06    ...
+    sub a                                                             ; 0380: 97          .
+    cnz cpuer                                                         ; 0381: c4 89 06    ...
+    mvi a, $80                                                        ; 0384: 3e 80       >.
+    add a                                                             ; 0386: 87          .
+    mvi b, 1                                                          ; 0387: 06 01       ..
+    mvi c, 2                                                          ; 0389: 0e 02       ..
+    mvi d, 3                                                          ; 038b: 16 03       ..
+    mvi e, 4                                                          ; 038d: 1e 04       ..
+    mvi h, 5                                                          ; 038f: 26 05       &.
+    mvi l, 6                                                          ; 0391: 2e 06       ..
+    adc b                                                             ; 0393: 88          .
+    mvi b, $80                                                        ; 0394: 06 80       ..
+    add b                                                             ; 0396: 80          .
+    add b                                                             ; 0397: 80          .
+    adc c                                                             ; 0398: 89          .
+    add b                                                             ; 0399: 80          .
+    add b                                                             ; 039a: 80          .
+    adc d                                                             ; 039b: 8a          .
+    add b                                                             ; 039c: 80          .
+    add b                                                             ; 039d: 80          .
+    adc e                                                             ; 039e: 8b          .
+    add b                                                             ; 039f: 80          .
+    add b                                                             ; 03a0: 80          .
+    adc h                                                             ; 03a1: 8c          .
+    add b                                                             ; 03a2: 80          .
+    add b                                                             ; 03a3: 80          .
+    adc l                                                             ; 03a4: 8d          .
+    add b                                                             ; 03a5: 80          .
+    add b                                                             ; 03a6: 80          .
+    adc a                                                             ; 03a7: 8f          .
+    cpi $37                                                           ; 03a8: fe 37       .7
+    cnz cpuer                                                         ; 03aa: c4 89 06    ...
+    mvi a, $80                                                        ; 03ad: 3e 80       >.
+    add a                                                             ; 03af: 87          .
+    mvi b, 1                                                          ; 03b0: 06 01       ..
+    sbb b                                                             ; 03b2: 98          .
+    mvi b, $ff                                                        ; 03b3: 06 ff       ..
+    add b                                                             ; 03b5: 80          .
+    sbb c                                                             ; 03b6: 99          .
+    add b                                                             ; 03b7: 80          .
+    sbb d                                                             ; 03b8: 9a          .
+    add b                                                             ; 03b9: 80          .
+    sbb e                                                             ; 03ba: 9b          .
+    add b                                                             ; 03bb: 80          .
+    sbb h                                                             ; 03bc: 9c          .
+    add b                                                             ; 03bd: 80          .
+    sbb l                                                             ; 03be: 9d          .
+    cpi $e0                                                           ; 03bf: fe e0       ..
+    cnz cpuer                                                         ; 03c1: c4 89 06    ...
+    mvi a, $80                                                        ; 03c4: 3e 80       >.
+    add a                                                             ; 03c6: 87          .
+    sbb a                                                             ; 03c7: 9f          .
+    cpi $ff                                                           ; 03c8: fe ff       ..
+    cnz cpuer                                                         ; 03ca: c4 89 06    ...
+    mvi a, $ff                                                        ; 03cd: 3e ff       >.
+    mvi b, $fe                                                        ; 03cf: 06 fe       ..
+    mvi c, $fc                                                        ; 03d1: 0e fc       ..
+    mvi d, $ef                                                        ; 03d3: 16 ef       ..
+    mvi e, $7f                                                        ; 03d5: 1e 7f       ..
+    mvi h, $f4                                                        ; 03d7: 26 f4       &.
+    mvi l, $bf                                                        ; 03d9: 2e bf       ..
+    ana a                                                             ; 03db: a7          .
+    ana c                                                             ; 03dc: a1          .
+    ana d                                                             ; 03dd: a2          .
+    ana e                                                             ; 03de: a3          .
+    ana h                                                             ; 03df: a4          .
+    ana l                                                             ; 03e0: a5          .
+    ana a                                                             ; 03e1: a7          .
+    cpi $24                                                           ; 03e2: fe 24       .$
+    cnz cpuer                                                         ; 03e4: c4 89 06    ...
+    xra a                                                             ; 03e7: af          .
+    mvi b, 1                                                          ; 03e8: 06 01       ..
+    mvi c, 2                                                          ; 03ea: 0e 02       ..
+    mvi d, 4                                                          ; 03ec: 16 04       ..
+    mvi e, 8                                                          ; 03ee: 1e 08       ..
+    mvi h, $10                                                        ; 03f0: 26 10       &.
+    mvi l, $20                                                        ; 03f2: 2e 20       .
+    ora b                                                             ; 03f4: b0          .
+    ora c                                                             ; 03f5: b1          .
+    ora d                                                             ; 03f6: b2          .
+    ora e                                                             ; 03f7: b3          .
+    ora h                                                             ; 03f8: b4          .
+    ora l                                                             ; 03f9: b5          .
+    ora a                                                             ; 03fa: b7          .
+    cpi $3f                                                           ; 03fb: fe 3f       .?
+    cnz cpuer                                                         ; 03fd: c4 89 06    ...
+    mvi a, 0                                                          ; 0400: 3e 00       >.
+    mvi h, $8f                                                        ; 0402: 26 8f       &.
+    mvi l, $4f                                                        ; 0404: 2e 4f       .O
+    xra b                                                             ; 0406: a8          .
+    xra c                                                             ; 0407: a9          .
+    xra d                                                             ; 0408: aa          .
+    xra e                                                             ; 0409: ab          .
+    xra h                                                             ; 040a: ac          .
+    xra l                                                             ; 040b: ad          .
+    cpi $cf                                                           ; 040c: fe cf       ..
+    cnz cpuer                                                         ; 040e: c4 89 06    ...
+    xra a                                                             ; 0411: af          .
+    cnz cpuer                                                         ; 0412: c4 89 06    ...
+    mvi b, $44                                                        ; 0415: 06 44       .D
+    mvi c, $45                                                        ; 0417: 0e 45       .E
+    mvi d, $46                                                        ; 0419: 16 46       .F
+    mvi e, $47                                                        ; 041b: 1e 47       .G
+    mvi h, 6                                                          ; 041d: 26 06       &.
+    mvi l, $a6                                                        ; 041f: 2e a6       ..
+    mov m, b                                                          ; 0421: 70          p
+    mvi b, 0                                                          ; 0422: 06 00       ..
+    mov b, m                                                          ; 0424: 46          F
+    mvi a, $44                                                        ; 0425: 3e 44       >D
+    cmp b                                                             ; 0427: b8          .
+    cnz cpuer                                                         ; 0428: c4 89 06    ...
+    mov m, d                                                          ; 042b: 72          r
+    mvi d, 0                                                          ; 042c: 16 00       ..
+    mov d, m                                                          ; 042e: 56          V
+    mvi a, $46                                                        ; 042f: 3e 46       >F
+    cmp d                                                             ; 0431: ba          .
+    cnz cpuer                                                         ; 0432: c4 89 06    ...
+    mov m, e                                                          ; 0435: 73          s
+    mvi e, 0                                                          ; 0436: 1e 00       ..
+    mov e, m                                                          ; 0438: 5e          ^
+    mvi a, $47                                                        ; 0439: 3e 47       >G
+    cmp e                                                             ; 043b: bb          .
+    cnz cpuer                                                         ; 043c: c4 89 06    ...
+    mov m, h                                                          ; 043f: 74          t
+    mvi h, 6                                                          ; 0440: 26 06       &.
+    mvi l, $a6                                                        ; 0442: 2e a6       ..
+    mov h, m                                                          ; 0444: 66          f
+    mvi a, 6                                                          ; 0445: 3e 06       >.
+    cmp h                                                             ; 0447: bc          .
+    cnz cpuer                                                         ; 0448: c4 89 06    ...
+    mov m, l                                                          ; 044b: 75          u
+    mvi h, 6                                                          ; 044c: 26 06       &.
+    mvi l, $a6                                                        ; 044e: 2e a6       ..
+    mov l, m                                                          ; 0450: 6e          n
+    mvi a, $a6                                                        ; 0451: 3e a6       >.
+    cmp l                                                             ; 0453: bd          .
+    cnz cpuer                                                         ; 0454: c4 89 06    ...
+    mvi h, 6                                                          ; 0457: 26 06       &.
+    mvi l, $a6                                                        ; 0459: 2e a6       ..
+    mvi a, $32                                                        ; 045b: 3e 32       >2
+    mov m, a                                                          ; 045d: 77          w
+    cmp m                                                             ; 045e: be          .
+    cnz cpuer                                                         ; 045f: c4 89 06    ...
+    add m                                                             ; 0462: 86          .
+    cpi $64                                                           ; 0463: fe 64       .d
+    cnz cpuer                                                         ; 0465: c4 89 06    ...
+    xra a                                                             ; 0468: af          .
+    mov a, m                                                          ; 0469: 7e          ~
+    cpi $32                                                           ; 046a: fe 32       .2
+    cnz cpuer                                                         ; 046c: c4 89 06    ...
+    mvi h, 6                                                          ; 046f: 26 06       &.
+    mvi l, $a6                                                        ; 0471: 2e a6       ..
+    mov a, m                                                          ; 0473: 7e          ~
+    sub m                                                             ; 0474: 96          .
+    cnz cpuer                                                         ; 0475: c4 89 06    ...
+    mvi a, $80                                                        ; 0478: 3e 80       >.
+    add a                                                             ; 047a: 87          .
+    adc m                                                             ; 047b: 8e          .
+    cpi $33                                                           ; 047c: fe 33       .3
+    cnz cpuer                                                         ; 047e: c4 89 06    ...
+    mvi a, $80                                                        ; 0481: 3e 80       >.
+    add a                                                             ; 0483: 87          .
+    sbb m                                                             ; 0484: 9e          .
+    cpi $cd                                                           ; 0485: fe cd       ..
+    cnz cpuer                                                         ; 0487: c4 89 06    ...
+    ana m                                                             ; 048a: a6          .
+    cnz cpuer                                                         ; 048b: c4 89 06    ...
+    mvi a, $25                                                        ; 048e: 3e 25       >%
+    ora m                                                             ; 0490: b6          .
+    cpi $37                                                           ; 0491: fe 37       .7
+    cnz cpuer                                                         ; 0493: c4 89 06    ...
+    xra m                                                             ; 0496: ae          .
+    cpi 5                                                             ; 0497: fe 05       ..
+    cnz cpuer                                                         ; 0499: c4 89 06    ...
+    mvi m, $55                                                        ; 049c: 36 55       6U
+    inr m                                                             ; 049e: 34          4
+    dcr m                                                             ; 049f: 35          5
+    add m                                                             ; 04a0: 86          .
+    cpi $5a                                                           ; 04a1: fe 5a       .Z
+    cnz cpuer                                                         ; 04a3: c4 89 06    ...
+    lxi bc, $12ff                                                     ; 04a6: 01 ff 12    ...
+    lxi de, $12ff                                                     ; 04a9: 11 ff 12    ...
+    lxi hl, $12ff                                                     ; 04ac: 21 ff 12    !..
+    inx b                                                             ; 04af: 03          .
+    inx d                                                             ; 04b0: 13          .
+    inx h                                                             ; 04b1: 23          #
+    mvi a, $13                                                        ; 04b2: 3e 13       >.
+    cmp b                                                             ; 04b4: b8          .
+    cnz cpuer                                                         ; 04b5: c4 89 06    ...
+    cmp d                                                             ; 04b8: ba          .
+    cnz cpuer                                                         ; 04b9: c4 89 06    ...
+    cmp h                                                             ; 04bc: bc          .
+    cnz cpuer                                                         ; 04bd: c4 89 06    ...
+    mvi a, 0                                                          ; 04c0: 3e 00       >.
+    cmp c                                                             ; 04c2: b9          .
+    cnz cpuer                                                         ; 04c3: c4 89 06    ...
+    cmp e                                                             ; 04c6: bb          .
+    cnz cpuer                                                         ; 04c7: c4 89 06    ...
+    cmp l                                                             ; 04ca: bd          .
+    cnz cpuer                                                         ; 04cb: c4 89 06    ...
+    dcx b                                                             ; 04ce: 0b          .
+    dcx d                                                             ; 04cf: 1b          .
+    dcx h                                                             ; 04d0: 2b          +
+    mvi a, $12                                                        ; 04d1: 3e 12       >.
+    cmp b                                                             ; 04d3: b8          .
+    cnz cpuer                                                         ; 04d4: c4 89 06    ...
+    cmp d                                                             ; 04d7: ba          .
+    cnz cpuer                                                         ; 04d8: c4 89 06    ...
+    cmp h                                                             ; 04db: bc          .
+    cnz cpuer                                                         ; 04dc: c4 89 06    ...
+    mvi a, $ff                                                        ; 04df: 3e ff       >.
+    cmp c                                                             ; 04e1: b9          .
+    cnz cpuer                                                         ; 04e2: c4 89 06    ...
+    cmp e                                                             ; 04e5: bb          .
+    cnz cpuer                                                         ; 04e6: c4 89 06    ...
+    cmp l                                                             ; 04e9: bd          .
+    cnz cpuer                                                         ; 04ea: c4 89 06    ...
+    sta temp0                                                         ; 04ed: 32 a6 06    2..
+    xra a                                                             ; 04f0: af          .
+    lda temp0                                                         ; 04f1: 3a a6 06    :..
+    cpi $ff                                                           ; 04f4: fe ff       ..
+    cnz cpuer                                                         ; 04f6: c4 89 06    ...
+    lhld tempp                                                        ; 04f9: 2a a4 06    *..
+    shld temp0                                                        ; 04fc: 22 a6 06    "..
+    lda tempp                                                         ; 04ff: 3a a4 06    :..
+    mov b, a                                                          ; 0502: 47          G
+    lda temp0                                                         ; 0503: 3a a6 06    :..
+    cmp b                                                             ; 0506: b8          .
+    cnz cpuer                                                         ; 0507: c4 89 06    ...
+    lda tempp+1                                                       ; 050a: 3a a5 06    :..
+    mov b, a                                                          ; 050d: 47          G
+    lda temp1                                                         ; 050e: 3a a7 06    :..
+    cmp b                                                             ; 0511: b8          .
+    cnz cpuer                                                         ; 0512: c4 89 06    ...
+    mvi a, $aa                                                        ; 0515: 3e aa       >.
+    sta temp0                                                         ; 0517: 32 a6 06    2..
+    mov b, h                                                          ; 051a: 44          D
+    mov c, l                                                          ; 051b: 4d          M
+    xra a                                                             ; 051c: af          .
+    ldax b                                                            ; 051d: 0a          .
+    cpi $aa                                                           ; 051e: fe aa       ..
+    cnz cpuer                                                         ; 0520: c4 89 06    ...
+    inr a                                                             ; 0523: 3c          <
+    stax b                                                            ; 0524: 02          .
+    lda temp0                                                         ; 0525: 3a a6 06    :..
+    cpi $ab                                                           ; 0528: fe ab       ..
+    cnz cpuer                                                         ; 052a: c4 89 06    ...
+    mvi a, $77                                                        ; 052d: 3e 77       >w
+    sta temp0                                                         ; 052f: 32 a6 06    2..
+    lhld tempp                                                        ; 0532: 2a a4 06    *..
+    lxi de, 0                                                         ; 0535: 11 00 00    ...
+    xchg                                                              ; 0538: eb          .
+    xra a                                                             ; 0539: af          .
+    ldax d                                                            ; 053a: 1a          .
+    cpi $77                                                           ; 053b: fe 77       .w
+    cnz cpuer                                                         ; 053d: c4 89 06    ...
+    xra a                                                             ; 0540: af          .
+    add h                                                             ; 0541: 84          .
+    add l                                                             ; 0542: 85          .
+    cnz cpuer                                                         ; 0543: c4 89 06    ...
+    mvi a, $cc                                                        ; 0546: 3e cc       >.
+    stax d                                                            ; 0548: 12          .
+    lda temp0                                                         ; 0549: 3a a6 06    :..
+    cpi $cc                                                           ; 054c: fe cc       ..
+    stax d                                                            ; 054e: 12          .
+    lda temp0                                                         ; 054f: 3a a6 06    :..
+    cpi $cc                                                           ; 0552: fe cc       ..
+    cnz cpuer                                                         ; 0554: c4 89 06    ...
+    lxi hl, $7777                                                     ; 0557: 21 77 77    !ww
+    dad h                                                             ; 055a: 29          )
+    mvi a, $ee                                                        ; 055b: 3e ee       >.
+    cmp h                                                             ; 055d: bc          .
+    cnz cpuer                                                         ; 055e: c4 89 06    ...
+    cmp l                                                             ; 0561: bd          .
+    cnz cpuer                                                         ; 0562: c4 89 06    ...
+    lxi hl, $5555                                                     ; 0565: 21 55 55    !UU
+    lxi bc, $ffff                                                     ; 0568: 01 ff ff    ...
+    dad b                                                             ; 056b: 09          .
+    mvi a, $55                                                        ; 056c: 3e 55       >U
+    cnc cpuer                                                         ; 056e: d4 89 06    ...
+    cmp h                                                             ; 0571: bc          .
+    cnz cpuer                                                         ; 0572: c4 89 06    ...
+    mvi a, $54                                                        ; 0575: 3e 54       >T
+    cmp l                                                             ; 0577: bd          .
+    cnz cpuer                                                         ; 0578: c4 89 06    ...
+    lxi hl, $aaaa                                                     ; 057b: 21 aa aa    !..
+    lxi de, $3333                                                     ; 057e: 11 33 33    .33
+    dad d                                                             ; 0581: 19          .
+    mvi a, $dd                                                        ; 0582: 3e dd       >.
+    cmp h                                                             ; 0584: bc          .
+    cnz cpuer                                                         ; 0585: c4 89 06    ...
+    cmp l                                                             ; 0588: bd          .
+    cnz cpuer                                                         ; 0589: c4 89 06    ...
+    stc                                                               ; 058c: 37          7
+    cnc cpuer                                                         ; 058d: d4 89 06    ...
+    cmc                                                               ; 0590: 3f          ?
+    cc cpuer                                                          ; 0591: dc 89 06    ...
+    mvi a, $aa                                                        ; 0594: 3e aa       >.
+    cma                                                               ; 0596: 2f          /
+    cpi $55                                                           ; 0597: fe 55       .U
+    cnz cpuer                                                         ; 0599: c4 89 06    ...
+    ora a                                                             ; 059c: b7          .
+    daa                                                               ; 059d: 27          '
+    cpi $55                                                           ; 059e: fe 55       .U
+    cnz cpuer                                                         ; 05a0: c4 89 06    ...
+    mvi a, $88                                                        ; 05a3: 3e 88       >.
+    add a                                                             ; 05a5: 87          .
+    daa                                                               ; 05a6: 27          '
+    cpi $76                                                           ; 05a7: fe 76       .v
+    cnz cpuer                                                         ; 05a9: c4 89 06    ...
+    xra a                                                             ; 05ac: af          .
+    mvi a, $aa                                                        ; 05ad: 3e aa       >.
+    daa                                                               ; 05af: 27          '
+    cnc cpuer                                                         ; 05b0: d4 89 06    ...
+    cpi $10                                                           ; 05b3: fe 10       ..
+    cnz cpuer                                                         ; 05b5: c4 89 06    ...
+    xra a                                                             ; 05b8: af          .
+    mvi a, $9a                                                        ; 05b9: 3e 9a       >.
+    daa                                                               ; 05bb: 27          '
+    cnc cpuer                                                         ; 05bc: d4 89 06    ...
+    cnz cpuer                                                         ; 05bf: c4 89 06    ...
+    stc                                                               ; 05c2: 37          7
+    mvi a, $42                                                        ; 05c3: 3e 42       >B
+    rlc                                                               ; 05c5: 07          .
+    cc cpuer                                                          ; 05c6: dc 89 06    ...
+    rlc                                                               ; 05c9: 07          .
+    cnc cpuer                                                         ; 05ca: d4 89 06    ...
+    cpi 9                                                             ; 05cd: fe 09       ..
+    cnz cpuer                                                         ; 05cf: c4 89 06    ...
+    rrc                                                               ; 05d2: 0f          .
+    cnc cpuer                                                         ; 05d3: d4 89 06    ...
+    rrc                                                               ; 05d6: 0f          .
+    cpi $42                                                           ; 05d7: fe 42       .B
+    cnz cpuer                                                         ; 05d9: c4 89 06    ...
+    ral                                                               ; 05dc: 17          .
+    ral                                                               ; 05dd: 17          .
+    cnc cpuer                                                         ; 05de: d4 89 06    ...
+    cpi 8                                                             ; 05e1: fe 08       ..
+    cnz cpuer                                                         ; 05e3: c4 89 06    ...
+    rar                                                               ; 05e6: 1f          .
+    rar                                                               ; 05e7: 1f          .
+    cc cpuer                                                          ; 05e8: dc 89 06    ...
+    cpi 2                                                             ; 05eb: fe 02       ..
+    cnz cpuer                                                         ; 05ed: c4 89 06    ...
+    lxi bc, $1234                                                     ; 05f0: 01 34 12    .4.
+    lxi de, $aaaa                                                     ; 05f3: 11 aa aa    ...
+    lxi hl, $5555                                                     ; 05f6: 21 55 55    !UU
+    xra a                                                             ; 05f9: af          .
+    push b                                                            ; 05fa: c5          .
+    push d                                                            ; 05fb: d5          .
+    push h                                                            ; 05fc: e5          .
+    push psw                                                          ; 05fd: f5          .
+    lxi bc, 0                                                         ; 05fe: 01 00 00    ...
+    lxi de, 0                                                         ; 0601: 11 00 00    ...
+    lxi hl, 0                                                         ; 0604: 21 00 00    !..
+    mvi a, $c0                                                        ; 0607: 3e c0       >.
+    adi $f0                                                           ; 0609: c6 f0       ..
+    pop psw                                                           ; 060b: f1          .
+    pop h                                                             ; 060c: e1          .
+    pop d                                                             ; 060d: d1          .
+    pop b                                                             ; 060e: c1          .
+    cc cpuer                                                          ; 060f: dc 89 06    ...
+    cnz cpuer                                                         ; 0612: c4 89 06    ...
+    cpo cpuer                                                         ; 0615: e4 89 06    ...
+    cm cpuer                                                          ; 0618: fc 89 06    ...
+    mvi a, $12                                                        ; 061b: 3e 12       >.
+    cmp b                                                             ; 061d: b8          .
+    cnz cpuer                                                         ; 061e: c4 89 06    ...
+    mvi a, $34                                                        ; 0621: 3e 34       >4
+    cmp c                                                             ; 0623: b9          .
+    cnz cpuer                                                         ; 0624: c4 89 06    ...
+    mvi a, $aa                                                        ; 0627: 3e aa       >.
+    cmp d                                                             ; 0629: ba          .
+    cnz cpuer                                                         ; 062a: c4 89 06    ...
+    cmp e                                                             ; 062d: bb          .
+    cnz cpuer                                                         ; 062e: c4 89 06    ...
+    mvi a, $55                                                        ; 0631: 3e 55       >U
+    cmp h                                                             ; 0633: bc          .
+    cnz cpuer                                                         ; 0634: c4 89 06    ...
+    cmp l                                                             ; 0637: bd          .
+    cnz cpuer                                                         ; 0638: c4 89 06    ...
+    lxi hl, 0                                                         ; 063b: 21 00 00    !..
+    dad sp                                                            ; 063e: 39          9
+    shld savstk                                                       ; 063f: 22 ab 06    "..
+    lxi sp, $06aa                                                     ; 0642: 31 aa 06    1..
+    dcx sp                                                            ; 0645: 3b          ;
+    dcx sp                                                            ; 0646: 3b          ;
+    inx sp                                                            ; 0647: 33          3
+    dcx sp                                                            ; 0648: 3b          ;
+    mvi a, $55                                                        ; 0649: 3e 55       >U
+    sta temp2                                                         ; 064b: 32 a8 06    2..
+    cma                                                               ; 064e: 2f          /
+    sta temp3                                                         ; 064f: 32 a9 06    2..
+    pop b                                                             ; 0652: c1          .
+    cmp b                                                             ; 0653: b8          .
+    cnz cpuer                                                         ; 0654: c4 89 06    ...
+    cma                                                               ; 0657: 2f          /
+    cmp c                                                             ; 0658: b9          .
+    cnz cpuer                                                         ; 0659: c4 89 06    ...
+    lxi hl, $06aa                                                     ; 065c: 21 aa 06    !..
+    sphl                                                              ; 065f: f9          .
+    lxi hl, $7733                                                     ; 0660: 21 33 77    !3w
+    dcx sp                                                            ; 0663: 3b          ;
+    dcx sp                                                            ; 0664: 3b          ;
+    xthl                                                              ; 0665: e3          .
+    lda temp3                                                         ; 0666: 3a a9 06    :..
+    cpi $77                                                           ; 0669: fe 77       .w
+    cnz cpuer                                                         ; 066b: c4 89 06    ...
+    lda temp2                                                         ; 066e: 3a a8 06    :..
+    cpi $33                                                           ; 0671: fe 33       .3
+    cnz cpuer                                                         ; 0673: c4 89 06    ...
+    mvi a, $55                                                        ; 0676: 3e 55       >U
+    cmp l                                                             ; 0678: bd          .
+    cnz cpuer                                                         ; 0679: c4 89 06    ...
+    cma                                                               ; 067c: 2f          /
+    cmp h                                                             ; 067d: bc          .
+    cnz cpuer                                                         ; 067e: c4 89 06    ...
+    lhld savstk                                                       ; 0681: 2a ab 06    *..
+    sphl                                                              ; 0684: f9          .
+    lxi hl, $069b                                                     ; 0685: 21 9b 06    !..
+    pchl                                                              ; 0688: e9          .
+
+cpuer:
+    lxi hl, cpu_error_message                                         ; 0689: 21 8b 01    !..
+    call msg                                                          ; 068c: cd 45 01    .E.
+    xthl                                                              ; 068f: e3          .
+    mov a, h                                                          ; 0690: 7c          |
+    call byte0                                                        ; 0691: cd 54 01    .T.
+    mov a, l                                                          ; 0694: 7d          }
+    call byte0                                                        ; 0695: cd 54 01    .T.
+    jmp wboot                                                         ; 0698: c3 00 00    ...
+
+cpuok:
+    lxi hl, cpu_ok_message                                            ; 069b: 21 74 01    !t.
+    call msg                                                          ; 069e: cd 45 01    .E.
+    jmp wboot                                                         ; 06a1: c3 00 00    ...
+
+tempp:
+    dw temp0                                                          ; 06a4: a6 06       ..
+temp0:
+    db 0                                                              ; 06a6: 00          .
+temp1:
+    db 0                                                              ; 06a7: 00          .
+temp2:
+    db 0                                                              ; 06a8: 00          .
+temp3:
+    db 0                                                              ; 06a9: 00          .
+temp4:
+    db 0                                                              ; 06aa: 00          .
+savstk:
+    dw 0                                                              ; 06ab: 00 00       ..
+pydis_end:
+; ASSERT ((cpu_error_message) == $018b)
+; ASSERT ((cpu_ok_message) == $0174)
+; ASSERT ((temp0) == $06a6)


### PR DESCRIPTION
    `./go --check-disassembly` or just `./go -c` checks disassemblies produced against known good disassemblies.
    `./go --make-known-good` or just `./go -m` copies the disassemblies produced to the known good disassemblies.